### PR TITLE
Fix broken cross-links between glossary and architecture docs

### DIFF
--- a/site/doc/01-introduction.md
+++ b/site/doc/01-introduction.md
@@ -50,10 +50,10 @@ a SQLite database.
 
 ## Next Steps
 
-- [Getting Started](02-getting-started) — install and
+- [Getting Started](/docs/02-getting-started/) — install and
   onboard in 2 minutes
-- [CLI Reference](05-cli) — all commands and options
-- [Plugin System](08-plugins) — extend Claw Patrol for custom
+- [CLI Reference](/docs/05-cli/) — all commands and options
+- [Plugin System](/docs/08-plugins/) — extend Claw Patrol for custom
   services
-- [Approval Rules](12-approval-rules) — gate outbound
+- [Approval Rules](/docs/12-approval-rules/) — gate outbound
   actions: allow, deny, defer to a human or an LLM judge

--- a/site/doc/02-getting-started.md
+++ b/site/doc/02-getting-started.md
@@ -27,7 +27,7 @@ On macOS, you'll be prompted to approve a Network Extension
 and proxy configuration. On Linux, you can choose between a
 systemd service or an ephemeral process.
 
-See [Onboarding](03-onboarding) for all the details about the
+See [Onboarding](/docs/03-onboarding/) for all the details about the
 onboarding process.
 
 ## Run an Agent

--- a/site/doc/03a-glossary.md
+++ b/site/doc/03a-glossary.md
@@ -26,7 +26,7 @@ hosts the dashboard and HITL pool, and forwards traffic upstream after
 secret injection. Configured by a top-level HCL file (`gateway.hcl`)
 split into operational fields (listen address, CA dir, WireGuard
 config) and the rest of the global config blocks.
-See [Architecture](04-architecture.md).
+See [Architecture](/docs/04-architecture/).
 
 ### Agent
 
