### PR TITLE
Rename Go module from clawpatrol-go to clawpatrol

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           cat > site/index.html <<HTML
           <!doctype html><meta charset=utf-8><title>clawpatrol releases</title>
           <h1>clawpatrol</h1>
-          <p>Install: <code>curl -fsSL https://denoland.github.io/clawpatrol-go/install.sh | sh</code></p>
+          <p>Install: <code>curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh</code></p>
           <p>Latest binaries: <a href="releases/latest/">releases/latest/</a></p>
           <p>This tag: <a href="releases/${TAG}/">releases/${TAG}/</a></p>
           HTML

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ ts-state/
 dist/
 /gateway
 /clawpatrol
-/clawpatrol-go
+/clawpatrol
 /unclaw
 *.log
 www/node_modules

--- a/WIREGUARD.md
+++ b/WIREGUARD.md
@@ -70,7 +70,7 @@ in promiscuous mode — same shape as unclaw's `boringtun` + `smoltcp`
 
 ```bash
 # on the gateway VM (real public IP needed)
-curl -fsSL https://denoland.github.io/clawpatrol-go/install.sh | sh
+curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
 
 cat > /etc/clawpatrol/gateway.hcl <<'EOF'
 listen       = "0.0.0.0:8443"
@@ -104,7 +104,7 @@ in `/opt/clawpatrol/oauth/`.
 ## Client setup
 
 ```bash
-curl -fsSL https://denoland.github.io/clawpatrol-go/install.sh | sh
+curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
 clawpatrol join --url http://your-gw.example.com:8080
 # approve at the displayed URL, done — claude/gh/codex just work
 ```

--- a/ai.go
+++ b/ai.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclparse"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 const ruleSystemPrompt = `You edit clawpatrol gateway policy expressed in the v14 typed-block HCL grammar.

--- a/config/compile.go
+++ b/config/compile.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/denoland/clawpatrol-go/config/match"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // CompiledPolicy is the runtime-friendly view of a loaded gateway:

--- a/config/compile_test.go
+++ b/config/compile_test.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/all"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
 )
 
 // TestCompile loads testdata/feature_minimal.hcl, lowers it via

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/denoland/clawpatrol-go/config"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/all"
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
 )
 
 var update = flag.Bool("update", false, "regenerate testdata goldens")

--- a/config/emit_test.go
+++ b/config/emit_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/denoland/clawpatrol-go/config"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/all"
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
 )
 
 // TestEmitRoundTrip loads each feature_*.hcl fixture, emits it back

--- a/config/match/match_test.go
+++ b/config/match/match_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/denoland/clawpatrol-go/config/match"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // httpReq builds a minimal Request for the HTTP matcher tests.

--- a/config/plugins/all/all.go
+++ b/config/plugins/all/all.go
@@ -4,8 +4,8 @@
 package all
 
 import (
-	_ "github.com/denoland/clawpatrol-go/config/plugins/approvers"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/credentials"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/endpoints"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/rules"
+	_ "github.com/denoland/clawpatrol/config/plugins/approvers"
+	_ "github.com/denoland/clawpatrol/config/plugins/credentials"
+	_ "github.com/denoland/clawpatrol/config/plugins/endpoints"
+	_ "github.com/denoland/clawpatrol/config/plugins/rules"
 )

--- a/config/plugins/approvers/approvers.go
+++ b/config/plugins/approvers/approvers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 // LLMApprover carries the model + the credential used to authenticate

