### PR TITLE
join: preserve SSH on linux --whole-machine via PostUp source-route

### DIFF
--- a/login.go
+++ b/login.go
@@ -860,6 +860,9 @@ func wgQuickUp(iface, conf string) error {
 		}
 	}
 	dst := filepath.Join("/etc/wireguard", iface+".conf")
+	if runtime.GOOS == "linux" {
+		conf = injectSSHExemptPostUp(conf)
+	}
 	tmp, err := os.CreateTemp("", "clawpatrol-wg-*.conf")
 	if err != nil {
 		return err
@@ -877,6 +880,59 @@ func wgQuickUp(iface, conf string) error {
 	c := runAsRoot("wg-quick", "up", iface)
 	c.Stdout, c.Stderr = os.Stdout, os.Stderr
 	return c.Run()
+}
+
+// injectSSHExemptPostUp inserts policy-routing PostUp/PostDown hooks
+// into the [Interface] block of a wg-quick conf so packets sourced
+// from the host's public IP keep using the original routing table.
+//
+// Without this, `AllowedIPs = 0.0.0.0/0` makes wg-quick replace the
+// default route with one through the tunnel — including reply packets
+// for inbound connections. SSH replies route through clawpatrol →
+// wrong source IP → in-flight admin session that ran `clawpatrol join
+// --whole-machine` dies mid-handshake. Same trick unclaw landed in
+// commit 53e0496.
+//
+// Returns conf unchanged when the host IP can't be detected (best
+// effort — better to bring up the tunnel than block on a heuristic).
+// Idempotent on the wire because PostUp's `ip rule add` is a single
+// rule with a fixed priority; re-runs add a duplicate but PostDown
+// removes one at a time and wg-quick down/up cycles cleanly.
+func injectSSHExemptPostUp(conf string) string {
+	hostIP := detectHostIP()
+	if hostIP == "" {
+		return conf
+	}
+	postUp := fmt.Sprintf("PostUp = ip rule add from %s lookup main priority 10", hostIP)
+	postDown := fmt.Sprintf("PostDown = ip rule del from %s lookup main priority 10", hostIP)
+	if strings.Contains(conf, postUp) {
+		return conf
+	}
+	// Insert before [Peer] (always present, terminates [Interface]).
+	// Falls back to append if [Peer] is missing for some reason.
+	idx := strings.Index(conf, "[Peer]")
+	if idx < 0 {
+		return conf + "\n" + postUp + "\n" + postDown + "\n"
+	}
+	return conf[:idx] + postUp + "\n" + postDown + "\n\n" + conf[idx:]
+}
+
+// detectHostIP returns the IPv4 address used to reach the public
+// internet, mirroring `ip -4 route get 1.1.1.1 | grep -oP 'src \K...'`.
+// Returns "" on any error so callers can decide to skip the rule.
+func detectHostIP() string {
+	out, err := exec.Command("ip", "-4", "route", "get", "1.1.1.1").Output()
+	if err != nil {
+		return ""
+	}
+	// Output: "1.1.1.1 via X dev eth0 src Y.Y.Y.Y uid 0 \n cache"
+	fields := strings.Fields(string(out))
+	for i, f := range fields {
+		if f == "src" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
 }
 
 // installTailscale runs the official one-line installer for the


### PR DESCRIPTION
## Summary
\`clawpatrol join --whole-machine\` on linux runs wg-quick with \`AllowedIPs=0.0.0.0/0\`, which replaces the default route. Reply packets for inbound SSH (and every other host-bound service) get sucked into the tunnel → wrong source IP → in-flight admin session drops mid-handshake. Reproduced on a cloud-vps Ubuntu VM today.

## Fix
Inject PostUp/PostDown into the \`[Interface]\` block before \`wg-quick up\` runs:

\`\`\`
PostUp  = ip rule add from <HOST_IP> lookup main priority 10
PostDown = ip rule del from <HOST_IP> lookup main priority 10
\`\`\`

Priority 10 wins over wg-quick's own \`not fwmark 51820 lookup 51820\` rule, so packets sourced from the public IP keep using the main table. Inbound services keep working; new outbound connections (which get a WG source IP) still go through the gateway as intended. Same mechanism ref-impl landed in commit 53e0496.

## Implementation notes
- \`detectHostIP\` shells out to \`ip -4 route get 1.1.1.1\` and parses the \`src\` field. Returns \`\"\"\` on error → injection becomes a no-op (better to bring up the tunnel than block on a heuristic).
- Insertion point: before \`[Peer]\` (always present, terminates \`[Interface]\`). Falls back to append.
- Idempotent: skip when the same PostUp line already appears in the conf.
- Linux-only — macOS uses the NE extension which doesn't have this problem.

## Test plan
- [ ] cloud-vps Ubuntu VM: \`clawpatrol join --url <gw> --whole-machine\` → existing SSH session survives, new SSH from another host succeeds
- [ ] \`wg-quick down clawpatrol\` cleans up the rule (PostDown)
- [ ] Outbound traffic from the VM still routes through the gateway
- [ ] HOST_IP detection failure path: tunnel still comes up, just no SSH protection

## Known limitation
Single-IP detection. Multi-homed hosts where SSH arrives on a non-default-route NIC will still drop. Matches ref-impl's current behavior; can extend by enumerating all \`ip -4 -o addr show scope global\` IPs in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)