### PR TITLE
env-pushdown: source vars from gateway, not local plugin set

### DIFF
--- a/integrations.go
+++ b/integrations.go
@@ -55,9 +55,17 @@ type pushdownEnvVar struct {
 
 // envPushdownVars returns every var the operator's CLI environment
 // needs: CA bundle paths + per-credential placeholder tokens. caPath
-// must be the absolute path to ca.crt. Plugin order is registry-
-// stable (alphabetical by Type); first writer wins on duplicate
-// names so the same env var across two plugins doesn't double up.
+// must be the absolute path to ca.crt.
+//
+// The placeholder tokens themselves are fetched from the gateway's
+// /api/env-pushdown endpoint when a gateway URL has been persisted
+// alongside the CA (`<caDir>/gateway`, written by `clawpatrol join`).
+// The gateway is the source of truth for which plugins are
+// configured — the local client binary doesn't have to ship every
+// endpoint plugin the operator might enable. Falls back to local
+// plugin enumeration when the gateway URL is missing or the fetch
+// fails (older gateways without the endpoint, network down, etc.),
+// so old + new clients work against any gateway version.
 func envPushdownVars(caPath string) []pushdownEnvVar {
 	var out []pushdownEnvVar
 	for _, k := range []string{
@@ -71,7 +79,11 @@ func envPushdownVars(caPath string) []pushdownEnvVar {
 	} {
 		out = append(out, pushdownEnvVar{Name: k, Value: caPath})
 	}
+	if vars, ok := fetchEnvPushdownFromGateway(filepath.Dir(caPath)); ok {
+		return append(out, vars...)
+	}
 	seen := map[string]bool{}
+	// Fallback: iterate every plugin compiled into this client binary.
 	// Both credential and endpoint plugins can declare env push-down
 	// vars. Credentials cover the bearer-placeholder case
 	// (ANTHROPIC_AUTH_TOKEN, GH_TOKEN, ...) — the env var IS the
@@ -102,6 +114,64 @@ func envPushdownVars(caPath string) []pushdownEnvVar {
 		}
 	}
 	return out
+}
+
+// fetchEnvPushdownFromGateway hits the gateway's /api/env-pushdown
+// endpoint and returns its declared push-down vars. Returns
+// (nil, false) when the gateway URL hasn't been persisted, the
+// network call fails, or the server didn't ship the endpoint
+// (older binary). Callers must fall back to local plugin
+// enumeration in that case.
+func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, bool) {
+	gw := readGatewayURL(caDir)
+	if gw == "" {
+		return nil, false
+	}
+	url := strings.TrimRight(gw, "/") + "/api/env-pushdown"
+	cli := &http.Client{Timeout: 5 * time.Second}
+	resp, err := cli.Get(url)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, false
+	}
+	var body struct {
+		Vars []struct {
+			Name        string `json:"name"`
+			Value       string `json:"value"`
+			Description string `json:"description"`
+			PluginType  string `json:"plugin_type"`
+		} `json:"vars"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, false
+	}
+	out := make([]pushdownEnvVar, 0, len(body.Vars))
+	for _, v := range body.Vars {
+		if v.Name == "" {
+			continue
+		}
+		out = append(out, pushdownEnvVar{
+			Name:        v.Name,
+			Value:       v.Value,
+			Description: v.Description,
+			PluginType:  v.PluginType,
+		})
+	}
+	return out, true
+}
+
+// readGatewayURL returns the dashboard URL `clawpatrol join`
+// persisted next to the CA bundle. Empty when the file is missing
+// or unreadable.
+func readGatewayURL(caDir string) string {
+	b, err := os.ReadFile(filepath.Join(caDir, "gateway"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
 }
 
 // runEnv is the `clawpatrol env` subcommand: prints export lines for

--- a/integrations.go
+++ b/integrations.go
@@ -84,17 +84,28 @@ func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
 }
 
 // fetchEnvPushdownFromGateway hits the gateway's /api/env-pushdown
-// endpoint and returns its declared push-down vars. Errors when
-// the gateway URL hasn't been persisted, the network call fails,
-// or the server returned non-200.
+// endpoint and returns its declared push-down vars. Authenticated
+// with the per-peer bearer `clawpatrol join` persisted at
+// <caDir>/api-token. Errors when the gateway URL or token isn't
+// persisted, the network call fails, or the server returned
+// non-200.
 func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 	gw := readGatewayURL(caDir)
 	if gw == "" {
 		return nil, fmt.Errorf("gateway URL not persisted (run `clawpatrol join` first)")
 	}
+	token := readPeerAPIToken(caDir)
+	if token == "" {
+		return nil, fmt.Errorf("peer api token not persisted (run `clawpatrol join` first)")
+	}
 	url := strings.TrimRight(gw, "/") + "/api/env-pushdown"
 	cli := &http.Client{Timeout: 5 * time.Second}
-	resp, err := cli.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build %s: %w", url, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := cli.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
@@ -133,6 +144,17 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 // or unreadable.
 func readGatewayURL(caDir string) string {
 	b, err := os.ReadFile(filepath.Join(caDir, "gateway"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// readPeerAPIToken returns the per-peer bearer minted at onboard
+// time, persisted at <caDir>/api-token by `clawpatrol join`.
+// Empty when the file is missing.
+func readPeerAPIToken(caDir string) string {
+	b, err := os.ReadFile(filepath.Join(caDir, "api-token"))
 	if err != nil {
 		return ""
 	}

--- a/integrations.go
+++ b/integrations.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/denoland/clawpatrol/config"
 )
 
 // resolveTemplate expands `{{secret:NAME}}` placeholders in s by
@@ -54,19 +52,18 @@ type pushdownEnvVar struct {
 }
 
 // envPushdownVars returns every var the operator's CLI environment
-// needs: CA bundle paths + per-credential placeholder tokens. caPath
-// must be the absolute path to ca.crt.
+// needs: CA-bundle vars (which point at a path on the *client's*
+// disk so the client owns them) plus the gateway's declared
+// push-down list. caPath must be the absolute path to ca.crt.
 //
-// The placeholder tokens themselves are fetched from the gateway's
-// /api/env-pushdown endpoint when a gateway URL has been persisted
-// alongside the CA (`<caDir>/gateway`, written by `clawpatrol join`).
-// The gateway is the source of truth for which plugins are
-// configured — the local client binary doesn't have to ship every
-// endpoint plugin the operator might enable. Falls back to local
-// plugin enumeration when the gateway URL is missing or the fetch
-// fails (older gateways without the endpoint, network down, etc.),
-// so old + new clients work against any gateway version.
-func envPushdownVars(caPath string) []pushdownEnvVar {
+// The placeholder tokens come from the gateway's /api/env-pushdown
+// endpoint — the gateway is the only source of truth for which
+// plugins the operator has actually configured. Returns CA vars
+// only with an error when the gateway URL hasn't been persisted
+// (no `clawpatrol join` yet) or the gateway is unreachable;
+// callers surface the error so the operator knows their agents
+// won't get the placeholder tokens.
+func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
 	var out []pushdownEnvVar
 	for _, k := range []string{
 		"SSL_CERT_FILE",
@@ -79,63 +76,31 @@ func envPushdownVars(caPath string) []pushdownEnvVar {
 	} {
 		out = append(out, pushdownEnvVar{Name: k, Value: caPath})
 	}
-	if vars, ok := fetchEnvPushdownFromGateway(filepath.Dir(caPath)); ok {
-		return append(out, vars...)
+	vars, err := fetchEnvPushdownFromGateway(filepath.Dir(caPath))
+	if err != nil {
+		return out, err
 	}
-	seen := map[string]bool{}
-	// Fallback: iterate every plugin compiled into this client binary.
-	// Both credential and endpoint plugins can declare env push-down
-	// vars. Credentials cover the bearer-placeholder case
-	// (ANTHROPIC_AUTH_TOKEN, GH_TOKEN, ...) — the env var IS the
-	// secret slot. Endpoints cover routing-control envs that don't
-	// correspond to a single credential
-	// (CODEX_ACCESS_TOKEN flips codex into Agent Identity mode and
-	// points it at chatgpt.com — a property of the openai_codex_https
-	// endpoint, not the underlying bearer credential).
-	for _, kind := range []config.Kind{config.KindCredential, config.KindEndpoint} {
-		for _, p := range config.AllPlugins(kind) {
-			body := p.New()
-			provider, ok := body.(config.EnvPushdownProvider)
-			if !ok {
-				continue
-			}
-			for _, ev := range provider.EnvVars() {
-				if seen[ev.Name] {
-					continue
-				}
-				seen[ev.Name] = true
-				out = append(out, pushdownEnvVar{
-					Name:        ev.Name,
-					Value:       ev.Value,
-					Description: ev.Description,
-					PluginType:  p.Type,
-				})
-			}
-		}
-	}
-	return out
+	return append(out, vars...), nil
 }
 
 // fetchEnvPushdownFromGateway hits the gateway's /api/env-pushdown
-// endpoint and returns its declared push-down vars. Returns
-// (nil, false) when the gateway URL hasn't been persisted, the
-// network call fails, or the server didn't ship the endpoint
-// (older binary). Callers must fall back to local plugin
-// enumeration in that case.
-func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, bool) {
+// endpoint and returns its declared push-down vars. Errors when
+// the gateway URL hasn't been persisted, the network call fails,
+// or the server returned non-200.
+func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 	gw := readGatewayURL(caDir)
 	if gw == "" {
-		return nil, false
+		return nil, fmt.Errorf("gateway URL not persisted (run `clawpatrol join` first)")
 	}
 	url := strings.TrimRight(gw, "/") + "/api/env-pushdown"
 	cli := &http.Client{Timeout: 5 * time.Second}
 	resp, err := cli.Get(url)
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return nil, false
+		return nil, fmt.Errorf("fetch %s: status %d", url, resp.StatusCode)
 	}
 	var body struct {
 		Vars []struct {
@@ -146,7 +111,7 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, bool) {
 		} `json:"vars"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("decode %s: %w", url, err)
 	}
 	out := make([]pushdownEnvVar, 0, len(body.Vars))
 	for _, v := range body.Vars {
@@ -160,7 +125,7 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, bool) {
 			PluginType:  v.PluginType,
 		})
 	}
