### PR TITLE
netstack & mac socketpair perf

### DIFF
--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -71,24 +71,30 @@ type netTun struct {
 type epNotify struct{ dev *netTun }
 
 func (n *epNotify) WriteNotify() {
-	pkt := n.dev.ep.Read()
-	if pkt == nil {
-		return
-	}
-	v := pkt.ToView()
-	pkt.DecRef()
-	b := v.AsSlice()
-	cp := make([]byte, len(b))
-	copy(cp, b)
-	select {
-	case n.dev.incomingPacket <- cp:
-	default:
+	for {
+		pkt := n.dev.ep.Read()
+		if pkt == nil {
+			return
+		}
+		v := pkt.ToView()
+		pkt.DecRef()
+		b := v.AsSlice()
+		cp := make([]byte, len(b))
+		copy(cp, b)
+		select {
+		case n.dev.incomingPacket <- cp:
+		default:
+		}
 	}
 }
 
+// netstackQueueSize matches the gateway side. 1024 was tight under
+// whole-machine bursts; 16384 absorbs realistic spikes.
+const netstackQueueSize = 16384
+
 func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	t := &netTun{
-		ep: channel.New(1024, uint32(mtu), ""),
+		ep: channel.New(netstackQueueSize, uint32(mtu), ""),
 		stack: stack.New(stack.Options{
 			NetworkProtocols: []stack.NetworkProtocolFactory{
 				ipv4.NewProtocol, ipv6.NewProtocol,
@@ -100,7 +106,7 @@ func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 			HandleLocal: false,
 		}),
 		events:         make(chan wgtun.Event, 10),
-		incomingPacket: make(chan []byte, 1024),
+		incomingPacket: make(chan []byte, netstackQueueSize),
 		mtu:            mtu,
 	}
 	t.ep.AddNotify(&epNotify{dev: t})
@@ -133,16 +139,30 @@ func (t *netTun) File() *os.File             { return nil }
 func (t *netTun) Name() (string, error)      { return "clawpatrol-wg", nil }
 func (t *netTun) MTU() (int, error)          { return t.mtu, nil }
 func (t *netTun) Events() <-chan wgtun.Event { return t.events }
-func (t *netTun) BatchSize() int             { return 1 }
+func (t *netTun) BatchSize() int             { return tunBatchSize }
+
+const tunBatchSize = 128
 
 func (t *netTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
 	pkt, ok := <-t.incomingPacket
 	if !ok {
 		return 0, os.ErrClosed
 	}
-	n := copy(bufs[0][offset:], pkt)
-	sizes[0] = n
-	return 1, nil
+	sizes[0] = copy(bufs[0][offset:], pkt)
+	count := 1
+	for count < len(bufs) {
+		select {
+		case more, ok := <-t.incomingPacket:
+			if !ok {
+				return count, os.ErrClosed
+			}
+			sizes[count] = copy(bufs[count][offset:], more)
+			count++
+		default:
+			return count, nil
+		}
+	}
+	return count, nil
 }
 
 func (t *netTun) Write(bufs [][]byte, offset int) (int, error) {
@@ -468,12 +488,25 @@ func wg_netstack_dial_udp(hostC *C.char, port C.int, errBuf *C.char, errLen C.in
 // callers run datagrams over a stream pair (good enough — extension
 // only sends complete datagrams at a time). Both ends close on
 // pump exit.
+//
+// Both ends get bumped SO_SNDBUF/SO_RCVBUF. macOS default for AF_UNIX
+// SOCK_STREAM is ~8KB which under whole-machine concurrency starved
+// the bridge — many flows hammered `write(fd, ...)`, the 8KB buffer
+// filled instantly, the GCD thread blocked, gateway-side TLS peek
+// timed out at 10s waiting for the ClientHello bytes that were stuck
+// in macOS kernel waiting for the buffer to drain. 1MB per direction
+// gives concurrent flows enough headroom to keep flowing.
 func spliceFD(gconn io.ReadWriteCloser) C.int {
 	pair, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
 		return -1
 	}
 	swiftFD, goFD := pair[0], pair[1]
+	const bufSize = 1 << 20 // 1 MiB
+	for _, fd := range pair {
+		_ = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF, bufSize)
+		_ = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, bufSize)
+	}
 	goFile := os.NewFile(uintptr(goFD), "wgsplice")
 	if goFile == nil {
 		syscall.Close(swiftFD)

--- a/wireguard.go
+++ b/wireguard.go
@@ -64,9 +64,18 @@ type netTun struct {
 	closed         bool
 }
 
+// netstackQueueSize is per-direction packet capacity for the gVisor
+// channel.Endpoint and the inbound buffer. 1024 packets (~1.5MB at
+// MTU 1500) was tight under whole-machine bursts — a single browser
+// page-load + system-service chatter overflowed the queue, packets
+// dropped silently, wg-go retransmitted, throughput tanked.
+// 16384 ≈ 24MB max which absorbs realistic bursts without ballooning
+// resident memory.
+const netstackQueueSize = 16384
+
 func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	dev := &netTun{
-		ep: channel.New(1024, uint32(mtu), ""),
+		ep: channel.New(netstackQueueSize, uint32(mtu), ""),
 		stack: stack.New(stack.Options{
 			NetworkProtocols: []stack.NetworkProtocolFactory{
 				ipv4.NewProtocol, ipv6.NewProtocol,
@@ -78,7 +87,7 @@ func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 			HandleLocal: false,
 		}),
 		events:         make(chan wgtun.Event, 10),
-		incomingPacket: make(chan []byte, 1024),
+		incomingPacket: make(chan []byte, netstackQueueSize),
 		mtu:            mtu,
 	}
 	dev.ep.AddNotify(&epNotify{dev: dev})
@@ -110,19 +119,24 @@ func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 type epNotify struct{ dev *netTun }
 
 func (n *epNotify) WriteNotify() {
-	pkt := n.dev.ep.Read()
-	if pkt == nil {
-		return
-	}
-	view := pkt.ToView()
-	pkt.DecRef()
-	b := view.AsSlice()
-	cp := make([]byte, len(b))
-	copy(cp, b)
-	select {
-	case n.dev.incomingPacket <- cp:
-	default:
-		// drop on full queue; wireguard-go will keep up under normal load
+	// Drain every available packet — channel.Endpoint may queue
+	// multiple writes between notifications, especially under burst.
+	for {
+		pkt := n.dev.ep.Read()
+		if pkt == nil {
+			return
+		}
+		view := pkt.ToView()
+		pkt.DecRef()
+		b := view.AsSlice()
+		cp := make([]byte, len(b))
+		copy(cp, b)
+		select {
+		case n.dev.incomingPacket <- cp:
+		default:
+			// dropped — incomingPacket is sized to absorb bursts; if it
+			// still overflows wg-go's reader is bottlenecked.
+		}
 	}
 }
 
@@ -130,16 +144,38 @@ func (t *netTun) File() *os.File             { return nil }
 func (t *netTun) Name() (string, error)      { return "clawpatrol-wg", nil }
 func (t *netTun) MTU() (int, error)          { return t.mtu, nil }
 func (t *netTun) Events() <-chan wgtun.Event { return t.events }
-func (t *netTun) BatchSize() int             { return 1 }
+func (t *netTun) BatchSize() int             { return tunBatchSize }
+
+// tunBatchSize lets wg-go pull up to N packets per Read syscall.
+// Each packet otherwise costs one channel recv + one Read trip
+// through wg-go's encryption pipeline. Batching amortizes the per-
+// packet overhead under burst traffic. 128 is what wireguard-go's
+// own kernel-tun adapter targets.
+const tunBatchSize = 128
 
 func (t *netTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
 	pkt, ok := <-t.incomingPacket
 	if !ok {
 		return 0, os.ErrClosed
 	}
-	n := copy(bufs[0][offset:], pkt)
-	sizes[0] = n
-	return 1, nil
+	sizes[0] = copy(bufs[0][offset:], pkt)
+	count := 1
+	// Drain any pending packets without blocking — the next Read call
+	// will block again when the channel drains, but we let wg-go
+	// process burst inflows in one trip.
+	for count < len(bufs) {
+		select {
+		case more, ok := <-t.incomingPacket:
+			if !ok {
+				return count, os.ErrClosed
+			}
+			sizes[count] = copy(bufs[count][offset:], more)
+			count++
+		default:
+			return count, nil
+		}
+	}
+	return count, nil
 }
 
 func (t *netTun) Write(bufs [][]byte, offset int) (int, error) {
@@ -333,7 +369,13 @@ func (s *WGServer) EnablePromiscuousForwarder(handler func(c net.Conn, dstIP str
 	if err := st.SetSpoofing(1, true); err != nil {
 		return fmt.Errorf("set spoofing: %v", err)
 	}
-	fwd := tcp.NewForwarder(st, 0, 1024, func(req *tcp.ForwarderRequest) {
+	// 16384 in-flight SYNs covers many peers × many concurrent flows.
+	// Default 1024 throttled multi-tenant whole-machine traffic:
+	// browsers + system services + agent CLIs combined easily exceed
+	// the cap, after which new SYNs sit queued at the netstack until
+	// older requests Complete. tcp.NewForwarder allocates lazily, so
+	// the higher bound only costs memory under actual load.
+	fwd := tcp.NewForwarder(st, 0, 16384, func(req *tcp.ForwarderRequest) {
 		id := req.ID()
 		var wq waiter.Queue
 		ep, err := req.CreateEndpoint(&wq)


### PR DESCRIPTION
Whole-machine clients hammer the gateway (browsers + system services
+ agent CLIs combined). The gVisor netstack on both sides was
configured for light load and dropped packets / throttled SYNs under
realistic burst → wg-go retransmits → user sees "slow internet".

Three fixes, both gateway (wireguard.go) and macOS extension
(macos/netstack/wgnetstack.go):

- channel.Endpoint queue + incomingPacket buffer: 1024 → 16384.
  ~24MB max @ MTU 1500. Absorbs realistic bursts without ballooning.

- WriteNotify: drain in a loop instead of one packet per callback.
  channel.Endpoint queues writes between notifications, especially
  under burst — single-read missed packets that were already enqueued.

- BatchSize: 1 → 128. wg-go now reads up to 128 packets per Read,
  amortizing the per-packet channel + cgo overhead. netTun.Read
  drains pending packets non-blockingly when bufs has room.

Plus gateway-side:
- tcp.NewForwarder maxInFlight 1024 → 16384. Default cap throttled
  multi-tenant traffic where browsers + sysservices + CLIs combined
  easily exceeded 1024 simultaneous SYNs. Forwarder allocates lazily
  so the higher bound costs memory only under actual load.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
