### PR TITLE
Apple-aligned NE hardening and dashboard perf

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -122,6 +122,12 @@ type AgentRegistry struct {
 	lc      *local.Client
 	onboard *onboardRegistry // set by Gateway ctor; supplies hostname/owner overrides in WG mode
 	db      *sql.DB          // optional; persists Session rows. nil → in-memory only.
+
+	// persistState debounces per-session DB writes (see persistSession).
+	// Separate mutex from r.mu so a slow SQLite write doesn't block
+	// snapshot()/track() readers.
+	persistMu    sync.Mutex
+	persistState map[string]persistMark
 }
 
 const activityBuckets = 30 // ~30s history at 1s sampling
@@ -393,13 +399,44 @@ func (r *AgentRegistry) recordLLMUsage(ip, sessionType, sessionID, sessionTitle,
 	r.persistSession(persistAgent, &persistSession)
 }
 
-// persistSession writes/updates the session row. No-op when r.db is nil.
+// persistSession writes/updates the session row. Debounced — a
+// session that's already been persisted within persistDebounce gets
+// skipped unless the title changed (which is what dashboard users
+// most want to see live). The skipped writes are coalesced into the
+// next call after the debounce expires; in-memory state is always
+// authoritative, the DB lags by ≤ persistDebounce.
+//
+// Why this matters: codex WS frames hit recordLLMUsage every output
+// token (tens per second on a streaming response). Without debounce
+// each one triggered an UPDATE — bursty SQLite writes serialize on
+// the writer thread and the per-event sink drain backs up. With
+// debounce the DB sees ~1 write/sec/session even under streaming.
+//
 // Called outside the registry lock so a slow disk write doesn't block
 // other request handlers.
+const persistDebounce = 2 * time.Second
+
 func (r *AgentRegistry) persistSession(ip string, s *Session) {
 	if r == nil || r.db == nil || s == nil {
 		return
 	}
+	key := ip + "|" + s.Type + "|" + s.ID
+	now := time.Now()
+
+	r.persistMu.Lock()
+	prev, hadPrev := r.persistState[key]
+	titleChanged := prev.title != s.Title
+	stale := !hadPrev || now.Sub(prev.at) >= persistDebounce
+	if !titleChanged && !stale {
+		r.persistMu.Unlock()
+		return
+	}
+	if r.persistState == nil {
+		r.persistState = map[string]persistMark{}
+	}
+	r.persistState[key] = persistMark{at: now, title: s.Title}
+	r.persistMu.Unlock()
+
 	_, _ = r.db.Exec(`
 		INSERT INTO sessions
 		  (agent_ip, type, id, title, model, tokens_in, tokens_out, ctx_used, ctx_max, reqs, first_at, last_at)
@@ -416,6 +453,11 @@ func (r *AgentRegistry) persistSession(ip string, s *Session) {
 	`, ip, s.Type, s.ID, s.Title, s.Model,
 		s.TokensIn, s.TokensOut, s.CtxUsed, s.CtxMax, s.Reqs,
 		s.FirstAt.UnixNano(), s.LastAt.UnixNano())
+}
+
+type persistMark struct {
+	at    time.Time
+	title string
 }
 
 // LoadSessions rehydrates persisted sessions from the DB into the

--- a/agents.go
+++ b/agents.go
@@ -670,13 +670,8 @@ func credentialsInProfile(policy *config.CompiledPolicy, profile string) map[str
 	return out
 }
 
-func (w *webMux) apiAgents(rw http.ResponseWriter, _ *http.Request) {
-	writeJSON(rw, w.agentsList())
-}
-
-// agentsList exposes the apiAgents payload as a Go slice so /api/state
-// can bundle it without re-marshaling. Same population logic; pulled
-// out of apiAgents verbatim.
+// agentsList backs the agents slice of /api/state. No HTTP handler —
+// the route was removed once App.tsx switched to bundled state.
 func (w *webMux) agentsList() []*Agent {
 	var snap []*Agent
 	if w.g.agents != nil {

--- a/agents.go
+++ b/agents.go
@@ -551,14 +551,20 @@ type Owner struct {
 }
 
 func (w *webMux) apiStatus(rw http.ResponseWriter, r *http.Request) {
+	writeJSON(rw, w.statusList(r))
+}
+
+// statusList exposes the apiStatus payload as a Go slice so /api/state
+// can bundle it without going through writeJSON. Same data shape; no
+// behavior change.
+func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 	out := []IntegrationRow{}
 	policy := w.g.policy.Load()
 	if policy == nil {
-		writeJSON(rw, out)
-		return
+		return out
 	}
 	profile := r.URL.Query().Get("profile")
-	allowed := credentialsInProfile(policy, profile) // nil = no filter
+	allowed := credentialsInProfile(policy, profile)
 
 	names := make([]string, 0, len(policy.Credentials))
 	for name := range policy.Credentials {
@@ -595,7 +601,7 @@ func (w *webMux) apiStatus(rw http.ResponseWriter, r *http.Request) {
 		}
 		out = append(out, row)
 	}
-	writeJSON(rw, out)
+	return out
 }
 
 // credentialsInProfile returns the set of credential bare names that
@@ -623,6 +629,13 @@ func credentialsInProfile(policy *config.CompiledPolicy, profile string) map[str
 }
 
 func (w *webMux) apiAgents(rw http.ResponseWriter, _ *http.Request) {
+	writeJSON(rw, w.agentsList())
+}
+
+// agentsList exposes the apiAgents payload as a Go slice so /api/state
+// can bundle it without re-marshaling. Same population logic; pulled
+// out of apiAgents verbatim.
+func (w *webMux) agentsList() []*Agent {
 	var snap []*Agent
 	if w.g.agents != nil {
 		snap = w.g.agents.snapshot()
@@ -699,7 +712,7 @@ func (w *webMux) apiAgents(rw http.ResponseWriter, _ *http.Request) {
 			a.Integrations = ids
 		}
 	}
-	writeJSON(rw, snap)
+	return snap
 }
 
 // apiAgentDelete drops a device from clawpatrol's view. Removes the

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -97,43 +97,29 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     }
 
     private func applyNetworkSettings(completionHandler: @escaping (Error?) -> Void) {
-        // Apple's DTS guidance on the canonical fast decline path
-        // (forum 716594): "Set up the rules so that you're not passed
-        // the flow." Returning false from handleNewFlow on a UDP flow
-        // we don't want is racy — Apple radar r.98382363 (also
-        // confirmed in forum 691711, 758113) shows it can stall the
-        // originating socket for ~30s (Chrome's QUIC fallback timer)
-        // or surface ECONNREFUSED. The fix is to never ask for UDP
-        // when we don't intend to tunnel every UDP flow:
-        //
-        //   per-process mode  → TCP only. UDP from non-clawpatrol
-        //                       processes (Chrome QUIC, system DNS,
-        //                       mDNS) goes through normal OS routing
-        //                       and never enters our handler. Caveat:
-        //                       UDP from clawpatrol-launched children
-        //                       isn't tunneled — agent CLIs we care
-        //                       about (claude, codex, gh) speak TCP
-        //                       HTTPS, so this is acceptable.
-        //
-        //   whole-machine     → TCP + UDP. Operator opted in to
-        //                       all-traffic; bridgeUDP claims every
-        //                       flow so the false-return stall doesn't
-        //                       apply. Excludes multicast / link-local.
-        //
-        // Settings are applied ONCE at startProxy and never toggled.
-        // forum 691341 shows mid-life setTunnelNetworkSettings can
-        // wedge the provider; treat the rule set as immutable.
+        // Exclude UDP/443 at rule layer: QUIC false-return races
+        // (radar r.98382363) cause ~30s Chrome stalls. Per-process
+        // adds UDP/53 so children resolve DNS. Settings applied once;
+        // mid-life setTunnelNetworkSettings wedges provider (691341).
         let settings = NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
         var included: [NENetworkRule] = [
             NENetworkRule(remoteNetwork: nil, remotePrefix: 0,
                           localNetwork: nil, localPrefix: 0,
                           protocol: .TCP, direction: .outbound),
         ]
+        var excluded: [NENetworkRule] = [
+            NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "0.0.0.0", port: "443"),
+                          remotePrefix: 0, localNetwork: nil, localPrefix: 0,
+                          protocol: .UDP, direction: .outbound),
+            NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "::", port: "443"),
+                          remotePrefix: 0, localNetwork: nil, localPrefix: 0,
+                          protocol: .UDP, direction: .outbound),
+        ]
         if wholeMachine {
             included.append(NENetworkRule(remoteNetwork: nil, remotePrefix: 0,
                                           localNetwork: nil, localPrefix: 0,
                                           protocol: .UDP, direction: .outbound))
-            settings.excludedNetworkRules = [
+            excluded.append(contentsOf: [
                 NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "224.0.0.0", port: "0"),
                               remotePrefix: 4, localNetwork: nil, localPrefix: 0,
                               protocol: .UDP, direction: .outbound),
@@ -143,9 +129,17 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "169.254.0.0", port: "0"),
                               remotePrefix: 16, localNetwork: nil, localPrefix: 0,
                               protocol: .UDP, direction: .outbound),