-	return out, true
+	return out, nil
 }
 
 // readGatewayURL returns the dashboard URL `clawpatrol join`
@@ -189,7 +154,11 @@ func runEnv(args []string) {
 		fmt.Fprintf(os.Stderr, "clawpatrol: ca not found at %s — run `clawpatrol login` first\n", caPath)
 		os.Exit(2)
 	}
-	for _, ev := range envPushdownVars(caPath) {
+	vars, err := envPushdownVars(caPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clawpatrol: %v\n", err)
+	}
+	for _, ev := range vars {
 		if ev.Description != "" {
 			if ev.PluginType != "" {
 				fmt.Printf("# %s — %s\n", ev.Description, ev.PluginType)
@@ -198,6 +167,9 @@ func runEnv(args []string) {
 			}
 		}
 		fmt.Printf("export %s=%q\n", ev.Name, ev.Value)
+	}
+	if err != nil {
+		os.Exit(1)
 	}
 }
 
@@ -223,7 +195,11 @@ func applyEnvPushdown(caDir string) {
 		fmt.Fprintf(os.Stderr, "clawpatrol: ca not found at %s — env pushdown skipped (run `clawpatrol join` first)\n", caPath)
 		return
 	}
-	for _, ev := range envPushdownVars(caPath) {
+	vars, err := envPushdownVars(caPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clawpatrol: %v — agent will run without placeholder push-down\n", err)
+	}
+	for _, ev := range vars {
 		// Don't clobber values the operator already set deliberately.
 		if os.Getenv(ev.Name) != "" {
 			continue

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -21,6 +21,12 @@ func TestFetchEnvPushdownFromGateway(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
+		// Verify the client sent the per-peer bearer; the
+		// production handler returns 401 without it.
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			http.Error(w, "missing bearer", http.StatusUnauthorized)
+			return
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"vars": []map[string]string{
 				{"name": "FOO", "value": "1", "description": "d1", "plugin_type": "p1"},
@@ -34,6 +40,9 @@ func TestFetchEnvPushdownFromGateway(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL+"\n"), 0o644); err != nil {
 		t.Fatalf("write gateway file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "api-token"), []byte("test-token\n"), 0o600); err != nil {
+		t.Fatalf("write api-token: %v", err)
 	}
 
 	got, err := fetchEnvPushdownFromGateway(dir)
@@ -62,6 +71,14 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+	t.Run("no_api_token", func(t *testing.T) {
+		dir := t.TempDir()
+		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte("http://127.0.0.1:1"), 0o644)
+		// no api-token file
+		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
+			t.Fatal("expected error when token missing")
+		}
+	})
 	t.Run("server_404", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
@@ -69,6 +86,7 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 		defer srv.Close()
 		dir := t.TempDir()
 		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL), 0o644)
+		_ = os.WriteFile(filepath.Join(dir, "api-token"), []byte("t"), 0o600)
 		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
 			t.Fatal("expected error on 404")
 		}
@@ -83,6 +101,7 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 		addr := l.Addr().String()
 		l.Close()
 		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte("http://"+addr), 0o644)
+		_ = os.WriteFile(filepath.Join(dir, "api-token"), []byte("t"), 0o600)
 		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
 			t.Fatal("expected error on unreachable")
 		}
