### PR TITLE
dnsvip: synthesise A/AAAA from gateway resolver for non-VIP names

### DIFF
--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -22,6 +22,7 @@
 package dnsvip
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -41,6 +42,15 @@ import (
 
 	"github.com/denoland/clawpatrol/config"
 )
+
+// hostResolver routes A/AAAA lookups for non-VIP names through the
+// gateway's host resolver chain — /etc/hosts + /etc/resolv.conf +
+// any platform-native split-horizon entries (Tailscale MagicDNS,
+// VPN-pushed servers, corp resolvers). PreferGo bypasses cgo's
+// getaddrinfo so macOS mDNSResponder doesn't coalesce the gateway's
+// own lookup onto the agent's in-flight tunnelled query and deadlock
+// both — the same hardening unclaw landed in dns.ts.
+var hostResolver = &net.Resolver{PreferGo: true}
 
 // RequiresVIP is the marker an endpoint plugin's body implements when
 // its hostnames need DNS-VIP interception (because the wire protocol
@@ -572,18 +582,102 @@ func (a *Allocator) intercepts(hostname string) bool {
 	return ok
 }
 
-// forwardUpstream sends the query to the IP the agent originally
-// addressed and returns the upstream's reply. Errors are converted to
-// SERVFAIL so the agent's resolver gets a clean response — log line
-// captures the actual cause.
+// forwardUpstream answers a query the VIP table didn't claim. For A
+// and AAAA we synthesise the response from the gateway's host
+// resolver — /etc/hosts, /etc/resolv.conf, and any platform-native
+// split-horizon backends — so internal names the operator's machine
+// can resolve work transparently inside `clawpatrol run`. The naive
+// alternative (forwarding verbatim to the dstIP the agent's
+// resolv.conf pointed at — typically 1.1.1.1 from the WG conf's
+// PostUp) produces NXDOMAIN for any internal name and is the bug
+// this layer exists to fix.
+//
+// Other record types (TXT / SRV / MX / CAA / etc.) keep their raw-
+// relay behavior. Go's stdlib doesn't expose a generic "any record
+// type" lookup, so synthesising from the local resolver would mean
+// re-implementing per-type serialisation against an incomplete API
+// surface. Relaying preserves wire fidelity (EDNS, flags, DNSSEC
+// records) and matches operator intent — if the agent's resolv.conf
+// names a specific resolver, that resolver answers TXT lookups.
+//
+// Errors collapse to NXDOMAIN (synthesised path) or SERVFAIL (relay
+// path). The split keeps the synth path's "name doesn't exist"
+// signal distinct from the relay path's "upstream unreachable".
 func (a *Allocator) forwardUpstream(q *dns.Msg, dstIP string) *dns.Msg {
+	if len(q.Question) == 0 {
+		return errorResp(q, dns.RcodeFormatError)
+	}
+	qd := q.Question[0]
+	switch qd.Qtype {
+	case dns.TypeA:
+		return synthIPResponse(q, "ip4")
+	case dns.TypeAAAA:
+		return synthIPResponse(q, "ip6")
+	default:
+		return relayUpstream(q, dstIP)
+	}
+}
+
+// synthIPResponse resolves the query name via the gateway's host
+// resolver and builds an A or AAAA response. network is "ip4" or
+// "ip6"; the returned message reuses the query's id and question.
+func synthIPResponse(q *dns.Msg, network string) *dns.Msg {
+	qd := q.Question[0]
+	name := strings.TrimSuffix(qd.Name, ".")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ips, err := hostResolver.LookupIP(ctx, network, name)
+	if err != nil || len(ips) == 0 {
+		// LookupIP folds DNS error codes (NXDOMAIN, SERVFAIL,
+		// timeout) into a single error type. Treat any failure as
+		// NXDOMAIN — the gateway has already exhausted its local
+		// resolver chain, and there's nowhere else to consult that
+		// would know about an internal name the operator's machine
+		// doesn't know about either.
+		return errorResp(q, dns.RcodeNameError)
+	}
+	resp := new(dns.Msg)
+	resp.SetReply(q)
+	resp.RecursionAvailable = true
+	for _, ip := range ips {
+		hdr := dns.RR_Header{
+			Name:   qd.Name,
+			Rrtype: qd.Qtype,
+			Class:  dns.ClassINET,
+			Ttl:    30,
+		}
+		switch qd.Qtype {
+		case dns.TypeA:
+			if ip4 := ip.To4(); ip4 != nil {
+				resp.Answer = append(resp.Answer, &dns.A{Hdr: hdr, A: ip4})
+			}
+		case dns.TypeAAAA:
+			if ip4 := ip.To4(); ip4 == nil {
+				resp.Answer = append(resp.Answer, &dns.AAAA{Hdr: hdr, AAAA: ip})
+			}
+		}
+	}
+	if len(resp.Answer) == 0 {
+		// Resolver returned addresses but none matched the query
+		// family (e.g. AAAA query, IPv4-only host). Empty NOERROR
+		// response — same shape DNS servers use for "name exists,
+		// no records of this type."
+		return resp
+	}
+	return resp
+}
+
+// relayUpstream forwards the query verbatim to the dstIP the agent
+// originally addressed and returns whatever comes back. Used for
+// record types the synth path doesn't handle.
+func relayUpstream(q *dns.Msg, dstIP string) *dns.Msg {
 	if dstIP == "" {
 		return errorResp(q, dns.RcodeServerFailure)
 	}
 	c := &dns.Client{Net: "udp", Timeout: 3 * time.Second}
 	in, _, err := c.Exchange(q, net.JoinHostPort(dstIP, "53"))
 	if err != nil {
-		log.Printf("dnsvip: forward to %s: %v", dstIP, err)
+		log.Printf("dnsvip: relay to %s: %v", dstIP, err)
 		return errorResp(q, dns.RcodeServerFailure)
 	}
 	return in

--- a/dnsvip/dnsvip_test.go
+++ b/dnsvip/dnsvip_test.go
@@ -340,3 +340,85 @@ func TestPersistenceDropsOutOfRangeEntries(t *testing.T) {
 		t.Fatalf("dnsvip.json unreadable: %v", err)
 	}
 }
