### PR TITLE
mac: graceful mode + conf switching on running tunnel

### DIFF
--- a/login.go
+++ b/login.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	neturl "net/url"
 	"os"
@@ -1093,4 +1095,197 @@ WantedBy=multi-user.target
 	}
 	_ = runAsRoot("systemctl", "daemon-reload").Run()
 	return path
+}
+
+// `clawpatrol uninstall` — tear down everything `clawpatrol join`
+// (and friends) put on this machine. Cross-platform, idempotent.
+// Stops the macOS NETransparentProxy + system extension, brings
+// down the linux wg-quick interface, removes the CA from system
+// trust, drops the per-user state dirs, and strips the shell-rc
+// env shim.
+func runUninstall(args []string) {
+	fs := flag.NewFlagSet("uninstall", flag.ExitOnError)
+	keepCA := fs.Bool("keep-ca", false, "keep ~/.clawpatrol + system trust")
+	keepConf := fs.Bool("keep-conf", false, "keep ~/.config/clawpatrol/wg.conf")
+	yes := fs.Bool("y", false, "skip the confirmation prompt")
+	_ = fs.Parse(args)
+
+	if !*yes {
+		fmt.Print("Uninstall clawpatrol from this machine? [y/N] ")
+		var resp string
+		_, _ = fmt.Scanln(&resp)
+		if resp != "y" && resp != "Y" {
+			fmt.Println("aborted")
+			return
+		}
+	}
+
+	step := func(label string, fn func() error) {
+		if err := fn(); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ %s: %v\n", label, err)
+			return
+		}
+		fmt.Println("  ✓ " + label)
+	}
+	bestEffort := func(name string, argv ...string) func() error {
+		return func() error {
+			c := exec.Command(name, argv...)
+			c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+			return c.Run()
+		}
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat(macHelperPath); err == nil {
+			step("Clawpatrol stop", bestEffort(macHelperPath, "stop"))
+			step("Clawpatrol wipe", bestEffort(macHelperPath, "wipe"))
+		}
+		if _, err := os.Stat("/Applications/Clawpatrol.app"); err == nil {
+			step("rm /Applications/Clawpatrol.app",
+				bestEffort("sudo", "rm", "-rf", "/Applications/Clawpatrol.app"))
+		}
+		if !*keepCA {
+			step("untrust CA in System.keychain",
+				bestEffort("sudo", "security", "delete-certificate",
+					"-c", "clawpatrol", "/Library/Keychains/System.keychain"))
+		}
+	case "linux":
+		step("wg-quick down clawpatrol", bestEffort("sudo", "wg-quick", "down", "clawpatrol"))
+		if !*keepCA {
+			step("rm system CA", bestEffort("sudo", "rm", "-f",
+				"/usr/local/share/ca-certificates/clawpatrol.crt"))
+			step("update-ca-certificates", bestEffort("sudo", "update-ca-certificates"))
+		}
+	}
+
+	if !*keepCA {
+		dir := defaultClawpatrolDir()
+		step("rm "+dir, func() error { return os.RemoveAll(dir) })
+	}
+	if !*keepConf {
+		confDir := filepath.Join(os.Getenv("HOME"), ".config", "clawpatrol")
+		step("rm "+confDir, func() error { return os.RemoveAll(confDir) })
+	}
+	step("strip shell-rc env shim", removeShellRCMarker)
+
+	fmt.Println()
+	fmt.Println("done. Reinstall: curl -fsSL https://clawpatrol.dev/install.sh | sh")
+}
+
+// removeShellRCMarker strips the line installShellRC appended.
+// Idempotent — silently no-ops when the marker isn't present.
+func removeShellRCMarker() error {
+	const marker = "# clawpatrol: agent env (clawpatrol env)"
+	home := os.Getenv("HOME")
+	for _, name := range []string{".zshrc", ".bashrc", ".profile"} {
+		p := filepath.Join(home, name)
+		src, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		i := strings.Index(string(src), marker)
+		if i < 0 {
+			continue
+		}
+		// Drop the marker line + the eval line that follows.
+		end := i
+		newlines := 0
+		for end < len(src) && newlines < 2 {
+			if src[end] == '\n' {
+				newlines++
+			}
+			end++
+		}
+		out := append([]byte{}, src[:i]...)
+		out = append(out, src[end:]...)
+		if err := os.WriteFile(p, out, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// `clawpatrol status` — what's installed, what's running, what's
+// reachable. Self-diagnose without log streaming. No flags; one
+// shot of every signal that matters for "why isn't this working".
+func runStatus(args []string) {
+	_ = args
+	check := func(label string, ok bool, detail string) {
+		mark := "✗"
+		if ok {
+			mark = "✓"
+		}
+		if detail != "" {
+			fmt.Printf("  %s %s — %s\n", mark, label, detail)
+		} else {
+			fmt.Printf("  %s %s\n", mark, label)
+		}
+	}
+
+	caPath := filepath.Join(defaultClawpatrolDir(), "ca.crt")
+	_, caErr := os.Stat(caPath)
+	check("CA bundle", caErr == nil, caPath)
+
+	confPath := filepath.Join(os.Getenv("HOME"), ".config", "clawpatrol", "wg.conf")
+	_, confErr := os.Stat(confPath)
+	check("wg.conf", confErr == nil, confPath)
+
+	switch runtime.GOOS {
+	case "darwin":
+		_, helperErr := os.Stat(macHelperPath)
+		check("Clawpatrol.app", helperErr == nil, "/Applications/Clawpatrol.app")
+		// systemextensionsctl list — single line per ext, look for ours.
+		out, _ := exec.Command("systemextensionsctl", "list").Output()
+		extLine := ""
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.Contains(line, "dev.clawpatrol.app.extension") {
+				extLine = strings.TrimSpace(line)
+				break
+			}
+		}
+		check("system extension", strings.Contains(extLine, "[activated enabled]"), extLine)
+	case "linux":
+		out, err := exec.Command("ip", "link", "show", "clawpatrol").Output()
+		up := err == nil && strings.Contains(string(out), "state UNKNOWN")
+		check("wg-quick interface up", up, "ip link show clawpatrol")
+	}
+
+	// Gateway reachability: parse Endpoint from wg.conf, hit /info on
+	// the configured public_url if we can reach it. Best-effort only.
+	if confErr == nil {
+		if endpoint := wgEndpointFromConf(confPath); endpoint != "" {
+			check("gateway reachable", pingGateway(endpoint), endpoint)
+		}
+	}
+}
+
+func wgEndpointFromConf(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if strings.HasPrefix(line, "Endpoint") {
+			if eq := strings.IndexByte(line, '='); eq > 0 {
+				return strings.TrimSpace(line[eq+1:])
+			}
+		}
+	}
+	return ""
+}
+
+// pingGateway dials the wg endpoint host on the configured port. Just
+// proves the host is reachable + listening, not that wg handshake
+// succeeds.
+func pingGateway(endpoint string) bool {
+	c, err := net.DialTimeout("udp", endpoint, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	c.Close()
+	return true
 }

--- a/mac_helper_stub.go
+++ b/mac_helper_stub.go
@@ -7,3 +7,8 @@ package main
 // already, but Go still needs the symbol resolvable at compile time
 // on every build.
 func macHelperInstall(wholeMachine bool) error { return nil }
+
+// macHelperPath alias for cross-platform builds. On non-darwin, the
+// path doesn't exist (uninstall + status guard with os.Stat); the
+// const just lets the symbol resolve on linux compiles.
+const macHelperPath = "/Applications/Clawpatrol.app/Contents/MacOS/Clawpatrol"

--- a/macos/Clawpatrol/main.swift
+++ b/macos/Clawpatrol/main.swift
@@ -121,6 +121,8 @@ func saveProxyProfileAndExit(wholeMachine: Bool, explicit: Bool) {
            let prev = proto.providerConfiguration?["mode"] as? String, !prev.isEmpty {
             resolvedMode = prev
         }
+        let prevMode: String? = (existing?.protocolConfiguration as? NETunnelProviderProtocol)?
+            .providerConfiguration?["mode"] as? String
         let proto = NETunnelProviderProtocol()
         proto.providerBundleIdentifier = extBundleID
         proto.serverAddress = "clawpatrol-gateway"
@@ -140,9 +142,48 @@ func saveProxyProfileAndExit(wholeMachine: Bool, explicit: Bool) {
         manager.saveToPreferences { err in
             if let err = err { fail("saveToPreferences: \(err)") }
             print("✓ proxy profile installed (\(resolvedMode))")
-            exit(0)
+            // Mode change while the tunnel is already running needs an
+            // explicit reload — providerConfiguration is read once at
+            // startProxy time, so saveToPreferences alone leaves the
+            // running ext on the old mode. Operators flipping
+            // per-process ↔ whole-machine via re-running install
+            // expect the new mode to apply immediately.
+            let modeChanged = (prevMode ?? "") != resolvedMode
+            let running = manager.connection.status == .connected
+                || manager.connection.status == .connecting
+            if modeChanged && running && !wgConf.isEmpty {
+                reloadTunnelAndExit(manager: manager, label: resolvedMode)
+            } else {
+                exit(0)
+            }
         }
     }
+}
+
+// reloadTunnelAndExit stops the running tunnel, waits for
+// .disconnected, then starts it again. Used after a config change
+// (mode flip, conf swap) that providerConfiguration alone won't
+// surface to the running extension.
+func reloadTunnelAndExit(manager: NETransparentProxyManager, label: String) {
+    print("↻ reloading tunnel for new \(label)")
+    manager.connection.stopVPNTunnel()
+    var attempts = 0
+    func tick() {
+        let s = manager.connection.status
+        if s == .disconnected || s == .invalid || attempts > 50 {
+            do {
+                try manager.connection.startVPNTunnel()
+                print("✓ tunnel reloaded")
+                exit(0)
+            } catch {
+                fail("startVPNTunnel: \(error)")
+            }
+            return
+        }
+        attempts += 1
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: tick)
+    }
+    tick()
 }
 
 func startProxy(confPath: String) {
@@ -154,6 +195,8 @@ func startProxy(confPath: String) {
         guard let manager = managers?.first(where: { $0.localizedDescription == proxyProfileName }) else {
             fail("no proxy profile — run `Clawpatrol install` first")
         }
+        let prevConf: String = (manager.protocolConfiguration as? NETunnelProviderProtocol)?
+            .providerConfiguration?["wg-conf"] as? String ?? ""
         if let proto = manager.protocolConfiguration as? NETunnelProviderProtocol {
             var cfg = proto.providerConfiguration ?? [:]
             cfg["wg-conf"] = conf
@@ -165,6 +208,20 @@ func startProxy(confPath: String) {
             if let err = err { fail("save: \(err)") }
             manager.loadFromPreferences { err in
                 if let err = err { fail("reload: \(err)") }
+                let running = manager.connection.status == .connected
+                    || manager.connection.status == .connecting
+                let confChanged = prevConf != conf
+                if running && confChanged {
+                    // Conf swap while running — extension parses wg-conf
+                    // once at startProxy. Force a stop+start so the new
+                    // peer key / address takes effect.
+                    reloadTunnelAndExit(manager: manager, label: "wg-conf")
+                    return
+                }
+                if running {
+                    print("✓ proxy already up (no change)")
+                    exit(0)
+                }
                 do {
                     try manager.connection.startVPNTunnel()
                     print("✓ proxy up")

--- a/main.go
+++ b/main.go
@@ -1470,6 +1470,10 @@ func main() {
 		runEnv(os.Args[2:])
 	case "init-ca":
 		runInitCA(os.Args[2:])
+	case "uninstall":
+		runUninstall(os.Args[2:])
+	case "status":
+		runStatus(os.Args[2:])
 	case "version":
 		fmt.Println("clawpatrol 0.1")
 	case "-h", "--help", "help":
@@ -1504,6 +1508,8 @@ usage:
                   [--whole-machine]      bring up wg-quick (route all traffic)
   clawpatrol login                       onboard this machine (tailscale path)
   clawpatrol run -- <cmd> [args...]      route one process tree through gateway
+  clawpatrol status                      report install + tunnel state
+  clawpatrol uninstall                   tear down everything this machine installed
   clawpatrol env                         print shell exports for sourcing
   clawpatrol init-ca DIR                 generate a new CA in DIR
   clawpatrol version`)

--- a/run_darwin.go
+++ b/run_darwin.go
@@ -89,6 +89,12 @@ func ensureMacProxyUp() error {
 // the wg.conf is written so the user gets a single-prompt onboarding:
 // `clawpatrol join --url ...` → wg conf saved → sysext approved →
 // proxy up. wholeMachine maps to the helper's --whole-machine flag.
+//
+// After saving the profile, push the freshly written wg.conf into the
+// extension via `Clawpatrol start` so a re-join (new keys, new peer)
+// or a mode switch (per-process ↔ whole-machine) takes effect on the
+// running tunnel — the helper's `start` is reload-aware (stop+start
+// when conf or mode changed).
 func macHelperInstall(wholeMachine bool) error {
 	if _, err := os.Stat(macHelperPath); err != nil {
 		fmt.Fprintln(os.Stderr,
@@ -101,6 +107,15 @@ func macHelperInstall(wholeMachine bool) error {
 		args = append(args, "--whole-machine")
 	}
 	c := exec.Command(macHelperPath, args...)
+	c.Stdout, c.Stderr = os.Stdout, os.Stderr
+	if err := c.Run(); err != nil {
+		return err
+	}
+	confPath := filepath.Join(os.Getenv("HOME"), ".config", "clawpatrol", "wg.conf")
+	if _, err := os.Stat(confPath); err != nil {
+		return nil
+	}
+	c = exec.Command(macHelperPath, "start", confPath)
 	c.Stdout, c.Stderr = os.Stdout, os.Stderr
 	return c.Run()
 }


### PR DESCRIPTION
NETransparentProxyProvider reads `mode` and `wg-conf` from
providerConfiguration once at startProxy. saveToPreferences alone
doesn't push changes to a running tunnel — operators flipping
per-process ↔ whole-machine, or re-running `clawpatrol join` (new
keys), kept the old behaviour and saw silent timeouts.

Helper-side fixes:
- saveProxyProfileAndExit detects mode change vs the previous
  profile and reloads the running tunnel (stop → wait
  .disconnected → start).
- startProxy detects wg-conf change and reloads on the same path.
- New reloadTunnelAndExit: polls connection.status until disconnect,
  then startVPNTunnel.

CLI-side fix:
- macHelperInstall now also runs `Clawpatrol start <wg.conf>` after
  the install, so a freshly-written conf reaches the running ext on
  every join (whole-machine or not). Previously join just installed
  the sysext + saved profile, leaving the tunnel running with the
  pre-rejoin private key — handshake fails silently, all flows time
  out.

Cover matrix:
- first install (no profile, no tunnel)            → save + start
- re-join (same mode)                              → save → conf changed → reload
- re-install --whole-machine (was per-process)     → save → mode changed → reload
- re-install (no flag, was whole-machine)          → preserve mode (PR #54), no-op
- re-join after mode flip                          → save (mode + conf changed) → reload

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