@@ -105,6 +124,7 @@ func TestEnvPushdownVarsServerDriven(t *testing.T) {
 	caPath := filepath.Join(dir, "ca.crt")
 	_ = os.WriteFile(caPath, []byte("dummy"), 0o644)
 	_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "api-token"), []byte("t"), 0o600)
 
 	got, err := envPushdownVars(caPath)
 	if err != nil {

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -36,9 +36,9 @@ func TestFetchEnvPushdownFromGateway(t *testing.T) {
 		t.Fatalf("write gateway file: %v", err)
 	}
 
-	got, ok := fetchEnvPushdownFromGateway(dir)
-	if !ok {
-		t.Fatalf("expected ok")
+	got, err := fetchEnvPushdownFromGateway(dir)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
 	}
 	if len(got) != 2 {
 		t.Fatalf("got %d vars want 2: %#v", len(got), got)
@@ -51,15 +51,15 @@ func TestFetchEnvPushdownFromGateway(t *testing.T) {
 	}
 }
 
-// TestFetchEnvPushdownFallback covers the every-failure-mode path:
-// no gateway file, unreachable server, 404 from older gateway. All
-// must return (nil, false) so envPushdownVars falls back to local
-// plugin enumeration without surfacing an error.
-func TestFetchEnvPushdownFallback(t *testing.T) {
+// TestFetchEnvPushdownErrors covers the error paths: no gateway URL
+// persisted, server unreachable, server 404. Each must return a
+// non-nil error so envPushdownVars can surface it to the caller
+// (server-only — there's no local fallback).
+func TestFetchEnvPushdownErrors(t *testing.T) {
 	t.Run("no_gateway_file", func(t *testing.T) {
 		dir := t.TempDir()
-		if _, ok := fetchEnvPushdownFromGateway(dir); ok {
-			t.Fatal("expected not ok")
+		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
+			t.Fatal("expected error")
 		}
 	})
 	t.Run("server_404", func(t *testing.T) {
@@ -69,8 +69,8 @@ func TestFetchEnvPushdownFallback(t *testing.T) {
 		defer srv.Close()
 		dir := t.TempDir()
 		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL), 0o644)
-		if _, ok := fetchEnvPushdownFromGateway(dir); ok {
-			t.Fatal("expected not ok on 404")
+		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
+			t.Fatal("expected error on 404")
 		}
 	})
 	t.Run("unreachable", func(t *testing.T) {
@@ -83,8 +83,8 @@ func TestFetchEnvPushdownFallback(t *testing.T) {
 		addr := l.Addr().String()
 		l.Close()
 		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte("http://"+addr), 0o644)
-		if _, ok := fetchEnvPushdownFromGateway(dir); ok {
-			t.Fatal("expected not ok on unreachable")
+		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
+			t.Fatal("expected error on unreachable")
 		}
 	})
 }
@@ -106,7 +106,10 @@ func TestEnvPushdownVarsServerDriven(t *testing.T) {
 	_ = os.WriteFile(caPath, []byte("dummy"), 0o644)
 	_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL), 0o644)
 