@@ -137,7 +137,7 @@ forges a per-host certificate signed by the Claw Patrol CA, terminates
 TLS itself, and re-establishes a fresh TLS connection upstream. The
 [per-host cert](#per-host-cert) is generated on demand and cached.
 This is also why the agent must trust the Claw Patrol CA. See
-[Architecture › MitM TLS Interception](04-architecture.md#mitm-tls-interception).
+[Architecture › MitM TLS Interception](/docs/04-architecture/#mitm-tls-interception).
 
 ### Per-host cert
 
@@ -325,4 +325,4 @@ SCRAM / cleartext handshake against the upstream and synthesizes
 See [MitM](#mitm) and [per-host cert](#per-host-cert) under Concepts.
 The interception bridge uses node:tls's
 "loopback bridge" pattern — see
-[Architecture › MitM TLS Interception](04-architecture.md#mitm-tls-interception).
+[Architecture › MitM TLS Interception](/docs/04-architecture/#mitm-tls-interception).

--- a/site/doc/04-architecture.md
+++ b/site/doc/04-architecture.md
@@ -353,4 +353,4 @@ prefix per RFC 1035.
 Every proxied request/response is logged to the SQLite database
 at `$CLAWPATROL_DATA/clients.db` with a 7-day retention (configurable
 via `ANALYTICS_RETENTION_DAYS`). See
-[Self-Hosting](06-self-hosting.md) for details.
+[Self-Hosting](/docs/06-self-hosting/) for details.

--- a/site/doc/04-architecture.md
+++ b/site/doc/04-architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> See [Glossary](03a-glossary.md) for definitions of gateway, endpoint,
+> See [Glossary](/docs/03a-glossary/) for definitions of gateway, endpoint,
 > credential, rule, profile, plugin, runtime, and the rest of the
 > vocabulary used below.
 

--- a/site/doc/06-self-hosting.md
+++ b/site/doc/06-self-hosting.md
@@ -43,7 +43,7 @@ docker run -v ~/.clawpatrol:/root/.clawpatrol -p 8080:8080 -p 8443:8443 clawpatr
 All configuration is via environment variables. Set them in
 your shell profile, systemd unit, or launchd plist.
 
-See [CLI Reference](05-cli) for the full list.
+See [CLI Reference](/docs/05-cli/) for the full list.
 
 ## Extending with Providers
 

--- a/site/doc/07-gateway.md
+++ b/site/doc/07-gateway.md
@@ -94,4 +94,4 @@ API.
 
 Local-gateway install modes (launchd on macOS, systemd system/user/linger
 on Linux, ephemeral per-invocation) are documented in
-[03-onboarding.md](03-onboarding.md).
+[Onboarding](/docs/03-onboarding/).

--- a/site/doc/08-plugins.md
+++ b/site/doc/08-plugins.md
@@ -233,7 +233,7 @@ Endpoints with `port !== 443` automatically get DNS entries registered. The
 framework scans endpoint `domains` and `port` to build the DNS entry table.
 WireGuard clients querying DNS for matching hostnames receive a virtual IP
 from `10.78.0.0/16`. Connections to those VIPs are routed to the proxy via
-iptables DNAT. See `doc/04-architecture.md` for details.
+iptables DNAT. See [Architecture](/docs/04-architecture/) for details.
 
 ### Config schema
 

--- a/site/doc/12-approval-rules.md
+++ b/site/doc/12-approval-rules.md
@@ -10,11 +10,11 @@ actions, how decisions are dispatched, where rules are stored, and the
 HTTP API surface used by the dashboard.
 
 For the broader request flow see
-[04-architecture.md](04-architecture.md) and
-[07-gateway.md](07-gateway.md). For the agent trust boundary see
-[11-security-model.md](11-security-model.md). For LLM cost concerns
+[Architecture](/docs/04-architecture/) and
+[Gateway](/docs/07-gateway/). For the agent trust boundary see
+[Security Model](/docs/11-security-model/). For LLM cost concerns
 referenced by the `require_llm` decision see
-[09-token-usage.md](09-token-usage.md).
+[Token Usage](/docs/09-token-usage/).
 
 
 ## Where rules sit
@@ -336,7 +336,7 @@ curl -s http://localhost:8080/api/action-schemas | jq
 
 Each entry comes from a plugin's `actionSchemas` export -- plugins
 declare their schemas through the plugin SDK; see
-[08-plugins.md](08-plugins.md). The catalog only ships the facet *keys*,
+[Plugins](/docs/08-plugins/). The catalog only ships the facet *keys*,
 not the full Zod schemas (Zod schemas are not JSON-serializable). The
 rule builder uses these keys to surface the supported `<facet>.<field>`
 prefixes.
@@ -384,7 +384,7 @@ After `evaluate()` selects a rule, `approvals/index.ts` lowers
   rule id and approver identity.
 
 The cost of these reviews shows up in the request log like any other
-LLM call -- see [09-token-usage.md](09-token-usage.md). Use the cache
+LLM call -- see [Token Usage](/docs/09-token-usage/). Use the cache
 TTL aggressively for repetitive actions.
 
 ### `require_human`
@@ -496,7 +496,7 @@ is fixed at `"pattern"`.
 
 All endpoints are under `/api/` on the dashboard listener (default
 `127.0.0.1:8080`). They require an authenticated session -- see
-[06-self-hosting.md](06-self-hosting.md) for how to drive them
+[Self-Hosting](/docs/06-self-hosting/) for how to drive them
 programmatically with a session cookie.
 
 ### `GET /api/rules`

--- a/site/doc/90-dev-setup.md
+++ b/site/doc/90-dev-setup.md
@@ -115,7 +115,7 @@ cd /path/to/clawpatrol
 docker build -t clawpatrol/sidecar:dev sidecar/
 ```
 
-Run the onboard script (see [03-onboarding.md](03-onboarding.md) for
+Run the onboard script (see [Onboarding](/docs/03-onboarding/) for
 the full flow):
 
 ```sh


### PR DESCRIPTION
The four cross-links between `site/doc/03a-glossary.md` and `site/doc/04-architecture.md` use relative `.md` paths. The site renders each doc at `/docs/<slug>/index.html` (`site/build-docs.ts`), and `marked` has no `.md` → slug rewriter, so `[Architecture](04-architecture.md)` resolves to `/docs/03a-glossary/04-architecture.md` and 404s.

Switches all four to absolute slug paths (`/docs/<slug>/[#anchor]`).