+
+// TestForwardUpstreamSynthesisesA covers the happy path of the
+// synthesis route: a name the gateway's host resolver knows about
+// (here "localhost", which every standards-compliant /etc/hosts
+// declares) round-trips to an A record without touching dstIP. This
+// is the path that lets agents reach internal-only names like
+// `clickhouse-o11y` even when their resolver inside the WG
+// namespace points at 1.1.1.1.
+func TestForwardUpstreamSynthesisesA(t *testing.T) {
+	a, err := New(t.TempDir(), DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("localhost.", dns.TypeA)
+
+	// dstIP is empty: if synthesis fails we'd fall to relayUpstream,
+	// which returns SERVFAIL for empty dstIP. Either an NXDOMAIN or
+	// a SERVFAIL would tell us the synth path didn't run.
+	resp := a.forwardUpstream(q, "")
+	if resp == nil {
+		t.Fatal("forwardUpstream returned nil")
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("rcode = %d (%s), want NOERROR — synth path didn't fire",
+			resp.Rcode, dns.RcodeToString[resp.Rcode])
+	}
+	if len(resp.Answer) == 0 {
+		t.Fatal("no answer records — local resolver should have returned 127.0.0.1")
+	}
+	rr, ok := resp.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("first answer is not an A record: %T", resp.Answer[0])
+	}
+	if !rr.A.IsLoopback() {
+		t.Errorf("localhost resolved to %v, expected loopback", rr.A)
+	}
+}
+
+// TestForwardUpstreamNXDomainOnUnresolvable covers the failure
+// branch of the synth path: the .invalid TLD is RFC-reserved as
+// "guaranteed not to resolve", so any compliant resolver returns
+// NXDOMAIN. Confirms we don't accidentally fall through to the
+// relay path on resolution errors.
+func TestForwardUpstreamNXDomainOnUnresolvable(t *testing.T) {
+	a, err := New(t.TempDir(), DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("nothing-here.invalid.", dns.TypeA)
+	resp := a.forwardUpstream(q, "")
+	if resp == nil {
+		t.Fatal("forwardUpstream returned nil")
+	}
+	if resp.Rcode != dns.RcodeNameError {
+		t.Errorf("rcode = %d (%s), want NXDOMAIN",
+			resp.Rcode, dns.RcodeToString[resp.Rcode])
+	}
+}
+
+// TestForwardUpstreamRelaysOtherTypes confirms TXT (and by
+// extension SRV/MX/CAA/etc.) skips the synth path and goes through
+// relayUpstream. We send dstIP="" so the relay path returns
+// SERVFAIL (its empty-dstIP guard) — the route taken is the
+// observable behavior.
+func TestForwardUpstreamRelaysOtherTypes(t *testing.T) {
+	a, err := New(t.TempDir(), DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeTXT)
+	resp := a.forwardUpstream(q, "")
+	if resp == nil {
+		t.Fatal("forwardUpstream returned nil")
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Errorf("rcode = %d (%s), want SERVFAIL — TXT should have hit relayUpstream's empty-dstIP guard",
+			resp.Rcode, dns.RcodeToString[resp.Rcode])
+	}
+}


### PR DESCRIPTION
## Summary

- Routes A / AAAA queries that miss the VIP table through the gateway's own host resolver (`/etc/hosts`, `/etc/resolv.conf`, platform-native backends) instead of forwarding to whatever public resolver the agent's `resolv.conf` named — fixes `DNS_ERROR` for any internal hostname inside `clawpatrol run`.
- Keeps the existing relay path for TXT / SRV / MX / CAA / etc. — Go's stdlib doesn't expose a generic record parser and operator intent for those types is "ask the nameserver I configured."
- Uses `net.Resolver{PreferGo: true}` to dodge the macOS `mDNSResponder` deadlock ref-impl documented in `src/dns.ts`.

## Why

Today the dnsvip allocator forwards every non-VIP query to the dstIP from the agent's `resolv.conf` line. The WG conf's `PostUp` hardcodes that to `1.1.1.1` / `8.8.8.8`. Those resolvers don't know about hosts entries on the operator's machine, MagicDNS, VPN-pushed DNS, or corporate split-horizon — so:

```
$ clawpatrol run -- clickhouse-client --host=clickhouse-o11y
Code: 198. DB::NetException: Not found address of host: clickhouse-o11y. (DNS_ERROR)
```

…even though `getent hosts clickhouse-o11y` on the operator's box succeeds. The gateway *itself* could resolve the name, but only ever asks 1.1.1.1.

This PR makes the gateway use its own resolver chain for A/AAAA misses, which is consistent with how it already dials upstreams (`g.dialer.DialContext` honors `/etc/hosts` etc.). After:

- `clickhouse-o11y` resolves via the operator's `/etc/hosts` or VPN DNS, gets returned to the agent verbatim — agent dials it, traffic goes through the WG forwarder, the gateway's outbound dialer resolves the same name through the same chain. No VIP needed for "passthrough" hosts.

## Architecture parity with ref-impl

ref-impl's `handleDnsPacket` (`src/dns.ts:782`) does the exact same split: `resolveAddresses` for A/AAAA, `forwardDnsQuery` for everything else. Including the macOS-specific c-ares hardening — same root cause, same shape of fix here via `PreferGo`.

## Test plan

- [x] `TestForwardUpstreamSynthesisesA` — `localhost` → A 127.0.0.1, with `dstIP=""` so any fall-through to the relay path would surface as SERVFAIL.
- [x] `TestForwardUpstreamNXDomainOnUnresolvable` — `nothing-here.invalid` (RFC-reserved TLD) returns NXDOMAIN through the synth path; doesn't fall through.
- [x] `TestForwardUpstreamRelaysOtherTypes` — TXT query with empty `dstIP` returns SERVFAIL, proving non-A/AAAA skipped `synthIPResponse` and hit `relayUpstream`.
- [x] `go test ./...` clean.
- [ ] Manual verification on a Linux host with an internal hostname in `/etc/hosts`: agent dials it through `clawpatrol run`, packet trace shows the gateway answered DNS locally without contacting `1.1.1.1`.
- [ ] Manual verification on macOS that the `PreferGo` path doesn't deadlock with mDNSResponder under load (matches ref-impl's documented failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)