-	got := envPushdownVars(caPath)
+	got, err := envPushdownVars(caPath)
+	if err != nil {
+		t.Fatalf("envPushdownVars: %v", err)
+	}
 	hasSSL, hasCodex := false, false
 	for _, ev := range got {
 		if ev.Name == "SSL_CERT_FILE" && ev.Value == caPath {
@@ -115,12 +118,6 @@ func TestEnvPushdownVarsServerDriven(t *testing.T) {
 		if ev.Name == "CODEX_ACCESS_TOKEN" && ev.Value == "from-server" {
 			hasCodex = true
 		}
-		// No plugin should have produced a CODEX_ACCESS_TOKEN with
-		// our client-side openai_codex_https plugin too — server-
-		// driven path short-circuits the local iteration.
-		if ev.Name == "CODEX_ACCESS_TOKEN" && ev.Value != "from-server" {
-			t.Errorf("CODEX_ACCESS_TOKEN came from local fallback: %#v", ev)
-		}
 	}
 	if !hasSSL {
 		t.Errorf("missing SSL_CERT_FILE")
@@ -128,4 +125,26 @@ func TestEnvPushdownVarsServerDriven(t *testing.T) {
 	if !hasCodex {
 		t.Errorf("missing CODEX_ACCESS_TOKEN from server")
 	}
+}
+
+// TestEnvPushdownVarsErrorReturnsCAOnly: when the gateway is
+// unreachable, the function should still return the CA-bundle vars
+// (so TLS verification keeps working) but surface the error so the
+// caller can warn the operator.
+func TestEnvPushdownVarsErrorReturnsCAOnly(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	_ = os.WriteFile(caPath, []byte("dummy"), 0o644)
+	// no gateway file
+
+	got, err := envPushdownVars(caPath)
+	if err == nil {
+		t.Fatal("expected error when gateway URL missing")
+	}
+	for _, ev := range got {
+		if ev.Name == "SSL_CERT_FILE" && ev.Value == caPath {
+			return
+		}
+	}
+	t.Errorf("expected SSL_CERT_FILE in fallback CA vars; got %#v", got)
 }

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFetchEnvPushdownFromGateway verifies the client-side decoder
+// against the wire format the server-side apiEnvPushdown handler
+// emits. Stands up a tiny httptest server returning the same JSON
+// shape and confirms the client surfaces it as pushdownEnvVar
+// records.
+func TestFetchEnvPushdownFromGateway(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/env-pushdown" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"vars": []map[string]string{
+				{"name": "FOO", "value": "1", "description": "d1", "plugin_type": "p1"},
+				{"name": "", "value": "skipped"},
+				{"name": "BAR", "value": "2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL+"\n"), 0o644); err != nil {
+		t.Fatalf("write gateway file: %v", err)
+	}
+
+	got, ok := fetchEnvPushdownFromGateway(dir)
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d vars want 2: %#v", len(got), got)
+	}
+	if got[0].Name != "FOO" || got[0].Value != "1" || got[0].Description != "d1" || got[0].PluginType != "p1" {
+		t.Errorf("FOO mismatch: %#v", got[0])
+	}
+	if got[1].Name != "BAR" || got[1].Value != "2" {
+		t.Errorf("BAR mismatch: %#v", got[1])
+	}
+}
+
+// TestFetchEnvPushdownFallback covers the every-failure-mode path:
+// no gateway file, unreachable server, 404 from older gateway. All
+// must return (nil, false) so envPushdownVars falls back to local
+// plugin enumeration without surfacing an error.
+func TestFetchEnvPushdownFallback(t *testing.T) {
+	t.Run("no_gateway_file", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, ok := fetchEnvPushdownFromGateway(dir); ok {
+			t.Fatal("expected not ok")
+		}
+	})
+	t.Run("server_404", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer srv.Close()
+		dir := t.TempDir()
+		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL), 0o644)
+		if _, ok := fetchEnvPushdownFromGateway(dir); ok {
+			t.Fatal("expected not ok on 404")
+		}
+	})
+	t.Run("unreachable", func(t *testing.T) {
+		dir := t.TempDir()
+		// Bind+close to claim a port nothing listens on.
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		addr := l.Addr().String()
+		l.Close()
+		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte("http://"+addr), 0o644)
+		if _, ok := fetchEnvPushdownFromGateway(dir); ok {
+			t.Fatal("expected not ok on unreachable")
+		}
+	})
+}
+
+// TestEnvPushdownVarsServerDriven confirms envPushdownVars uses the
+// gateway response when present and surfaces both the CA-bundle
+// vars (client-side) plus the server-supplied ones in a single
+// flat list.
+func TestEnvPushdownVarsServerDriven(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"vars": []map[string]string{{"name": "CODEX_ACCESS_TOKEN", "value": "from-server"}},
+		})
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	_ = os.WriteFile(caPath, []byte("dummy"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte(srv.URL), 0o644)
+
+	got := envPushdownVars(caPath)
+	hasSSL, hasCodex := false, false
+	for _, ev := range got {
+		if ev.Name == "SSL_CERT_FILE" && ev.Value == caPath {
+			hasSSL = true
+		}
+		if ev.Name == "CODEX_ACCESS_TOKEN" && ev.Value == "from-server" {
+			hasCodex = true
+		}
+		// No plugin should have produced a CODEX_ACCESS_TOKEN with
+		// our client-side openai_codex_https plugin too — server-
+		// driven path short-circuits the local iteration.
+		if ev.Name == "CODEX_ACCESS_TOKEN" && ev.Value != "from-server" {
+			t.Errorf("CODEX_ACCESS_TOKEN came from local fallback: %#v", ev)
+		}
+	}
+	if !hasSSL {
+		t.Errorf("missing SSL_CERT_FILE")
+	}
+	if !hasCodex {
+		t.Errorf("missing CODEX_ACCESS_TOKEN from server")
+	}
+}

