### PR TITLE
mac ext: skip self in ancestorMatches PPID walk

### DIFF
--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -382,7 +382,14 @@ private func ancestorMatches(pid: pid_t) -> Bool {
     }
     ancestorCacheLock.unlock()
 
-    var cur = pid
+    // Start at the parent — the process itself is never "its own
+    // ancestor". Without this, any process whose binary is named
+    // "clawpatrol" (including the gateway) would match on the first
+    // iteration and have its outbound flows tunneled back into itself.
+    guard let first = parentPid(of: pid), first != pid else {
+        return false
+    }
+    var cur = first
     var visited = Set<pid_t>()
     var matches = false
     while cur > 1 && !visited.contains(cur) {


### PR DESCRIPTION
## Summary
- Fix infinite loop when gateway runs on same machine as the NE: the gateway binary is named "clawpatrol", so `ancestorMatches` matched on the first iteration (the process itself) and tunneled splice connections back into the gateway.
- Start the PPID walk at the parent so only actual descendants get tunneled.

## Test plan
- [x] `clawpatrol run curl https://tinyclouds.org` completes (passthrough splice)
- [x] `clawpatrol run curl -4 https://tinyclouds.org` completes
- [ ] Verify managed endpoints (e.g. api.anthropic.com) still tunnel correctly