-            ]
+            ])
+        } else {
+            included.append(NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "0.0.0.0", port: "53"),
+                                          remotePrefix: 0, localNetwork: nil, localPrefix: 0,
+                                          protocol: .UDP, direction: .outbound))
+            included.append(NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "::", port: "53"),
+                                          remotePrefix: 0, localNetwork: nil, localPrefix: 0,
+                                          protocol: .UDP, direction: .outbound))
         }
         settings.includedNetworkRules = included
+        settings.excludedNetworkRules = excluded
         setTunnelNetworkSettings(settings, completionHandler: completionHandler)
     }
 

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -37,21 +37,6 @@ private let parentBundleID = "dev.clawpatrol.app"
 class TransparentProxyProvider: NETransparentProxyProvider {
     private var wholeMachine = false
 
-    // rulesActive tracks which includedNetworkRules variant is currently
-    // applied: full (intercept TCP+UDP) when ≥1 session is registered,
-    // empty (kernel skips us entirely) when idle. Toggling between the
-    // two on session register/unregister is the hard guarantee that
-    // per-process mode never breaks the rest of the machine's
-    // internet — when no clawpatrol session is running, NE simply
-    // doesn't see flows, so even a slow/buggy handleNewFlow can't
-    // stall an unrelated app's UDP socket. wholeMachine bypasses this
-    // dance entirely (always-on full rules).
-    private var rulesActive = false
-    // Serializes setTunnelNetworkSettings calls from session
-    // register/unregister so two concurrent CLI invocations don't
-    // race the rule toggle.
-    private let rulesMu = NSLock()
-
     override func startProxy(options: [String: Any]?,
                              completionHandler: @escaping (Error?) -> Void) {
         os_log("startProxy", log: log, type: .info)
@@ -106,103 +91,62 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             startSessionListener()
             startSessionReaper()
             DispatchQueue.main.async {
-                self.applyNetworkSettings { err in
-                    // Wire the rules toggle ONLY after the initial
-                    // settings landed. Otherwise a clawpatrol-run that
-                    // registers between startSessionListener and
-                    // applyNetworkSettings would race two
-                    // setTunnelNetworkSettings calls — Apple
-                    // serializes them but ordering is undefined.
-                    if err == nil {
-                        sessionsChangedHook = { [weak self] active in
-                            self?.updateRulesForSessions(active: active)
-                        }
-                        // If a session registered during the brief
-                        // window before the hook was wired, catch it
-                        // up now.
-                        if !self.wholeMachine && sessionsActive() {
-                            self.updateRulesForSessions(active: true)
-                        }
-                    }
-                    completionHandler(err)
-                }
+                self.applyNetworkSettings(completionHandler: completionHandler)
             }
         }
     }
 
     private func applyNetworkSettings(completionHandler: @escaping (Error?) -> Void) {
-        // Initial settings post-handshake: full rules in whole-machine
-        // mode (operator opted in to all-traffic), empty otherwise so
-        // idle clawpatrol doesn't intercept the host's traffic. The
-        // toggle to full rules happens in updateRulesForSessions when
-        // the first `clawpatrol run` registers a session.
-        if wholeMachine {
-            setTunnelNetworkSettings(activeSettings(), completionHandler: completionHandler)
-            rulesActive = true
-            return
-        }
-        setTunnelNetworkSettings(idleSettings(), completionHandler: completionHandler)
-        rulesActive = false
-    }
-
-    // activeSettings: intercept all outbound TCP+UDP, filter in
-    // handleNewFlow. excluded rules cover multicast / link-local where
-    // tunneling is never correct.
-    private func activeSettings() -> NETransparentProxyNetworkSettings {
-        let s = NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
-        s.includedNetworkRules = [
+        // Apple's DTS guidance on the canonical fast decline path
+        // (forum 716594): "Set up the rules so that you're not passed
+        // the flow." Returning false from handleNewFlow on a UDP flow
+        // we don't want is racy — Apple radar r.98382363 (also
+        // confirmed in forum 691711, 758113) shows it can stall the
+        // originating socket for ~30s (Chrome's QUIC fallback timer)
+        // or surface ECONNREFUSED. The fix is to never ask for UDP
+        // when we don't intend to tunnel every UDP flow:
+        //
+        //   per-process mode  → TCP only. UDP from non-clawpatrol
+        //                       processes (Chrome QUIC, system DNS,
+        //                       mDNS) goes through normal OS routing
+        //                       and never enters our handler. Caveat:
+        //                       UDP from clawpatrol-launched children
+        //                       isn't tunneled — agent CLIs we care
+        //                       about (claude, codex, gh) speak TCP
+        //                       HTTPS, so this is acceptable.
+        //
+        //   whole-machine     → TCP + UDP. Operator opted in to
+        //                       all-traffic; bridgeUDP claims every
+        //                       flow so the false-return stall doesn't
+        //                       apply. Excludes multicast / link-local.
+        //
+        // Settings are applied ONCE at startProxy and never toggled.
+        // forum 691341 shows mid-life setTunnelNetworkSettings can
+        // wedge the provider; treat the rule set as immutable.
+        let settings = NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
+        var included: [NENetworkRule] = [
             NENetworkRule(remoteNetwork: nil, remotePrefix: 0,
                           localNetwork: nil, localPrefix: 0,
                           protocol: .TCP, direction: .outbound),
-            NENetworkRule(remoteNetwork: nil, remotePrefix: 0,
-                          localNetwork: nil, localPrefix: 0,
-                          protocol: .UDP, direction: .outbound),
         ]
-        s.excludedNetworkRules = [
-            NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "224.0.0.0", port: "0"),
-                          remotePrefix: 4, localNetwork: nil, localPrefix: 0,
-                          protocol: .UDP, direction: .outbound),
-            NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "ff00::", port: "0"),
-                          remotePrefix: 8, localNetwork: nil, localPrefix: 0,
-                          protocol: .UDP, direction: .outbound),
-            NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "169.254.0.0", port: "0"),
-                          remotePrefix: 16, localNetwork: nil, localPrefix: 0,
-                          protocol: .UDP, direction: .outbound),
-        ]
-        return s
-    }
-
-    // idleSettings: empty includedNetworkRules. Apple's NE evaluates
-    // these as "don't intercept anything" — flows go through normal
-    // OS routing as if the proxy provider didn't exist. Used in
-    // per-process mode whenever the session registry is empty.
-    private func idleSettings() -> NETransparentProxyNetworkSettings {
-        NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
-    }
-
-    // updateRulesForSessions toggles the active rule set based on
-    // whether the session registry has any entries. Called from
-    // sessionRegister/sessionUnregister via a tiny callback so the
-    // bookkeeping lives next to the session set.
-    func updateRulesForSessions(active: Bool) {
-        if wholeMachine { return } // always-on; never toggle
-        rulesMu.lock()
-        if active == rulesActive {
-            rulesMu.unlock()
-            return
+        if wholeMachine {
+            included.append(NENetworkRule(remoteNetwork: nil, remotePrefix: 0,
+                                          localNetwork: nil, localPrefix: 0,
+                                          protocol: .UDP, direction: .outbound))
+            settings.excludedNetworkRules = [
+                NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "224.0.0.0", port: "0"),
+                              remotePrefix: 4, localNetwork: nil, localPrefix: 0,
+                              protocol: .UDP, direction: .outbound),
+                NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "ff00::", port: "0"),
+                              remotePrefix: 8, localNetwork: nil, localPrefix: 0,
+                              protocol: .UDP, direction: .outbound),
+                NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "169.254.0.0", port: "0"),
+                              remotePrefix: 16, localNetwork: nil, localPrefix: 0,
+                              protocol: .UDP, direction: .outbound),
+            ]
         }