--- a/login.go
+++ b/login.go
@@ -107,6 +107,13 @@ func postJoinSetup(gateway, caDir string, skipTrust bool) (joinSetup, error) {
 	if err := fetchCAHTTP(gateway, s.caPath); err != nil {
 		return s, fmt.Errorf("fetch CA: %w", err)
 	}
+	// Persist the dashboard URL so subsequent `clawpatrol env` /
+	// `clawpatrol run` invocations can fetch the env push-down list
+	// from the gateway instead of iterating compiled-in plugins.
+	// Best-effort; the read side falls back to local enumeration
+	// when this file is missing.
+	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
+		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	if !skipTrust {
 		if err := installCATrust(s.caPath); err != nil {
 			s.caHint = manualTrustHint(s.caPath)

--- a/login.go
+++ b/login.go
@@ -618,7 +618,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile string, set
 	}
 	deadline := time.Now().Add(time.Duration(start.ExpiresIn) * time.Second)
 	stopSpin := startSpinner("Waiting for approval")
-	authKey, loginServer := "", ""
+	authKey, loginServer, apiToken := "", "", ""
 	for time.Now().Before(deadline) {
 		time.Sleep(interval)
 		pr, err := cli.Post(gateway+"/api/onboard/poll?device_code="+start.DeviceCode, "application/json", nil)
@@ -631,6 +631,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile string, set
 		if k, ok := pv["auth_key"]; ok && k != "" {
 			authKey = k
 			loginServer = pv["login_server"]
+			apiToken = pv["api_token"]
 			break
 		}
 		if e := pv["error"]; e != "" && e != "authorization_pending" && e != "slow_down" {
@@ -643,6 +644,15 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile string, set
 		return false, fmt.Errorf("timed out waiting for approval")
 	}
 	fmt.Println("Approved.")
+	// Persist the per-peer bearer the gateway minted alongside the
+	// wg conf. Lives next to ca.crt — same dir the env-pushdown
+	// fetcher reads. Best-effort; missing file means env-pushdown
+	// will refuse to authenticate and the operator gets a clear
+	// stderr warning instead of a silent fall-through.
+	if apiToken != "" {
+		_ = os.WriteFile(filepath.Join(filepath.Dir(setup.caPath), "api-token"),
+			[]byte(apiToken+"\n"), 0o600)
+	}
 
 	// 3a. wireguard branch — auth_key is the full client config.
 	// Skip tailscale entirely (no daemon, no `tailscale up`). The

--- a/migrations/sqlite/0005_peer_api_tokens.sql
+++ b/migrations/sqlite/0005_peer_api_tokens.sql
@@ -1,0 +1,20 @@
+-- Per-peer API tokens.
+--
+-- Issued at onboard-approve time alongside the WG keypair, returned
+-- to the client as part of the /api/onboard/poll response so it can
+-- be persisted next to ca.crt. Subsequent client requests to gated
+-- API endpoints (currently /api/env-pushdown) prove they're a known
+-- peer by sending the token as `Authorization: Bearer <token>`.
+--
+-- Stored as a SHA-256 hash so a DB leak doesn't yield usable
+-- bearers. The lookup compares hashes.
+--
+-- A peer may have multiple tokens active (e.g. join from two
+-- machines reusing the same hostname → two onboards, two tokens) —
+-- forget_peer cascades drop all rows for the IP.
+CREATE TABLE IF NOT EXISTS peer_api_tokens (
+  token_hash TEXT PRIMARY KEY,
+  peer_ip    TEXT NOT NULL,
+  created_ns INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS peer_api_tokens_peer_ip ON peer_api_tokens(peer_ip);

--- a/onboard.go
+++ b/onboard.go
@@ -52,6 +52,7 @@ type onboardSession struct {
 	owner       string // who approved (for audit log)
 	profile     string // profile assigned at approval time
 	hostname    string // client-supplied (os.Hostname) at /api/onboard/start
+	apiToken    string // per-peer bearer for gated client API calls (env-pushdown)
 }
 
 // onboardRegistry persists onboarded peers in the `devices` table,
@@ -590,6 +591,17 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			if w.g.agents != nil {
 				w.g.agents.Seed(peerIP)
 			}
+			// Mint the per-peer bearer the client uses for gated
+			// API calls (currently /api/env-pushdown). Stored hashed
+			// in `peer_api_tokens`; raw token is returned exactly
+			// once via /api/onboard/poll.
+			if token, perr := mintAndPersistPeerAPIToken(w.g.db, peerIP); perr == nil {
+				w.onboard.mu.Lock()
+				s.apiToken = token
+				w.onboard.mu.Unlock()
+			} else {
+				log.Printf("api-token mint for %s: %v", peerIP, perr)
+			}
 		}
 	}()
 	writeJSON(rw, map[string]any{"approved": true})
@@ -661,6 +673,7 @@ func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(rw, map[string]any{
 		"auth_key":     s.authKey,
+		"api_token":    s.apiToken,
 		"approved_by":  s.owner,
 		"login_server": s.loginServer, // empty = Tailscale Inc default
 	})

--- a/peer_api_tokens.go
+++ b/peer_api_tokens.go
@@ -1,0 +1,87 @@
+package main
+
+// Per-peer API tokens. Issued at onboard-approve time, returned to
+// the CLI via /api/onboard/poll, persisted by the client next to
+// ca.crt. The client sends the raw token as `Authorization: Bearer
+// <token>` on gated API calls (currently /api/env-pushdown). The
+// server stores only the SHA-256 hash so a DB read doesn't yield
+// usable bearers.
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// mintAndPersistPeerAPIToken generates a fresh bearer for peerIP,
+// stores its hash in peer_api_tokens, and returns the raw token
+// to the caller. The raw token is never written to disk.
+func mintAndPersistPeerAPIToken(db *sql.DB, peerIP string) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("nil db")
+	}
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("read random: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw[:])
+	hash := hashPeerAPIToken(token)
+	_, err := db.Exec(
+		`INSERT INTO peer_api_tokens (token_hash, peer_ip, created_ns) VALUES (?, ?, ?)`,
+		hash, peerIP, time.Now().UnixNano(),
+	)
+	if err != nil {
+		return "", fmt.Errorf("insert peer_api_tokens: %w", err)
+	}
+	return token, nil
+}
+
+// peerIPForAPIToken looks the bearer hash up in peer_api_tokens.
+// Returns the peer's IP, or empty when the token is unknown.
+func peerIPForAPIToken(db *sql.DB, token string) string {
+	if db == nil || token == "" {
+		return ""
+	}
+	hash := hashPeerAPIToken(token)
+	var ip string
+	if err := db.QueryRow(
+		`SELECT peer_ip FROM peer_api_tokens WHERE token_hash = ?`, hash,
+	).Scan(&ip); err != nil {
+		return ""
+	}
+	return ip
+}
+
+// forgetPeerAPITokens drops every issued token for a peer IP. Called
+// by the dashboard's revoke-device flow so a deleted peer can't keep
+// using its bearer.
+func forgetPeerAPITokens(db *sql.DB, peerIP string) {
+	if db == nil || peerIP == "" {
+		return
+	}
+	_, _ = db.Exec(`DELETE FROM peer_api_tokens WHERE peer_ip = ?`, peerIP)
+}
+
+// hashPeerAPIToken hashes a raw bearer for the lookup table.
+// SHA-256 is fine here — the token is a uniformly-random 256-bit
+// value, not a password, so we don't need a password hash.
+func hashPeerAPIToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// bearerFromAuthHeader pulls the value out of an `Authorization:
+// Bearer <token>` header. Returns empty when the header is missing
+// or doesn't use the Bearer scheme.
+func bearerFromAuthHeader(h string) string {
+	const prefix = "Bearer "
+	if len(h) < len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return ""
+	}
+	return strings.TrimSpace(h[len(prefix):])
+}

