### PR TITLE
mac ext: unix-socket session registry + PID-set ancestor; gh avatar in agents table

### DIFF
--- a/macos/Clawpatrol/main.swift
+++ b/macos/Clawpatrol/main.swift
@@ -56,6 +56,15 @@ NSApplication.shared.run()
 func runWrapped() {
     let argv = Array(CommandLine.arguments.dropFirst(2)).filter { $0 != "--" }
     if argv.isEmpty { usage() }
+
+    // IPC handshake — synchronously register our PID with the
+    // extension's session listener before posix_spawn'ing the child.
+    // The handshake guarantees the ext has the PID in its registry
+    // before the child's first flow can fire. See sessionRegister()
+    // in Provider.swift for protocol details.
+    sessionIPC("register \(getpid())")
+    defer { sessionIPC("unregister \(getpid())") }
+
     var pid: pid_t = 0
     let cargs = argv.map { strdup($0) } + [nil]
     var actions: posix_spawn_file_actions_t? = nil
@@ -70,6 +79,42 @@ func runWrapped() {
     var status: Int32 = 0
     waitpid(pid, &status, 0)
     exit((status >> 8) & 0xff)
+}
+
+// sessionIPC dials /tmp/clawpatrol.sock and sends a single newline-
+// framed verb. Best-effort: failures (sysext not yet running, sandbox
+// quirk) just no-op. The wrapped child won't be tunneled in that
+// case, but blocking the user's command on extension plumbing is
+// worse than passthrough.
+func sessionIPC(_ msg: String) {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    if fd < 0 { return }
+    defer { Darwin.close(fd) }
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let bytes = "/tmp/clawpatrol.sock".utf8CString
+    withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+        ptr.withMemoryRebound(to: CChar.self, capacity: bytes.count) { p in
+            for (i, b) in bytes.enumerated() {
+                p.advanced(by: i).pointee = b
+            }
+        }
+    }
+    let len = socklen_t(MemoryLayout<sockaddr_un>.size)
+    let rc = withUnsafePointer(to: &addr) { ap -> Int32 in
+        ap.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+            Darwin.connect(fd, sa, len)
+        }
+    }
+    if rc != 0 { return }
+    var line = msg + "\n"
+    _ = line.withUTF8 { buf in
+        Darwin.write(fd, buf.baseAddress, buf.count)
+    }
+    var reply = [UInt8](repeating: 0, count: 8)
+    _ = reply.withUnsafeMutableBufferPointer { p in
+        Darwin.read(fd, p.baseAddress, p.count)
+    }
 }
 
 class ExtDelegate: NSObject, OSSystemExtensionRequestDelegate {

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -84,6 +84,12 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 return
             }
             os_log("wg handshake complete", log: log, type: .info)
+            // IPC listener — synchronous handshake from clawpatrol
+            // CLI registers its PID before exec'ing the wrapped child,
+            // eliminating the start-of-flow race a file-watcher would
+            // have. Idempotent if startProxy fires twice.
+            startSessionListener()
+            startSessionReaper()
             DispatchQueue.main.async {
                 self.applyNetworkSettings(completionHandler: completionHandler)
             }
@@ -336,39 +342,145 @@ private func pidFromAuditToken(_ data: Data) -> pid_t? {
     }
 }
 
-// Walk PPID chain looking for an ancestor that's "us":
-//   - path under /Applications/Clawpatrol.app/  (GUI app + sysext host)
-//   - OR basename == "clawpatrol"               (standalone CLI from
-//                                                 install.sh, lives at
-//                                                 $HOME/.local/bin by
-//                                                 default but operators
-//                                                 may override via
-//                                                 CLAWPATROL_PREFIX)
-// SecCode-based identifier matching (the obvious approach) is
-// unreliable in sysext context — SecCodeCopySigningInformation works
-// inconsistently. Path + basename matching is good enough.
-private let parentBundlePathPrefix = "/Applications/Clawpatrol.app/"
-private let cliBinaryName = "clawpatrol"
-private let MAX_PROC_PATH = 4096
-private let bsdInfoSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+// Session registry — populated synchronously by `clawpatrol run`
+// (Go) or `Clawpatrol run` (Swift helper) over the unix socket at
+// sessionSockPath before the wrapped child exec's. Mirrors unclaw's
+// SessionRegistry, transport-agnostic so the Go CLI can speak it
+// without an ObjC runtime.
+//
+// Wire protocol (newline-framed ASCII):
+//   client → "register <pid>\n"      ext → "ok\n"
+//   client → "unregister <pid>\n"    ext → "ok\n"
+// Unknown verbs reply "err\n". Connection close = no-op; lingering
+// PIDs are reaped via kill(pid, 0).
+//
+// Why /tmp: sysext sandbox allows /private/tmp (alias /tmp);
+// /var/run requires root for both bind AND connect, but the CLI runs
+// as user. /tmp is world-RW which is fine — registering a non-
+// clawpatrol PID just means the ext might tunnel that PID's flows,
+// a local authz concern only the host's user controls anyway.
+let sessionSockPath = "/tmp/clawpatrol.sock"
 
