### PR TITLE
Add ClickHouse native protocol gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ macos/build/
 macos/netstack/libwgnetstack.a
 macos/netstack/libwgnetstack.h
 *.swp
+
+# Gas Town (added by gt)
+.runtime/
+.claude/
+.logs/
+__pycache__/
+state.json
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,11 +22,3 @@ macos/build/
 macos/netstack/libwgnetstack.a
 macos/netstack/libwgnetstack.h
 *.swp
-
-# Gas Town (added by gt)
-.runtime/
-.claude/
-.logs/
-__pycache__/
-state.json
-CLAUDE.md

--- a/ca.go
+++ b/ca.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -69,7 +70,11 @@ func (c *CertCache) mint(host string) (*tls.Certificate, error) {
 		NotAfter:     time.Now().Add(30 * 24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{host},
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{host}
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, c.caCert, &leafKey.PublicKey, c.caKey)
 	if err != nil {

--- a/config/plugins/credentials/clickhouse.go
+++ b/config/plugins/credentials/clickhouse.go
@@ -33,12 +33,20 @@ func (c *ClickhouseCredential) InjectHTTP(_ context.Context, req *http.Request, 
 	return nil
 }
 
+// ClickhouseAuth implements runtime.ClickhouseAuthCredential — the
+// clickhouse_native endpoint runtime calls this once per session to
+// learn what (user, password) to substitute into the Hello packet.
+func (c *ClickhouseCredential) ClickhouseAuth(sec runtime.Secret) (string, string) {
+	return c.User, string(sec.Bytes)
+}
+
 func (*ClickhouseCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "ClickHouse password"}}
 }
 
 func init() {
 	var _ runtime.HTTPCredentialRuntime = (*ClickhouseCredential)(nil)
+	var _ runtime.ClickhouseAuthCredential = (*ClickhouseCredential)(nil)
 	config.Register(&config.Plugin{
 		Kind:    config.KindCredential,
 		Type:    "clickhouse_credential",

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -85,6 +85,9 @@ func (e *ClickhouseNativeEndpoint) port() int {
 	if e.Port > 0 {
 		return e.Port
 	}
+	if e.TLS {
+		return 9440
+	}
 	return 9000
 }
 

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -1,17 +1,45 @@
 package endpoints
 
 // clickhouse_native endpoint: ClickHouse's binary native protocol
-// (default port 9000). Pairs with clickhouse_https for the same
-// upstream cluster.
+// (default port 9000 plaintext / 9440 TLS). Pairs with
+// clickhouse_https for the same upstream cluster.
+//
+// Iter 1 scope: parse the Hello packet, swap placeholder bytes in
+// the agent-supplied (username, password) for the credential's real
+// values, emit one connection event, then transparent bidirectional
+// pipe. SQL parsing lands in a follow-up iteration.
 
 import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// ClickhouseNativeEndpoint addresses one ClickHouse server reachable
+// via the binary native protocol. Operators bind a single
+// clickhouse_credential; the runtime parses the agent's Hello and
+// substitutes the credential's (user, password) where the agent
+// embedded a placeholder.
+//
+// TLS toggles upstream TLS-wrapping. The native protocol is
+// persistent (no inner TLS negotiation), so this is a one-time
+// decision per endpoint. Default false: WG already encrypts
+// agent→gateway and most self-hosted ClickHouse on a private network
+// runs plaintext on 9000. Operators using cloud ClickHouse on 9440
+// flip TLS=true and set Port=9440.
 type ClickhouseNativeEndpoint struct {
 	Hosts      []string `hcl:"hosts"`
+	Port       int      `hcl:"port,optional"`
+	TLS        bool     `hcl:"tls,optional"`
 	Credential string   `hcl:"credential,optional"`
 }
 
@@ -20,20 +48,277 @@ func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
 	return singleBinding(e.Credential)
 }
 
+// ConnRouteHosts implements runtime.ConnRouter — clickhouse native
+// arrives at the WG forwarder as raw conns (no SNI), so the gateway
+// indexes the upstream host:port → endpoint at policy-load time.
+func (e *ClickhouseNativeEndpoint) ConnRouteHosts() []string {
+	port := e.port()
+	out := make([]string, 0, len(e.Hosts))
+	for _, h := range e.Hosts {
+		out = append(out, fmt.Sprintf("%s:%d", h, port))
+	}
+	return out
+}
+
+func (e *ClickhouseNativeEndpoint) port() int {
+	if e.Port > 0 {
+		return e.Port
+	}
+	return 9000
+}
+
+// ClickhouseNativeEndpointRuntime is the per-connection handler.
+// Stateless — all per-session state lives on ConnHandle.
+type ClickhouseNativeEndpointRuntime struct{}
+
 func init() {
+	var _ runtime.ConnEndpointRuntime = ClickhouseNativeEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "clickhouse_native",
-		Family: "sql",
-		New:    func() any { return &ClickhouseNativeEndpoint{} },
-		Refs:   singularRef,
-		Build:  passthroughBuild,
+		Kind:    config.KindEndpoint,
+		Type:    "clickhouse_native",
+		Family:  "sql",
+		New:     func() any { return &ClickhouseNativeEndpoint{} },
+		Refs:    singularRef,
+		Runtime: ClickhouseNativeEndpointRuntime{},
+		Build:   passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseNativeEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
+			if e.Port > 0 {
+				b.SetAttributeValue("port", cty.NumberIntVal(int64(e.Port)))
+			}
+			if e.TLS {
+				b.SetAttributeValue("tls", cty.BoolVal(true))
+			}
 			if e.Credential != "" {
 				config.SetIdent(b, "credential", e.Credential)
 			}
 		},
 	})
 }
+
+// HandleConn services one inbound native-protocol connection.
+//
+// Flow:
+//
+//  1. Read the agent's first packet, parse Hello.
+//  2. Resolve the bound credential, fetch its secret. Swap any
+//     placeholder substring inside Hello.username / Hello.password.
+//  3. Dial upstream (TLS or plain), send the (possibly modified) Hello.
+//  4. Emit one ConnEvent describing the session.
+//  5. Bidirectional pipe until either side closes.
+//
+// Errors before the upstream dial close the agent's conn silently —
+// the native protocol has no Error packet at the pre-handshake stage
+// that we could send back without first observing the server-side
+// reply.
+func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
+	defer ch.Conn.Close()
+	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
+		return fmt.Errorf("clickhouse_native runtime invoked on non-sql endpoint %v", ch.Endpoint)
+	}
+	chEp, ok := ch.Endpoint.Body.(*ClickhouseNativeEndpoint)
+	if !ok {
+		return fmt.Errorf("clickhouse_native runtime invoked on non-native endpoint %v", ch.Endpoint)
+	}
+	upstreamAddr := chNativeUpstreamAddr(ch.Endpoint, chEp)
+	if upstreamAddr == "" {
+		return fmt.Errorf("clickhouse_native endpoint %q has no host", ch.Endpoint.Name)
+	}
+
+	// Step 1: read agent's Hello. ClickHouse's native protocol begins
+	// with a single client Hello packet (type 0). We accumulate bytes
+	// until parseHello succeeds — typical Hellos fit in one read but
+	// large client_name strings can span multiple TCP segments.
+	hello, leftover, err := chReadHello(ch.Conn)
+	if err != nil {
+		return fmt.Errorf("read hello: %w", err)
+	}
+
+	// Step 2: resolve credential and inject. Single-credential native
+	// endpoints today; multi-credential dispatch via placeholder lands
+	// when SQL parsing does in iter 2.
+	claimedUser := hello.Username
+	injected := false
+	if cc := chPickCredential(ch.Endpoint); cc != nil {
+		if auth, ok := cc.Credential.Body.(runtime.ClickhouseAuthCredential); ok {
+			sec, secErr := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
+			if secErr == nil {
+				realUser, realPassword := auth.ClickhouseAuth(sec)
+				before := hello.Username + "\x00" + hello.Password
+				if realUser != "" {
+					hello.Username = realUser
+				}
+				if realPassword != "" {
+					hello.Password = realPassword
+				}
+				if hello.Username+"\x00"+hello.Password != before {
+					injected = true
+				}
+			} else {
+				log.Printf("clickhouse_native %s: fetch secret %q: %v", ch.Endpoint.Name, cc.Credential.Symbol.Name, secErr)
+			}
+		}
+	}
+
+	// Step 3: dial upstream + send hello.
+	upstream, err := ch.DialUpstream(ctx, "tcp", upstreamAddr)
+	if err != nil {
+		return fmt.Errorf("dial upstream %s: %w", upstreamAddr, err)
+	}
+	defer upstream.Close()
+
+	if chEp.TLS {
+		host := upstreamAddr
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		tc := tls.Client(upstream, &tls.Config{ServerName: host})
+		if err := tc.Handshake(); err != nil {
+			return fmt.Errorf("upstream tls: %w", err)
+		}
+		upstream = tc
+	}
+
+	rewritten := chSerializeHello(hello)
+	if _, err := upstream.Write(rewritten); err != nil {
+		return fmt.Errorf("send hello: %w", err)
+	}
+	// Any bytes the agent sent past the Hello (rare — clients usually
+	// wait for ServerHello before pipelining) follow immediately.
+	if len(leftover) > 0 {
+		if _, err := upstream.Write(leftover); err != nil {
+			return fmt.Errorf("forward post-hello: %w", err)
+		}
+	}
+
+	// Step 4: emit the connection event. One event per TCP session —
+	// the native protocol is persistent, per-query parsing isn't here
+	// yet, so the connection itself is the unit of audit.
+	database := hello.Database
+	if database == "" {
+		database = "default"
+	}
+	host, port := chHostPort(upstreamAddr)
+	summary := fmt.Sprintf("%s@%s:%d/%s", hello.Username, host, port, database)
+	if injected {
+		summary += " (placeholder injected)"
+	}
+	if ch.Emit != nil {
+		ch.Emit(runtime.ConnEvent{
+			Action:  "allow",
+			Verb:    "connect",
+			Summary: summary,
+		})
+	}
+	log.Printf("clickhouse_native %s: connect user=%q claimed=%q db=%q client=%q rev=%d injected=%v",
+		ch.Endpoint.Name, hello.Username, claimedUser, database,
+		hello.ClientName, hello.ProtocolRevision, injected)
+
+	// Step 5: bidirectional pipe.
+	chPipe(ch.Conn, upstream)
+	return nil
+}
+
+// chPickCredential returns the (only) credential bound to the
+// endpoint, or nil. Multi-credential dispatch by placeholder will
+// move into the SQL-parsing iteration.
+func chPickCredential(ep *config.CompiledEndpoint) *config.CompiledCredential {
+	if ep == nil || len(ep.Credentials) == 0 {
+		return nil
+	}
+	return ep.Credentials[0]
+}
+
+func chNativeUpstreamAddr(ep *config.CompiledEndpoint, body *ClickhouseNativeEndpoint) string {
+	for _, h := range ep.Hosts {
+		if h == "" {
+			continue
+		}
+		// ep.Hosts entries already carry the port from ConnRouteHosts.
+		if _, _, err := net.SplitHostPort(h); err == nil {
+			return h
+		}
+		return fmt.Sprintf("%s:%d", h, body.port())
+	}
+	return ""
+}
+
+func chHostPort(addr string) (string, int) {
+	h, p, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr, 0
+	}
+	port := 0
+	for _, c := range p {
+		if c < '0' || c > '9' {
+			return h, 0
+		}
+		port = port*10 + int(c-'0')
+	}
+	return h, port
+}
+
+// chPipe shuttles bytes between agent and upstream, half-closing each
+// direction on EOF. Mirrors main.pipe but lives here so the plugin
+// stays self-contained.
+func chPipe(a, b net.Conn) {
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(b, a)
+		if cw, ok := b.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(a, b)
+		if cw, ok := a.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+}
+
+// chReadHello reads from r until enough bytes have arrived to fully
+// decode a client Hello. Returns the parsed packet and any leftover
+// bytes already pulled past the Hello (rare — clients usually wait
+// for ServerHello before sending more — but possible).
+//
+// ClickHouse's native protocol prefixes nothing about packet length:
+// the Hello is a sequence of VarUInt + length-prefixed strings.
+// ParseChHello is incremental — we attempt a parse on each read and
+// retry when errChShortBuffer surfaces.
+func chReadHello(r io.Reader) (ChHello, []byte, error) {
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 4096)
+	for {
+		n, readErr := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			h, consumed, err := chParseHello(buf)
+			if err == nil {
+				return h, buf[consumed:], nil
+			}
+			if err != errChShortBuffer {
+				return ChHello{}, nil, err
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF && len(buf) > 0 {
+				return ChHello{}, nil, fmt.Errorf("hello truncated after %d bytes", len(buf))
+			}
+			return ChHello{}, nil, readErr
+		}
+		if len(buf) > 1<<20 {
+			return ChHello{}, nil, fmt.Errorf("hello exceeded 1 MiB without parsing")
+		}
+	}
+}
+
+// chSerializeHello / chParseHello are thin wrappers over the protocol
+// helpers in clickhouse_native_protocol.go.
+func chSerializeHello(h ChHello) []byte             { return SerializeChHello(h) }
+func chParseHello(buf []byte) (ChHello, int, error) { return ParseChHello(buf) }

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -74,9 +74,12 @@ func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
 // to handleVIPConn → this plugin's HandleConn.
 func (e *ClickhouseNativeEndpoint) RequiresVIP() bool { return true }
 
