### PR TITLE
Add SSH endpoint plugin with DNS-MitM virtual IPs

### DIFF
--- a/config/plugins/credentials/ssh.go
+++ b/config/plugins/credentials/ssh.go
@@ -1,10 +1,12 @@
 package credentials
 
-// ssh credential: the wire-protocol user + key/password the SSH
-// endpoint runtime uses when terminating upstream auth on the agent's
-// behalf. The agent never sees the upstream auth challenge; the
-// gateway accepts whatever the agent's SSH client offers (WG is the
-// trust boundary) and replays the credential's material upstream.
+// ssh credential: the auth material the SSH endpoint runtime replays
+// upstream on the agent's behalf. The credential carries only key /
+// password / host-pubkey-pin — the username sent upstream is the one
+// the agent typed, passed through verbatim. Per-username dispatch
+// (e.g. `ssh root@host` vs `ssh deploy@host` picking different keys)
+// lives on the endpoint via the `credentials = [{user=..., credential=...}]`
+// list, mirroring postgres' placeholder-based dispatch.
 //
 // Material is split across slots so operators can paste a multi-line
 // PEM into one textarea and a single-line passphrase into another:
@@ -20,23 +22,20 @@ package credentials
 
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/plugins/sshproto"
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
-type SSHCredential struct {
-	User string `hcl:"user,optional"`
-}
+type SSHCredential struct{}
 
 // SSHAuth implements sshproto.AuthCredential. Returns the raw
 // material; the SSH endpoint runtime parses keys via
 // golang.org/x/crypto/ssh and surfaces parse errors with line
 // context.
 func (s *SSHCredential) SSHAuth(sec runtime.Secret) (sshproto.Creds, error) {
-	creds := sshproto.Creds{User: s.User}
+	creds := sshproto.Creds{}
 	if v, ok := sec.Extras["private_key"]; ok {
 		creds.PrivateKey = []byte(v)
 	}
@@ -86,11 +85,6 @@ func init() {
 		New:     newer[SSHCredential](),
 		Runtime: (*SSHCredential)(nil),
 		Build:   passthrough,
-		Emit: func(body any, _ string, b *hclwrite.Body) {
-			v := body.(*SSHCredential)
-			if v.User != "" {
-				b.SetAttributeValue("user", cty.StringVal(v.User))
-			}
-		},
+		Emit:    func(any, string, *hclwrite.Body) {},
 	})
 }

--- a/config/plugins/credentials/ssh.go
+++ b/config/plugins/credentials/ssh.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/plugins/sshproto"
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
@@ -30,12 +31,12 @@ type SSHCredential struct {
 	User string `hcl:"user,optional"`
 }
 
-// SSHAuth implements runtime.SSHAuthCredential. Returns the raw
+// SSHAuth implements sshproto.AuthCredential. Returns the raw
 // material; the SSH endpoint runtime parses keys via
 // golang.org/x/crypto/ssh and surfaces parse errors with line
 // context.
-func (s *SSHCredential) SSHAuth(sec runtime.Secret) (runtime.SSHCreds, error) {
-	creds := runtime.SSHCreds{User: s.User}
+func (s *SSHCredential) SSHAuth(sec runtime.Secret) (sshproto.Creds, error) {
+	creds := sshproto.Creds{User: s.User}
 	if v, ok := sec.Extras["private_key"]; ok {
 		creds.PrivateKey = []byte(v)
 	}
@@ -78,7 +79,7 @@ func (*SSHCredential) SecretSlots() []config.SecretSlot {
 }
 
 func init() {
-	var _ runtime.SSHAuthCredential = (*SSHCredential)(nil)
+	var _ sshproto.AuthCredential = (*SSHCredential)(nil)
 	config.Register(&config.Plugin{
 		Kind:    config.KindCredential,
 		Type:    "ssh",

--- a/config/plugins/credentials/ssh.go
+++ b/config/plugins/credentials/ssh.go
@@ -1,0 +1,95 @@
+package credentials
+
+// ssh credential: the wire-protocol user + key/password the SSH
+// endpoint runtime uses when terminating upstream auth on the agent's
+// behalf. The agent never sees the upstream auth challenge; the
+// gateway accepts whatever the agent's SSH client offers (WG is the
+// trust boundary) and replays the credential's material upstream.
+//
+// Material is split across slots so operators can paste a multi-line
+// PEM into one textarea and a single-line passphrase into another:
+//
+//   private_key  multi-line   OpenSSH / PKCS#8 / PKCS#1 PEM
+//   passphrase   single-line  optional, decrypts private_key
+//   password     single-line  optional, used when no key is set
+//   host_pubkey  single-line  optional, ssh-keyscan-style line for
+//                             upstream host pinning
+//
+// At least one of (private_key, password) must be filled at runtime —
+// the endpoint surfaces a clear error to the agent if both are empty.
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+type SSHCredential struct {
+	User string `hcl:"user,optional"`
+}
+
+// SSHAuth implements runtime.SSHAuthCredential. Returns the raw
+// material; the SSH endpoint runtime parses keys via
+// golang.org/x/crypto/ssh and surfaces parse errors with line
+// context.
+func (s *SSHCredential) SSHAuth(sec runtime.Secret) (runtime.SSHCreds, error) {
+	creds := runtime.SSHCreds{User: s.User}
+	if v, ok := sec.Extras["private_key"]; ok {
+		creds.PrivateKey = []byte(v)
+	}
+	if v, ok := sec.Extras["passphrase"]; ok {
+		creds.Passphrase = v
+	}
+	if v, ok := sec.Extras["password"]; ok {
+		creds.Password = v
+	}
+	if v, ok := sec.Extras["host_pubkey"]; ok {
+		creds.HostPubkey = v
+	}
+	return creds, nil
+}
+
+func (*SSHCredential) SecretSlots() []config.SecretSlot {
+	return []config.SecretSlot{
+		{
+			Name:        "private_key",
+			Label:       "SSH private key (PEM)",
+			Multiline:   true,
+			Description: "OpenSSH / PKCS#8 / PKCS#1 format. Leave empty to use password auth instead.",
+		},
+		{
+			Name:        "passphrase",
+			Label:       "Key passphrase (optional)",
+			Description: "Required only when the private key is encrypted.",
+		},
+		{
+			Name:        "password",
+			Label:       "SSH password (optional)",
+			Description: "Used when no private key is provided.",
+		},
+		{
+			Name:        "host_pubkey",
+			Label:       "Upstream host pubkey (optional)",
+			Description: "Single ssh-keyscan-style line. When set, the gateway pins the upstream's host key against it; otherwise the WG tunnel is the trust boundary.",
+		},
+	}
+}
+
+func init() {
+	var _ runtime.SSHAuthCredential = (*SSHCredential)(nil)
+	config.Register(&config.Plugin{
+		Kind:    config.KindCredential,
+		Type:    "ssh",
+		New:     newer[SSHCredential](),
+		Runtime: (*SSHCredential)(nil),
+		Build:   passthrough,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			v := body.(*SSHCredential)
+			if v.User != "" {
+				b.SetAttributeValue("user", cty.StringVal(v.User))
+			}
+		},
+	})
+}

--- a/config/plugins/endpoints/https.go
+++ b/config/plugins/endpoints/https.go
@@ -70,7 +70,7 @@ func init() {
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*HTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
-			emitCredentialBinding(b, e.Credential, e.Credentials)
+			emitCredentialBinding(b, e.Credential, e.Credentials, "placeholder")
 		},
 	})
 }

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -169,7 +169,7 @@ func init() {
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*OpenAICodexHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
-			emitCredentialBinding(b, e.Credential, e.Credentials)
+			emitCredentialBinding(b, e.Credential, e.Credentials, "placeholder")
 		},
 	})
 }

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -126,7 +126,7 @@ func init() {
 			e := body.(*PostgresEndpoint)
 			b.SetAttributeValue("host", cty.StringVal(e.Host))
 			b.SetAttributeValue("database", cty.StringVal(e.Database))
-			emitCredentialBinding(b, e.Credential, e.Credentials)
+			emitCredentialBinding(b, e.Credential, e.Credentials, "placeholder")
 		},
 	})
 }

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -54,18 +54,30 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
-// SSHEndpoint binds one or more host:port tuples to a single SSH
-// credential. Multi-credential dispatch isn't supported in v1 — SSH
-// has no convenient placeholder slot like postgres' StartupMessage
-// password, so adding it would require a UX-affecting decision.
+// SSHEndpoint binds one or more host:port tuples to one or more SSH
+// credentials. The agent's username is the discriminator for
+// per-username dispatch (mirrors postgres' placeholder-based dispatch,
+// just spelled `user` because that's what SSH calls it):
+//
+//   credential = X                                  // any user → X
+//   credentials = [{ user = "root",   credential = X },
+//                  { user = "deploy", credential = Y },
+//                  { credential = Z }]              // fallback
+//
+// The agent's username is also passed through verbatim as the upstream
+// SSH user — credentials carry only auth material (key / password /
+// host_pubkey), never a username override.
 type SSHEndpoint struct {
-	Hosts      []string `hcl:"hosts"`
-	Credential string   `hcl:"credential,optional"`
+	Hosts          []string  `hcl:"hosts"`
+	Credential     string    `hcl:"credential,optional"`
+	CredentialsRaw cty.Value `hcl:"credentials,optional" json:"-"`
+
+	Credentials []CredentialEntry `json:"Credentials,omitempty"`
 }
 
 func (e *SSHEndpoint) EndpointHosts() []string { return e.Hosts }
 func (e *SSHEndpoint) EndpointCredentials() []config.CredBinding {
-	return singleBinding(e.Credential)
+	return bindings(e.Credential, e.Credentials)
 }
 
 // ConnRouteHosts implements runtime.ConnRouter — gives the gateway's
@@ -81,6 +93,11 @@ func (e *SSHEndpoint) ConnRouteHosts() []string { return e.Hosts }
 // second one behind the same upstream IP).
 func (e *SSHEndpoint) RequiresVIP() bool { return true }
 
+// hasCredentialsRaw plumbing — lets the shared multiCredValidate hook
+// read CredentialsRaw and stash the parsed entries back.
+func (e *SSHEndpoint) credentialAndRaw() (string, cty.Value)         { return e.Credential, e.CredentialsRaw }
+func (e *SSHEndpoint) setCredentialEntries(es []CredentialEntry)     { e.Credentials = es }
+
 // SSHEndpointRuntime is stateful only in the host-key cache: each
 // endpoint's persisted ed25519 key is parsed once and reused for the
 // lifetime of the process. The runtime struct itself is shared
@@ -93,13 +110,14 @@ type SSHEndpointRuntime struct {
 func init() {
 	rt := &SSHEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "ssh",
-		Family:  "ssh",
-		New:     func() any { return &SSHEndpoint{} },
-		Refs:    singularRef,
-		Runtime: rt,
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "ssh",
+		Family:   "ssh",
+		New:      func() any { return &SSHEndpoint{} },
+		Refs:     singularRef,
+		Validate: multiCredValidate,
+		Runtime:  rt,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*SSHEndpoint)
 			if len(e.Hosts) > 0 {
@@ -109,7 +127,7 @@ func init() {
 				}
 				b.SetAttributeValue("hosts", cty.ListVal(vals))
 			}
-			emitCredentialBinding(b, e.Credential, nil)
+			emitCredentialBinding(b, e.Credential, e.Credentials, "user")
 		},
 	})
 }
@@ -149,17 +167,10 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 		return fmt.Errorf("ssh endpoint %q has no host matching dst port %d", ch.Endpoint.Name, ch.DstPort)
 	}
 
-	// Step 3: resolve credential and parse the auth material before
-	// the SSH handshake, so we can fail loudly on the agent side
-	// rather than after a successful client greeting.
-	upstreamCfg, err := rt.upstreamClientConfig(ch, ep)
-	if err != nil {
-		return fmt.Errorf("ssh credential: %w", err)
-	}
-
-	// Step 4: agent-side server. Accept anything the client offers —
+	// Step 3: agent-side server. Accept anything the client offers —
 	// WG is the trust boundary, same model postgres uses for its
-	// SCRAM-offload.
+	// SCRAM-offload. The handshake also gives us the agent's
+	// username, which we need before resolving the credential.
 	srvCfg := &ssh.ServerConfig{
 		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
 			return &ssh.Permissions{}, nil
@@ -176,6 +187,25 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 		return fmt.Errorf("ssh server handshake: %w", err)
 	}
 	defer srvConn.Close()
+
+	agentUser := srvConn.User()
+	if agentUser == "" {
+		return fmt.Errorf("agent did not specify a username")
+	}
+
+	// Step 4: pick the credential for this username and build the
+	// upstream SSH client config. Per-username dispatch lives on the
+	// endpoint via `credentials = [{user=..., credential=...}, ...]`;
+	// the singular `credential = X` form collapses to a one-entry list
+	// with empty Placeholder (catchall).
+	cc := pickSSHCredential(ch.Endpoint, agentUser)
+	if cc == nil {
+		return fmt.Errorf("ssh endpoint %q has no credential matching agent user %q", ch.Endpoint.Name, agentUser)
+	}
+	upstreamCfg, err := rt.upstreamClientConfig(ch, cc, agentUser)
+	if err != nil {
+		return fmt.Errorf("ssh credential %q: %w", cc.Credential.Symbol.Name, err)
+	}
 
 	// Step 5: dial upstream and do the client handshake. DialUpstream
 	// takes a real hostname:port and resolves it on the gateway's
@@ -199,7 +229,7 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 		ch.Emit(runtime.ConnEvent{
 			Action:  "allow",
 			Verb:    "ssh",
-			Summary: fmt.Sprintf("%s@%s", upstreamCfg.User, upstreamAddr),
+			Summary: fmt.Sprintf("%s@%s", agentUser, upstreamAddr),
 		})
 	}
 
@@ -235,28 +265,47 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	return nil
 }
 
