### PR TITLE
mitm: look up HTTP credential secret by profile, not peer IP

### DIFF
--- a/main.go
+++ b/main.go
@@ -1235,11 +1235,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			// etc.) live on Body. Invoke methods through Body so the
 			// receiver is the real instance.
 			if injector, ok := cc.Credential.Body.(runtime.HTTPCredentialRuntime); ok {
-				sec, err := g.secrets.Get(cc.Credential.Symbol.Name, pip)
+				sec, err := g.secrets.Get(cc.Credential.Symbol.Name, profile)
 				if err != nil {
-					log.Printf("secret %s/%s: %v — forwarding without injection", cc.Credential.Symbol.Name, pip, err)
+					log.Printf("secret %s/%s: %v — forwarding without injection", cc.Credential.Symbol.Name, profile, err)
 				} else if len(sec.Bytes) == 0 {
-					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, pip, secretEnvName(cc.Credential.Symbol.Name))
+					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
 				} else if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
 					log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
 				}


### PR DESCRIPTION
* `mitmHTTPS` was calling `g.secrets.Get(name, pip)` where `pip` is
  the WireGuard peer IP (e.g. `10.55.0.12`). The store keys on the
  profile name in all three tiers — `credential_secrets.profile`
  column, `OAuthRegistry.Token(id, owner=profile)`, and
  `EnvSecretStore`. The lookup missed every tier, returned empty
  bytes, and the placeholder token leaked upstream — `gh auth
  status` reported "The token in GH_TOKEN is invalid" even though
  an OAuth token was stored for the device's profile.
* The postgres path already threads `profile` through `ConnHandle`;
  only the HTTPS path was passing the IP. `profile` is already in
  scope at `mitmHTTPS:1076`, so the fix is one line plus the two
  matching log statements.