### PR TITLE
Add meta description for SEO

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <title>Claw Patrol — The security proxy for AI agents</title>
+    <meta name="description"
+      content="Open-source forward proxy that intercepts all agent traffic, injects secrets without exposing them, and inspects protocols like Postgres and Kubernetes. No code changes required." />
     <link
       rel="preload"
       as="font"


### PR DESCRIPTION
Adds a `<meta name="description">` tag to the landing page for search engine results.

**This PR SHOULD trigger a Cloudflare Pages build** (site/ change).