-// ── Upstream auth ─────────────────────────────────────────────────────
+// ── Credential dispatch + upstream auth ──────────────────────────────
 
-func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, ep *SSHEndpoint) (*ssh.ClientConfig, error) {
-	cred := ch.Endpoint.Credentials
-	if len(cred) == 0 {
-		return nil, fmt.Errorf("endpoint %q has no credential bound", ch.Endpoint.Name)
+// pickSSHCredential resolves the agent username to a CompiledCredential.
+// Single-binding endpoints (one entry, no placeholder) return that
+// entry. Multi-credential endpoints pick the entry whose Placeholder
+// (= HCL `user`) matches; if no entry matches and there's a
+// no-placeholder fallback, that wins. Returns nil when nothing fits —
+// the caller refuses the connection rather than silently routing
+// through a credential not meant for the user.
+func pickSSHCredential(ep *config.CompiledEndpoint, agentUser string) *config.CompiledCredential {
+	if ep == nil || len(ep.Credentials) == 0 {
+		return nil
 	}
-	cc := cred[0]
+	if len(ep.Credentials) == 1 && ep.Credentials[0].Placeholder == "" {
+		return ep.Credentials[0]
+	}
+	var fallback *config.CompiledCredential
+	for _, c := range ep.Credentials {
+		if c.Placeholder == "" {
+			fallback = c
+			continue
+		}
+		if agentUser == c.Placeholder {
+			return c
+		}
+	}
+	return fallback
+}
+
+func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, cc *config.CompiledCredential, agentUser string) (*ssh.ClientConfig, error) {
 	auth, ok := cc.Credential.Body.(sshproto.AuthCredential)
 	if !ok {
-		return nil, fmt.Errorf("credential %q does not implement sshproto.AuthCredential (use credential type \"ssh\")", cc.Credential.Symbol.Name)
+		return nil, fmt.Errorf("does not implement sshproto.AuthCredential (use credential type \"ssh\")")
 	}
 	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
 	if err != nil {
-		return nil, fmt.Errorf("fetch secret for %q: %w", cc.Credential.Symbol.Name, err)
+		return nil, fmt.Errorf("fetch secret: %w", err)
 	}
 	creds, err := auth.SSHAuth(sec)
 	if err != nil {
 		return nil, err
-	}
-	if creds.User == "" {
-		return nil, fmt.Errorf("credential %q has no user — set `user = ...` in HCL", cc.Credential.Symbol.Name)
 	}
 
 	var methods []ssh.AuthMethod
@@ -268,7 +317,7 @@ func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, ep *S
 			signer, err = ssh.ParsePrivateKey(creds.PrivateKey)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("parse private_key for credential %q: %w", cc.Credential.Symbol.Name, err)
+			return nil, fmt.Errorf("parse private_key: %w", err)
 		}
 		methods = append(methods, ssh.PublicKeys(signer))
 	}
@@ -276,16 +325,16 @@ func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, ep *S
 		methods = append(methods, ssh.Password(creds.Password))
 	}
 	if len(methods) == 0 {
-		return nil, fmt.Errorf("credential %q has neither private_key nor password — paste one via the dashboard", cc.Credential.Symbol.Name)
+		return nil, fmt.Errorf("neither private_key nor password set — paste one via the dashboard")
 	}
 
 	hostKeyCb, err := buildHostKeyCallback(creds.HostPubkey, ch.Endpoint.Name)
 	if err != nil {
-		return nil, fmt.Errorf("parse host_pubkey for credential %q: %w", cc.Credential.Symbol.Name, err)
+		return nil, fmt.Errorf("parse host_pubkey: %w", err)
 	}
 
 	return &ssh.ClientConfig{
-		User:            creds.User,
+		User:            agentUser,
 		Auth:            methods,
 		HostKeyCallback: hostKeyCb,
 		Timeout:         30 * time.Second,

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -50,6 +50,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/plugins/sshproto"
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
@@ -230,9 +231,9 @@ func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, ep *S
 		return nil, fmt.Errorf("endpoint %q has no credential bound", ch.Endpoint.Name)
 	}
 	cc := cred[0]
-	auth, ok := cc.Credential.Body.(runtime.SSHAuthCredential)
+	auth, ok := cc.Credential.Body.(sshproto.AuthCredential)
 	if !ok {
-		return nil, fmt.Errorf("credential %q does not implement SSHAuth (use credential type \"ssh\")", cc.Credential.Symbol.Name)
+		return nil, fmt.Errorf("credential %q does not implement sshproto.AuthCredential (use credential type \"ssh\")", cc.Credential.Symbol.Name)
 	}
 	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
 	if err != nil {

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -59,10 +59,10 @@ import (
 // per-username dispatch (mirrors postgres' placeholder-based dispatch,
 // just spelled `user` because that's what SSH calls it):
 //
-//   credential = X                                  // any user → X
-//   credentials = [{ user = "root",   credential = X },
-//                  { user = "deploy", credential = Y },
-//                  { credential = Z }]              // fallback
+//	credential = X                                  // any user → X
+//	credentials = [{ user = "root",   credential = X },
+//	               { user = "deploy", credential = Y },
+//	               { credential = Z }]              // fallback
 //
 // The agent's username is also passed through verbatim as the upstream
 // SSH user — credentials carry only auth material (key / password /
@@ -95,8 +95,8 @@ func (e *SSHEndpoint) RequiresVIP() bool { return true }
 
 // hasCredentialsRaw plumbing — lets the shared multiCredValidate hook
 // read CredentialsRaw and stash the parsed entries back.
-func (e *SSHEndpoint) credentialAndRaw() (string, cty.Value)         { return e.Credential, e.CredentialsRaw }
-func (e *SSHEndpoint) setCredentialEntries(es []CredentialEntry)     { e.Credentials = es }
+func (e *SSHEndpoint) credentialAndRaw() (string, cty.Value)     { return e.Credential, e.CredentialsRaw }
+func (e *SSHEndpoint) setCredentialEntries(es []CredentialEntry) { e.Credentials = es }
 
 // SSHEndpointRuntime is stateful only in the host-key cache: each
 // endpoint's persisted ed25519 key is parsed once and reused for the

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -203,23 +203,35 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 		})
 	}
 
-	// Step 6: bidirectional pump. Each side has a channel-open feed
-	// and a global-request feed; we forward them across.
-	var wg sync.WaitGroup
-	wg.Add(4)
-	go func() { defer wg.Done(); pumpChannels(clientConn, srvChans) }()
-	go func() { defer wg.Done(); pumpChannels(srvConn, clientChans) }()
-	go func() { defer wg.Done(); pumpGlobalReqs(clientConn, srvReqs) }()
-	go func() { defer wg.Done(); pumpGlobalReqs(srvConn, clientReqs) }()
+	// Step 6: bidirectional pump. Two waitgroups — `dispatch` covers
+	// the four conn-level demuxers (channel + global-request feeds);
+	// `chans` covers each individual proxyChannel goroutine spawned
+	// by the channel demuxers. Tracking the channel proxies separately
+	// is what makes graceful close possible: when one SSH conn dies
+	// we close the other only after all in-flight channel proxies
+	// have drained, so a fast `ssh host echo hi` doesn't lose its
+	// final bytes when the upstream half tears down (visible as ~10%
+	// blank-output flake when running tests in tight succession).
+	var dispatch, chans sync.WaitGroup
+	dispatch.Add(4)
+	go func() { defer dispatch.Done(); pumpChannels(clientConn, srvChans, &chans) }()
+	go func() { defer dispatch.Done(); pumpChannels(srvConn, clientChans, &chans) }()
+	go func() { defer dispatch.Done(); pumpGlobalReqs(clientConn, srvReqs) }()
+	go func() { defer dispatch.Done(); pumpGlobalReqs(srvConn, clientReqs) }()
 
 	// Wait for either half to drop.
 	exit := make(chan struct{}, 2)
 	go func() { _ = srvConn.Wait(); exit <- struct{}{} }()
 	go func() { _ = clientConn.Wait(); exit <- struct{}{} }()
 	<-exit
+	// Drain in-flight channel proxies — proxyChannel handles its own
+	// teardown gracefully (forwards exit-status, then Closes) so by
+	// the time chans.Wait() returns every byte that was going to flow
+	// has flowed.
+	chans.Wait()
 	srvConn.Close()
 	clientConn.Close()
-	wg.Wait()
+	dispatch.Wait()
 	return nil
 }
 
@@ -317,10 +329,10 @@ func warnHostKeyOnce(endpointName string) {
 // ── Channel + request pumps ───────────────────────────────────────────
 
 // pumpChannels accepts incoming channel-open requests from one side
-// and opens the same type on the other. Each successful pair gets a
-// data-copy goroutine in each direction plus a per-channel request
-// pump in each direction.
-func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel) {
+// and opens the same type on the other. Each successful pair runs
+// proxyChannel (tracked via wg so HandleConn can drain in-flight
+// channels before closing the SSH conns).
+func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel, wg *sync.WaitGroup) {
 	for newCh := range source {
 		targetCh, targetReqs, err := target.OpenChannel(newCh.ChannelType(), newCh.ExtraData())
 		if err != nil {
@@ -337,36 +349,90 @@ func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel) {
 			targetCh.Close()
 			continue
 		}
-		go pumpChannelReqs(targetCh, sourceReqs)
-		go pumpChannelReqs(sourceCh, targetReqs)
-		go func(dst, src ssh.Channel) {
-			_, _ = io.Copy(dst, src)
-			_ = dst.CloseWrite()
-		}(targetCh, sourceCh)
-		go func(dst, src ssh.Channel) {
-			_, _ = io.Copy(dst, src)
-			_ = src.CloseWrite()
-		}(sourceCh, targetCh)
-		// Forward stderr too (channel extended-data type 1).
-		go func(dst, src ssh.Channel) {
-			_, _ = io.Copy(dst.Stderr(), src.Stderr())
-		}(targetCh, sourceCh)
-		go func(dst, src ssh.Channel) {
-			_, _ = io.Copy(dst.Stderr(), src.Stderr())
-		}(sourceCh, targetCh)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proxyChannel(sourceCh, sourceReqs, targetCh, targetReqs)
+		}()
 	}
 }
 
