### PR TITLE
relay: feed agent activity sparkline from wgRelay

### DIFF
--- a/main.go
+++ b/main.go
@@ -2254,4 +2254,7 @@ func (g *Gateway) wgRelay(c net.Conn, dstIP string, dstPort int) {
 		In: rx, Out: tx,
 		Ms: time.Since(start).Milliseconds(),
 	})
+	if g.agents != nil && pip != "" {
+		g.agents.track(pip, host, rx, tx)
+	}
 }


### PR DESCRIPTION
## Summary
PR #103 made passthrough flows show up in **request history** via `sink.Emit`, but the per-agent **activity sparkline** is a separate signal: it reads `AgentRegistry.BytesIn/BytesOut`, fed by `agents.track(...)`. Only `mitmHTTPS` / `splice` / `ws` call it. `wgRelay` didn't, so ssh / git-over-ssh / arbitrary-port sessions stayed flat in the graph.

Mirror the splice pattern (`main.go:1383`): call `g.agents.track(pip, host, rx, tx)` after `pipe` completes.

## Test plan
- [ ] WG agent → `git clone git@github.com:...` → activity sparkline lights up on agent row
- [ ] Existing MITM activity unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)