### PR TITLE
macos: bump CFBundleVersion + release: purge CF cache

### DIFF
--- a/.github/scripts/build-macos-app.sh
+++ b/.github/scripts/build-macos-app.sh
@@ -25,10 +25,28 @@ build_netstack() {
   popd >/dev/null
 }
 
+# bump_build_number stamps CFBundleVersion = git commit count on both
+# the .app and extension Info.plists. sysextd treats system extensions
+# with the same (CFBundleShortVersionString, CFBundleVersion) tuple as
+# the running one as a no-op activation, so without a bump here a
+# `Clawpatrol install` after an in-place .app replacement leaves the
+# old extension binary running. Commit count is monotonic across
+# rebuilds; sysextd accepts the higher number and swaps the ext.
+bump_build_number() {
+  local n
+  n=$(git rev-list --count HEAD 2>/dev/null || echo 1)
+  /usr/bin/plutil -replace CFBundleVersion -string "$n" \
+    macos/Clawpatrol/Info.plist
+  /usr/bin/plutil -replace CFBundleVersion -string "$n" \
+    macos/ClawpatrolExtension/Info.plist
+  echo "==> CFBundleVersion = $n"
+}
+
 # If no Apple ID, build unsigned (local dev / PR checks).
 if [ -z "${APPLE_ID:-}" ]; then
   echo "==> Building unsigned (no APPLE_ID set)"
   build_netstack
+  bump_build_number
   brew install xcodegen 2>/dev/null || true
   xcodegen --spec macos/project.yml
   xcodebuild \
@@ -76,6 +94,7 @@ echo -n "$APPLE_PROVISIONING_PROFILE_EXT" | base64 --decode \
 
 # 4. Build the Go cgo netstack archive.
 build_netstack
+bump_build_number
 
 # 5. Patch project for distribution: switch entitlements to
 #    -systemextension variants, swap profile names from dev to release.

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,8 @@
+# Cloudflare Pages serves clawpatrol.dev. Default behaviour caches
+# /install.sh hard at the edge — a fresh release's install.sh doesn't
+# reach `curl | sh` users until the TTL expires. Tell CF to revalidate
+# every request so the next deploy is visible immediately.
+
+/install.sh
+  Cache-Control: no-cache, no-store, must-revalidate
+  CDN-Cache-Control: no-store

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -40,7 +40,7 @@ esac
 command -v curl >/dev/null 2>&1 || fail "curl required"
 mkdir -p "$PREFIX"
 
-# --- source-build branch (private repo — needs gh auth) -------------
+# source-build branch (private repo — needs gh auth)
 if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
   REF="${CLAWPATROL_REF:-main}"
   command -v go  >/dev/null 2>&1 || fail "go toolchain required for source build"
@@ -72,14 +72,14 @@ if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
   exit 0
 fi
 
-# --- binary download (default) --------------------------------------
+# binary download (default)
 URL="${BASE}/releases/${VERSION}/clawpatrol-${OS}-${ARCH}"
 TMP=$(mktemp)
 trap 'rm -f "$TMP"' EXIT INT TERM
 say "downloading ${URL}"
 curl -fsSL -o "$TMP" "$URL" || fail "download failed (no release for ${OS}-${ARCH} at ${VERSION}?)"
 
-# --- optional sha256 verify -----------------------------------------
+# optional sha256 verify
 SUMS=$(curl -fsSL "${BASE}/releases/${VERSION}/SHA256SUMS" 2>/dev/null || true)
 if [ -n "$SUMS" ]; then
   EXPECTED=$(printf '%s\n' "$SUMS" | awk -v f="clawpatrol-${OS}-${ARCH}" '$2==f{print $1}')
@@ -109,4 +109,28 @@ esac
 
 "$PREFIX/clawpatrol" version 2>/dev/null || true
 echo
+
+# macOS: install Clawpatrol.app for `clawpatrol run`
+# The .app holds the system extension that intercepts per-process
+# flows. Without it `clawpatrol run` errors. Pulled from the same
+# release as the Go binary, expanded to /Applications. Skip silently
+# if the artifact isn't present (older releases or unsigned dev runs).
+if [ "$OS" = "darwin" ]; then
+  APP_URL="${BASE}/releases/${VERSION}/Clawpatrol.app.tar.gz"
+  APP_TMP=$(mktemp -d)
+  if curl -fsSL -o "$APP_TMP/app.tgz" "$APP_URL" 2>/dev/null; then
+    say "installing Clawpatrol.app to /Applications"
+    rm -rf /Applications/Clawpatrol.app 2>/dev/null \
+      || sudo rm -rf /Applications/Clawpatrol.app 2>/dev/null \
+      || fail "couldn't remove old /Applications/Clawpatrol.app (need sudo?)"
+    if ! tar -xzf "$APP_TMP/app.tgz" -C /Applications 2>/dev/null; then
+      sudo tar -xzf "$APP_TMP/app.tgz" -C /Applications \
+        || fail "extract Clawpatrol.app failed"
+    fi
+  else
+    say "Clawpatrol.app not in this release; skipping (run \`clawpatrol run\` won't work on macOS until you install the .app)"
+  fi
+  rm -rf "$APP_TMP"
+fi
+
 echo "next: clawpatrol join --url <gateway-url>"


### PR DESCRIPTION
## Summary

Two fixes the demo flow exposed.

### CFBundleVersion bump
sysextd treats a system-extension activation as a no-op when (CFBundleShortVersionString, CFBundleVersion) match the running ext. Hardcoded `CFBundleVersion=1` meant every release left users running the previous extension binary — only fix today is SIP-disable + `systemextensionsctl uninstall`, blocked under SIP.

`build-macos-app.sh` now stamps both Info.plists with `CFBundleVersion = git rev-list --count HEAD` before xcodebuild. Monotonic across rebuilds, sysextd accepts the higher number, swaps the running ext on next `Clawpatrol install`.

### site install.sh sync + CF cache header

`site/public/install.sh` was a stale copy of the repo root install.sh, missing the macOS `.app` installer block — `curl https://clawpatrol.dev/install.sh` always skipped the /Applications/Clawpatrol.app step. Sync the file.

CF Pages was also caching `/install.sh` hard at the edge. Add `site/public/_headers` with `Cache-Control: no-cache, no-store, must-revalidate` + `CDN-Cache-Control: no-store` so every release deploy is reachable immediately.

## Test plan

- [ ] After deploy: `curl -I https://clawpatrol.dev/install.sh` shows `cf-cache-status: DYNAMIC` (no edge caching)
- [ ] `curl -fsSL https://clawpatrol.dev/install.sh | sh` installs both clawpatrol bin + Clawpatrol.app
- [ ] On a Mac with old extension active: `Clawpatrol install` triggers a real reactivation; `systemextensionsctl list` shows the new build number

🤖 Generated with [Claude Code](https://claude.com/claude-code)