-func pumpChannelReqs(target ssh.Channel, source <-chan *ssh.Request) {
-	for r := range source {
-		ok, err := target.SendRequest(r.Type, r.WantReply, r.Payload)
-		if err != nil {
-			ok = false
-		}
-		if r.WantReply {
-			_ = r.Reply(ok, nil)
+// proxyChannel splices two ssh.Channels in both directions
+// (stdout/stdin AND stderr) plus their per-channel request streams.
+//
+// Each "direction" is the pair (data pump, request forwarder) that
+// reads from one side and writes to the other. A direction is
+// COMPLETE when its source has been fully drained — both the channel
+// data buffer (read until EOF) AND the request stream (read until
+// closed, which happens only after channel-close, which the peer
+// sends AFTER any final exit-status / signal). So when a direction
+// completes, we know every byte and every request has been forwarded.
+//
+// Whichever direction completes first triggers a Close on the OTHER
+// side's channel: that unsticks the slower direction's data pump,
+// which would otherwise block forever on a peer that left its stdin
+// open (notably the OpenSSH client during `ssh host cmd`). Closing
+// only the OTHER side keeps the now-finished direction's bytes
+// intact — closing too eagerly would cut off in-flight reads on the
+// fast side and lose the last few bytes of output (~10% flake rate
+// in `ssh host echo X` stress tests).
+func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs <-chan *ssh.Request) {
+	// pumpDir copies both stdout and stderr from src to dst, then
+	// emits channel-eof. Combining the two before CloseWrite is
+	// required: stderr is just extended-data on the same channel,
+	// and SSH treats any extended-data after channel-eof as a
+	// protocol violation. Without this, OpenSSH disconnects with
+	// "Received extended_data after EOF on channel 0" the moment
+	// the remote process exits with anything on stderr.
+	pumpDir := func(dst, src ssh.Channel, done chan<- struct{}) {
+		defer close(done)
+		var inner sync.WaitGroup
+		inner.Add(2)
+		go func() { defer inner.Done(); _, _ = io.Copy(dst, src) }()
+		go func() { defer inner.Done(); _, _ = io.Copy(dst.Stderr(), src.Stderr()) }()
+		inner.Wait()
+		_ = dst.CloseWrite()
+	}
+	forwardReqs := func(target ssh.Channel, source <-chan *ssh.Request, done chan<- struct{}) {
+		defer close(done)
+		for r := range source {
+			ok, err := target.SendRequest(r.Type, r.WantReply, r.Payload)
+			if err != nil {
+				ok = false
+			}
+			if r.WantReply {
+				_ = r.Reply(ok, nil)
+			}
 		}
 	}
+
+	pumpA := make(chan struct{}) // upstream→agent data finished
+	pumpB := make(chan struct{}) // agent→upstream data finished
+	reqA := make(chan struct{})  // upstream→agent reqs finished
+	reqB := make(chan struct{})  // agent→upstream reqs finished
+	go pumpDir(a, b, pumpA)
+	go pumpDir(b, a, pumpB)
+	go forwardReqs(a, bReqs, reqA)
+	go forwardReqs(b, aReqs, reqB)
+
+	// fromUpstream / fromAgent fire when a full direction
+	// (data + reqs) has drained — at that point its source channel
+	// is fully closed and every byte/request has been forwarded.
+	fromUpstream := make(chan struct{})
+	fromAgent := make(chan struct{})
+	go func() { <-pumpA; <-reqA; close(fromUpstream) }()
+	go func() { <-pumpB; <-reqB; close(fromAgent) }()
+
+	// Whichever direction finishes first closes the OPPOSITE side to
+	// unstick its blocked pump. Then wait for the other direction.
+	select {
+	case <-fromUpstream:
+		_ = a.Close()
+	case <-fromAgent:
+		_ = b.Close()
+	}
+	<-fromUpstream
+	<-fromAgent
 }
 
 func pumpGlobalReqs(target ssh.Conn, source <-chan *ssh.Request) {

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -1,0 +1,493 @@
+package endpoints
+
+// ssh endpoint: schema, plugin registration, and the wire-protocol
+// gateway that terminates SSH on both sides. The gateway acts as an
+// SSH server toward the agent (accepting any auth — WireGuard is the
+// trust boundary) and an SSH client toward the upstream, replaying
+// the credential's user/key/password to authenticate. Channels and
+// global requests are spliced both directions, so interactive
+// sessions, exec, port forwarding, and SFTP all "just work" without
+// per-channel logic.
+//
+// Endpoint shape:
+//
+//   endpoint "ssh" "build-host" {
+//     hosts      = ["build.example.com:2222"]
+//     credential = build-host-cred
+//   }
+//
+// SSH carries no SNI / Host header, so we can't disambiguate at TCP
+// accept time. The dnsvip package gives every SSH-able hostname a
+// virtual IP from a private range and answers agent DNS queries with
+// that IP; when the conn lands on the VIP, dispatch consults the
+// VIP table to recover the hostname (and thus the endpoint).
+//
+// The gateway-side host key is per-endpoint, persisted under
+// <ca_dir>/ssh/<endpoint>.key (lazy-generated ed25519 on first use).
+// Operators add the printed fingerprint to their known_hosts so
+// `ssh user@hostname` doesn't prompt.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// SSHEndpoint binds one or more host:port tuples to a single SSH
+// credential. Multi-credential dispatch isn't supported in v1 — SSH
+// has no convenient placeholder slot like postgres' StartupMessage
+// password, so adding it would require a UX-affecting decision.
+type SSHEndpoint struct {
+	Hosts      []string `hcl:"hosts"`
+	Credential string   `hcl:"credential,optional"`
+}
+
+func (e *SSHEndpoint) EndpointHosts() []string { return e.Hosts }
+func (e *SSHEndpoint) EndpointCredentials() []config.CredBinding {
+	return singleBinding(e.Credential)
+}
+
+// ConnRouteHosts implements runtime.ConnRouter — gives the gateway's
+// IP-keyed dispatch index a chance to route direct-IP dialers (an
+// agent that bypasses DNS) back to the same endpoint. The VIP path
+// in dnsvip is the primary route; this is the safety net.
+func (e *SSHEndpoint) ConnRouteHosts() []string { return e.Hosts }
+
+// RequiresVIP marks the endpoint as needing a DNS-MitM virtual IP.
+// SSH always returns true: the wire protocol can't be disambiguated
+// at TCP accept time, so even a single SSH endpoint benefits from a
+// dedicated VIP (avoids ambiguity if the operator later adds a
+// second one behind the same upstream IP).
+func (e *SSHEndpoint) RequiresVIP() bool { return true }
+
+// SSHEndpointRuntime is stateful only in the host-key cache: each
+// endpoint's persisted ed25519 key is parsed once and reused for the
+// lifetime of the process. The runtime struct itself is shared
+// across all SSH endpoints — config dispatch picks the right
+// endpoint via ch.Endpoint.
+type SSHEndpointRuntime struct {
+	keyCache sync.Map // endpoint name → ssh.Signer
+}
+
+func init() {
+	rt := &SSHEndpointRuntime{}
+	config.Register(&config.Plugin{
+		Kind:    config.KindEndpoint,
+		Type:    "ssh",
+		Family:  "ssh",
+		New:     func() any { return &SSHEndpoint{} },
+		Refs:    singularRef,
+		Runtime: rt,
+		Build:   passthroughBuild,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			e := body.(*SSHEndpoint)
+			if len(e.Hosts) > 0 {
+				vals := make([]cty.Value, len(e.Hosts))
+				for i, h := range e.Hosts {
+					vals[i] = cty.StringVal(h)
+				}
+				b.SetAttributeValue("hosts", cty.ListVal(vals))
+			}
+			emitCredentialBinding(b, e.Credential, nil)
+		},
+	})
+}
+
+// Compile-time interface checks.
+var (
+	_ runtime.ConnEndpointRuntime = (*SSHEndpointRuntime)(nil)
+	_ runtime.ConnRouter          = (*SSHEndpoint)(nil)
+)
+
+// ── HandleConn ────────────────────────────────────────────────────────
+
+func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
+	defer ch.Conn.Close()
+	if ch.Endpoint == nil || ch.Endpoint.Family != "ssh" {
+		return fmt.Errorf("ssh runtime invoked on non-ssh endpoint %v", ch.Endpoint)
+	}
+	if ch.CADir == "" {
+		return fmt.Errorf("ssh runtime needs CADir to persist host keys; gateway hasn't set ca_dir")
+	}
+	ep, ok := ch.Endpoint.Body.(*SSHEndpoint)
+	if !ok {
+		return fmt.Errorf("ssh endpoint %q body is %T, expected *SSHEndpoint", ch.Endpoint.Name, ch.Endpoint.Body)
+	}
+
+	// Step 1: load or mint the per-endpoint host key.
+	hostKey, err := rt.hostKeyFor(ch.Endpoint.Name, ch.CADir)
+	if err != nil {
+		return fmt.Errorf("host key for endpoint %q: %w", ch.Endpoint.Name, err)
+	}
+
+	// Step 2: pick the upstream host:port. If the endpoint has a
+	// single host that's the easy case; with multiple, prefer the
+	// one whose port matches the agent's destination port.
+	upstreamAddr := pickUpstream(ep.Hosts, ch.DstPort)
+	if upstreamAddr == "" {
+		return fmt.Errorf("ssh endpoint %q has no host matching dst port %d", ch.Endpoint.Name, ch.DstPort)
+	}
+
+	// Step 3: resolve credential and parse the auth material before
+	// the SSH handshake, so we can fail loudly on the agent side
+	// rather than after a successful client greeting.
+	upstreamCfg, err := rt.upstreamClientConfig(ch, ep)
+	if err != nil {
+		return fmt.Errorf("ssh credential: %w", err)
+	}
+
+	// Step 4: agent-side server. Accept anything the client offers —
+	// WG is the trust boundary, same model postgres uses for its
+	// SCRAM-offload.
+	srvCfg := &ssh.ServerConfig{
+		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
+			return &ssh.Permissions{}, nil
+		},
+		PublicKeyCallback: func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.Permissions, error) {
+			return &ssh.Permissions{}, nil
+		},
+		ServerVersion: "SSH-2.0-clawpatrol",
+	}
+	srvCfg.AddHostKey(hostKey)
+
+	srvConn, srvChans, srvReqs, err := ssh.NewServerConn(ch.Conn, srvCfg)
+	if err != nil {
+		return fmt.Errorf("ssh server handshake: %w", err)
+	}
+	defer srvConn.Close()
+
+	// Step 5: dial upstream and do the client handshake. DialUpstream
+	// takes a real hostname:port and resolves it on the gateway's
+	// network (NOT inside the WG netstack), so the gateway's normal
+	// DNS path applies — the VIP only exists inside the tunnel.
+	dialCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	upConn, err := ch.DialUpstream(dialCtx, "tcp", upstreamAddr)
+	if err != nil {
+		return fmt.Errorf("dial upstream %s: %w", upstreamAddr, err)
+	}
+	defer upConn.Close()
+
+	clientConn, clientChans, clientReqs, err := ssh.NewClientConn(upConn, upstreamAddr, upstreamCfg)
+	if err != nil {
+		return fmt.Errorf("ssh client handshake to %s: %w", upstreamAddr, err)
+	}
+	defer clientConn.Close()
+
+	if ch.Emit != nil {
+		ch.Emit(runtime.ConnEvent{
+			Action:  "allow",
+			Verb:    "ssh",
+			Summary: fmt.Sprintf("%s@%s", upstreamCfg.User, upstreamAddr),
+		})
+	}
+
+	// Step 6: bidirectional pump. Each side has a channel-open feed
+	// and a global-request feed; we forward them across.
+	var wg sync.WaitGroup
+	wg.Add(4)
+	go func() { defer wg.Done(); pumpChannels(clientConn, srvChans) }()
+	go func() { defer wg.Done(); pumpChannels(srvConn, clientChans) }()
+	go func() { defer wg.Done(); pumpGlobalReqs(clientConn, srvReqs) }()
+	go func() { defer wg.Done(); pumpGlobalReqs(srvConn, clientReqs) }()
+
+	// Wait for either half to drop.
+	exit := make(chan struct{}, 2)
+	go func() { _ = srvConn.Wait(); exit <- struct{}{} }()
+	go func() { _ = clientConn.Wait(); exit <- struct{}{} }()
+	<-exit
+	srvConn.Close()
+	clientConn.Close()
+	wg.Wait()
+	return nil
+}
+
+// ── Upstream auth ─────────────────────────────────────────────────────
+
+func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, ep *SSHEndpoint) (*ssh.ClientConfig, error) {
+	cred := ch.Endpoint.Credentials
+	if len(cred) == 0 {
+		return nil, fmt.Errorf("endpoint %q has no credential bound", ch.Endpoint.Name)
+	}
+	cc := cred[0]
+	auth, ok := cc.Credential.Body.(runtime.SSHAuthCredential)
+	if !ok {
+		return nil, fmt.Errorf("credential %q does not implement SSHAuth (use credential type \"ssh\")", cc.Credential.Symbol.Name)
+	}
+	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
+	if err != nil {
+		return nil, fmt.Errorf("fetch secret for %q: %w", cc.Credential.Symbol.Name, err)
+	}
+	creds, err := auth.SSHAuth(sec)
+	if err != nil {
+		return nil, err
+	}
+	if creds.User == "" {
+		return nil, fmt.Errorf("credential %q has no user — set `user = ...` in HCL", cc.Credential.Symbol.Name)
+	}
+
+	var methods []ssh.AuthMethod
+	if len(creds.PrivateKey) > 0 {
+		var signer ssh.Signer
+		if creds.Passphrase != "" {
+			signer, err = ssh.ParsePrivateKeyWithPassphrase(creds.PrivateKey, []byte(creds.Passphrase))
+		} else {
+			signer, err = ssh.ParsePrivateKey(creds.PrivateKey)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse private_key for credential %q: %w", cc.Credential.Symbol.Name, err)
+		}
+		methods = append(methods, ssh.PublicKeys(signer))
+	}
+	if creds.Password != "" {
+		methods = append(methods, ssh.Password(creds.Password))
+	}
+	if len(methods) == 0 {
+		return nil, fmt.Errorf("credential %q has neither private_key nor password — paste one via the dashboard", cc.Credential.Symbol.Name)
+	}
+
+	hostKeyCb, err := buildHostKeyCallback(creds.HostPubkey, ch.Endpoint.Name)
+	if err != nil {
+		return nil, fmt.Errorf("parse host_pubkey for credential %q: %w", cc.Credential.Symbol.Name, err)
+	}
+
+	return &ssh.ClientConfig{
+		User:            creds.User,
+		Auth:            methods,
+		HostKeyCallback: hostKeyCb,
+		Timeout:         30 * time.Second,
+		ClientVersion:   "SSH-2.0-clawpatrol",
+	}, nil
+}
+
+// buildHostKeyCallback returns a HostKeyCallback that pins to the
+// supplied authorized_keys-style line, or — when no pin is set —
+// accepts anything with a one-time warning logged per endpoint
+// (WG already encrypts the path between agent and gateway, but the
+// gateway-to-upstream segment is over the host's internet uplink
+// and benefits from a pin).
+func buildHostKeyCallback(hostPubkey, endpointName string) (ssh.HostKeyCallback, error) {
+	if hostPubkey == "" {
+		warnHostKeyOnce(endpointName)
+		return ssh.InsecureIgnoreHostKey(), nil
+	}
+	pubkey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(hostPubkey))
+	if err != nil {
+		return nil, err
+	}
+	pinned := pubkey.Marshal()
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if !bytes.Equal(key.Marshal(), pinned) {
+			return fmt.Errorf("upstream host key for %s does not match credential's pin", hostname)
+		}
+		return nil
+	}, nil
+}
+
+var hostKeyWarnOnce sync.Map // endpoint name → struct{}
+
+func warnHostKeyOnce(endpointName string) {
+	if _, loaded := hostKeyWarnOnce.LoadOrStore(endpointName, struct{}{}); loaded {
+		return
+	}
+	log.Printf("ssh: endpoint %q has no host_pubkey pin; trusting upstream host key blindly", endpointName)
+}
+
+// ── Channel + request pumps ───────────────────────────────────────────
+
+// pumpChannels accepts incoming channel-open requests from one side
+// and opens the same type on the other. Each successful pair gets a
+// data-copy goroutine in each direction plus a per-channel request
+// pump in each direction.
+func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel) {
+	for newCh := range source {
+		targetCh, targetReqs, err := target.OpenChannel(newCh.ChannelType(), newCh.ExtraData())
+		if err != nil {
+			var ocErr *ssh.OpenChannelError
+			if errors.As(err, &ocErr) {
+				_ = newCh.Reject(ocErr.Reason, ocErr.Message)
+			} else {
+				_ = newCh.Reject(ssh.ConnectionFailed, err.Error())
+			}
+			continue
+		}
+		sourceCh, sourceReqs, err := newCh.Accept()
+		if err != nil {
+			targetCh.Close()
+			continue
+		}
+		go pumpChannelReqs(targetCh, sourceReqs)
+		go pumpChannelReqs(sourceCh, targetReqs)
+		go func(dst, src ssh.Channel) {
+			_, _ = io.Copy(dst, src)
+			_ = dst.CloseWrite()
+		}(targetCh, sourceCh)
+		go func(dst, src ssh.Channel) {
+			_, _ = io.Copy(dst, src)
+			_ = src.CloseWrite()
+		}(sourceCh, targetCh)
+		// Forward stderr too (channel extended-data type 1).
+		go func(dst, src ssh.Channel) {
+			_, _ = io.Copy(dst.Stderr(), src.Stderr())
+		}(targetCh, sourceCh)
+		go func(dst, src ssh.Channel) {
+			_, _ = io.Copy(dst.Stderr(), src.Stderr())
+		}(sourceCh, targetCh)
+	}
+}
+
+func pumpChannelReqs(target ssh.Channel, source <-chan *ssh.Request) {
+	for r := range source {
+		ok, err := target.SendRequest(r.Type, r.WantReply, r.Payload)
+		if err != nil {
+			ok = false
+		}
+		if r.WantReply {
+			_ = r.Reply(ok, nil)
+		}
+	}
+}
+
+func pumpGlobalReqs(target ssh.Conn, source <-chan *ssh.Request) {
+	for r := range source {
+		ok, payload, err := target.SendRequest(r.Type, r.WantReply, r.Payload)
+		if err != nil {
+			ok = false
+			payload = nil
+		}
+		if r.WantReply {
+			_ = r.Reply(ok, payload)
+		}
+	}
+}
+
+// ── Host key persistence ──────────────────────────────────────────────
+
+func (rt *SSHEndpointRuntime) hostKeyFor(endpointName, caDir string) (ssh.Signer, error) {
+	if v, ok := rt.keyCache.Load(endpointName); ok {
+		return v.(ssh.Signer), nil
+	}
+	dir := filepath.Join(caDir, "ssh")
+	path := filepath.Join(dir, safeFileName(endpointName)+".key")
+
+	if data, err := os.ReadFile(path); err == nil {
+		signer, err := ssh.ParsePrivateKey(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		rt.keyCache.Store(endpointName, signer)
+		return signer, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := writeFileAtomic(path, pemData, 0o600); err != nil {
+		return nil, err
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("ssh: minted host key for endpoint %q at %s — fingerprint %s",
+		endpointName, path, ssh.FingerprintSHA256(signer.PublicKey()))
+	rt.keyCache.Store(endpointName, signer)
+	return signer, nil
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".sshkey-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// safeFileName maps an endpoint name to a filesystem-safe form.
+// Endpoint names already follow HCL identifier rules so this is
+// belt-and-suspenders against future relaxations.
+func safeFileName(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.':
+			return r
+		}
+		return '_'
+	}, s)
+}
+
+// pickUpstream picks the host:port from hosts that matches dstPort.
+// When dstPort is 0 (direct dispatch with no port hint) or no host
+// has a matching port, returns the first non-empty host.
+func pickUpstream(hosts []string, dstPort uint16) string {
+	if len(hosts) == 0 {
+		return ""
+	}
+	if dstPort != 0 {
+		want := fmt.Sprintf(":%d", dstPort)
+		for _, h := range hosts {
+			if strings.HasSuffix(h, want) {
+				return h
+			}
+			// Bare hostname with default port 22.
+			if dstPort == 22 && !strings.Contains(h, ":") {
+				return h + ":22"
+			}
+		}
+	}
+	first := hosts[0]
+	if !strings.Contains(first, ":") {
+		first += ":22"
+	}
+	return first
+}

--- a/config/plugins/endpoints/ssh_test.go
+++ b/config/plugins/endpoints/ssh_test.go
@@ -1,0 +1,90 @@
+package endpoints
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// pickSSHCredential covers the multi-credential dispatch contract:
+// * exact-user match wins
+// * catchall (no Placeholder) is the fallback
+// * with no credentials → nil
+// * single no-Placeholder entry → that entry, regardless of agent user
+// * no match + no fallback → nil
+func TestPickSSHCredential(t *testing.T) {
+	mk := func(placeholder, name string) *config.CompiledCredential {
+		return &config.CompiledCredential{
+			Placeholder: placeholder,
+			Credential: &config.Entity{
+				Symbol: &config.Symbol{Kind: config.KindCredential, Type: "ssh", Name: name},
+			},
+		}
+	}
+	cases := []struct {
+		name    string
+		creds   []*config.CompiledCredential
+		user    string
+		want    string // expected credential name; "" for nil
+	}{
+		{"empty list", nil, "anybody", ""},
+		{"singular catchall — matches any user", []*config.CompiledCredential{mk("", "default")}, "anybody", "default"},
+		{"singular catchall — empty user", []*config.CompiledCredential{mk("", "default")}, "", "default"},
+		{
+			"multi: exact match",
+			[]*config.CompiledCredential{
+				mk("root", "root-cred"),
+				mk("deploy", "deploy-cred"),
+				mk("", "fallback-cred"),
+			},
+			"deploy",
+			"deploy-cred",
+		},
+		{
+			"multi: fallback when no exact match",
+			[]*config.CompiledCredential{
+				mk("root", "root-cred"),
+				mk("deploy", "deploy-cred"),
+				mk("", "fallback-cred"),
+			},
+			"alice",
+			"fallback-cred",
+		},
+		{
+			"multi: no match + no fallback → nil",
+			[]*config.CompiledCredential{
+				mk("root", "root-cred"),
+				mk("deploy", "deploy-cred"),
+			},
+			"alice",
+			"",
+		},
+		{
+			"multi: matched user takes precedence over catchall order",
+			[]*config.CompiledCredential{
+				mk("", "fallback-cred"),
+				mk("root", "root-cred"),
+			},
+			"root",
+			"root-cred",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ep := &config.CompiledEndpoint{Credentials: c.creds}
+			got := pickSSHCredential(ep, c.user)
+			if c.want == "" {
+				if got != nil {
+					t.Fatalf("expected nil; got %q", got.Credential.Symbol.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q; got nil", c.want)
+			}
+			if got.Credential.Symbol.Name != c.want {
+				t.Fatalf("expected %q; got %q", c.want, got.Credential.Symbol.Name)
+			}
+		})
+	}
+}

--- a/config/plugins/endpoints/ssh_test.go
+++ b/config/plugins/endpoints/ssh_test.go
@@ -22,10 +22,10 @@ func TestPickSSHCredential(t *testing.T) {
 		}
 	}
 	cases := []struct {
-		name    string
-		creds   []*config.CompiledCredential
-		user    string
-		want    string // expected credential name; "" for nil
+		name  string
+		creds []*config.CompiledCredential
+		user  string
+		want  string // expected credential name; "" for nil
 	}{
 		{"empty list", nil, "anybody", ""},
 		{"singular catchall — matches any user", []*config.CompiledCredential{mk("", "default")}, "anybody", "default"},

--- a/config/plugins/endpoints/util.go
+++ b/config/plugins/endpoints/util.go
@@ -88,7 +88,13 @@ func validateBinding(decoded any, kind string, name string, blockRange hcl.Range
 
 // parseCredentialList walks a raw cty.Value list of objects into
 // typed CredentialEntry values. Each object must have a "credential"
-// attribute; "placeholder" is optional.
+// attribute; the dispatch key is optional and may be spelled either
+// "placeholder" (postgres / https flavour — the agent's wire-level
+// discriminator string) or "user" (ssh — the agent's username),
+// whichever reads more naturally for the protocol. Both forms compile
+// to the same CredentialEntry.Placeholder field. Specifying both on
+// one entry is an error. Within a list there must be at most one
+// fallback entry (no dispatch key) and no duplicate dispatch values.
 func parseCredentialList(raw cty.Value, blockRange hcl.Range) ([]CredentialEntry, hcl.Diagnostics) {
 	if raw.IsNull() {
 		return nil, nil
@@ -111,7 +117,7 @@ func parseCredentialList(raw cty.Value, blockRange hcl.Range) ([]CredentialEntry
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "credentials list element must be an object",
-				Detail:   fmt.Sprintf("Got %s; expected `{ placeholder = ..., credential = ... }`.", t.FriendlyName()),
+				Detail:   fmt.Sprintf("Got %s; expected `{ placeholder|user = ..., credential = ... }`.", t.FriendlyName()),
 				Subject:  &blockRange,
 			})
 			continue
@@ -131,13 +137,55 @@ func parseCredentialList(raw cty.Value, blockRange hcl.Range) ([]CredentialEntry
 			})
 			continue
 		}
+		hasPlaceholder := false
 		if t.HasAttribute("placeholder") {
 			pv := el.GetAttr("placeholder")
-			if !pv.IsNull() && pv.Type() == cty.String {
+			if !pv.IsNull() && pv.Type() == cty.String && pv.AsString() != "" {
 				entry.Placeholder = pv.AsString()
+				hasPlaceholder = true
+			}
+		}
+		if t.HasAttribute("user") {
+			uv := el.GetAttr("user")
+			if !uv.IsNull() && uv.Type() == cty.String && uv.AsString() != "" {
+				if hasPlaceholder {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "credentials entry has both `placeholder` and `user`",
+						Detail:   "Pick one — they're aliases for the same dispatch key.",
+						Subject:  &blockRange,
+					})
+					continue
+				}
+				entry.Placeholder = uv.AsString()
 			}
 		}
 		out = append(out, entry)
+	}
+	// Enforce: at most one fallback entry; no duplicate dispatch keys.
+	seen := map[string]bool{}
+	fallbacks := 0
+	for _, e := range out {
+		if e.Placeholder == "" {
+			fallbacks++
+			continue
+		}
+		if seen[e.Placeholder] {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("duplicate credentials dispatch key %q", e.Placeholder),
+				Subject:  &blockRange,
+			})
+		}
+		seen[e.Placeholder] = true
+	}
+	if fallbacks > 1 {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "credentials list has more than one fallback entry",
+			Detail:   "An entry without `placeholder`/`user` is the catchall; only one is allowed.",
+			Subject:  &blockRange,
+		})
 	}
 	return out, diags
 }