-private func processIsClawpatrol(path: String) -> Bool {
-    if path.hasPrefix(parentBundlePathPrefix) { return true }
-    if let slash = path.lastIndex(of: "/") {
-        let after = path.index(after: slash)
-        if path[after...] == cliBinaryName { return true }
-    } else if path == cliBinaryName {
-        return true
-    }
-    return false
+private var sessionPidsSet: Set<pid_t> = []
+private let sessionPidsLock = NSLock()
+
+private func sessionPids() -> Set<pid_t> {
+    sessionPidsLock.lock()
+    defer { sessionPidsLock.unlock() }
+    return sessionPidsSet
+}
+private func sessionRegister(_ pid: pid_t) {
+    sessionPidsLock.lock()
+    sessionPidsSet.insert(pid)
+    sessionPidsLock.unlock()
+    // Ancestor cache invalidates because new session PID changes
+    // the verdict for any descendant — clear and let it re-warm.
+    ancestorCacheLock.lock()
+    ancestorCache.removeAll(keepingCapacity: true)
+    ancestorCacheLock.unlock()
+}
+private func sessionUnregister(_ pid: pid_t) {
+    sessionPidsLock.lock()
+    sessionPidsSet.remove(pid)
+    sessionPidsLock.unlock()
+    ancestorCacheLock.lock()
+    ancestorCache.removeAll(keepingCapacity: true)
+    ancestorCacheLock.unlock()
 }
 
-// Per-pid cache for ancestorMatches. proc_pidpath + proc_pidinfo are
-// syscalls; on whole-machine every flow walks the chain and hammers
-// these (5-10 syscalls per flow × thousands of flows/sec). Cache the
-// terminal verdict (matches?) keyed by pid with a 5s TTL — pids get
-// recycled fast on macOS, so don't keep stale entries.
-private struct ancestorCacheEntry { let matches: Bool; let expires: Date }
+// Reaper: every 5s drop registered PIDs whose process is gone.
+// Covers SIGKILLed CLIs that didn't get to send unregister.
+private var sessionReaperTimer: DispatchSourceTimer?
+private func startSessionReaper() {
+    let t = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+    t.schedule(deadline: .now() + 5, repeating: 5)
+    t.setEventHandler {
+        for pid in sessionPids() where kill(pid, 0) != 0 {
+            sessionUnregister(pid)
+        }
+    }
+    t.resume()
+    sessionReaperTimer = t
+}
+
+private var sessionListenFD: Int32 = -1
+private func startSessionListener() {
+    unlink(sessionSockPath)
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    if fd < 0 { return }
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = sessionSockPath.utf8CString
+    withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+        ptr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { p in
+            for (i, b) in pathBytes.enumerated() {
+                p.advanced(by: i).pointee = b
+            }
+        }
+    }
+    let len = socklen_t(MemoryLayout<sockaddr_un>.size)
+    let rc = withUnsafePointer(to: &addr) { ap -> Int32 in
+        ap.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+            Darwin.bind(fd, sa, len)
+        }
+    }
+    if rc != 0 { Darwin.close(fd); return }
+    chmod(sessionSockPath, 0o666)
+    if listen(fd, 16) != 0 { Darwin.close(fd); return }
+    sessionListenFD = fd
+    DispatchQueue.global(qos: .userInitiated).async {
+        while true {
+            let cfd = Darwin.accept(fd, nil, nil)
+            if cfd < 0 { continue }
+            DispatchQueue.global(qos: .userInitiated).async {
+                serviceSessionClient(cfd)
+            }
+        }
+    }
+}
+
+private func serviceSessionClient(_ fd: Int32) {
+    defer { Darwin.close(fd) }
+    var buf = [UInt8](repeating: 0, count: 256)
+    var pending = ""
+    while true {
+        let n = buf.withUnsafeMutableBufferPointer { p -> Int in
+            Darwin.read(fd, p.baseAddress, p.count)
+        }
+        if n <= 0 { return }
+        pending += String(bytes: buf[0..<n], encoding: .utf8) ?? ""
+        while let nl = pending.firstIndex(of: "\n") {
+            let line = String(pending[..<nl])
+            pending = String(pending[pending.index(after: nl)...])
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            var reply = "err\n"
+            if parts.count == 2, let pid = pid_t(parts[1]) {
+                switch parts[0] {
+                case "register":   sessionRegister(pid);   reply = "ok\n"
+                case "unregister": sessionUnregister(pid); reply = "ok\n"
+                default: break
+                }
+            }
+            _ = reply.withCString { cs in
+                Darwin.write(fd, cs, strlen(cs))
+            }
+        }
+    }
+}
+
+// Ancestor match — walk PPID chain via proc_pidinfo only (no
+// proc_pidpath; Set<pid_t> membership instead of string compares).
+// Mirrors unclaw/UnclawExtension/ProcessTree.swift. The path-based
+// check we used previously was the actual cause of the
+// Chrome-hangs-during-clawpatrol-run symptom: proc_pidpath is
+// ~50–200µs per level, and Chrome spawns many helper processes whose
+// flows all hit handleNewFlow. Walking 5–10 levels × hundreds of
+// concurrent flows × the path syscall = handleNewFlow returning
+// slowly enough to mis-route UDP. proc_pidinfo is ~5µs and Set
+// membership is nanoseconds.
+private let bsdInfoSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+
+private struct ancestorCacheEntry { let sessionPID: pid_t; let expires: Date }
 private var ancestorCache: [pid_t: ancestorCacheEntry] = [:]
 private let ancestorCacheLock = NSLock()
 private let ancestorCacheTTL: TimeInterval = 5
