### PR TITLE
clickhouse_native: sslmode for self-signed upstreams

### DIFF
--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
@@ -37,11 +38,17 @@ import (
 // TLS posture. Default false: WG-only deployments where the operator
 // wants plaintext on the inner hop (typical self-hosted ClickHouse
 // on 9000 behind a private network) leave it off.
+//
+// AcceptInvalidCertificate mirrors clickhouse-client's flag of the
+// same name: when true and tls is on, the gateway skips upstream cert
+// validation. Use for self-hosted ClickHouse fronted by a private CA.
+// Default false keeps full validation against system roots.
 type ClickhouseNativeEndpoint struct {
-	Hosts      []string `hcl:"hosts"`
-	Port       int      `hcl:"port,optional"`
-	TLS        bool     `hcl:"tls,optional"`
-	Credential string   `hcl:"credential,optional"`
+	Hosts                    []string `hcl:"hosts"`
+	Port                     int      `hcl:"port,optional"`
+	TLS                      bool     `hcl:"tls,optional"`
+	AcceptInvalidCertificate bool     `hcl:"accept_invalid_certificate,optional"`
+	Credential               string   `hcl:"credential,optional"`
 }
 
 // EndpointHosts returns the endpoint's host:port list, normalized so
@@ -102,13 +109,14 @@ type ClickhouseNativeEndpointRuntime struct{}
 func init() {
 	var _ runtime.ConnEndpointRuntime = ClickhouseNativeEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "clickhouse_native",
-		Family:  "sql",
-		New:     func() any { return &ClickhouseNativeEndpoint{} },
-		Refs:    singularRef,
-		Runtime: ClickhouseNativeEndpointRuntime{},
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "clickhouse_native",
+		Family:   "sql",
+		New:      func() any { return &ClickhouseNativeEndpoint{} },
+		Refs:     singularRef,
+		Runtime:  ClickhouseNativeEndpointRuntime{},
+		Validate: validateClickhouseNativeEndpoint,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseNativeEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
@@ -118,9 +126,31 @@ func init() {
 			if e.TLS {
 				b.SetAttributeValue("tls", cty.BoolVal(true))
 			}
+			if e.AcceptInvalidCertificate {
+				b.SetAttributeValue("accept_invalid_certificate", cty.BoolVal(true))
+			}
 			if e.Credential != "" {
 				config.SetIdent(b, "credential", e.Credential)
 			}
 		},
 	})
+}
+
+// validateClickhouseNativeEndpoint rejects accept_invalid_certificate
+// when tls is off — the flag only affects the upstream TLS handshake,
+// so without tls there's nothing for it to do.
+func validateClickhouseNativeEndpoint(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
+	e, ok := d.(*ClickhouseNativeEndpoint)
+	if !ok {
+		return nil
+	}
+	if e.AcceptInvalidCertificate && !e.TLS {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("accept_invalid_certificate set without tls on clickhouse_native endpoint %q", name),
+			Detail:   "accept_invalid_certificate only affects the upstream TLS handshake; set `tls = true` to enable TLS, or remove accept_invalid_certificate.",
+			Subject:  &ctx.Block.DefRange,
+		}}
+	}
+	return nil
 }

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -151,7 +151,7 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 		if h, _, err := net.SplitHostPort(host); err == nil {
 			host = h
 		}
-		tc := tls.Client(upstream, &tls.Config{ServerName: host})
+		tc := tls.Client(upstream, chUpstreamTLSConfig(host, chEp.AcceptInvalidCertificate))
 		if err := tc.HandshakeContext(ctx); err != nil {
 			chEmitError(ch, "tls-handshake", err.Error())
 			return fmt.Errorf("upstream tls: %w", err)
@@ -199,6 +199,20 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 	// Step 5: bidirectional pipe.
 	chPipe(ch.Conn, upstream)
 	return nil
+}
+
+// chUpstreamTLSConfig builds the upstream tls.Config from the
+// endpoint's AcceptInvalidCertificate flag. False (default) keeps the
+// public-roots, hostname-matched check. True disables both —
+// necessary for self-hosted ClickHouse fronted by a private CA, at
+// the cost of trusting whatever cert the upstream presents (MITM
+// exposure on the wg→clickhouse hop). Operators opt in per endpoint;
+// the default stays safe.
+func chUpstreamTLSConfig(host string, acceptInvalidCert bool) *tls.Config {
+	return &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: acceptInvalidCert,
+	}
 }
 
 // chEmitError emits a structured error ConnEvent if the host wired

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -251,6 +251,33 @@ func TestClickhouseDefaultPortTLS(t *testing.T) {
 	}
 }
 
