### PR TITLE
release: auto-trigger on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:


### PR DESCRIPTION
Pages-published binaries (releases/latest/) only refreshed on tag
push or manual workflow_dispatch, so install.sh kept handing out
pre-merge binaries until someone remembered to dispatch the
workflow.

* Add `push: branches: [main]` so every merged PR refreshes the
  latest binary alongside the existing tag-push path.
* Tag pushes keep publishing to releases/<tag>/; main pushes
  overwrite releases/latest/ with the freshest main HEAD.