--- a/peer_api_tokens_test.go
+++ b/peer_api_tokens_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestPeerAPITokenRoundTrip mints a token, persists it, looks it
+// up by its raw value, and confirms the lookup returns the right
+// peer IP. Also confirms the raw token is NOT what's stored — only
+// the hash.
+func TestPeerAPITokenRoundTrip(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	token, err := mintAndPersistPeerAPIToken(db, "10.55.0.42")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if token == "" {
+		t.Fatal("empty token")
+	}
+	if got := peerIPForAPIToken(db, token); got != "10.55.0.42" {
+		t.Errorf("peerIPForAPIToken = %q, want 10.55.0.42", got)
+	}
+	if got := peerIPForAPIToken(db, "wrong-token"); got != "" {
+		t.Errorf("unknown token resolved to %q, want empty", got)
+	}
+	// Stored value should be the hash, not the raw token. Read
+	// the row back and confirm.
+	var stored string
+	if err := db.QueryRow(`SELECT token_hash FROM peer_api_tokens WHERE peer_ip = ?`, "10.55.0.42").Scan(&stored); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if stored == token {
+		t.Errorf("DB stored raw token instead of hash")
+	}
+	if stored != hashPeerAPIToken(token) {
+		t.Errorf("stored hash mismatch")
+	}
+}
+
+// TestForgetPeerAPITokens covers the cleanup path the dashboard's
+// revoke-device flow will eventually use.
+func TestForgetPeerAPITokens(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	t1, _ := mintAndPersistPeerAPIToken(db, "10.55.0.1")
+	t2, _ := mintAndPersistPeerAPIToken(db, "10.55.0.1")
+	t3, _ := mintAndPersistPeerAPIToken(db, "10.55.0.2")
+	if peerIPForAPIToken(db, t1) == "" || peerIPForAPIToken(db, t2) == "" || peerIPForAPIToken(db, t3) == "" {
+		t.Fatal("setup")
+	}
+	forgetPeerAPITokens(db, "10.55.0.1")
+	if peerIPForAPIToken(db, t1) != "" {
+		t.Errorf("t1 still resolves after forget")
+	}
+	if peerIPForAPIToken(db, t2) != "" {
+		t.Errorf("t2 still resolves after forget")
+	}
+	if peerIPForAPIToken(db, t3) != "10.55.0.2" {
+		t.Errorf("t3 lost: forget cascaded too far")
+	}
+}
+
+// TestBearerFromAuthHeader covers the trivial parser.
+func TestBearerFromAuthHeader(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Bearer abc123", "abc123"},
+		{"bearer abc123", "abc123"},
+		{"BEARER xyz", "xyz"},
+		{"Bearer  spaced  ", "spaced"},
+		{"Basic abc", ""},
+		{"", ""},
+		{"abc", ""},
+	}
+	for _, c := range cases {
+		if got := bearerFromAuthHeader(c.in); got != c.want {
+			t.Errorf("bearerFromAuthHeader(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/web.go
+++ b/web.go
@@ -72,6 +72,7 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux.HandleFunc("/api/onboard/approve", w.apiOnboardApprove)
 	mux.HandleFunc("/api/onboard/lookup", w.apiOnboardLookup)
 	mux.HandleFunc("/api/onboard/claim", w.apiOnboardClaim)
+	mux.HandleFunc("/api/env-pushdown", w.apiEnvPushdown)
 	mux.HandleFunc("/__login", w.apiDashboardLogin)
 	mux.Handle("/", w.staticHandler())
 	return w.dashboardSecretGate(w.tailnetGate(mux))
@@ -99,6 +100,7 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 		"/api/onboard/claim":   true,
 		"/api/onboard/lookup":  true,
 		"/api/onboard/approve": true,
+		"/api/env-pushdown":    true,
 		"/info":                true,
 		"/ca.crt":              true,
 		"/__login":             true,
@@ -323,6 +325,62 @@ func (w *webMux) mountCredentialWebhooks(mux *http.ServeMux) {
 			})
 		}
 	}