+// TestClickhouseUpstreamTLSConfig pins the AcceptInvalidCertificate
+// → InsecureSkipVerify mapping that gates the self-signed-CA opt-out.
+func TestClickhouseUpstreamTLSConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		acceptInvalidCert bool
+		wantSkip          bool
+		wantSrvName       string
+	}{
+		{"default verifies", false, false, "ch.example.com"},
+		{"accept_invalid skips verification", true, true, "ch.example.com"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := chUpstreamTLSConfig("ch.example.com", c.acceptInvalidCert)
+			if cfg.InsecureSkipVerify != c.wantSkip {
+				t.Errorf("acceptInvalidCert=%v InsecureSkipVerify=%v, want %v",
+					c.acceptInvalidCert, cfg.InsecureSkipVerify, c.wantSkip)
+			}
+			if cfg.ServerName != c.wantSrvName {
+				t.Errorf("acceptInvalidCert=%v ServerName=%q, want %q",
+					c.acceptInvalidCert, cfg.ServerName, c.wantSrvName)
+			}
+		})
+	}
+}
+
 // TestChHostPort exercises the host:port splitter — including the
 // IPv6 + named-port edge cases that strconv.Atoi covers but the
 // hand-rolled digit walk did not.

--- a/config/testdata/error_clickhouse_native_accept_invalid.errors.txt
+++ b/config/testdata/error_clickhouse_native_accept_invalid.errors.txt
@@ -1,0 +1,1 @@
+error: error_clickhouse_native_accept_invalid.hcl:3:1: accept_invalid_certificate set without tls on clickhouse_native endpoint "bad-accept-invalid" — accept_invalid_certificate only affects the upstream TLS handshake; set `tls = true` to enable TLS, or remove accept_invalid_certificate.

--- a/config/testdata/error_clickhouse_native_accept_invalid.hcl
+++ b/config/testdata/error_clickhouse_native_accept_invalid.hcl
@@ -1,0 +1,7 @@
+credential "clickhouse_credential" "ch" {}
+
+endpoint "clickhouse_native" "bad-accept-invalid" {
+  hosts                      = ["ch.example.com"]
+  accept_invalid_certificate = true
+  credential                 = ch
+}

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -346,6 +346,7 @@
           ],
           "Port": 0,
           "TLS": false,
+          "AcceptInvalidCertificate": false,
           "Credential": "ch-o11y"
         },
         "family": "sql",

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -72,6 +72,21 @@ endpoint "https" "github" {
   credential = github-pat
 }
 
+# ClickHouse over the native protocol. `tls = true` enables TLS on
+# the upstream hop. `accept_invalid_certificate = true` (mirrors
+# clickhouse-client's flag) skips upstream cert validation — use for
+# self-hosted ClickHouse fronted by a private CA; trusts whatever
+# cert the upstream presents. Default keeps full cert validation
+# against system roots.
+#
+# credential "clickhouse_credential" "ch-self-hosted" {}
+# endpoint "clickhouse_native" "ch-self-hosted" {
+#   hosts                      = ["clickhouse.internal:9440"]
+#   tls                        = true
+#   accept_invalid_certificate = true
+#   credential                 = ch-self-hosted
+# }
+
 # Approvers: who arbitrates when a rule needs human / LLM review.
 
 approver "human_approver" "ops" {


### PR DESCRIPTION
## Summary

Adds an `sslmode` field on `clickhouse_native` endpoints so operators
can accept self-signed (or private-CA) upstream TLS certificates.
Without this, self-hosted ClickHouse deployments behind a private CA
fail the upstream handshake.

Mirrors postgres's vocabulary:

- `verify-full` (default) — full cert validation against system roots
  (current behaviour preserved)
- `require` — TLS but skip cert validation; trusts whatever cert the
  upstream presents

`prefer` / `disable` aren't accepted: clickhouse_native has no
in-protocol TLS negotiation, so the existing `tls` boolean already
covers hard on/off.

## Test plan

- [x] `go test ./config/...` (new unit test for the SSLMode →
      InsecureSkipVerify mapping; error fixture for invalid sslmode;
      golden update for the existing endpoint)
- [x] `go vet ./config/...` (clean for changed files; pre-existing
      unreachable-code warning in postgres.go untouched)
- [x] Schema round-trip preserved (full.hcl golden test)