### PR TITLE
Refuse to serve dashboard when no auth is configured

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,12 @@ type Gateway struct {
 	LogPath         string `hcl:"log_path,optional"`
 	OAuthDir        string `hcl:"oauth_dir,optional"`
 	DashboardSecret string `hcl:"dashboard_secret,optional"`
+	// InsecureNoDashboardSecret opts out of dashboard auth. Required
+	// (alongside an empty DashboardSecret) for the gateway to serve
+	// the dashboard at all — otherwise the secret gate replies with a
+	// misconfiguration page on every request. Verbose by design so
+	// you can't disable auth by accident.
+	InsecureNoDashboardSecret bool `hcl:"insecure_no_dashboard_secret,optional"`
 
 	Tailscale *Tailscale `hcl:"tailscale,block"`
 

--- a/config/emit.go
+++ b/config/emit.go
@@ -66,6 +66,9 @@ func emitOperational(body *hclwrite.Body, gw *Gateway) {
 	setStr("log_path", gw.LogPath)
 	setStr("oauth_dir", gw.OAuthDir)
 	setStr("dashboard_secret", gw.DashboardSecret)
+	if gw.InsecureNoDashboardSecret {
+		body.SetAttributeValue("insecure_no_dashboard_secret", cty.BoolVal(true))
+	}
 
 	if gw.Tailscale != nil && !isZeroTailscale(gw.Tailscale) {
 		body.AppendNewline()

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -34,6 +34,16 @@ admin_email = "test@example.com"
 ca_dir      = "/opt/clawpatrol/ca"
 oauth_dir   = "/opt/clawpatrol/oauth"
 
+# Dashboard auth — pick exactly one. The gateway refuses to serve the
+# dashboard / APIs until one of these is set, to avoid silently
+# exposing it on a public network.
+#
+#   dashboard_secret = "<long random string>"   # production
+#   insecure_no_dashboard_secret = true         # testing only — anyone
+#                                               # who can reach the
+#                                               # dashboard URL gets in
+dashboard_secret = "change-me-to-a-long-random-string"
+
 gateway {
   control        = "wireguard"
   wg_endpoint    = "66.42.120.196:51820"

--- a/main.go
+++ b/main.go
@@ -266,6 +266,22 @@ func (g *Gateway) watchConfig(path string) {
 		g.cfg = next
 		log.Printf("config reloaded: %d endpoints across %d profile(s)",
 			len(policy.Endpoints), len(policy.Profiles))
+		logDashboardSecretState(next)
+	}
+}
+
+// logDashboardSecretState emits a one-line summary of dashboard-auth
+// state every time the config (re)loads, so an accidentally-open
+// dashboard shows up in `journalctl -u clawpatrol-gateway` even when
+// nobody opens the dashboard in a browser.
+func logDashboardSecretState(cfg *config.Gateway) {
+	switch {
+	case cfg.DashboardSecret != "":
+		log.Printf("dashboard auth: enabled (dashboard_secret set)")
+	case cfg.InsecureNoDashboardSecret:
+		log.Printf("dashboard auth: DISABLED via insecure_no_dashboard_secret — anyone who reaches the dashboard URL gets in")
+	default:
+		log.Printf("dashboard auth: MISCONFIGURED — gateway.hcl is missing both dashboard_secret and insecure_no_dashboard_secret; dashboard will refuse to serve until one is set")
 	}
 }
 
@@ -1485,6 +1501,7 @@ func runGateway(args []string) {
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}
+	logDashboardSecretState(cfg)
 	certs, err := loadCA(cfg.CADir)
 	if err != nil {
 		log.Fatalf("ca: %v", err)

--- a/web.go
+++ b/web.go
@@ -111,8 +111,12 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 // dashboardSecretGate requires every non-public request to carry the
 // configured dashboard_secret (cookie / header / query). Onboarding
 // + health endpoints stay open so brand-new clients can still join.
-// When dashboard_secret is empty the gate is a no-op — installs
-// without an explicit secret keep their current open behavior.
+//
+// When dashboard_secret is empty, the gate's behavior depends on
+// insecure_no_dashboard_secret: if that's true, the gate is a no-op
+// (testing escape hatch); otherwise the gate refuses to serve and
+// every gated route returns a misconfiguration error so an open
+// dashboard isn't published by accident.
 func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 	publicPaths := map[string]bool{
 		"/api/onboard/start":     true,
@@ -125,9 +129,28 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 		"/ca.crt":                true,
 		"/__login":               true,
 	}
+	// /info and /ca.crt are public-by-design (health + cert distribution).
+	// They keep working even when the dashboard is misconfigured so
+	// monitoring + already-onboarded clients aren't taken offline.
+	alwaysOpen := map[string]bool{
+		"/info":   true,
+		"/ca.crt": true,
+	}
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		secret := w.g.cfg.DashboardSecret
-		if secret == "" || publicPaths[r.URL.Path] {
+		if secret == "" {
+			if alwaysOpen[r.URL.Path] {
+				next.ServeHTTP(rw, r)
+				return
+			}
+			if w.g.cfg.InsecureNoDashboardSecret {
+				next.ServeHTTP(rw, r)
+				return
+			}
+			renderDashboardMisconfigured(rw, r)
+			return
+		}
+		if publicPaths[r.URL.Path] {
 			next.ServeHTTP(rw, r)
 			return
 		}
@@ -142,6 +165,29 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 		}
 		http.Redirect(rw, r, "/__login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
 	})
+}
+
+const dashboardMisconfiguredMsg = "dashboard refuses to serve: gateway.hcl is missing both `dashboard_secret` and `insecure_no_dashboard_secret`. Set `dashboard_secret = \"<long random string>\"` to require a password, or `insecure_no_dashboard_secret = true` to explicitly run without auth (testing only)."
+
+func renderDashboardMisconfigured(rw http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		http.Error(rw, dashboardMisconfiguredMsg, http.StatusServiceUnavailable)
+		return
+	}
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	rw.WriteHeader(http.StatusServiceUnavailable)
+	fmt.Fprintf(rw, `<!doctype html>
+<html><head><meta charset="utf-8"><title>clawpatrol — dashboard disabled</title>
+<style>body{font:14px/1.5 -apple-system,system-ui,sans-serif;max-width:42em;margin:6em auto;padding:0 1em;color:#222}code{background:#f3f3f3;padding:.1em .3em;border-radius:3px}h1{font-size:1.4em}</style>
+</head><body>
+<h1>Dashboard refuses to serve</h1>
+<p>Your <code>gateway.hcl</code> sets neither <code>dashboard_secret</code> nor <code>insecure_no_dashboard_secret</code>, so the dashboard is locked to avoid being exposed without auth.</p>
+<p>Pick one and reload (the gateway hot-reloads <code>gateway.hcl</code> within a few seconds):</p>
+<ul>
+<li><code>dashboard_secret = "&lt;long random string&gt;"</code> — production, requires a password.</li>
+<li><code>insecure_no_dashboard_secret = true</code> — testing only, anyone who reaches this URL gets in.</li>
+</ul>
+</body></html>`)
 }
 
 func checkDashboardSecret(r *http.Request, want string) bool {


### PR DESCRIPTION
* The `dashboard_secret` gate was a no-op when the field was empty,
  so dropping the line (e.g. while porting `gateway.hcl` across the
  recent typed-block schema change) silently published an open
  dashboard. The deployed config on `prod.example.com` lost its
  secret exactly this way.
* Require either `dashboard_secret = "..."` or an explicit opt-out
  `insecure_no_dashboard_secret = true`. Otherwise the gate now
  serves a 503 misconfiguration page (HTML for browsers, plain text
  for `/api/*`) on every gated route. `/info` and `/ca.crt` stay
  reachable so health checks and already-onboarded clients aren't
  taken offline.
* Log a one-line state summary on every (re)load so an
  accidentally-open dashboard shows up in `journalctl`:
  `enabled` / `DISABLED via insecure_no_dashboard_secret` /
  `MISCONFIGURED`.
* Document both options in `gateway.example.hcl` with a placeholder
  `dashboard_secret` so the example can't be deployed verbatim
  without an obvious credential change.
* `config.Gateway` gains `InsecureNoDashboardSecret bool` (HCL key
  `insecure_no_dashboard_secret`) and `config/emit.go` round-trips
  it. The field hot-reloads via the existing `watchConfig` swap.