### PR TITLE
release CI: fix linux stub + arm64-only mac build

### DIFF
--- a/.github/scripts/build-macos-app.sh
+++ b/.github/scripts/build-macos-app.sh
@@ -35,6 +35,7 @@ if [ -z "${APPLE_ID:-}" ]; then
     -project "$PROJECT" \
     -scheme "$SCHEME" \
     -configuration Release \
+    -arch arm64 ONLY_ACTIVE_ARCH=NO \
     CODE_SIGN_IDENTITY="-" \
     CODE_SIGNING_REQUIRED=NO \
     CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION=YES \
@@ -92,11 +93,14 @@ sed -i '' \
 brew install xcodegen 2>/dev/null || true
 xcodegen --spec macos/project.yml
 
-# 6. Archive.
+# 6. Archive. arm64-only — libwgnetstack.a is built for darwin/arm64
+# (apple silicon). Universal would require a separate amd64 build of
+# the Go archive + lipo, which we skip until x86_64 macs matter.
 xcodebuild \
   -project "$PROJECT" \
   -scheme "$SCHEME" \
   -configuration Release \
+  -arch arm64 ONLY_ACTIVE_ARCH=NO \
   -archivePath "$BUILD_DIR/Clawpatrol.xcarchive" \
   OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
   archive

--- a/mac_helper_stub.go
+++ b/mac_helper_stub.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package main
+
+// macHelperInstall is darwin-only — no-op on every other platform.
+// login.go's runJoin guards the call with `runtime.GOOS == "darwin"`
+// already, but Go still needs the symbol resolvable at compile time
+// on every build.
+func macHelperInstall(wholeMachine bool) error { return nil }

--- a/run_linux.go
+++ b/run_linux.go
@@ -2,6 +2,11 @@
 
 package main
 
+// macHelperInstall is darwin-only — no-op on linux. login.go calls
+// it from runJoin under `runtime.GOOS == "darwin"`, but the compiler
+// still needs the symbol on every platform.
+func macHelperInstall(wholeMachine bool) error { return nil }
+
 // `clawpatrol run -- <cmd> [args...]` — route a single process tree's
 // traffic through the gateway, leave the rest of the machine alone.
 // Same shape as ../unclaw/native/napi/src/client_linux/netns.rs and

--- a/run_linux.go
+++ b/run_linux.go
@@ -2,11 +2,6 @@
 
 package main
 
-// macHelperInstall is darwin-only — no-op on linux. login.go calls
-// it from runJoin under `runtime.GOOS == "darwin"`, but the compiler
-// still needs the symbol on every platform.
-func macHelperInstall(wholeMachine bool) error { return nil }
-
 // `clawpatrol run -- <cmd> [args...]` — route a single process tree's
 // traffic through the gateway, leave the rest of the machine alone.
 // Same shape as ../unclaw/native/napi/src/client_linux/netns.rs and

--- a/run_other.go
+++ b/run_other.go
@@ -5,9 +5,3 @@ package main
 func runRun(args []string) {
 	fail("clawpatrol run is not supported on this platform — linux + macOS only.")
 }
-
-// macHelperInstall is a no-op everywhere except darwin. login.go's
-// runJoin guards the call with `runtime.GOOS == "darwin"` already,
-// but Go still needs the symbol resolvable at compile time on every
-// build.
-func macHelperInstall(wholeMachine bool) error { return nil }

--- a/run_other.go
+++ b/run_other.go
@@ -6,4 +6,8 @@ func runRun(args []string) {
 	fail("clawpatrol run is not supported on this platform — linux + macOS only.")
 }
 
+// macHelperInstall is a no-op everywhere except darwin. login.go's
+// runJoin guards the call with `runtime.GOOS == "darwin"` already,
+// but Go still needs the symbol resolvable at compile time on every
+// build.
 func macHelperInstall(wholeMachine bool) error { return nil }


### PR DESCRIPTION
Fixes 2 release.yml failures:

- linux `undefined: macHelperInstall` — stub on linux side
- macOS x86_64 SwiftCompile fail — pin arm64 (libwgnetstack.a is darwin/arm64 only)