--- a/config/plugins/approvers/llm_runtime.go
+++ b/config/plugins/approvers/llm_runtime.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 const llmJudgeSystem = `You are a security gate. Decide whether the operator's policy intends the gateway to ALLOW or DENY this request. The policy text is the source of truth.

--- a/config/plugins/approvers/runtime.go
+++ b/config/plugins/approvers/runtime.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // DashboardApprover: pool.Add → wait for the dashboard's PUT

--- a/config/plugins/credentials/credentials.go
+++ b/config/plugins/credentials/credentials.go
@@ -22,8 +22,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // Bearer / cookie / header tokens — generic HTTP auth shapes ----------

--- a/config/plugins/credentials/env_pushdown.go
+++ b/config/plugins/credentials/env_pushdown.go
@@ -1,6 +1,6 @@
 package credentials
 
-import "github.com/denoland/clawpatrol-go/config"
+import "github.com/denoland/clawpatrol/config"
 
 // Per-credential EnvVars() implementations. Placeholder values are
 // chosen to look like real tokens so the agent CLI's startup

--- a/config/plugins/credentials/oauth_flows.go
+++ b/config/plugins/credentials/oauth_flows.go
@@ -1,6 +1,6 @@
 package credentials
 
-import "github.com/denoland/clawpatrol-go/config"
+import "github.com/denoland/clawpatrol/config"
 
 // OAuth flow definitions for the built-in OAuth credential types.
 // Each lives next to the credential plugin that returns it via

--- a/config/plugins/credentials/secret_slots.go
+++ b/config/plugins/credentials/secret_slots.go
@@ -1,6 +1,6 @@
 package credentials
 
-import "github.com/denoland/clawpatrol-go/config"
+import "github.com/denoland/clawpatrol/config"
 
 // Per-credential SecretSlots() implementations. The dashboard uses
 // these to render the connect-credential modal — one input per slot.

--- a/config/plugins/credentials/slack_hitl.go
+++ b/config/plugins/credentials/slack_hitl.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // NotifyHITL posts a Block Kit approval prompt to the operator's

--- a/config/plugins/endpoints/endpoints.go
+++ b/config/plugins/endpoints/endpoints.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // CredentialEntry is one row inside an endpoint's credentials list.

--- a/config/plugins/endpoints/postgres_runtime.go
+++ b/config/plugins/endpoints/postgres_runtime.go
@@ -35,9 +35,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 const sslRequestCode = 80877103

--- a/config/plugins/rules/rules.go
+++ b/config/plugins/rules/rules.go
@@ -25,8 +25,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // RuleBody is the shared shape across all three rule types. The

--- a/config/runtime/checker.go
+++ b/config/runtime/checker.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"fmt"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 // init installs a plugin checker on the config registry that

--- a/config/runtime/dispatch.go
+++ b/config/runtime/dispatch.go
@@ -1,8 +1,8 @@
 package runtime
 
 import (
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // HostEndpoint resolves a profile + SNI host (with port stripped to

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/all"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 const fixture = `

--- a/config/runtime/k8s_parse.go
+++ b/config/runtime/k8s_parse.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/denoland/clawpatrol-go/config/match"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // ParseK8sPath best-effort decomposes a Kubernetes API request into

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -14,8 +14,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // HTTPCredentialRuntime is the credential-plugin contract for HTTP

--- a/config/runtime/tls_test.go
+++ b/config/runtime/tls_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/denoland/clawpatrol-go/config/plugins/all"
-	"github.com/denoland/clawpatrol-go/config/plugins/credentials"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/config/plugins/credentials"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // TestMTLSConfigure round-trips a freshly-generated cert / key / CA

--- a/dial.go
+++ b/dial.go
@@ -17,8 +17,8 @@ import (
 
 	utls "github.com/refraction-networking/utls"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // servePorts is a no-op until the postgres / clickhouse_native

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/denoland/clawpatrol-go
+module github.com/denoland/clawpatrol
 
 go 1.26.1
 

--- a/integrations.go
+++ b/integrations.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 // resolveTemplate expands `{{secret:NAME}}` placeholders in s by

--- a/main.go
+++ b/main.go
@@ -22,11 +22,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/match"
-	_ "github.com/denoland/clawpatrol-go/config/plugins/all"
-	"github.com/denoland/clawpatrol-go/config/plugins/approvers"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/config/plugins/approvers"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // Tailscale aliases the operational tailscale-block type loaded from

--- a/oauth.go
+++ b/oauth.go
@@ -13,7 +13,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 const ScopeUser = "user"

--- a/postgres_index.go
+++ b/postgres_index.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 // pgIndex resolves WG-forwarder dstIPs back to the postgres endpoint

--- a/secrets.go
+++ b/secrets.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // gatewaySecretStore is the SecretStore the gateway hands to

--- a/slack_interactive.go
+++ b/slack_interactive.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // apiSlackInteractive handles Slack's interactive payload POSTs —

--- a/tailscale.go
+++ b/tailscale.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 )
 
 func openListener(cfg *config.Gateway) (net.Listener, error) {

--- a/tailscale_tsnet.go
+++ b/tailscale_tsnet.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/denoland/clawpatrol-go/config"
+	"github.com/denoland/clawpatrol/config"
 	"tailscale.com/tsnet"
 )
 

--- a/web.go
+++ b/web.go
@@ -28,8 +28,8 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/denoland/clawpatrol-go/config"
-	"github.com/denoland/clawpatrol-go/config/runtime"
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 //go:embed all:www/dist


### PR DESCRIPTION
Updates module path and all imports. Binary will now be named `clawpatrol` instead of `clawpatrol-go`.