### PR TITLE
Analytics: per-device latency chart, expandable request detail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/refraction-networking/utls v1.8.2
 	github.com/zclconf/go-cty v1.16.3
@@ -57,7 +58,6 @@ require (
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect

--- a/login.go
+++ b/login.go
@@ -412,6 +412,7 @@ func fetchCA(ip, dst string) error {
 }
 
 func installCATrust(caPath string) error {
+	fmt.Println("Installing CA certificate into system trust store (requires sudo)...")
 	switch runtime.GOOS {
 	case "darwin":
 		return exec.Command("sudo", "security", "add-trusted-cert",

--- a/main.go
+++ b/main.go
@@ -1516,6 +1516,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Action = "allow"
 		}
 		ev.Status = resp.StatusCode
+		ev.ReqHeaders = flatHeaders(req.Header)
 		ev.RespHeaders = flatHeaders(resp.Header)
 		ev.In = reqS.n
 		ev.Out = respS.n

--- a/main.go
+++ b/main.go
@@ -5,10 +5,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	cryptorand "crypto/rand"
 	"crypto/tls"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -30,6 +28,7 @@ import (
 	_ "github.com/denoland/clawpatrol/config/plugins/all"
 	"github.com/denoland/clawpatrol/config/plugins/approvers"
 	"github.com/denoland/clawpatrol/config/runtime"
+	"github.com/google/uuid"
 )
 
 // Tailscale aliases the operational tailscale-block type loaded from
@@ -78,13 +77,11 @@ func parseDurationOr(s string, def time.Duration) time.Duration {
 	return d
 }
 
-// newReqID returns a short hex token that correlates start/end/frame
-// events for a single request. 8 random bytes is plenty when the
-// dashboard is the only consumer; collisions just merge two rows.
+// newReqID returns a UUIDv7 string. Time-ordered + random tail;
+// used both for start/end/frame correlation and as the persistent
+// action key in the DB / detail page URL.
 func newReqID() string {
-	var b [8]byte
-	_, _ = cryptorand.Read(b[:])
-	return hex.EncodeToString(b[:])
+	return uuid.Must(uuid.NewV7()).String()
 }
 
 // loadConfig parses the gateway HCL via the typed-block grammar and
@@ -1474,7 +1471,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Reason = err.Error()
 			ev.Ms = time.Since(start).Milliseconds()
 			ev.ReqSha = reqS.sha()
-			ev.ReqSample = reqS.sample()
+			ev.ReqBody = reqS.sample()
 			ev.In = reqS.n
 			g.emitEnd(ev)
 			return
@@ -1519,12 +1516,13 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Action = "allow"
 		}
 		ev.Status = resp.StatusCode
+		ev.RespHeaders = flatHeaders(resp.Header)
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()
-		ev.ReqSample = reqS.sample()
+		ev.ReqBody = reqS.sample()
 		ev.RespSha = respS.sha()
-		ev.RespSample = respS.sample()
+		ev.RespBody = respS.sample()
 		ev.Ms = time.Since(start).Milliseconds()
 		g.emitEnd(ev)
 		if g.agents != nil && agentAddr != "" {

--- a/migrations/sqlite/0004_action_samples.sql
+++ b/migrations/sqlite/0004_action_samples.sql
@@ -1,0 +1,8 @@
+ALTER TABLE actions ADD COLUMN action_id TEXT;
+ALTER TABLE actions ADD COLUMN req_body TEXT;
+ALTER TABLE actions ADD COLUMN resp_body TEXT;
+ALTER TABLE actions ADD COLUMN resp_headers TEXT;
+
+CREATE INDEX actions_action_id_idx ON actions(action_id);
+
+INSERT INTO _schema (version) VALUES (4);

--- a/migrations/sqlite/0005_action_samples.sql
+++ b/migrations/sqlite/0005_action_samples.sql
@@ -1,8 +1,9 @@
 ALTER TABLE actions ADD COLUMN action_id TEXT;
 ALTER TABLE actions ADD COLUMN req_body TEXT;
 ALTER TABLE actions ADD COLUMN resp_body TEXT;
+ALTER TABLE actions ADD COLUMN req_headers TEXT;
 ALTER TABLE actions ADD COLUMN resp_headers TEXT;
 
 CREATE INDEX actions_action_id_idx ON actions(action_id);
 
-INSERT INTO _schema (version) VALUES (4);
+INSERT INTO _schema (version) VALUES (5);

--- a/web.go
+++ b/web.go
@@ -798,23 +798,23 @@ func allIntegrationKeys() []string { return displayOrder }
 // by the dashboard SSE stream and the on-disk event log).
 
 type Event struct {
-	Ts time.Time `json:"ts"`
-	ID string    `json:"id,omitempty"` // UUIDv7; correlates start/end/frame + DB key
-	Phase      string    `json:"phase,omitempty"` // "" (legacy/end), "start", "end", "frame"
-	Mode       string    `json:"mode"`
-	Agent      string    `json:"agent,omitempty"`
-	AgentIP    string    `json:"agent_ip,omitempty"`
-	Host       string    `json:"host"`
-	Method     string    `json:"method,omitempty"`
-	Path       string    `json:"path,omitempty"`
-	Status     int       `json:"status,omitempty"`
-	In         int64     `json:"in,omitempty"`
-	Out        int64     `json:"out,omitempty"`
-	Ms         int64     `json:"ms"`
-	Action     string    `json:"action,omitempty"`
-	Reason     string    `json:"reason,omitempty"`
-	ReqSha     string    `json:"req_sha,omitempty"`
-	ReqBody    string    `json:"req_body,omitempty"`
+	Ts          time.Time         `json:"ts"`
+	ID          string            `json:"id,omitempty"`    // UUIDv7; correlates start/end/frame + DB key
+	Phase       string            `json:"phase,omitempty"` // "" (legacy/end), "start", "end", "frame"
+	Mode        string            `json:"mode"`
+	Agent       string            `json:"agent,omitempty"`
+	AgentIP     string            `json:"agent_ip,omitempty"`
+	Host        string            `json:"host"`
+	Method      string            `json:"method,omitempty"`
+	Path        string            `json:"path,omitempty"`
+	Status      int               `json:"status,omitempty"`
+	In          int64             `json:"in,omitempty"`
+	Out         int64             `json:"out,omitempty"`
+	Ms          int64             `json:"ms"`
+	Action      string            `json:"action,omitempty"`
+	Reason      string            `json:"reason,omitempty"`
+	ReqSha      string            `json:"req_sha,omitempty"`
+	ReqBody     string            `json:"req_body,omitempty"`
 	RespSha     string            `json:"resp_sha,omitempty"`
 	RespBody    string            `json:"resp_body,omitempty"`
 	ReqHeaders  map[string]string `json:"req_headers,omitempty"`

--- a/web.go
+++ b/web.go
@@ -67,6 +67,7 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux.HandleFunc("/api/credentials/set", w.apiCredentialsSet)
 	mux.HandleFunc("/api/credentials/clear", w.apiCredentialsClear)
 	mux.HandleFunc("/api/events", w.apiEventsSSE)
+	mux.HandleFunc("/api/actions/", w.apiActionByID)
 	mux.HandleFunc("/api/onboard/start", w.apiOnboardStart)
 	mux.HandleFunc("/api/onboard/poll", w.apiOnboardPoll)
 	mux.HandleFunc("/api/onboard/approve", w.apiOnboardApprove)
@@ -711,6 +712,77 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (w *webMux) apiActionByID(
+	rw http.ResponseWriter, r *http.Request,
+) {
+	// Path: /api/actions/<uuid>
+	actionID := strings.TrimPrefix(r.URL.Path, "/api/actions/")
+	if actionID == "" {
+		http.Error(rw, "missing id", 400)
+		return
+	}
+	var (
+		e           Event
+		tsNs        int64
+		mode        sql.NullString
+		agentIP     sql.NullString
+		method      sql.NullString
+		path        sql.NullString
+		status      sql.NullInt64
+		in, ot      sql.NullInt64
+		ms          sql.NullInt64
+		action      sql.NullString
+		reason      sql.NullString
+		reqSha      sql.NullString
+		respSha     sql.NullString
+		reqBody     sql.NullString
+		respBody    sql.NullString
+		respHeaders sql.NullString
+	)
+	err := w.g.db.QueryRow(`
+		SELECT ts_ns, mode, agent_ip, host, method, path,
+		       status, bytes_in, bytes_out, ms, action,
+		       reason, req_sha, resp_sha,
+		       req_body, resp_body, resp_headers
+		FROM actions WHERE action_id = ?`, actionID,
+	).Scan(
+		&tsNs, &mode, &agentIP, &e.Host,
+		&method, &path, &status, &in, &ot, &ms,
+		&action, &reason, &reqSha, &respSha,
+		&reqBody, &respBody, &respHeaders,
+	)
+	if err == sql.ErrNoRows {
+		http.Error(rw, "not found", 404)
+		return
+	}
+	if err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	e.ID = actionID
+	e.Ts = time.Unix(0, tsNs).UTC()
+	e.Mode = mode.String
+	e.AgentIP = agentIP.String
+	e.Method = method.String
+	e.Path = path.String
+	e.Status = int(status.Int64)
+	e.In = in.Int64
+	e.Out = ot.Int64
+	e.Ms = ms.Int64
+	e.Action = action.String
+	e.Reason = reason.String
+	e.ReqSha = reqSha.String
+	e.RespSha = respSha.String
+	e.ReqBody = reqBody.String
+	e.RespBody = respBody.String
+	if respHeaders.String != "" {
+		_ = json.Unmarshal(
+			[]byte(respHeaders.String), &e.RespHeaders,
+		)
+	}
+	writeJSON(rw, e)
+}
+
 func writeJSON(rw http.ResponseWriter, v any) {
 	rw.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(rw).Encode(v)
@@ -726,8 +798,8 @@ func allIntegrationKeys() []string { return displayOrder }
 // by the dashboard SSE stream and the on-disk event log).
 
 type Event struct {
-	Ts         time.Time `json:"ts"`
-	ID         string    `json:"id,omitempty"`    // request id; correlates start/end/frame
+	Ts time.Time `json:"ts"`
+	ID string    `json:"id,omitempty"` // UUIDv7; correlates start/end/frame + DB key
 	Phase      string    `json:"phase,omitempty"` // "" (legacy/end), "start", "end", "frame"
 	Mode       string    `json:"mode"`
 	Agent      string    `json:"agent,omitempty"`
@@ -742,9 +814,10 @@ type Event struct {
 	Action     string    `json:"action,omitempty"`
 	Reason     string    `json:"reason,omitempty"`
 	ReqSha     string    `json:"req_sha,omitempty"`
-	ReqSample  string    `json:"req_sample,omitempty"`
-	RespSha    string    `json:"resp_sha,omitempty"`
-	RespSample string    `json:"resp_sample,omitempty"`
+	ReqBody    string    `json:"req_body,omitempty"`
+	RespSha     string            `json:"resp_sha,omitempty"`
+	RespBody    string            `json:"resp_body,omitempty"`
+	RespHeaders map[string]string `json:"resp_headers,omitempty"`
 	// Frame is set for Phase="frame" only — a single WS frame's text
 	// payload (truncated at sampleCap). Direction is "c→s" or "s→c"
 	// to disambiguate masked client frames from unmasked server frames.
@@ -775,8 +848,10 @@ func NewSink(db *sql.DB, buf int) (*Sink, error) {
 
 func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 	rows, err := db.Query(`
-		SELECT ts_ns, mode, agent_ip, host, method, path, status,
-		       bytes_in, bytes_out, ms, action, reason, req_sha, resp_sha
+		SELECT action_id, ts_ns, mode, agent_ip, host,
+		       method, path, status, bytes_in, bytes_out,
+		       ms, action, reason, req_sha, resp_sha,
+		       req_body, resp_body, resp_headers
 		FROM actions ORDER BY id DESC LIMIT ?`, n)
 	if err != nil {
 		return nil, err
@@ -785,23 +860,33 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 	out := make([]Event, 0, n)
 	for rows.Next() {
 		var (
-			e       Event
-			tsNs    int64
-			mode    sql.NullString
-			agentIP sql.NullString
-			method  sql.NullString
-			path    sql.NullString
-			status  sql.NullInt64
-			in, ot  sql.NullInt64
-			ms      sql.NullInt64
-			action  sql.NullString
-			reason  sql.NullString
-			reqSha  sql.NullString
-			respSha sql.NullString
+			e           Event
+			actionID    sql.NullString
+			tsNs        int64
+			mode        sql.NullString
+			agentIP     sql.NullString
+			method      sql.NullString
+			path        sql.NullString
+			status      sql.NullInt64
+			in, ot      sql.NullInt64
+			ms          sql.NullInt64
+			action      sql.NullString
+			reason      sql.NullString
+			reqSha      sql.NullString
+			respSha     sql.NullString
+			reqBody     sql.NullString
+			respBody    sql.NullString
+			respHeaders sql.NullString
 		)
-		if err := rows.Scan(&tsNs, &mode, &agentIP, &e.Host, &method, &path, &status, &in, &ot, &ms, &action, &reason, &reqSha, &respSha); err != nil {
+		if err := rows.Scan(
+			&actionID, &tsNs, &mode, &agentIP, &e.Host,
+			&method, &path, &status, &in, &ot, &ms,
+			&action, &reason, &reqSha, &respSha,
+			&reqBody, &respBody, &respHeaders,
+		); err != nil {
 			return nil, err
 		}
+		e.ID = actionID.String
 		e.Ts = time.Unix(0, tsNs).UTC()
 		e.Mode = mode.String
 		e.AgentIP = agentIP.String
@@ -815,6 +900,13 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		e.Reason = reason.String
 		e.ReqSha = reqSha.String
 		e.RespSha = respSha.String
+		e.ReqBody = reqBody.String
+		e.RespBody = respBody.String
+		if respHeaders.String != "" {
+			_ = json.Unmarshal(
+				[]byte(respHeaders.String), &e.RespHeaders,
+			)
+		}
 		out = append(out, e)
 	}
 	if err := rows.Err(); err != nil {
@@ -852,11 +944,23 @@ func (s *Sink) drain() {
 		// the table for long-poll / WS sessions.
 		persist := e.Phase == "" || e.Phase == "end"
 		if s.db != nil && persist {
-			_, _ = s.db.Exec(`
+			var rhJSON []byte
+			if len(e.RespHeaders) > 0 {
+				rhJSON, _ = json.Marshal(e.RespHeaders)
+			}
+			s.db.Exec(`
 				INSERT INTO actions
-				 (ts_ns, mode, agent_ip, host, method, path, status, bytes_in, bytes_out, ms, action, reason, req_sha, resp_sha)
-				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-			`, e.Ts.UnixNano(), e.Mode, e.AgentIP, e.Host, e.Method, e.Path, e.Status, e.In, e.Out, e.Ms, e.Action, e.Reason, e.ReqSha, e.RespSha)
+				 (action_id, ts_ns, mode, agent_ip, host,
+				  method, path, status, bytes_in, bytes_out,
+				  ms, action, reason, req_sha, resp_sha,
+				  req_body, resp_body, resp_headers)
+				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+			`, e.ID, e.Ts.UnixNano(), e.Mode, e.AgentIP,
+				e.Host, e.Method, e.Path, e.Status,
+				e.In, e.Out, e.Ms, e.Action, e.Reason,
+				e.ReqSha, e.RespSha,
+				e.ReqBody, e.RespBody,
+				string(rhJSON))
 		}
 		s.mu.Lock()
 		// Recent ring is the SSE backlog replayed to fresh
@@ -919,6 +1023,14 @@ type sampler struct {
 	cap  int
 	buf  bytes.Buffer
 	n    int64
+}
+
+func flatHeaders(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for k, v := range h {
+		out[k] = strings.Join(v, ", ")
+	}
+	return out
 }
 
 func newSampler(capBytes int) *sampler {

--- a/web.go
+++ b/web.go
@@ -737,19 +737,22 @@ func (w *webMux) apiActionByID(
 		respSha     sql.NullString
 		reqBody     sql.NullString
 		respBody    sql.NullString
+		reqHeaders  sql.NullString
 		respHeaders sql.NullString
 	)
 	err := w.g.db.QueryRow(`
 		SELECT ts_ns, mode, agent_ip, host, method, path,
 		       status, bytes_in, bytes_out, ms, action,
 		       reason, req_sha, resp_sha,
-		       req_body, resp_body, resp_headers
+		       req_body, resp_body,
+		       req_headers, resp_headers
 		FROM actions WHERE action_id = ?`, actionID,
 	).Scan(
 		&tsNs, &mode, &agentIP, &e.Host,
 		&method, &path, &status, &in, &ot, &ms,
 		&action, &reason, &reqSha, &respSha,
-		&reqBody, &respBody, &respHeaders,
+		&reqBody, &respBody,
+		&reqHeaders, &respHeaders,
 	)
 	if err == sql.ErrNoRows {
 		http.Error(rw, "not found", 404)
@@ -775,11 +778,8 @@ func (w *webMux) apiActionByID(
 	e.RespSha = respSha.String
 	e.ReqBody = reqBody.String
 	e.RespBody = respBody.String
-	if respHeaders.String != "" {
-		_ = json.Unmarshal(
-			[]byte(respHeaders.String), &e.RespHeaders,
-		)
-	}
+	unmarshalHeaders(reqHeaders.String, &e.ReqHeaders)
+	unmarshalHeaders(respHeaders.String, &e.RespHeaders)
 	writeJSON(rw, e)
 }
 
@@ -817,6 +817,7 @@ type Event struct {
 	ReqBody    string    `json:"req_body,omitempty"`
 	RespSha     string            `json:"resp_sha,omitempty"`
 	RespBody    string            `json:"resp_body,omitempty"`
+	ReqHeaders  map[string]string `json:"req_headers,omitempty"`
 	RespHeaders map[string]string `json:"resp_headers,omitempty"`
 	// Frame is set for Phase="frame" only — a single WS frame's text
 	// payload (truncated at sampleCap). Direction is "c→s" or "s→c"
@@ -851,7 +852,8 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		SELECT action_id, ts_ns, mode, agent_ip, host,
 		       method, path, status, bytes_in, bytes_out,
 		       ms, action, reason, req_sha, resp_sha,
-		       req_body, resp_body, resp_headers
+		       req_body, resp_body,
+		       req_headers, resp_headers
 		FROM actions ORDER BY id DESC LIMIT ?`, n)
 	if err != nil {
 		return nil, err
@@ -876,13 +878,15 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 			respSha     sql.NullString
 			reqBody     sql.NullString
 			respBody    sql.NullString
+			reqHeaders  sql.NullString
 			respHeaders sql.NullString
 		)
 		if err := rows.Scan(
 			&actionID, &tsNs, &mode, &agentIP, &e.Host,
 			&method, &path, &status, &in, &ot, &ms,
 			&action, &reason, &reqSha, &respSha,
-			&reqBody, &respBody, &respHeaders,
+			&reqBody, &respBody,
+			&reqHeaders, &respHeaders,
 		); err != nil {
 			return nil, err
 		}
@@ -902,11 +906,8 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		e.RespSha = respSha.String
 		e.ReqBody = reqBody.String
 		e.RespBody = respBody.String
-		if respHeaders.String != "" {
-			_ = json.Unmarshal(
-				[]byte(respHeaders.String), &e.RespHeaders,
-			)
-		}
+		unmarshalHeaders(reqHeaders.String, &e.ReqHeaders)
+		unmarshalHeaders(respHeaders.String, &e.RespHeaders)
 		out = append(out, e)
 	}
 	if err := rows.Err(); err != nil {
@@ -944,23 +945,27 @@ func (s *Sink) drain() {
 		// the table for long-poll / WS sessions.
 		persist := e.Phase == "" || e.Phase == "end"
 		if s.db != nil && persist {
-			var rhJSON []byte
+			var rqhJSON, rshJSON []byte
+			if len(e.ReqHeaders) > 0 {
+				rqhJSON, _ = json.Marshal(e.ReqHeaders)
+			}
 			if len(e.RespHeaders) > 0 {
-				rhJSON, _ = json.Marshal(e.RespHeaders)
+				rshJSON, _ = json.Marshal(e.RespHeaders)
 			}
 			s.db.Exec(`
 				INSERT INTO actions
 				 (action_id, ts_ns, mode, agent_ip, host,
 				  method, path, status, bytes_in, bytes_out,
 				  ms, action, reason, req_sha, resp_sha,
-				  req_body, resp_body, resp_headers)
-				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+				  req_body, resp_body,
+				  req_headers, resp_headers)
+				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 			`, e.ID, e.Ts.UnixNano(), e.Mode, e.AgentIP,
 				e.Host, e.Method, e.Path, e.Status,
 				e.In, e.Out, e.Ms, e.Action, e.Reason,
 				e.ReqSha, e.RespSha,
 				e.ReqBody, e.RespBody,
-				string(rhJSON))
+				string(rqhJSON), string(rshJSON))
 		}
 		s.mu.Lock()
 		// Recent ring is the SSE backlog replayed to fresh
@@ -1023,6 +1028,12 @@ type sampler struct {
 	cap  int
 	buf  bytes.Buffer
 	n    int64
+}
+
+func unmarshalHeaders(s string, dst *map[string]string) {
+	if s != "" {
+		_ = json.Unmarshal([]byte(s), dst)
+	}
 }
 
 func flatHeaders(h http.Header) map[string]string {

--- a/web.go
+++ b/web.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -851,9 +852,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 	rows, err := db.Query(`
 		SELECT action_id, ts_ns, mode, agent_ip, host,
 		       method, path, status, bytes_in, bytes_out,
-		       ms, action, reason, req_sha, resp_sha,
-		       req_body, resp_body,
-		       req_headers, resp_headers
+		       ms, action, reason, req_sha, resp_sha
 		FROM actions ORDER BY id DESC LIMIT ?`, n)
 	if err != nil {
 		return nil, err
@@ -862,31 +861,25 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 	out := make([]Event, 0, n)
 	for rows.Next() {
 		var (
-			e           Event
-			actionID    sql.NullString
-			tsNs        int64
-			mode        sql.NullString
-			agentIP     sql.NullString
-			method      sql.NullString
-			path        sql.NullString
-			status      sql.NullInt64
-			in, ot      sql.NullInt64
-			ms          sql.NullInt64
-			action      sql.NullString
-			reason      sql.NullString
-			reqSha      sql.NullString
-			respSha     sql.NullString
-			reqBody     sql.NullString
-			respBody    sql.NullString
-			reqHeaders  sql.NullString
-			respHeaders sql.NullString
+			e        Event
+			actionID sql.NullString
+			tsNs     int64
+			mode     sql.NullString
+			agentIP  sql.NullString
+			method   sql.NullString
+			path     sql.NullString
+			status   sql.NullInt64
+			in, ot   sql.NullInt64
+			ms       sql.NullInt64
+			action   sql.NullString
+			reason   sql.NullString
+			reqSha   sql.NullString
+			respSha  sql.NullString
 		)
 		if err := rows.Scan(
 			&actionID, &tsNs, &mode, &agentIP, &e.Host,
 			&method, &path, &status, &in, &ot, &ms,
 			&action, &reason, &reqSha, &respSha,
-			&reqBody, &respBody,
-			&reqHeaders, &respHeaders,
 		); err != nil {
 			return nil, err
 		}
@@ -904,10 +897,6 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		e.Reason = reason.String
 		e.ReqSha = reqSha.String
 		e.RespSha = respSha.String
-		e.ReqBody = reqBody.String
-		e.RespBody = respBody.String
-		unmarshalHeaders(reqHeaders.String, &e.ReqHeaders)
-		unmarshalHeaders(respHeaders.String, &e.RespHeaders)
 		out = append(out, e)
 	}
 	if err := rows.Err(); err != nil {
@@ -974,7 +963,16 @@ func (s *Sink) drain() {
 		// terminal events. frame events for already-closed WS streams
 		// also have nowhere to go on reconnect.
 		if persist {
-			s.recent = append(s.recent, e)
+			// Strip bodies from backlog — SSE consumers
+			// (LiveRequests, AnalyticsPage) only need
+			// metadata; the detail page fetches full data
+			// via /api/actions/<id>.
+			lite := e
+			lite.ReqBody = ""
+			lite.RespBody = ""
+			lite.ReqHeaders = nil
+			lite.RespHeaders = nil
+			s.recent = append(s.recent, lite)
 			if len(s.recent) > s.recentCap {
 				s.recent = s.recent[len(s.recent)-s.recentCap:]
 			}
@@ -1036,10 +1034,18 @@ func unmarshalHeaders(s string, dst *map[string]string) {
 	}
 }
 
+var sensitiveHeader = regexp.MustCompile(
+	`(?i)auth|token|secret|key|password|cookie`,
+)
+
 func flatHeaders(h http.Header) map[string]string {
 	out := make(map[string]string, len(h))
 	for k, v := range h {
-		out[k] = strings.Join(v, ", ")
+		if sensitiveHeader.MatchString(k) {
+			out[k] = "***"
+		} else {
+			out[k] = strings.Join(v, ", ")
+		}
 	}
 	return out
 }

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -8,6 +8,7 @@
       "name": "clawpatrol-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@observablehq/plot": "^0.6.17",
         "@types/prismjs": "^1.26.6",
         "prismjs": "^1.30.0",
         "react": "^18.3.1",
@@ -69,6 +70,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -799,6 +801,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@observablehq/plot": {
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz",
+      "integrity": "sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "interval-tree-1d": "^1.0.0",
+        "isoformat": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1227,6 +1243,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1354,6 +1371,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
+      "license": "MIT"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1387,6 +1410,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1507,6 +1531,417 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1523,6 +1958,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/didyoumean": {
@@ -1733,6 +2177,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/interval-tree-1d": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz",
+      "integrity": "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1795,12 +2269,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isoformat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/isoformat/-/isoformat-0.2.1.tgz",
+      "integrity": "sha512-tFLRAygk9NqrRPhJSnNGh7g7oaVWDwR0wKh/GM2LgmPa50Eg4UfyaCO4I8k6EqJHl1/uh2RAD6g06n5ygEnrjQ==",
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2045,6 +2526,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2223,6 +2705,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2235,6 +2718,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2319,6 +2803,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -2387,6 +2877,18 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -2555,6 +3057,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2640,6 +3143,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/www/package.json
+++ b/www/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b --noEmit && vite build"
   },
   "dependencies": {
+    "@observablehq/plot": "^0.6.17",
     "@types/prismjs": "^1.26.6",
     "prismjs": "^1.30.0",
     "react": "^18.3.1",

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { AgentsTable } from "./components/AgentsTable";
+import { AnalyticsPage } from "./components/AnalyticsPage";
 import { ConnectModal } from "./components/ConnectModal";
 import { DevicePage } from "./components/DevicePage";
 import { LiveRequests } from "./components/LiveRequests";
@@ -9,9 +10,18 @@ import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
 import { getStatus, getAgents, getWhoami, type Integration, type Agent, type Whoami } from "./lib/api";
 
-function parseRoute(): { name: "main" } | { name: "device"; ip: string } | { name: "onboard"; code: string } {
+type Route =
+  | { name: "main" }
+  | { name: "device"; ip: string }
+  | { name: "analytics"; ip: string }
+  | { name: "onboard"; code: string };
+
+function parseRoute(): Route {
   const h = window.location.hash;
-  if (h.startsWith("#/onboard/")) return { name: "onboard", code: decodeURIComponent(h.slice("#/onboard/".length)) };
+  if (h.startsWith("#/onboard/"))
+    return { name: "onboard", code: decodeURIComponent(h.slice("#/onboard/".length)) };
+  const a = h.match(/^#\/analytics\/(.+)$/);
+  if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
   const m = h.match(/^#\/device\/(.+)$/);
   if (m) return { name: "device", ip: decodeURIComponent(m[1]) };
   return { name: "main" };
@@ -83,12 +93,22 @@ export default function App() {
           </div>
           <section className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
             <div className="overflow-x-auto">
-              <AgentsTable agents={agents} integrations={integrations} onSelect={(ip) => navigate("#/device/" + encodeURIComponent(ip))} />
+              <AgentsTable
+                agents={agents}
+                integrations={integrations}
+                onSelect={(ip) => navigate("#/device/" + encodeURIComponent(ip))}
+                onAnalytics={(ip) => navigate("#/analytics/" + encodeURIComponent(ip))}
+              />
             </div>
           </section>
           <HITLBar />
           <LiveRequests height="420px" />
         </main>
+      ) : route.name === "analytics" ? (
+        <AnalyticsPage
+          ip={route.ip}
+          onBack={() => navigate("")}
+        />
       ) : route.name === "onboard" ? (
         <OnboardPage code={route.code} onBack={() => navigate("")} />
       ) : (

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -5,6 +5,7 @@ import { ConnectModal } from "./components/ConnectModal";
 import { DevicePage } from "./components/DevicePage";
 import { LiveRequests } from "./components/LiveRequests";
 import { OnboardPage } from "./components/OnboardPage";
+import { RequestDetailPage } from "./components/RequestDetailPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
@@ -14,12 +15,15 @@ type Route =
   | { name: "main" }
   | { name: "device"; ip: string }
   | { name: "analytics"; ip: string }
-  | { name: "onboard"; code: string };
+  | { name: "onboard"; code: string }
+  | { name: "request"; id: string };
 
 function parseRoute(): Route {
   const h = window.location.hash;
   if (h.startsWith("#/onboard/"))
     return { name: "onboard", code: decodeURIComponent(h.slice("#/onboard/".length)) };
+  const r = h.match(/^#\/request\/([^/]+)$/);
+  if (r) return { name: "request", id: decodeURIComponent(r[1]) };
   const a = h.match(/^#\/analytics\/(.+)$/);
   if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
   const m = h.match(/^#\/device\/(.+)$/);
@@ -109,6 +113,8 @@ export default function App() {
           ip={route.ip}
           onBack={() => navigate("")}
         />
+      ) : route.name === "request" ? (
+        <RequestDetailPage id={route.id} onBack={() => navigate("")} />
       ) : route.name === "onboard" ? (
         <OnboardPage code={route.code} onBack={() => navigate("")} />
       ) : (

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -19,15 +19,20 @@ type Route =
   | { name: "request"; id: string };
 
 function parseRoute(): Route {
-  const h = window.location.hash;
+  // Strip query string before matching routes.
+  const raw = window.location.hash;
+  const qi = raw.indexOf("?");
+  const h = qi < 0 ? raw : raw.slice(0, qi);
   if (h.startsWith("#/onboard/"))
     return { name: "onboard", code: decodeURIComponent(h.slice("#/onboard/".length)) };
   const r = h.match(/^#\/request\/([^/]+)$/);
   if (r) return { name: "request", id: decodeURIComponent(r[1]) };
+  const da = h.match(/^#\/device\/([^/]+)\/analytics$/);
+  if (da) return { name: "analytics", ip: decodeURIComponent(da[1]) };
+  const m = h.match(/^#\/device\/([^/]+)$/);
+  if (m) return { name: "device", ip: decodeURIComponent(m[1]) };
   const a = h.match(/^#\/analytics\/(.+)$/);
   if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
-  const m = h.match(/^#\/device\/(.+)$/);
-  if (m) return { name: "device", ip: decodeURIComponent(m[1]) };
   return { name: "main" };
 }
 
@@ -101,7 +106,7 @@ export default function App() {
                 agents={agents}
                 integrations={integrations}
                 onSelect={(ip) => navigate("#/device/" + encodeURIComponent(ip))}
-                onAnalytics={(ip) => navigate("#/analytics/" + encodeURIComponent(ip))}
+                onAnalytics={(ip) => navigate("#/device/" + encodeURIComponent(ip) + "/analytics")}
               />
             </div>
           </section>
@@ -109,12 +114,9 @@ export default function App() {
           <LiveRequests height="420px" />
         </main>
       ) : route.name === "analytics" ? (
-        <AnalyticsPage
-          ip={route.ip}
-          onBack={() => navigate("")}
-        />
+        <AnalyticsPage ip={route.ip} agents={agents} />
       ) : route.name === "request" ? (
-        <RequestDetailPage id={route.id} onBack={() => navigate("")} />
+        <RequestDetailPage id={route.id} agents={agents} />
       ) : route.name === "onboard" ? (
         <OnboardPage code={route.code} onBack={() => navigate("")} />
       ) : (

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -72,6 +72,21 @@ export function AgentsTable({
                   <span className="text-[13px] font-semibold text-[#171717] truncate">
                     {a.hostname || a.ip}
                   </span>
+                  {onAnalytics && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onAnalytics(a.ip);
+                      }}
+                      className="p-1 rounded hover:bg-[#e5e5e5] transition-colors text-[#a3a3a3] hover:text-[#171717] flex-shrink-0"
+                      title="Analytics"
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M3 3v18h18" />
+                        <path d="m7 16 4-8 4 4 4-6" />
+                      </svg>
+                    </button>
+                  )}
                 </div>
                 <div className="md:hidden text-[10px] text-[#a3a3a3] truncate mt-0.5">
                   {a.profile || "—"}
@@ -108,28 +123,6 @@ export function AgentsTable({
                     };
                   })}
                 />
-              </Td>
-              <Td className="w-[32px]">
-                {onAnalytics && (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAnalytics(a.ip);
-                    }}
-                    className="p-1 rounded hover:bg-[#e5e5e5]
-                      transition-colors text-[#a3a3a3]
-                      hover:text-[#525252]"
-                    title="Analytics"
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24"
-                      fill="none" stroke="currentColor"
-                      strokeWidth="2" strokeLinecap="round"
-                      strokeLinejoin="round">
-                      <path d="M3 3v18h18" />
-                      <path d="m7 16 4-8 4 4 4-6" />
-                    </svg>
-                  </button>
-                )}
               </Td>
             </tr>
           );

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -10,10 +10,12 @@ export function AgentsTable({
   agents,
   integrations,
   onSelect,
+  onAnalytics,
 }: {
   agents: Agent[];
   integrations?: Integration[];
   onSelect?: (ip: string) => void;
+  onAnalytics?: (ip: string) => void;
 }) {
   // id → Integration lookup so the icon stack can pick the right
   // logo per credential type (postgres/slack/etc, not just the
@@ -39,12 +41,13 @@ export function AgentsTable({
           <Th className="text-right">REQS</Th>
           <Th className="hidden lg:table-cell">IP</Th>
           <Th>INTEGRATIONS</Th>
+          <Th className="w-[32px]">{""}</Th>
         </tr>
       </thead>
       <tbody>
         {stable.length === 0 && (
           <tr>
-            <td colSpan={6} className="px-5 py-8 text-center text-[11px] text-[#a3a3a3]">
+            <td colSpan={7} className="px-5 py-8 text-center text-[11px] text-[#a3a3a3]">
               It's empty in here
             </td>
           </tr>
@@ -105,6 +108,28 @@ export function AgentsTable({
                     };
                   })}
                 />
+              </Td>
+              <Td className="w-[32px]">
+                {onAnalytics && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onAnalytics(a.ip);
+                    }}
+                    className="p-1 rounded hover:bg-[#e5e5e5]
+                      transition-colors text-[#a3a3a3]
+                      hover:text-[#525252]"
+                    title="Analytics"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24"
+                      fill="none" stroke="currentColor"
+                      strokeWidth="2" strokeLinecap="round"
+                      strokeLinejoin="round">
+                      <path d="M3 3v18h18" />
+                      <path d="m7 16 4-8 4 4 4-6" />
+                    </svg>
+                  </button>
+                )}
               </Td>
             </tr>
           );

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -1,70 +1,157 @@
 import { useEffect, useRef, useState } from "react";
 import * as Plot from "@observablehq/plot";
-import type { EventRecord } from "../lib/api";
+import type { Agent, EventRecord } from "../lib/api";
 import { LiveRequests } from "./LiveRequests";
 
-export function AnalyticsPage({ ip, onBack }: {
+const RANGES = [
+  "1m", "5m", "15m", "30m", "1h", "6h", "24h",
+] as const;
+type Range = typeof RANGES[number];
+type ColorBy = "host" | "status";
+type Scale = "log" | "linear";
+
+const RANGE_MS: Record<Range, number> = {
+  "1m": 60e3, "5m": 300e3, "15m": 900e3,
+  "30m": 1800e3, "1h": 3600e3, "6h": 21600e3,
+  "24h": 86400e3,
+};
+
+// --- query string helpers ---
+
+function qsGet(key: string, fallback: string): string {
+  const h = window.location.hash;
+  const qi = h.indexOf("?");
+  if (qi < 0) return fallback;
+  const p = new URLSearchParams(h.slice(qi));
+  return p.get(key) ?? fallback;
+}
+
+function qsSet(key: string, value: string) {
+  const h = window.location.hash;
+  const qi = h.indexOf("?");
+  const base = qi < 0 ? h : h.slice(0, qi);
+  const p = new URLSearchParams(qi < 0 ? "" : h.slice(qi));
+  p.set(key, value);
+  window.location.hash = base + "?" + p.toString();
+}
+
+function useQS<T extends string>(
+  key: string, fallback: T, valid: readonly T[],
+): [T, (v: T) => void] {
+  const init = qsGet(key, fallback) as T;
+  const [val, setVal] = useState(
+    valid.includes(init) ? init : fallback,
+  );
+  const set = (v: T) => { setVal(v); qsSet(key, v); };
+  return [val, set];
+}
+
+// --- page ---
+
+export function AnalyticsPage({ ip, agents }: {
   ip: string;
-  onBack: () => void;
+  agents: Agent[];
 }) {
+  const deviceName =
+    agents.find(a => a.ip === ip)?.hostname || ip;
   const [events, setEvents] = useState<EventRecord[]>([]);
 
   useEffect(() => {
     setEvents([]);
-    const url = `/api/events?agent=${encodeURIComponent(ip)}`;
+    const url =
+      `/api/events?agent=${encodeURIComponent(ip)}`;
     const es = new EventSource(url);
     es.onmessage = (e) => {
       try {
         const ev = JSON.parse(e.data) as EventRecord;
-        setEvents((prev) => [ev, ...prev].slice(0, 2000));
+        setEvents((prev) => [ev, ...prev].slice(0, 5000));
       } catch { /* ignore */ }
     };
     return () => es.close();
   }, [ip]);
 
   return (
-    <main className="flex-1 mx-auto w-full max-w-[1100px]
-      px-4 sm:px-6 py-8 space-y-6">
-      <div className="flex items-center gap-4">
-        <button
-          onClick={onBack}
-          className="text-[#a3a3a3] hover:text-[#171717]
-            transition-colors text-sm"
+    <main className="flex-1 mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-8 space-y-6">
+      <nav className="text-[11px] text-[#a3a3a3] flex items-center gap-1.5">
+        <a href="#/" className="hover:text-[#171717]">
+          clawpatrol
+        </a>
+        <span>/</span>
+        <a
+          href={`#/device/${encodeURIComponent(ip)}`}
+          className="hover:text-[#171717]"
         >
-          ← back
-        </button>
-        <h1 className="font-serif text-[28px] sm:text-[36px]
-          leading-none tracking-tight text-[#171717]">
-          {ip}
-        </h1>
-      </div>
+          {deviceName}
+        </a>
+        <span>/</span>
+        <span className="text-[#525252]">analytics</span>
+      </nav>
       <LatencyChart events={events} />
       <LiveRequests agentIP={ip} height="500px" />
     </main>
   );
 }
 
-function LatencyChart({ events }: { events: EventRecord[] }) {
+// --- chart ---
+
+function LatencyChart({ events }: {
+  events: EventRecord[];
+}) {
   const ref = useRef<HTMLDivElement>(null);
+  const [colorBy, setColorBy] =
+    useQS("color", "host" as ColorBy, ["host", "status"]);
+  const [scale, setScale] =
+    useQS("scale", "log" as Scale, ["log", "linear"]);
+  const [range, setRange] =
+    useQS("range", "5m" as Range, RANGES);
 
   useEffect(() => {
     if (!ref.current || events.length === 0) return;
 
+    const cutoff = Date.now() - RANGE_MS[range];
     const dots = events
-      .filter((e) => e.ms > 0)
+      .filter((e) => e.ms > 0 && new Date(e.ts).getTime() >= cutoff)
       .map((e) => ({
         t: new Date(e.ts),
         ms: e.ms,
         host: e.host,
+        id: e.id,
+        statusCode: e.status ?? 0,
         status: e.status
           ? e.status >= 500 ? "5xx"
           : e.status >= 400 ? "4xx"
           : e.status >= 300 ? "3xx"
           : "2xx"
-          : "—",
+          : "\u2014",
       }));
 
-    if (dots.length === 0) return;
+    if (dots.length === 0) {
+      ref.current.replaceChildren();
+      return;
+    }
+
+    const statusColor = {
+      domain: ["2xx", "3xx", "4xx", "5xx", "\u2014"],
+      range: [
+        "#16a34a", "#ca8a04", "#ea580c",
+        "#dc2626", "#a3a3a3",
+      ],
+      legend: true,
+    };
+
+    const hosts = [...new Set(dots.map(d => d.host))];
+    const PALETTE = [
+      "#2563eb", "#16a34a", "#ea580c", "#7c3aed",
+      "#0891b2", "#ca8a04", "#dc2626", "#4f46e5",
+      "#059669", "#d97706", "#be185d", "#0d9488",
+    ];
+    const hostColor = {
+      domain: hosts,
+      range: hosts.map(
+        (_, i) => PALETTE[i % PALETTE.length],
+      ),
+      legend: true,
+    };
 
     const chart = Plot.plot({
       width: ref.current.clientWidth,
@@ -72,56 +159,118 @@ function LatencyChart({ events }: { events: EventRecord[] }) {
       marginLeft: 60,
       marginBottom: 40,
       y: {
-        type: "log",
+        type: scale,
         label: "Latency (ms)",
         grid: true,
       },
       x: {
         type: "time",
         label: null,
+        domain: [new Date(cutoff), new Date()],
       },
-      color: {
-        domain: ["2xx", "3xx", "4xx", "5xx", "—"],
-        range: [
-          "#16a34a", "#ca8a04", "#ea580c",
-          "#dc2626", "#a3a3a3",
-        ],
-        legend: true,
-      },
+      color: colorBy === "status"
+        ? statusColor : hostColor,
       marks: [
         Plot.dot(dots, {
           x: "t",
           y: "ms",
-          fill: "status",
+          fill: colorBy === "status" ? "status" : "host",
           r: 3,
           fillOpacity: 0.7,
-          title: (d: typeof dots[0]) =>
-            `${d.host}\n${d.ms}ms (${d.status})`,
+          channels: {
+            host: "host",
+            statusCode: "statusCode",
+            id: "id",
+          },
         }),
+        Plot.tip(dots, Plot.pointer({
+          x: "t",
+          y: "ms",
+          title: (d: typeof dots[0]) =>
+            `${d.host}\n${d.statusCode || "\u2014"} \u2022 ${d.ms}ms`,
+        })),
         Plot.ruleY([0]),
       ],
     });
 
+    chart.addEventListener("click", (evt) => {
+      const el = evt.target as SVGElement;
+      const circle = el.closest("circle");
+      if (!circle) return;
+      const i = (circle as any).__data__;
+      if (typeof i === "number" && dots[i]?.id) {
+        window.location.hash =
+          `#/request/${dots[i].id}`;
+      }
+    });
+    chart.querySelectorAll("circle").forEach((c) => {
+      (c as SVGElement).style.cursor = "pointer";
+    });
+
     ref.current.replaceChildren(chart);
     return () => chart.remove();
-  }, [events]);
+  }, [events, colorBy, scale, range]);
 
   return (
-    <div className="bg-white border border-[#e5e5e5] rounded
-      overflow-hidden">
-      <div className="px-4 py-2.5 text-[10px] uppercase
-        tracking-[.12em] text-[#a3a3a3] border-b
-        border-[#e5e5e5]">
-        Latency
+    <div className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[#e5e5e5] flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
+          Latency
+        </span>
+        <div className="flex items-center gap-4">
+          <Toggle
+            options={[...RANGES]}
+            value={range}
+            onChange={setRange}
+          />
+          <Toggle
+            options={["host", "status"] as ColorBy[]}
+            value={colorBy}
+            onChange={setColorBy}
+          />
+          <Toggle
+            options={["log", "linear"] as Scale[]}
+            value={scale}
+            onChange={setScale}
+          />
+        </div>
       </div>
       <div ref={ref} className="p-4 min-h-[320px]">
         {events.length === 0 && (
-          <div className="flex items-center justify-center
-            h-[280px] text-[11px] text-[#a3a3a3]">
+          <div className="flex items-center justify-center h-[280px] text-[11px] text-[#a3a3a3]">
             Collecting data...
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// --- toggle ---
+
+function Toggle<T extends string>({
+  options, value, onChange,
+}: {
+  options: T[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex text-[10px] border border-[#e5e5e5] rounded overflow-hidden">
+      {options.map((o) => (
+        <button
+          key={o}
+          onClick={() => onChange(o)}
+          className={
+            "px-2 py-0.5 " +
+            (o === value
+              ? "bg-[#171717] text-white"
+              : "text-[#737373] hover:bg-[#f5f5f5]")
+          }
+        >
+          {o}
+        </button>
+      ))}
     </div>
   );
 }

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react";
+import * as Plot from "@observablehq/plot";
+import type { EventRecord } from "./LiveRequests";
+import { LiveRequests } from "./LiveRequests";
+
+export function AnalyticsPage({ ip, onBack }: {
+  ip: string;
+  onBack: () => void;
+}) {
+  const [events, setEvents] = useState<EventRecord[]>([]);
+
+  useEffect(() => {
+    setEvents([]);
+    const url = `/api/events?agent=${encodeURIComponent(ip)}`;
+    const es = new EventSource(url);
+    es.onmessage = (e) => {
+      try {
+        const ev = JSON.parse(e.data) as EventRecord;
+        setEvents((prev) => [ev, ...prev].slice(0, 2000));
+      } catch { /* ignore */ }
+    };
+    return () => es.close();
+  }, [ip]);
+
+  return (
+    <main className="flex-1 mx-auto w-full max-w-[1100px]
+      px-4 sm:px-6 py-8 space-y-6">
+      <div className="flex items-center gap-4">
+        <button
+          onClick={onBack}
+          className="text-[#a3a3a3] hover:text-[#171717]
+            transition-colors text-sm"
+        >
+          ← back
+        </button>
+        <h1 className="font-serif text-[28px] sm:text-[36px]
+          leading-none tracking-tight text-[#171717]">
+          {ip}
+        </h1>
+      </div>
+      <LatencyChart events={events} />
+      <LiveRequests agentIP={ip} height="500px" />
+    </main>
+  );
+}
+
+function LatencyChart({ events }: { events: EventRecord[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current || events.length === 0) return;
+
+    const dots = events
+      .filter((e) => e.ms > 0)
+      .map((e) => ({
+        t: new Date(e.ts),
+        ms: e.ms,
+        host: e.host,
+        status: e.status
+          ? e.status >= 500 ? "5xx"
+          : e.status >= 400 ? "4xx"
+          : e.status >= 300 ? "3xx"
+          : "2xx"
+          : "—",
+      }));
+
+    if (dots.length === 0) return;
+
+    const chart = Plot.plot({
+      width: ref.current.clientWidth,
+      height: 280,
+      marginLeft: 60,
+      marginBottom: 40,
+      y: {
+        type: "log",
+        label: "Latency (ms)",
+        grid: true,
+      },
+      x: {
+        type: "time",
+        label: null,
+      },
+      color: {
+        domain: ["2xx", "3xx", "4xx", "5xx", "—"],
+        range: [
+          "#16a34a", "#ca8a04", "#ea580c",
+          "#dc2626", "#a3a3a3",
+        ],
+        legend: true,
+      },
+      marks: [
+        Plot.dot(dots, {
+          x: "t",
+          y: "ms",
+          fill: "status",
+          r: 3,
+          fillOpacity: 0.7,
+          title: (d: typeof dots[0]) =>
+            `${d.host}\n${d.ms}ms (${d.status})`,
+        }),
+        Plot.ruleY([0]),
+      ],
+    });
+
+    ref.current.replaceChildren(chart);
+    return () => chart.remove();
+  }, [events]);
+
+  return (
+    <div className="bg-white border border-[#e5e5e5] rounded
+      overflow-hidden">
+      <div className="px-4 py-2.5 text-[10px] uppercase
+        tracking-[.12em] text-[#a3a3a3] border-b
+        border-[#e5e5e5]">
+        Latency
+      </div>
+      <div ref={ref} className="p-4 min-h-[320px]">
+        {events.length === 0 && (
+          <div className="flex items-center justify-center
+            h-[280px] text-[11px] text-[#a3a3a3]">
+            Collecting data...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import * as Plot from "@observablehq/plot";
-import type { EventRecord } from "./LiveRequests";
+import type { EventRecord } from "../lib/api";
 import { LiveRequests } from "./LiveRequests";
 
 export function AnalyticsPage({ ip, onBack }: {

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -53,9 +53,11 @@ export function DevicePage({
   if (!a) {
     return (
       <main className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-5">
-        <button onClick={onBack} className="text-[11px] text-[#737373] hover:text-[#171717] mb-3">
-          ← back
-        </button>
+        <nav className="text-[11px] text-[#a3a3a3] flex items-center gap-1.5 mb-3">
+          <a href="#/" className="hover:text-[#171717]">clawpatrol</a>
+          <span>/</span>
+          <span className="text-[#525252]">{ip}</span>
+        </nav>
         <div className="bg-white border border-[#e5e5e5] rounded px-5 py-8 text-center text-[12px] text-[#a3a3a3]">
           no agent with ip {ip}
         </div>
@@ -81,9 +83,11 @@ export function DevicePage({
   return (
     <main className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-5 space-y-5">
       <div className="flex items-center justify-between">
-        <button onClick={onBack} className="text-[11px] text-[#737373] hover:text-[#171717]">
-          ← back
-        </button>
+        <nav className="text-[11px] text-[#a3a3a3] flex items-center gap-1.5">
+          <a href="#/" className="hover:text-[#171717]">clawpatrol</a>
+          <span>/</span>
+          <span className="text-[#525252]">{dev.hostname || dev.ip}</span>
+        </nav>
         <div className="flex items-center gap-2">
           <ProfilePicker
             current={a.profile ?? ""}

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -116,7 +116,8 @@ function Row({ ev }: { ev: RowState }) {
       <div
         onClick={onClick}
         className={
-          "px-4 py-2 flex items-center gap-3 min-w-0 cursor-pointer transition-colors"
+          "px-4 py-2 flex items-center gap-3 min-w-0 transition-colors"
+          + (onClick ? " cursor-pointer" : "")
           + (inFlight ? " opacity-70" : "")
           + " hover:bg-[#f9f9f9]"
         }

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -1,25 +1,5 @@
 import { useEffect, useState } from "react";
-
-export type EventRecord = {
-  ts: string;
-  id?: string;
-  phase?: "" | "start" | "end" | "frame";
-  mode: string;
-  agent_ip?: string;
-  host: string;
-  method?: string;
-  path?: string;
-  status?: number;
-  in?: number;
-  out?: number;
-  ms: number;
-  action?: string;
-  reason?: string;
-  frame?: string;
-  direction?: string;
-  req_sample?: string;
-  resp_sample?: string;
-};
+import { type EventRecord } from "../lib/api";
 
 type RowState = EventRecord & { frames?: { direction: string; frame: string; ts: string }[] };
 
@@ -29,11 +9,9 @@ export function LiveRequests({ agentIP, max = 200, height }: {
   height?: string;
 }) {
   const [events, setEvents] = useState<RowState[]>([]);
-  const [selected, setSelected] = useState<number | null>(null);
 
   useEffect(() => {
     setEvents([]);
-    setSelected(null);
     const url = agentIP
       ? `/api/events?agent=${encodeURIComponent(agentIP)}`
       : "/api/events";
@@ -64,16 +42,7 @@ export function LiveRequests({ agentIP, max = 200, height }: {
           </div>
         ) : (
           events.map((e, i) => (
-            <div key={i}>
-              <Row
-                ev={e}
-                active={selected === i}
-                onClick={() => setSelected(
-                  selected === i ? null : i,
-                )}
-              />
-              {selected === i && <Detail ev={e} />}
-            </div>
+            <Row key={i} ev={e} />
           ))
         )}
       </div>
@@ -122,11 +91,10 @@ function pathSeparator(path: string): string {
   return path.startsWith("/") ? "" : " ";
 }
 
-function Row({ ev, active, onClick }: {
-  ev: RowState;
-  active?: boolean;
-  onClick?: () => void;
-}) {
+function Row({ ev }: { ev: RowState }) {
+  const onClick = ev.id
+    ? () => { window.location.hash = `#/request/${ev.id}`; }
+    : undefined;
   const t = new Date(ev.ts);
   const time =
     t.toLocaleTimeString([], { hour12: false })
@@ -150,7 +118,7 @@ function Row({ ev, active, onClick }: {
         className={
           "px-4 py-2 flex items-center gap-3 min-w-0 cursor-pointer transition-colors"
           + (inFlight ? " opacity-70" : "")
-          + (active ? " bg-[#f0f0f0]" : " hover:bg-[#f9f9f9]")
+          + " hover:bg-[#f9f9f9]"
         }
       >
         <span className="text-[10px] tabular-nums text-[#a3a3a3] flex-shrink-0">{time}</span>
@@ -187,76 +155,6 @@ function Row({ ev, active, onClick }: {
 function InFlightSpinner() {
   return (
     <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#a3a3a3] animate-pulse align-middle" />
-  );
-}
-
-function Detail({ ev }: { ev: RowState }) {
-  const hasReq = ev.req_sample && ev.req_sample.length > 0;
-  const hasResp = ev.resp_sample && ev.resp_sample.length > 0;
-  if (!hasReq && !hasResp) {
-    return (
-      <div className="px-6 py-3 bg-[#fafafa] border-b border-[#e5e5e5] text-[11px] text-[#a3a3a3]">
-        No request/response body captured
-        {ev.mode === "splice" && " (spliced connection)"}
-      </div>
-    );
-  }
-  return (
-    <div className="bg-[#fafafa] border-b border-[#e5e5e5] text-[11px]">
-      <div className="flex gap-0 divide-x divide-[#e5e5e5]">
-        {hasReq && (
-          <div className="flex-1 min-w-0">
-            <div className="px-4 py-1.5 text-[10px] uppercase tracking-wider text-[#a3a3a3] border-b border-[#e5e5e5]">
-              Request
-            </div>
-            <BodyBlock body={ev.req_sample!} />
-          </div>
-        )}
-        {hasResp && (
-          <div className="flex-1 min-w-0">
-            <div className="px-4 py-1.5 text-[10px] uppercase tracking-wider text-[#a3a3a3] border-b border-[#e5e5e5]">
-              Response {ev.status && `(${ev.status})`}
-            </div>
-            <BodyBlock body={ev.resp_sample!} />
-          </div>
-        )}
-      </div>
-      {(ev.action || ev.reason) && (
-        <div className="px-4 py-2 border-t border-[#e5e5e5] text-[10px] text-[#737373]">
-          {ev.action && (
-            <span className={
-              ev.action === "deny"
-                ? "text-[#dc2626] font-semibold"
-                : "text-[#16a34a]"
-            }>
-              {ev.action}
-            </span>
-          )}
-          {ev.reason && (
-            <span className="ml-2">{ev.reason}</span>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function BodyBlock({ body }: { body: string }) {
-  let content = body;
-  let isJson = false;
-  try {
-    const parsed = JSON.parse(body);
-    content = JSON.stringify(parsed, null, 2);
-    isJson = true;
-  } catch { /* not json */ }
-  return (
-    <pre className={
-      "px-4 py-3 overflow-x-auto max-h-[300px] overflow-y-auto"
-      + " whitespace-pre-wrap break-all font-mono text-[11px]"
-      + (isJson ? " text-[#525252]" : " text-[#737373]")
-    }>
-      {content}
-    </pre>
   );
 }
 

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -17,6 +17,8 @@ export type EventRecord = {
   reason?: string;
   frame?: string;
   direction?: string;
+  req_sample?: string;
+  resp_sample?: string;
 };
 
 type RowState = EventRecord & { frames?: { direction: string; frame: string; ts: string }[] };
@@ -27,9 +29,11 @@ export function LiveRequests({ agentIP, max = 200, height }: {
   height?: string;
 }) {
   const [events, setEvents] = useState<RowState[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
 
   useEffect(() => {
     setEvents([]);
+    setSelected(null);
     const url = agentIP
       ? `/api/events?agent=${encodeURIComponent(agentIP)}`
       : "/api/events";
@@ -59,7 +63,18 @@ export function LiveRequests({ agentIP, max = 200, height }: {
             Waiting for requests<AnimatedDots />
           </div>
         ) : (
-          events.map((e, i) => <Row key={i} ev={e} />)
+          events.map((e, i) => (
+            <div key={i}>
+              <Row
+                ev={e}
+                active={selected === i}
+                onClick={() => setSelected(
+                  selected === i ? null : i,
+                )}
+              />
+              {selected === i && <Detail ev={e} />}
+            </div>
+          ))
         )}
       </div>
     </div>
@@ -107,10 +122,15 @@ function pathSeparator(path: string): string {
   return path.startsWith("/") ? "" : " ";
 }
 
-function Row({ ev }: { ev: RowState }) {
+function Row({ ev, active, onClick }: {
+  ev: RowState;
+  active?: boolean;
+  onClick?: () => void;
+}) {
   const t = new Date(ev.ts);
   const time =
-    t.toLocaleTimeString([], { hour12: false }) + "." + String(t.getMilliseconds()).padStart(3, "0");
+    t.toLocaleTimeString([], { hour12: false })
+    + "." + String(t.getMilliseconds()).padStart(3, "0");
   const inFlight = ev.phase === "start";
   const status = ev.status || 0;
   const statusColor = inFlight
@@ -125,7 +145,14 @@ function Row({ ev }: { ev: RowState }) {
   const hasFrames = (ev.frames?.length ?? 0) > 0;
   return (
     <div className="border-b border-[#f5f5f5]">
-      <div className={"px-4 py-2 hover:bg-[#f9f9f9] flex items-center gap-3 min-w-0 " + (inFlight ? "opacity-70" : "")}>
+      <div
+        onClick={onClick}
+        className={
+          "px-4 py-2 flex items-center gap-3 min-w-0 cursor-pointer transition-colors"
+          + (inFlight ? " opacity-70" : "")
+          + (active ? " bg-[#f0f0f0]" : " hover:bg-[#f9f9f9]")
+        }
+      >
         <span className="text-[10px] tabular-nums text-[#a3a3a3] flex-shrink-0">{time}</span>
         <ModeIcon mode={ev.mode} />
         {ev.method && (
@@ -160,6 +187,76 @@ function Row({ ev }: { ev: RowState }) {
 function InFlightSpinner() {
   return (
     <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#a3a3a3] animate-pulse align-middle" />
+  );
+}
+
+function Detail({ ev }: { ev: RowState }) {
+  const hasReq = ev.req_sample && ev.req_sample.length > 0;
+  const hasResp = ev.resp_sample && ev.resp_sample.length > 0;
+  if (!hasReq && !hasResp) {
+    return (
+      <div className="px-6 py-3 bg-[#fafafa] border-b border-[#e5e5e5] text-[11px] text-[#a3a3a3]">
+        No request/response body captured
+        {ev.mode === "splice" && " (spliced connection)"}
+      </div>
+    );
+  }
+  return (
+    <div className="bg-[#fafafa] border-b border-[#e5e5e5] text-[11px]">
+      <div className="flex gap-0 divide-x divide-[#e5e5e5]">
+        {hasReq && (
+          <div className="flex-1 min-w-0">
+            <div className="px-4 py-1.5 text-[10px] uppercase tracking-wider text-[#a3a3a3] border-b border-[#e5e5e5]">
+              Request
+            </div>
+            <BodyBlock body={ev.req_sample!} />
+          </div>
+        )}
+        {hasResp && (
+          <div className="flex-1 min-w-0">
+            <div className="px-4 py-1.5 text-[10px] uppercase tracking-wider text-[#a3a3a3] border-b border-[#e5e5e5]">
+              Response {ev.status && `(${ev.status})`}
+            </div>
+            <BodyBlock body={ev.resp_sample!} />
+          </div>
+        )}
+      </div>
+      {(ev.action || ev.reason) && (
+        <div className="px-4 py-2 border-t border-[#e5e5e5] text-[10px] text-[#737373]">
+          {ev.action && (
+            <span className={
+              ev.action === "deny"
+                ? "text-[#dc2626] font-semibold"
+                : "text-[#16a34a]"
+            }>
+              {ev.action}
+            </span>
+          )}
+          {ev.reason && (
+            <span className="ml-2">{ev.reason}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BodyBlock({ body }: { body: string }) {
+  let content = body;
+  let isJson = false;
+  try {
+    const parsed = JSON.parse(body);
+    content = JSON.stringify(parsed, null, 2);
+    isJson = true;
+  } catch { /* not json */ }
+  return (
+    <pre className={
+      "px-4 py-3 overflow-x-auto max-h-[300px] overflow-y-auto"
+      + " whitespace-pre-wrap break-all font-mono text-[11px]"
+      + (isJson ? " text-[#525252]" : " text-[#737373]")
+    }>
+      {content}
+    </pre>
   );
 }
 

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -1,0 +1,395 @@
+import { useState, useEffect } from "react";
+import {
+  getAction,
+  type EventRecord,
+} from "../lib/api";
+
+export function RequestDetailPage({
+  id,
+  onBack,
+}: {
+  id: string;
+  onBack: () => void;
+}) {
+  const [ev, setEv] = useState<EventRecord | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAction(id)
+      .then(setEv)
+      .catch((e) => setErr(e.message ?? "load failed"));
+  }, [id]);
+
+  if (err) {
+    return (
+      <Shell onBack={onBack}>
+        <div className="text-[13px] text-[#dc2626]">{err}</div>
+      </Shell>
+    );
+  }
+  if (!ev) {
+    return (
+      <Shell onBack={onBack}>
+        <div className="text-[12px] text-[#a3a3a3]">Loading...</div>
+      </Shell>
+    );
+  }
+
+  const t = new Date(ev.ts);
+  const time =
+    t.toLocaleDateString() + " " +
+    t.toLocaleTimeString([], { hour12: false }) +
+    "." + String(t.getMilliseconds()).padStart(3, "0");
+  const status = ev.status || 0;
+  const statusColor =
+    status >= 500 ? "text-[#dc2626]"
+    : status >= 400 ? "text-[#ea580c]"
+    : status >= 300 ? "text-[#ca8a04]"
+    : status >= 200 ? "text-[#16a34a]"
+    : "text-[#737373]";
+  const path = ev.path ?? "";
+  const fullUrl = ev.host +
+    (path.startsWith("/") ? "" : " ") + path;
+  const hasReq = !!ev.req_body;
+  const hasResp = !!ev.resp_body;
+  const hasHeaders = ev.resp_headers &&
+    Object.keys(ev.resp_headers).length > 0;
+
+  return (
+    <Shell onBack={onBack}>
+      {/* header */}
+      <div className="bg-white border border-[#e5e5e5] rounded p-5 space-y-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <ModeIcon mode={ev.mode} />
+          {ev.method && (
+            <span className="text-[12px] uppercase font-semibold text-[#525252]">
+              {ev.method}
+            </span>
+          )}
+          <span className={"text-[13px] tabular-nums font-semibold " + statusColor}>
+            {status || "\u2014"}
+          </span>
+          <span className="text-[13px] text-[#171717] break-all font-mono" title={fullUrl}>
+            {fullUrl}
+          </span>
+        </div>
+        <div className="flex items-center gap-4 text-[11px] text-[#737373] flex-wrap">
+          <span>{time}</span>
+          <span>{ev.ms}ms</span>
+          {ev.agent_ip && <span>{ev.agent_ip}</span>}
+        </div>
+        {(ev.action || ev.reason) && (
+          <div className="flex items-center gap-2 text-[11px]">
+            {ev.action && (
+              <span className={
+                "px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase " +
+                (ev.action === "deny"
+                  ? "bg-[#fef2f2] text-[#dc2626]"
+                  : "bg-[#f0fdf4] text-[#16a34a]")
+              }>
+                {ev.action}
+              </span>
+            )}
+            {ev.reason && (
+              <span className="text-[#737373]">{ev.reason}</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* sections */}
+      {(hasReq || hasResp || hasHeaders) ? (
+        <div className="bg-white border border-[#e5e5e5] rounded divide-y divide-[#e5e5e5]">
+          {hasReq && (
+            <Section title="Request body">
+              <HttpBody text={ev.req_body!} />
+            </Section>
+          )}
+          {hasHeaders && (
+            <Section title="Response headers">
+              <Headers obj={ev.resp_headers!} />
+            </Section>
+          )}
+          {hasResp && (
+            <Section title={
+              `Response body${status ? ` (${status})` : ""}`
+            }>
+              <HttpBody text={ev.resp_body!} />
+            </Section>
+          )}
+        </div>
+      ) : (
+        <div className="bg-white border border-[#e5e5e5] rounded px-5 py-4 text-[12px] text-[#a3a3a3]">
+          No request/response body captured
+          {ev.mode === "splice" && " (spliced connection)"}
+        </div>
+      )}
+
+      {/* footer */}
+      <div className="flex items-center gap-6 text-[10px] text-[#a3a3a3] flex-wrap">
+        {(ev.in != null && ev.in > 0) && (
+          <span>in: {fmtBytes(ev.in)}</span>
+        )}
+        {(ev.out != null && ev.out > 0) && (
+          <span>out: {fmtBytes(ev.out)}</span>
+        )}
+        {ev.req_sha && (
+          <span className="font-mono" title={ev.req_sha}>
+            req_sha: {ev.req_sha.slice(0, 12)}
+          </span>
+        )}
+        {ev.resp_sha && (
+          <span className="font-mono" title={ev.resp_sha}>
+            resp_sha: {ev.resp_sha.slice(0, 12)}
+          </span>
+        )}
+      </div>
+    </Shell>
+  );
+}
+
+// --- layout ---
+
+function Shell({ onBack, children }: {
+  onBack: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-5 space-y-5">
+      <button
+        onClick={onBack}
+        className="text-[11px] text-[#737373] hover:text-[#171717]"
+      >
+        &#8592; back
+      </button>
+      {children}
+    </main>
+  );
+}
+
+function Section({ title, children }: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details open>
+      <summary className="cursor-pointer px-4 py-2.5 text-[10px] uppercase tracking-wider font-medium text-[#a3a3a3] hover:text-[#525252] select-none">
+        {title}
+      </summary>
+      <div className="border-t border-[#f5f5f5]">
+        {children}
+      </div>
+    </details>
+  );
+}
+
+// --- headers ---
+
+const SENSITIVE = /auth|token|secret|key|password|cookie/i;
+
+function Headers({ obj }: { obj: Record<string, string> }) {
+  return (
+    <pre className="overflow-auto whitespace-pre-wrap break-all px-4 py-3 font-mono text-[11px] leading-relaxed">
+      {Object.entries(obj).map(([k, v]) => (
+        <div key={k}>
+          <span className="font-semibold text-[#171717]">{k}</span>
+          <span className="text-[#a3a3a3]">: </span>
+          {SENSITIVE.test(k)
+            ? <span className="text-[#a3a3a3]">{"*".repeat(Math.min(v.length, 24))}</span>
+            : <span className="text-[#525252]">{v}</span>}
+        </div>
+      ))}
+    </pre>
+  );
+}
+
+// --- body rendering (JSON tree / SSE / plain) ---
+
+function HttpBody({ text }: { text: string }) {
+  if (!text) return (
+    <div className="px-4 py-3 text-[11px] text-[#a3a3a3]">
+      (empty)
+    </div>
+  );
+  // Try JSON
+  let parsed: unknown;
+  try { parsed = JSON.parse(text); } catch { /* */ }
+  if (parsed !== undefined) {
+    return (
+      <div className="overflow-auto px-4 py-3 font-mono text-[11px] leading-relaxed">
+        <JsonNode value={parsed} />
+      </div>
+    );
+  }
+  return (
+    <pre className="overflow-auto whitespace-pre-wrap break-all px-4 py-3 font-mono text-[11px] text-[#525252]">
+      {text}
+    </pre>
+  );
+}
+
+// --- JSON tree (ported from unclaw) ---
+
+const LONG_STRING = 120;
+
+function JsonNode({ value }: { value: unknown }) {
+  if (value === null) {
+    return <span className="font-semibold text-[#a3a3a3]">null</span>;
+  }
+  if (typeof value === "boolean") {
+    return <span className="font-semibold text-[#7c3aed]">{String(value)}</span>;
+  }
+  if (typeof value === "number") {
+    return <span className="text-[#2563eb]">{String(value)}</span>;
+  }
+  if (typeof value === "string") {
+    return <StringNode value={value} />;
+  }
+  if (Array.isArray(value)) {
+    return (
+      <Collapsible bracket={["[", "]"]} count={value.length}>
+        {value.map((v, i) => (
+          <div key={i} className="pl-5">
+            <JsonNode value={v} />
+            {i < value.length - 1 && ","}
+          </div>
+        ))}
+      </Collapsible>
+    );
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(
+      value as Record<string, unknown>,
+    );
+    return (
+      <Collapsible bracket={["{", "}"]} count={entries.length}>
+        {entries.map(([k, v], i) => (
+          <div key={k} className="pl-5">
+            <span className="text-[#be123c]">
+              {JSON.stringify(k)}
+            </span>
+            {": "}
+            <JsonNode value={v} />
+            {i < entries.length - 1 && ","}
+          </div>
+        ))}
+      </Collapsible>
+    );
+  }
+  return <span>{String(value)}</span>;
+}
+
+function StringNode({ value }: { value: string }) {
+  const raw = JSON.stringify(value);
+  const long = raw.length > LONG_STRING;
+  const [expanded, setExpanded] = useState(!long);
+
+  if (!long) {
+    return <span className="text-[#15803d]">{raw}</span>;
+  }
+  if (!expanded) {
+    return (
+      <span>
+        <span className="text-[#15803d]">
+          {raw.slice(0, LONG_STRING)}
+        </span>
+        <button
+          onClick={() => setExpanded(true)}
+          className="ml-1 text-[#2563eb] hover:underline"
+        >
+          +{raw.length - LONG_STRING} more
+        </button>
+      </span>
+    );
+  }
+  const inner = raw.slice(1, -1);
+  const lines = inner.split("\\n");
+  return (
+    <span className="text-[#15803d]">
+      {'"'}
+      {lines.map((line, i) => (
+        <span key={i}>
+          {line}
+          {i < lines.length - 1 && (
+            <>
+              <span className="text-[#a3a3a3]">\n</span>
+              <br />
+            </>
+          )}
+        </span>
+      ))}
+      {'"'}
+      <button
+        onClick={() => setExpanded(false)}
+        className="ml-1 text-[#2563eb] hover:underline"
+      >
+        less
+      </button>
+    </span>
+  );
+}
+
+function Collapsible({ bracket, count, children }: {
+  bracket: [string, string];
+  count: number;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(true);
+  if (count === 0) {
+    return <span>{bracket[0]}{bracket[1]}</span>;
+  }
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="text-[#a3a3a3] hover:text-[#525252]"
+      >
+        {bracket[0]}{" "}
+        <span className="text-[#2563eb]">
+          {count} items
+        </span>
+        {" "}{bracket[1]}
+      </button>
+    );
+  }
+  return (
+    <span>
+      <button
+        onClick={() => setOpen(false)}
+        className="hover:text-[#a3a3a3]"
+      >
+        {bracket[0]}
+      </button>
+      {children}
+      <div>{bracket[1]}</div>
+    </span>
+  );
+}
+
+// --- utils ---
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return n + " B";
+  if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+  return (n / 1024 / 1024).toFixed(1) + " MB";
+}
+
+function ModeIcon({ mode }: { mode: string }) {
+  if (mode === "mitm") {
+    return (
+      <span title="MITM" className="flex-shrink-0">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="#f6821f">
+          <path d="M7 10V7a5 5 0 0 1 10 0v3h1a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h1Zm2 0h6V7a3 3 0 1 0-6 0v3Z" />
+        </svg>
+      </span>
+    );
+  }
+  return (
+    <span title="Splice" className="flex-shrink-0">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#a3a3a3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M5 12h14" />
+        <path d="m13 6 6 6-6 6" />
+      </svg>
+    </span>
+  );
+}

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect } from "react";
 import {
   getAction,
+  type Agent,
   type EventRecord,
 } from "../lib/api";
 
 export function RequestDetailPage({
   id,
-  onBack,
+  agents,
 }: {
   id: string;
-  onBack: () => void;
+  agents: Agent[];
 }) {
   const [ev, setEv] = useState<EventRecord | null>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -22,14 +23,14 @@ export function RequestDetailPage({
 
   if (err) {
     return (
-      <Shell onBack={onBack}>
+      <Shell>
         <div className="text-[13px] text-[#dc2626]">{err}</div>
       </Shell>
     );
   }
   if (!ev) {
     return (
-      <Shell onBack={onBack}>
+      <Shell>
         <div className="text-[12px] text-[#a3a3a3]">Loading...</div>
       </Shell>
     );
@@ -52,11 +53,18 @@ export function RequestDetailPage({
     (path.startsWith("/") ? "" : " ") + path;
   const hasReq = !!ev.req_body;
   const hasResp = !!ev.resp_body;
-  const hasHeaders = ev.resp_headers &&
+  const hasReqH = ev.req_headers &&
+    Object.keys(ev.req_headers).length > 0;
+  const hasRespH = ev.resp_headers &&
     Object.keys(ev.resp_headers).length > 0;
+  const hasSections = hasReq || hasResp || hasReqH || hasRespH;
 
   return (
-    <Shell onBack={onBack}>
+    <Shell
+      agentIP={ev.agent_ip}
+      agentName={agents.find(a => a.ip === ev.agent_ip)?.hostname}
+      requestId={ev.id}
+    >
       {/* header */}
       <div className="bg-white border border-[#e5e5e5] rounded p-5 space-y-3">
         <div className="flex items-center gap-3 flex-wrap">
@@ -98,14 +106,19 @@ export function RequestDetailPage({
       </div>
 
       {/* sections */}
-      {(hasReq || hasResp || hasHeaders) ? (
+      {hasSections ? (
         <div className="bg-white border border-[#e5e5e5] rounded divide-y divide-[#e5e5e5]">
+          {hasReqH && (
+            <Section title="Request headers">
+              <Headers obj={ev.req_headers!} />
+            </Section>
+          )}
           {hasReq && (
             <Section title="Request body">
               <HttpBody text={ev.req_body!} />
             </Section>
           )}
-          {hasHeaders && (
+          {hasRespH && (
             <Section title="Response headers">
               <Headers obj={ev.resp_headers!} />
             </Section>
@@ -150,18 +163,48 @@ export function RequestDetailPage({
 
 // --- layout ---
 
-function Shell({ onBack, children }: {
-  onBack: () => void;
+function Breadcrumbs({ agentIP, agentName, requestId }: {
+  agentIP?: string;
+  agentName?: string;
+  requestId?: string;
+}) {
+  return (
+    <nav className="text-[11px] text-[#a3a3a3] flex items-center gap-1.5">
+      <a href="#/" className="hover:text-[#171717]">
+        clawpatrol
+      </a>
+      {agentIP && (
+        <>
+          <span>/</span>
+          <a
+            href={`#/device/${encodeURIComponent(agentIP)}`}
+            className="hover:text-[#171717]"
+          >
+            {agentName || agentIP}
+          </a>
+        </>
+      )}
+      {requestId && (
+        <>
+          <span>/</span>
+          <span className="text-[#525252] font-mono">
+            {requestId.slice(0, 8)}
+          </span>
+        </>
+      )}
+    </nav>
+  );
+}
+
+function Shell({ children, agentIP, agentName, requestId }: {
   children: React.ReactNode;
+  agentIP?: string;
+  agentName?: string;
+  requestId?: string;
 }) {
   return (
     <main className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-5 space-y-5">
-      <button
-        onClick={onBack}
-        className="text-[11px] text-[#737373] hover:text-[#171717]"
-      >
-        &#8592; back
-      </button>
+      <Breadcrumbs agentIP={agentIP} agentName={agentName} requestId={requestId} />
       {children}
     </main>
   );
@@ -205,19 +248,83 @@ function Headers({ obj }: { obj: Record<string, string> }) {
 
 // --- body rendering (JSON tree / SSE / plain) ---
 
+// tryParseJSON attempts JSON.parse; on failure (e.g. truncated at
+// the 4KB sampler cap) walks backward to find the last position
+// where closing all open containers yields valid JSON.
+function tryParseJSON(text: string): {
+  parsed: unknown; truncated: boolean;
+} | null {
+  try {
+    return { parsed: JSON.parse(text), truncated: false };
+  } catch { /* fall through */ }
+  // Walk the string tracking container depth, ignoring string
+  // interiors. At each position where we're outside a string
+  // and just finished a complete value (after , or : or [ or {),
+  // record it as a candidate cut point.
+  let inStr = false;
+  let esc = false;
+  const stack: string[] = [];
+  let lastGoodCut = -1;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (esc) { esc = false; continue; }
+    if (ch === "\\") { esc = true; continue; }
+    if (ch === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (ch === "{") stack.push("}");
+    else if (ch === "[") stack.push("]");
+    else if (ch === "}" || ch === "]") {
+      stack.pop();
+      lastGoodCut = i + 1;
+    } else if (ch === ",") {
+      lastGoodCut = i;
+    }
+  }
+  // Try cutting at each candidate, newest first
+  for (let cut = lastGoodCut; cut > 0; cut--) {
+    // Re-scan up to cut to get the stack state
+    const st: string[] = [];
+    let ins = false;
+    let es = false;
+    for (let i = 0; i < cut; i++) {
+      const c = text[i];
+      if (es) { es = false; continue; }
+      if (c === "\\") { es = true; continue; }
+      if (c === '"') { ins = !ins; continue; }
+      if (ins) continue;
+      if (c === "{") st.push("}");
+      else if (c === "[") st.push("]");
+      else if (c === "}" || c === "]") st.pop();
+    }
+    let attempt = text.slice(0, cut);
+    // Strip trailing comma
+    if (attempt.endsWith(",")) {
+      attempt = attempt.slice(0, -1);
+    }
+    attempt += st.reverse().join("");
+    try {
+      return { parsed: JSON.parse(attempt), truncated: true };
+    } catch { continue; }
+  }
+  return null;
+}
+
 function HttpBody({ text }: { text: string }) {
   if (!text) return (
     <div className="px-4 py-3 text-[11px] text-[#a3a3a3]">
       (empty)
     </div>
   );
-  // Try JSON
-  let parsed: unknown;
-  try { parsed = JSON.parse(text); } catch { /* */ }
-  if (parsed !== undefined) {
+  const result = tryParseJSON(text);
+  if (result) {
     return (
       <div className="overflow-auto px-4 py-3 font-mono text-[11px] leading-relaxed">
-        <JsonNode value={parsed} />
+        <JsonNode value={result.parsed} />
+        {result.truncated && (
+          <div className="mt-2 text-[10px] text-[#a3a3a3]">
+            (truncated)
+          </div>
+        )}
       </div>
     );
   }

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -283,6 +283,36 @@ export async function oauthRevoke(id: string, owner: string): Promise<void> {
   if (!r.ok) throw new Error(await r.text());
 }
 
+export async function getAction(id: string): Promise<EventRecord> {
+  const r = await api(`/api/actions/${id}`);
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+export type EventRecord = {
+  ts: string;
+  id?: string;
+  phase?: "" | "start" | "end" | "frame";
+  mode: string;
+  agent_ip?: string;
+  host: string;
+  method?: string;
+  path?: string;
+  status?: number;
+  in?: number;
+  out?: number;
+  ms: number;
+  action?: string;
+  reason?: string;
+  frame?: string;
+  direction?: string;
+  req_sha?: string;
+  resp_sha?: string;
+  req_body?: string;
+  resp_body?: string;
+  resp_headers?: Record<string, string>;
+};
+
 export async function oauthExchange(state: string, code: string): Promise<{ connected: boolean; owner: string; expires: number }> {
   const r = await api("/api/oauth/exchange", {
     method: "POST",

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -310,6 +310,7 @@ export type EventRecord = {
   resp_sha?: string;
   req_body?: string;
   resp_body?: string;
+  req_headers?: Record<string, string>;
   resp_headers?: Record<string, string>;
 };
 


### PR DESCRIPTION
Adds three features to the dashboard:

1. **Live requests**: click any row to expand and see req/res body samples (JSON pretty-printed)
2. **Devices table**: chart icon per row links to analytics page for that device
3. **Analytics page**: Observable Plot scatter chart (latency vs time, colored by status code) + filtered live requests stream

Route: `#/analytics/<ip>`