-// ConnRouteHosts mirrors EndpointHosts so legacy ConnIndex consumers
-// that key off the ConnRouter interface stay wired even though VIP
-// dispatch is the active path for clickhouse_native.
+// ConnRouteHosts mirrors EndpointHosts so every host lands in the
+// gateway's conn-index. Hostname entries reach HandleConn through the
+// VIP path (RequiresVIP=true allocates a per-host VIP); IP-literal
+// entries are skipped by dnsvip — there's no DNS query to intercept —
+// and reach HandleConn through the WG forwarder's direct-IP dispatch,
+// which keys off this index.
 func (e *ClickhouseNativeEndpoint) ConnRouteHosts() []string {
 	return e.EndpointHosts()
 }

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -8,13 +8,12 @@ package endpoints
 // the agent-supplied (username, password) for the credential's real
 // values, emit one connection event, then transparent bidirectional
 // pipe. SQL parsing lands in a follow-up iteration.
+//
+// Schema and HCL plumbing live here. The per-connection runtime
+// (HandleConn, helpers, pipe) lives in clickhouse_native_runtime.go.
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
-	"io"
-	"log"
 	"net"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -51,10 +50,20 @@ func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
 // ConnRouteHosts implements runtime.ConnRouter — clickhouse native
 // arrives at the WG forwarder as raw conns (no SNI), so the gateway
 // indexes the upstream host:port → endpoint at policy-load time.
+//
+// Hosts may be supplied as bare hostnames or as host:port literals.
+// The bare form is normalized to host:e.port(); the host:port form
+// is preserved verbatim, so an operator binding a cluster on mixed
+// ports gets the literal each member declared rather than a
+// silently-double-suffixed `host:port:port`.
 func (e *ClickhouseNativeEndpoint) ConnRouteHosts() []string {
 	port := e.port()
 	out := make([]string, 0, len(e.Hosts))
 	for _, h := range e.Hosts {
+		if _, _, err := net.SplitHostPort(h); err == nil {
+			out = append(out, h)
+			continue
+		}
 		out = append(out, fmt.Sprintf("%s:%d", h, port))
 	}
 	return out
@@ -69,6 +78,7 @@ func (e *ClickhouseNativeEndpoint) port() int {
 
 // ClickhouseNativeEndpointRuntime is the per-connection handler.
 // Stateless — all per-session state lives on ConnHandle.
+// HandleConn is implemented in clickhouse_native_runtime.go.
 type ClickhouseNativeEndpointRuntime struct{}
 
 func init() {
@@ -96,229 +106,3 @@ func init() {
 		},
 	})
 }