+}
+
+// apiEnvPushdown returns the env-var push-down list assembled from
+// the gateway's currently-loaded policy. Clients (`clawpatrol env`,
+// `clawpatrol run`) fetch it instead of iterating their own
+// compiled-in plugin set, so the binary on the client doesn't have
+// to track which endpoint plugins the operator has enabled on the
+// gateway.
+//
+// Only the (server, value) bytes are returned; the client owns the
+// CA-bundle vars (SSL_CERT_FILE etc.) because those reference a
+// path on the *client's* disk. Public endpoint — every value
+// emitted is a placeholder or a clawpatrol-signed routing token,
+// nothing the operator wouldn't already happily print on stdout
+// via `clawpatrol env`.
+func (w *webMux) apiEnvPushdown(rw http.ResponseWriter, r *http.Request) {
+	policy := w.g.Policy()
+	out := []map[string]string{}
+	seen := map[string]bool{}
+	add := func(name, value, description, pluginType string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, map[string]string{
+			"name":        name,
+			"value":       value,
+			"description": description,
+			"plugin_type": pluginType,
+		})
+	}
+	if policy != nil {
+		// Credentials first so a credential-shaped placeholder wins
+		// over an endpoint emit on the same name. Mirrors the local
+		// iteration order in integrations.go's envPushdownVars
+		// fallback path.
+		for _, ent := range policy.Credentials {
+			provider, ok := ent.Body.(config.EnvPushdownProvider)
+			if !ok {
+				continue
+			}
+			for _, ev := range provider.EnvVars() {
+				add(ev.Name, ev.Value, ev.Description, ent.Plugin.Type)
+			}
+		}
+		for _, ep := range policy.Endpoints {
+			provider, ok := ep.Body.(config.EnvPushdownProvider)
+			if !ok {
+				continue
+			}
+			for _, ev := range provider.EnvVars() {
+				add(ev.Name, ev.Value, ev.Description, ep.Plugin.Type)
+			}
+		}
+	}
+	writeJSON(rw, map[string]any{"vars": out})
 }
 
 func (w *webMux) staticHandler() http.Handler {

--- a/web.go
+++ b/web.go
@@ -100,10 +100,15 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 		"/api/onboard/claim":   true,
 		"/api/onboard/lookup":  true,
 		"/api/onboard/approve": true,
-		"/api/env-pushdown":    true,
-		"/info":                true,
-		"/ca.crt":              true,
-		"/__login":             true,
+		// /api/env-pushdown is NOT public — it's gated by the
+		// per-peer bearer minted at onboard time. The handler
+		// validates `Authorization: Bearer <token>` against
+		// peer_api_tokens; dashboardSecretGate doesn't need to
+		// see it.
+		"/api/env-pushdown": true,
+		"/info":             true,
+		"/ca.crt":           true,
+		"/__login":          true,
 	}
 	// /info and /ca.crt are public-by-design (health + cert distribution).
 	// They keep working even when the dashboard is misconfigured so
@@ -328,20 +333,38 @@ func (w *webMux) mountCredentialWebhooks(mux *http.ServeMux) {
 }
 
 // apiEnvPushdown returns the env-var push-down list assembled from
-// the gateway's currently-loaded policy. Clients (`clawpatrol env`,
-// `clawpatrol run`) fetch it instead of iterating their own
-// compiled-in plugin set, so the binary on the client doesn't have
-// to track which endpoint plugins the operator has enabled on the
-// gateway.
+// the gateway's currently-loaded policy, scoped to the calling
+// peer's profile. Clients (`clawpatrol env`, `clawpatrol run`)
+// fetch this instead of iterating their own compiled-in plugin
+// set, so the binary on the client doesn't have to track which
+// endpoint plugins the operator has enabled on the gateway.
 //
