### PR TITLE
ssh: accept the `none` userauth method so no-credential clients connect cleanly

### DIFF
--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -171,7 +171,17 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	// WG is the trust boundary, same model postgres uses for its
 	// SCRAM-offload. The handshake also gives us the agent's
 	// username, which we need before resolving the credential.
+	//
+	// NoClientAuth advertises the `none` userauth method so a plain
+	// `ssh user@host` with no key and no password just works —
+	// without it the OpenSSH client falls through to publickey, then
+	// password, and ends up prompting for a password it'll then
+	// accept anything for, which is gratuitously confusing. The
+	// PasswordCallback / PublicKeyCallback below stay in place so
+	// clients that DO offer credentials still succeed (they just
+	// aren't required to).
 	srvCfg := &ssh.ServerConfig{
+		NoClientAuth: true,
 		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
 			return &ssh.Permissions{}, nil
 		},


### PR DESCRIPTION
The agent-side SSH server is purely ceremonial — WireGuard already
authenticated the peer — but the previous config only advertised
\`publickey\` and \`password\`. An OpenSSH client without a usable
identity fell through to the password method and required typing
literally any character; without a password it failed.

Setting \`NoClientAuth = true\` advertises the standard \`none\`
userauth method, so \`ssh user@host\` from inside the WG tunnel just
works with no key, no password, no prompt. The \`PasswordCallback\` /
\`PublicKeyCallback\` hooks stay in place so clients that DO offer
credentials still succeed (they just aren't required to).

Verified end-to-end against a real upstream sshd: \`ssh\` with
\`-o PubkeyAuthentication=no -o PasswordAuthentication=no\` and \`ssh\`
with \`-o PreferredAuthentications=none\` both authenticate as the
agent username and run \`whoami\` on the upstream successfully.