-        rulesActive = active
-        rulesMu.unlock()
-        let settings = active ? activeSettings() : idleSettings()
-        DispatchQueue.main.async { [weak self] in
-            self?.setTunnelNetworkSettings(settings) { err in
-                if let err = err {
-                    os_log("rules toggle %{public}@: %{public}@",
-                           log: log, type: .error,
-                           active ? "active" : "idle", err.localizedDescription)
-                }
-            }
-        }
+        settings.includedNetworkRules = included
+        setTunnelNetworkSettings(settings, completionHandler: completionHandler)
     }
 
     override func stopProxy(with reason: NEProviderStopReason,
@@ -448,13 +392,6 @@ let sessionSockPath = "/tmp/clawpatrol.sock"
 private var sessionPidsSet: Set<pid_t> = []
 private let sessionPidsLock = NSLock()
 
-// sessionsChangedHook fires after every register/unregister transition
-// with the new "any sessions registered?" state. The provider sets it
-// at startProxy to call updateRulesForSessions; the toggle from false
-// → true (or vice versa) re-applies setTunnelNetworkSettings so the
-// kernel either intercepts everything (active) or nothing (idle).
-var sessionsChangedHook: ((Bool) -> Void)?
-
 private func sessionPids() -> Set<pid_t> {
     sessionPidsLock.lock()
     defer { sessionPidsLock.unlock() }
@@ -463,7 +400,6 @@ private func sessionPids() -> Set<pid_t> {
 private func sessionRegister(_ pid: pid_t) {
     sessionPidsLock.lock()
     sessionPidsSet.insert(pid)
-    let active = !sessionPidsSet.isEmpty
     sessionPidsLock.unlock()
     // Do NOT invalidate the ancestor cache here. The cache stores
     // "was this pid a descendant of any session pid I checked?". A
@@ -475,20 +411,16 @@ private func sessionRegister(_ pid: pid_t) {
     // helper, system service, and background daemon re-walked its
     // full PPID chain via proc_pidinfo, the per-flow handleNewFlow
     // latency spiked, and macOS started stalling unrelated UDP
-    // sockets. Leaving the cache intact keeps existing flows on
-    // their O(1) cached false verdict while the new session's
-    // descendants get fresh lookups.
-    sessionsChangedHook?(active)
+    // sockets.
 }
 private func sessionUnregister(_ pid: pid_t) {
     sessionPidsLock.lock()
     sessionPidsSet.remove(pid)
-    let active = !sessionPidsSet.isEmpty
     sessionPidsLock.unlock()
-    // On unregister we DO want to evict cache entries that pointed
-    // to this session pid — their descendants are no longer
-    // tunneled. Walk the cache once and drop the matches; cheaper
-    // than removeAll because most entries are unrelated negatives.
+    // On unregister evict cache entries that pointed to this
+    // session pid — their descendants are no longer tunneled. Walk
+    // the cache once and drop the matches; cheaper than removeAll
+    // because most entries are unrelated negatives.
     ancestorCacheLock.lock()
     if !ancestorCache.isEmpty {
         for (k, v) in ancestorCache where v.sessionPID == pid {
@@ -496,7 +428,6 @@ private func sessionUnregister(_ pid: pid_t) {
         }
     }
     ancestorCacheLock.unlock()
-    sessionsChangedHook?(active)
 }
 
 // Reaper: every 5s drop registered PIDs whose process is gone.
@@ -591,24 +522,44 @@ private func serviceSessionClient(_ fd: Int32) {
 // membership is nanoseconds.
 private let bsdInfoSize = Int32(MemoryLayout<proc_bsdinfo>.size)
 
+// ancestorCache memoizes the verdict for each (pid, start_time) seen
+// in handleNewFlow. start_time is included in the key so the cache
+// is immune to PID reuse — macOS recycles PIDs aggressively under
+// fork-heavy workloads and a stale entry under bare-pid keying could
+// flip a non-clawpatrol flow into "tunneled" or vice versa.
+//
+// Pattern matches unclaw's SessionRegistry.swift:57-61 (start-time
+// validation on read) and Apple Endpoint Security guidance (audit
+// tokens are the canonical anti-reuse key, but pidversion isn't
+// exposed via proc_pidinfo so start_time is the next best thing).
+//
+// 60s TTL: long-running browser helpers (Chrome, Slack) shouldn't
+// re-walk their PPID chain every few seconds. The reaper already
+// drops session pids within 5s of process exit, so a stale "matched"
+// verdict is at most 5s out of date.
+private struct ancestorCacheKey: Hashable {
+    let pid: pid_t
+    let startTimeSec: UInt64
+}
 private struct ancestorCacheEntry { let sessionPID: pid_t; let expires: Date }
-private var ancestorCache: [pid_t: ancestorCacheEntry] = [:]
+private var ancestorCache: [ancestorCacheKey: ancestorCacheEntry] = [:]
 private let ancestorCacheLock = NSLock()
-// 5s was too aggressive — long-running browser helper PIDs (Chrome,
-// Slack, Discord) hit handleNewFlow continuously and re-walked their
-// full PPID chain every 5s. macOS doesn't recycle PIDs fast enough
-// to make 60s a real concern, and the Reaper already drops a PID
-// from the session set within 5s of the underlying process dying.
-// The remaining staleness window: a PID that ages out, gets recycled
-// to a clawpatrol descendant within 60s, and lands a flow before its
-// cache entry expires. Vanishingly rare; the failure mode is "one
-// flow not tunneled" not "machine internet broken".
 private let ancestorCacheTTL: TimeInterval = 60
 
+// procStartTime returns the start_time field of proc_bsdinfo for pid.
+// 0 on failure — keep the entry in cache anyway under the bare-pid
+// key so a transient lookup miss doesn't disable caching.
+private func procStartTime(_ pid: pid_t) -> UInt64 {
+    var info = proc_bsdinfo()
+    let n = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, bsdInfoSize)
+    return n == bsdInfoSize ? UInt64(info.pbi_start_tvsec) : 0
+}
+
 private func ancestorMatches(pid: pid_t) -> Bool {
+    let key = ancestorCacheKey(pid: pid, startTimeSec: procStartTime(pid))
     let now = Date()
     ancestorCacheLock.lock()
-    if let e = ancestorCache[pid], e.expires > now {
+    if let e = ancestorCache[key], e.expires > now {
         let v = e.sessionPID != 0
         ancestorCacheLock.unlock()
         return v
@@ -635,7 +586,7 @@ private func ancestorMatches(pid: pid_t) -> Bool {
     }
 
     ancestorCacheLock.lock()
-    ancestorCache[pid] = ancestorCacheEntry(sessionPID: sessionPID, expires: now.addingTimeInterval(ancestorCacheTTL))
+    ancestorCache[key] = ancestorCacheEntry(sessionPID: sessionPID, expires: now.addingTimeInterval(ancestorCacheTTL))
     if ancestorCache.count > 4096 {
         ancestorCache = ancestorCache.filter { $0.value.expires > now }
     }

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -37,6 +37,21 @@ private let parentBundleID = "dev.clawpatrol.app"
 class TransparentProxyProvider: NETransparentProxyProvider {
     private var wholeMachine = false
 
+    // rulesActive tracks which includedNetworkRules variant is currently
+    // applied: full (intercept TCP+UDP) when ≥1 session is registered,
+    // empty (kernel skips us entirely) when idle. Toggling between the
+    // two on session register/unregister is the hard guarantee that
+    // per-process mode never breaks the rest of the machine's
+    // internet — when no clawpatrol session is running, NE simply
+    // doesn't see flows, so even a slow/buggy handleNewFlow can't
+    // stall an unrelated app's UDP socket. wholeMachine bypasses this
+    // dance entirely (always-on full rules).
+    private var rulesActive = false
+    // Serializes setTunnelNetworkSettings calls from session
+    // register/unregister so two concurrent CLI invocations don't
+    // race the rule toggle.
+    private let rulesMu = NSLock()
+
     override func startProxy(options: [String: Any]?,
                              completionHandler: @escaping (Error?) -> Void) {
         os_log("startProxy", log: log, type: .info)
@@ -91,15 +106,51 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             startSessionListener()
             startSessionReaper()
             DispatchQueue.main.async {
-                self.applyNetworkSettings(completionHandler: completionHandler)
+                self.applyNetworkSettings { err in
+                    // Wire the rules toggle ONLY after the initial
+                    // settings landed. Otherwise a clawpatrol-run that
+                    // registers between startSessionListener and
+                    // applyNetworkSettings would race two
+                    // setTunnelNetworkSettings calls — Apple
+                    // serializes them but ordering is undefined.
+                    if err == nil {
+                        sessionsChangedHook = { [weak self] active in
+                            self?.updateRulesForSessions(active: active)
+                        }
+                        // If a session registered during the brief
+                        // window before the hook was wired, catch it
+                        // up now.
+                        if !self.wholeMachine && sessionsActive() {
+                            self.updateRulesForSessions(active: true)
+                        }
+                    }
+                    completionHandler(err)
+                }
             }
         }
     }
 
     private func applyNetworkSettings(completionHandler: @escaping (Error?) -> Void) {
-        // Intercept everything outbound — filter inside handleNewFlow.
-        let settings = NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
-        settings.includedNetworkRules = [
+        // Initial settings post-handshake: full rules in whole-machine
+        // mode (operator opted in to all-traffic), empty otherwise so
+        // idle clawpatrol doesn't intercept the host's traffic. The
+        // toggle to full rules happens in updateRulesForSessions when
+        // the first `clawpatrol run` registers a session.
+        if wholeMachine {
+            setTunnelNetworkSettings(activeSettings(), completionHandler: completionHandler)
+            rulesActive = true
+            return
+        }
+        setTunnelNetworkSettings(idleSettings(), completionHandler: completionHandler)
+        rulesActive = false
+    }
+
+    // activeSettings: intercept all outbound TCP+UDP, filter in
+    // handleNewFlow. excluded rules cover multicast / link-local where
+    // tunneling is never correct.
+    private func activeSettings() -> NETransparentProxyNetworkSettings {
+        let s = NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
+        s.includedNetworkRules = [
             NENetworkRule(remoteNetwork: nil, remotePrefix: 0,
                           localNetwork: nil, localPrefix: 0,
                           protocol: .TCP, direction: .outbound),
@@ -107,7 +158,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                           localNetwork: nil, localPrefix: 0,
                           protocol: .UDP, direction: .outbound),
         ]
-        settings.excludedNetworkRules = [
+        s.excludedNetworkRules = [
             NENetworkRule(remoteNetwork: NWHostEndpoint(hostname: "224.0.0.0", port: "0"),
                           remotePrefix: 4, localNetwork: nil, localPrefix: 0,
                           protocol: .UDP, direction: .outbound),
@@ -118,7 +169,40 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                           remotePrefix: 16, localNetwork: nil, localPrefix: 0,
                           protocol: .UDP, direction: .outbound),
         ]
-        setTunnelNetworkSettings(settings, completionHandler: completionHandler)
+        return s
+    }
+
+    // idleSettings: empty includedNetworkRules. Apple's NE evaluates
+    // these as "don't intercept anything" — flows go through normal
+    // OS routing as if the proxy provider didn't exist. Used in
+    // per-process mode whenever the session registry is empty.
+    private func idleSettings() -> NETransparentProxyNetworkSettings {
+        NETransparentProxyNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
+    }
+
+    // updateRulesForSessions toggles the active rule set based on
+    // whether the session registry has any entries. Called from
+    // sessionRegister/sessionUnregister via a tiny callback so the
+    // bookkeeping lives next to the session set.
+    func updateRulesForSessions(active: Bool) {
+        if wholeMachine { return } // always-on; never toggle
+        rulesMu.lock()
+        if active == rulesActive {
+            rulesMu.unlock()
+            return
+        }
+        rulesActive = active
+        rulesMu.unlock()
+        let settings = active ? activeSettings() : idleSettings()
+        DispatchQueue.main.async { [weak self] in
+            self?.setTunnelNetworkSettings(settings) { err in
+                if let err = err {
+                    os_log("rules toggle %{public}@: %{public}@",
+                           log: log, type: .error,
+                           active ? "active" : "idle", err.localizedDescription)
+                }
+            }
+        }
     }
 
     override func stopProxy(with reason: NEProviderStopReason,
@@ -364,6 +448,13 @@ let sessionSockPath = "/tmp/clawpatrol.sock"
 private var sessionPidsSet: Set<pid_t> = []
 private let sessionPidsLock = NSLock()
 
+// sessionsChangedHook fires after every register/unregister transition
+// with the new "any sessions registered?" state. The provider sets it
+// at startProxy to call updateRulesForSessions; the toggle from false
+// → true (or vice versa) re-applies setTunnelNetworkSettings so the
+// kernel either intercepts everything (active) or nothing (idle).
+var sessionsChangedHook: ((Bool) -> Void)?
+
 private func sessionPids() -> Set<pid_t> {
     sessionPidsLock.lock()
     defer { sessionPidsLock.unlock() }
@@ -372,20 +463,40 @@ private func sessionPids() -> Set<pid_t> {
 private func sessionRegister(_ pid: pid_t) {
     sessionPidsLock.lock()
     sessionPidsSet.insert(pid)
+    let active = !sessionPidsSet.isEmpty
     sessionPidsLock.unlock()
-    // Ancestor cache invalidates because new session PID changes
-    // the verdict for any descendant — clear and let it re-warm.
-    ancestorCacheLock.lock()
-    ancestorCache.removeAll(keepingCapacity: true)
-    ancestorCacheLock.unlock()
+    // Do NOT invalidate the ancestor cache here. The cache stores
+    // "was this pid a descendant of any session pid I checked?". A
+    // new session pid only changes the verdict for processes that
+    // descend from it — and those processes don't exist yet at
+    // register time (the CLI registers before exec'ing the child).
+    // Dumping the cache on every register made the first 100ms
+    // after `clawpatrol run` a cold-cache storm: every Chrome
+    // helper, system service, and background daemon re-walked its
+    // full PPID chain via proc_pidinfo, the per-flow handleNewFlow
+    // latency spiked, and macOS started stalling unrelated UDP
+    // sockets. Leaving the cache intact keeps existing flows on
+    // their O(1) cached false verdict while the new session's
+    // descendants get fresh lookups.
+    sessionsChangedHook?(active)
 }
 private func sessionUnregister(_ pid: pid_t) {
     sessionPidsLock.lock()
     sessionPidsSet.remove(pid)
+    let active = !sessionPidsSet.isEmpty
     sessionPidsLock.unlock()
+    // On unregister we DO want to evict cache entries that pointed
+    // to this session pid — their descendants are no longer
+    // tunneled. Walk the cache once and drop the matches; cheaper
+    // than removeAll because most entries are unrelated negatives.
     ancestorCacheLock.lock()
-    ancestorCache.removeAll(keepingCapacity: true)
+    if !ancestorCache.isEmpty {
+        for (k, v) in ancestorCache where v.sessionPID == pid {
+            ancestorCache.removeValue(forKey: k)
+        }
+    }
     ancestorCacheLock.unlock()
+    sessionsChangedHook?(active)
 }
 
 // Reaper: every 5s drop registered PIDs whose process is gone.
@@ -483,7 +594,16 @@ private let bsdInfoSize = Int32(MemoryLayout<proc_bsdinfo>.size)
 private struct ancestorCacheEntry { let sessionPID: pid_t; let expires: Date }
 private var ancestorCache: [pid_t: ancestorCacheEntry] = [:]
 private let ancestorCacheLock = NSLock()
-private let ancestorCacheTTL: TimeInterval = 5
+// 5s was too aggressive — long-running browser helper PIDs (Chrome,
+// Slack, Discord) hit handleNewFlow continuously and re-walked their
+// full PPID chain every 5s. macOS doesn't recycle PIDs fast enough
+// to make 60s a real concern, and the Reaper already drops a PID
+// from the session set within 5s of the underlying process dying.
+// The remaining staleness window: a PID that ages out, gets recycled
+// to a clawpatrol descendant within 60s, and lands a flow before its
+// cache entry expires. Vanishingly rare; the failure mode is "one
+// flow not tunneled" not "machine internet broken".
+private let ancestorCacheTTL: TimeInterval = 60
 
 private func ancestorMatches(pid: pid_t) -> Bool {
     let now = Date()

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -263,11 +264,39 @@ type Gateway struct {
 	connIdx atomic.Pointer[runtime.ConnIndex]
 	// dnsvip owns the hostname↔virtual-IP table for endpoints whose
 	// wire protocol can't be disambiguated at TCP-accept time (SSH
-	// today). The DNS server hijacks A/AAAA queries inside the WG
-	// tunnel so an agent's `ssh user@host` resolves to a unique VIP
-	// the gateway can route by. Single allocator shared across the
-	// process; mutate-in-place + RWMutex inside.
+	// today).
 	dnsvip *dnsvip.Allocator
+	// transports memoizes one http.Transport per endpoint. Avoids the
+	// per-request allocation + idle-conn-pool reset of the old path.
+	transports sync.Map // *config.CompiledEndpoint -> *http.Transport
+}
+
+// transportFor returns the cached http.Transport for ep, building it
+// on first use. dialBrowserTLS for Cloudflare-fronted hosts; mTLS
+// endpoints stay on dialUpstream so credential plugins run.
+func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
+	if v, ok := g.transports.Load(ep); ok {
+		return v.(*http.Transport)
+	}
+	tr := &http.Transport{
+		DialContext: g.dialer.DialContext,
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			h, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				h = addr
+			}
+			if needsBrowserTLS(h) && !endpointWantsClientCert(ep) {
+				return dialBrowserTLS(ctx, network, addr, h)
+			}
+			return g.dialUpstream(ctx, network, addr, h, ep)
+		},
+		ForceAttemptHTTP2:   false,
+		IdleConnTimeout:     30 * time.Second,
+		MaxIdleConns:        128,
+		MaxIdleConnsPerHost: 8,
+	}
+	actual, _ := g.transports.LoadOrStore(ep, tr)
+	return actual.(*http.Transport)
 }
 
 // Policy returns the current snapshot of the lowered runtime policy.
@@ -1348,29 +1377,12 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 	}
 	defer tc.Close()
 
-	transport := &http.Transport{
-		DialContext: g.dialer.DialContext,
-		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			h, _, err := net.SplitHostPort(addr)
-			if err != nil {
-				h = host
-			}
-			// Cloudflare-fronted hosts (chatgpt.com, openai.com)
-			// fingerprint-block plain Go TLS handshakes on the
-			// REST path with "Attack detected" 405 — same WAF rule
-			// that triggered on the WS upgrade. uTLS Chrome
-			// fingerprint clears it. mTLS-required endpoints stay
-			// on dialUpstream so the credential plugin can stamp
-			// client certs.
-			if needsBrowserTLS(h) && !endpointWantsClientCert(ep) {
-				return dialBrowserTLS(ctx, network, addr, h)
-			}
-			return g.dialUpstream(ctx, network, addr, h, ep)
-		},
-		ForceAttemptHTTP2: false,
-		IdleConnTimeout:   30 * time.Second,
-	}
-	defer transport.CloseIdleConnections()
+	// transport is shared across all requests for this endpoint.
+	// Old path allocated a fresh http.Transport per mitmHTTPS call,
+	// which threw away the idle-conn pool and racked up ~10KB of
+	// internal map allocations per request. Per-endpoint cache lets
+	// repeat requests to the same upstream reuse keep-alives.
+	transport := g.transportFor(ep)
 
 	br := bufio.NewReader(tc)
 	for {

--- a/web.go
+++ b/web.go
@@ -52,6 +52,11 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux.HandleFunc("/api/whoami", w.apiWhoami)
 	mux.HandleFunc("/api/status", w.apiStatus)
 	mux.HandleFunc("/api/agents", w.apiAgents)
+	// /api/state is the dashboard's single-call refresh endpoint —
+	// bundles whoami+status+agents in one round-trip and returns 304
+	// when the JSON hash matches If-None-Match. Replaces the three
+	// parallel per-3s fetches App.refresh used to fire.
+	mux.HandleFunc("/api/state", w.apiState)
 	mux.HandleFunc("/api/agents/delete", w.apiAgentDelete)
 	mux.HandleFunc("/api/agents/profile", w.apiAgentProfile)
 	mux.HandleFunc("/api/profiles", w.apiProfiles)
@@ -481,20 +486,55 @@ func (w *webMux) ownerForCaller(r *http.Request) (key, label string) {
 }
 
 func (w *webMux) apiWhoami(rw http.ResponseWriter, r *http.Request) {
+	writeJSON(rw, w.whoamiData(r))
+}
+
+// whoamiData exposes the apiWhoami payload as a Go map so /api/state
+// can bundle it without round-tripping through writeJSON +
+// re-decoding. Cheap (no DB hit; just config + tailscale whois).
+func (w *webMux) whoamiData(r *http.Request) map[string]string {
 	user, device, host := w.callerIdentity(r)
-	// Read public_url straight from the live config so that an
-	// operator editing gateway.hcl sees the new value reflected
-	// without a gateway restart (mtime watcher swaps cfg).
 	pu := w.g.cfg.PublicURL
 	if pu == "" {
 		pu = w.publicURL
 	}
-	writeJSON(rw, map[string]string{
+	return map[string]string{
 		"user":       user,
 		"device":     device,
 		"host":       host,
 		"public_url": pu,
-	})
+	}
+}
+
+// apiState is the dashboard's combined refresh endpoint. Bundles
+// whoami + status (integrations) + agents into one response with an
+// ETag — when the JSON hash matches If-None-Match the gateway returns
+// 304 with no body, so an idle dashboard polling every 5s costs ~120
+// bytes per round-trip instead of three full payloads. Cuts dashboard
+// per-poll work from 3 fetches × 3 marshals → 1 fetch × 1 marshal +
+// hash compare.
+func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
+	state := map[string]any{
+		"whoami":       w.whoamiData(r),
+		"integrations": w.statusList(r),
+		"agents":       w.agentsList(),
+	}
+	body, err := json.Marshal(state)
+	if err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	sum := sha256.Sum256(body)
+	tag := `"` + hex.EncodeToString(sum[:8]) + `"`
+	if r.Header.Get("If-None-Match") == tag {
+		rw.Header().Set("ETag", tag)
+		rw.WriteHeader(http.StatusNotModified)
+		return
+	}
+	rw.Header().Set("ETag", tag)
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Cache-Control", "no-cache") // force browser to revalidate via If-None-Match
+	rw.Write(body)
 }
 
 // apiStatus returns the credentials list for the dashboard. Filters

--- a/web.go
+++ b/web.go
@@ -42,6 +42,13 @@ type webMux struct {
 	mu        sync.Mutex
 	sessions  map[string]*oauthSession
 	onboard   *onboardRegistry
+
+	// stateCache: per-caller TTL'd memo for /api/state. RWMutex
+	// because reads vastly outnumber writes — every dashboard tab
+	// polls every 5s, but the cached entry only refreshes once per
+	// stateCacheTTL (1s). 99% of polls are RLock-only.
+	stateCacheMu sync.RWMutex
+	stateCache   map[string]stateCacheEntry
 }
 
 func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Handler {
@@ -509,11 +516,29 @@ func (w *webMux) whoamiData(r *http.Request) map[string]string {
 // apiState is the dashboard's combined refresh endpoint. Bundles
 // whoami + status (integrations) + agents into one response with an
 // ETag — when the JSON hash matches If-None-Match the gateway returns
-// 304 with no body, so an idle dashboard polling every 5s costs ~120
-// bytes per round-trip instead of three full payloads. Cuts dashboard
-// per-poll work from 3 fetches × 3 marshals → 1 fetch × 1 marshal +
-// hash compare.
+// 304 with no body. Server-side caches the last (tag, body) under a
+// short TTL so concurrent dashboards on the same tag answer 304
+// without re-marshaling+hashing; only the first request per change-
+// window pays the full cost. Whoami varies per-caller so the cache
+// is keyed by (caller-user, profile).
+//
+// Cache TTL is conservatively short (1s) so changes propagate to
+// idle dashboards within their 5s poll window without us needing a
+// real invalidation hook off every credential mutation.
 func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
+	user, _, _ := w.callerIdentity(r)
+	cacheKey := user + "|" + r.URL.Query().Get("profile")
+	now := time.Now()
+
+	w.stateCacheMu.RLock()
+	if c, ok := w.stateCache[cacheKey]; ok && now.Sub(c.At) < stateCacheTTL {
+		body, tag := c.Body, c.Tag
+		w.stateCacheMu.RUnlock()
+		serveState(rw, r, body, tag)
+		return
+	}
+	w.stateCacheMu.RUnlock()
+
 	state := map[string]any{
 		"whoami":       w.whoamiData(r),
 		"integrations": w.statusList(r),
@@ -526,6 +551,26 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 	}
 	sum := sha256.Sum256(body)
 	tag := `"` + hex.EncodeToString(sum[:8]) + `"`
+
+	w.stateCacheMu.Lock()
+	if w.stateCache == nil {
+		w.stateCache = map[string]stateCacheEntry{}
+	}
+	w.stateCache[cacheKey] = stateCacheEntry{Body: body, Tag: tag, At: now}
+	w.stateCacheMu.Unlock()
+
+	serveState(rw, r, body, tag)
+}
+
+const stateCacheTTL = 1 * time.Second
+
+type stateCacheEntry struct {
+	Body []byte
+	Tag  string
+	At   time.Time
+}
+
+func serveState(rw http.ResponseWriter, r *http.Request, body []byte, tag string) {
 	if r.Header.Get("If-None-Match") == tag {
 		rw.Header().Set("ETag", tag)
 		rw.WriteHeader(http.StatusNotModified)
@@ -533,7 +578,7 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 	}
 	rw.Header().Set("ETag", tag)
 	rw.Header().Set("Content-Type", "application/json")
-	rw.Header().Set("Cache-Control", "no-cache") // force browser to revalidate via If-None-Match
+	rw.Header().Set("Cache-Control", "no-cache")
 	rw.Write(body)
 }
 
@@ -796,9 +841,9 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	fmt.Fprint(rw, ": connected\n\n")
-	// Replay backlog (oldest → newest) so a refreshed dashboard sees the
-	// last few hundred events instead of an empty stream. Frontend
-	// prepends each event, so newest still ends up at the top.
+	// Replay backlog (oldest → newest). Backlog events are unmarshaled
+	// Event values from the recent ring; live events ship pre-marshaled
+	// in eventPacket.raw so we skip a Marshal call per subscriber.
 	for _, ev := range backlog {
 		if wantIP != "" && ev.AgentIP != wantIP {
 			continue
@@ -821,18 +866,14 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 		case <-keepalive.C:
 			fmt.Fprint(rw, ": ka\n\n")
 			flusher.Flush()
-		case ev, ok := <-ch:
+		case pkt, ok := <-ch:
 			if !ok {
 				return
 			}
-			if wantIP != "" && ev.AgentIP != wantIP {
+			if wantIP != "" && pkt.ev.AgentIP != wantIP {
 				continue
 			}
-			b, err := json.Marshal(ev)
-			if err != nil {
-				continue
-			}
-			fmt.Fprintf(rw, "data: %s\n\n", b)
+			fmt.Fprintf(rw, "data: %s\n\n", pkt.raw)
 			flusher.Flush()
 		}
 	}
@@ -952,21 +993,47 @@ type Event struct {
 	Direction string `json:"direction,omitempty"`
 }
 
+// eventPacket carries an event plus its marshaled JSON bytes. drain()
+// marshals once and ships the same bytes to every subscriber so a
+// busy gateway doesn't pay N × json.Marshal per event when N
+// dashboards are connected.
+type eventPacket struct {
+	ev  Event
+	raw []byte
+}
+
 type Sink struct {
-	ch        chan Event
-	db        *sql.DB
-	drops     atomic.Uint64
-	mu        sync.Mutex
-	subs      []chan Event
-	recent    []Event // ring of recent events for backlog replay
-	recentCap int
+	ch    chan Event
+	db    *sql.DB
+	drops atomic.Uint64
+	mu    sync.Mutex
+	subs  []chan eventPacket
+	// Recent ring backlog. recent is sized once at construction; we
+	// write at recentNext (modulo cap) and rotate. Old behavior used
+	// `append + slice` which reallocated on every overflow, churning
+	// GC at ~10 alloc/sec on a busy gateway. Lazy fill: until we wrap,
+	// recentLen tracks valid entries.
+	recent     []Event
+	recentNext int
+	recentLen  int
+	recentCap  int
 }
 
 func NewSink(db *sql.DB, buf int) (*Sink, error) {
 	s := &Sink{ch: make(chan Event, buf), db: db, recentCap: 500}
+	s.recent = make([]Event, s.recentCap)
 	if db != nil {
 		if seed, err := readTailEvents(db, s.recentCap); err == nil && len(seed) > 0 {
-			s.recent = seed
+			// Seed fills oldest→newest; place at indices 0..len(seed)-1
+			// and set recentNext to the next slot, recentLen to length.
+			n := len(seed)
+			if n > s.recentCap {
+				seed = seed[n-s.recentCap:]
+				n = s.recentCap
+			}
+			copy(s.recent, seed)
+			s.recentLen = n
+			s.recentNext = n % s.recentCap
 		}
 	}
 	go s.drain()
@@ -1081,51 +1148,82 @@ func (s *Sink) drain() {
 				e.ReqBody, e.RespBody,
 				string(rqhJSON), string(rshJSON))
 		}
+
+		// Marshal once per event regardless of subscriber count. Old
+		// path marshaled inside each subscriber's SSE handler — N
+		// dashboards = N json.Marshal calls per event. Now it's 1.
+		raw, err := json.Marshal(e)
+		if err != nil {
+			continue
+		}
+		pkt := eventPacket{ev: e, raw: raw}
+
 		s.mu.Lock()
-		// Recent ring is the SSE backlog replayed to fresh
-		// dashboards. start events without matching ends would render
-		// as stuck in-flight rows on every reconnect, so only keep
-		// terminal events. frame events for already-closed WS streams
-		// also have nowhere to go on reconnect.
+		// Recent ring updated under lock since RecentAndSubscribe
+		// snapshots it. Circular write: O(1) regardless of cap.
+		// Strip bodies from the backlog copy — SSE consumers only
+		// need metadata; the detail page fetches full data via
+		// /api/actions/<id>.
 		if persist {
-			// Strip bodies from backlog — SSE consumers
-			// (LiveRequests, AnalyticsPage) only need
-			// metadata; the detail page fetches full data
-			// via /api/actions/<id>.
 			lite := e
 			lite.ReqBody = ""
 			lite.RespBody = ""
 			lite.ReqHeaders = nil
 			lite.RespHeaders = nil
-			s.recent = append(s.recent, lite)
-			if len(s.recent) > s.recentCap {
-				s.recent = s.recent[len(s.recent)-s.recentCap:]
+			s.recent[s.recentNext] = lite
+			s.recentNext = (s.recentNext + 1) % s.recentCap
+			if s.recentLen < s.recentCap {
+				s.recentLen++
 			}
 		}
-		for _, sub := range s.subs {
+		// Copy subs out of the lock, fan-out without holding mu so
+		// a slow channel doesn't serialize the gateway. Cheap copy
+		// (slice of channel pointers, len ~= dashboards open).
+		subs := append([]chan eventPacket(nil), s.subs...)
+		s.mu.Unlock()
+
+		for _, sub := range subs {
 			select {
-			case sub <- e:
+			case sub <- pkt:
 			default:
 				// slow consumer; drop
+				s.drops.Add(1)
 			}
 		}
-		s.mu.Unlock()
 	}
+}
+
+// recentSnapshot copies the ring into a flat oldest→newest slice.
+// Caller must hold s.mu (or call from RecentAndSubscribe which does).
+func (s *Sink) recentSnapshot() []Event {
+	if s.recentLen == 0 {
+		return nil
+	}
+	out := make([]Event, s.recentLen)
+	if s.recentLen < s.recentCap {
+		copy(out, s.recent[:s.recentLen])
+		return out
+	}
+	// Wrapped: oldest entry sits at recentNext, walk forward modulo cap.
+	for i := 0; i < s.recentCap; i++ {
+		out[i] = s.recent[(s.recentNext+i)%s.recentCap]
+	}
+	return out
 }
 
 // RecentAndSubscribe atomically snapshots the backlog and registers a
 // subscriber under the same lock so no event is missed or duplicated
-// between the two. Caller should write the snapshot first, then loop on
-// the channel for new events.
-func (s *Sink) RecentAndSubscribe() ([]Event, <-chan Event, func()) {
+// between the two. Channel ships eventPackets — drain marshaled the
+// JSON once and shares those bytes across every subscriber.
+func (s *Sink) RecentAndSubscribe() ([]Event, <-chan eventPacket, func()) {
 	if s == nil {
-		ch := make(chan Event)
+		ch := make(chan eventPacket)
 		close(ch)
 		return nil, ch, func() {}
 	}
-	ch := make(chan Event, 64)
+	ch := make(chan eventPacket, 64)
 	s.mu.Lock()
-	snap := append([]Event(nil), s.recent...)
+	snap := s.recentSnapshot()
 	s.subs = append(s.subs, ch)
 	s.mu.Unlock()
 	cancel := func() {
@@ -1141,7 +1239,7 @@ func (s *Sink) RecentAndSubscribe() ([]Event, <-chan Event, func()) {
 	return snap, ch, cancel
 }
 
-func (s *Sink) Subscribe() (<-chan Event, func()) {
+func (s *Sink) Subscribe() (<-chan eventPacket, func()) {
 	_, ch, cancel := s.RecentAndSubscribe()
 	return ch, cancel
 }

--- a/web.go
+++ b/web.go
@@ -56,9 +56,9 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux := http.NewServeMux()
 	mux.HandleFunc("/info", w.serveInfo)
 	mux.HandleFunc("/ca.crt", w.serveCA)
-	mux.HandleFunc("/api/whoami", w.apiWhoami)
+	// /api/whoami + /api/agents are gone — superseded by /api/state.
+	// /api/status stays because DevicePage scopes it with ?profile=.
 	mux.HandleFunc("/api/status", w.apiStatus)
-	mux.HandleFunc("/api/agents", w.apiAgents)
 	// /api/state is the dashboard's single-call refresh endpoint —
 	// bundles whoami+status+agents in one round-trip and returns 304
 	// when the JSON hash matches If-None-Match. Replaces the three
@@ -492,13 +492,9 @@ func (w *webMux) ownerForCaller(r *http.Request) (key, label string) {
 	return host, host
 }
 
-func (w *webMux) apiWhoami(rw http.ResponseWriter, r *http.Request) {
-	writeJSON(rw, w.whoamiData(r))
-}
-
-// whoamiData exposes the apiWhoami payload as a Go map so /api/state
-// can bundle it without round-tripping through writeJSON +
-// re-decoding. Cheap (no DB hit; just config + tailscale whois).
+// whoamiData backs the whoami slice of /api/state. No HTTP handler —
+// the route was removed once App.tsx switched to the bundled
+// /api/state response.
 func (w *webMux) whoamiData(r *http.Request) map[string]string {
 	user, device, host := w.callerIdentity(r)
 	pu := w.g.cfg.PublicURL

--- a/wireguard.go
+++ b/wireguard.go
@@ -489,6 +489,18 @@ func (s *WGServer) PublicKey() (string, error) {
 	return s.publicKey, nil
 }
 
+// udpRelayBufPool reuses 64KB UDP packet buffers across flows. Each
+// relayUDP previously allocated 130KB of buffers per connection (two
+// 65535-byte slices) that lived for the entire flow. Pool keeps a
+// small set warm and recycles on close — saves ~13MB resident per 100
+// concurrent UDP flows.
+var udpRelayBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 65535)
+		return &b
+	},
+}
+
 // relayUDP shuttles datagrams between a netstack UDP conn (peer side)
 // and the real upstream over the host's network. Both directions run
 // until one half closes.
@@ -505,7 +517,9 @@ func relayUDP(c net.Conn, dstIP string, dstPort uint16) {
 	defer up.Close()
 	done := make(chan struct{}, 2)
 	go func() {
-		buf := make([]byte, 65535)
+		bp := udpRelayBufPool.Get().(*[]byte)
+		defer udpRelayBufPool.Put(bp)
+		buf := *bp
 		for {
 			n, err := c.Read(buf)
 			if err != nil {
@@ -518,7 +532,9 @@ func relayUDP(c net.Conn, dstIP string, dstPort uint16) {
 		done <- struct{}{}
 	}()
 	go func() {
-		buf := make([]byte, 65535)
+		bp := udpRelayBufPool.Get().(*[]byte)
+		defer udpRelayBufPool.Put(bp)
+		buf := *bp
 		for {
 			n, _, err := up.ReadFromUDP(buf)
 			if err != nil {

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -9,7 +9,7 @@ import { RequestDetailPage } from "./components/RequestDetailPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
-import { getStatus, getAgents, getWhoami, type Integration, type Agent, type Whoami } from "./lib/api";
+import { getState, type Integration, type Agent, type Whoami } from "./lib/api";
 
 type Route =
   | { name: "main" }
@@ -54,10 +54,13 @@ export default function App() {
 
   async function refresh() {
     try {
-      const [i, a, w] = await Promise.all([getStatus(), getAgents(), getWhoami()]);
-      setIntegrations(i || []);
-      setAgents(a || []);
-      setWhoami(w);
+      // Single round-trip; getState ETags so the no-change path is a
+      // 304 (no body, no JSON parse). Replaces three parallel fetches
+      // that ran every 3 s — one bundled fetch every 5 s now.
+      const s = await getState();
+      setIntegrations(s.integrations || []);
+      setAgents(s.agents || []);
+      setWhoami(s.whoami);
     } catch {
       /* swallow */
     }
@@ -65,7 +68,7 @@ export default function App() {
 
   useEffect(() => {
     refresh();
-    const t = setInterval(refresh, 3000);
+    const t = setInterval(refresh, 5000);
     return () => clearInterval(t);
   }, []);
 

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -58,16 +58,30 @@ export function AnalyticsPage({ ip, agents }: {
 
   useEffect(() => {
     setEvents([]);
-    const url =
-      `/api/events?agent=${encodeURIComponent(ip)}`;
+    const url = `/api/events?agent=${encodeURIComponent(ip)}`;
     const es = new EventSource(url);
+    // rAF-batched render: SSE on a busy gateway fires dozens of
+    // events/sec. setState per event = re-render per event. Coalesce
+    // into one commit per browser frame (~16 ms).
+    let pending: EventRecord[] = [];
+    let raf = 0;
+    const flush = () => {
+      raf = 0;
+      if (pending.length === 0) return;
+      const batch = pending;
+      pending = [];
+      setEvents((prev) => [...batch.reverse(), ...prev].slice(0, 5000));
+    };
     es.onmessage = (e) => {
       try {
-        const ev = JSON.parse(e.data) as EventRecord;
-        setEvents((prev) => [ev, ...prev].slice(0, 5000));
+        pending.push(JSON.parse(e.data) as EventRecord);
+        if (raf === 0) raf = requestAnimationFrame(flush);
       } catch { /* ignore */ }
     };
-    return () => es.close();
+    return () => {
+      es.close();
+      if (raf !== 0) cancelAnimationFrame(raf);
+    };
   }, [ip]);
 
   return (

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -16,13 +16,36 @@ export function LiveRequests({ agentIP, max = 200, height }: {
       ? `/api/events?agent=${encodeURIComponent(agentIP)}`
       : "/api/events";
     const es = new EventSource(url);
+
+    // Batched render: SSE can fire dozens of events per second on a
+    // busy gateway (start + frame + end per request). setState every
+    // event = a re-render every event = jank. Buffer parsed events
+    // into pending[] and flush via requestAnimationFrame; the React
+    // commit happens at most once per browser frame (~16 ms) no
+    // matter how many events arrived in between.
+    let pending: EventRecord[] = [];
+    let raf = 0;
+    const flush = () => {
+      raf = 0;
+      if (pending.length === 0) return;
+      const batch = pending;
+      pending = [];
+      setEvents((prev) => {
+        let next = prev;
+        for (const ev of batch) next = mergeEvent(next, ev, max);
+        return next;
+      });
+    };
     es.onmessage = (e) => {
       try {
-        const ev = JSON.parse(e.data) as EventRecord;
-        setEvents((prev) => mergeEvent(prev, ev, max));
+        pending.push(JSON.parse(e.data) as EventRecord);
+        if (raf === 0) raf = requestAnimationFrame(flush);
       } catch { /* ignore */ }
     };
-    return () => es.close();
+    return () => {
+      es.close();
+      if (raf !== 0) cancelAnimationFrame(raf);
+    };
   }, [agentIP, max]);
 
   return (

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -257,6 +257,30 @@ export async function getWhoami(): Promise<Whoami> {
   return r.json();
 }
 
+// /api/state bundles whoami + integrations + agents in one ETag'd
+// response. Module-level lastTag persists across getState calls so
+// the 304 fast path kicks in on every poll after the first; cached
+// value returned on 304 means consumers always get a non-null shape.
+//
+// Browser fetch with default cache + ETag would also revalidate, but
+// the cached body is still copied into JS land — going through If-
+// None-Match explicitly skips JSON.parse on the no-change path too.
+type StateResp = { whoami: Whoami; integrations: Integration[]; agents: Agent[] };
+let lastStateTag = "";
+let lastState: StateResp | null = null;
+export async function getState(): Promise<StateResp> {
+  const headers: Record<string, string> = {};
+  if (lastStateTag) headers["If-None-Match"] = lastStateTag;
+  const r = await fetch("/api/state", { headers, credentials: "same-origin" });
+  if (r.status === 304 && lastState) return lastState;
+  if (!r.ok) throw new Error(await r.text());
+  const tag = r.headers.get("ETag");
+  if (tag) lastStateTag = tag;
+  const body = (await r.json()) as StateResp;
+  lastState = body;
+  return body;
+}
+
 export type OAuthStartResp =
   | { flow?: "auth_code"; auth_url: string; state: string; owner: string }
   | { flow: "device"; user_code: string; verification_uri: string; state: string; owner: string; interval: number; expires_in: number };

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -245,18 +245,6 @@ export async function deleteAgent(ip: string): Promise<void> {
   if (!r.ok) throw new Error(await r.text());
 }
 
-export async function getAgents(): Promise<Agent[]> {
-  const r = await api("/api/agents");
-  if (!r.ok) throw new Error(await r.text());
-  return r.json();
-}
-
-export async function getWhoami(): Promise<Whoami> {
-  const r = await api("/api/whoami");
-  if (!r.ok) throw new Error(await r.text());
-  return r.json();
-}
-
 // /api/state bundles whoami + integrations + agents in one ETag'd
 // response. Module-level lastTag persists across getState calls so
 // the 304 fast path kicks in on every poll after the first; cached


### PR DESCRIPTION
Three Apple-aligned hardening fixes from the prior-art research round.

1. Per-process mode no longer asks the kernel for QUIC (UDP/443) flows.
   Apple DTS guidance (forum 716594) is unambiguous: "Set up the
   rules so that you're not passed the flow." Returning false on a
   UDP flow we don't want to tunnel is racy — Apple radar
   r.98382363 + forum threads 691711 / 758113 confirm that returning
   false on UDP can stall the originating socket for ~30s (Chrome's
   QUIC fallback timer) or surface ECONNREFUSED on system DNS.

2. Removed the dynamic includedNetworkRules toggle from the
   previous commit. Forum 691341 documents mid-life
   setTunnelNetworkSettings calls wedging the provider; Apple's
   guidance is to treat the rule set as immutable post-startProxy.
   Settings now apply ONCE at startProxy and stay.

3. ancestor cache key is now (pid, start_time) instead of bare pid.
   macOS recycles PIDs aggressively; a stale "matched" entry under
   bare-pid keying could flip a non-clawpatrol flow into tunneled
   or vice versa. Mirrors ref-impl's SessionRegistry.swift:57-61
   start-time validation pattern and Apple Endpoint Security
   guidance (audit tokens are the canonical anti-reuse key, but
   pidversion isn't exposed via proc_pidinfo so start_time is the
   next best thing).