### PR TITLE
Update install URL to clawpatrol.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ```
-curl -fsSL https://denoland.github.io/clawpatrol-go/install.sh | sh
+curl -fsSL https://clawpatrol.dev/install.sh | sh
 ```
 
 ```


### PR DESCRIPTION
README still pointed at the old GitHub Pages URL for the install script. Now points to clawpatrol.dev.

**This PR should NOT trigger a Cloudflare Pages build** (no site/ changes).