### PR TITLE
Deploy site to Cloudflare Pages via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,27 @@
+name: Deploy Site
+
+on:
+  push:
+    branches: [main]
+    paths: [site/**, .github/workflows/deploy-site.yml]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+        working-directory: site
+      - run: npm run build
+        working-directory: site
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site/dist --project-name=clawpatrol-site


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that builds and deploys `site/` to Cloudflare Pages on push to main
- Only triggers on changes to `site/` or the workflow file itself
- Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets (already set)

## Test plan
- [ ] Merge and verify the deploy action runs successfully
- [ ] Confirm site is live on Cloudflare Pages