### PR TITLE
analytics: count-by charts, top routes, filtering

### DIFF
--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -14,7 +14,7 @@ import { getState, type Integration, type Agent, type Whoami } from "./lib/api";
 type Route =
   | { name: "main" }
   | { name: "device"; ip: string }
-  | { name: "analytics"; ip: string }
+  | { name: "analytics"; ip?: string }
   | { name: "onboard"; code: string }
   | { name: "request"; id: string };
 
@@ -27,12 +27,14 @@ function parseRoute(): Route {
     return { name: "onboard", code: decodeURIComponent(h.slice("#/onboard/".length)) };
   const r = h.match(/^#\/request\/([^/]+)$/);
   if (r) return { name: "request", id: decodeURIComponent(r[1]) };
+  if (h === "#/analytics") return { name: "analytics" };
+  const a = h.match(/^#\/analytics\/([^/]+)$/);
+  if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
+  // Legacy device/IP/analytics URL
   const da = h.match(/^#\/device\/([^/]+)\/analytics$/);
   if (da) return { name: "analytics", ip: decodeURIComponent(da[1]) };
   const m = h.match(/^#\/device\/([^/]+)$/);
   if (m) return { name: "device", ip: decodeURIComponent(m[1]) };
-  const a = h.match(/^#\/analytics\/(.+)$/);
-  if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
   return { name: "main" };
 }
 
@@ -92,6 +94,16 @@ export default function App() {
             >
               +
             </button>
+            <a
+              href="#/analytics"
+              className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
+              title="analytics"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 3v18h18" />
+                <path d="m7 16 4-8 4 4 4-6" />
+              </svg>
+            </a>
             <button
               onClick={() => setShowSettings(true)}
               className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
@@ -109,7 +121,7 @@ export default function App() {
                 agents={agents}
                 integrations={integrations}
                 onSelect={(ip) => navigate("#/device/" + encodeURIComponent(ip))}
-                onAnalytics={(ip) => navigate("#/device/" + encodeURIComponent(ip) + "/analytics")}
+                onAnalytics={(ip) => navigate("#/analytics/" + encodeURIComponent(ip))}
               />
             </div>
           </section>

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import * as Plot from "@observablehq/plot";
 import type { Agent, EventRecord } from "../lib/api";
-import { LiveRequests } from "./LiveRequests";
+
 
 const RANGES = [
   "1m", "5m", "15m", "30m", "1h", "6h", "24h",
 ] as const;
 type Range = typeof RANGES[number];
-type ColorBy = "host" | "status";
+type ColorBy = "host" | "status" | "device";
 type Scale = "log" | "linear";
 
 const RANGE_MS: Record<Range, number> = {
@@ -49,16 +49,31 @@ function useQS<T extends string>(
 // --- page ---
 
 export function AnalyticsPage({ ip, agents }: {
-  ip: string;
+  ip?: string;
   agents: Agent[];
 }) {
-  const deviceName =
-    agents.find(a => a.ip === ip)?.hostname || ip;
+  const deviceName = ip
+    ? agents.find(a => a.ip === ip)?.hostname || ip
+    : undefined;
   const [events, setEvents] = useState<EventRecord[]>([]);
+  const [range, setRange] =
+    useQS("range", "1h" as Range, RANGES);
+  const [filterDevice, setFilterDevice] = useState<
+    string | null
+  >(null);
+  const [filterHost, setFilterHost] = useState<
+    string | null
+  >(null);
+  const isGlobal = !ip;
+  const agentNames = new Map(
+    agents.map(a => [a.ip, a.hostname || a.ip]),
+  );
 
   useEffect(() => {
     setEvents([]);
-    const url = `/api/events?agent=${encodeURIComponent(ip)}`;
+    const url = ip
+      ? `/api/events?agent=${encodeURIComponent(ip)}`
+      : "/api/events";
     const es = new EventSource(url);
     // rAF-batched render: SSE on a busy gateway fires dozens of
     // events/sec. setState per event = re-render per event. Coalesce
@@ -84,52 +99,217 @@ export function AnalyticsPage({ ip, agents }: {
     };
   }, [ip]);
 
+  const cutoff = Date.now() - RANGE_MS[range];
+  const timeFiltered = events.filter(
+    (e) => new Date(e.ts).getTime() >= cutoff,
+  );
+  // Additional client-side filters from bar chart clicks
+  const filtered = timeFiltered.filter((e) => {
+    if (filterDevice && e.agent_ip !== filterDevice)
+      return false;
+    if (filterHost && e.host !== filterHost) return false;
+    return true;
+  });
+  const hasFilter = filterDevice || filterHost;
+  const filterLabel = filterDevice
+    ? agentNames.get(filterDevice) ?? filterDevice
+    : filterHost ?? "";
+
   return (
     <main className="flex-1 mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-8 space-y-6">
-      <nav className="text-[11px] text-[#a3a3a3] flex items-center gap-1.5">
-        <a href="#/" className="hover:text-[#171717]">
-          clawpatrol
-        </a>
-        <span>/</span>
-        <a
-          href={`#/device/${encodeURIComponent(ip)}`}
-          className="hover:text-[#171717]"
-        >
-          {deviceName}
-        </a>
-        <span>/</span>
-        <span className="text-[#525252]">analytics</span>
-      </nav>
-      <LatencyChart events={events} />
-      <LiveRequests agentIP={ip} height="500px" />
+      <div className="flex items-center justify-between">
+        <div className="flex items-baseline gap-2">
+          <a href="#/" className="text-[11px] text-[#a3a3a3] hover:text-[#171717]">
+            clawpatrol
+          </a>
+          <span className="text-[11px] text-[#a3a3a3]">/</span>
+          {deviceName ? (
+            <>
+              <a
+                href={`#/device/${encodeURIComponent(ip!)}`}
+                className="text-[16px] font-semibold text-[#171717] hover:underline"
+              >
+                {deviceName}
+              </a>
+              <span className="text-[11px] text-[#a3a3a3]">/</span>
+            </>
+          ) : null}
+          <span className="text-[11px] text-[#525252]">analytics</span>
+          {hasFilter && (
+            <button
+              onClick={() => { setFilterDevice(null); setFilterHost(null); }}
+              className="ml-2 px-2.5 py-0.5 rounded text-[11px] border border-[#171717] bg-[#171717] text-white flex items-center gap-1.5"
+            >
+              {filterLabel}
+              <span className="text-[10px]">&times;</span>
+            </button>
+          )}
+        </div>
+        <Toggle
+          options={[...RANGES]}
+          value={range}
+          onChange={setRange}
+        />
+      </div>
+
+      <div className={"grid gap-4 " + (isGlobal ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1")}>
+        {isGlobal && (
+          <BarCard
+            title="Count by device"
+            events={timeFiltered}
+            field="agent_ip"
+            active={filterDevice}
+            labelFn={(v) => agentNames.get(v) ?? v}
+            colorFn={deviceColor}
+            onClickFn={(v) => {
+              setFilterDevice(
+                filterDevice === v ? null : v,
+              );
+              setFilterHost(null);
+            }}
+          />
+        )}
+        <BarCard
+          title="Count by host"
+          events={timeFiltered}
+          field="host"
+          active={filterHost}
+          onClickFn={(v) => {
+            setFilterHost(filterHost === v ? null : v);
+            setFilterDevice(null);
+          }}
+        />
+      </div>
+      <LatencyChart
+        events={events}
+        filtered={filtered}
+        isGlobal={isGlobal}
+        agents={agents}
+      />
+      <TopRoutes events={filtered} />
+      <EventList events={filtered} />
     </main>
   );
 }
 
+// --- event list (time-filtered) ---
+
+function EventList({ events }: { events: EventRecord[] }) {
+  return (
+    <div className="bg-white border border-[#e5e5e5] rounded overflow-hidden"
+      style={{ height: "500px" }}
+    >
+      <div className="flex items-center px-4 py-2.5 text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] border-b border-[#e5e5e5]">
+        <span>REQUESTS</span>
+        <span className="ml-2 tabular-nums">{events.length}</span>
+      </div>
+      <div className="flex-1 overflow-y-auto" style={{ height: "calc(100% - 36px)" }}>
+        {events.length === 0 ? (
+          <div className="px-5 py-8 text-center text-[11px] text-[#a3a3a3]">
+            No requests in this time range
+          </div>
+        ) : events.map((e, i) => (
+          <EventRow key={e.id || i} ev={e} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EventRow({ ev }: { ev: EventRecord }) {
+  const onClick = ev.id
+    ? () => { window.location.hash = `#/request/${ev.id}`; }
+    : undefined;
+  const t = new Date(ev.ts);
+  const time = t.toLocaleTimeString([], { hour12: false })
+    + "." + String(t.getMilliseconds()).padStart(3, "0");
+  const status = ev.status || 0;
+  const statusColor =
+    status >= 500 ? "text-[#dc2626]"
+    : status >= 400 ? "text-[#ea580c]"
+    : status >= 300 ? "text-[#ca8a04]"
+    : status >= 200 ? "text-[#16a34a]"
+    : "text-[#737373]";
+  const path = ev.path ?? "";
+  const sep = path.startsWith("/") ? "" : " ";
+  return (
+    <div
+      onClick={onClick}
+      className={
+        "px-4 py-2 border-b border-[#f5f5f5] flex items-center gap-3 min-w-0 transition-colors hover:bg-[#f9f9f9]"
+        + (onClick ? " cursor-pointer" : "")
+      }
+    >
+      <span className="text-[10px] tabular-nums text-[#a3a3a3] flex-shrink-0">{time}</span>
+      {ev.method && (
+        <span className="text-[10px] uppercase font-semibold text-[#525252] flex-shrink-0 w-[44px]">{ev.method}</span>
+      )}
+      <span className={"text-[11px] tabular-nums flex-shrink-0 w-[36px] " + statusColor}>
+        {status || "\u2014"}
+      </span>
+      <span className="text-[12px] text-[#171717] truncate flex-1 min-w-0">
+        <span className="text-[#737373]">{ev.host}</span>
+        {sep && <span> </span>}
+        <span>{path}</span>
+      </span>
+      <span className="text-[10px] tabular-nums text-[#a3a3a3] flex-shrink-0">
+        {ev.ms}ms
+      </span>
+    </div>
+  );
+}
+
+// --- stable color from string hash ---
+
+function stableHue(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = Math.imul(31, h) + s.charCodeAt(i) | 0;
+  }
+  return ((h % 360) + 360) % 360;
+}
+// Hosts: warm palette (saturated, mid-lightness)
+const hostColor = (s: string) =>
+  `hsl(${stableHue(s)}, 70%, 45%)`;
+// Devices: cool-shifted, lower saturation, darker
+const deviceColor = (s: string) =>
+  `hsl(${(stableHue(s) + 180) % 360}, 50%, 35%)`;
+
 // --- chart ---
 
-function LatencyChart({ events }: {
+function LatencyChart({ filtered, isGlobal, agents }: {
   events: EventRecord[];
+  filtered: EventRecord[];
+  isGlobal: boolean;
+  agents: Agent[];
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const colorOptions: ColorBy[] = isGlobal
+    ? ["device", "host", "status"]
+    : ["host", "status"];
   const [colorBy, setColorBy] =
-    useQS("color", "host" as ColorBy, ["host", "status"]);
+    useQS("color", colorOptions[0], colorOptions);
   const [scale, setScale] =
     useQS("scale", "log" as Scale, ["log", "linear"]);
-  const [range, setRange] =
-    useQS("range", "5m" as Range, RANGES);
+  const [range] =
+    useQS("range", "1h" as Range, RANGES);
+
+  const agentNames = new Map(
+    agents.map(a => [a.ip, a.hostname || a.ip]),
+  );
 
   useEffect(() => {
-    if (!ref.current || events.length === 0) return;
+    if (!ref.current || filtered.length === 0) return;
 
     const cutoff = Date.now() - RANGE_MS[range];
-    const dots = events
-      .filter((e) => e.ms > 0 && new Date(e.ts).getTime() >= cutoff)
+    const dots = filtered
+      .filter((e) => e.ms > 0)
       .map((e) => ({
         t: new Date(e.ts),
         ms: e.ms,
         host: e.host,
         id: e.id,
+        device: agentNames.get(e.agent_ip ?? "") ?? e.agent_ip ?? "?",
         statusCode: e.status ?? 0,
         status: e.status
           ? e.status >= 500 ? "5xx"
@@ -144,28 +324,31 @@ function LatencyChart({ events }: {
       return;
     }
 
-    const statusColor = {
-      domain: ["2xx", "3xx", "4xx", "5xx", "\u2014"],
-      range: [
-        "#16a34a", "#ca8a04", "#ea580c",
-        "#dc2626", "#a3a3a3",
-      ],
-      legend: true,
-    };
+    const colorField =
+      colorBy === "status" ? "status"
+      : colorBy === "device" ? "device"
+      : "host";
 
-    const hosts = [...new Set(dots.map(d => d.host))];
-    const PALETTE = [
-      "#2563eb", "#16a34a", "#ea580c", "#7c3aed",
-      "#0891b2", "#ca8a04", "#dc2626", "#4f46e5",
-      "#059669", "#d97706", "#be185d", "#0d9488",
-    ];
-    const hostColor = {
-      domain: hosts,
-      range: hosts.map(
-        (_, i) => PALETTE[i % PALETTE.length],
-      ),
-      legend: true,
-    };
+    const vals = [...new Set(dots.map(
+      d => d[colorField] as string,
+    ))];
+
+    const colorCfg = colorBy === "status"
+      ? {
+          domain: ["2xx", "3xx", "4xx", "5xx", "\u2014"],
+          range: [
+            "#16a34a", "#ca8a04", "#ea580c",
+            "#dc2626", "#a3a3a3",
+          ],
+          legend: true,
+        }
+      : {
+          domain: vals,
+          range: vals.map((v) =>
+            colorBy === "device" ? deviceColor(v) : hostColor(v),
+          ),
+          legend: true,
+        };
 
     const chart = Plot.plot({
       width: ref.current.clientWidth,
@@ -182,26 +365,21 @@ function LatencyChart({ events }: {
         label: null,
         domain: [new Date(cutoff), new Date()],
       },
-      color: colorBy === "status"
-        ? statusColor : hostColor,
+      color: colorCfg,
       marks: [
         Plot.dot(dots, {
           x: "t",
           y: "ms",
-          fill: colorBy === "status" ? "status" : "host",
+          fill: colorField,
           r: 3,
           fillOpacity: 0.7,
-          channels: {
-            host: "host",
-            statusCode: "statusCode",
-            id: "id",
-          },
+          channels: { id: "id" },
         }),
         Plot.tip(dots, Plot.pointer({
           x: "t",
           y: "ms",
           title: (d: typeof dots[0]) =>
-            `${d.host}\n${d.statusCode || "\u2014"} \u2022 ${d.ms}ms`,
+            `${d.host}\n${d.device}\n${d.statusCode || "\u2014"} \u2022 ${d.ms}ms`,
         })),
         Plot.ruleY([0]),
       ],
@@ -221,9 +399,30 @@ function LatencyChart({ events }: {
       (c as SVGElement).style.cursor = "pointer";
     });
 
+    // Make legend swatches clickable when colored by device
+    if (colorBy === "device") {
+      const nameToIP = new Map(
+        agents.map(a => [a.hostname || a.ip, a.ip]),
+      );
+      chart.querySelectorAll(
+        "[aria-label='color'] [aria-label]",
+      ).forEach((el) => {
+        const label = el.getAttribute("aria-label") ?? "";
+        const devIP = nameToIP.get(label);
+        if (!devIP) return;
+        const span = el as HTMLElement;
+        span.style.cursor = "pointer";
+        span.addEventListener("click", (e) => {
+          e.stopPropagation();
+          window.location.hash =
+            `#/analytics/${encodeURIComponent(devIP)}`;
+        });
+      });
+    }
+
     ref.current.replaceChildren(chart);
     return () => chart.remove();
-  }, [events, colorBy, scale, range]);
+  }, [filtered, colorBy, scale, range]);
 
   return (
     <div className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
@@ -233,12 +432,7 @@ function LatencyChart({ events }: {
         </span>
         <div className="flex items-center gap-4">
           <Toggle
-            options={[...RANGES]}
-            value={range}
-            onChange={setRange}
-          />
-          <Toggle
-            options={["host", "status"] as ColorBy[]}
+            options={colorOptions}
             value={colorBy}
             onChange={setColorBy}
           />
@@ -250,7 +444,7 @@ function LatencyChart({ events }: {
         </div>
       </div>
       <div ref={ref} className="p-4 min-h-[320px]">
-        {events.length === 0 && (
+        {filtered.length === 0 && (
           <div className="flex items-center justify-center h-[280px] text-[11px] text-[#a3a3a3]">
             Collecting data...
           </div>
@@ -285,6 +479,177 @@ function Toggle<T extends string>({
           {o}
         </button>
       ))}
+    </div>
+  );
+}
+
+// --- top routes ---
+
+type RouteRow = {
+  key: string;
+  method: string;
+  host: string;
+  path: string;
+  count: number;
+  avgMs: number;
+  p99Ms: number;
+};
+
+function TopRoutes({ events }: { events: EventRecord[] }) {
+  const [sortBy, setSortBy] = useState<
+    "count" | "avgMs" | "p99Ms"
+  >("count");
+
+  const byRoute = new Map<string, number[]>();
+  for (const e of events) {
+    if (!e.ms) continue;
+    const k = `${e.method ?? ""}|${e.host}|${e.path ?? ""}`;
+    const arr = byRoute.get(k);
+    if (arr) arr.push(e.ms);
+    else byRoute.set(k, [e.ms]);
+  }
+
+  const rows: RouteRow[] = [];
+  for (const [k, latencies] of byRoute) {
+    const [method, host, path] = k.split("|");
+    const sorted = latencies.slice().sort((a, b) => a - b);
+    const avg = sorted.reduce((a, b) => a + b, 0) /
+      sorted.length;
+    const p99i = Math.floor(sorted.length * 0.99);
+    rows.push({
+      key: k,
+      method,
+      host,
+      path,
+      count: sorted.length,
+      avgMs: Math.round(avg),
+      p99Ms: sorted[Math.min(p99i, sorted.length - 1)],
+    });
+  }
+
+  rows.sort((a, b) => b[sortBy] - a[sortBy]);
+  if (!rows.length) return null;
+  const maxCount = rows[0].count;
+
+  const hdr = (
+    label: string,
+    field: "count" | "avgMs" | "p99Ms",
+  ) => (
+    <th
+      className="px-2 py-1.5 text-right text-[10px] font-medium uppercase text-[#a3a3a3] cursor-pointer hover:text-[#525252] select-none"
+      onClick={() => setSortBy(field)}
+    >
+      {label}{sortBy === field ? " \u25BE" : ""}
+    </th>
+  );
+
+  const fmtMs = (ms: number) => {
+    if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${ms}ms`;
+  };
+
+  return (
+    <div className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
+      <div className="px-4 py-2.5 text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] border-b border-[#e5e5e5]">
+        Top Routes
+      </div>
+      <table className="w-full table-fixed text-[11px]">
+        <thead>
+          <tr className="border-b border-[#f5f5f5]">
+            <th className="px-3 py-1.5 text-left text-[10px] font-medium uppercase text-[#a3a3a3]">
+              Route
+            </th>
+            {hdr("Reqs", "count")}
+            {hdr("Avg", "avgMs")}
+            {hdr("p99", "p99Ms")}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 20).map((d) => {
+            const pct = maxCount > 0
+              ? (d.count / maxCount) * 100 : 0;
+            return (
+              <tr
+                key={d.key}
+                className="border-b border-[#f5f5f5] hover:bg-[#f9f9f9]"
+              >
+                <td className="px-3 py-1.5 font-mono truncate max-w-0" title={`${d.method} ${d.host}${d.path}`}>
+                  <span className="text-[#a3a3a3]">{d.method}</span>{" "}{d.host}<span className="text-[#525252]">{d.path}</span>
+                </td>
+                <td className="px-2 py-1.5 text-right whitespace-nowrap">
+                  <div className="flex items-center justify-end gap-1.5">
+                    <div className="w-12 h-1.5 bg-[#f5f5f5] rounded-full">
+                      <div className="h-full bg-[#a3a3a3] rounded-full" style={{ width: `${pct}%` }} />
+                    </div>
+                    <span className="w-6 text-right tabular-nums">{d.count}</span>
+                  </div>
+                </td>
+                <td className="px-2 py-1.5 text-right text-[#737373] tabular-nums">{fmtMs(d.avgMs)}</td>
+                <td className="px-2 py-1.5 text-right text-[#737373] tabular-nums">{fmtMs(d.p99Ms)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// --- horizontal bar card ---
+
+function BarCard({ title, events, field, active, labelFn, colorFn, onClickFn }: {
+  title: string;
+  events: EventRecord[];
+  field: "host" | "agent_ip";
+  active?: string | null;
+  labelFn?: (v: string) => string;
+  colorFn?: (label: string) => string;
+  onClickFn?: (v: string) => void;
+}) {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const v = (field === "host" ? e.host : e.agent_ip) ?? "";
+    if (!v) continue;
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  const items = [...counts.entries()]
+    .map(([k, v]) => ({ key: k, label: labelFn ? labelFn(k) : k, value: v }))
+    .sort((a, b) => b.value - a.value);
+
+  if (!items.length) return null;
+  const max = items[0].value;
+
+  return (
+    <div className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
+      <div className="px-4 py-2.5 text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] border-b border-[#e5e5e5]">
+        {title}
+      </div>
+      <div className="p-3 space-y-0.5">
+        {items.map((item) => {
+          const pct = max > 0 ? (item.value / max) * 100 : 0;
+          const isActive = active === item.key;
+          return (
+            <div
+              key={item.key}
+              className={
+                "flex items-center gap-2 px-1 py-0.5 rounded cursor-pointer "
+                + (isActive ? "bg-[#f0f0f0]" : "hover:bg-[#f5f5f5]")
+              }
+              onClick={onClickFn ? () => onClickFn(item.key) : undefined}
+            >
+              <span className={"w-32 truncate text-[11px] " + (isActive ? "text-[#171717] font-semibold" : "text-[#525252]")} title={item.label}>
+                {item.label}
+              </span>
+              <div className="flex-1 h-3 bg-[#f5f5f5] rounded-full">
+                <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: isActive ? "#171717" : (colorFn ? colorFn(item.label) : hostColor(item.label)) }} />
+              </div>
+              <span className="w-8 text-right text-[11px] text-[#737373] tabular-nums">
+                {item.value}
+              </span>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -108,6 +108,16 @@ export function DevicePage({
               }
             }}
           />
+          <a
+            href={`#/analytics/${encodeURIComponent(ip)}`}
+            title="analytics"
+            className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 3v18h18" />
+              <path d="m7 16 4-8 4 4 4-6" />
+            </svg>
+          </a>
           <button
             type="button"
             onClick={remove}

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -169,16 +169,16 @@ function Breadcrumbs({ agentIP, agentName, requestId }: {
   requestId?: string;
 }) {
   return (
-    <nav className="text-[11px] text-[#a3a3a3] flex items-center gap-1.5">
-      <a href="#/" className="hover:text-[#171717]">
+    <nav className="flex items-baseline gap-2">
+      <a href="#/" className="text-[11px] text-[#a3a3a3] hover:text-[#171717]">
         clawpatrol
       </a>
       {agentIP && (
         <>
-          <span>/</span>
+          <span className="text-[11px] text-[#a3a3a3]">/</span>
           <a
             href={`#/device/${encodeURIComponent(agentIP)}`}
-            className="hover:text-[#171717]"
+            className="text-[16px] font-semibold text-[#171717] hover:underline"
           >
             {agentName || agentIP}
           </a>
@@ -186,8 +186,8 @@ function Breadcrumbs({ agentIP, agentName, requestId }: {
       )}
       {requestId && (
         <>
-          <span>/</span>
-          <span className="text-[#525252] font-mono">
+          <span className="text-[11px] text-[#a3a3a3]">/</span>
+          <span className="text-[11px] text-[#525252] font-mono">
             {requestId.slice(0, 8)}
           </span>
         </>


### PR DESCRIPTION

<img width="1080" height="817" alt="Screenshot 2026-05-05 at 9 37 59 PM" src="https://github.com/user-attachments/assets/3117871c-6239-490a-820b-eaf8d182a8a8" />

## Summary
- Count-by-device and count-by-host horizontal bar charts at top of analytics page
- Click a bar to filter latency chart, top routes, and request list; click again or x to clear
- Top Routes sortable table (reqs, avg latency, p99)
- Time-range-filtered request list replaces LiveRequests
- Stable hash-based colors (host and device get distinct palettes)
- Analytics URL: #/analytics (all), #/analytics/<ip> (per-device)
- Analytics button on device page + index header
- Breadcrumbs + time range on single line

## Test plan
- [ ] Global analytics shows count-by-device + count-by-host side by side
- [ ] Click a device/host bar to filter, click again or x pill to clear
- [ ] Latency chart colors match bar chart colors in host mode
- [ ] Time range toggle filters all sections consistently