### PR TITLE
oauth: match Anthropic token endpoint by URL, not hardcoded ID

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -304,8 +304,8 @@ func newState(it *OAuthIntegration, owner string, db *sql.DB) *oauthState {
 
 func (s *oauthState) setToken(tok *oauth2.Token) {
 	var base oauth2.TokenSource
-	switch s.id {
-	case "claude":
+	switch {
+	case isAnthropicTokenURL(s.cfg.Endpoint.TokenURL):
 		// Anthropic's token endpoint requires a JSON body for refresh
 		// (returns "Invalid request format" otherwise). Stdlib oauth2
 		// only sends form-urlencoded.
@@ -892,13 +892,17 @@ func (w *webMux) pollDeviceFlow(rw http.ResponseWriter, sess *oauthSession) {
 // the standard form-urlencoded body), so we hand-roll the request for
 // claude integration. Other providers use the stdlib oauth2.Exchange.
 func exchangeOAuthCode(ctx context.Context, sess *oauthSession, code, state string) (*oauth2.Token, error) {
-	if sess.id == "claude" {
+	if isAnthropicTokenURL(sess.cfg.Endpoint.TokenURL) {
 		return exchangeAnthropicCode(ctx, sess, code, state)
 	}
 	return sess.cfg.Exchange(ctx, code,
 		oauth2.SetAuthURLParam("code_verifier", sess.verifier),
 		oauth2.SetAuthURLParam("redirect_uri", sess.cfg.RedirectURL),
 	)
+}
+
+func isAnthropicTokenURL(u string) bool {
+	return strings.Contains(u, "anthropic.com/")
 }
 
 func exchangeAnthropicCode(ctx context.Context, sess *oauthSession, code, state string) (*oauth2.Token, error) {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestExchangeAnthropicSendsJSON(t *testing.T) {
+	var gotCT string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotCT = r.Header.Get("Content-Type")
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "tok",
+				"token_type":   "bearer",
+				"expires_in":   3600,
+			})
+		}))
+	defer srv.Close()
+
+	sess := &oauthSession{
+		verifier: "v",
+		state:    "s",
+		cfg: &oauth2.Config{
+			ClientID: "cid",
+			Endpoint: oauth2.Endpoint{
+				TokenURL: srv.URL + "/v1/oauth/token",
+			},
+			RedirectURL: "https://example.com/cb",
+		},
+	}
+	// Patch the URL to include anthropic.com so the
+	// dispatch picks the JSON path.
+	sess.cfg.Endpoint.TokenURL =
+		srv.URL + "/anthropic.com/v1/oauth/token"
+
+	tok, err := exchangeOAuthCode(
+		context.Background(), sess, "code", "state",
+	)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if tok.AccessToken != "tok" {
+		t.Fatalf("got token %q", tok.AccessToken)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json",
+			gotCT)
+	}
+	if gotBody["grant_type"] != "authorization_code" {
+		t.Errorf("grant_type = %q", gotBody["grant_type"])
+	}
+	if gotBody["code"] != "code" {
+		t.Errorf("code = %q", gotBody["code"])
+	}
+}
+
+func TestExchangeNonAnthropicUsesFormEncoded(t *testing.T) {
+	var gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotCT = r.Header.Get("Content-Type")
+			// oauth2 stdlib parses JSON responses fine, but
+			// the key assertion is what Content-Type the
+			// *request* used.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "tok",
+				"token_type":   "bearer",
+				"expires_in":   3600,
+			})
+		}))
+	defer srv.Close()
+
+	sess := &oauthSession{
+		verifier: "v",
+		state:    "s",
+		cfg: &oauth2.Config{
+			ClientID: "cid",
+			Endpoint: oauth2.Endpoint{
+				TokenURL: srv.URL + "/oauth/token",
+			},
+			RedirectURL: "https://example.com/cb",
+		},
+	}
+
+	_, err := exchangeOAuthCode(
+		context.Background(), sess, "code", "state",
+	)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	want := "application/x-www-form-urlencoded"
+	if gotCT != want {
+		t.Errorf("Content-Type = %q, want %q", gotCT, want)
+	}
+}


### PR DESCRIPTION
## Summary
- `exchangeOAuthCode` and `setToken` checked `sess.id == "claude"` to route through the JSON token exchange/refresh paths. The plugin system names integrations from the HCL config (e.g. `"anthropic-oauth"`), so the check never matched.
- Token exchange returned "Invalid request format"; refresh would silently use form-urlencoded and fail after access token expiry.
- Match on the token URL containing `anthropic.com/` instead of a hardcoded integration ID.

## Test plan
- [x] Anthropic OAuth connect flow succeeds from dashboard
- [ ] Token refresh works after access token expiry (~8h)