### PR TITLE
env pushdown: silence anthropic_manual_key + add DENO_CERT/PIP_CERT + opt-out

### DIFF
--- a/config/plugins/credentials/anthropic_manual_key.go
+++ b/config/plugins/credentials/anthropic_manual_key.go
@@ -26,10 +26,18 @@ func (*AnthropicManualKey) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Anthropic API key", Description: "sk-ant-…"}}
 }
 
+// EnvVars intentionally returns nothing.
+//
+// Pushing ANTHROPIC_API_KEY conflicts with the AnthropicOAuthSubscription
+// plugin's ANTHROPIC_AUTH_TOKEN — Claude Code and the Anthropic SDKs
+// honor whichever is set first, and when both are set with placeholders,
+// the SDK's own validation rejects the request before it reaches the
+// gateway. Until the env-pushdown layer scopes vars to the profile's
+// active credentials (rather than the union of every registered
+// plugin), the manual-key plugin stays silent. Operators who want the
+// x-api-key header still get it via InjectHTTP — no pushdown needed.
 func (*AnthropicManualKey) EnvVars() []config.EnvVar {
-	return []config.EnvVar{
-		{Name: "ANTHROPIC_API_KEY", Value: phClaude, Description: "Anthropic API key (manual)"},
-	}
+	return nil
 }
 
 func init() {

--- a/integrations.go
+++ b/integrations.go
@@ -126,7 +126,15 @@ func runEnv(args []string) {
 // command, so the wrapped agent CLI inherits the placeholders + CA
 // paths without the operator having to source `clawpatrol env`
 // separately.
+//
+// Opt-out: setting CLAWPATROL_NO_ENV=1 disables the entire pushdown.
+// Use when an agent CLI is incompatible with one of the pushed vars
+// (e.g. an OPENAI_API_KEY placeholder that forces a CLI into API
+// mode when its native auth would have worked through the tunnel).
 func applyEnvPushdown(caDir string) {
+	if os.Getenv("CLAWPATROL_NO_ENV") == "1" {
+		return
+	}
 	caPath := filepath.Join(caDir, "ca.crt")
 	if _, err := os.Stat(caPath); err != nil {
 		// CA not set up yet — `clawpatrol join` hasn't run. Don't

--- a/integrations.go
+++ b/integrations.go
@@ -66,6 +66,8 @@ func envPushdownVars(caPath string) []pushdownEnvVar {
 		"REQUESTS_CA_BUNDLE",
 		"CURL_CA_BUNDLE",
 		"GIT_SSL_CAINFO",
+		"DENO_CERT",
+		"PIP_CERT",
 	} {
 		out = append(out, pushdownEnvVar{Name: k, Value: caPath})
 	}


### PR DESCRIPTION
## Summary

Three env-pushdown fixes, bundled because they share the same site (\`integrations.go\` + the anthropic credential plugins).

- **\`anthropic_manual_key\` no longer pushes \`ANTHROPIC_API_KEY\`.** Conflicted with \`anthropic_oauth\`'s \`ANTHROPIC_AUTH_TOKEN\` — when both were set to placeholders, Claude Code and the Anthropic SDKs picked \`ANTHROPIC_API_KEY\` first and rejected the request locally before it ever reached the gateway. Until env pushdown is scoped to a profile's *active* credentials (rather than the union of every registered plugin), the manual-key plugin stays silent. Operators who want the \`x-api-key\` header still get it via \`InjectHTTP\` — no env needed for that.
- **Add \`DENO_CERT\` + \`PIP_CERT\`** to the CA-bundle pushdown set, matching ref-impl's \`join.sh\`. Catches deno scripts and pip-installed CLIs that bundle their own trust stores.
- **\`CLAWPATROL_NO_ENV=1\` opt-out** — disables the entire pushdown. Useful when an agent CLI is incompatible with one of the pushed vars (e.g. an \`OPENAI_API_KEY\` placeholder forcing a CLI into API mode when its native OAuth would have worked through the tunnel).

## Test plan

- [ ] \`clawpatrol run env | grep ANTHROPIC\` → only \`ANTHROPIC_AUTH_TOKEN\` set, no \`ANTHROPIC_API_KEY\`.
- [ ] \`clawpatrol run claude\` — Claude Code authenticates without the API-key shadow rejection.
- [ ] \`clawpatrol run env | grep -E 'DENO_CERT|PIP_CERT'\` → both set to ca.crt path.
- [ ] \`CLAWPATROL_NO_ENV=1 clawpatrol run env | grep -E 'CERT|BUNDLE|TOKEN|API_KEY'\` — none of the pushdown vars present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)