@@ -198,7 +246,13 @@ var singularRef = []config.RefSpec{
 // `credentials = [{...}, {...}]` (multi-credential dispatch). The
 // list form needs raw tokens because each entry's `credential` value
 // is a bare identifier ref, not a quoted string.
-func emitCredentialBinding(b *hclwrite.Body, single string, list []CredentialEntry) {
+//
+// dispatchKey is the HCL keyword the protocol uses for the dispatch
+// value — "placeholder" for postgres / https / openai_codex (where
+// the agent embeds an arbitrary discriminator string in the wire
+// protocol), or "user" for ssh (where the agent's username is the
+// natural label). Both compile to the same CredentialEntry.Placeholder.
+func emitCredentialBinding(b *hclwrite.Body, single string, list []CredentialEntry, dispatchKey string) {
 	if len(list) == 0 {
 		if single != "" {
 			config.SetIdent(b, "credential", single)
@@ -213,7 +267,7 @@ func emitCredentialBinding(b *hclwrite.Body, single string, list []CredentialEnt
 		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("    {")})
 		if e.Placeholder != "" {
 			tokens = append(tokens,
-				&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(" placeholder = ")},
+				&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(" " + dispatchKey + " = ")},
 				&hclwrite.Token{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`)},
 				&hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(e.Placeholder)},
 				&hclwrite.Token{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},

--- a/config/plugins/sshproto/sshproto.go
+++ b/config/plugins/sshproto/sshproto.go
@@ -16,13 +16,14 @@ import (
 )
 
 // Creds is the materialised view an SSH credential hands to the SSH
-// endpoint runtime. PrivateKey is the raw PEM bytes (PKCS#1, PKCS#8
-// or OpenSSH format — golang.org/x/crypto/ssh.ParsePrivateKey* handles
-// all three). HostPubkey, when non-empty, is a single-line
+// endpoint runtime. The credential carries only auth material — the
+// upstream username comes from the agent (whatever the SSH client
+// sent in the connect line). PrivateKey is the raw PEM bytes (PKCS#1,
+// PKCS#8 or OpenSSH format — golang.org/x/crypto/ssh.ParsePrivateKey*
+// handles all three). HostPubkey, when non-empty, is a single-line
 // authorized_keys-style entry the endpoint pins for upstream
 // verification (matches `ssh-keyscan` output).
 type Creds struct {
-	User       string
 	PrivateKey []byte
 	Passphrase string
 	Password   string

--- a/config/plugins/sshproto/sshproto.go
+++ b/config/plugins/sshproto/sshproto.go
@@ -1,0 +1,49 @@
+// Package sshproto holds the protocol-specific contract that bridges
+// the SSH endpoint plugin and the SSH credential plugin. Lives in
+// config/plugins/ rather than config/runtime/ so the runtime stays
+// generic — runtime only knows about the cross-protocol shapes
+// (HTTP / Postgres / TLS / ConnEndpoint) and discovers protocol
+// extensions like this one through the AcceptCredentialRuntime hook.
+//
+// Both plugins import this package — the credential side declares it
+// satisfies AuthCredential, the endpoint side type-asserts against
+// it. There is no other consumer.
+package sshproto
+
+import (
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// Creds is the materialised view an SSH credential hands to the SSH
+// endpoint runtime. PrivateKey is the raw PEM bytes (PKCS#1, PKCS#8
+// or OpenSSH format — golang.org/x/crypto/ssh.ParsePrivateKey* handles
+// all three). HostPubkey, when non-empty, is a single-line
+// authorized_keys-style entry the endpoint pins for upstream
+// verification (matches `ssh-keyscan` output).
+type Creds struct {
+	User       string
+	PrivateKey []byte
+	Passphrase string
+	Password   string
+	HostPubkey string
+}
+
+// AuthCredential is what the SSH endpoint runtime needs from a
+// credential plugin to authenticate upstream on the agent's behalf.
+// The credential never sees the agent connection — it just returns
+// the material; the endpoint runtime drives the upstream handshake.
+// Mirrors the postgres SCRAM-offload split.
+type AuthCredential interface {
+	SSHAuth(sec runtime.Secret) (Creds, error)
+}
+
+// Teach the runtime's credential checker about AuthCredential so
+// plugins implementing it pass init-time validation without runtime
+// having to import this package.
+func init() {
+	runtime.AcceptCredentialRuntime(func(p *config.Plugin) bool {
+		_, ok := p.Runtime.(AuthCredential)
+		return ok
+	})
+}

--- a/config/runtime/checker.go
+++ b/config/runtime/checker.go
@@ -18,6 +18,22 @@ func init() {
 	config.AddPluginChecker(checkRuntime)
 }
 
+// extraCredChecks holds protocol-specific extensions to the credential
+// runtime check. Plugin packages that introduce a new credential
+// runtime interface (e.g. config/plugins/sshproto) call
+// AcceptCredentialRuntime so their interface joins the accepted set
+// without runtime needing to import the protocol-specific package.
+var extraCredChecks []func(*config.Plugin) bool
+
+// AcceptCredentialRuntime registers an additional credential
+// runtime-interface check. checkRuntime accepts a credential plugin
+// when ANY registered check (or built-in interface) matches its
+// Runtime — out-of-tree credential families plug in here from their
+// own init() rather than editing this file.
+func AcceptCredentialRuntime(check func(*config.Plugin) bool) {
+	extraCredChecks = append(extraCredChecks, check)
+}
+
 func checkRuntime(p *config.Plugin) []string {
 	if p.Runtime == nil {
 		return nil
@@ -28,10 +44,15 @@ func checkRuntime(p *config.Plugin) []string {
 		_, pg := p.Runtime.(PostgresCredentialRuntime)
 		_, pgAuth := p.Runtime.(PostgresAuthCredential)
 		_, tlsR := p.Runtime.(TLSCredentialRuntime)
-		_, sshR := p.Runtime.(SSHAuthCredential)
-		if !http && !pg && !pgAuth && !tlsR && !sshR {
-			return []string{fmt.Sprintf("Runtime %T satisfies no credential runtime interface (HTTP / Postgres / TLS / SSH)", p.Runtime)}
+		if http || pg || pgAuth || tlsR {
+			return nil
 		}
+		for _, check := range extraCredChecks {
+			if check(p) {
+				return nil
+			}
+		}
+		return []string{fmt.Sprintf("Runtime %T satisfies no credential runtime interface (HTTP / Postgres / TLS or a registered protocol extension)", p.Runtime)}
 	case config.KindEndpoint:
 		// Endpoint plugins satisfy any combination of
 		// PlaceholderDetector and ConnEndpointRuntime. Plugins with

--- a/config/runtime/checker.go
+++ b/config/runtime/checker.go
@@ -28,8 +28,9 @@ func checkRuntime(p *config.Plugin) []string {
 		_, pg := p.Runtime.(PostgresCredentialRuntime)
 		_, pgAuth := p.Runtime.(PostgresAuthCredential)
 		_, tlsR := p.Runtime.(TLSCredentialRuntime)
-		if !http && !pg && !pgAuth && !tlsR {
-			return []string{fmt.Sprintf("Runtime %T satisfies no credential runtime interface (HTTP / Postgres / TLS)", p.Runtime)}
+		_, sshR := p.Runtime.(SSHAuthCredential)
+		if !http && !pg && !pgAuth && !tlsR && !sshR {
+			return []string{fmt.Sprintf("Runtime %T satisfies no credential runtime interface (HTTP / Postgres / TLS / SSH)", p.Runtime)}
 		}
 	case config.KindEndpoint:
 		// Endpoint plugins satisfy any combination of

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -66,6 +66,29 @@ type PostgresAuthCredential interface {
 	PostgresAuth(sec Secret) (user, password string)
 }
 
+// SSHCreds is the materialised view an SSH credential hands to the
+// SSH endpoint runtime. PrivateKey is the raw PEM bytes (PKCS#1, PKCS#8
+// or OpenSSH format — golang.org/x/crypto/ssh.ParsePrivateKey* handles
+// all three). HostPubkey, when non-empty, is a single-line
+// authorized_keys-style entry the endpoint pins for upstream
+// verification (matches `ssh-keyscan` output).
+type SSHCreds struct {
+	User       string
+	PrivateKey []byte
+	Passphrase string
+	Password   string
+	HostPubkey string
+}
+
+// SSHAuthCredential is what the SSH endpoint runtime needs from a
+// credential plugin to authenticate upstream on the agent's behalf.
+// The credential never sees the agent connection — it just returns the
+// material; the endpoint runtime drives the upstream handshake. Mirrors
+// the postgres SCRAM-offload split.
+type SSHAuthCredential interface {
+	SSHAuth(sec Secret) (SSHCreds, error)
+}
+
 // TLSCredentialRuntime customizes the upstream TLS configuration
 // before the dial. mTLS credentials use this to add a client cert
 // (Certificates) and an optional custom root pool (RootCAs); other
@@ -126,6 +149,18 @@ type ConnHandle struct {
 	// support HITL for this conn family — plugins must default to
 	// deny in that case.
 	Approve func(req ApproveCallRequest) ApproveVerdict
+	// CADir is the gateway's CA / persistent state root (matches
+	// cfg.CADir). Endpoint runtimes that need to persist material
+	// per endpoint — e.g. SSH host keys at <CADir>/ssh/<name>.key —
+	// derive paths from this. Empty when the gateway hasn't been
+	// configured with a CA dir; plugins that need persistence error
+	// out clearly in that case.
+	CADir string
+	// DstPort is the destination port the agent connection arrived
+	// on (post-VIP / direct dial). Endpoints whose host strings
+	// carry a non-default port (`hosts = ["x.com:22222"]`) consult
+	// this to pick which Hosts[i] the connection corresponds to.
+	DstPort uint16
 }
 
 // ApproveCallRequest is what a ConnEndpointRuntime hands to

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -66,29 +66,6 @@ type PostgresAuthCredential interface {
 	PostgresAuth(sec Secret) (user, password string)
 }
 
-// SSHCreds is the materialised view an SSH credential hands to the
-// SSH endpoint runtime. PrivateKey is the raw PEM bytes (PKCS#1, PKCS#8
-// or OpenSSH format — golang.org/x/crypto/ssh.ParsePrivateKey* handles
-// all three). HostPubkey, when non-empty, is a single-line
-// authorized_keys-style entry the endpoint pins for upstream
-// verification (matches `ssh-keyscan` output).
-type SSHCreds struct {
-	User       string
-	PrivateKey []byte
-	Passphrase string
-	Password   string
-	HostPubkey string
-}
-
-// SSHAuthCredential is what the SSH endpoint runtime needs from a
-// credential plugin to authenticate upstream on the agent's behalf.
-// The credential never sees the agent connection — it just returns the
-// material; the endpoint runtime drives the upstream handshake. Mirrors
-// the postgres SCRAM-offload split.
-type SSHAuthCredential interface {
-	SSHAuth(sec Secret) (SSHCreds, error)
-}
-
 // TLSCredentialRuntime customizes the upstream TLS configuration
 // before the dial. mTLS credentials use this to add a client cert
 // (Certificates) and an optional custom root pool (RootCAs); other

--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -1,0 +1,587 @@
+// Package dnsvip handles DNS interception and virtual-IP allocation
+// for non-HTTP endpoints that can't be disambiguated at TCP-accept
+// time. The canonical case is SSH: a TCP connection to port 22
+// carries no SNI / Host header, so an agent dialling
+// "ssh build.example.com" reaches the gateway's WG forwarder with
+// nothing more than a destination IP. To know which logical endpoint
+// the user meant, clawpatrol gives every SSH-able hostname a unique
+// IP from a private range (10.78.0.0/16 v4, fd78::/64 v6) and answers
+// agent DNS queries with those instead of the real upstream IP. When
+// the connection comes back, the destination IP is the VIP — and the
+// VIP is keyed to exactly one hostname.
+//
+// VIPs are stable across both restarts and policy reloads (persisted
+// to <state_dir>/dnsvip.json). When a hostname leaves policy its slot
+// is freed and reused by the next allocation, so the table doesn't
+// grow without bound across long-lived gateways.
+//
+// The package depends on miekg/dns only for wire-format parsing and
+// serialisation; the server loops are hand-rolled because the
+// netstack hands us per-flow conns rather than a listener miekg/dns
+// could `ActivateAndServe` against.
+package dnsvip
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// RequiresVIP is the marker an endpoint plugin's body implements when
+// its hostnames need DNS-VIP interception (because the wire protocol
+// can't be routed by destination IP alone). The dnsvip Allocator picks
+// it up at policy build time and assigns a VIP per hostname.
+//
+// Endpoints that opt in must also implement runtime.ConnRouter — the
+// dnsvip walker reads the host:port list from there to keep the
+// "what hosts does this endpoint claim" knowledge in one place.
+type RequiresVIP interface {
+	RequiresVIP() bool
+}
+
+// EndpointHit is what LookupVIP returns: the endpoint(s) bound to a
+// VIP plus the port the host:port binding declared. Multiple endpoints
+// can share a hostname (and therefore a VIP) — caller filters by
+// profile and matches DstPort to pick.
+type EndpointHit struct {
+	Endpoint *config.CompiledEndpoint
+	Port     uint16
+}
+
+// Default CIDRs. Picked to be unlikely to collide with the WG subnet
+// (10.55.0.0/24 in the example config) and outside any common LAN
+// range. Operators with constraints override via the gateway block.
+var (
+	DefaultCIDR4 = netip.MustParsePrefix("10.78.0.0/16")
+	DefaultCIDR6 = netip.MustParsePrefix("fd78::/64")
+)
+
+// MaxID caps allocations. v4 /16 holds 65535 usable IDs; v6 /64
+// would technically hold 2^32 but we share a single ID space with v4
+// so the v4 ceiling rules. Sentinel keeps allocator panics out of
+// pathological reload loops.
+const MaxID uint32 = 0xFFFE
+
+type entry struct {
+	ID       uint32     `json:"id"`
+	Hostname string     `json:"hostname"`
+	V4       netip.Addr `json:"v4"`
+	V6       netip.Addr `json:"v6"`
+}
+
+type persistFile struct {
+	Version int     `json:"version"`
+	Entries []entry `json:"entries"`
+}
+
+// Allocator owns the hostname↔VIP table and serves DNS over the
+// netstack-supplied conns. Construction loads from disk; the gateway
+// calls RebuildFromPolicy on every policy load to reconcile
+// allocations against the current endpoint set.
+type Allocator struct {
+	statePath string
+	cidr4     netip.Prefix
+	cidr6     netip.Prefix
+
+	mu        sync.RWMutex
+	byName    map[string]*entry        // hostname → entry
+	byV4      map[netip.Addr]*entry    // 10.78.x.y → entry
+	byV6      map[netip.Addr]*entry    // fd78::N → entry
+	endpoints map[string][]EndpointHit // hostname → hits
+	free      []uint32                 // recycled IDs
+	used      map[uint32]struct{}      // ID set, for fast in-use check
+}
+
+// New constructs an allocator and loads any existing state from
+// stateDir/dnsvip.json. cidr4/cidr6 may be passed as zero-valued
+// netip.Prefix to use the package defaults. A non-existent state
+// file is fine — the allocator starts empty.
+func New(stateDir string, cidr4, cidr6 netip.Prefix) (*Allocator, error) {
+	if !cidr4.IsValid() {
+		cidr4 = DefaultCIDR4
+	}
+	if !cidr6.IsValid() {
+		cidr6 = DefaultCIDR6
+	}
+	if !cidr4.Addr().Is4() {
+		return nil, fmt.Errorf("cidr4 must be IPv4: %s", cidr4)
+	}
+	if !cidr6.Addr().Is6() || cidr6.Addr().Is4In6() {
+		return nil, fmt.Errorf("cidr6 must be IPv6: %s", cidr6)
+	}
+	a := &Allocator{
+		statePath: filepath.Join(stateDir, "dnsvip.json"),
+		cidr4:     cidr4,
+		cidr6:     cidr6,
+		byName:    map[string]*entry{},
+		byV4:      map[netip.Addr]*entry{},
+		byV6:      map[netip.Addr]*entry{},
+		endpoints: map[string][]EndpointHit{},
+		used:      map[uint32]struct{}{},
+	}
+	if err := a.load(); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+func (a *Allocator) load() error {
+	data, err := os.ReadFile(a.statePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("dnsvip: read %s: %w", a.statePath, err)
+	}
+	var f persistFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return fmt.Errorf("dnsvip: parse %s: %w", a.statePath, err)
+	}
+	for i := range f.Entries {
+		e := &f.Entries[i]
+		// Defensive: skip entries whose VIPs fall outside the
+		// configured CIDRs (operator changed the prefix between
+		// boots). They'll be reallocated fresh on next rebuild.
+		if !a.cidr4.Contains(e.V4) || !a.cidr6.Contains(e.V6) {
+			log.Printf("dnsvip: dropping persisted entry %s — VIP outside configured CIDRs", e.Hostname)
+			continue
+		}
+		a.byName[e.Hostname] = e
+		a.byV4[e.V4] = e
+		a.byV6[e.V6] = e
+		a.used[e.ID] = struct{}{}
+	}
+	return nil
+}
+
+func (a *Allocator) persistLocked() error {
+	if a.statePath == "" {
+		return nil
+	}
+	out := persistFile{Version: 1}
+	for _, e := range a.byName {
+		out.Entries = append(out.Entries, *e)
+	}
+	sort.Slice(out.Entries, func(i, j int) bool { return out.Entries[i].ID < out.Entries[j].ID })
+	buf, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(a.statePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "dnsvip-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(buf); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, a.statePath)
+}
+
+// vipForID derives the (v4, v6) pair for an ID. v4 occupies the last
+// two octets of cidr4; v6 occupies the last 32 bits of cidr6. ID 0 is
+// reserved (network address); IDs start at 1.
+func (a *Allocator) vipForID(id uint32) (netip.Addr, netip.Addr) {
+	v4 := a.cidr4.Addr().As4()
+	v4[2] = byte(id >> 8)
+	v4[3] = byte(id)
+	v6 := a.cidr6.Addr().As16()
+	v6[12] = byte(id >> 24)
+	v6[13] = byte(id >> 16)
+	v6[14] = byte(id >> 8)
+	v6[15] = byte(id)
+	return netip.AddrFrom4(v4), netip.AddrFrom16(v6)
+}
+
+// allocateLocked picks an unused ID — preferring the free-list before
+// scanning forward — and creates an entry for hostname.
+func (a *Allocator) allocateLocked(hostname string) (*entry, error) {
+	// Free-list first: deterministic recycling means deleted slots
+	// fill in before we extend the table.
+	for len(a.free) > 0 {
+		id := a.free[0]
+		a.free = a.free[1:]
+		if _, taken := a.used[id]; taken {
+			continue
+		}
+		return a.makeEntry(id, hostname), nil
+	}
+	for id := uint32(1); id <= MaxID; id++ {
+		if _, taken := a.used[id]; taken {
+			continue
+		}
+		return a.makeEntry(id, hostname), nil
+	}
+	return nil, fmt.Errorf("dnsvip: VIP pool exhausted (%d allocated)", len(a.used))
+}
+
+func (a *Allocator) makeEntry(id uint32, hostname string) *entry {
+	v4, v6 := a.vipForID(id)
+	e := &entry{ID: id, Hostname: hostname, V4: v4, V6: v6}
+	a.byName[hostname] = e
+	a.byV4[v4] = e
+	a.byV6[v6] = e
+	a.used[id] = struct{}{}
+	return e
+}
+
+// RebuildFromPolicy reconciles the VIP table against the current
+// compiled policy. Hostnames newly in policy get fresh VIP pairs;
+// hostnames that disappeared have their pair freed back to the
+// free-list. The endpoint→hit map is rebuilt from scratch every
+// time. Persists on success.
+func (a *Allocator) RebuildFromPolicy(policy *config.CompiledPolicy) error {
+	if a == nil {
+		return nil
+	}
+	required := collectRequiredHosts(policy)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Free entries no longer required.
+	for hostname, e := range a.byName {
+		if _, keep := required[hostname]; keep {
+			continue
+		}
+		delete(a.byName, hostname)
+		delete(a.byV4, e.V4)
+		delete(a.byV6, e.V6)
+		delete(a.used, e.ID)
+		a.free = append(a.free, e.ID)
+	}
+	// Allocate new ones in deterministic hostname order so persisted
+	// IDs match across machines that load the same policy from
+	// scratch (cosmetic — VIP order shouldn't be operator-visible
+	// except when comparing dnsvip.json across replicas).
+	var newHosts []string
+	for h := range required {
+		if _, exists := a.byName[h]; !exists {
+			newHosts = append(newHosts, h)
+		}
+	}
+	sort.Strings(newHosts)
+	for _, h := range newHosts {
+		if _, err := a.allocateLocked(h); err != nil {
+			return err
+		}
+	}
+
+	// Rebuild the endpoint→hits map.
+	a.endpoints = map[string][]EndpointHit{}
+	for hostname, hits := range required {
+		a.endpoints[hostname] = hits
+	}
+
+	return a.persistLocked()
+}
+
+// collectRequiredHosts walks the policy and returns the hostname →
+// []EndpointHit map for endpoints that opted into VIPs. Endpoints
+// must also be ConnRouters — that's where we get the host:port list
+// (the same one ConnIndex uses for direct-IP routing). A host string
+// without a port falls back to that protocol's default; SSH is the
+// only RequiresVIP plugin in v1 so the default is 22.
+func collectRequiredHosts(policy *config.CompiledPolicy) map[string][]EndpointHit {
+	out := map[string][]EndpointHit{}
+	if policy == nil {
+		return out
+	}
+	for _, ep := range policy.Endpoints {
+		req, ok := ep.Body.(RequiresVIP)
+		if !ok || !req.RequiresVIP() {
+			continue
+		}
+		// Use the compiled Hosts list (already populated via
+		// EndpointHosts()) — same source ConnIndex consumes.
+		for _, hp := range ep.Hosts {
+			host, portStr, err := net.SplitHostPort(hp)
+			if err != nil {
+				host = hp
+				portStr = ""
+			}
+			if host == "" {
+				continue
+			}
+			var port uint16 = defaultPortFor(ep)
+			if portStr != "" {
+				var p uint16
+				if _, err := fmt.Sscanf(portStr, "%d", &p); err == nil {
+					port = p
+				}
+			}
+			out[host] = append(out[host], EndpointHit{Endpoint: ep, Port: port})
+		}
+	}
+	return out
+}
+
+// defaultPortFor returns the default port for a VIP-needing endpoint
+// when its host string omits one. SSH is the only RequiresVIP plugin
+// today; future plugins can extend the switch.
+func defaultPortFor(ep *config.CompiledEndpoint) uint16 {
+	switch ep.Plugin.Type {
+	case "ssh":
+		return 22
+	}
+	return 0
+}
+
+// IsVIP reports whether dstIP falls in either configured VIP range.
+// dstIP is the netstack-extracted destination string (already in
+// canonical form — IPv4 dotted, IPv6 colon-separated).
+func (a *Allocator) IsVIP(dstIP string) bool {
+	if a == nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(dstIP)
+	if err != nil {
+		return false
+	}
+	return a.cidr4.Contains(addr) || a.cidr6.Contains(addr)
+}
+
+// LookupVIP resolves a destination IP back to the EndpointHits bound
+// to the corresponding hostname. Empty result means the IP isn't a
+// recognised VIP (caller falls back to ConnIndex).
+func (a *Allocator) LookupVIP(dstIP string) (hostname string, hits []EndpointHit) {
+	if a == nil {
+		return "", nil
+	}
+	addr, err := netip.ParseAddr(dstIP)
+	if err != nil {
+		return "", nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var e *entry
+	if addr.Is4() {
+		e = a.byV4[addr]
+	} else {
+		e = a.byV6[addr]
+	}
+	if e == nil {
+		return "", nil
+	}
+	return e.Hostname, a.endpoints[e.Hostname]
+}
+
+// HostnameFor returns the hostname behind a VIP, or "" if not a VIP.
+// Convenience for tests / logging.
+func (a *Allocator) HostnameFor(addr netip.Addr) string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var e *entry
+	if addr.Is4() {
+		e = a.byV4[addr]
+	} else {
+		e = a.byV6[addr]
+	}
+	if e == nil {
+		return ""
+	}
+	return e.Hostname
+}
+
+// VIPsFor returns the (v4, v6) pair for a hostname, both zero when
+// not allocated. Used by tests / dashboard surfaces.
+func (a *Allocator) VIPsFor(hostname string) (netip.Addr, netip.Addr) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	e := a.byName[hostname]
+	if e == nil {
+		return netip.Addr{}, netip.Addr{}
+	}
+	return e.V4, e.V6
+}
+
+// ── DNS handling ──────────────────────────────────────────────────────
+
+// ServeUDP loops over a single UDP "conn" handed up by the netstack.
+// Each agent's UDP flow gets its own gonet UDP conn, so we read one
+// datagram, build a response, write it back, and continue until the
+// peer goes idle. Mirrors the relayUDP loop pattern in wireguard.go.
+//
+// dstIP is the address the agent thought it was talking to (the
+// system-resolver IP it picked, e.g. 1.1.1.1). When a query falls
+// outside the VIP table we forward it there verbatim so the agent's
+// existing DNS configuration keeps working — the gateway hijacks
+// only the names it has policy for.
+func (a *Allocator) ServeUDP(c net.Conn, dstIP string) {
+	defer c.Close()
+	buf := make([]byte, 4096)
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(60 * time.Second))
+		n, err := c.Read(buf)
+		if err != nil {
+			return
+		}
+		resp := a.handleWire(buf[:n], dstIP)
+		if resp == nil {
+			continue
+		}
+		_, _ = c.Write(resp)
+	}
+}
+
+// ServeTCP serves the RFC 1035 length-prefixed framing variant. The
+// netstack gives us one TCP conn per agent flow; we loop until the
+// agent closes (DNS-over-TCP supports pipelining).
+func (a *Allocator) ServeTCP(c net.Conn, dstIP string) {
+	defer c.Close()
+	hdr := make([]byte, 2)
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(60 * time.Second))
+		if _, err := io.ReadFull(c, hdr); err != nil {
+			return
+		}
+		length := binary.BigEndian.Uint16(hdr)
+		if length == 0 {
+			continue
+		}
+		body := make([]byte, length)
+		if _, err := io.ReadFull(c, body); err != nil {
+			return
+		}
+		resp := a.handleWire(body, dstIP)
+		if resp == nil {
+			continue
+		}
+		out := make([]byte, 2+len(resp))
+		binary.BigEndian.PutUint16(out[:2], uint16(len(resp)))
+		copy(out[2:], resp)
+		if _, err := c.Write(out); err != nil {
+			return
+		}
+	}
+}
+
+// handleWire parses the wire bytes and returns the response wire
+// bytes — the on-the-wire return value, ready to ship. A nil return
+// means we couldn't even build a SERVFAIL (parse failure of the
+// agent's bytes is the only path) and the caller should drop.
+func (a *Allocator) handleWire(in []byte, dstIP string) []byte {
+	q := new(dns.Msg)
+	if err := q.Unpack(in); err != nil {
+		log.Printf("dnsvip: parse query: %v", err)
+		return nil
+	}
+	resp := a.handleQuery(q, dstIP)
+	if resp == nil {
+		return nil
+	}
+	out, err := resp.Pack()
+	if err != nil {
+		log.Printf("dnsvip: pack response: %v", err)
+		return nil
+	}
+	return out
+}
+
+// handleQuery is the actual responder. Splits intercepted from
+// non-intercepted: if any question targets a known VIP-hostname we
+// answer locally; otherwise we forward the entire message to dstIP
+// verbatim. A query for a known hostname's "wrong" type (e.g. MX) is
+// answered NOERROR + empty so resolvers don't loop into upstream and
+// learn the real address.
+func (a *Allocator) handleQuery(q *dns.Msg, dstIP string) *dns.Msg {
+	if len(q.Question) == 0 {
+		return errorResp(q, dns.RcodeFormatError)
+	}
+	intercept := false
+	for _, qq := range q.Question {
+		if a.intercepts(strings.TrimSuffix(qq.Name, ".")) {
+			intercept = true
+			break
+		}
+	}
+	if !intercept {
+		return a.forwardUpstream(q, dstIP)
+	}
+	resp := new(dns.Msg)
+	resp.SetReply(q)
+	resp.Authoritative = true
+	resp.RecursionAvailable = true
+	for _, qq := range q.Question {
+		host := strings.TrimSuffix(qq.Name, ".")
+		v4, v6 := a.VIPsFor(host)
+		switch qq.Qtype {
+		case dns.TypeA:
+			if v4.IsValid() {
+				resp.Answer = append(resp.Answer, &dns.A{
+					Hdr: dns.RR_Header{Name: qq.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   v4.AsSlice(),
+				})
+			}
+		case dns.TypeAAAA:
+			if v6.IsValid() {
+				resp.Answer = append(resp.Answer, &dns.AAAA{
+					Hdr:  dns.RR_Header{Name: qq.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 30},
+					AAAA: v6.AsSlice(),
+				})
+			}
+		default:
+			// Other types (MX, TXT, SRV, NS) on intercepted names
+			// → NOERROR + empty answer. We don't proxy them upstream
+			// because doing so leaks the real IP and also opens an
+			// inconsistency window where a client might race the
+			// upstream answer ahead of the intercepted A.
+		}
+	}
+	return resp
+}
+
+func (a *Allocator) intercepts(hostname string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	_, ok := a.byName[hostname]
+	return ok
+}
+
+// forwardUpstream sends the query to the IP the agent originally
+// addressed and returns the upstream's reply. Errors are converted to
+// SERVFAIL so the agent's resolver gets a clean response — log line
+// captures the actual cause.
+func (a *Allocator) forwardUpstream(q *dns.Msg, dstIP string) *dns.Msg {
+	if dstIP == "" {
+		return errorResp(q, dns.RcodeServerFailure)
+	}
+	c := &dns.Client{Net: "udp", Timeout: 3 * time.Second}
+	in, _, err := c.Exchange(q, net.JoinHostPort(dstIP, "53"))
+	if err != nil {
+		log.Printf("dnsvip: forward to %s: %v", dstIP, err)
+		return errorResp(q, dns.RcodeServerFailure)
+	}
+	return in
+}
+
+func errorResp(q *dns.Msg, rcode int) *dns.Msg {
+	r := new(dns.Msg)
+	r.SetRcode(q, rcode)
+	return r
+}

--- a/dnsvip/dnsvip_test.go
+++ b/dnsvip/dnsvip_test.go
@@ -1,0 +1,268 @@
+package dnsvip
+
+import (
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/miekg/dns"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// fakePolicy builds a CompiledPolicy whose endpoints opt into VIPs.
+// The plugin Type drives defaultPortFor lookups, so we set it to
+// "ssh" — that's the only RequiresVIP plugin in v1 and the one the
+// allocator is designed against.
+func fakePolicy(t *testing.T, hosts ...[]string) *config.CompiledPolicy {
+	t.Helper()
+	p := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{},
+	}
+	for i, hh := range hosts {
+		name := "ep" + string(rune('A'+i))
+		p.Endpoints[name] = &config.CompiledEndpoint{
+			Name:   name,
+			Family: "ssh",
+			Plugin: &config.Plugin{Type: "ssh"},
+			Hosts:  hh,
+			Body:   testBody{hosts: hh},
+		}
+	}
+	return p
+}
+
+// testBody implements RequiresVIP. We don't need ConnRouter here
+// because dnsvip reads ep.Hosts directly (the same source ConnIndex
+// reads, plus that's already populated by the loader).
+type testBody struct {
+	hosts []string
+}
+
+func (testBody) RequiresVIP() bool { return true }
+
+func TestRebuildAllocatesAndIsStable(t *testing.T) {
+	dir := t.TempDir()
+	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := fakePolicy(t, []string{"a.example.com:22"}, []string{"b.example.com:22"})
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild 1: %v", err)
+	}
+	v4a, v6a := a.VIPsFor("a.example.com")
+	v4b, v6b := a.VIPsFor("b.example.com")
+	if !v4a.IsValid() || !v6a.IsValid() || !v4b.IsValid() || !v6b.IsValid() {
+		t.Fatalf("VIPs not allocated: a=(%v,%v) b=(%v,%v)", v4a, v6a, v4b, v6b)
+	}
+	if v4a == v4b || v6a == v6b {
+		t.Fatalf("collision: a=(%v,%v) b=(%v,%v)", v4a, v6a, v4b, v6b)
+	}
+
+	// Stability across rebuilds when policy is unchanged.
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild 2: %v", err)
+	}
+	v4a2, v6a2 := a.VIPsFor("a.example.com")
+	if v4a2 != v4a || v6a2 != v6a {
+		t.Fatalf("VIPs drifted after no-op rebuild: was (%v,%v) now (%v,%v)", v4a, v6a, v4a2, v6a2)
+	}
+
+	// Persistence: load a fresh allocator from the same dir.
+	b, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New 2: %v", err)
+	}
+	v4a3, v6a3 := b.VIPsFor("a.example.com")
+	if v4a3 != v4a || v6a3 != v6a {
+		t.Fatalf("VIPs lost after restart: was (%v,%v) loaded (%v,%v)", v4a, v6a, v4a3, v6a3)
+	}
+}
+
+func TestRebuildFreesAndRecycles(t *testing.T) {
+	dir := t.TempDir()
+	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Allocate three.
+	if err := a.RebuildFromPolicy(fakePolicy(t,
+		[]string{"a.example.com:22"},
+		[]string{"b.example.com:22"},
+		[]string{"c.example.com:22"},
+	)); err != nil {
+		t.Fatalf("Rebuild 1: %v", err)
+	}
+	v4a, _ := a.VIPsFor("a.example.com")
+	v4b, _ := a.VIPsFor("b.example.com")
+	v4c, _ := a.VIPsFor("c.example.com")
+	allDistinct := v4a != v4b && v4b != v4c && v4a != v4c
+	if !allDistinct {
+		t.Fatalf("non-distinct: %v %v %v", v4a, v4b, v4c)
+	}
+
+	// Drop b. b's VIP must be released.
+	if err := a.RebuildFromPolicy(fakePolicy(t,
+		[]string{"a.example.com:22"},
+		[]string{"c.example.com:22"},
+	)); err != nil {
+		t.Fatalf("Rebuild 2: %v", err)
+	}
+	if v4, _ := a.VIPsFor("b.example.com"); v4.IsValid() {
+		t.Fatalf("b should have been freed, still has %v", v4)
+	}
+
+	// Add a new hostname; it should pick up b's freed slot before
+	// extending nextID.
+	if err := a.RebuildFromPolicy(fakePolicy(t,
+		[]string{"a.example.com:22"},
+		[]string{"c.example.com:22"},
+		[]string{"d.example.com:22"},
+	)); err != nil {
+		t.Fatalf("Rebuild 3: %v", err)
+	}
+	v4d, _ := a.VIPsFor("d.example.com")
+	if v4d != v4b {
+		t.Fatalf("expected d to recycle b's slot %v, got %v", v4b, v4d)
+	}
+}
+
+func TestExhaustion(t *testing.T) {
+	// Use a tiny v4 CIDR so we run out fast. /29 leaves us with 7
+	// usable IDs (1..7 — id 0 reserved). The v6 CIDR can stay big.
+	dir := t.TempDir()
+	cidr4 := netip.MustParsePrefix("10.99.0.0/29")
+	a, err := New(dir, cidr4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// MaxID is the global cap (0xFFFE) — bigger than the /29 — so
+	// the limiting factor is the network address space. Allocate
+	// until the per-CIDR address actually exceeds the prefix.
+	// (vipForID picks low octets from id; id 8 would land at
+	// 10.99.0.8 which is *outside* the /29 but vipForID doesn't
+	// know that. The prefix ceiling is enforced by the caller's
+	// understanding.)
+	//
+	// For the unit test we instead validate the MaxID sentinel by
+	// constructing 0xFFFF allocations — too slow. Instead, lean on
+	// the smaller bound: stuff IDs onto the used set up to MaxID-1
+	// and assert the next allocation errors.
+	a.mu.Lock()
+	for id := uint32(1); id <= MaxID; id++ {
+		a.used[id] = struct{}{}
+	}
+	_, err = a.allocateLocked("doomed.example.com")
+	if err == nil {
+		t.Fatalf("expected exhaustion error past MaxID; got nil")
+	}
+	a.mu.Unlock()
+}
+
+func TestDNSARecordRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := fakePolicy(t, []string{"a.example.com:22"})
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	v4a, v6a := a.VIPsFor("a.example.com")
+	q := new(dns.Msg)
+	q.SetQuestion("a.example.com.", dns.TypeA)
+	resp := a.handleQuery(q, "")
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("A: expected 1 answer, got %v", resp)
+	}
+	aRR := resp.Answer[0].(*dns.A)
+	if !net.IP(v4a.AsSlice()).Equal(aRR.A) {
+		t.Fatalf("A: got %v want %v", aRR.A, v4a)
+	}
+
+	q.SetQuestion("a.example.com.", dns.TypeAAAA)
+	resp = a.handleQuery(q, "")
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("AAAA: expected 1 answer, got %v", resp)
+	}
+	aaaaRR := resp.Answer[0].(*dns.AAAA)
+	if !net.IP(v6a.AsSlice()).Equal(aaaaRR.AAAA) {
+		t.Fatalf("AAAA: got %v want %v", aaaaRR.AAAA, v6a)
+	}
+
+	// Other types on intercepted names: NOERROR + empty.
+	q.SetQuestion("a.example.com.", dns.TypeMX)
+	resp = a.handleQuery(q, "")
+	if resp == nil || len(resp.Answer) != 0 || resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("MX on intercepted host: expected NOERROR + empty, got rcode=%d answers=%d", resp.Rcode, len(resp.Answer))
+	}
+}
+
+func TestLookupVIP(t *testing.T) {
+	dir := t.TempDir()
+	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := fakePolicy(t, []string{"a.example.com:22"})
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	v4, v6 := a.VIPsFor("a.example.com")
+
+	host, hits := a.LookupVIP(v4.String())
+	if host != "a.example.com" || len(hits) != 1 {
+		t.Fatalf("v4 lookup: host=%q hits=%v", host, hits)
+	}
+	if hits[0].Port != 22 {
+		t.Fatalf("expected port 22, got %d", hits[0].Port)
+	}
+
+	host, hits = a.LookupVIP(v6.String())
+	if host != "a.example.com" || len(hits) != 1 {
+		t.Fatalf("v6 lookup: host=%q hits=%v", host, hits)
+	}
+
+	// Non-VIP returns nothing.
+	host, hits = a.LookupVIP("8.8.8.8")
+	if host != "" || hits != nil {
+		t.Fatalf("non-VIP returned host=%q hits=%v", host, hits)
+	}
+}
+
+func TestPersistenceDropsOutOfRangeEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Allocate with the default CIDRs.
+	{
+		a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := a.RebuildFromPolicy(fakePolicy(t, []string{"x.example.com:22"})); err != nil {
+			t.Fatalf("Rebuild: %v", err)
+		}
+	}
+
+	// Reload with different CIDRs — the persisted entry should be
+	// dropped (its VIPs fall outside the new prefixes).
+	cidr4 := netip.MustParsePrefix("10.42.0.0/16")
+	cidr6 := netip.MustParsePrefix("fd42::/64")
+	a, err := New(dir, cidr4, cidr6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if v4, _ := a.VIPsFor("x.example.com"); v4.IsValid() {
+		t.Fatalf("expected entry to be dropped after CIDR change, still have %v", v4)
+	}
+
+	// Persisted file should still be readable next time.
+	want := filepath.Join(dir, "dnsvip.json")
+	if _, err := os.ReadFile(want); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("dnsvip.json unreadable: %v", err)
+	}
+}

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -94,9 +94,34 @@ rule "http_rule" "github-writes" {
   approve  = [ops]
 }
 
+# SSH endpoints. The wire protocol carries no SNI / Host header, so
+# the gateway runs a DNS server inside the WG tunnel and answers
+# A/AAAA queries for SSH-able hostnames with virtual IPs from
+# 10.78.0.0/16 and fd78::/64. When the client connects to the VIP
+# the gateway recovers the hostname, terminates SSH on both halves,
+# and uses the credential below for upstream auth.
+#
+# VIPs are persisted under <state_dir>/dnsvip.json so they survive
+# restarts AND policy reloads — clients' cached DNS answers stay
+# valid through gateway hops. Each SSH endpoint also gets its own
+# persisted host key under <ca_dir>/ssh/<endpoint>.key on first use;
+# add the printed fingerprint to the user's known_hosts file (the
+# dashboard surfaces it per endpoint).
+
+credential "ssh" "build-host-cred" {
+  user = "deploy"
+  # private_key + (optional) passphrase + (optional) host_pubkey live
+  # in the secret store — paste them via the dashboard.
+}
+
+endpoint "ssh" "build-host" {
+  hosts      = ["build.example.com:2222"]
+  credential = build-host-cred
+}
+
 # Profiles: bind a device identity to an endpoint set. Rules ride along
 # automatically because they're attached to endpoints.
 
 profile "default" {
-  endpoints = [github]
+  endpoints = [github, build-host]
 }

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -109,7 +109,6 @@ rule "http_rule" "github-writes" {
 # dashboard surfaces it per endpoint).
 
 credential "ssh" "build-host-cred" {
-  user = "deploy"
   # private_key + (optional) passphrase + (optional) host_pubkey live
   # in the secret store — paste them via the dashboard.
 }
@@ -117,6 +116,10 @@ credential "ssh" "build-host-cred" {
 endpoint "ssh" "build-host" {
   hosts      = ["build.example.com:2222"]
   credential = build-host-cred
+  # The agent's username (`ssh user@build.example.com`) is passed
+  # through to the upstream verbatim. For per-username dispatch use
+  # `credentials = [{user="root", credential=...}, {credential=...}]`
+  # — last entry without `user` is the catchall.
 }
 
 # Profiles: bind a device identity to an endpoint set. Rules ride along

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect
+	github.com/miekg/dns v1.1.72 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
-github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
-github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
+github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
+github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/denoland/clawpatrol/config/plugins/all"
 	"github.com/denoland/clawpatrol/config/plugins/approvers"
 	"github.com/denoland/clawpatrol/config/runtime"
+	"github.com/denoland/clawpatrol/dnsvip"
 	"github.com/google/uuid"
 )
 
@@ -260,6 +261,13 @@ type Gateway struct {
 	// implements runtime.ConnRouter (postgres today, future binary
 	// protocols). Rebuilt on every policy load.
 	connIdx atomic.Pointer[runtime.ConnIndex]
+	// dnsvip owns the hostname↔virtual-IP table for endpoints whose
+	// wire protocol can't be disambiguated at TCP-accept time (SSH
+	// today). The DNS server hijacks A/AAAA queries inside the WG
+	// tunnel so an agent's `ssh user@host` resolves to a unique VIP
+	// the gateway can route by. Single allocator shared across the
+	// process; mutate-in-place + RWMutex inside.
+	dnsvip *dnsvip.Allocator
 }
 
 // Policy returns the current snapshot of the lowered runtime policy.
@@ -323,6 +331,11 @@ func (g *Gateway) watchConfig(path string) {
 		g.policy.Store(policy)
 		registerOAuthCredentials(g.oauth, policy)
 		g.connIdx.Store(runtime.BuildConnIndex(policy))
+		if g.dnsvip != nil {
+			if err := g.dnsvip.RebuildFromPolicy(policy); err != nil {
+				log.Printf("dnsvip rebuild on reload: %v", err)
+			}
+		}
 		// Hot-swap the operational *config.Gateway too — AdminEmail /
 		// PublicURL / DashboardSecret reads pick up immediately.
 		// Listen / CADir / Tailscale changes are not applied (restart).
@@ -1107,6 +1120,112 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 	}
 }
 
+// handleVIPConn dispatches an inbound TCP connection whose dst IP
+// falls in the dnsvip range. The VIP table maps the IP back to the
+// hostname → endpoints that claimed a VIP at policy build; profile
+// filter picks the one for this device. Today the only RequiresVIP
+// plugin is "ssh", but the path is generic so future binary
+// protocols (clickhouse_native with a hostname-keyed dispatch quirk,
+// for instance) can plug in without a separate forwarder branch.
+func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
+	defer otelTrackConn("vip_conn")()
+	pip := peerIP(c)
+	profile := g.profileFor(pip)
+	policy := g.Policy()
+
+	hostname, hits := g.dnsvip.LookupVIP(dstIP)
+	if hostname == "" || len(hits) == 0 {
+		log.Printf("vip %s:%d: VIP allocated but no endpoint binding (stale?); dropping", dstIP, dstPort)
+		c.Close()
+		return
+	}
+	// Profile-filter the hits, then port-match. Port match handles
+	// the case where one hostname is bound to multiple endpoints on
+	// different ports (rare but legal).
+	var ep *config.CompiledEndpoint
+	var matchedPort uint16
+	for _, h := range hits {
+		if h.Endpoint == nil {
+			continue
+		}
+		if profile != "" {
+			if prof, ok := policy.Profiles[profile]; ok {
+				if _, in := prof.Endpoints[h.Endpoint.Name]; !in {
+					continue
+				}
+			}
+		}
+		if dstPort != 0 && h.Port != 0 && dstPort != h.Port {
+			continue
+		}
+		ep = h.Endpoint
+		matchedPort = h.Port
+		break
+	}
+	if ep == nil {
+		log.Printf("vip %s:%d (host %q): no endpoint matches profile %q + port", dstIP, dstPort, hostname, profile)
+		c.Close()
+		return
+	}
+
+	connRT, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime)
+	if !ok {
+		log.Printf("vip endpoint %q plugin lacks ConnEndpointRuntime", ep.Name)
+		c.Close()
+		return
+	}
+
+	mode := ep.Plugin.Type // "ssh" today; future plugins surface as their own mode tag
+	ch := &runtime.ConnHandle{
+		Conn:     c,
+		Endpoint: ep,
+		Policy:   policy,
+		Profile:  profile,
+		PeerIP:   pip,
+		Secrets:  g.secrets,
+		CADir:    g.cfg.CADir,
+		DstPort:  matchedPort,
+		DialUpstream: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Plugin passes the *real* upstream host:port — the
+			// gateway's host network resolves it (the VIP only
+			// exists inside the WG netstack).
+			if addr == "" {
+				return nil, fmt.Errorf("vip dispatch: plugin gave empty upstream addr")
+			}
+			return g.dialer.DialContext(ctx, network, addr)
+		},
+		Emit: func(ev runtime.ConnEvent) {
+			if g.sink == nil {
+				return
+			}
+			g.sink.Emit(Event{
+				Mode: mode, Host: hostname, AgentIP: pip,
+				Method: ev.Verb, Path: ev.Summary,
+				Action: ev.Action, Reason: ev.Reason,
+			})
+		},
+		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
+			return g.runApproveChain(context.Background(), req.Stages, runApproveCtx{
+				AgentIP: pip, Host: hostname, Method: req.Verb, Path: req.Summary,
+				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
+				Endpoint: ep, Rule: req.Rule, Profile: profile,
+			})
+		},
+	}
+	if err := connRT.HandleConn(context.Background(), ch); err != nil {
+		log.Printf("%s vip %s (%s): %v", mode, dstIP, hostname, err)
+	}
+}
+
+// handleDNSTCPConn dispatches an inbound TCP/53 flow to the dnsvip
+// allocator's TCP serving loop. The udpDispatch closure handles the
+// UDP variant; this is its TCP twin so DNS-over-TCP queries (large
+// answers, axfr-style retries, or simply `dig +tcp`) keep working.
+func (g *Gateway) handleDNSTCPConn(c net.Conn, dstIP string) {
+	defer otelTrackConn("dns_tcp")()
+	g.dnsvip.ServeTCP(c, dstIP)
+}
+
 // firstPostgresEndpoint returns the first postgres-family endpoint in
 // the device's profile. Multi-postgres profiles need DNS-aware
 // matching against the WG forwarder's dstIP — tracked as follow-up;
@@ -1837,6 +1956,20 @@ func runGateway(args []string) {
 	registerOAuthCredentials(oauthReg, policy)
 	g.policy.Store(policy)
 	g.connIdx.Store(runtime.BuildConnIndex(policy))
+	// dnsvip is opt-in by policy: if no endpoint requires VIPs, the
+	// allocator stays empty and ServeUDP / ServeTCP are never called
+	// (no endpoint dispatches port-53 to them). Construct
+	// unconditionally so reloads that *add* an SSH endpoint don't
+	// have to re-init. Persists to <stateDir>/dnsvip.json so VIPs
+	// survive restarts.
+	dvip, err := dnsvip.New(stateDir, dnsvip.DefaultCIDR4, dnsvip.DefaultCIDR6)
+	if err != nil {
+		log.Fatalf("dnsvip init: %v", err)
+	}
+	g.dnsvip = dvip
+	if err := g.dnsvip.RebuildFromPolicy(policy); err != nil {
+		log.Fatalf("dnsvip build: %v", err)
+	}
 	log.Printf("policy: %d endpoints across %d profiles", len(policy.Endpoints), len(policy.Profiles))
 	go g.watchConfig(*cfgPath)
 	if err := g.onboard.Load(db); err != nil {
@@ -1905,13 +2038,20 @@ func runGateway(args []string) {
 		setWGServer(wg)
 		dashMux := newWebMux(g, cfg.CADir, *cfg.Tailscale, cfg.PublicURL)
 		dashPort := portOf(cfg.InfoListen)
-		if err := wg.EnablePromiscuousForwarder(func(c net.Conn, dstIP string, dstPort uint16) {
+		tcpDispatch := func(c net.Conn, dstIP string, dstPort uint16) {
 			log.Printf("wg-fwd: %s:%d", dstIP, dstPort)
 			switch {
 			case dstPort == 443:
 				g.handle(c)
 			case dstPort == 5432:
 				g.handlePostgresConn(c, dstIP)
+			case dstPort == 53:
+				g.handleDNSTCPConn(c, dstIP)
+			case g.dnsvip.IsVIP(dstIP):
+				// Any port on a VIP belongs to the SSH endpoint that
+				// hostname maps to. Future RequiresVIP plugins can
+				// branch on ep.Plugin.Type inside handleVIPConn.
+				g.handleVIPConn(c, dstIP, dstPort)
 			case dashPort != 0 && int(dstPort) == dashPort:
 				_ = http.Serve(&oneShotListener{c: c}, dashMux)
 			default:
@@ -1920,10 +2060,18 @@ func runGateway(args []string) {
 				// (clickhouse_native, etc.).
 				wgRelay(c, dstIP, int(dstPort))
 			}
-		}); err != nil {
+		}
+		udpDispatch := func(c net.Conn, dstIP string, dstPort uint16) bool {
+			if dstPort == 53 {
+				g.dnsvip.ServeUDP(c, dstIP)
+				return true
+			}
+			return false
+		}
+		if err := wg.EnablePromiscuousForwarder(tcpDispatch, udpDispatch); err != nil {
 			log.Fatalf("wireguard forwarder: %v", err)
 		}
-		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :%d=dash, else=relay)", dashPort)
+		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :53=dns-vip, VIP=ssh, :%d=dash, else=relay)", dashPort)
 	}
 
 	ln, err := openListener(cfg)

--- a/wireguard.go
+++ b/wireguard.go
@@ -363,13 +363,24 @@ func wg6FromV4(v4 netip.Addr) netip.Addr {
 }
 
 // EnablePromiscuousForwarder turns the netstack into an L3 sink.
-// SYNs to ANY destination IP/port reach `handler`; the wrapped net.Conn
-// already carries the original 4-tuple via TransportEndpointID. Mirrors
-// unclaw/smoltcp's set_any_ip + dynamic listener pool model.
+// SYNs to ANY destination IP/port reach `tcpHandler`; the wrapped
+// net.Conn already carries the original 4-tuple via
+// TransportEndpointID. Mirrors unclaw/smoltcp's set_any_ip + dynamic
+// listener pool model.
 //
-// Caller dispatches by dstPort (e.g. 443 → MITM, dash port → mux,
+// udpHandler is consulted before the default UDP relay: it may take
+// over a flow (return true) — used for DNS interception so the
+// gateway can answer A queries with VIPs for SSH-able hostnames —
+// or pass (return false) to fall through to relayUDP, which shuttles
+// datagrams to the real upstream over the host's network. Pass nil
+// for the all-relay default.
+//
+// Caller dispatches TCP by dstPort (e.g. 443 → MITM, dash port → mux,
 // else → transparent relay to the real upstream IP).
-func (s *WGServer) EnablePromiscuousForwarder(handler func(c net.Conn, dstIP string, dstPort uint16)) error {
+func (s *WGServer) EnablePromiscuousForwarder(
+	tcpHandler func(c net.Conn, dstIP string, dstPort uint16),
+	udpHandler func(c net.Conn, dstIP string, dstPort uint16) bool,
+) error {
 	st := s.tun.stack
 	if err := st.SetPromiscuousMode(1, true); err != nil {
 		return fmt.Errorf("set promiscuous: %v", err)
@@ -393,11 +404,12 @@ func (s *WGServer) EnablePromiscuousForwarder(handler func(c net.Conn, dstIP str
 		}
 		req.Complete(false)
 		c := gonet.NewTCPConn(&wq, ep)
-		go handler(c, id.LocalAddress.String(), id.LocalPort)
+		go tcpHandler(c, id.LocalAddress.String(), id.LocalPort)
 	})
 	st.SetTransportProtocolHandler(tcp.ProtocolNumber, fwd.HandlePacket)
 
-	// UDP forwarder — DNS, QUIC, etc. need to reach real upstreams.
+	// UDP forwarder — DNS interception (when udpHandler claims the
+	// flow) or transparent relay (default).
 	udpFwd := udp.NewForwarder(st, func(req *udp.ForwarderRequest) bool {
 		id := req.ID()
 		var wq waiter.Queue
@@ -405,8 +417,15 @@ func (s *WGServer) EnablePromiscuousForwarder(handler func(c net.Conn, dstIP str
 		if err != nil {
 			return true
 		}
-		go relayUDP(gonet.NewUDPConn(&wq, ep),
-			id.LocalAddress.String(), id.LocalPort)
+		c := gonet.NewUDPConn(&wq, ep)
+		dstIP := id.LocalAddress.String()
+		dstPort := id.LocalPort
+		go func() {
+			if udpHandler != nil && udpHandler(c, dstIP, dstPort) {
+				return
+			}
+			relayUDP(c, dstIP, dstPort)
+		}()
 		return true
 	})
 	st.SetTransportProtocolHandler(udp.ProtocolNumber, udpFwd.HandlePacket)


### PR DESCRIPTION
SSH carries no SNI / Host header, so a TCP conn to port 22 can't be
disambiguated at accept time. The gateway runs a DNS server inside the
WG tunnel and answers A/AAAA queries for SSH-able hostnames with virtual
IPs from `10.78.0.0/16` (v4) and `fd78::/64` (v6). When a connection
lands on the VIP, dispatch recovers the hostname and the SSH endpoint
runtime terminates SSH on both halves, replaying the credential's
key/password upstream while passing the agent's username through
unchanged.

* New `dnsvip` package: hostname to (v4, v6) allocator + DNS server (UDP
  & TCP via miekg/dns wire format). VIPs persist to
  `<state_dir>/dnsvip.json` so they survive restarts AND policy reloads;
  freed IDs go on a free-list and are recycled by the next allocation.
* New `endpoint "ssh"` plugin: `ConnRouter` + `RequiresVIP` +
  `ConnEndpointRuntime`. Per-endpoint persisted ed25519 host key under
  `<ca_dir>/ssh/<endpoint>.key` (fingerprint logged on first mint).
  Accept-any-auth on the agent side; upstream auth via
  `golang.org/x/crypto/ssh` using the credential picked for the agent's
  username; channels, global requests, and stderr spliced both
  directions.
* New `credential "ssh"` plugin: empty body — auth material lives in the
  secret slots (`private_key`, `passphrase`, `password`, `host_pubkey`
  for upstream pinning). The credential never overrides the username.
* Per-username credential dispatch on the endpoint via the existing
  multi-credential machinery, spelled `user` for SSH:

  ```hcl
  endpoint "ssh" "shared-host" {
    hosts = ["shared.example.com:22"]
    credentials = [
      { user = "root",   credential = root-pass },
      { user = "deploy", credential = deploy-key },
      { credential = fallback-key },   # any other agent user
    ]
  }
  ```

  Or singular for the common case:

  ```hcl
  endpoint "ssh" "build-host" {
    hosts      = ["build.example.com:2222"]
    credential = build-host-cred
  }
  ```

* New `config/plugins/sshproto` package owns the protocol-specific
  `AuthCredential` interface and `Creds` struct, so `runtime` doesn't
  carry SSH-specific symbols. `runtime.AcceptCredentialRuntime` is the
  registration hook protocol packages call from `init()` to teach the
  credential checker about their interface.
* `runtime`: `CADir` and `DstPort` on `ConnHandle` (generic).
* `wireguard.go`: `EnablePromiscuousForwarder` gains a UDP handler that
  may claim the flow; falls through to `relayUDP` when unclaimed.
* `main.go`: dnsvip allocator built at boot, rebuilt on reload;
  forwarder dispatches `:53` (UDP+TCP) to dnsvip and any-port-on- VIP to
  a generic `handleVIPConn` that routes via the endpoint plugin's
  `ConnEndpointRuntime`.

## Not in this PR

**Protocol decode / rule enforcement.** The SSH runtime is transparent
today — it terminates auth, splices channels and global requests as
opaque byte streams, and emits one `Action: "allow"` event at session
start. Unlike the postgres runtime (which decodes Query / Parse,
extracts verb / tables / functions, runs each through `match.Request`
and emits per-query events), nothing inside an SSH session is currently
inspected or gateable. The wire is decodable inside `proxyChannel` —
`exec` / `shell` / `subsystem` / `direct-tcpip` / `tcpip-forward` all
flow through known hooks — and adding an `ssh_rule` family (mirroring
`sql_rule`) plus per-channel matching is a follow-up PR. Tracked
separately so this change stays focused on the wire gateway + DNS-VIP
plumbing.

Other deferred items: `ssh_rule` rule plugin, per-channel ACLs (no-exec
/ no-sftp / no-forward), reverse-forwarding policy.

## Tests

* `dnsvip` unit tests cover stable allocation, free-list recycling,
  persistence round-trip, exhaustion, A/AAAA round-trip,
  intercepted-host MX → NOERROR+empty, VIP reverse lookup, and
  CIDR-change drop.
* `pickSSHCredential` unit test covers exact-match wins, fallback on no
  match, no-match + no-fallback returns nil.
* End-to-end against a real upstream sshd on macOS arm64 and Linux
  x86_64: 50 sequential `echo` execs, 10 parallel sessions, 1 MB
  roundtrip, scp upload + download, local port-forward, exit- status
  codes 0/1/7/42/99 all faithful, stdout / stderr / stdin pipe all OK.
  Pass-through verified end-to-end with one credential shared across
  multiple upstream users (`ssh root@host` and `ssh operator@host`
  through the same gateway both land on the upstream as the username
  typed; `ssh nobody@host` rejected upstream because the key isn't
  authorised for that user).
