### PR TITLE
rename action_samples migration to 0006

### DIFF
--- a/migrations/sqlite/0006_action_samples.sql
+++ b/migrations/sqlite/0006_action_samples.sql
@@ -6,4 +6,4 @@ ALTER TABLE actions ADD COLUMN resp_headers TEXT;
 
 CREATE INDEX actions_action_id_idx ON actions(action_id);
 
-INSERT INTO _schema (version) VALUES (5);
+INSERT INTO _schema (version) VALUES (6);


### PR DESCRIPTION
## Summary
- 0005 was taken by peer_api_tokens; rename action_samples to 0006

## Test plan
- [x] `ls migrations/sqlite/` shows no duplicates