@@ -377,26 +489,25 @@ private func ancestorMatches(pid: pid_t) -> Bool {
     let now = Date()
     ancestorCacheLock.lock()
     if let e = ancestorCache[pid], e.expires > now {
+        let v = e.sessionPID != 0
         ancestorCacheLock.unlock()
-        return e.matches
+        return v
     }
     ancestorCacheLock.unlock()
 
+    let registered = sessionPids()
+    if registered.isEmpty { return false }
+
     // Start at the parent — the process itself is never "its own
-    // ancestor". Without this, any process whose binary is named
-    // "clawpatrol" (including the gateway) would match on the first
-    // iteration and have its outbound flows tunneled back into itself.
-    guard let first = parentPid(of: pid), first != pid else {
-        return false
-    }
+    // ancestor".
+    guard let first = parentPid(of: pid), first != pid else { return false }
     var cur = first
     var visited = Set<pid_t>()
-    var matches = false
+    var sessionPID: pid_t = 0
     while cur > 1 && !visited.contains(cur) {
         visited.insert(cur)
-        if let path = processBinaryPath(pid: cur),
-           processIsClawpatrol(path: path) {
-            matches = true
+        if registered.contains(cur) {
+            sessionPID = cur
             break
         }
         guard let ppid = parentPid(of: cur), ppid != cur else { break }
@@ -404,23 +515,16 @@ private func ancestorMatches(pid: pid_t) -> Bool {
     }
 
     ancestorCacheLock.lock()
-    ancestorCache[pid] = ancestorCacheEntry(matches: matches, expires: now.addingTimeInterval(ancestorCacheTTL))
+    ancestorCache[pid] = ancestorCacheEntry(sessionPID: sessionPID, expires: now.addingTimeInterval(ancestorCacheTTL))
     if ancestorCache.count > 4096 {
-        // Cap memory: drop expired entries on overflow.
         ancestorCache = ancestorCache.filter { $0.value.expires > now }
     }
     ancestorCacheLock.unlock()
-    return matches
+    return sessionPID != 0
 }
 
 private func parentPid(of pid: pid_t) -> pid_t? {
     var info = proc_bsdinfo()
     let n = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, bsdInfoSize)
     return n == bsdInfoSize ? pid_t(info.pbi_ppid) : nil
-}
-
-private func processBinaryPath(pid: pid_t) -> String? {
-    var path = [CChar](repeating: 0, count: MAX_PROC_PATH)
-    let n = proc_pidpath(pid, &path, UInt32(MAX_PROC_PATH))
-    return n > 0 ? String(cString: path) : nil
 }

--- a/run_darwin.go
+++ b/run_darwin.go
@@ -18,13 +18,63 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"time"
 )
 
 const macHelperPath = "/Applications/Clawpatrol.app/Contents/MacOS/Clawpatrol"
