### PR TITLE
join: lower SSH-exempt PostUp pref 10 → 5 so it beats wg-quick

### DIFF
--- a/login.go
+++ b/login.go
@@ -903,8 +903,15 @@ func injectSSHExemptPostUp(conf string) string {
 	if hostIP == "" {
 		return conf
 	}
-	postUp := fmt.Sprintf("PostUp = ip rule add from %s lookup main priority 10", hostIP)
-	postDown := fmt.Sprintf("PostDown = ip rule del from %s lookup main priority 10", hostIP)
+	// Priority 5 — must beat wg-quick's two own rules:
+	//   pref 8: from all lookup main suppress_prefixlength 0
+	//   pref 9: not fwmark 51820 lookup 51820
+	// Pref 10 (what unclaw originally used in commit 53e0496) gets
+	// shadowed by pref 9 — pref 9 matches every non-fwmarked packet
+	// first → table 51820 → clawpatrol iface → SYN-ACK exits the wrong
+	// interface, SSH session dies. Observed on Ubuntu 24.04 / Vultr.
+	postUp := fmt.Sprintf("PostUp = ip rule add from %s lookup main priority 5", hostIP)
+	postDown := fmt.Sprintf("PostDown = ip rule del from %s lookup main priority 5", hostIP)
 	if strings.Contains(conf, postUp) {
 		return conf
 	}


### PR DESCRIPTION
## Summary
Follow-up to #108. The PostUp rule \`ip rule add from <HOST_IP> lookup main priority 10\` (pattern ref-impl shipped in 53e0496) is shadowed on Ubuntu 24.04 by wg-quick's own rules:

\`\`\`
8:  from all lookup main suppress_prefixlength 0
9:  not fwmark 51820 lookup 51820
10: from <HOST_IP> lookup main          ← never evaluated
\`\`\`

Pref 9 matches every non-fwmarked packet first → table 51820 → clawpatrol → SYN-ACK exits the tunnel, SSH session dies even though our rule is installed. Reproduced today on a cloud-vps Ubuntu VM: tcpdump showed \`enp1s0 In\` SYN from client, \`clawpatrol Out\` SYN-ACK reply.

## Fix
Lower the priority from 10 → 5 so the source-route rule beats both of wg-quick's. Manually verified the live VM recovered SSH the moment \`ip rule add ... priority 5\` was added.

## Test plan
- [ ] Ubuntu 24.04 / cloud-vps VM: \`clawpatrol join --whole-machine\` over SSH → admin session stays alive
- [ ] \`ip rule show\` lists the pref 5 rule above wg-quick's pref 8/9
- [ ] \`ip route get <client-ip> from <HOST_IP>\` returns \`dev enp1s0\`
- [ ] \`wg-quick down/up\` cycle leaves no leaked rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)