### PR TITLE
profile-tenancy follow-ups (rules table cleanup, connect-to-profile)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,13 +109,17 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           mkdir -p site/releases/${TAG}
-          cp artifacts/clawpatrol-*/clawpatrol-* site/releases/${TAG}/
-          # macOS .app for `clawpatrol run` per-process tunnel; install.sh
-          # picks this up on darwin in addition to the Go binary.
-          if [ -f artifacts/macos-app/Clawpatrol.app.tar.gz ]; then
-            cp artifacts/macos-app/Clawpatrol.app.tar.gz site/releases/${TAG}/
+          cp artifacts/clawpatrol-* site/releases/${TAG}/
+          # macOS .app for `clawpatrol run` per-process tunnel;
+          # install.sh picks this up on darwin in addition to the Go
+          # binary. download-artifact's merge-multiple flattens, so
+          # the file lands directly under artifacts/.
+          if [ -f artifacts/Clawpatrol.app.tar.gz ]; then
+            cp artifacts/Clawpatrol.app.tar.gz site/releases/${TAG}/
           fi
-          (cd site/releases/${TAG} && sha256sum clawpatrol-* Clawpatrol.app.tar.gz 2>/dev/null > SHA256SUMS || sha256sum clawpatrol-* > SHA256SUMS)
+          (cd site/releases/${TAG} \
+            && sha256sum clawpatrol-* Clawpatrol.app.tar.gz 2>/dev/null > SHA256SUMS \
+            || sha256sum clawpatrol-* > SHA256SUMS)
           # `latest` mirror
           cp -r site/releases/${TAG} site/releases/latest
           cp install.sh site/install.sh

--- a/integrations.go
+++ b/integrations.go
@@ -315,23 +315,28 @@ func expandDefaults(cfg *Config) error {
 					cfg.OAuth = append(cfg.OAuth, *def.OAuth)
 					haveOAuth[def.OAuth.ID] = true
 				}