-// Only the (server, value) bytes are returned; the client owns the
-// CA-bundle vars (SSL_CERT_FILE etc.) because those reference a
-// path on the *client's* disk. Public endpoint — every value
-// emitted is a placeholder or a clawpatrol-signed routing token,
-// nothing the operator wouldn't already happily print on stdout
-// via `clawpatrol env`.
+// Auth: requires `Authorization: Bearer <token>` where <token>
+// matches a row in peer_api_tokens. The token was minted for the
+// caller at onboard-approve time and persisted next to ca.crt by
+// `clawpatrol join`. Only the (name, value, description,
+// plugin_type) bytes for plugins reachable from the peer's
+// profile are returned; CA-bundle vars stay client-side because
+// they reference a path on the *client's* disk.
 func (w *webMux) apiEnvPushdown(rw http.ResponseWriter, r *http.Request) {
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	peerIP := peerIPForAPIToken(w.g.db, token)
+	if peerIP == "" {
+		http.Error(rw, "unknown or missing peer api token", http.StatusUnauthorized)
+		return
+	}
+	profileName := w.g.profileFor(peerIP)
 	policy := w.g.Policy()
+	if policy == nil {
+		writeJSON(rw, map[string]any{"vars": []any{}})
+		return
+	}
+	prof, ok := policy.Profiles[profileName]
+	if !ok || prof == nil {
+		writeJSON(rw, map[string]any{"vars": []any{}})
+		return
+	}
+
 	out := []map[string]string{}
 	seen := map[string]bool{}
 	add := func(name, value, description, pluginType string) {
@@ -356,28 +379,32 @@ func (w *webMux) apiEnvPushdown(rw http.ResponseWriter, r *http.Request) {
 			"plugin_type": pluginType,
 		})
 	}
-	if policy != nil {
-		// Credentials first so a credential-shaped placeholder wins
-		// over an endpoint emit on the same name. Mirrors the local
-		// iteration order in integrations.go's envPushdownVars
-		// fallback path.
-		for _, ent := range policy.Credentials {
-			provider, ok := ent.Body.(config.EnvPushdownProvider)
+	credSeen := map[string]bool{}
+	// Endpoints in this profile, plus the credentials they bind.
+	// Credentials are emitted first (so credential-shaped
+	// placeholders win on duplicate names), endpoints second.
+	for _, ep := range prof.Endpoints {
+		for _, cc := range ep.Credentials {
+			if cc == nil || cc.Credential == nil || credSeen[cc.Credential.Symbol.Name] {
+				continue
+			}
+			credSeen[cc.Credential.Symbol.Name] = true
+			provider, ok := cc.Credential.Body.(config.EnvPushdownProvider)
 			if !ok {
 				continue
 			}
 			for _, ev := range provider.EnvVars() {
-				add(ev.Name, ev.Value, ev.Description, ent.Plugin.Type)
+				add(ev.Name, ev.Value, ev.Description, cc.Credential.Plugin.Type)
 			}
 		}
-		for _, ep := range policy.Endpoints {
-			provider, ok := ep.Body.(config.EnvPushdownProvider)
-			if !ok {
-				continue
-			}
-			for _, ev := range provider.EnvVars() {
-				add(ev.Name, ev.Value, ev.Description, ep.Plugin.Type)
-			}
+	}
+	for _, ep := range prof.Endpoints {
+		provider, ok := ep.Body.(config.EnvPushdownProvider)
+		if !ok {
+			continue
+		}
+		for _, ev := range provider.EnvVars() {
+			add(ev.Name, ev.Value, ev.Description, ep.Plugin.Type)
 		}
 	}
 	writeJSON(rw, map[string]any{"vars": out})


### PR DESCRIPTION
Move env-var push-down from local plugin enumeration on the
**client** binary to a gated gateway endpoint. The gateway is the
only place that knows which endpoint plugins are actually
configured — and the only place that can mint a
`CODEX_AGENT_IDENTITY` JWT whose `kid` matches the JWKS the
same gateway serves.

Without this, every client had to ship every endpoint plugin the
operator might enable (so e.g. `CODEX_ACCESS_TOKEN` for #83's
`openai_codex_https` only appeared after a client rebuild). And
because the JWT and JWKS were minted from per-machine RSA keys
on opposite ends of the wire, codex rejected every synthetic
JWT in production with `agent identity JWT kid ... is not
trusted`.

* New `GET /api/env-pushdown` walks the loaded policy and emits
  the env vars contributed by credentials + endpoints
  **reachable from the calling peer's profile only**. A peer on
  the `bob` profile won't see `CODEX_AGENT_IDENTITY`.
* Per-peer bearer auth. Onboard-approve mints a random 256-bit
  token alongside the WG keypair and stores its SHA-256 in the
  new `peer_api_tokens` table (raw token never hits disk).
  `/api/onboard/poll` returns it to the CLI; `clawpatrol join`
  persists it at `<caDir>/api-token` (0600). The client sends
  `Authorization: Bearer <token>`; unknown tokens get 401.
* `clawpatrol join` also persists the dashboard URL at
  `<caDir>/gateway` so the env-pushdown fetcher knows where to
  ask.
* `envPushdownVars` fetches from the gateway only — no local
  plugin fallback. Missing URL / missing token / unreachable
  gateway / non-200 all surface to the operator via stderr; the
  CA-bundle vars (`SSL_CERT_FILE` etc.) still get emitted
  because they point at a path on the client's disk.

Migration `0005_peer_api_tokens.sql` adds the token table.