### PR TITLE
codex: WS upgrade detection + device-code OAuth + chatgpt-account-id + uTLS for chatgpt.com

### DIFF
--- a/config/plugins/credentials/openai_codex.go
+++ b/config/plugins/credentials/openai_codex.go
@@ -5,7 +5,10 @@ package credentials
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/runtime"
@@ -18,25 +21,80 @@ func (a *OpenAICodexOAuth) InjectHTTP(_ context.Context, req *http.Request, sec 
 		return nil
 	}
 	req.Header.Set("Authorization", "Bearer "+string(sec.Bytes))
+	// chatgpt.com's /backend-api/codex/responses endpoint returns 405
+	// without the `chatgpt-account-id` header. The id is buried in the
+	// access token's JWT claims (claims.chatgpt_account_id, or the
+	// nested "https://api.openai.com/auth".chatgpt_account_id form).
+	// Decode + stamp matching unclaw's openai-codex plugin behavior.
+	if id := chatgptAccountID(string(sec.Bytes)); id != "" {
+		req.Header.Set("chatgpt-account-id", id)
+	}
 	return nil
 }
 
-func (*OpenAICodexOAuth) EnvVars() []config.EnvVar {
-	return []config.EnvVar{
-		{Name: "OPENAI_API_KEY", Value: phOpenAI, Description: "OpenAI / Codex CLI"},
+// chatgptAccountID extracts the chatgpt_account_id claim from an
+// OpenAI-issued JWT (id_token or access_token). Returns empty string
+// when the token isn't a JWT or the claim is missing — caller skips
+// the header in that case.
+func chatgptAccountID(jwt string) string {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return ""
 	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// JWTs sometimes ship with padding; try the URL-safe variant.
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return ""
+		}
+	}
+	var claims struct {
+		ChatGPTAccountID string `json:"chatgpt_account_id"`
+		Auth             struct {
+			ChatGPTAccountID string `json:"chatgpt_account_id"`
+		} `json:"https://api.openai.com/auth"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	if claims.ChatGPTAccountID != "" {
+		return claims.ChatGPTAccountID
+	}
+	return claims.Auth.ChatGPTAccountID
 }
+
+// EnvVars intentionally returns nothing.
+//
+// Pushing OPENAI_API_KEY flips codex out of subscription/OAuth mode
+// into API-key mode, which uses a different request shape — it sends
+// GET to chatgpt.com/backend-api/codex/responses, server replies 405
+// (POST only). Subscription mode reads ~/.codex/auth.json for the
+// real JWT and POSTs correctly. Until we ship the agent-shim that
+// writes a placeholder auth.json (matching unclaw), the cleanest
+// path is to leave OPENAI_API_KEY unset and let codex pick up the
+// real auth.json.
+func (*OpenAICodexOAuth) EnvVars() []config.EnvVar { return nil }
 
 func (a *OpenAICodexOAuth) OAuthFlow() *config.OAuthIntegration {
 	return &config.OAuthIntegration{
 		Type:   "oauth2",
 		Header: "Authorization",
 		Prefix: "Bearer ",
+		// Non-standard "openai_device" flow handled in oauth.go:
+		// start hits deviceauth/usercode (JSON), poll hits
+		// deviceauth/token (JSON, returns authorization_code +
+		// code_verifier), then we exchange via /oauth/token.
+		Flow: "openai_device",
 		OAuth: config.OAuthConfig{
+			// Codex CLI client_id — same as the desktop app uses, so
+			// device-code prompts on auth.openai.com/codex/device
+			// recognize the request.
 			ClientID:     "app_EMoamEEZ73f0CkXaXp7hrann",
-			AuthURL:      "https://auth.openai.com/oauth/authorize",
+			DeviceURL:    "https://auth.openai.com/api/accounts/deviceauth/usercode",
+			AuthURL:      "https://auth.openai.com/api/accounts/deviceauth/token",
 			TokenURL:     "https://auth.openai.com/oauth/token",
-			RedirectURI:  "http://localhost:1455/auth/callback",
+			RedirectURI:  "https://auth.openai.com/deviceauth/callback",
 			Scopes:       []string{"openid", "profile", "email", "offline_access"},
 			RefreshToken: "{{secret:CODEX_REFRESH}}",
 		},

--- a/dial.go
+++ b/dial.go
@@ -14,12 +14,48 @@ import (
 	"crypto/tls"
 	"log"
 	"net"
+	"strings"
 
 	utls "github.com/refraction-networking/utls"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/runtime"
 )
+
+// browserTLSHosts: hosts whose Cloudflare WAF rejects plain Go TLS
+// fingerprints. Match suffix so subdomains (e.g. backend-api.chatgpt.com,
+// auth.openai.com) get the uTLS Chrome treatment too. Add new hosts
+// here when "Attack detected" 405s show up in the gateway log.
+var browserTLSHosts = []string{
+	"chatgpt.com",
+	"openai.com",
+}
+
+func needsBrowserTLS(host string) bool {
+	h := strings.ToLower(host)
+	for _, suffix := range browserTLSHosts {
+		if h == suffix || strings.HasSuffix(h, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// endpointWantsClientCert reports whether ep declares any credential
+// implementing TLSCredentialRuntime. Such endpoints (mtls / k8s) need
+// the upstream Config to carry a client cert, which dialBrowserTLS
+// can't satisfy — fall back to dialUpstream.
+func endpointWantsClientCert(ep *config.CompiledEndpoint) bool {
+	if ep == nil {
+		return false
+	}
+	for _, cc := range ep.Credentials {
+		if _, ok := cc.Credential.Body.(runtime.TLSCredentialRuntime); ok {
+			return true
+		}
+	}
+	return false
+}
 
 // servePorts is a no-op until the postgres / clickhouse_native
 // endpoint plugins land their wire-protocol runtime hooks.

--- a/main.go
+++ b/main.go
@@ -1243,17 +1243,25 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 
 		// Forward upstream. Hop-by-hop / proxy-leak headers stripped
 		// per RFC 7230 §6.1 plus chatgpt.com / Cloudflare flagged set.
+		// WS upgrade requests skip this strip block — Connection +
+		// Upgrade are part of the handshake (codex hits chatgpt.com
+		// /backend-api/codex/responses as a WS upgrade and the server
+		// flags requests with Sec-Websocket-* but no Upgrade as
+		// "Attack detected"). isWSUpgrade is checked again below to
+		// route through handleWSUpgrade after credential injection.
 		req.URL.Scheme = "https"
 		req.URL.Host = host
 		req.Host = host
 		req.RequestURI = ""
-		for _, h := range []string{
-			"Connection", "Keep-Alive", "Proxy-Authenticate",
-			"Proxy-Authorization", "Te", "Trailers", "Transfer-Encoding", "Upgrade",
-			"Cf-Worker", "Cf-Ray", "Cf-Ew-Via", "Cf-Connecting-Ip", "Cdn-Loop",
-			"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "Via",
-		} {
-			req.Header.Del(h)
+		if !isWSUpgrade(req) {
+			for _, h := range []string{
+				"Connection", "Keep-Alive", "Proxy-Authenticate",
+				"Proxy-Authorization", "Te", "Trailers", "Transfer-Encoding", "Upgrade",
+				"Cf-Worker", "Cf-Ray", "Cf-Ew-Via", "Cf-Connecting-Ip", "Cdn-Loop",
+				"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "Via",
+			} {
+				req.Header.Del(h)
+			}
 		}
 
 		// Credential injection. Pick the credential entry that

--- a/main.go
+++ b/main.go
@@ -1119,11 +1119,16 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			if err != nil {
 				h = host
 			}
-			// mTLS-equipped endpoints (k8s API servers, internal
-			// CAs) carry a credential whose TLSCredentialRuntime
-			// configures the upstream tls.Config — adds a client
-			// cert + a custom root pool. Endpoints with no TLS
-			// credential dial via plain stdlib TLS.
+			// Cloudflare-fronted hosts (chatgpt.com, openai.com)
+			// fingerprint-block plain Go TLS handshakes on the
+			// REST path with "Attack detected" 405 — same WAF rule
+			// that triggered on the WS upgrade. uTLS Chrome
+			// fingerprint clears it. mTLS-required endpoints stay
+			// on dialUpstream so the credential plugin can stamp
+			// client certs.
+			if needsBrowserTLS(h) && !endpointWantsClientCert(ep) {
+				return dialBrowserTLS(ctx, network, addr, h)
+			}
 			return g.dialUpstream(ctx, network, addr, h, ep)
 		},
 		ForceAttemptHTTP2: false,

--- a/oauth.go
+++ b/oauth.go
@@ -520,6 +520,10 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		w.startDeviceFlow(rw, id, flow, owner, ownerLabel)
 		return
 	}
+	if flow.Flow == "openai_device" {
+		w.startOpenAIDeviceFlow(rw, id, flow, owner, ownerLabel)
+		return
+	}
 
 	verifier := randomString(64)
 	sum := sha256.Sum256([]byte(verifier))
@@ -651,6 +655,170 @@ func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthInt
 		"expires_in":       dr.ExpiresIn,
 		"owner":            ownerLabel,
 	})
+}
+
+// startOpenAIDeviceFlow drives the non-RFC-8628 device-code flow that
+// auth.openai.com exposes for the codex CLI. Mirrors unclaw's
+// src/plugins/openai-codex/index.ts: POST JSON to deviceauth/usercode,
+// the resulting device_auth_id + user_code are persisted in the
+// session and fed to the poll handler. Verification URL is hardcoded
+// to https://auth.openai.com/codex/device since OpenAI's response
+// doesn't include one.
+func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OAuthIntegration, owner, ownerLabel string) {
+	clientID := resolveTemplate(it.OAuth.ClientID)
+	body, _ := json.Marshal(map[string]string{"client_id": clientID})
+	req, _ := http.NewRequest("POST", it.OAuth.DeviceURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "clawpatrol/1.0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(rw, "openai deviceauth: "+err.Error(), 502)
+		return
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		http.Error(rw, fmt.Sprintf("openai deviceauth %d: %s", resp.StatusCode, string(respBody)), 502)
+		return
+	}
+	// OpenAI ships `interval` as a quoted string ("5") rather than a
+	// JSON number — pull it as json.Number to accept both shapes.
+	var dr struct {
+		DeviceAuthID string      `json:"device_auth_id"`
+		UserCode     string      `json:"user_code"`
+		Interval     json.Number `json:"interval"`
+	}
+	if err := json.Unmarshal(respBody, &dr); err != nil || dr.DeviceAuthID == "" || dr.UserCode == "" {
+		http.Error(rw, "openai deviceauth parse: "+string(respBody), 502)
+		return
+	}
+	state := randomString(32)
+	w.mu.Lock()
+	w.sessions[state] = &oauthSession{
+		state:    state,
+		id:       id,
+		owner:    owner,
+		created:  time.Now(),
+		// Pack device_auth_id|user_code into verifier so pollDeviceFlow
+		// can split them; cfg.RedirectURL carries the codex-specific
+		// callback used in the auth-code exchange.
+		verifier: dr.DeviceAuthID + "|" + dr.UserCode,
+		cfg: &oauth2.Config{
+			ClientID:    clientID,
+			RedirectURL: it.OAuth.RedirectURI,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  it.OAuth.AuthURL,  // poll endpoint
+				TokenURL: it.OAuth.TokenURL, // exchange endpoint
+			},
+		},
+	}
+	w.mu.Unlock()
+	interval, _ := dr.Interval.Int64()
+	if interval <= 0 {
+		interval = 5
+	}
+	// Tag as plain "device" in the response so the dashboard's
+	// ConnectModal renders the user-code UI (it switches on
+	// `flow === "device"`). The internal openai_device dispatch is
+	// in the session-id lookup at poll time.
+	writeJSON(rw, map[string]any{
+		"flow":             "device",
+		"state":            state,
+		"user_code":        dr.UserCode,
+		"verification_uri": "https://auth.openai.com/codex/device",
+		"interval":         interval,
+		"owner":            ownerLabel,
+	})
+}
+
+// pollOpenAIDeviceFlow runs one iteration of the codex device-code
+// poll. 202/204 = still pending; 200 with authorization_code +
+// code_verifier triggers the /oauth/token exchange that returns the
+// real access token bundle.
+func (w *webMux) pollOpenAIDeviceFlow(rw http.ResponseWriter, sess *oauthSession) {
+	parts := strings.SplitN(sess.verifier, "|", 2)
+	if len(parts) != 2 {
+		http.Error(rw, "session corrupt", 500)
+		return
+	}
+	deviceAuthID, userCode := parts[0], parts[1]
+	pollBody, _ := json.Marshal(map[string]string{
+		"device_auth_id": deviceAuthID,
+		"user_code":      userCode,
+	})
+	req, _ := http.NewRequest("POST", sess.cfg.Endpoint.AuthURL, bytes.NewReader(pollBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "clawpatrol/1.0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(rw, "openai poll: "+err.Error(), 502)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 202 || resp.StatusCode == 204 {
+		writeJSON(rw, map[string]string{"error": "authorization_pending"})
+		return
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var pr struct {
+		AuthorizationCode string `json:"authorization_code"`
+		CodeVerifier      string `json:"code_verifier"`
+	}
+	if err := json.Unmarshal(body, &pr); err != nil || pr.AuthorizationCode == "" || pr.CodeVerifier == "" {
+		writeJSON(rw, map[string]string{"error": "authorization_pending"})
+		return
+	}
+	// Exchange auth code for tokens via the standard /oauth/token
+	// endpoint (form-urlencoded body, PKCE code_verifier).
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", pr.AuthorizationCode)
+	form.Set("code_verifier", pr.CodeVerifier)
+	form.Set("client_id", sess.cfg.ClientID)
+	form.Set("redirect_uri", sess.cfg.RedirectURL)
+	exReq, _ := http.NewRequest("POST", sess.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
+	exReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	exReq.Header.Set("Accept", "application/json")
+	exResp, err := http.DefaultClient.Do(exReq)
+	if err != nil {
+		http.Error(rw, "openai exchange: "+err.Error(), 502)
+		return
+	}
+	defer exResp.Body.Close()
+	exBody, _ := io.ReadAll(exResp.Body)
+	if exResp.StatusCode != 200 {
+		http.Error(rw, fmt.Sprintf("openai exchange %d: %s", exResp.StatusCode, string(exBody)), 502)
+		return
+	}
+	var tr struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(exBody, &tr); err != nil || tr.AccessToken == "" {
+		http.Error(rw, "openai exchange parse", 502)
+		return
+	}
+	tok := &oauth2.Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		TokenType:    tr.TokenType,
+	}
+	if tr.ExpiresIn > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	w.mu.Lock()
+	delete(w.sessions, sess.state)
+	w.mu.Unlock()
+	if err := w.g.oauth.Set(sess.id, sess.owner, tok); err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	writeJSON(rw, map[string]any{"connected": true, "owner": sess.owner})
 }
 
 // pollDeviceFlow exchanges device_code for a token. Called by the
@@ -787,6 +955,14 @@ func (w *webMux) apiOAuthDevicePoll(rw http.ResponseWriter, r *http.Request) {
 	w.mu.Unlock()
 	if sess == nil {
 		http.Error(rw, "unknown state (expired)", 400)
+		return
+	}
+	// Dispatch by integration's flow type. openai_device uses the
+	// codex deviceauth/token endpoint shape (JSON body, returns
+	// authorization_code + code_verifier instead of a token); the
+	// stdlib RFC-8628 path covers github.
+	if it := w.g.oauth.Integration(sess.id); it != nil && it.Flow == "openai_device" {
+		w.pollOpenAIDeviceFlow(rw, sess)
 		return
 	}
 	w.pollDeviceFlow(rw, sess)

--- a/wireguard.go
+++ b/wireguard.go
@@ -290,10 +290,18 @@ func StartWGServer(ts Tailscale, stateDir string) (*WGServer, error) {
 	srv := &WGServer{tun: tun, dev: dev, serverIP: serverIP, publicKey: pub, db: globalDB}
 	// Replay persisted (pubkey → ip) pairs into the in-memory device
 	// so reboots don't strand existing clients.
+	//
+	// Must register BOTH the v4 /32 and the v6 fd77::<n>/128 allowed_ip
+	// to match AddPeer. Replaying v4 only meant peers whose client-side
+	// ULA was active (gateway-emitted wg-quick now sets v6 too) had
+	// their fd77:: outbound packets land at a peer with no matching
+	// allowed_ip → dropped → client thinks the gateway is unreachable
+	// after every restart, fixed only by re-joining.
 	for pubkey, ip := range srv.loadPeers() {
+		v6 := wg6FromV4(netip.MustParseAddr(ip))
 		_ = dev.IpcSet(fmt.Sprintf(
-			"public_key=%s\nreplace_allowed_ips=true\nallowed_ip=%s/32\n",
-			pubkey, ip))
+			"public_key=%s\nreplace_allowed_ips=true\nallowed_ip=%s/32\nallowed_ip=%s/128\n",
+			pubkey, ip, v6.String()))
 	}
 	return srv, nil
 }


### PR DESCRIPTION
## Summary

Multi-fix PR that makes \`clawpatrol run codex\` work end-to-end under MITM, mirroring ref-impl's openai-codex plugin.

### 1. WS upgrade detection runs before hop-by-hop strip

Codex hits \`chatgpt.com/backend-api/codex/responses\` as a WebSocket upgrade (\`Sec-Websocket-*\` + \`Openai-Beta: responses_websockets=2026-02-06\`). Our strip block was deleting \`Connection\` + \`Upgrade\` before \`isWSUpgrade(req)\` ran, so the request forwarded as a plain GET. chatgpt.com's WAF flagged the \`Sec-Websocket-*\` + no-Upgrade combo as **\"Attack detected\"**. Now \`isWSUpgrade\` is checked before the strip; WS upgrade requests skip it entirely so the handshake headers reach \`handleWSUpgrade\` intact.

### 2. \`openai_device\` flow handlers in oauth.go

OpenAI's codex CLI uses a non-standard device-code dance, not RFC 8628:

\`\`\`
POST auth.openai.com/api/accounts/deviceauth/usercode
  → {device_auth_id, user_code, interval}
POST auth.openai.com/api/accounts/deviceauth/token
  → 202 (pending) | {authorization_code, code_verifier}
POST auth.openai.com/oauth/token  (form-urlencoded, PKCE)
  → access_token bundle
\`\`\`

Replaces the previous auth-code+PKCE redirect-paste UX. Frontend sees \`flow=\"device\"\` so the existing ConnectModal user-code UI renders unchanged. \`interval\` comes back as a JSON string in OpenAI's response — handled via \`json.Number\`.

### 3. \`openai_codex_oauth\` credential plugin

- \`InjectHTTP\` stamps \`chatgpt-account-id\` from the access token's JWT claims (\`claims.chatgpt_account_id\` or the nested \`https://api.openai.com/auth.chatgpt_account_id\` form). Without this, \`/backend-api/codex/responses\` returns 405.
- Drops the \`OPENAI_API_KEY\` env pushdown — it forced codex into API-key mode (different request shape; GET probes that 405). The OAuth-stored bundle in \`OAuthRegistry\` is enough.

### 4. uTLS Chrome fingerprint extended to chatgpt.com / openai.com REST

Already in this PR's first commit. Cloudflare flags plain Go TLS fingerprints with \"Attack detected\" 405. Same uTLS Chrome ALPN-clamped handshake we already use for WS upgrades.

## Test plan

- [ ] Disconnect codex on dashboard, click Connect → device-code modal shows user_code, page at auth.openai.com/codex/device asks for the code.
- [ ] After approval, dashboard shows \"Connected\".
- [ ] \`clawpatrol run codex\` → enter prompt → response streams. No \"Attack detected\". Gateway log shows \`ws-upgrade chatgpt.com /backend-api/codex/responses\`.
- [ ] mTLS endpoints (k8s) unchanged — still use \`dialUpstream\` with client cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)