### PR TITLE
ipv6 in wg netstack (gateway + macOS extension)

### DIFF
--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -48,6 +48,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/icmp"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
@@ -85,13 +86,18 @@ func (n *epNotify) WriteNotify() {
 	}
 }
 
-func newNetTUN(addr netip.Addr, mtu int) (*netTun, error) {
+func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	t := &netTun{
 		ep: channel.New(1024, uint32(mtu), ""),
 		stack: stack.New(stack.Options{
-			NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol},
-			TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol4},
-			HandleLocal:        false,
+			NetworkProtocols: []stack.NetworkProtocolFactory{
+				ipv4.NewProtocol, ipv6.NewProtocol,
+			},
+			TransportProtocols: []stack.TransportProtocolFactory{
+				tcp.NewProtocol, udp.NewProtocol,
+				icmp.NewProtocol4, icmp.NewProtocol6,
+			},
+			HandleLocal: false,
 		}),
 		events:         make(chan wgtun.Event, 10),
 		incomingPacket: make(chan []byte, 1024),
@@ -101,14 +107,24 @@ func newNetTUN(addr netip.Addr, mtu int) (*netTun, error) {
 	if e := t.stack.CreateNIC(1, t.ep); e != nil {
 		return nil, fmt.Errorf("CreateNIC: %v", e)
 	}
-	pa := tcpip.ProtocolAddress{
+	pa4 := tcpip.ProtocolAddress{
 		Protocol:          ipv4.ProtocolNumber,
 		AddressWithPrefix: tcpip.AddrFromSlice(addr.AsSlice()).WithPrefix(),
 	}
-	if e := t.stack.AddProtocolAddress(1, pa, stack.AddressProperties{}); e != nil {
-		return nil, fmt.Errorf("AddProtocolAddress: %v", e)
+	if e := t.stack.AddProtocolAddress(1, pa4, stack.AddressProperties{}); e != nil {
+		return nil, fmt.Errorf("AddProtocolAddress v4: %v", e)
+	}
+	if addr6.IsValid() {
+		pa6 := tcpip.ProtocolAddress{
+			Protocol:          ipv6.ProtocolNumber,
+			AddressWithPrefix: tcpip.AddrFromSlice(addr6.AsSlice()).WithPrefix(),
+		}
+		if e := t.stack.AddProtocolAddress(1, pa6, stack.AddressProperties{}); e != nil {
+			return nil, fmt.Errorf("AddProtocolAddress v6: %v", e)
+		}
 	}
 	t.stack.AddRoute(tcpip.Route{Destination: header.IPv4EmptySubnet, NIC: 1})
+	t.stack.AddRoute(tcpip.Route{Destination: header.IPv6EmptySubnet, NIC: 1})
 	t.events <- wgtun.EventUp
 	return t, nil
 }
@@ -138,9 +154,12 @@ func (t *netTun) Write(bufs [][]byte, offset int) (int, error) {
 		pkb := stack.NewPacketBuffer(stack.PacketBufferOptions{
 			Payload: buffer.MakeWithData(pkt),
 		})
-		if pkt[0]>>4 == 4 {
+		switch pkt[0] >> 4 {
+		case 4:
 			t.ep.InjectInbound(header.IPv4ProtocolNumber, pkb)
-		} else {
+		case 6:
+			t.ep.InjectInbound(header.IPv6ProtocolNumber, pkb)
+		default:
 			pkb.DecRef()
 		}
 	}
@@ -236,13 +255,33 @@ func wg_netstack_init(confC *C.char, errBuf *C.char, errLen C.int) C.int {
 		setErr(errBuf, errLen, perr.Error())
 		return -1
 	}
-	addrStr := strings.SplitN(addr, "/", 2)[0]
-	clientIP, err := netip.ParseAddr(addrStr)
-	if err != nil {
-		setErr(errBuf, errLen, "parse client IP: "+err.Error())
+	// Address may carry both v4 and v6 separated by ", ". Each part is
+	// `addr/prefix`. wg-quick conf written by the gateway emits e.g.
+	// `Address = 10.55.0.10/32, fd77::a/128`.
+	var clientIP, clientIP6 netip.Addr
+	for _, part := range strings.Split(addr, ",") {
+		s := strings.TrimSpace(part)
+		if s == "" {
+			continue
+		}
+		if i := strings.IndexByte(s, '/'); i >= 0 {
+			s = s[:i]
+		}
+		ip, perr := netip.ParseAddr(s)
+		if perr != nil {
+			continue
+		}
+		if ip.Is4() && !clientIP.IsValid() {
+			clientIP = ip
+		} else if ip.Is6() && !clientIP6.IsValid() {
+			clientIP6 = ip
+		}
+	}
+	if !clientIP.IsValid() {
+		setErr(errBuf, errLen, "parse client IP: no IPv4 in Address")
 		return -1
 	}
-	t, err := newNetTUN(clientIP, 1420)
+	t, err := newNetTUN(clientIP, clientIP6, 1420)
 	if err != nil {
 		setErr(errBuf, errLen, "newNetTUN: "+err.Error())
 		return -1
@@ -260,7 +299,7 @@ func wg_netstack_init(confC *C.char, errBuf *C.char, errLen C.int) C.int {
 		return -1
 	}
 	ipc := fmt.Sprintf(
-		"private_key=%s\npublic_key=%s\nendpoint=%s\nallowed_ip=0.0.0.0/0\n",
+		"private_key=%s\npublic_key=%s\nendpoint=%s\nallowed_ip=0.0.0.0/0\nallowed_ip=::/0\n",
 		privHex, pubHex, ep,
 	)
 	if ka > 0 {
@@ -376,12 +415,16 @@ func wg_netstack_dial_tcp(hostC *C.char, port C.int, errBuf *C.char, errLen C.in
 		setErr(errBuf, errLen, "parse host: "+err.Error())
 		return -1
 	}
+	proto := ipv4.ProtocolNumber
+	if ip.Is6() {
+		proto = ipv6.ProtocolNumber
+	}
 	addr := tcpip.FullAddress{
 		NIC:  1,
 		Addr: tcpip.AddrFromSlice(ip.AsSlice()),
 		Port: uint16(port),
 	}
-	gconn, err := gonet.DialContextTCP(context.Background(), tun.stack, addr, ipv4.ProtocolNumber)
+	gconn, err := gonet.DialContextTCP(context.Background(), tun.stack, addr, proto)
 	if err != nil {
 		setErr(errBuf, errLen, "DialContextTCP: "+err.Error())
 		return -1
@@ -401,12 +444,16 @@ func wg_netstack_dial_udp(hostC *C.char, port C.int, errBuf *C.char, errLen C.in
 		setErr(errBuf, errLen, "parse host: "+err.Error())
 		return -1
 	}
+	proto := ipv4.ProtocolNumber
+	if ip.Is6() {
+		proto = ipv6.ProtocolNumber
+	}
 	addr := tcpip.FullAddress{
 		NIC:  1,
 		Addr: tcpip.AddrFromSlice(ip.AsSlice()),
 		Port: uint16(port),
 	}
-	gconn, err := gonet.DialUDP(tun.stack, nil, &addr, ipv4.ProtocolNumber)
+	gconn, err := gonet.DialUDP(tun.stack, nil, &addr, proto)
 	if err != nil {
 		setErr(errBuf, errLen, "DialUDP: "+err.Error())
 		return -1

--- a/wireguard.go
+++ b/wireguard.go
@@ -41,6 +41,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/icmp"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
@@ -63,13 +64,18 @@ type netTun struct {
 	closed         bool
 }
 
-func newNetTUN(addr netip.Addr, mtu int) (*netTun, error) {
+func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	dev := &netTun{
 		ep: channel.New(1024, uint32(mtu), ""),
 		stack: stack.New(stack.Options{
-			NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol},
-			TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol4},
-			HandleLocal:        false,
+			NetworkProtocols: []stack.NetworkProtocolFactory{
+				ipv4.NewProtocol, ipv6.NewProtocol,
+			},
+			TransportProtocols: []stack.TransportProtocolFactory{
+				tcp.NewProtocol, udp.NewProtocol,
+				icmp.NewProtocol4, icmp.NewProtocol6,
+			},
+			HandleLocal: false,
 		}),
 		events:         make(chan wgtun.Event, 10),
 		incomingPacket: make(chan []byte, 1024),
@@ -79,14 +85,24 @@ func newNetTUN(addr netip.Addr, mtu int) (*netTun, error) {
 	if e := dev.stack.CreateNIC(1, dev.ep); e != nil {
 		return nil, fmt.Errorf("CreateNIC: %v", e)
 	}
-	pa := tcpip.ProtocolAddress{
+	pa4 := tcpip.ProtocolAddress{
 		Protocol:          ipv4.ProtocolNumber,
 		AddressWithPrefix: tcpip.AddrFromSlice(addr.AsSlice()).WithPrefix(),
 	}
-	if e := dev.stack.AddProtocolAddress(1, pa, stack.AddressProperties{}); e != nil {
-		return nil, fmt.Errorf("AddProtocolAddress: %v", e)
+	if e := dev.stack.AddProtocolAddress(1, pa4, stack.AddressProperties{}); e != nil {
+		return nil, fmt.Errorf("AddProtocolAddress v4: %v", e)
+	}
+	if addr6.IsValid() {
+		pa6 := tcpip.ProtocolAddress{
+			Protocol:          ipv6.ProtocolNumber,
+			AddressWithPrefix: tcpip.AddrFromSlice(addr6.AsSlice()).WithPrefix(),
+		}
+		if e := dev.stack.AddProtocolAddress(1, pa6, stack.AddressProperties{}); e != nil {
+			return nil, fmt.Errorf("AddProtocolAddress v6: %v", e)
+		}
 	}
 	dev.stack.AddRoute(tcpip.Route{Destination: header.IPv4EmptySubnet, NIC: 1})
+	dev.stack.AddRoute(tcpip.Route{Destination: header.IPv6EmptySubnet, NIC: 1})
 	dev.events <- wgtun.EventUp
 	return dev, nil
 }
@@ -152,9 +168,12 @@ func (t *netTun) Write(bufs [][]byte, offset int) (int, error) {
 		switch pkt[0] >> 4 {
 		case 4:
 			t.ep.InjectInbound(header.IPv4ProtocolNumber, pkb)
+		case 6:
+			t.ep.InjectInbound(header.IPv6ProtocolNumber, pkb)
 		default:
 			pkb.DecRef()
 		}
+
 	}
 	return len(bufs), nil
 }
@@ -214,8 +233,9 @@ func StartWGServer(ts Tailscale, stateDir string) (*WGServer, error) {
 		return nil, fmt.Errorf("wg subnet: %w", err)
 	}
 	serverIP := prefix.Addr().Next() // x.x.x.1
+	serverIP6 := wg6FromV4(serverIP) // fd77::<last-octet>
 
-	tun, err := newNetTUN(serverIP, 1420)
+	tun, err := newNetTUN(serverIP, serverIP6, 1420)
 	if err != nil {
 		return nil, err
 	}
@@ -266,9 +286,10 @@ func (s *WGServer) AddPeer(pubkeyHex, peerIP string) error {
 			}
 		}
 	}
+	peerIP6 := wg6FromV4(netip.MustParseAddr(peerIP))
 	if err := s.dev.IpcSet(fmt.Sprintf(
-		"public_key=%s\nreplace_allowed_ips=true\nallowed_ip=%s/32\n",
-		pubkeyHex, peerIP,
+		"public_key=%s\nreplace_allowed_ips=true\nallowed_ip=%s/32\nallowed_ip=%s/128\n",
+		pubkeyHex, peerIP, peerIP6.String(),
 	)); err != nil {
 		return err
 	}
@@ -280,6 +301,21 @@ func (s *WGServer) AddPeer(pubkeyHex, peerIP string) error {
 		return err
 	}
 	return nil
+}
+
+// wg6FromV4 derives the per-peer IPv6 address from a peer's wg v4
+// address: fd77::<last-octet>. ULA prefix; matches unclaw's scheme so
+// no extra HCL config is needed.
+func wg6FromV4(v4 netip.Addr) netip.Addr {
+	if !v4.Is4() {
+		return netip.Addr{}
+	}
+	o := v4.As4()
+	var b [16]byte
+	b[0] = 0xfd
+	b[1] = 0x77
+	b[15] = o[3]
+	return netip.AddrFrom16(b)
 }
 
 // EnablePromiscuousForwarder turns the netstack into an L3 sink.
@@ -590,18 +626,19 @@ func (w *wireguardOnboarder) MintKey(ctx context.Context, reuseIP string) (strin
 	// Avoiding `DNS =` because wg-quick needs resolvconf/openresolv
 	// for that, which many minimal images lack. Backup-then-restore
 	// keeps system DNS sane after `wg-quick down`.
+	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
 	conf := fmt.Sprintf(`[Interface]
 PrivateKey = %s
-Address = %s/32
+Address = %s/32, %s/128
 PostUp = cp /etc/resolv.conf /etc/resolv.conf.clawpatrol.bak 2>/dev/null; printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
 PostDown = mv /etc/resolv.conf.clawpatrol.bak /etc/resolv.conf 2>/dev/null || true
 
 [Peer]
 PublicKey = %s
 Endpoint = %s
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = 0.0.0.0/0, ::/0
 PersistentKeepalive = 25
-`, clientPrivB64, ip, serverPubB64, w.ts.WGEndpoint)
+`, clientPrivB64, ip, ip6, serverPubB64, w.ts.WGEndpoint)
 	return conf, "wireguard://" + w.iface(), ip, nil
 }
 


### PR DESCRIPTION
## Summary

Node's happy-eyeballs picks IPv6 first when available. Both the gateway's WG netstack and the macOS extension's wgnetstack only registered \`ipv4.NewProtocol\` — flows landed at \`api.anthropic.com\`'s AAAA address, dial returned \`network is unreachable\`, and the agent saw ECONNRESET. Mirrors ref-impl's NE: route v6 through the same wg tunnel.

## Server (wireguard.go)

- newNetTUN registers ipv4 + ipv6 protocols and icmp v4 + v6.
- Inject v6 packets in netTun.Write.
- Per-peer v6 derived from v4: \`fd77::<last-octet>\` (ULA, matches ref-impl's wg6 derivation).
- AddPeer registers both \`<v4>/32\` and \`<v6>/128\` allowed_ip.
- wireguardOnboarder.MintKey emits \`Address = <v4>/32, <v6>/128\` + \`AllowedIPs = 0.0.0.0/0, ::/0\`.
- Promiscuous forwarder unchanged — tcp/udp Forwarders are protocol-agnostic; v6 protocol address + route + spoofing is enough.

## Client (macos/netstack/wgnetstack.go)

- newNetTUN takes v4 + v6 addrs, same protocol set as server.
- Inject v6 packets in Write.
- parseWG splits comma-list Address; picks v4 + v6.
- IpcSet allowed_ip adds \`::/0\`.
- dial_tcp / dial_udp pick ipv4 vs ipv6 ProtocolNumber from the parsed dst IP family.

## Operator action after merge

\`\`\`
# rejoin to get new wg.conf with v6 line
clawpatrol join --url https://<gateway>

# rebuild + reinstall the mac app/extension
cd macos && ./install.sh
\`\`\`

## Test plan

- [ ] \`claude\` connects without ECONNRESET on a network with IPv6 to api.anthropic.com
- [ ] \`curl -6\` and \`curl -4\` both work via \`clawpatrol run\`
- [ ] Linux client with the new conf still works (v4 path unchanged)
- [ ] Existing peers without rejoining still work — server's \`AddPeer\` upgrade only kicks in on next \`clawpatrol join\` (their old v4-only allowed_ip stays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)