### PR TITLE
macos: derive CFBundleVersion from release tag

### DIFF
--- a/.github/scripts/build-macos-app.sh
+++ b/.github/scripts/build-macos-app.sh
@@ -33,13 +33,29 @@ build_netstack() {
 # old extension binary running. Commit count is monotonic across
 # rebuilds; sysextd accepts the higher number and swaps the ext.
 bump_build_number() {
-  local n
-  n=$(git rev-list --count HEAD 2>/dev/null || echo 1)
-  /usr/bin/plutil -replace CFBundleVersion -string "$n" \
+  # CFBundleShortVersionString = release tag (`v0.1.2` → `0.1.2`).
+  # CFBundleVersion bumps too. sysextd treats the (short, build) tuple
+  # as the ext identity — same tuple = no-op activation, leaves the
+  # running ext in place. Bumping short to the release tag forces
+  # sysextd to swap on next `Clawpatrol install`.
+  #
+  # Local dev builds (no RELEASE_TAG) fall back to a timestamp so
+  # iterating builds also rotates the version.
+  local v
+  if [ -n "${RELEASE_TAG:-}" ]; then
+    v="${RELEASE_TAG#v}"
+  else
+    v="0.0.$(date +%s)"
+  fi
+  /usr/bin/plutil -replace CFBundleShortVersionString -string "$v" \
     macos/Clawpatrol/Info.plist
-  /usr/bin/plutil -replace CFBundleVersion -string "$n" \
+  /usr/bin/plutil -replace CFBundleShortVersionString -string "$v" \
     macos/ClawpatrolExtension/Info.plist
-  echo "==> CFBundleVersion = $n"
+  /usr/bin/plutil -replace CFBundleVersion -string "$v" \
+    macos/Clawpatrol/Info.plist
+  /usr/bin/plutil -replace CFBundleVersion -string "$v" \
+    macos/ClawpatrolExtension/Info.plist
+  echo "==> CFBundleShortVersionString = CFBundleVersion = $v"
 }
 
 # If no Apple ID, build unsigned (local dev / PR checks).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         with: { go-version: "1.23" }
       - name: build + sign + notarize Clawpatrol.app
         env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}


### PR DESCRIPTION
Last release stamped CFBundleVersion=1 because CI's shallow checkout
made `git rev-list --count HEAD` return 1 instead of the commit count
— sysextd saw the same version and skipped the ext swap.

Use the release tag instead (v0.1.2 → 0.1.2). Tag changes per release
so sysextd treats every published build as strictly newer.

- build-macos-app.sh: writes both CFBundleShortVersionString and
  CFBundleVersion = ${RELEASE_TAG#v}. Local dev builds (no env var)
  fall back to 0.0.$(date +%s) so iterating still rotates.
- release.yml: passes RELEASE_TAG through from
  github.event.inputs.tag (workflow_dispatch) / github.ref_name
  (push:tag).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
