### PR TITLE
relay: emit dashboard events + bigger pipe buffer

### DIFF
--- a/main.go
+++ b/main.go
@@ -1098,7 +1098,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 		// No postgres policy → relay verbatim. Closes when either
 		// side hangs up.
 		log.Printf("pg %s: no postgres endpoint in profile %q; relaying", dstIP, profile)
-		wgRelay(c, dstIP, 5432)
+		g.wgRelay(c, dstIP, 5432)
 		return
 	}
 
@@ -1391,7 +1391,8 @@ func (g *Gateway) splice(c net.Conn, host string) {
 func pipe(a, b net.Conn) (rx, tx int64) {
 	done := make(chan struct{}, 2)
 	go func() {
-		n, _ := io.Copy(b, a)
+		buf := make([]byte, 256<<10)
+		n, _ := io.CopyBuffer(b, a, buf)
 		atomic.AddInt64(&tx, n)
 		if cw, ok := b.(interface{ CloseWrite() error }); ok {
 			cw.CloseWrite()
@@ -1399,7 +1400,8 @@ func pipe(a, b net.Conn) (rx, tx int64) {
 		done <- struct{}{}
 	}()
 	go func() {
-		n, _ := io.Copy(a, b)
+		buf := make([]byte, 256<<10)
+		n, _ := io.CopyBuffer(a, b, buf)
 		atomic.AddInt64(&rx, n)
 		if cw, ok := a.(interface{ CloseWrite() error }); ok {
 			cw.CloseWrite()
@@ -2136,7 +2138,7 @@ func runGateway(args []string) {
 				if g.tryDirectIPConn(c, dstIP, dstPort) {
 					return
 				}
-				wgRelay(c, dstIP, int(dstPort))
+				g.wgRelay(c, dstIP, int(dstPort))
 			}
 		}
 		udpDispatch := func(c net.Conn, dstIP string, dstPort uint16) bool {
@@ -2226,12 +2228,30 @@ func (l *oneShotListener) Addr() net.Addr {
 // wgRelay is the catch-all path: WG peer wants to talk to a host we
 // don't MITM (plain HTTP, ssh, anything not on :443 or the dash port).
 // Dials the real dst from the host network and pipes bytes both ways.
-func wgRelay(c net.Conn, dstIP string, dstPort int) {
+// Emits a sink Event so transparently-relayed flows show up in the
+// dashboard request history alongside MITM traffic — without this,
+// ssh / git-over-ssh / arbitrary-port connections went silent.
+func (g *Gateway) wgRelay(c net.Conn, dstIP string, dstPort int) {
 	defer c.Close()
+	pip := peerIP(c)
+	profile := g.profileFor(pip)
+	host := fmt.Sprintf("%s:%d", dstIP, dstPort)
+	start := time.Now()
 	up, err := net.DialTimeout("tcp", net.JoinHostPort(dstIP, strconv.Itoa(dstPort)), 10*time.Second)
 	if err != nil {
+		g.sink.Emit(Event{
+			Mode: "relay", AgentIP: pip, Agent: profile,
+			Host: host, Action: "deny", Reason: err.Error(),
+			Ms: time.Since(start).Milliseconds(),
+		})
 		return
 	}
 	defer up.Close()
-	pipe(c, up)
+	rx, tx := pipe(c, up)
+	g.sink.Emit(Event{
+		Mode: "relay", AgentIP: pip, Agent: profile,
+		Host: host, Action: "allow",
+		In: rx, Out: tx,
+		Ms: time.Since(start).Milliseconds(),
+	})
 }


### PR DESCRIPTION
## Summary
- Passthrough flows (ssh, git-over-ssh, plain HTTP, any non-MITM port) hit `wgRelay` → silent `io.Copy`. No `sink.Emit`, so dashboard request history showed nothing for these connections.
- `wgRelay` now emits a `Mode: "relay"` `Event` with rx/tx, duration, and allow/deny + reason on dial failure. Same path as MITM events → flows up via SSE + persists into `actions`.
- Promoted `wgRelay` to a method on `*Gateway` to access `sink` / `profileFor`. Both call sites updated (`handlePostgresConn` fallback + WG dispatch default).
- Bumped `pipe`'s `io.Copy` → `io.CopyBuffer` w/ 256 KiB. Default 32 KiB buffer starves throughput on userspace-WG paths — observed `git clone git@github.com:...` running at ~763 kbps with `app_limited=1` on sender; bigger buffer lets BBR ramp.

## Test plan
- [ ] `go build ./...` — passes
- [ ] WG agent → `git clone git@github.com:...` shows up in dashboard with mode=relay, host=`<ip>:22`, bytes_in/out
- [ ] WG agent → arbitrary `curl http://<host>` (port 80) shows in dashboard
- [ ] MITM events still emit normally (regression check)
- [ ] Re-measure clone throughput after buffer bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)