### PR TITLE
linux run: split v4+v6 Address; drop fd77 ghost rows on boot

### DIFF
--- a/main.go
+++ b/main.go
@@ -1691,11 +1691,16 @@ func runGateway(args []string) {
 	// renders them on boot, before any traffic arrives. Without this,
 	// devices disappear after every gateway restart and only reappear
 	// on the next request from each peer.
+	// Clean fd77:: ghost rows left by older builds where SetExternalIPs
+	// upserted both v4 and v6 allowed_ips as separate device IDs. Drop
+	// them on every boot — the v4 row carries the same metadata and
+	// will be re-seeded below.
+	_, _ = db.Exec("DELETE FROM devices WHERE id LIKE 'fd77:%'")
 	if rows, err := db.Query("SELECT id FROM devices"); err == nil {
 		for rows.Next() {
 			var ip string
 			if rows.Scan(&ip) == nil {
-				g.agents.Seed(ip)
+				g.agents.Seed(canonicalPeerIP(ip))
 			}
 		}
 		rows.Close()

--- a/onboard.go
+++ b/onboard.go
@@ -87,6 +87,11 @@ func newOnboardRegistry() *onboardRegistry {
 // approvedIpv6 model — the dashboard shows these in place of the wg /32,
 // which is just a routing artefact. Persists through to the devices row.
 func (r *onboardRegistry) SetExternalIPs(ip, v4, v6 string) {
+	// Both v4 and v6 wg-side allowed_ips reach this path (one fd77::<n>
+	// per peer); collapse to the canonical v4 so each device exists as a
+	// single row. Without this the dashboard shows ghost fd77:: entries
+	// alongside the real device.
+	ip = canonicalPeerIP(ip)
 	if ip == "" || (v4 == "" && v6 == "") {
 		return
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -188,16 +188,33 @@ func runRunChild() {
 	wgUpR.Close()
 
 	cfg := mustParseRunConf(os.Getenv("CLAWPATROL_RUN_CONF"))
-	addr := cfg.Address
-	if !strings.Contains(addr, "/") {
-		addr += "/32"
+	// Address may carry both v4 and v6 separated by ", " — gateway-emitted
+	// wg-quick conf looks like `Address = 10.55.0.5/32, fd77::5/128`. The
+	// `ip addr add` command rejects the comma-joined form ("any valid
+	// prefix is expected rather than ..."), so split + assign each addr.
+	var addrs []string
+	for _, part := range strings.Split(cfg.Address, ",") {
+		s := strings.TrimSpace(part)
+		if s == "" {
+			continue
+		}
+		if !strings.Contains(s, "/") {
+			s += "/32"
+		}
+		addrs = append(addrs, s)
 	}
-	for _, a := range [][]string{
+	if len(addrs) == 0 {
+		fail("wg conf: empty Address")
+	}
+	steps := [][]string{
 		{"ip", "link", "set", "lo", "up"},
 		{"ip", "link", "set", tunIfName, "mtu", fmt.Sprintf("%d", tunMTU), "up"},
-		{"ip", "addr", "add", addr, "dev", tunIfName},
-		{"ip", "route", "add", "default", "dev", tunIfName},
-	} {
+	}
+	for _, a := range addrs {
+		steps = append(steps, []string{"ip", "addr", "add", a, "dev", tunIfName})
+	}
+	steps = append(steps, []string{"ip", "route", "add", "default", "dev", tunIfName})
+	for _, a := range steps {
 		c := exec.Command(a[0], a[1:]...)
 		c.Stderr = os.Stderr
 		if err := c.Run(); err != nil {


### PR DESCRIPTION
## Summary

Two unrelated wg/IPv6 fixes.

### \`clawpatrol run\` on linux: split v4+v6 \`Address\` line

Failing with:
\`\`\`
Error: any valid prefix is expected rather than \"10.55.0.5/32, fd77::5/128\".
clawpatrol: ip addr add 10.55.0.5/32, fd77::5/128 dev wg0: exit status 1
\`\`\`

The gateway-emitted wg-quick conf carries both v4 and v6 in a single \`Address = 10.55.0.5/32, fd77::5/128\` line. \`ip addr add\` rejects the comma-joined form. Split on commas and run one \`ip addr add\` per prefix.

### Dashboard: ghost \`fd77::\` device rows

Dashboard was showing rows like \`fd77::5\`, \`fd77::7\`, \`fd77::a\`, ... alongside the real devices, with no hostname / profile and zero traffic. \`EndpointsByIP\` returns one entry per \`allowed_ip\` per peer (both the v4 \`/32\` and the v6 \`/128\`) — \`apiAgents\` fed each into \`SetExternalIPs\`, which upserted a separate \`devices\` row for each. \`SetExternalIPs\` now canonicalizes the IP via \`canonicalPeerIP\` so both addresses fold into the same device row. The boot path drops any pre-existing \`fd77\` rows (one-shot cleanup, idempotent) and re-canonicalizes the seed loop so stale state from older builds clears on next gateway start.

## Test plan

- [ ] On a linux peer: \`clawpatrol run -- curl https://httpbin.org/ip\` — succeeds without the \`ip addr add\` error.
- [ ] After gateway restart: dashboard agents table shows no \`fd77::*\` rows.
- [ ] New peer joins with v6 enabled: appears once (as v4) in the dashboard, not twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)