### PR TITLE
release CI: fix artifact paths under merge-multiple

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,13 +109,17 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           mkdir -p site/releases/${TAG}
-          cp artifacts/clawpatrol-*/clawpatrol-* site/releases/${TAG}/
-          # macOS .app for `clawpatrol run` per-process tunnel; install.sh
-          # picks this up on darwin in addition to the Go binary.
-          if [ -f artifacts/macos-app/Clawpatrol.app.tar.gz ]; then
-            cp artifacts/macos-app/Clawpatrol.app.tar.gz site/releases/${TAG}/
+          cp artifacts/clawpatrol-* site/releases/${TAG}/
+          # macOS .app for `clawpatrol run` per-process tunnel;
+          # install.sh picks this up on darwin in addition to the Go
+          # binary. download-artifact's merge-multiple flattens, so
+          # the file lands directly under artifacts/.
+          if [ -f artifacts/Clawpatrol.app.tar.gz ]; then
+            cp artifacts/Clawpatrol.app.tar.gz site/releases/${TAG}/
           fi
-          (cd site/releases/${TAG} && sha256sum clawpatrol-* Clawpatrol.app.tar.gz 2>/dev/null > SHA256SUMS || sha256sum clawpatrol-* > SHA256SUMS)
+          (cd site/releases/${TAG} \
+            && sha256sum clawpatrol-* Clawpatrol.app.tar.gz 2>/dev/null > SHA256SUMS \
+            || sha256sum clawpatrol-* > SHA256SUMS)
           # `latest` mirror
           cp -r site/releases/${TAG} site/releases/latest
           cp install.sh site/install.sh


### PR DESCRIPTION
Workflow uses `download-artifact` with `merge-multiple: true` which flattens — files end up at `artifacts/clawpatrol-*`, not `artifacts/<artifact-name>/clawpatrol-*`. Fix the cp pattern + add the macOS .app.