### PR TITLE
ssh: drop OpenSSH UpdateHostKeys global requests at the gateway

### DIFF
--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -496,6 +496,12 @@ func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs
 
 func pumpGlobalReqs(target ssh.Conn, source <-chan *ssh.Request) {
 	for r := range source {
+		if isProxyDroppedGlobalReq(r.Type) {
+			if r.WantReply {
+				_ = r.Reply(false, nil)
+			}
+			continue
+		}
 		ok, payload, err := target.SendRequest(r.Type, r.WantReply, r.Payload)
 		if err != nil {
 			ok = false
@@ -505,6 +511,28 @@ func pumpGlobalReqs(target ssh.Conn, source <-chan *ssh.Request) {
 			_ = r.Reply(ok, payload)
 		}
 	}
+}
+
+// isProxyDroppedGlobalReq names global requests we deliberately swallow
+// at the gateway instead of forwarding. Currently just OpenSSH's
+// UpdateHostKeys exchange (RFC draft, names below): the agent sees the
+// gateway's per-endpoint host key, not the upstream's, and the
+// signed-payload includes the SSH session id — which is necessarily
+// different on the agent↔gateway and gateway↔upstream halves of a
+// proxied conn. Forwarding the exchange transparently makes the OpenSSH
+// client log "client_global_hostkeys_prove_confirm: server gave bad
+// signature" because it's verifying upstream's signature against the
+// agent-side session id. Dropping the request makes UpdateHostKeys
+// silently no-op for proxied SSH — agents can't auto-rotate the
+// gateway's known_hosts entry that way, but rotation of an
+// MITM gateway's host key is an operator concern anyway, not something
+// the upstream can usefully advertise.
+func isProxyDroppedGlobalReq(name string) bool {
+	switch name {
+	case "hostkeys-00@openssh.com", "hostkeys-prove-00@openssh.com":
+		return true
+	}
+	return false
 }
 
 // ── Host key persistence ──────────────────────────────────────────────


### PR DESCRIPTION
After auth, OpenSSH's sshd sends \`hostkeys-00@openssh.com\` listing
all of its host keys; the client follows up with
\`hostkeys-prove-00@openssh.com\` so the server signs a challenge
with each key, proving possession before the client caches them
for \`known_hosts\` auto-rotation. The signed payload is
\`"hostkeys-prove-00@openssh.com" || session_id || hostkey\`.

In a proxied connection the agent↔gateway and gateway↔upstream
session ids are necessarily different, so transparently forwarding
the exchange makes the OpenSSH client log
\`client_global_hostkeys_prove_confirm: server gave bad signature
for RSA key 0: incorrect signature\` — it's verifying upstream's
signature against the agent-side session id, which can't match.
The connection succeeds (it's an opportunistic rotation feature)
but the warning shows up on every login.

Drop both global requests at the gateway. \`UpdateHostKeys\` silently
no-ops for SSH endpoints, which is fine: the agent only ever sees
the gateway's per-endpoint host key, and rotating that is an
operator concern (cycle the file under
\`<ca_dir>/ssh/<endpoint>.key\`) not something the upstream can
usefully advertise.

Verified end-to-end against a real upstream sshd: the warning no
longer appears on \`ssh user@host\` through the gateway; session
otherwise behaves identically.