+
+const sessionSockPath = "/tmp/clawpatrol.sock"
+
+// registerSession dials the extension's IPC socket and synchronously
+// hands it our PID before any wrapped command starts. The handshake
+// guarantees the ext has the PID registered before the child exec's
+// first flow can fire — a file-based registry would race at the
+// directory-mtime layer. Returns a cleanup that sends the matching
+// unregister.
+//
+// Best-effort: if the socket can't be reached (sysext not running
+// yet, sandbox issue) we proceed without registering. The child
+// won't be tunneled but the command isn't blocked on IPC plumbing.
+func registerSession() func() {
+	pid := os.Getpid()
+	if err := sessionIPC(fmt.Sprintf("register %d\n", pid)); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ session register: %v (proceeding without tunnel)\n", err)
+		return func() {}
+	}
+	return func() {
+		_ = sessionIPC(fmt.Sprintf("unregister %d\n", pid))
+	}
+}
+
+// sessionIPC dials sessionSockPath, writes msg, expects "ok\n".
+// Tight 2s deadline — the listener should respond in microseconds;
+// anything slower means the ext is wedged and we shouldn't block.
+func sessionIPC(msg string) error {
+	d := net.Dialer{Timeout: 2 * time.Second}
+	c, err := d.Dial("unix", sessionSockPath)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	c.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := c.Write([]byte(msg)); err != nil {
+		return err
+	}
+	buf := make([]byte, 8)
+	n, err := c.Read(buf)
+	if err != nil {
+		return err
+	}
+	if string(buf[:n]) != "ok\n" {
+		return fmt.Errorf("ext replied %q", string(buf[:n]))
+	}
+	return nil
+}
 
 func runRun(args []string) {
 	if _, err := os.Stat(macHelperPath); err != nil {
@@ -35,6 +85,12 @@ func runRun(args []string) {
 	if err := ensureMacProxyUp(); err != nil {
 		fail(fmt.Sprintf("ensure proxy up: %v", err))
 	}
+	// IPC handshake — synchronously register our PID with the
+	// extension's session listener before exec'ing the helper. The
+	// handshake guarantees the ext has the PID in its registry
+	// before any descendant flow can fire.
+	cleanup := registerSession()
+	defer cleanup()
 	// Stamp CA + placeholder env vars on the current process so the
 	// helper inherits them and forwards them to the wrapped child.
 	applyEnvPushdown(defaultClawpatrolDir())

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -91,7 +91,19 @@ export function AgentsTable({
               </Td>
               <Td>
                 <IntegrationStack
-                  items={(a.integrations ?? []).map((id) => ({ id, type: byId.get(id)?.type }))}
+                  items={(a.integrations ?? []).map((id) => {
+                    const it = byId.get(id);
+                    // Pick the owner row matching this device's profile
+                    // so two profiles connected to different GH accounts
+                    // surface distinct avatars in their respective rows.
+                    const owner = it?.owners?.find((o) => o.owner === a.profile)
+                      ?? it?.owners?.[0];
+                    return {
+                      id,
+                      type: it?.type,
+                      avatar_url: owner?.avatar_url,
+                    };
+                  })}
                 />
               </Td>
             </tr>

--- a/www/src/components/IntegrationStack.tsx
+++ b/www/src/components/IntegrationStack.tsx
@@ -1,15 +1,19 @@
+import * as React from "react";
 import { IntegrationIcon } from "./Logos";
 
 // Overlapping circles a la GitHub avatar stack. Items carry both the
 // credential bare-name (id) and the plugin type — IntegrationIcon uses
 // the type to pick a brand logo, falling back to the id for the
 // claude/codex/github built-ins where the bare name happens to match
-// the brand.
+// the brand. avatar_url, when present, replaces the brand logo with
+// the connected user's PFP (e.g. github avatar) so two devices in
+// different profiles connected to different accounts are
+// visually distinguishable in the agents table.
 export function IntegrationStack({
   items,
   size = 20,
 }: {
-  items: { id: string; type?: string }[];
+  items: { id: string; type?: string; avatar_url?: string }[];
   size?: number;
 }) {
   if (!items?.length) return <span className="text-[10px] text-[#a3a3a3]">—</span>;
@@ -28,11 +32,35 @@ export function IntegrationStack({
             zIndex: items.length - i,
           }}
         >
-          <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
-            <IntegrationIcon id={it.id} type={it.type} className="w-full h-full" />
-          </span>
+          {it.avatar_url
+            ? <StackAvatar src={it.avatar_url} fallbackId={it.id} fallbackType={it.type} size={size} inner={inner} />
+            : <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
+                <IntegrationIcon id={it.id} type={it.type} className="w-full h-full" />
+              </span>}
         </span>
       ))}
     </div>
+  );
+}
+
+function StackAvatar({
+  src, fallbackId, fallbackType, size, inner,
+}: {
+  src: string; fallbackId: string; fallbackType?: string;
+  size: number; inner: number;
+}) {
+  const [broken, setBroken] = React.useState(false);
+  if (broken) {
+    return <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
+      <IntegrationIcon id={fallbackId} type={fallbackType} className="w-full h-full" />
+    </span>;
+  }
+  return (
+    <img
+      src={src}
+      alt=""
+      onError={() => setBroken(true)}
+      style={{ width: size, height: size, objectFit: "cover" }}
+    />
   );
 }

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -202,7 +202,10 @@ function Card({
           ? <OwnerAvatar src={me.avatar_url} fallbackId={i.id} fallbackType={i.type} />
           : <IntegrationIcon id={i.id} type={i.type} className="w-[16px] h-[16px] flex-shrink-0" />}
         <span className="text-[12px] font-semibold text-[#171717] truncate" title={me?.display_name ?? i.id}>
-          {me?.display_name ?? TYPE_LABEL[i.type] ?? i.name}
+          {(() => {
+            const label = TYPE_LABEL[i.type] ?? i.name;
+            return me?.display_name ? `${label} (${me.display_name})` : label;
+          })()}
         </span>
         <span className="ml-auto flex items-center gap-1.5 flex-shrink-0">
           {connected && (


### PR DESCRIPTION
## Summary

Two unrelated fixes.

### mac ext: replace path-matching ancestor walk with PID-set lookup, swap session-file registry for synchronous unix-socket handshake

Root cause of \"Chrome stalls when \`clawpatrol run claude\` is active\" was \`proc_pidpath\` per-level being too slow (~50–200µs) under the per-flow concurrency Chrome generates. Walking 5–10 levels × hundreds of concurrent flows × the path syscall = \`handleNewFlow\` returning slowly enough to mis-route UDP at the kernel layer. Mirrors ref-impl's \`ProcessTree.swift\`: \`proc_pidinfo\` only (~5µs/level) plus \`Set<pid_t>\` membership (nanoseconds) instead of string compares.

Session registry switched from a session-file directory to a unix socket at \`/tmp/clawpatrol.sock\`. Files raced — between Go writing the \`.session\` file and the ext seeing the new directory entry, the child's first flow could fire and miss the registry. Sockets are synchronous:

```
clawpatrol run claude:
  1. dial /tmp/clawpatrol.sock
  2. send \"register <self-pid>\\n\"
  3. read \"ok\\n\"   ← ext has registered before we proceed
  4. exec claude
```

Wire protocol (newline-framed): \`register <pid>\` / \`unregister <pid>\` → \`ok\` | \`err\`. Sandbox-friendly: sysext binds \`/private/tmp\` (alias \`/tmp\`), 0666 perms so the unprivileged Go CLI can connect. Reaper timer drops PIDs whose process is gone (handles SIGKILLed CLIs that miss unregister). Both Go (\`run_darwin.go\`) and the Swift helper (\`main.swift\`) speak the protocol.

### dashboard: agents-table integration column shows the connected user's avatar; integration cards read \"Github (login)\"

The earlier \`IntegrationsCards\` avatar work didn't reach the agents-table integration column — that path uses \`IntegrationStack\` which was still hardcoded to the brand icon. Plumb \`avatar_url\` through: \`AgentsTable\` picks the \`Owner\` row matching the device's profile, hands its \`avatar_url\` to \`IntegrationStack\`, which renders an \`<img>\` in place of the \`IntegrationIcon\` (with icon as fallback on load failure). Two devices in different profiles connected to different GitHub accounts are now visually distinguishable from the agents table at a glance.

Card title now reads \`Github (alice)\` — provider type label first, display name in parens — instead of just the display name.

## Test plan

- [ ] Reinstall sysext, \`clawpatrol run claude\` in one terminal, hit api.anthropic.com — gateway logs show the request.
- [ ] In another terminal, browse Chrome to github.com — no 30 s stall.
- [ ] \`/tmp/clawpatrol.sock\` exists with 0666 perms after sysext start.
- [ ] Disconnect + reconnect GitHub OAuth → agents table integration stack shows the user avatar instead of the GH logo for the device.
- [ ] Card title in IntegrationsCards reads \`Github (login)\` when connected.
- [ ] Avatar URL that 404s falls back to the brand icon, no broken-image glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)