-
-// HandleConn services one inbound native-protocol connection.
-//
-// Flow:
-//
-//  1. Read the agent's first packet, parse Hello.
-//  2. Resolve the bound credential, fetch its secret. Swap any
-//     placeholder substring inside Hello.username / Hello.password.
-//  3. Dial upstream (TLS or plain), send the (possibly modified) Hello.
-//  4. Emit one ConnEvent describing the session.
-//  5. Bidirectional pipe until either side closes.
-//
-// Errors before the upstream dial close the agent's conn silently —
-// the native protocol has no Error packet at the pre-handshake stage
-// that we could send back without first observing the server-side
-// reply.
-func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
-	defer ch.Conn.Close()
-	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
-		return fmt.Errorf("clickhouse_native runtime invoked on non-sql endpoint %v", ch.Endpoint)
-	}
-	chEp, ok := ch.Endpoint.Body.(*ClickhouseNativeEndpoint)
-	if !ok {
-		return fmt.Errorf("clickhouse_native runtime invoked on non-native endpoint %v", ch.Endpoint)
-	}
-	upstreamAddr := chNativeUpstreamAddr(ch.Endpoint, chEp)
-	if upstreamAddr == "" {
-		return fmt.Errorf("clickhouse_native endpoint %q has no host", ch.Endpoint.Name)
-	}
-
-	// Step 1: read agent's Hello. ClickHouse's native protocol begins
-	// with a single client Hello packet (type 0). We accumulate bytes
-	// until parseHello succeeds — typical Hellos fit in one read but
-	// large client_name strings can span multiple TCP segments.
-	hello, leftover, err := chReadHello(ch.Conn)
-	if err != nil {
-		return fmt.Errorf("read hello: %w", err)
-	}
-
-	// Step 2: resolve credential and inject. Single-credential native
-	// endpoints today; multi-credential dispatch via placeholder lands
-	// when SQL parsing does in iter 2.
-	claimedUser := hello.Username
-	injected := false
-	if cc := chPickCredential(ch.Endpoint); cc != nil {
-		if auth, ok := cc.Credential.Body.(runtime.ClickhouseAuthCredential); ok {
-			sec, secErr := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
-			if secErr == nil {
-				realUser, realPassword := auth.ClickhouseAuth(sec)
-				before := hello.Username + "\x00" + hello.Password
-				if realUser != "" {
-					hello.Username = realUser
-				}
-				if realPassword != "" {
-					hello.Password = realPassword
-				}
-				if hello.Username+"\x00"+hello.Password != before {
-					injected = true
-				}
-			} else {
-				log.Printf("clickhouse_native %s: fetch secret %q: %v", ch.Endpoint.Name, cc.Credential.Symbol.Name, secErr)
-			}
-		}
-	}
-
-	// Step 3: dial upstream + send hello.
-	upstream, err := ch.DialUpstream(ctx, "tcp", upstreamAddr)
-	if err != nil {
-		return fmt.Errorf("dial upstream %s: %w", upstreamAddr, err)
-	}
-	defer upstream.Close()
-
-	if chEp.TLS {
-		host := upstreamAddr
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		}
-		tc := tls.Client(upstream, &tls.Config{ServerName: host})
-		if err := tc.Handshake(); err != nil {
-			return fmt.Errorf("upstream tls: %w", err)
-		}
-		upstream = tc
-	}
-
-	rewritten := chSerializeHello(hello)
-	if _, err := upstream.Write(rewritten); err != nil {
-		return fmt.Errorf("send hello: %w", err)
-	}
-	// Any bytes the agent sent past the Hello (rare — clients usually
-	// wait for ServerHello before pipelining) follow immediately.
-	if len(leftover) > 0 {
-		if _, err := upstream.Write(leftover); err != nil {
-			return fmt.Errorf("forward post-hello: %w", err)
-		}
-	}
-
-	// Step 4: emit the connection event. One event per TCP session —
-	// the native protocol is persistent, per-query parsing isn't here
-	// yet, so the connection itself is the unit of audit.
-	database := hello.Database
-	if database == "" {
-		database = "default"
-	}
-	host, port := chHostPort(upstreamAddr)
-	summary := fmt.Sprintf("%s@%s:%d/%s", hello.Username, host, port, database)
-	if injected {
-		summary += " (placeholder injected)"
-	}
-	if ch.Emit != nil {
-		ch.Emit(runtime.ConnEvent{
-			Action:  "allow",
-			Verb:    "connect",
-			Summary: summary,
-		})
-	}
-	log.Printf("clickhouse_native %s: connect user=%q claimed=%q db=%q client=%q rev=%d injected=%v",
-		ch.Endpoint.Name, hello.Username, claimedUser, database,
-		hello.ClientName, hello.ProtocolRevision, injected)
-
-	// Step 5: bidirectional pipe.
-	chPipe(ch.Conn, upstream)
-	return nil
-}
-
-// chPickCredential returns the (only) credential bound to the
-// endpoint, or nil. Multi-credential dispatch by placeholder will
-// move into the SQL-parsing iteration.
-func chPickCredential(ep *config.CompiledEndpoint) *config.CompiledCredential {
-	if ep == nil || len(ep.Credentials) == 0 {
-		return nil
-	}
-	return ep.Credentials[0]
-}
-
-func chNativeUpstreamAddr(ep *config.CompiledEndpoint, body *ClickhouseNativeEndpoint) string {
-	for _, h := range ep.Hosts {
-		if h == "" {
-			continue
-		}
-		// ep.Hosts entries already carry the port from ConnRouteHosts.
-		if _, _, err := net.SplitHostPort(h); err == nil {
-			return h
-		}
-		return fmt.Sprintf("%s:%d", h, body.port())
-	}
-	return ""
-}
-
-func chHostPort(addr string) (string, int) {
-	h, p, err := net.SplitHostPort(addr)
-	if err != nil {
-		return addr, 0
-	}
-	port := 0
-	for _, c := range p {
-		if c < '0' || c > '9' {
-			return h, 0
-		}
-		port = port*10 + int(c-'0')
-	}
-	return h, port
-}
-
-// chPipe shuttles bytes between agent and upstream, half-closing each
-// direction on EOF. Mirrors main.pipe but lives here so the plugin
-// stays self-contained.
-func chPipe(a, b net.Conn) {
-	done := make(chan struct{}, 2)
-	go func() {
-		_, _ = io.Copy(b, a)
-		if cw, ok := b.(interface{ CloseWrite() error }); ok {
-			_ = cw.CloseWrite()
-		}
-		done <- struct{}{}
-	}()
-	go func() {
-		_, _ = io.Copy(a, b)
-		if cw, ok := a.(interface{ CloseWrite() error }); ok {
-			_ = cw.CloseWrite()
-		}
-		done <- struct{}{}
-	}()
-	<-done
-	<-done
-}
-
-// chReadHello reads from r until enough bytes have arrived to fully
-// decode a client Hello. Returns the parsed packet and any leftover
-// bytes already pulled past the Hello (rare — clients usually wait
-// for ServerHello before sending more — but possible).
-//
-// ClickHouse's native protocol prefixes nothing about packet length:
-// the Hello is a sequence of VarUInt + length-prefixed strings.
-// ParseChHello is incremental — we attempt a parse on each read and
-// retry when errChShortBuffer surfaces.
-func chReadHello(r io.Reader) (ChHello, []byte, error) {
-	buf := make([]byte, 0, 1024)
-	tmp := make([]byte, 4096)
-	for {
-		n, readErr := r.Read(tmp)
-		if n > 0 {
-			buf = append(buf, tmp[:n]...)
-			h, consumed, err := chParseHello(buf)
-			if err == nil {
-				return h, buf[consumed:], nil
-			}
-			if err != errChShortBuffer {
-				return ChHello{}, nil, err
-			}
-		}
-		if readErr != nil {
-			if readErr == io.EOF && len(buf) > 0 {
-				return ChHello{}, nil, fmt.Errorf("hello truncated after %d bytes", len(buf))
-			}
-			return ChHello{}, nil, readErr
-		}
-		if len(buf) > 1<<20 {
-			return ChHello{}, nil, fmt.Errorf("hello exceeded 1 MiB without parsing")
-		}
-	}
-}
-
-// chSerializeHello / chParseHello are thin wrappers over the protocol
-// helpers in clickhouse_native_protocol.go.
-func chSerializeHello(h ChHello) []byte             { return SerializeChHello(h) }
-func chParseHello(buf []byte) (ChHello, int, error) { return ParseChHello(buf) }

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -29,12 +29,14 @@ import (
 // substitutes the credential's (user, password) where the agent
 // embedded a placeholder.
 //
-// TLS toggles upstream TLS-wrapping. The native protocol is
-// persistent (no inner TLS negotiation), so this is a one-time
-// decision per endpoint. Default false: WG already encrypts
-// agent→gateway and most self-hosted ClickHouse on a private network
-// runs plaintext on 9000. Operators using cloud ClickHouse on 9440
-// flip TLS=true and set Port=9440.
+// TLS toggles TLS on both hops: the gateway terminates the agent's
+// TLS using a leaf minted off the gateway CA, parses the Hello in
+// plaintext, then re-wraps to upstream. The wrapped client therefore
+// keeps speaking native-over-TLS exactly as it would against the
+// real cloud ClickHouse — `clawpatrol run` is transparent to its
+// TLS posture. Default false: WG-only deployments where the operator
+// wants plaintext on the inner hop (typical self-hosted ClickHouse
+// on 9000 behind a private network) leave it off.
 type ClickhouseNativeEndpoint struct {
 	Hosts      []string `hcl:"hosts"`
 	Port       int      `hcl:"port,optional"`
@@ -42,21 +44,13 @@ type ClickhouseNativeEndpoint struct {
 	Credential string   `hcl:"credential,optional"`
 }
 
-func (e *ClickhouseNativeEndpoint) EndpointHosts() []string { return e.Hosts }
-func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
-	return singleBinding(e.Credential)
-}
-
-// ConnRouteHosts implements runtime.ConnRouter — clickhouse native
-// arrives at the WG forwarder as raw conns (no SNI), so the gateway
-// indexes the upstream host:port → endpoint at policy-load time.
-//
-// Hosts may be supplied as bare hostnames or as host:port literals.
-// The bare form is normalized to host:e.port(); the host:port form
-// is preserved verbatim, so an operator binding a cluster on mixed
-// ports gets the literal each member declared rather than a
-// silently-double-suffixed `host:port:port`.
-func (e *ClickhouseNativeEndpoint) ConnRouteHosts() []string {
+// EndpointHosts returns the endpoint's host:port list, normalized so
+// every entry carries an explicit port. The dnsvip allocator and
+// runtime helpers both consume this; emitting host:port everywhere
+// lets a single endpoint mix bare hostnames and host:port literals
+// in HCL without the plugin or dnsvip having to special-case the
+// "default port" rule.
+func (e *ClickhouseNativeEndpoint) EndpointHosts() []string {
 	port := e.port()
 	out := make([]string, 0, len(e.Hosts))
 	for _, h := range e.Hosts {
@@ -67,6 +61,24 @@ func (e *ClickhouseNativeEndpoint) ConnRouteHosts() []string {
 		out = append(out, fmt.Sprintf("%s:%d", h, port))
 	}
 	return out
+}
+func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
+	return singleBinding(e.Credential)
+}
+
+// RequiresVIP opts the endpoint into DNS-VIP interception. The wire
+// protocol carries no SNI / Host header, so the gateway can't
+// dispatch on dst IP alone — dnsvip allocates a stable VIP per
+// hostname at policy build, intercepts the agent's DNS query for
+// that hostname, and the WG forwarder routes the resulting traffic
+// to handleVIPConn → this plugin's HandleConn.
+func (e *ClickhouseNativeEndpoint) RequiresVIP() bool { return true }
+
+// ConnRouteHosts mirrors EndpointHosts so legacy ConnIndex consumers
+// that key off the ConnRouter interface stay wired even though VIP
+// dispatch is the active path for clickhouse_native.
+func (e *ClickhouseNativeEndpoint) ConnRouteHosts() []string {
+	return e.EndpointHosts()
 }
 
 func (e *ClickhouseNativeEndpoint) port() int {

--- a/config/plugins/endpoints/clickhouse_native_protocol.go
+++ b/config/plugins/endpoints/clickhouse_native_protocol.go
@@ -1,0 +1,184 @@
+package endpoints
+
+// ClickHouse native-protocol Hello packet parser/serializer.
+//
+// Wire format mirrors what clickhouse-server expects on a fresh
+// connection: VarUInt packet type (0 = Hello) followed by a sequence
+// of VarUInt + length-prefixed UTF-8 strings:
+//
+//	type=0 | client_name | major | minor | revision | database | user | password
+//
+// Past the password, newer clients may send addendum bytes
+// (interserver secret, quota key, etc.); we preserve them verbatim.
+//
+// Mirrors the unclaw plugin's protocol.ts so the two stay easy to
+// cross-reference. See denoland/unclaw, refinery/rig/src/plugins/
+// clickhouse/protocol.ts.
+
+import "errors"
+
+// errChShortBuffer surfaces from the parsers when the buffer is
+// exhausted mid-packet. Callers use it to drive an
+// "accumulate-and-retry" read loop.
+var errChShortBuffer = errors.New("clickhouse: short buffer")
+
+// ChHello is the decoded client Hello.
+//
+// Trailing carries any bytes after the password — addendum data,
+// inline post-Hello pipelining — preserved so the rewritten packet
+// is byte-identical for fields we don't touch.
+type ChHello struct {
+	PacketType       int
+	ClientName       string
+	VersionMajor     int
+	VersionMinor     int
+	ProtocolRevision int
+	Database         string
+	Username         string
+	Password         string
+	Trailing         []byte
+}
+
+// ParseChHello reads a Hello from buf. Returns the decoded packet,
+// the number of bytes consumed (excluding Trailing — Trailing is
+// caller-owned bytes past the password), and any error. Returns
+// errChShortBuffer when buf is incomplete and a retry-with-more-bytes
+// could succeed.
+func ParseChHello(buf []byte) (ChHello, int, error) {
+	off := 0
+
+	pktType, n, err := readChVarUInt(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+	if pktType != 0 {
+		return ChHello{}, 0, errors.New("clickhouse: not a Hello packet")
+	}
+
+	clientName, n, err := readChString(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	major, n, err := readChVarUInt(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	minor, n, err := readChVarUInt(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	rev, n, err := readChVarUInt(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	database, n, err := readChString(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	user, n, err := readChString(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	pass, n, err := readChString(buf, off)
+	if err != nil {
+		return ChHello{}, 0, err
+	}
+	off += n
+
+	return ChHello{
+		PacketType:       pktType,
+		ClientName:       clientName,
+		VersionMajor:     major,
+		VersionMinor:     minor,
+		ProtocolRevision: rev,
+		Database:         database,
+		Username:         user,
+		Password:         pass,
+	}, off, nil
+}
+
+// SerializeChHello rewrites a Hello back to wire bytes. Trailing
+// bytes (parsed by the caller out of band, then attached to h) are
+// appended as-is.
+func SerializeChHello(h ChHello) []byte {
+	out := make([]byte, 0, 64+len(h.ClientName)+len(h.Database)+len(h.Username)+len(h.Password)+len(h.Trailing))
+	out = appendChVarUInt(out, h.PacketType)
+	out = appendChString(out, h.ClientName)
+	out = appendChVarUInt(out, h.VersionMajor)
+	out = appendChVarUInt(out, h.VersionMinor)
+	out = appendChVarUInt(out, h.ProtocolRevision)
+	out = appendChString(out, h.Database)
+	out = appendChString(out, h.Username)
+	out = appendChString(out, h.Password)
+	out = append(out, h.Trailing...)
+	return out
+}
+
+// readChVarUInt decodes a LEB128-style unsigned varint. ClickHouse
+// caps payload sizes well below 2^63 so int is safe; we still bound
+// shift to 63 to fail loudly on malformed packets.
+func readChVarUInt(buf []byte, off int) (int, int, error) {
+	value := 0
+	shift := uint(0)
+	i := off
+	for {
+		if i >= len(buf) {
+			return 0, 0, errChShortBuffer
+		}
+		b := buf[i]
+		value |= int(b&0x7f) << shift
+		i++
+		if b&0x80 == 0 {
+			return value, i - off, nil
+		}
+		shift += 7
+		if shift >= 64 {
+			return 0, 0, errors.New("clickhouse: varuint too long")
+		}
+	}
+}
+
+// appendChVarUInt encodes value as LEB128 and appends to dst.
+func appendChVarUInt(dst []byte, value int) []byte {
+	v := uint64(value)
+	for v > 0x7f {
+		dst = append(dst, byte(0x80|(v&0x7f)))
+		v >>= 7
+	}
+	dst = append(dst, byte(v&0x7f))
+	return dst
+}
+
+// readChString decodes a VarUInt-prefixed UTF-8 string.
+func readChString(buf []byte, off int) (string, int, error) {
+	length, ln, err := readChVarUInt(buf, off)
+	if err != nil {
+		return "", 0, err
+	}
+	start := off + ln
+	end := start + length
+	if end > len(buf) {
+		return "", 0, errChShortBuffer
+	}
+	return string(buf[start:end]), ln + length, nil
+}
+
+// appendChString encodes a length-prefixed string.
+func appendChString(dst []byte, s string) []byte {
+	dst = appendChVarUInt(dst, len(s))
+	dst = append(dst, s...)
+	return dst
+}

--- a/config/plugins/endpoints/clickhouse_native_protocol.go
+++ b/config/plugins/endpoints/clickhouse_native_protocol.go
@@ -15,7 +15,10 @@ package endpoints
 // cross-reference. See denoland/unclaw, refinery/rig/src/plugins/
 // clickhouse/protocol.ts.
 
-import "errors"
+import (
+	"errors"
+	"unicode/utf8"
+)
 
 // errChShortBuffer surfaces from the parsers when the buffer is
 // exhausted mid-packet. Callers use it to drive an
@@ -27,12 +30,17 @@ var errChShortBuffer = errors.New("clickhouse: short buffer")
 // Trailing carries any bytes after the password — addendum data,
 // inline post-Hello pipelining — preserved so the rewritten packet
 // is byte-identical for fields we don't touch.
+//
+// VarUInt fields are typed as uint64 to match the ClickHouse wire
+// spec (LEB128-encoded uint64). Current revisions fit in int but
+// future revisions or non-Hello packets carrying e.g. block sizes
+// are immune to overflow.
 type ChHello struct {
-	PacketType       int
+	PacketType       uint64
 	ClientName       string
-	VersionMajor     int
-	VersionMinor     int
-	ProtocolRevision int
+	VersionMajor     uint64
+	VersionMinor     uint64
+	ProtocolRevision uint64
 	Database         string
 	Username         string
 	Password         string
@@ -127,11 +135,11 @@ func SerializeChHello(h ChHello) []byte {
 	return out
 }
 
-// readChVarUInt decodes a LEB128-style unsigned varint. ClickHouse
-// caps payload sizes well below 2^63 so int is safe; we still bound
-// shift to 63 to fail loudly on malformed packets.
-func readChVarUInt(buf []byte, off int) (int, int, error) {
-	value := 0
+// readChVarUInt decodes a LEB128-encoded uint64 (the ClickHouse
+// VarUInt). Returns the decoded value, the number of bytes
+// consumed, and any error.
+func readChVarUInt(buf []byte, off int) (uint64, int, error) {
+	var value uint64
 	shift := uint(0)
 	i := off
 	for {
@@ -139,7 +147,7 @@ func readChVarUInt(buf []byte, off int) (int, int, error) {
 			return 0, 0, errChShortBuffer
 		}
 		b := buf[i]
-		value |= int(b&0x7f) << shift
+		value |= uint64(b&0x7f) << shift
 		i++
 		if b&0x80 == 0 {
 			return value, i - off, nil
@@ -152,33 +160,42 @@ func readChVarUInt(buf []byte, off int) (int, int, error) {
 }
 
 // appendChVarUInt encodes value as LEB128 and appends to dst.
-func appendChVarUInt(dst []byte, value int) []byte {
-	v := uint64(value)
-	for v > 0x7f {
-		dst = append(dst, byte(0x80|(v&0x7f)))
-		v >>= 7
+func appendChVarUInt(dst []byte, value uint64) []byte {
+	for value > 0x7f {
+		dst = append(dst, byte(0x80|(value&0x7f)))
+		value >>= 7
 	}
-	dst = append(dst, byte(v&0x7f))
+	dst = append(dst, byte(value&0x7f))
 	return dst
 }
 
-// readChString decodes a VarUInt-prefixed UTF-8 string.
+// readChString decodes a VarUInt-prefixed UTF-8 string. Rejects
+// malformed UTF-8 to keep arbitrary peer bytes out of downstream
+// loggers / renderers.
 func readChString(buf []byte, off int) (string, int, error) {
 	length, ln, err := readChVarUInt(buf, off)
 	if err != nil {
 		return "", 0, err
 	}
-	start := off + ln
-	end := start + length
-	if end > len(buf) {
+	if length > uint64(len(buf)-off-ln) {
+		// Either truncated or the length claims more than the
+		// remaining buffer can ever hold (length doesn't fit in int).
+		// Both are "need more bytes" from the read loop's POV; the
+		// 1 MiB cap in chReadHello catches a malicious huge length.
 		return "", 0, errChShortBuffer
 	}
-	return string(buf[start:end]), ln + length, nil
+	start := off + ln
+	end := start + int(length)
+	s := string(buf[start:end])
+	if !utf8.ValidString(s) {
+		return "", 0, errors.New("clickhouse: invalid UTF-8 in string")
+	}
+	return s, ln + int(length), nil
 }
 
 // appendChString encodes a length-prefixed string.
 func appendChString(dst []byte, s string) []byte {
-	dst = appendChVarUInt(dst, len(s))
+	dst = appendChVarUInt(dst, uint64(len(s)))
 	dst = append(dst, s...)
 	return dst
 }

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -46,10 +46,47 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 		chEmitError(ch, "wrong-endpoint-type", ch.Endpoint.Name)
 		return err
 	}
-	upstreamAddr := chNativeUpstreamAddr(ch.Endpoint, chEp)
+	upstreamAddr := chPickUpstream(ch.Endpoint.Hosts, ch.UpstreamHost, ch.DstPort, chEp.port())
 	if upstreamAddr == "" {
 		chEmitError(ch, "no-host", ch.Endpoint.Name)
 		return fmt.Errorf("clickhouse_native endpoint %q has no host", ch.Endpoint.Name)
+	}
+
+	// Inbound TLS termination. The wrapped agent (clickhouse-client
+	// --secure, etc.) speaks native-over-TLS exactly as it would
+	// against the real upstream; we terminate here using a leaf
+	// minted off the gateway CA so the SAN matches whatever SNI the
+	// agent sent. Agents already trust the gateway CA via the
+	// SSL_CERT_FILE env-var pushdown that `clawpatrol run` stamps,
+	// so verification passes without any client-side opt-out.
+	//
+	// Falls back to the dst host (UpstreamHost when dialed by name,
+	// else the upstream host slice's first entry) when the client
+	// didn't carry SNI — covers bare-IP dialing and odd clients that
+	// omit it.
+	if chEp.TLS && ch.MintCert != nil {
+		fallback := ch.UpstreamHost
+		if fallback == "" {
+			h, _ := chHostPort(upstreamAddr)
+			fallback = h
+		}
+		mint := ch.MintCert
+		tc := tls.Server(ch.Conn, &tls.Config{
+			GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				host := chi.ServerName
+				if host == "" {
+					host = fallback
+				}
+				return mint(host)
+			},
+		})
+		if err := tc.HandshakeContext(ctx); err != nil {
+			chEmitError(ch, "inbound-tls-handshake", err.Error())
+			return fmt.Errorf("inbound tls: %w", err)
+		}
+		// Splice the wrapped conn back onto the handle so downstream
+		// helpers (chReadHello, chPipe) operate on plaintext.
+		ch.Conn = tc
 	}
 
 	// Step 1: read agent's Hello. ClickHouse's native protocol begins
@@ -194,16 +231,45 @@ func chPickCredential(ep *config.CompiledEndpoint) *config.CompiledCredential {
 	return ep.Credentials[0]
 }
 
-func chNativeUpstreamAddr(ep *config.CompiledEndpoint, body *ClickhouseNativeEndpoint) string {
-	for _, h := range ep.Hosts {
+// chPickUpstream resolves the upstream addr the plugin should dial.
+//
+// Preference order:
+//
+//  1. (upstreamHost, dstPort) — VIP-dispatched conns: the agent
+//     dialed a specific hostname which dnsvip mapped to a VIP plus
+//     the matched port; that pair is the canonical upstream.
+//  2. host whose declared port equals dstPort — disambiguates
+//     multi-host endpoints where each member runs on a different
+//     port (rare but legal).
+//  3. first non-empty host — single-host endpoint, or the operator
+//     just declared one.
+//
+// hosts entries are normalized by EndpointHosts to host:port so the
+// helper can split cleanly; defaultPort is the plugin's fallback
+// (9000) used only when an entry slipped through without a port.
+func chPickUpstream(hosts []string, upstreamHost string, dstPort uint16, defaultPort int) string {
+	if upstreamHost != "" && dstPort != 0 {
+		return net.JoinHostPort(upstreamHost, strconv.Itoa(int(dstPort)))
+	}
+	if dstPort != 0 {
+		want := strconv.Itoa(int(dstPort))
+		for _, h := range hosts {
+			if h == "" {
+				continue
+			}
+			if _, p, err := net.SplitHostPort(h); err == nil && p == want {
+				return h
+			}
+		}
+	}
+	for _, h := range hosts {
 		if h == "" {
 			continue
 		}
-		// ep.Hosts entries already carry the port from ConnRouteHosts.
 		if _, _, err := net.SplitHostPort(h); err == nil {
 			return h
 		}
-		return fmt.Sprintf("%s:%d", h, body.port())
+		return net.JoinHostPort(h, strconv.Itoa(defaultPort))
 	}
 	return ""
 }

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -1,0 +1,280 @@
+package endpoints
+
+// Per-connection runtime for the clickhouse_native endpoint. Schema
+// and registration live in clickhouse_native.go.
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// HandleConn services one inbound native-protocol connection.
+//
+// Flow:
+//
+//  1. Read the agent's first packet, parse Hello.
+//  2. Resolve the bound credential, fetch its secret. Swap any
+//     placeholder substring inside Hello.username / Hello.password.
+//  3. Dial upstream (TLS or plain), send the (possibly modified) Hello.
+//  4. Emit one ConnEvent describing the session.
+//  5. Bidirectional pipe until either side closes.
+//
+// Errors before the upstream dial close the agent's conn silently —
+// the native protocol has no Error packet at the pre-handshake stage
+// that we could send back without first observing the server-side
+// reply — but every pre-pipe failure path emits a structured
+// ConnEvent{Action:"error", Reason:...} so the dashboard / JSONL
+// log gets first-class signal, not just a stdout log line.
+func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
+	defer ch.Conn.Close()
+	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
+		err := fmt.Errorf("clickhouse_native runtime invoked on non-sql endpoint %v", ch.Endpoint)
+		chEmitError(ch, "wrong-family", "")
+		return err
+	}
+	chEp, ok := ch.Endpoint.Body.(*ClickhouseNativeEndpoint)
+	if !ok {
+		err := fmt.Errorf("clickhouse_native runtime invoked on non-native endpoint %v", ch.Endpoint)
+		chEmitError(ch, "wrong-endpoint-type", ch.Endpoint.Name)
+		return err
+	}
+	upstreamAddr := chNativeUpstreamAddr(ch.Endpoint, chEp)
+	if upstreamAddr == "" {
+		chEmitError(ch, "no-host", ch.Endpoint.Name)
+		return fmt.Errorf("clickhouse_native endpoint %q has no host", ch.Endpoint.Name)
+	}
+
+	// Step 1: read agent's Hello. ClickHouse's native protocol begins
+	// with a single client Hello packet (type 0). We accumulate bytes
+	// until ParseChHello succeeds — typical Hellos fit in one read but
+	// large client_name strings can span multiple TCP segments.
+	hello, leftover, err := chReadHello(ch.Conn)
+	if err != nil {
+		chEmitError(ch, "read-hello", err.Error())
+		return fmt.Errorf("read hello: %w", err)
+	}
+
+	// Step 2: resolve credential and inject. Single-credential native
+	// endpoints today; multi-credential dispatch via placeholder lands
+	// when SQL parsing does in iter 2.
+	//
+	// Hard-fail on secret-fetch errors and on missing real credential
+	// material. Soft-failing here would leak the agent's placeholder
+	// Hello upstream, which (a) reveals the placeholder shape to the
+	// server and (b) produces an opaque auth-fail downstream — better
+	// to drop the conn with a structured Reason and let the operator
+	// fix the credential binding. Mirrors postgres's pgWriteError
+	// discipline.
+	claimedUser := hello.Username
+	injected := false
+	if cc := chPickCredential(ch.Endpoint); cc != nil {
+		auth, ok := cc.Credential.Body.(runtime.ClickhouseAuthCredential)
+		if !ok {
+			chEmitError(ch, "credential-not-clickhouse-auth", cc.Credential.Symbol.Name)
+			return fmt.Errorf("clickhouse_native: credential %q does not implement ClickhouseAuthCredential",
+				cc.Credential.Symbol.Name)
+		}
+		sec, secErr := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
+		if secErr != nil {
+			chEmitError(ch, "secret-fetch", fmt.Sprintf("%s: %v", cc.Credential.Symbol.Name, secErr))
+			return fmt.Errorf("clickhouse_native: fetch secret %q: %w", cc.Credential.Symbol.Name, secErr)
+		}
+		realUser, realPassword := auth.ClickhouseAuth(sec)
+		if realUser == "" || realPassword == "" {
+			chEmitError(ch, "secret-empty", cc.Credential.Symbol.Name)
+			return fmt.Errorf("clickhouse_native: credential %q produced empty user or password",
+				cc.Credential.Symbol.Name)
+		}
+		before := hello.Username + "\x00" + hello.Password
+		hello.Username = realUser
+		hello.Password = realPassword
+		if hello.Username+"\x00"+hello.Password != before {
+			injected = true
+		}
+	}
+
+	// Step 3: dial upstream + send hello.
+	upstream, err := ch.DialUpstream(ctx, "tcp", upstreamAddr)
+	if err != nil {
+		chEmitError(ch, "dial-upstream", fmt.Sprintf("%s: %v", upstreamAddr, err))
+		return fmt.Errorf("dial upstream %s: %w", upstreamAddr, err)
+	}
+	defer upstream.Close()
+
+	if chEp.TLS {
+		host := upstreamAddr
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		tc := tls.Client(upstream, &tls.Config{ServerName: host})
+		if err := tc.HandshakeContext(ctx); err != nil {
+			chEmitError(ch, "tls-handshake", err.Error())
+			return fmt.Errorf("upstream tls: %w", err)
+		}
+		upstream = tc
+	}
+
+	rewritten := SerializeChHello(hello)
+	if _, err := upstream.Write(rewritten); err != nil {
+		chEmitError(ch, "send-hello", err.Error())
+		return fmt.Errorf("send hello: %w", err)
+	}
+	// Any bytes the agent sent past the Hello (rare — clients usually
+	// wait for ServerHello before pipelining) follow immediately.
+	if len(leftover) > 0 {
+		if _, err := upstream.Write(leftover); err != nil {
+			chEmitError(ch, "forward-post-hello", err.Error())
+			return fmt.Errorf("forward post-hello: %w", err)
+		}
+	}
+
+	// Step 4: emit the connection event. One event per TCP session —
+	// the native protocol is persistent, per-query parsing isn't here
+	// yet, so the connection itself is the unit of audit.
+	database := hello.Database
+	if database == "" {
+		database = "default"
+	}
+	host, port := chHostPort(upstreamAddr)
+	summary := fmt.Sprintf("%s@%s:%d/%s", hello.Username, host, port, database)
+	if injected {
+		summary += " (placeholder injected)"
+	}
+	if ch.Emit != nil {
+		ch.Emit(runtime.ConnEvent{
+			Action:  "allow",
+			Verb:    "connect",
+			Summary: summary,
+		})
+	}
+	log.Printf("clickhouse_native %s: connect user=%q claimed=%q db=%q client=%q rev=%d injected=%v",
+		ch.Endpoint.Name, hello.Username, claimedUser, database,
+		hello.ClientName, hello.ProtocolRevision, injected)
+
+	// Step 5: bidirectional pipe.
+	chPipe(ch.Conn, upstream)
+	return nil
+}
+
+// chEmitError emits a structured error ConnEvent if the host wired
+// an emit callback. Reason is a stable short tag, Detail is free
+// form (error message, name, etc.) — keep the dashboard's filter
+// surface narrow.
+func chEmitError(ch *runtime.ConnHandle, reason, detail string) {
+	if ch == nil || ch.Emit == nil {
+		return
+	}
+	summary := reason
+	if detail != "" {
+		summary = reason + ": " + detail
+	}
+	ch.Emit(runtime.ConnEvent{
+		Action:  "error",
+		Verb:    "connect",
+		Reason:  reason,
+		Summary: summary,
+	})
+}
+
+// chPickCredential returns the (only) credential bound to the
+// endpoint, or nil. Multi-credential dispatch by placeholder will
+// move into the SQL-parsing iteration.
+func chPickCredential(ep *config.CompiledEndpoint) *config.CompiledCredential {
+	if ep == nil || len(ep.Credentials) == 0 {
+		return nil
+	}
+	return ep.Credentials[0]
+}
+
+func chNativeUpstreamAddr(ep *config.CompiledEndpoint, body *ClickhouseNativeEndpoint) string {
+	for _, h := range ep.Hosts {
+		if h == "" {
+			continue
+		}
+		// ep.Hosts entries already carry the port from ConnRouteHosts.
+		if _, _, err := net.SplitHostPort(h); err == nil {
+			return h
+		}
+		return fmt.Sprintf("%s:%d", h, body.port())
+	}
+	return ""
+}
+
+func chHostPort(addr string) (string, int) {
+	h, p, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr, 0
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return h, 0
+	}
+	return h, port
+}
+
+// chPipe shuttles bytes between agent and upstream, half-closing each
+// direction on EOF. Mirrors main.pipe but lives here so the plugin
+// stays self-contained.
+func chPipe(a, b net.Conn) {
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(b, a)
+		if cw, ok := b.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(a, b)
+		if cw, ok := a.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+}
+
+// chReadHello reads from r until enough bytes have arrived to fully
+// decode a client Hello. Returns the parsed packet and any leftover
+// bytes already pulled past the Hello (rare — clients usually wait
+// for ServerHello before sending more — but possible).
+//
+// ClickHouse's native protocol prefixes nothing about packet length:
+// the Hello is a sequence of VarUInt + length-prefixed strings.
+// ParseChHello is incremental — we attempt a parse on each read and
+// retry when errChShortBuffer surfaces.
+func chReadHello(r io.Reader) (ChHello, []byte, error) {
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 4096)
+	for {
+		n, readErr := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			h, consumed, err := ParseChHello(buf)
+			if err == nil {
+				return h, buf[consumed:], nil
+			}
+			if err != errChShortBuffer {
+				return ChHello{}, nil, err
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF && len(buf) > 0 {
+				return ChHello{}, nil, fmt.Errorf("hello truncated after %d bytes", len(buf))
+			}
+			return ChHello{}, nil, readErr
+		}
+		if len(buf) > 1<<20 {
+			return ChHello{}, nil, fmt.Errorf("hello exceeded 1 MiB without parsing")
+		}
+	}
+}

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -246,7 +246,8 @@ func chPickCredential(ep *config.CompiledEndpoint) *config.CompiledCredential {
 //
 // hosts entries are normalized by EndpointHosts to host:port so the
 // helper can split cleanly; defaultPort is the plugin's fallback
-// (9000) used only when an entry slipped through without a port.
+// (9000 plaintext / 9440 TLS) used only when an entry slipped through
+// without a port.
 func chPickUpstream(hosts []string, upstreamHost string, dstPort uint16, defaultPort int) string {
 	if upstreamHost != "" && dstPort != 0 {
 		return net.JoinHostPort(upstreamHost, strconv.Itoa(int(dstPort)))

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -239,3 +239,72 @@ func TestChHostPort(t *testing.T) {
 		}
 	}
 }
+
+// TestClickhouseRequiresVIP nails down the marker — clickhouse_native
+// always opts into VIP allocation. The dispatcher's IP-literal carve-
+// out happens at the dnsvip layer (entries whose host is an IP are
+// skipped during VIP allocation), not by toggling RequiresVIP per
+// host, so the plugin can return a constant true.
+func TestClickhouseRequiresVIP(t *testing.T) {
+	e := &ClickhouseNativeEndpoint{}
+	if !e.RequiresVIP() {
+		t.Fatal("ClickhouseNativeEndpoint.RequiresVIP() = false, want true")
+	}
+}
+
+// TestClickhousePickUpstream covers the upstream-resolver helper
+// across the dispatch shapes the plugin has to handle: VIP path
+// (UpstreamHost + DstPort known), direct-IP fallback (only DstPort),
+// and the legacy first-host fallback when both are missing. Multi-
+// host / mixed-port endpoints rely on DstPort matching to disambiguate.
+func TestClickhousePickUpstream(t *testing.T) {
+	cases := []struct {
+		name         string
+		hosts        []string
+		upstreamHost string
+		dstPort      uint16
+		defaultPort  int
+		want         string
+	}{
+		{
+			name:         "vip path: hostname + port supplied",
+			hosts:        []string{"a.example.com:9440", "b.example.com:9440"},
+			upstreamHost: "b.example.com",
+			dstPort:      9440,
+			defaultPort:  9000,
+			want:         "b.example.com:9440",
+		},
+		{
+			name:        "direct-ip path: only dst port → port-matched first host",
+			hosts:       []string{"172.17.0.1:19440", "192.168.1.5:9000"},
+			dstPort:     9000,
+			defaultPort: 9000,
+			want:        "192.168.1.5:9000",
+		},
+		{
+			name:        "fallback: no upstream/port → first host",
+			hosts:       []string{"only.example.com:9000"},
+			defaultPort: 9000,
+			want:        "only.example.com:9000",
+		},
+		{
+			name:        "bare hostname falls back to defaultPort",
+			hosts:       []string{"bare.example.com"},
+			defaultPort: 9000,
+			want:        "bare.example.com:9000",
+		},
+		{
+			name:        "no hosts → empty string",
+			hosts:       nil,
+			defaultPort: 9000,
+			want:        "",
+		},
+	}
+	for _, c := range cases {
+		got := chPickUpstream(c.hosts, c.upstreamHost, c.dstPort, c.defaultPort)
+		if got != c.want {
+			t.Errorf("%s: chPickUpstream(%v, %q, %d, %d) = %q, want %q",
+				c.name, c.hosts, c.upstreamHost, c.dstPort, c.defaultPort, got, c.want)
+		}
+	}
+}

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -1,0 +1,166 @@
+package endpoints
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestChVarUInt exercises the LEB128 varint helpers across the byte
+// boundaries that matter on the wire (single-byte, two-byte rollover,
+// the protocol-revision range that real ClickHouse clients land in).
+func TestChVarUInt(t *testing.T) {
+	cases := []int{0, 1, 0x7f, 0x80, 0x3fff, 54448 /* recent CH revision */, 1 << 28}
+	for _, v := range cases {
+		buf := appendChVarUInt(nil, v)
+		got, n, err := readChVarUInt(buf, 0)
+		if err != nil {
+			t.Fatalf("readChVarUInt(%d): %v", v, err)
+		}
+		if got != v {
+			t.Errorf("varuint roundtrip: got %d, want %d (bytes=%v)", got, v, buf)
+		}
+		if n != len(buf) {
+			t.Errorf("varuint(%d) consumed %d bytes, want %d", v, n, len(buf))
+		}
+	}
+}
+
+func TestChVarUIntShortBuffer(t *testing.T) {
+	// 0x80 alone signals "more bytes follow" but there are none.
+	if _, _, err := readChVarUInt([]byte{0x80}, 0); err != errChShortBuffer {
+		t.Fatalf("readChVarUInt(short): err = %v, want errChShortBuffer", err)
+	}
+}
+
+// TestChHelloRoundtrip verifies that parse(serialize(h)) == h for a
+// representative client Hello.
+func TestChHelloRoundtrip(t *testing.T) {
+	h := ChHello{
+		PacketType:       0,
+		ClientName:       "ClickHouse client",
+		VersionMajor:     24,
+		VersionMinor:     8,
+		ProtocolRevision: 54448,
+		Database:         "analytics",
+		Username:         "alice",
+		Password:         "hunter2",
+	}
+	wire := SerializeChHello(h)
+	got, n, err := ParseChHello(wire)
+	if err != nil {
+		t.Fatalf("ParseChHello: %v", err)
+	}
+	if n != len(wire) {
+		t.Errorf("ParseChHello consumed %d, want %d", n, len(wire))
+	}
+	if diff := cmp.Diff(h, got); diff != "" {
+		t.Errorf("hello mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestChHelloPlaceholderInjection mirrors the gateway's rewrite path:
+// parse → swap username/password → serialize. The rewritten bytes
+// must (a) decode back to the new fields and (b) preserve every other
+// field byte-for-byte so the upstream sees the agent's exact client
+// metadata.
+func TestChHelloPlaceholderInjection(t *testing.T) {
+	original := ChHello{
+		PacketType:       0,
+		ClientName:       "agent-cli",
+		VersionMajor:     1,
+		VersionMinor:     0,
+		ProtocolRevision: 54448,
+		Database:         "default",
+		Username:         "CLAWPATROL_PH_user",
+		Password:         "CLAWPATROL_PH_pass",
+	}
+	wire := SerializeChHello(original)
+
+	parsed, _, err := ParseChHello(wire)
+	if err != nil {
+		t.Fatalf("ParseChHello: %v", err)
+	}
+	parsed.Username = "real-user"
+	parsed.Password = "real-pass"
+	rewritten := SerializeChHello(parsed)
+
+	final, _, err := ParseChHello(rewritten)
+	if err != nil {
+		t.Fatalf("ParseChHello rewritten: %v", err)
+	}
+	if final.Username != "real-user" || final.Password != "real-pass" {
+		t.Errorf("injection failed: got user=%q pass=%q", final.Username, final.Password)
+	}
+	// Non-credential fields untouched.
+	if final.ClientName != original.ClientName ||
+		final.Database != original.Database ||
+		final.VersionMajor != original.VersionMajor ||
+		final.ProtocolRevision != original.ProtocolRevision {
+		t.Errorf("non-credential fields drifted: %+v vs %+v", final, original)
+	}
+}
+
+// TestChHelloShortBuffer drives the incremental-parse contract
+// HandleConn relies on: when the buffer ends mid-packet, the parser
+// returns errChShortBuffer so the caller can read more bytes.
+func TestChHelloShortBuffer(t *testing.T) {
+	wire := SerializeChHello(ChHello{
+		PacketType:       0,
+		ClientName:       "ClickHouse client",
+		VersionMajor:     24,
+		VersionMinor:     8,
+		ProtocolRevision: 54448,
+		Database:         "analytics",
+		Username:         "alice",
+		Password:         "hunter2",
+	})
+	for cut := 0; cut < len(wire); cut++ {
+		_, _, err := ParseChHello(wire[:cut])
+		if err != errChShortBuffer {
+			t.Errorf("ParseChHello(prefix len=%d): err = %v, want errChShortBuffer", cut, err)
+		}
+	}
+}
+
+// TestChHelloRejectsNonHello asserts that the parser refuses packets
+// whose first VarUInt isn't 0 (Hello). Important because the runtime
+// dispatches off the result and we don't want a Query packet to be
+// silently treated as a Hello.
+func TestChHelloRejectsNonHello(t *testing.T) {
+	bad := appendChVarUInt(nil, 1) // packet type 1 = Query
+	bad = appendChString(bad, "x")
+	if _, _, err := ParseChHello(bad); err == nil {
+		t.Errorf("ParseChHello accepted non-Hello packet")
+	}
+}
+
+// TestChHelloPreservesTrailing confirms post-password bytes (addendum
+// data, inline pipelined packets) survive a parse + serialize cycle
+// when reattached.
+func TestChHelloPreservesTrailing(t *testing.T) {
+	h := ChHello{
+		PacketType:       0,
+		ClientName:       "c",
+		VersionMajor:     1,
+		VersionMinor:     0,
+		ProtocolRevision: 54448,
+		Database:         "d",
+		Username:         "u",
+		Password:         "p",
+		Trailing:         []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	wire := SerializeChHello(h)
+	parsed, consumed, err := ParseChHello(wire)
+	if err != nil {
+		t.Fatalf("ParseChHello: %v", err)
+	}
+	if !bytes.Equal(wire[consumed:], h.Trailing) {
+		t.Errorf("trailing bytes lost: got %x, want %x", wire[consumed:], h.Trailing)
+	}
+	parsed.Trailing = wire[consumed:]
+	if !bytes.Equal(SerializeChHello(parsed), wire) {
+		t.Errorf("serialize(parse(wire)) != wire")
+	}
+}

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -217,6 +217,40 @@ func TestClickhouseConnRouteHostsNoDoublePort(t *testing.T) {
 	}
 }
 
+// TestClickhouseDefaultPortTLS pins the default-port fork: when the
+// operator omits Port, plaintext endpoints land on 9000 and TLS
+// endpoints on 9440 (ClickHouse's published convention). An explicit
+// Port always wins over the TLS-derived default.
+func TestClickhouseDefaultPortTLS(t *testing.T) {
+	cases := []struct {
+		name string
+		e    ClickhouseNativeEndpoint
+		want string
+	}{
+		{
+			name: "no port, plaintext → 9000",
+			e:    ClickhouseNativeEndpoint{Hosts: []string{"ch.example.com"}},
+			want: "ch.example.com:9000",
+		},
+		{
+			name: "no port, tls → 9440",
+			e:    ClickhouseNativeEndpoint{Hosts: []string{"ch.example.com"}, TLS: true},
+			want: "ch.example.com:9440",
+		},
+		{
+			name: "explicit port wins over tls default",
+			e:    ClickhouseNativeEndpoint{Hosts: []string{"ch.example.com"}, TLS: true, Port: 9001},
+			want: "ch.example.com:9001",
+		},
+	}
+	for _, c := range cases {
+		got := c.e.EndpointHosts()
+		if len(got) != 1 || got[0] != c.want {
+			t.Errorf("%s: EndpointHosts() = %v, want [%q]", c.name, got, c.want)
+		}
+	}
+}
+
 // TestChHostPort exercises the host:port splitter — including the
 // IPv6 + named-port edge cases that strconv.Atoi covers but the
 // hand-rolled digit walk did not.

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -11,7 +11,7 @@ import (
 // boundaries that matter on the wire (single-byte, two-byte rollover,
 // the protocol-revision range that real ClickHouse clients land in).
 func TestChVarUInt(t *testing.T) {
-	cases := []int{0, 1, 0x7f, 0x80, 0x3fff, 54448 /* recent CH revision */, 1 << 28}
+	cases := []uint64{0, 1, 0x7f, 0x80, 0x3fff, 54448 /* recent CH revision */, 1 << 28, 1 << 50, ^uint64(0)}
 	for _, v := range cases {
 		buf := appendChVarUInt(nil, v)
 		got, n, err := readChVarUInt(buf, 0)
@@ -162,5 +162,80 @@ func TestChHelloPreservesTrailing(t *testing.T) {
 	parsed.Trailing = wire[consumed:]
 	if !bytes.Equal(SerializeChHello(parsed), wire) {
 		t.Errorf("serialize(parse(wire)) != wire")
+	}
+}
+
+// TestChHelloRejectsInvalidUTF8 confirms that the string reader
+// refuses non-UTF-8 bytes inside a length-prefixed string. Defends
+// the per-session log + ConnEvent surface against arbitrary-byte
+// peers.
+func TestChHelloRejectsInvalidUTF8(t *testing.T) {
+	// Build a Hello where client_name carries a stray 0xff (invalid
+	// UTF-8 lead byte). Hand-craft the wire bytes — the serializer
+	// won't produce these from a string.
+	var wire []byte
+	wire = appendChVarUInt(wire, 0)              // packet type Hello
+	wire = appendChVarUInt(wire, 1)              // client_name length
+	wire = append(wire, 0xff)                    // invalid UTF-8 byte
+	wire = appendChVarUInt(wire, 1)              // major
+	wire = appendChVarUInt(wire, 0)              // minor
+	wire = appendChVarUInt(wire, 54448)          // revision
+	wire = appendChString(wire, "default")       // database
+	wire = appendChString(wire, "u")             // user
+	wire = appendChString(wire, "p")             // password
+	if _, _, err := ParseChHello(wire); err == nil {
+		t.Errorf("ParseChHello accepted invalid UTF-8 in client_name")
+	}
+}
+
+// TestClickhouseConnRouteHostsNoDoublePort verifies the
+// host-port-already-present branch: if an operator binds a host as
+// "ch.example.com:9000", ConnRouteHosts must preserve it verbatim
+// rather than producing "ch.example.com:9000:9000".
+func TestClickhouseConnRouteHostsNoDoublePort(t *testing.T) {
+	e := &ClickhouseNativeEndpoint{
+		Hosts: []string{
+			"bare.example.com",
+			"with-port.example.com:9001",
+			"[::1]:9002",
+		},
+		Port: 9000,
+	}
+	got := e.ConnRouteHosts()
+	want := []string{
+		"bare.example.com:9000",
+		"with-port.example.com:9001",
+		"[::1]:9002",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ConnRouteHosts: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ConnRouteHosts[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestChHostPort exercises the host:port splitter — including the
+// IPv6 + named-port edge cases that strconv.Atoi covers but the
+// hand-rolled digit walk did not.
+func TestChHostPort(t *testing.T) {
+	cases := []struct {
+		addr     string
+		wantHost string
+		wantPort int
+	}{
+		{"host:9000", "host", 9000},
+		{"[::1]:9000", "::1", 9000},
+		{"host:not-a-port", "host", 0},
+		{"no-colon", "no-colon", 0},
+	}
+	for _, c := range cases {
+		h, p := chHostPort(c.addr)
+		if h != c.wantHost || p != c.wantPort {
+			t.Errorf("chHostPort(%q) = (%q,%d), want (%q,%d)",
+				c.addr, h, p, c.wantHost, c.wantPort)
+		}
 	}
 }

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -174,15 +174,15 @@ func TestChHelloRejectsInvalidUTF8(t *testing.T) {
 	// UTF-8 lead byte). Hand-craft the wire bytes — the serializer
 	// won't produce these from a string.
 	var wire []byte
-	wire = appendChVarUInt(wire, 0)              // packet type Hello
-	wire = appendChVarUInt(wire, 1)              // client_name length
-	wire = append(wire, 0xff)                    // invalid UTF-8 byte
-	wire = appendChVarUInt(wire, 1)              // major
-	wire = appendChVarUInt(wire, 0)              // minor
-	wire = appendChVarUInt(wire, 54448)          // revision
-	wire = appendChString(wire, "default")       // database
-	wire = appendChString(wire, "u")             // user
-	wire = appendChString(wire, "p")             // password
+	wire = appendChVarUInt(wire, 0)        // packet type Hello
+	wire = appendChVarUInt(wire, 1)        // client_name length
+	wire = append(wire, 0xff)              // invalid UTF-8 byte
+	wire = appendChVarUInt(wire, 1)        // major
+	wire = appendChVarUInt(wire, 0)        // minor
+	wire = appendChVarUInt(wire, 54448)    // revision
+	wire = appendChString(wire, "default") // database
+	wire = appendChString(wire, "u")       // user
+	wire = appendChString(wire, "p")       // password
 	if _, _, err := ParseChHello(wire); err == nil {
 		t.Errorf("ParseChHello accepted invalid UTF-8 in client_name")
 	}

--- a/config/runtime/checker.go
+++ b/config/runtime/checker.go
@@ -43,8 +43,9 @@ func checkRuntime(p *config.Plugin) []string {
 		_, http := p.Runtime.(HTTPCredentialRuntime)
 		_, pg := p.Runtime.(PostgresCredentialRuntime)
 		_, pgAuth := p.Runtime.(PostgresAuthCredential)
+		_, chAuth := p.Runtime.(ClickhouseAuthCredential)
 		_, tlsR := p.Runtime.(TLSCredentialRuntime)
-		if http || pg || pgAuth || tlsR {
+		if http || pg || pgAuth || chAuth || tlsR {
 			return nil
 		}
 		for _, check := range extraCredChecks {
@@ -52,7 +53,7 @@ func checkRuntime(p *config.Plugin) []string {
 				return nil
 			}
 		}
-		return []string{fmt.Sprintf("Runtime %T satisfies no credential runtime interface (HTTP / Postgres / TLS or a registered protocol extension)", p.Runtime)}
+		return []string{fmt.Sprintf("Runtime %T satisfies no credential runtime interface (HTTP / Postgres / Clickhouse / TLS or a registered protocol extension)", p.Runtime)}
 	case config.KindEndpoint:
 		// Endpoint plugins satisfy any combination of
 		// PlaceholderDetector and ConnEndpointRuntime. Plugins with

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -149,6 +149,21 @@ type ConnHandle struct {
 	// carry a non-default port (`hosts = ["x.com:22222"]`) consult
 	// this to pick which Hosts[i] the connection corresponds to.
 	DstPort uint16
+	// UpstreamHost is the hostname the agent dialed, resolved from
+	// the VIP table at dispatch time. Populated for VIP-routed conns
+	// only; empty for direct-IP / fixed-port dispatches (postgres).
+	// Plugins use it to (a) pass a real hostname to DialUpstream so
+	// the gateway's host network can resolve it, and (b) drive SNI /
+	// SAN matching when the protocol layers TLS on top.
+	UpstreamHost string
+	// MintCert returns a leaf certificate signed by the gateway CA
+	// for the given hostname (or IP literal). Plugins that
+	// TLS-terminate inbound traffic — clickhouse_native with
+	// `tls = true`, future binary protocols — call this from a
+	// `tls.Config.GetCertificate` callback so the SAN matches the
+	// SNI the client sent. nil when the dispatcher can't mint
+	// (gateway has no CA).
+	MintCert func(host string) (*tls.Certificate, error)
 }
 
 // ApproveCallRequest is what a ConnEndpointRuntime hands to

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -66,6 +66,17 @@ type PostgresAuthCredential interface {
 	PostgresAuth(sec Secret) (user, password string)
 }
 
+// ClickhouseAuthCredential is what the clickhouse_native endpoint
+// runtime needs from a credential plugin to inject secrets into the
+// agent's Hello packet. The credential returns its (user, password);
+// the runtime swaps placeholder bytes the agent embedded in the
+// Hello's username / password slots before forwarding the packet
+// upstream. Same shape as PostgresAuth — kept distinct so the
+// checker can confirm a credential is wired for the right protocol.
+type ClickhouseAuthCredential interface {
+	ClickhouseAuth(sec Secret) (user, password string)
+}
+
 // TLSCredentialRuntime customizes the upstream TLS configuration
 // before the dial. mTLS credentials use this to add a client cert
 // (Certificates) and an optional custom root pool (RootCAs); other

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -344,6 +344,8 @@
           "Hosts": [
             "clickhouse-o11y.tail9a48e.ts.net"
           ],
+          "Port": 0,
+          "TLS": false,
           "Credential": "ch-o11y"
         },
         "family": "sql",

--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -307,6 +307,12 @@ func (a *Allocator) RebuildFromPolicy(policy *config.CompiledPolicy) error {
 // (the same one ConnIndex uses for direct-IP routing). A host string
 // without a port falls back to that protocol's default; SSH is the
 // only RequiresVIP plugin in v1 so the default is 22.
+//
+// IP-literal entries are skipped: VIPs exist to recover hostname
+// identity from a TCP dst IP, but agents dialing an IP literal never
+// issue a DNS query, so allocating a VIP for one is wasted state. The
+// gateway's direct-IP dispatch path (consulting ConnIndex inside the
+// WG forwarder's default case) covers those entries instead.
 func collectRequiredHosts(policy *config.CompiledPolicy) map[string][]EndpointHit {
 	out := map[string][]EndpointHit{}
 	if policy == nil {
@@ -326,6 +332,9 @@ func collectRequiredHosts(policy *config.CompiledPolicy) map[string][]EndpointHi
 				portStr = ""
 			}
 			if host == "" {
+				continue
+			}
+			if net.ParseIP(host) != nil {
 				continue
 			}
 			var port uint16 = defaultPortFor(ep)

--- a/dnsvip/dnsvip_test.go
+++ b/dnsvip/dnsvip_test.go
@@ -235,6 +235,35 @@ func TestLookupVIP(t *testing.T) {
 	}
 }
 
+// IP-literal entries opt out of VIP allocation: agents dialing an IP
+// literal don't issue a DNS query, so a VIP for "172.17.0.1" is
+// stranded state. The direct-IP dispatch path covers those entries.
+func TestRebuildSkipsIPLiteralHosts(t *testing.T) {
+	dir := t.TempDir()
+	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Mixed slice: one hostname, one IPv4 literal, one IPv6 literal.
+	pol := fakePolicy(t, []string{
+		"upstream.example.com:22",
+		"172.17.0.1:22",
+		"[fd00::1]:22",
+	})
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	if v4, _ := a.VIPsFor("upstream.example.com"); !v4.IsValid() {
+		t.Fatalf("hostname did not get a VIP")
+	}
+	if v4, _ := a.VIPsFor("172.17.0.1"); v4.IsValid() {
+		t.Errorf("IPv4 literal got a VIP: %v (should be skipped)", v4)
+	}
+	if v4, _ := a.VIPsFor("fd00::1"); v4.IsValid() {
+		t.Errorf("IPv6 literal got a VIP: %v (should be skipped)", v4)
+	}
+}
+
 func TestPersistenceDropsOutOfRangeEntries(t *testing.T) {
 	dir := t.TempDir()
 	// Allocate with the default CIDRs.

--- a/dnsvip/dnsvip_test.go
+++ b/dnsvip/dnsvip_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/plugins/endpoints"
 )
 
 // fakePolicy builds a CompiledPolicy whose endpoints opt into VIPs.
@@ -261,6 +262,50 @@ func TestRebuildSkipsIPLiteralHosts(t *testing.T) {
 	}
 	if v4, _ := a.VIPsFor("fd00::1"); v4.IsValid() {
 		t.Errorf("IPv6 literal got a VIP: %v (should be skipped)", v4)
+	}
+}
+
+// TestRebuildResolvesDefaultPortForTLSEndpoint pins the integration
+// between an endpoint plugin's default-port resolution and the VIP
+// index. A clickhouse_native endpoint with tls=true and no explicit
+// port should land in the VIP table keyed at the TLS default (9440),
+// not at the unresolved 0 — otherwise an agent dialing <vip>:9440
+// (the natural TLS port) misses the index and falls through to the
+// unmatched-traffic path. The same shape applies to any future plugin
+// whose EndpointHosts() does TLS-conditional default-port resolution.
+func TestRebuildResolvesDefaultPortForTLSEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	body := &endpoints.ClickhouseNativeEndpoint{
+		Hosts: []string{"ch.example.com"},
+		TLS:   true,
+	}
+	ep := &config.CompiledEndpoint{
+		Name:   "ch",
+		Family: "sql",
+		Plugin: &config.Plugin{Type: "clickhouse_native", Family: "sql"},
+		Body:   body,
+		Hosts:  body.EndpointHosts(),
+	}
+	pol := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{"ch": ep},
+	}
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	v4, _ := a.VIPsFor("ch.example.com")
+	if !v4.IsValid() {
+		t.Fatalf("ch.example.com did not get a VIP")
+	}
+	host, hits := a.LookupVIP(v4.String())
+	if host != "ch.example.com" || len(hits) != 1 {
+		t.Fatalf("LookupVIP(%v): host=%q hits=%d, want ch.example.com / 1", v4, host, len(hits))
+	}
+	if hits[0].Port != 9440 {
+		t.Fatalf("hit port = %d, want 9440 (TLS default)", hits[0].Port)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1158,9 +1158,6 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 // for instance) can plug in without a separate forwarder branch.
 func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 	defer otelTrackConn("vip_conn")()
-	pip := peerIP(c)
-	profile := g.profileFor(pip)
-	policy := g.Policy()
 
 	hostname, hits := g.dnsvip.LookupVIP(dstIP)
 	if hostname == "" || len(hits) == 0 {
@@ -1168,6 +1165,9 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 		c.Close()
 		return
 	}
+	pip := peerIP(c)
+	profile := g.profileFor(pip)
+	policy := g.Policy()
 	// Profile-filter the hits, then port-match. Port match handles
 	// the case where one hostname is bound to multiple endpoints on
 	// different ports (rare but legal).
@@ -1196,15 +1196,66 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 		c.Close()
 		return
 	}
+	g.dispatchConnEndpoint(c, dstIP, matchedPort, ep, hostname)
+}
 
+// tryDirectIPConn is the post-VIP fallback that dispatches inbound
+// connections to ConnEndpointRuntime plugins whose endpoint hosts are
+// IP literals (or hostnames whose resolved IP happens to land in the
+// conn-index). Returns true when a matching endpoint claimed the
+// connection so the caller skips wgRelay.
+//
+// Mirrors handlePostgresConn's index-then-dispatch pattern, but
+// generalised: any endpoint whose body implements ConnRouter +
+// whose plugin Runtime satisfies ConnEndpointRuntime is eligible.
+// The clickhouse_native plugin uses this path when an operator binds
+// it to bare-IP hosts (`hosts = ["172.17.0.1"]`) — those entries are
+// skipped by dnsvip (no DNS query to intercept) so direct-IP dispatch
+// is the only way they reach the plugin. profile filter prevents one
+// device from punching into another profile's endpoint by IP.
+func (g *Gateway) tryDirectIPConn(c net.Conn, dstIP string, dstPort uint16) bool {
+	idx := g.connIdx.Load()
+	if idx == nil {
+		return false
+	}
+	pip := peerIP(c)
+	profile := g.profileFor(pip)
+	policy := g.Policy()
+	candidates := idx.Lookup(dstIP)
+	ep := pickEndpointForProfile(candidates, policy, profile)
+	if ep == nil {
+		return false
+	}
+	if _, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime); !ok {
+		return false
+	}
+	g.dispatchConnEndpoint(c, dstIP, dstPort, ep, "")
+	return true
+}
+
+// dispatchConnEndpoint hands one accepted conn to the endpoint's
+// ConnEndpointRuntime. Shared between handleVIPConn and
+// tryDirectIPConn; hostname is the agent-dialed name (set by the VIP
+// path, empty for direct-IP). Closes c on a runtime-mismatch fail
+// path; otherwise the plugin owns the conn lifetime.
+func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16, ep *config.CompiledEndpoint, hostname string) {
 	connRT, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime)
 	if !ok {
-		log.Printf("vip endpoint %q plugin lacks ConnEndpointRuntime", ep.Name)
+		log.Printf("conn dispatch: endpoint %q plugin lacks ConnEndpointRuntime", ep.Name)
 		c.Close()
 		return
 	}
-
-	mode := ep.Plugin.Type // "ssh" today; future plugins surface as their own mode tag
+	pip := peerIP(c)
+	profile := g.profileFor(pip)
+	policy := g.Policy()
+	mode := ep.Plugin.Type
+	// Event Host carries the hostname when known (VIP path), else the
+	// dst IP — keeps the dashboard's "where is this traffic going"
+	// column populated for both dispatch shapes.
+	eventHost := hostname
+	if eventHost == "" {
+		eventHost = dstIP
+	}
 	ch := &runtime.ConnHandle{
 		Conn:         c,
 		Endpoint:     ep,
@@ -1213,7 +1264,7 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 		PeerIP:       pip,
 		Secrets:      g.secrets,
 		CADir:        g.cfg.CADir,
-		DstPort:      matchedPort,
+		DstPort:      dstPort,
 		UpstreamHost: hostname,
 		MintCert: func(host string) (*tls.Certificate, error) {
 			return g.certs.mint(host)
@@ -1221,9 +1272,10 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 		DialUpstream: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			// Plugin passes the *real* upstream host:port — the
 			// gateway's host network resolves it (the VIP only
-			// exists inside the WG netstack).
+			// exists inside the WG netstack; direct-IP dispatch
+			// already has the real IP).
 			if addr == "" {
-				return nil, fmt.Errorf("vip dispatch: plugin gave empty upstream addr")
+				return nil, fmt.Errorf("conn dispatch: plugin gave empty upstream addr")
 			}
 			return g.dialer.DialContext(ctx, network, addr)
 		},
@@ -1232,21 +1284,25 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 				return
 			}
 			g.sink.Emit(Event{
-				Mode: mode, Host: hostname, AgentIP: pip,
+				Mode: mode, Host: eventHost, AgentIP: pip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
 			})
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
 			return g.runApproveChain(context.Background(), req.Stages, runApproveCtx{
-				AgentIP: pip, Host: hostname, Method: req.Verb, Path: req.Summary,
+				AgentIP: pip, Host: eventHost, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
 				Endpoint: ep, Rule: req.Rule, Profile: profile,
 			})
 		},
 	}
 	if err := connRT.HandleConn(context.Background(), ch); err != nil {
-		log.Printf("%s vip %s (%s): %v", mode, dstIP, hostname, err)
+		if hostname != "" {
+			log.Printf("%s vip %s (%s): %v", mode, dstIP, hostname, err)
+		} else {
+			log.Printf("%s direct %s:%d: %v", mode, dstIP, dstPort, err)
+		}
 	}
 }
 
@@ -2071,9 +2127,15 @@ func runGateway(args []string) {
 			case dashPort != 0 && int(dstPort) == dashPort:
 				_ = http.Serve(&oneShotListener{c: c}, dashMux)
 			default:
-				// Anything else relays transparently until its
-				// endpoint plugin's wire-protocol runtime ships
-				// (clickhouse_native, etc.).
+				// Direct-IP dispatch via conn-index: catches
+				// clickhouse_native and friends when the operator
+				// binds them to IP-literal hosts (dnsvip skips
+				// those — they don't need DNS interception). Falls
+				// through to transparent relay when no endpoint
+				// claims the dst.
+				if g.tryDirectIPConn(c, dstIP, dstPort) {
+					return
+				}
 				wgRelay(c, dstIP, int(dstPort))
 			}
 		}
@@ -2087,7 +2149,7 @@ func runGateway(args []string) {
 		if err := wg.EnablePromiscuousForwarder(tcpDispatch, udpDispatch); err != nil {
 			log.Fatalf("wireguard forwarder: %v", err)
 		}
-		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :53=dns-vip, VIP=ssh, :%d=dash, else=relay)", dashPort)
+		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :53=dns-vip, VIP=ssh|ch_native, :%d=dash, plugins=conn-index, else=relay)", dashPort)
 	}
 
 	ln, err := openListener(cfg)

--- a/main.go
+++ b/main.go
@@ -1206,14 +1206,18 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 
 	mode := ep.Plugin.Type // "ssh" today; future plugins surface as their own mode tag
 	ch := &runtime.ConnHandle{
-		Conn:     c,
-		Endpoint: ep,
-		Policy:   policy,
-		Profile:  profile,
-		PeerIP:   pip,
-		Secrets:  g.secrets,
-		CADir:    g.cfg.CADir,
-		DstPort:  matchedPort,
+		Conn:         c,
+		Endpoint:     ep,
+		Policy:       policy,
+		Profile:      profile,
+		PeerIP:       pip,
+		Secrets:      g.secrets,
+		CADir:        g.cfg.CADir,
+		DstPort:      matchedPort,
+		UpstreamHost: hostname,
+		MintCert: func(host string) (*tls.Certificate, error) {
+			return g.certs.mint(host)
+		},
 		DialUpstream: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			// Plugin passes the *real* upstream host:port — the
 			// gateway's host network resolves it (the VIP only


### PR DESCRIPTION
First-pass ClickHouse native protocol support for the gateway. Mirrors the postgres plugin shape.

Scope:
- Parse the client Hello and swap placeholder username/password bytes for the bound credential's real values.
- Emit one `ConnEvent` per session.
- Pipe bidirectionally after auth.

Out of scope (follow-up): SQL query parsing.

Adds:
- `ClickhouseAuthCredential` interface; `clickhouse_credential` implements it.
- `ClickhouseNativeEndpoint` gains `Port`, TLS, `ConnRouter`.
- `ClickhouseNativeEndpointRuntime` implements `ConnEndpointRuntime`.
- `VarUInt` + Hello parser/serializer with roundtrip + short-buffer tests.
- Generic conn-index dispatch in the WG forwarder so operators can run on either 9000 (plaintext) or 9440 (TLS) without a port-table edit.