+				// host→integration is recorded on cfg.HostIntegration
+				// instead of being expanded into visible Rules. The
+				// MITM path consults the map when no user rule matches
+				// a host, synthesizing an in-memory Rule with the
+				// right Auth field for credential injection.
 				for _, host := range def.Hosts {
-					if declared[host] {
-						continue
+					if cfg.HostIntegration == nil {
+						cfg.HostIntegration = map[string]string{}
 					}
-					if err := emit(Rule{Host: host, Auth: name}); err != nil {
-						return err
+					if _, set := cfg.HostIntegration[host]; !set {
+						cfg.HostIntegration[host] = name
 					}
 				}
 				continue
 			}
 			if in, ok := custom[name]; ok {
 				for _, host := range in.Hosts {
-					if declared[host] {
-						continue
+					if cfg.HostIntegration == nil {
+						cfg.HostIntegration = map[string]string{}
 					}
-					if err := emit(Rule{Host: host, Auth: name}); err != nil {
-						return err
+					if _, set := cfg.HostIntegration[host]; !set {
+						cfg.HostIntegration[host] = name
 					}
 				}
 				continue

--- a/main.go
+++ b/main.go
@@ -1419,13 +1419,20 @@ func truncate(s string, n int) string {
 	return s
 }
 
-// ownerForRequest returns the user-scoped credential-owner key for a
-// peer. Falls back to peer IP when whois unavailable. For tagged
-// (onboarded) devices, the override populated by /api/onboard/claim
-// resolves the IP to the human approver — without it, Tailscale OAuth
-// only reports "tagged-devices" and per-user credential lookups miss.
+// ownerForRequest returns the credential-bucket key for a peer. With
+// the profile-as-tenant model, that's the device's assigned profile
+// name (devices.profile). Falls back to the peer's onboard-mapped
+// owner email and finally peer IP for un-onboarded clients — both
+// preserve compatibility with credentials saved before the profile
+// migration. Whois lookup remains in place for tailscale-control mode
+// where the dashboard still binds creds to the human's login.
 func (g *Gateway) ownerForRequest(c net.Conn, _ *OAuthIntegration) string {
 	ip := peerIP(c)
+	if g.onboard != nil {
+		if profile := g.onboard.ProfileForIP(ip); profile != "" {
+			return profile
+		}
+	}
 	login := ""
 	if g.agents != nil && g.agents.lc != nil {
 		if who := g.agents.lookupWhois(ip); who != nil && !who.UserProfile.IsZero() {

--- a/main.go
+++ b/main.go
@@ -69,6 +69,14 @@ type Config struct {
 	// TopRules.
 	Rules []Rule
 	OAuth []OAuthIntegration
+
+	// HostIntegration maps a hostname to the integration name whose
+	// credential should be injected when the gateway MITMs that host.
+	// Populated by expandDefaults from each profile's `integrations`
+	// list. Not decoded from HCL, not surfaced in /api/rules — kept
+	// invisible to the rules table since they're not policy decisions
+	// but auth-injection wiring.
+	HostIntegration map[string]string
 }
 
 // Profile binds integrations + rulesets + inline rules. Each onboarded
@@ -1462,8 +1470,16 @@ func (g *Gateway) handle(raw net.Conn) {
 	pip := peerIP(c)
 	hostRule := selectHostRule(g.Rules(), host, pip, g.profileFor(pip))
 	if hostRule == nil {
-		g.splice(c, host)
-		return
+		// No user rule for this host. If it's an integration host,
+		// synthesize a transient Rule so MITM still injects the right
+		// credential. Otherwise pass-through (default-allow with no
+		// inspection).
+		if integ := g.cfg.HostIntegration[host]; integ != "" {
+			hostRule = &Rule{Host: host, Auth: integ}
+		} else {
+			g.splice(c, host)
+			return
+		}
 	}
 	if hostRule.Match == nil && hostRule.Action == "deny" {
 		log.Printf("deny %s: %s", host, hostRule.Reason)

--- a/migrations/sqlite/0001_initial.sql
+++ b/migrations/sqlite/0001_initial.sql
@@ -1,10 +1,17 @@
 -- 0001_initial — clawpatrol persistent state.
 --
 -- Tables:
---   devices         — onboarded peer identity (WG IP → owner / hostname / profile)
+--   devices         — onboarded peer identity (WG IP → hostname / profile)
 --   wg_peers        — (pubkey, ip) registrations for the wireguard-go device
---   credentials     — per-(integration, owner) OAuth tokens (was oauth-*.json)
---   actions         — request event log (was gateway.log JSONL)
+--   credentials     — per-(integration, profile) OAuth tokens
+--   actions         — request event log
+--
+-- Profile is the tenancy unit: a profile bundles integrations + rulesets
+-- in gateway.hcl, devices are bound to a profile, credentials/secrets
+-- live per profile. The "user" / "owner" concept is intentionally absent
+-- — `clawpatrol join` records (peer ip → profile), the gateway looks up
+-- credentials by that profile at MITM time, and the dashboard scopes
+-- everything to the operator-selected profile.
 --
 -- Rules + integrations live in gateway.hcl (HCL is the source of
 -- truth for policy). This DB only persists STATE — onboarding,
@@ -14,9 +21,8 @@
 -- this file just inserts the v1 row at the end.
 
 CREATE TABLE devices (
-  id           TEXT PRIMARY KEY,         -- WG tunnel IP for now
+  id           TEXT PRIMARY KEY,         -- WG tunnel IP
   name         TEXT,                     -- hostname from `clawpatrol join`
-  owner        TEXT NOT NULL,            -- email; falls back to peer IP
   profile      TEXT,                     -- assigned profile name (gateway.hcl)
   blocked      INTEGER NOT NULL DEFAULT 0,
   created_ns   INTEGER NOT NULL,
@@ -35,13 +41,13 @@ CREATE TABLE wg_peers (
 
 CREATE TABLE credentials (
   id             TEXT NOT NULL,          -- 'claude' | 'codex' | 'github' | custom
-  owner          TEXT NOT NULL,
+  profile        TEXT NOT NULL,          -- profile that owns this credential
   access_token   TEXT,
   token_type     TEXT,
   refresh_token  TEXT,
   expiry_ns      INTEGER,
   updated_ns     INTEGER NOT NULL,
-  PRIMARY KEY (id, owner)
+  PRIMARY KEY (id, profile)
 );
 
 CREATE TABLE actions (

--- a/oauth.go
+++ b/oauth.go
@@ -157,7 +157,7 @@ func (r *OAuthRegistry) Revoke(id, owner string) {
 		return
 	}
 	if r.db != nil {
-		_, _ = r.db.Exec("DELETE FROM credentials WHERE id=? AND owner=?", id, owner)
+		_, _ = r.db.Exec("DELETE FROM credentials WHERE id=? AND profile=?", id, owner)
 	}
 	delete(r.states, stateKey(id, owner))
 }
@@ -310,9 +310,9 @@ func (s *oauthState) persist(t *oauth2.Token) {
 		expiryNs = t.Expiry.UnixNano()
 	}
 	_, _ = s.db.Exec(`
-		INSERT INTO credentials (id, owner, access_token, token_type, refresh_token, expiry_ns, updated_ns)
+		INSERT INTO credentials (id, profile, access_token, token_type, refresh_token, expiry_ns, updated_ns)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id, owner) DO UPDATE SET
+		ON CONFLICT(id, profile) DO UPDATE SET
 			access_token  = excluded.access_token,
 			token_type    = excluded.token_type,
 			refresh_token = excluded.refresh_token,
@@ -327,7 +327,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 	if r.db == nil {
 		return nil
 	}
-	rows, err := r.db.Query("SELECT id, owner, access_token, token_type, refresh_token, expiry_ns FROM credentials")
+	rows, err := r.db.Query("SELECT id, profile, access_token, token_type, refresh_token, expiry_ns FROM credentials")
 	if err != nil {
 		return err
 	}

--- a/onboard.go
+++ b/onboard.go
@@ -49,6 +49,7 @@ type onboardSession struct {
 	loginServer string // "wireguard://<iface>" for WG mode; empty for Tailscale
 	err         string
 	owner       string // who approved (for audit log)
+	profile     string // profile assigned at approval time
 	hostname    string // client-supplied (os.Hostname) at /api/onboard/start
 }
 
@@ -100,7 +101,7 @@ func (r *onboardRegistry) Load(db *sql.DB) error {
 	if db == nil {
 		return nil
 	}
-	rows, err := db.Query("SELECT id, name, owner, profile FROM devices")
+	rows, err := db.Query("SELECT id, name, profile FROM devices")
 	if err != nil {
 		return err
 	}
@@ -109,13 +110,11 @@ func (r *onboardRegistry) Load(db *sql.DB) error {
 		var (
 			ip      string
 			name    sql.NullString
-			owner   string
 			profile sql.NullString
 		)
-		if err := rows.Scan(&ip, &name, &owner, &profile); err != nil {
+		if err := rows.Scan(&ip, &name, &profile); err != nil {
 			return err
 		}
-		r.ownerByIP[ip] = owner
 		if name.Valid {
 			r.hostnameByIP[ip] = name.String
 		}
@@ -127,25 +126,29 @@ func (r *onboardRegistry) Load(db *sql.DB) error {
 }
 
 // upsertLocked writes the in-memory tuple for ip into the devices row.
-// Caller holds r.mu.
+// Caller holds r.mu. Persists the row for any IP we've seen claim or
+// hostname/profile data; rows for un-claimed IPs land with NULLs and
+// fill in as the claim flow progresses.
 func (r *onboardRegistry) upsertLocked(ip string) {
 	if r.db == nil {
 		return
 	}
-	owner := r.ownerByIP[ip]
-	if owner == "" {
-		return
+	if _, seen := r.profileByIP[ip]; !seen {
+		if _, hn := r.hostnameByIP[ip]; !hn {
+			if _, owner := r.ownerByIP[ip]; !owner {
+				return
+			}
+		}
 	}
 	now := time.Now().UnixNano()
 	_, _ = r.db.Exec(`
-		INSERT INTO devices (id, name, owner, profile, created_ns, last_seen_ns)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO devices (id, name, profile, created_ns, last_seen_ns)
+		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			name         = excluded.name,
-			owner        = excluded.owner,
 			profile      = excluded.profile,
 			last_seen_ns = excluded.last_seen_ns
-	`, ip, nullStr(r.hostnameByIP[ip]), owner, nullStr(r.profileByIP[ip]), now, now)
+	`, ip, nullStr(r.hostnameByIP[ip]), nullStr(r.profileByIP[ip]), now, now)
 }
 
 func nullStr(s string) any {

--- a/web.go
+++ b/web.go
@@ -304,19 +304,26 @@ func (w *webMux) callerIdentity(r *http.Request) (user, device, displayHost stri
 	return who.UserProfile.LoginName, who.Node.StableID, who.Node.HostName
 }
 
-// ownerForCaller returns the user-scoped credential-owner key for a
-// dashboard request. In WG mode (no tailnet identity), every dashboard
-// caller resolves to the operator-configured admin_email so OAuth
-// tokens land under the same key the gateway uses to look them up at
-// MITM time (see Gateway.ownerForRequest, which also falls back to
-// admin_email for peer IPs that aren't whois-resolvable).
+// ownerForCaller returns the credential-bucket key for a dashboard
+// request. With the profile-as-tenant model, that key is the profile
+// name selected by the operator — passed via `?profile=<name>` query
+// param or the `X-Clawpatrol-Profile` header. Falls back to the first
+// declared profile in gateway.hcl, or admin_email when no profiles
+// are configured (legacy single-tenant mode).
 func (w *webMux) ownerForCaller(r *http.Request) (key, label string) {
-	user, _, host := w.callerIdentity(r)
-	wgMode := !strings.EqualFold(w.g.cfg.Gateway.Control, "tailscale") &&
-		w.g.cfg.Gateway.Control != ""
-	if wgMode && w.g.cfg.AdminEmail != "" {
+	if p := r.URL.Query().Get("profile"); p != "" {
+		return p, p
+	}
+	if p := r.Header.Get("X-Clawpatrol-Profile"); p != "" {
+		return p, p
+	}
+	if profiles := w.g.cfg.Profiles; len(profiles) > 0 {
+		return profiles[0].Name, profiles[0].Name
+	}
+	if w.g.cfg.AdminEmail != "" {
 		return w.g.cfg.AdminEmail, w.g.cfg.AdminEmail
 	}
+	user, _, host := w.callerIdentity(r)
 	if user != "" {
 		return user, user
 	}
@@ -374,21 +381,25 @@ func (w *webMux) apiAgents(rw http.ResponseWriter, _ *http.Request) {
 	// the list at first sighting (a freshly-onboarded device whose
 	// user later connects Claude wouldn't reflect the new connection).
 	for _, a := range snap {
-		// Onboarded devices show up as Tailscale's "tagged-devices"
-		// pseudo-user since OAuth client_credentials always mints
-		// tagged auth keys. Substitute the human approver who claimed
-		// this IP via /api/onboard/claim.
-		if a.User == "" || a.User == "tagged-devices" {
-			if owner := w.onboard.OwnerForIP(a.IP); owner != "" {
-				a.User = owner
+		// Per-profile credentials: the agent's Integrations list
+		// reflects what the device's bound profile has connected. Falls
+		// back to the legacy per-user lookup for tailnet-control-mode
+		// installs that still bucket creds by login.
+		profile := w.onboard.ProfileForIP(a.IP)
+		if profile == "" {
+			if a.User == "" || a.User == "tagged-devices" {
+				if owner := w.onboard.OwnerForIP(a.IP); owner != "" {
+					a.User = owner
+				}
 			}
+			profile = a.User
 		}
-		if a.User == "" {
+		if profile == "" {
 			continue
 		}
 		var ids []string
 		for _, id := range allIntegrationKeys() {
-			if conn, _ := w.g.oauth.Status(id, a.User); conn {
+			if conn, _ := w.g.oauth.Status(id, profile); conn {
 				ids = append(ids, id)
 			}
 		}
@@ -1141,6 +1152,12 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	code := r.URL.Query().Get("code")
+	// Operator picks which profile this device joins. Falls back to the
+	// first declared profile when the dashboard didn't pass one.
+	profile := r.URL.Query().Get("profile")
+	if profile == "" && len(w.g.cfg.Profiles) > 0 {
+		profile = w.g.cfg.Profiles[0].Name
+	}
 	s := w.onboard.byUserCode(code)
 	if s == nil {
 		http.Error(rw, "unknown or expired code", 404)
@@ -1154,6 +1171,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	}
 	s.approved = true
 	s.owner = owner
+	s.profile = profile
 	w.onboard.mu.Unlock()
 
 	// Mint key in background so the approve click returns fast.
@@ -1178,8 +1196,8 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 		// public gateway URL becomes unreachable).
 		if peerIP != "" {
 			w.onboard.ClaimIP(dc, peerIP, "")
-			if len(w.g.cfg.Profiles) > 0 {
-				w.onboard.AssignProfile(peerIP, w.g.cfg.Profiles[0].Name)
+			if profile != "" {
+				w.onboard.AssignProfile(peerIP, profile)
 			}
 			// Seed the agents registry so the dashboard shows the
 			// device immediately, before it sends any traffic.

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -7,7 +7,7 @@ import { OnboardPage } from "./components/OnboardPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
-import { getStatus, getAgents, getWhoami, type Integration, type Agent, type Whoami } from "./lib/api";
+import { getStatus, getAgents, getWhoami, listProfiles, activeProfile, setActiveProfile, type Integration, type Agent, type Whoami } from "./lib/api";
 
 function parseRoute(): { name: "main" } | { name: "device"; ip: string } | { name: "onboard"; code: string } {
   const h = window.location.hash;
@@ -25,11 +25,27 @@ export default function App() {
   const [showAddDevice, setShowAddDevice] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [route, setRoute] = useState(parseRoute());
+  const [profiles, setProfiles] = useState<string[]>([]);
+  const [profile, setProfileState] = useState<string>(activeProfile());
 
   useEffect(() => {
     const onHash = () => setRoute(parseRoute());
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+
+  // Load available profiles once. Default the active profile to the
+  // first one when nothing is selected — backend does the same on
+  // unset header, but reflecting it in localStorage keeps the UI
+  // honest if the operator opens devtools.
+  useEffect(() => {
+    listProfiles().then((ps) => {
+      setProfiles(ps || []);
+      if (!profile && ps && ps.length > 0) {
+        setActiveProfile(ps[0]);
+        setProfileState(ps[0]);
+      }
+    }).catch(() => {});
   }, []);
 
   async function refresh() {
@@ -62,6 +78,23 @@ export default function App() {
             <h1 className="font-serif text-[44px] sm:text-[56px] leading-none tracking-tight text-[#171717]">
               clawpatrol
             </h1>
+            {profiles.length > 0 && (
+              <select
+                value={profile}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setActiveProfile(v);
+                  setProfileState(v);
+                  refresh();
+                }}
+                className="border border-[#e5e5e5] rounded px-2 py-1 text-sm text-[#525252] hover:border-[#171717] hover:text-[#171717] transition-colors"
+                title="active profile (credential bucket)"
+              >
+                {profiles.map((p) => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+            )}
             <button
               onClick={() => setShowAddDevice(true)}
               className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] text-[22px] leading-none flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -7,7 +7,7 @@ import { OnboardPage } from "./components/OnboardPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
-import { getStatus, getAgents, getWhoami, listProfiles, activeProfile, setActiveProfile, type Integration, type Agent, type Whoami } from "./lib/api";
+import { getStatus, getAgents, getWhoami, type Integration, type Agent, type Whoami } from "./lib/api";
 
 function parseRoute(): { name: "main" } | { name: "device"; ip: string } | { name: "onboard"; code: string } {
   const h = window.location.hash;
@@ -25,27 +25,11 @@ export default function App() {
   const [showAddDevice, setShowAddDevice] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [route, setRoute] = useState(parseRoute());
-  const [profiles, setProfiles] = useState<string[]>([]);
-  const [profile, setProfileState] = useState<string>(activeProfile());
 
   useEffect(() => {
     const onHash = () => setRoute(parseRoute());
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);
-  }, []);
-
-  // Load available profiles once. Default the active profile to the
-  // first one when nothing is selected — backend does the same on
-  // unset header, but reflecting it in localStorage keeps the UI
-  // honest if the operator opens devtools.
-  useEffect(() => {
-    listProfiles().then((ps) => {
-      setProfiles(ps || []);
-      if (!profile && ps && ps.length > 0) {
-        setActiveProfile(ps[0]);
-        setProfileState(ps[0]);
-      }
-    }).catch(() => {});
   }, []);
 
   async function refresh() {
@@ -78,23 +62,6 @@ export default function App() {
             <h1 className="font-serif text-[44px] sm:text-[56px] leading-none tracking-tight text-[#171717]">
               clawpatrol
             </h1>
-            {profiles.length > 0 && (
-              <select
-                value={profile}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setActiveProfile(v);
-                  setProfileState(v);
-                  refresh();
-                }}
-                className="border border-[#e5e5e5] rounded px-2 py-1 text-sm text-[#525252] hover:border-[#171717] hover:text-[#171717] transition-colors"
-                title="active profile (credential bucket)"
-              >
-                {profiles.map((p) => (
-                  <option key={p} value={p}>{p}</option>
-                ))}
-              </select>
-            )}
             <button
               onClick={() => setShowAddDevice(true)}
               className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] text-[22px] leading-none flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -27,7 +27,7 @@ export function AgentsTable({
       <thead>
         <tr className="border-b border-[#e5e5e5]">
           <Th>DEVICE</Th>
-          <Th className="hidden md:table-cell">USER</Th>
+          <Th className="hidden md:table-cell">PROFILE</Th>
           <Th>ACTIVITY</Th>
           <Th className="text-right">REQS</Th>
           <Th className="hidden lg:table-cell">IP</Th>
@@ -64,11 +64,11 @@ export function AgentsTable({
                   </span>
                 </div>
                 <div className="md:hidden text-[10px] text-[#a3a3a3] truncate mt-0.5">
-                  {a.user || a.ip}
+                  {a.profile || "—"}
                 </div>
               </Td>
               <Td className="hidden md:table-cell text-[11px] text-[#525252] truncate">
-                {a.user || "—"}
+                {a.profile || "—"}
               </Td>
               <Td>
                 <div className="flex items-center gap-2">

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -110,7 +110,7 @@ export function DevicePage({
           <div className="min-w-0">
             <div className="text-[15px] font-semibold text-[#171717] truncate">{a.hostname || a.ip}</div>
             <div className="text-[11px] text-[#737373] truncate">
-              {a.user || "—"} · {a.ip}
+              {a.profile || "—"} · {a.ip}
               {a.os && <> · <span className="uppercase tracking-[.08em]">{a.os}</span></>}
             </div>
           </div>
@@ -138,6 +138,7 @@ export function DevicePage({
       <IntegrationsCards
         list={allForUser}
         whoami={whoami}
+        profile={a.profile}
         onConnect={onConnect}
         onRefresh={onRefresh}
       />

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -12,15 +12,20 @@ const PRETTY: Record<string, string> = {
 export function IntegrationsCards({
   list,
   whoami,
+  profile,
   onConnect,
   onRefresh,
 }: {
   list: Integration[];
   whoami: Whoami | null;
+  profile?: string;
   onConnect: (id: string) => void;
   onRefresh: () => void;
 }) {
-  const youKey = whoami?.user || whoami?.host || "";
+  // Credentials are bucketed by profile. The card is "connected" if
+  // the device's profile has a token for that integration. Fall back
+  // to whoami when no profile is set (legacy single-tenant configs).
+  const youKey = profile || whoami?.user || whoami?.host || "";
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5">
       {list.map((i) => {

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -1,3 +1,23 @@
+// Active profile = the credential bucket the dashboard is operating
+// against. Persisted to localStorage so reloads keep context. Backend
+// reads it from the X-Clawpatrol-Profile header on every API call.
+const PROFILE_KEY = "clawpatrol.profile";
+export function activeProfile(): string {
+  return (typeof localStorage !== "undefined" && localStorage.getItem(PROFILE_KEY)) || "";
+}
+export function setActiveProfile(name: string) {
+  if (typeof localStorage === "undefined") return;
+  if (name) localStorage.setItem(PROFILE_KEY, name);
+  else localStorage.removeItem(PROFILE_KEY);
+}
+
+async function api(input: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers || {});
+  const p = activeProfile();
+  if (p) headers.set("X-Clawpatrol-Profile", p);
+  return fetch(input, { ...init, headers });
+}
+
 export type Owner = {
   owner: string;
   connected: boolean;
@@ -63,7 +83,7 @@ export type RuleSummary = {
 };
 
 export async function getRules(): Promise<RuleSummary[]> {
-  const r = await fetch("/api/rules");
+  const r = await api("/api/rules");
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
@@ -73,14 +93,14 @@ export async function getRules(): Promise<RuleSummary[]> {
 // (HCL is the on-disk format; JSON is just the dashboard transport.)
 
 export async function getRulesJSON(): Promise<string> {
-  const r = await fetch("/api/rules");
+  const r = await api("/api/rules");
   if (!r.ok) throw new Error(await r.text());
   const data = await r.json();
   return JSON.stringify(data ?? [], null, 2);
 }
 
 export async function putRulesJSON(json: string): Promise<{ ok: boolean; count: number }> {
-  const r = await fetch("/api/rules", {
+  const r = await api("/api/rules", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: json,
@@ -90,20 +110,20 @@ export async function putRulesJSON(json: string): Promise<{ ok: boolean; count: 
 }
 
 export async function getDeviceRules(ip: string): Promise<RuleSummary[]> {
-  const r = await fetch(`/api/rules/device?ip=${encodeURIComponent(ip)}`);
+  const r = await api(`/api/rules/device?ip=${encodeURIComponent(ip)}`);
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function getDeviceRulesJSON(ip: string): Promise<string> {
-  const r = await fetch(`/api/rules/device?ip=${encodeURIComponent(ip)}`);
+  const r = await api(`/api/rules/device?ip=${encodeURIComponent(ip)}`);
   if (!r.ok) throw new Error(await r.text());
   const data = await r.json();
   return JSON.stringify(data ?? [], null, 2);
 }
 
 export async function putDeviceRulesJSON(ip: string, json: string): Promise<{ ok: boolean; count: number }> {
-  const r = await fetch(`/api/rules/device?ip=${encodeURIComponent(ip)}`, {
+  const r = await api(`/api/rules/device?ip=${encodeURIComponent(ip)}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: json,
@@ -116,13 +136,13 @@ export async function putDeviceRulesJSON(ip: string, json: string): Promise<{ ok
 // device-scoped /api/rules/device?format=hcl path return raw HCL text.
 
 export async function getConfigHCL(): Promise<string> {
-  const r = await fetch("/api/config");
+  const r = await api("/api/config");
   if (!r.ok) throw new Error(await r.text());
   return r.text();
 }
 
 export async function putConfigHCL(hcl: string): Promise<{ ok: boolean; bytes: number }> {
-  const r = await fetch("/api/config", {
+  const r = await api("/api/config", {
     method: "PUT",
     headers: { "Content-Type": "text/plain" },
     body: hcl,
@@ -132,26 +152,26 @@ export async function putConfigHCL(hcl: string): Promise<{ ok: boolean; bytes: n
 }
 
 export async function getDeviceRulesHCL(ip: string): Promise<string> {
-  const r = await fetch(`/api/rules/device?ip=${encodeURIComponent(ip)}&format=hcl`);
+  const r = await api(`/api/rules/device?ip=${encodeURIComponent(ip)}&format=hcl`);
   if (!r.ok) throw new Error(await r.text());
   return r.text();
 }
 
 export async function listProfiles(): Promise<string[]> {
-  const r = await fetch("/api/profiles");
+  const r = await api("/api/profiles");
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function setDeviceProfile(ip: string, profile: string): Promise<void> {
-  const r = await fetch(`/api/agents/profile?ip=${encodeURIComponent(ip)}&profile=${encodeURIComponent(profile)}`, {
+  const r = await api(`/api/agents/profile?ip=${encodeURIComponent(ip)}&profile=${encodeURIComponent(profile)}`, {
     method: "POST",
   });
   if (!r.ok) throw new Error(await r.text());
 }
 
 export async function putDeviceRulesHCL(ip: string, hcl: string): Promise<{ ok: boolean; count: number }> {
-  const r = await fetch(`/api/rules/device?ip=${encodeURIComponent(ip)}&format=hcl`, {
+  const r = await api(`/api/rules/device?ip=${encodeURIComponent(ip)}&format=hcl`, {
     method: "PUT",
     headers: { "Content-Type": "text/plain" },
     body: hcl,
@@ -174,13 +194,13 @@ export type HITLPending = {
 };
 
 export async function getHITLPending(): Promise<HITLPending[]> {
-  const r = await fetch("/api/hitl/pending");
+  const r = await api("/api/hitl/pending");
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function decideHITL(id: string, allow: boolean): Promise<void> {
-  const r = await fetch("/api/hitl/decide", {
+  const r = await api("/api/hitl/decide", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id, allow }),
@@ -189,7 +209,7 @@ export async function decideHITL(id: string, allow: boolean): Promise<void> {
 }
 
 export async function aiEditRules(prompt: string, currentYAML: string, scope: "global" | "device", agent?: string): Promise<{ yaml: string }> {
-  const r = await fetch("/api/rules/ai", {
+  const r = await api("/api/rules/ai", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ prompt, current_yaml: currentYAML, scope, agent: agent ?? "" }),
@@ -206,24 +226,24 @@ export type Whoami = {
 };
 
 export async function getStatus(): Promise<Integration[]> {
-  const r = await fetch("/api/status");
+  const r = await api("/api/status");
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function deleteAgent(ip: string): Promise<void> {
-  const r = await fetch(`/api/agents/delete?ip=${encodeURIComponent(ip)}`, { method: "POST" });
+  const r = await api(`/api/agents/delete?ip=${encodeURIComponent(ip)}`, { method: "POST" });
   if (!r.ok) throw new Error(await r.text());
 }
 
 export async function getAgents(): Promise<Agent[]> {
-  const r = await fetch("/api/agents");
+  const r = await api("/api/agents");
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function getWhoami(): Promise<Whoami> {
-  const r = await fetch("/api/whoami");
+  const r = await api("/api/whoami");
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
@@ -233,19 +253,19 @@ export type OAuthStartResp =
   | { flow: "device"; user_code: string; verification_uri: string; state: string; owner: string; interval: number; expires_in: number };
 
 export async function oauthStart(id: string): Promise<OAuthStartResp> {
-  const r = await fetch(`/api/oauth/start?id=${encodeURIComponent(id)}`, { method: "POST" });
+  const r = await api(`/api/oauth/start?id=${encodeURIComponent(id)}`, { method: "POST" });
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function oauthDevicePoll(state: string): Promise<{ connected?: boolean; owner?: string; error?: string; detail?: string }> {
-  const r = await fetch(`/api/oauth/device-poll?state=${encodeURIComponent(state)}`, { method: "POST" });
+  const r = await api(`/api/oauth/device-poll?state=${encodeURIComponent(state)}`, { method: "POST" });
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
 
 export async function oauthRevoke(id: string, owner: string): Promise<void> {
-  const r = await fetch("/api/oauth/revoke", {
+  const r = await api("/api/oauth/revoke", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id, owner }),
@@ -254,7 +274,7 @@ export async function oauthRevoke(id: string, owner: string): Promise<void> {
 }
 
 export async function oauthExchange(state: string, code: string): Promise<{ connected: boolean; owner: string; expires: number }> {
-  const r = await fetch("/api/oauth/exchange", {
+  const r = await api("/api/oauth/exchange", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ state, code }),

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -1,22 +1,7 @@
-// Active profile = the credential bucket the dashboard is operating
-// against. Persisted to localStorage so reloads keep context. Backend
-// reads it from the X-Clawpatrol-Profile header on every API call.
-const PROFILE_KEY = "clawpatrol.profile";
-export function activeProfile(): string {
-  return (typeof localStorage !== "undefined" && localStorage.getItem(PROFILE_KEY)) || "";
-}
-export function setActiveProfile(name: string) {
-  if (typeof localStorage === "undefined") return;
-  if (name) localStorage.setItem(PROFILE_KEY, name);
-  else localStorage.removeItem(PROFILE_KEY);
-}
-
-async function api(input: string, init: RequestInit = {}): Promise<Response> {
-  const headers = new Headers(init.headers || {});
-  const p = activeProfile();
-  if (p) headers.set("X-Clawpatrol-Profile", p);
-  return fetch(input, { ...init, headers });
-}
+// Profile is per-device, not per-dashboard. The OAuth connect flow
+// picks which profile a credential lands under via an explicit query
+// param on /api/oauth/start; everything else is single-tenant.
+const api = fetch;
 
 export type Owner = {
   owner: string;
@@ -252,8 +237,9 @@ export type OAuthStartResp =
   | { flow?: "auth_code"; auth_url: string; state: string; owner: string }
   | { flow: "device"; user_code: string; verification_uri: string; state: string; owner: string; interval: number; expires_in: number };
 
-export async function oauthStart(id: string): Promise<OAuthStartResp> {
-  const r = await api(`/api/oauth/start?id=${encodeURIComponent(id)}`, { method: "POST" });
+export async function oauthStart(id: string, profile?: string): Promise<OAuthStartResp> {
+  const qs = `id=${encodeURIComponent(id)}` + (profile ? `&profile=${encodeURIComponent(profile)}` : "");
+  const r = await api(`/api/oauth/start?${qs}`, { method: "POST" });
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }


### PR DESCRIPTION
Builds on #34. Rules table only shows user-authored rules now; integration host wiring lives in cfg.HostIntegration. Dashboard says 'profile' instead of 'user'.