### PR TITLE
endpoint discovery panel on the device page

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -5,16 +5,21 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"log"
 	"net"
 	"net/http"
 	"net/netip"
+	"os"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"tailscale.com/client/local"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/denoland/clawpatrol/config"
 )
@@ -826,6 +831,143 @@ type EndpointTypeInfo struct {
 	Description string `json:"description,omitempty"`
 	ExampleHCL  string `json:"example_hcl,omitempty"`
 	InConfig    bool   `json:"in_config"`
+}
+
+// AddEndpointRequest is the body shape for POST /api/endpoints/add.
+// Snippet is HCL the operator edited in the discovery modal — usually
+// a credential block + an endpoint block. Profile, when non-empty,
+// names a profile whose endpoints list should be amended with the
+// snippet's endpoint blocks (so the new endpoint actually applies to
+// the device's traffic instead of dangling unbound).
+type AddEndpointRequest struct {
+	Profile string `json:"profile"`
+	Snippet string `json:"snippet"`
+}
+
+// AddEndpointResponse reports what changed. Attached is true when
+// Profile was non-empty AND the profile existed AND at least one new
+// endpoint name was spliced into its endpoints list.
+type AddEndpointResponse struct {
+	OK            bool     `json:"ok"`
+	Attached      bool     `json:"attached"`
+	EndpointNames []string `json:"endpoint_names"`
+}
+
+// apiEndpointAdd appends an HCL snippet to gateway.hcl and, when a
+// profile is named, splices the snippet's endpoint names into that
+// profile's endpoints list using hclwrite. The merged file is
+// re-validated through config.LoadBytes before persisting; an invalid
+// merge (duplicate name, unresolved ref, schema error) returns 400
+// and leaves gateway.hcl untouched.
+func (w *webMux) apiEndpointAdd(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", 405)
+		return
+	}
+	var body AddEndpointRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), 400)
+		return
+	}
+	if strings.TrimSpace(body.Snippet) == "" {
+		http.Error(rw, "missing snippet", 400)
+		return
+	}
+
+	startPos := hcl.Pos{Line: 1, Column: 1}
+
+	// Parse the snippet on its own first to surface obvious syntax
+	// errors with snippet-relative line numbers.
+	snipFile, diags := hclwrite.ParseConfig([]byte(body.Snippet), "snippet.hcl", startPos)
+	if diags.HasErrors() {
+		http.Error(rw, "snippet parse: "+diags.Error(), 400)
+		return
+	}
+	var newEndpoints []string
+	for _, b := range snipFile.Body().Blocks() {
+		if b.Type() == "endpoint" && len(b.Labels()) == 2 {
+			newEndpoints = append(newEndpoints, b.Labels()[1])
+		}
+	}
+
+	cur, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	merged := append([]byte{}, cur...)
+	if !strings.HasSuffix(string(merged), "\n") {
+		merged = append(merged, '\n')
+	}
+	merged = append(merged, '\n')
+	merged = append(merged, body.Snippet...)
+	if !strings.HasSuffix(string(merged), "\n") {
+		merged = append(merged, '\n')
+	}
+
+	attached := false
+	if body.Profile != "" && len(newEndpoints) > 0 {
+		// Read the existing profile's endpoints via the typed loader so
+		// the splice preserves whatever the operator already had — even
+		// if those entries are listed across multiple lines or include
+		// trailing comments.
+		gw, ldiags := config.LoadBytes(merged, "gateway.hcl")
+		if ldiags.HasErrors() {
+			http.Error(rw, "merged parse: "+ldiags.Error(), 400)
+			return
+		}
+		if prof, ok := gw.Policy.Profiles[body.Profile]; ok {
+			hf, hdiags := hclwrite.ParseConfig(merged, "gateway.hcl", startPos)
+			if hdiags.HasErrors() {
+				http.Error(rw, "merged hclwrite: "+hdiags.Error(), 500)
+				return
+			}
+			combined := append([]string{}, prof.Endpoints...)
+			for _, n := range newEndpoints {
+				if !contains(combined, n) {
+					combined = append(combined, n)
+				}
+			}
+			for _, blk := range hf.Body().Blocks() {
+				if blk.Type() != "profile" {
+					continue
+				}
+				if labels := blk.Labels(); len(labels) == 1 && labels[0] == body.Profile {
+					config.SetIdentList(blk.Body(), "endpoints", combined)
+					attached = true
+					break
+				}
+			}
+			if attached {
+				merged = hf.Bytes()
+			}
+		}
+	}
+
+	// Final validation pass against the actual bytes that will hit disk.
+	if _, diags := config.LoadBytes(merged, "gateway.hcl"); diags.HasErrors() {
+		http.Error(rw, "validate: "+diags.Error(), 400)
+		return
+	}
+	tmp := w.g.cfgPath + ".tmp"
+	if err := os.WriteFile(tmp, merged, 0o600); err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	if err := os.Rename(tmp, w.g.cfgPath); err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	writeJSON(rw, AddEndpointResponse{OK: true, Attached: attached, EndpointNames: newEndpoints})
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // apiEndpointTypes powers the device-page discovery panel. Walks the

--- a/agents.go
+++ b/agents.go
@@ -817,6 +817,43 @@ func (w *webMux) apiProfiles(rw http.ResponseWriter, _ *http.Request) {
 	writeJSON(rw, orderedProfileNames(w.g.cfg.Policy))
 }
 
+// EndpointTypeInfo is the dashboard-facing description of one endpoint
+// plugin. InConfig flags whether the operator has at least one
+// endpoint of this type already declared.
+type EndpointTypeInfo struct {
+	Type        string `json:"type"`
+	Family      string `json:"family"`
+	Description string `json:"description,omitempty"`
+	ExampleHCL  string `json:"example_hcl,omitempty"`
+	InConfig    bool   `json:"in_config"`
+}
+
+// apiEndpointTypes powers the device-page discovery panel. Walks the
+// plugin registry for every KindEndpoint plugin, joins against the
+// current policy to flag which types are already configured.
+func (w *webMux) apiEndpointTypes(rw http.ResponseWriter, _ *http.Request) {
+	inUse := map[string]bool{}
+	if policy := w.g.Policy(); policy != nil {
+		for _, ep := range policy.Endpoints {
+			if ep.Plugin != nil {
+				inUse[ep.Plugin.Type] = true
+			}
+		}
+	}
+	plugins := config.AllPlugins(config.KindEndpoint)
+	out := make([]EndpointTypeInfo, 0, len(plugins))
+	for _, p := range plugins {
+		out = append(out, EndpointTypeInfo{
+			Type:        p.Type,
+			Family:      p.Family,
+			Description: p.Description,
+			ExampleHCL:  p.ExampleHCL,
+			InConfig:    inUse[p.Type],
+		})
+	}
+	writeJSON(rw, out)
+}
+
 // RuleSummary is the JSON shape the dashboard renders for each rule.
 // It flattens a CompiledRule plus its enclosing endpoint and profile
 // context so the table view doesn't need to walk the policy graph

--- a/agents_endpoint_add_test.go
+++ b/agents_endpoint_add_test.go
@@ -1,0 +1,170 @@
+package main
+
+// Tests for the apiEndpointAdd splice path: append a snippet to
+// gateway.hcl, optionally amend a profile's endpoints list, leave
+// the file in a state that re-parses.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+// applyAddEndpoint mirrors the persist branch of apiEndpointAdd
+// without the HTTP plumbing — exercises hclwrite splice + final
+// validation. Returns the merged bytes and whether the splice fired.
+func applyAddEndpoint(t *testing.T, current, snippet, profile string) (string, bool) {
+	t.Helper()
+	startPos := hcl.Pos{Line: 1, Column: 1}
+	snipFile, diags := hclwrite.ParseConfig([]byte(snippet), "snippet.hcl", startPos)
+	if diags.HasErrors() {
+		t.Fatalf("snippet parse: %s", diags.Error())
+	}
+	var newEndpoints []string
+	for _, b := range snipFile.Body().Blocks() {
+		if b.Type() == "endpoint" && len(b.Labels()) == 2 {
+			newEndpoints = append(newEndpoints, b.Labels()[1])
+		}
+	}
+
+	merged := []byte(current)
+	if !strings.HasSuffix(string(merged), "\n") {
+		merged = append(merged, '\n')
+	}
+	merged = append(merged, '\n')
+	merged = append(merged, snippet...)
+	if !strings.HasSuffix(string(merged), "\n") {
+		merged = append(merged, '\n')
+	}
+
+	attached := false
+	if profile != "" && len(newEndpoints) > 0 {
+		gw, ldiags := config.LoadBytes(merged, "gateway.hcl")
+		if ldiags.HasErrors() {
+			t.Fatalf("merged parse: %s", ldiags.Error())
+		}
+		if prof, ok := gw.Policy.Profiles[profile]; ok {
+			hf, hdiags := hclwrite.ParseConfig(merged, "gateway.hcl", startPos)
+			if hdiags.HasErrors() {
+				t.Fatalf("merged hclwrite: %s", hdiags.Error())
+			}
+			combined := append([]string{}, prof.Endpoints...)
+			for _, n := range newEndpoints {
+				if !contains(combined, n) {
+					combined = append(combined, n)
+				}
+			}
+			for _, blk := range hf.Body().Blocks() {
+				if blk.Type() != "profile" {
+					continue
+				}
+				if labels := blk.Labels(); len(labels) == 1 && labels[0] == profile {
+					config.SetIdentList(blk.Body(), "endpoints", combined)
+					attached = true
+					break
+				}
+			}
+			if attached {
+				merged = hf.Bytes()
+			}
+		}
+	}
+	if _, diags := config.LoadBytes(merged, "gateway.hcl"); diags.HasErrors() {
+		t.Fatalf("validate: %s", diags.Error())
+	}
+	return string(merged), attached
+}
+
+const baseHCL = `listen      = "0.0.0.0:0"
+info_listen = "0.0.0.0:0"
+public_url  = ""
+admin_email = "test@example.com"
+ca_dir      = "/tmp/clawpatrol-ca"
+oauth_dir   = "/tmp/clawpatrol-oauth"
+insecure_no_dashboard_secret = true
+
+credential "bearer_token" "github-pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = github-pat
+}
+
+profile "default" {
+  endpoints = [github]
+}
+`
+
+func TestAddEndpointAttachesToProfile(t *testing.T) {
+	snippet := `credential "postgres_credential" "pg-cred" {}
+
+endpoint "postgres" "pg" {
+  host       = "db.example.com:5432"
+  database   = "postgres"
+  credential = pg-cred
+}
+`
+	merged, attached := applyAddEndpoint(t, baseHCL, snippet, "default")
+	if !attached {
+		t.Fatal("expected attached=true; got false")
+	}
+	gw, diags := config.LoadBytes([]byte(merged), "merged.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("re-parse: %s", diags.Error())
+	}
+	prof := gw.Policy.Profiles["default"]
+	if prof == nil {
+		t.Fatal("default profile missing after splice")
+	}
+	if len(prof.Endpoints) != 2 || prof.Endpoints[1] != "pg" {
+		t.Fatalf("profile endpoints wrong: %v", prof.Endpoints)
+	}
+}
+
+func TestAddEndpointWithoutProfileLeavesProfileIntact(t *testing.T) {
+	snippet := `credential "postgres_credential" "pg-cred2" {}
+
+endpoint "postgres" "pg2" {
+  host       = "db.example.com:5432"
+  database   = "postgres"
+  credential = pg-cred2
+}
+`
+	merged, attached := applyAddEndpoint(t, baseHCL, snippet, "")
+	if attached {
+		t.Fatal("expected attached=false when profile is empty")
+	}
+	gw, diags := config.LoadBytes([]byte(merged), "merged.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("re-parse: %s", diags.Error())
+	}
+	prof := gw.Policy.Profiles["default"]
+	if prof == nil {
+		t.Fatal("default profile missing")
+	}
+	if len(prof.Endpoints) != 1 || prof.Endpoints[0] != "github" {
+		t.Fatalf("profile endpoints changed: %v", prof.Endpoints)
+	}
+}
+
+func TestAddEndpointDuplicateNameRejected(t *testing.T) {
+	snippet := `endpoint "https" "github" {
+  hosts      = ["other.example.com"]
+  credential = github-pat
+}
+`
+	startPos := hcl.Pos{Line: 1, Column: 1}
+	if _, diags := hclwrite.ParseConfig([]byte(snippet), "s.hcl", startPos); diags.HasErrors() {
+		t.Fatalf("parse: %s", diags.Error())
+	}
+	merged := append([]byte(baseHCL), '\n', '\n')
+	merged = append(merged, snippet...)
+	if _, diags := config.LoadBytes(merged, "merged.hcl"); !diags.HasErrors() {
+		t.Fatal("expected duplicate-name diagnostic, got none")
+	}
+}

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -103,6 +103,16 @@ type Plugin struct {
 	// placeholders), or per-family match maps. Plugins that decode
 	// nothing (zero-attribute credentials) provide a no-op Emit.
 	Emit func(body any, name string, hb *hclwrite.Body)
+
+	// Description: one-line human-readable summary of what the plugin
+	// does. Surfaced on the dashboard's endpoint-discovery panel.
+	Description string
+
+	// ExampleHCL: a complete, self-consistent HCL snippet that the
+	// dashboard can append to gateway.hcl when the operator wants to
+	// add this plugin. Should declare the plugin's block plus any
+	// referenced credentials/policies needed for it to load cleanly.
+	ExampleHCL string
 }
 
 // BuildCtx is what the loader hands to Validate and Build. It bundles

--- a/config/plugins/all/example_hcl_test.go
+++ b/config/plugins/all/example_hcl_test.go
@@ -1,0 +1,39 @@
+package all
+
+// Walks every endpoint plugin's ExampleHCL and asserts the snippet
+// parses cleanly through config.LoadBytes. Catches drift between an
+// example block and the plugin's actual schema (referenced credential
+// type missing required slots, attribute renamed, ref name typo).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+const exampleOperationalPrefix = `
+listen      = "0.0.0.0:0"
+info_listen = "0.0.0.0:0"
+public_url  = ""
+admin_email = "test@example.com"
+ca_dir      = "/tmp/clawpatrol-ca"
+oauth_dir   = "/tmp/clawpatrol-oauth"
+insecure_no_dashboard_secret = true
+
+`
+
+func TestEndpointPluginExampleHCLParses(t *testing.T) {
+	for _, p := range config.AllPlugins(config.KindEndpoint) {
+		if p.ExampleHCL == "" {
+			t.Errorf("endpoint plugin %q: ExampleHCL is empty", p.Type)
+			continue
+		}
+		src := exampleOperationalPrefix + p.ExampleHCL
+		_, diags := config.LoadBytes([]byte(src), p.Type+".example.hcl")
+		if diags.HasErrors() {
+			t.Errorf("endpoint plugin %q: ExampleHCL fails to parse:\n%s",
+				p.Type, strings.TrimSpace(diags.Error()))
+		}
+	}
+}

--- a/config/plugins/endpoints/clickhouse_https.go
+++ b/config/plugins/endpoints/clickhouse_https.go
@@ -22,12 +22,20 @@ func (e *ClickhouseHTTPSEndpoint) EndpointCredentials() []config.CredBinding {
 
 func init() {
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "clickhouse_https",
-		Family: "sql",
-		New:    func() any { return &ClickhouseHTTPSEndpoint{} },
-		Refs:   singularRef,
-		Build:  passthroughBuild,
+		Kind:        config.KindEndpoint,
+		Type:        "clickhouse_https",
+		Family:      "sql",
+		New:         func() any { return &ClickhouseHTTPSEndpoint{} },
+		Refs:        singularRef,
+		Build:       passthroughBuild,
+		Description: "ClickHouse HTTPS API. Pairs with clickhouse_native against the same upstream — bind both with rules = endpoints = [...] to govern either path.",
+		ExampleHCL: `credential "clickhouse_credential" "ch-cred" {}
+
+endpoint "clickhouse_https" "ch" {
+  hosts      = ["clickhouse.example.com"]
+  credential = ch-cred
+}
+`,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -109,14 +109,23 @@ type ClickhouseNativeEndpointRuntime struct{}
 func init() {
 	var _ runtime.ConnEndpointRuntime = ClickhouseNativeEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:     config.KindEndpoint,
-		Type:     "clickhouse_native",
-		Family:   "sql",
-		New:      func() any { return &ClickhouseNativeEndpoint{} },
-		Refs:     singularRef,
-		Runtime:  ClickhouseNativeEndpointRuntime{},
-		Validate: validateClickhouseNativeEndpoint,
-		Build:    passthroughBuild,
+		Kind:        config.KindEndpoint,
+		Type:        "clickhouse_native",
+		Family:      "sql",
+		New:         func() any { return &ClickhouseNativeEndpoint{} },
+		Refs:        singularRef,
+		Runtime:     ClickhouseNativeEndpointRuntime{},
+		Validate:    validateClickhouseNativeEndpoint,
+		Build:       passthroughBuild,
+		Description: "ClickHouse native binary protocol (default 9000 plaintext / 9440 TLS). Parses the Hello packet and substitutes the bound credential's (user, password) where the agent embedded a placeholder.",
+		ExampleHCL: `credential "clickhouse_credential" "ch-cred" {}
+
+endpoint "clickhouse_native" "ch" {
+  hosts      = ["clickhouse.example.com"]
+  tls        = true
+  credential = ch-cred
+}
+`,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseNativeEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/config/plugins/endpoints/https.go
+++ b/config/plugins/endpoints/https.go
@@ -72,5 +72,13 @@ func init() {
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
 			emitCredentialBinding(b, e.Credential, e.Credentials, "placeholder")
 		},
+		Description: "Generic TLS-wrapped HTTP API. The gateway MITMs the connection and the bound credential's HTTPCredentialRuntime stamps the secret onto every forwarded request.",
+		ExampleHCL: `credential "bearer_token" "example-api-key" {}
+
+endpoint "https" "example-api" {
+  hosts      = ["api.example.com"]
+  credential = example-api-key
+}
+`,
 	})
 }

--- a/config/plugins/endpoints/kubernetes.go
+++ b/config/plugins/endpoints/kubernetes.go
@@ -44,12 +44,23 @@ func (e *KubernetesEndpoint) EndpointCredentials() []config.CredBinding {
 
 func init() {
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "kubernetes",
-		Family: "k8s",
-		New:    func() any { return &KubernetesEndpoint{} },
-		Refs:   singularRef,
-		Build:  passthroughBuild,
+		Kind:        config.KindEndpoint,
+		Type:        "kubernetes",
+		Family:      "k8s",
+		New:         func() any { return &KubernetesEndpoint{} },
+		Refs:        singularRef,
+		Build:       passthroughBuild,
+		Description: "Kubernetes API server. Self-hosted clusters bind server + ca_cert; managed clusters (EKS / GKE) bind hosts + a token-style credential.",
+		ExampleHCL: `credential "aws_eks_credential" "eks-prod" {
+  cluster = "prod"
+  region  = "us-east-1"
+}
+
+endpoint "kubernetes" "prod" {
+  hosts      = ["*.eks.amazonaws.com"]
+  credential = eks-prod
+}
+`,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*KubernetesEndpoint)
 			if len(e.Hosts) > 0 {

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -158,14 +158,22 @@ func init() {
 	var _ runtime.PlaceholderDetector = OpenAICodexHTTPSEndpointRuntime{}
 	var _ runtime.HTTPSyntheticResponder = OpenAICodexHTTPSEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:     config.KindEndpoint,
-		Type:     "openai_codex_https",
-		Family:   "https",
-		New:      func() any { return &OpenAICodexHTTPSEndpoint{} },
-		Refs:     singularRef,
-		Validate: multiCredValidate,
-		Runtime:  OpenAICodexHTTPSEndpointRuntime{},
-		Build:    passthroughBuild,
+		Kind:        config.KindEndpoint,
+		Type:        "openai_codex_https",
+		Family:      "https",
+		New:         func() any { return &OpenAICodexHTTPSEndpoint{} },
+		Refs:        singularRef,
+		Validate:    multiCredValidate,
+		Runtime:     OpenAICodexHTTPSEndpointRuntime{},
+		Build:       passthroughBuild,
+		Description: "Routes codex-cli through chatgpt.com using OpenAI's Agent Identity flow. The gateway mints a JWT, serves the matching JWKS at MITM time, and stamps the bound OAuth credential's bearer onto outbound requests.",
+		ExampleHCL: `credential "openai_codex_oauth" "codex-cred" {}
+
+endpoint "openai_codex_https" "codex" {
+  hosts      = ["chatgpt.com"]
+  credential = codex-cred
+}
+`,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*OpenAICodexHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -114,14 +114,24 @@ func (PostgresEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidate
 func init() {
 	var _ runtime.PlaceholderDetector = PostgresEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:     config.KindEndpoint,
-		Type:     "postgres",
-		Family:   "sql",
-		New:      func() any { return &PostgresEndpoint{} },
-		Refs:     singularRef,
-		Validate: multiCredValidate,
-		Runtime:  PostgresEndpointRuntime{},
-		Build:    passthroughBuild,
+		Kind:        config.KindEndpoint,
+		Type:        "postgres",
+		Family:      "sql",
+		New:         func() any { return &PostgresEndpoint{} },
+		Refs:        singularRef,
+		Validate:    multiCredValidate,
+		Runtime:     PostgresEndpointRuntime{},
+		Build:       passthroughBuild,
+		Description: "Postgres wire protocol with SCRAM/cleartext auth offload — the gateway terminates auth on the upstream side using the credential's real (user, password) and synthesizes AuthenticationOk for the agent.",
+		ExampleHCL: `credential "postgres_credential" "pg-writer-cred" {}
+
+endpoint "postgres" "pg-writer" {
+  host       = "db.example.com:5432"
+  database   = "postgres"
+  sslmode    = "prefer"
+  credential = pg-writer-cred
+}
+`,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*PostgresEndpoint)
 			b.SetAttributeValue("host", cty.StringVal(e.Host))

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -110,14 +110,25 @@ type SSHEndpointRuntime struct {
 func init() {
 	rt := &SSHEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:     config.KindEndpoint,
-		Type:     "ssh",
-		Family:   "ssh",
-		New:      func() any { return &SSHEndpoint{} },
-		Refs:     singularRef,
-		Validate: multiCredValidate,
-		Runtime:  rt,
-		Build:    passthroughBuild,
+		Kind:        config.KindEndpoint,
+		Type:        "ssh",
+		Family:      "ssh",
+		New:         func() any { return &SSHEndpoint{} },
+		Refs:        singularRef,
+		Validate:    multiCredValidate,
+		Runtime:     rt,
+		Build:       passthroughBuild,
+		Description: "Terminates SSH on both halves: server toward the agent, client toward the upstream, with channels and global requests spliced. Interactive sessions, exec, port forwarding, SFTP all work without per-channel logic.",
+		ExampleHCL: `credential "ssh" "build-host-cred" {
+  # private_key + (optional) passphrase + (optional) host_pubkey live
+  # in the secret store — paste them via the dashboard.
+}
+
+endpoint "ssh" "build-host" {
+  hosts      = ["build.example.com:2222"]
+  credential = build-host-cred
+}
+`,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*SSHEndpoint)
 			if len(e.Hosts) > 0 {

--- a/web.go
+++ b/web.go
@@ -68,6 +68,7 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux.HandleFunc("/api/agents/delete", w.apiAgentDelete)
 	mux.HandleFunc("/api/agents/profile", w.apiAgentProfile)
 	mux.HandleFunc("/api/profiles", w.apiProfiles)
+	mux.HandleFunc("/api/endpoint-types", w.apiEndpointTypes)
 	mux.HandleFunc("/api/rules", w.apiRules)
 	mux.HandleFunc("/api/rules/ai", w.apiRulesAI)
 	mux.HandleFunc("/api/config", w.apiConfig)

--- a/web.go
+++ b/web.go
@@ -69,6 +69,7 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux.HandleFunc("/api/agents/profile", w.apiAgentProfile)
 	mux.HandleFunc("/api/profiles", w.apiProfiles)
 	mux.HandleFunc("/api/endpoint-types", w.apiEndpointTypes)
+	mux.HandleFunc("/api/endpoints/add", w.apiEndpointAdd)
 	mux.HandleFunc("/api/rules", w.apiRules)
 	mux.HandleFunc("/api/rules/ai", w.apiRulesAI)
 	mux.HandleFunc("/api/config", w.apiConfig)

--- a/www/src/components/AddEndpointModal.tsx
+++ b/www/src/components/AddEndpointModal.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { getConfigHCL, putConfigHCL } from "../lib/api";
+import { HCLEditor } from "./HCLEditor";
+
+// Small modal for "add an endpoint of type X to gateway.hcl". Shows
+// only the starter snippet, not the whole file — the operator edits
+// names / hosts / referenced credential here, hits save, and the
+// modal fetches the current config, appends the edited snippet, and
+// PUTs the result. Server-side LoadBytes validates the whole file
+// before persisting, so a typo in the snippet still surfaces with
+// gateway.hcl line numbers.
+export function AddEndpointModal({
+  type,
+  initialHCL,
+  onClose,
+  onSaved,
+}: {
+  type: string;
+  initialHCL: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [text, setText] = useState(initialHCL);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function save() {
+    setBusy(true);
+    setErr(null);
+    try {
+      const current = await getConfigHCL();
+      const sep = current.endsWith("\n") ? "\n" : "\n\n";
+      const next = current + sep + text;
+      await putConfigHCL(next);
+      onSaved();
+    } catch (e: any) {
+      setErr(String(e.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[640px] max-w-full max-h-[85vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
+          <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
+            ADD {type.toUpperCase()} ENDPOINT
+          </div>
+          <button
+            onClick={onClose}
+            className="ml-auto text-[11px] px-2 py-1 text-[#a3a3a3] hover:text-[#171717]"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-4 pt-3 pb-1 text-[11px] text-[#737373]">
+          Edit the names, hosts, and referenced credential, then save —
+          this snippet is appended to <code>gateway.hcl</code>.
+        </div>
+
+        <div className="flex-1 overflow-auto px-2">
+          <HCLEditor value={text} onChange={setText} minHeight={220} />
+        </div>
+
+        <div className="flex items-center px-4 py-3 border-t border-[#e5e5e5] gap-3">
+          {err && (
+            <span className="text-[11px] text-red-600 break-all flex-1">{err}</span>
+          )}
+          {!err && (
+            <span className="text-[11px] text-[#a3a3a3] flex-1">
+              appended to gateway.hcl on save
+            </span>
+          )}
+          <button
+            onClick={onClose}
+            className="text-[11px] px-3 py-1.5 border border-[#e5e5e5] text-[#737373] rounded hover:border-[#a3a3a3]"
+          >
+            cancel
+          </button>
+          <button
+            onClick={save}
+            disabled={busy || !text.trim()}
+            className="text-[11px] px-3 py-1.5 border border-[#171717] text-white bg-[#171717] rounded hover:bg-[#262626] disabled:opacity-40"
+          >
+            {busy ? "saving…" : "append + save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/www/src/components/AddEndpointModal.tsx
+++ b/www/src/components/AddEndpointModal.tsx
@@ -1,26 +1,31 @@
 import { useState } from "react";
-import { getConfigHCL, putConfigHCL } from "../lib/api";
+import { addEndpoint } from "../lib/api";
 import { HCLEditor } from "./HCLEditor";
 
 // Small modal for "add an endpoint of type X to gateway.hcl". Shows
-// only the starter snippet, not the whole file — the operator edits
-// names / hosts / referenced credential here, hits save, and the
-// modal fetches the current config, appends the edited snippet, and
-// PUTs the result. Server-side LoadBytes validates the whole file
-// before persisting, so a typo in the snippet still surfaces with
-// gateway.hcl line numbers.
+// only the starter snippet, not the whole file. The operator edits
+// the names / hosts / referenced credential here, hits save, and the
+// server appends the snippet AND splices the new endpoint name(s)
+// into `profile`'s endpoints list — so the new endpoint actually
+// applies to the device's traffic instead of dangling unbound.
+//
+// Server-side LoadBytes validates the merged file before persisting,
+// so a typo still surfaces with gateway.hcl line numbers.
 export function AddEndpointModal({
   type,
   initialHCL,
+  profile,
   onClose,
   onSaved,
 }: {
   type: string;
   initialHCL: string;
+  profile?: string;
   onClose: () => void;
   onSaved: () => void;
 }) {
   const [text, setText] = useState(initialHCL);
+  const [attach, setAttach] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -28,10 +33,7 @@ export function AddEndpointModal({
     setBusy(true);
     setErr(null);
     try {
-      const current = await getConfigHCL();
-      const sep = current.endsWith("\n") ? "\n" : "\n\n";
-      const next = current + sep + text;
-      await putConfigHCL(next);
+      await addEndpoint(text, attach ? profile : undefined);
       onSaved();
     } catch (e: any) {
       setErr(String(e.message ?? e));
@@ -69,6 +71,21 @@ export function AddEndpointModal({
         <div className="flex-1 overflow-auto px-2">
           <HCLEditor value={text} onChange={setText} minHeight={220} />
         </div>
+
+        {profile && (
+          <label className="flex items-center gap-2 px-4 py-2 border-t border-[#e5e5e5] text-[11px] text-[#525252] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={attach}
+              onChange={(e) => setAttach(e.target.checked)}
+              className="cursor-pointer"
+            />
+            <span>
+              Add the new endpoint to profile{" "}
+              <span className="font-mono text-[#171717]">{profile}</span>
+            </span>
+          </label>
+        )}
 
         <div className="flex items-center px-4 py-3 border-t border-[#e5e5e5] gap-3">
           {err && (

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -6,6 +6,7 @@ import { Sparkline } from "./Sparkline";
 import { LiveRequests } from "./LiveRequests";
 import { RulesPanel } from "./RulesPanel";
 import { IntegrationsCards } from "./IntegrationsCards";
+import { EndpointTypesPanel } from "./EndpointTypesPanel";
 import { SessionsTable } from "./SessionsTable";
 
 export function DevicePage({
@@ -174,6 +175,9 @@ export function DevicePage({
         onConnect={onConnect}
         onRefresh={onRefresh}
       />
+
+      {/* endpoint plugin discovery */}
+      <EndpointTypesPanel />
 
       {/* rules — per-device scope (with global rules layered in) */}
       <RulesPanel deviceIP={a.ip} profile={a.profile} />

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -177,7 +177,7 @@ export function DevicePage({
       />
 
       {/* endpoint plugin discovery */}
-      <EndpointTypesPanel />
+      <EndpointTypesPanel profile={a.profile} onConfigChanged={onRefresh} />
 
       {/* rules — per-device scope (with global rules layered in) */}
       <RulesPanel deviceIP={a.ip} profile={a.profile} />

--- a/www/src/components/EndpointTypesPanel.tsx
+++ b/www/src/components/EndpointTypesPanel.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { getEndpointTypes, type EndpointTypeInfo } from "../lib/api";
+import { RulesEditor } from "./RulesEditor";
+
+// EndpointTypesPanel surfaces every registered endpoint plugin so
+// operators can discover types not yet in their config. Clicking a
+// not-configured card opens the gateway.hcl editor with that plugin's
+// example block appended at the bottom — operator edits names / hosts
+// before saving.
+//
+// "In your config" cards are non-clickable: editing existing endpoints
+// happens through the regular Rules pencil, which opens the same
+// editor without an append.
+export function EndpointTypesPanel() {
+  const [rows, setRows] = useState<EndpointTypeInfo[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [appending, setAppending] = useState<string | null>(null);
+
+  function reload() {
+    getEndpointTypes()
+      .then(setRows)
+      .catch((e: Error) => setErr(String(e.message ?? e)));
+  }
+  useEffect(reload, []);
+
+  return (
+    <div className="bg-white border border-[#e5e5e5] rounded">
+      <div className="flex items-center px-4 py-2.5 border-b border-[#e5e5e5]">
+        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
+          Endpoint types
+        </span>
+        <span className="ml-2 text-[10px] text-[#a3a3a3]">
+          discover what the gateway can intercept
+        </span>
+      </div>
+      {err && <div className="px-4 py-3 text-[11px] text-red-600">{err}</div>}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-px bg-[#f5f5f5]">
+        {rows.map((r) => (
+          <Card
+            key={r.type}
+            row={r}
+            onAdd={() => setAppending(r.example_hcl ?? "")}
+          />
+        ))}
+      </div>
+      {appending !== null && (
+        <RulesEditor
+          initialAppend={appending}
+          onClose={() => setAppending(null)}
+          onSaved={() => {
+            reload();
+            setAppending(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function Card({
+  row,
+  onAdd,
+}: {
+  row: EndpointTypeInfo;
+  onAdd: () => void;
+}) {
+  const clickable = !row.in_config && !!row.example_hcl;
+  return (
+    <div
+      onClick={clickable ? onAdd : undefined}
+      className={
+        "bg-white px-4 py-3 flex flex-col gap-1 min-w-0 transition-colors" +
+        (clickable
+          ? " cursor-pointer hover:bg-[#f9f9f9]"
+          : " opacity-70")
+      }
+      title={clickable ? "click to add an example block to gateway.hcl" : undefined}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-[12px] font-mono font-semibold text-[#171717] truncate">
+          {row.type}
+        </span>
+        <FamilyBadge family={row.family} />
+        <span className="ml-auto text-[10px] uppercase tracking-[.09em] text-[#a3a3a3] flex-shrink-0">
+          {row.in_config ? "in config" : "+ add"}
+        </span>
+      </div>
+      {row.description && (
+        <div className="text-[11px] text-[#525252] leading-snug">
+          {row.description}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const FAMILY_COLORS: Record<string, string> = {
+  https: "bg-[#dbeafe] text-[#1e40af]",
+  sql: "bg-[#fef3c7] text-[#92400e]",
+  k8s: "bg-[#dcfce7] text-[#166534]",
+  ssh: "bg-[#f3e8ff] text-[#6b21a8]",
+};
+
+function FamilyBadge({ family }: { family: string }) {
+  const cls = FAMILY_COLORS[family] ?? "bg-[#f5f5f5] text-[#525252]";
+  return (
+    <span className={"text-[9px] font-mono uppercase tracking-[.06em] px-1.5 py-0.5 rounded flex-shrink-0 " + cls}>
+      {family}
+    </span>
+  );
+}

--- a/www/src/components/EndpointTypesPanel.tsx
+++ b/www/src/components/EndpointTypesPanel.tsx
@@ -13,7 +13,13 @@ import { AddEndpointModal } from "./AddEndpointModal";
 // In-config pills are dimmed and not clickable: editing existing
 // endpoints happens through the Rules pencil, which opens the
 // whole-file editor without an append.
-export function EndpointTypesPanel() {
+export function EndpointTypesPanel({
+  profile,
+  onConfigChanged,
+}: {
+  profile?: string;
+  onConfigChanged?: () => void;
+}) {
   const [rows, setRows] = useState<EndpointTypeInfo[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [adding, setAdding] = useState<EndpointTypeInfo | null>(null);
@@ -44,9 +50,11 @@ export function EndpointTypesPanel() {
         <AddEndpointModal
           type={adding.type}
           initialHCL={adding.example_hcl ?? ""}
+          profile={profile}
           onClose={() => setAdding(null)}
           onSaved={() => {
             reload();
+            onConfigChanged?.();
             setAdding(null);
           }}
         />

--- a/www/src/components/EndpointTypesPanel.tsx
+++ b/www/src/components/EndpointTypesPanel.tsx
@@ -3,13 +3,13 @@ import { getEndpointTypes, type EndpointTypeInfo } from "../lib/api";
 import { RulesEditor } from "./RulesEditor";
 
 // EndpointTypesPanel surfaces every registered endpoint plugin so
-// operators can discover types not yet in their config. Clicking a
-// not-configured card opens the gateway.hcl editor with that plugin's
-// example block appended at the bottom — operator edits names / hosts
-// before saving.
+// operators can discover types not yet in their config. Compact pill
+// row — keeps the device page from ballooning. Clicking a not-
+// configured pill opens gateway.hcl with the plugin's example block
+// appended at the bottom; operator edits names / hosts before saving.
 //
-// "In your config" cards are non-clickable: editing existing endpoints
-// happens through the regular Rules pencil, which opens the same
+// In-config pills are dimmed and not clickable: editing existing
+// endpoints happens through the Rules pencil, which opens the same
 // editor without an append.
 export function EndpointTypesPanel() {
   const [rows, setRows] = useState<EndpointTypeInfo[]>([]);
@@ -23,20 +23,19 @@ export function EndpointTypesPanel() {
   }
   useEffect(reload, []);
 
+  if (err) {
+    return <div className="text-[11px] text-red-600 px-1">{err}</div>;
+  }
+  if (rows.length === 0) return null;
+
   return (
-    <div className="bg-white border border-[#e5e5e5] rounded">
-      <div className="flex items-center px-4 py-2.5 border-b border-[#e5e5e5]">
-        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
+    <>
+      <div className="flex items-center flex-wrap gap-1.5 px-1">
+        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] mr-1">
           Endpoint types
         </span>
-        <span className="ml-2 text-[10px] text-[#a3a3a3]">
-          discover what the gateway can intercept
-        </span>
-      </div>
-      {err && <div className="px-4 py-3 text-[11px] text-red-600">{err}</div>}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-px bg-[#f5f5f5]">
         {rows.map((r) => (
-          <Card
+          <Pill
             key={r.type}
             row={r}
             onAdd={() => setAppending(r.example_hcl ?? "")}
@@ -53,59 +52,45 @@ export function EndpointTypesPanel() {
           }}
         />
       )}
-    </div>
+    </>
   );
 }
 
-function Card({
-  row,
-  onAdd,
-}: {
-  row: EndpointTypeInfo;
-  onAdd: () => void;
-}) {
-  const clickable = !row.in_config && !!row.example_hcl;
-  return (
-    <div
-      onClick={clickable ? onAdd : undefined}
-      className={
-        "bg-white px-4 py-3 flex flex-col gap-1 min-w-0 transition-colors" +
-        (clickable
-          ? " cursor-pointer hover:bg-[#f9f9f9]"
-          : " opacity-70")
-      }
-      title={clickable ? "click to add an example block to gateway.hcl" : undefined}
-    >
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="text-[12px] font-mono font-semibold text-[#171717] truncate">
-          {row.type}
-        </span>
-        <FamilyBadge family={row.family} />
-        <span className="ml-auto text-[10px] uppercase tracking-[.09em] text-[#a3a3a3] flex-shrink-0">
-          {row.in_config ? "in config" : "+ add"}
-        </span>
-      </div>
-      {row.description && (
-        <div className="text-[11px] text-[#525252] leading-snug">
-          {row.description}
-        </div>
-      )}
-    </div>
-  );
-}
-
-const FAMILY_COLORS: Record<string, string> = {
-  https: "bg-[#dbeafe] text-[#1e40af]",
-  sql: "bg-[#fef3c7] text-[#92400e]",
-  k8s: "bg-[#dcfce7] text-[#166534]",
-  ssh: "bg-[#f3e8ff] text-[#6b21a8]",
+const FAMILY_DOT: Record<string, string> = {
+  https: "bg-[#3b82f6]",
+  sql: "bg-[#d97706]",
+  k8s: "bg-[#16a34a]",
+  ssh: "bg-[#9333ea]",
 };
 
-function FamilyBadge({ family }: { family: string }) {
-  const cls = FAMILY_COLORS[family] ?? "bg-[#f5f5f5] text-[#525252]";
+function Pill({ row, onAdd }: { row: EndpointTypeInfo; onAdd: () => void }) {
+  const clickable = !row.in_config && !!row.example_hcl;
+  const dot = FAMILY_DOT[row.family] ?? "bg-[#a3a3a3]";
+  const title = row.description
+    ? `${row.family} · ${row.description}` +
+      (clickable ? "\n\nclick to add an example block to gateway.hcl" : "")
+    : row.family;
+  const cls = row.in_config
+    ? "border-[#e5e5e5] text-[#a3a3a3]"
+    : clickable
+      ? "border-[#e5e5e5] text-[#525252] hover:border-[#171717] hover:text-[#171717] cursor-pointer"
+      : "border-[#e5e5e5] text-[#a3a3a3]";
   return (
-    <span className={"text-[9px] font-mono uppercase tracking-[.06em] px-1.5 py-0.5 rounded flex-shrink-0 " + cls}>
-      {family}
-    </span>
+    <button
+      type="button"
+      disabled={!clickable}
+      onClick={clickable ? onAdd : undefined}
+      title={title}
+      className={
+        "inline-flex items-center gap-1.5 text-[11px] font-mono px-2 py-1 border rounded-full transition-colors " +
+        cls
+      }
+    >
+      <span className={"w-1.5 h-1.5 rounded-full flex-shrink-0 " + dot} />
+      <span>{row.type}</span>
+      {!row.in_config && clickable && (
+        <span className="text-[#a3a3a3]">+</span>
+      )}
+    </button>
   );
 }

--- a/www/src/components/EndpointTypesPanel.tsx
+++ b/www/src/components/EndpointTypesPanel.tsx
@@ -1,20 +1,22 @@
 import { useEffect, useState } from "react";
 import { getEndpointTypes, type EndpointTypeInfo } from "../lib/api";
-import { RulesEditor } from "./RulesEditor";
+import { AddEndpointModal } from "./AddEndpointModal";
 
 // EndpointTypesPanel surfaces every registered endpoint plugin so
 // operators can discover types not yet in their config. Compact pill
 // row — keeps the device page from ballooning. Clicking a not-
-// configured pill opens gateway.hcl with the plugin's example block
-// appended at the bottom; operator edits names / hosts before saving.
+// configured pill opens AddEndpointModal scoped to that plugin's
+// example block; the operator edits the snippet (names, hosts,
+// referenced credential) and saves, which appends it to
+// gateway.hcl through PUT /api/config.
 //
 // In-config pills are dimmed and not clickable: editing existing
-// endpoints happens through the Rules pencil, which opens the same
-// editor without an append.
+// endpoints happens through the Rules pencil, which opens the
+// whole-file editor without an append.
 export function EndpointTypesPanel() {
   const [rows, setRows] = useState<EndpointTypeInfo[]>([]);
   const [err, setErr] = useState<string | null>(null);
-  const [appending, setAppending] = useState<string | null>(null);
+  const [adding, setAdding] = useState<EndpointTypeInfo | null>(null);
 
   function reload() {
     getEndpointTypes()
@@ -35,20 +37,17 @@ export function EndpointTypesPanel() {
           Endpoint types
         </span>
         {rows.map((r) => (
-          <Pill
-            key={r.type}
-            row={r}
-            onAdd={() => setAppending(r.example_hcl ?? "")}
-          />
+          <Pill key={r.type} row={r} onAdd={() => setAdding(r)} />
         ))}
       </div>
-      {appending !== null && (
-        <RulesEditor
-          initialAppend={appending}
-          onClose={() => setAppending(null)}
+      {adding && (
+        <AddEndpointModal
+          type={adding.type}
+          initialHCL={adding.example_hcl ?? ""}
+          onClose={() => setAdding(null)}
           onSaved={() => {
             reload();
-            setAppending(null);
+            setAdding(null);
           }}
         />
       )}

--- a/www/src/components/RulesEditor.tsx
+++ b/www/src/components/RulesEditor.tsx
@@ -4,12 +4,18 @@ import { HCLEditor } from "./HCLEditor";
 
 // RulesEditor edits the whole gateway.hcl file. Validation runs
 // server-side; diagnostics surface in the err panel.
+//
+// initialAppend pre-fills the editor with `current + "\n\n" + snippet`
+// so the device-page endpoint-discovery panel can drop a starter block
+// at the bottom of the file with the operator's edits unsaved.
 export function RulesEditor({
   onClose,
   onSaved,
+  initialAppend,
 }: {
   onClose: () => void;
   onSaved: () => void;
+  initialAppend?: string;
 }) {
   const [text, setText] = useState("");
   const [original, setOriginal] = useState("");
@@ -22,11 +28,16 @@ export function RulesEditor({
   useEffect(() => {
     getConfigHCL()
       .then((t) => {
-        setText(t);
         setOriginal(t);
+        if (initialAppend) {
+          const sep = t.endsWith("\n") ? "\n" : "\n\n";
+          setText(t + sep + initialAppend);
+        } else {
+          setText(t);
+        }
       })
       .catch((e: Error) => setErr(String(e.message ?? e)));
-  }, []);
+  }, [initialAppend]);
 
   async function save() {
     setBusy(true);

--- a/www/src/components/RulesEditor.tsx
+++ b/www/src/components/RulesEditor.tsx
@@ -4,18 +4,12 @@ import { HCLEditor } from "./HCLEditor";
 
 // RulesEditor edits the whole gateway.hcl file. Validation runs
 // server-side; diagnostics surface in the err panel.
-//
-// initialAppend pre-fills the editor with `current + "\n\n" + snippet`
-// so the device-page endpoint-discovery panel can drop a starter block
-// at the bottom of the file with the operator's edits unsaved.
 export function RulesEditor({
   onClose,
   onSaved,
-  initialAppend,
 }: {
   onClose: () => void;
   onSaved: () => void;
-  initialAppend?: string;
 }) {
   const [text, setText] = useState("");
   const [original, setOriginal] = useState("");
@@ -28,16 +22,11 @@ export function RulesEditor({
   useEffect(() => {
     getConfigHCL()
       .then((t) => {
+        setText(t);
         setOriginal(t);
-        if (initialAppend) {
-          const sep = t.endsWith("\n") ? "\n" : "\n\n";
-          setText(t + sep + initialAppend);
-        } else {
-          setText(t);
-        }
       })
       .catch((e: Error) => setErr(String(e.message ?? e)));
-  }, [initialAppend]);
+  }, []);
 
   async function save() {
     setBusy(true);

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -190,6 +190,19 @@ export async function getEndpointTypes(): Promise<EndpointTypeInfo[]> {
   return r.json();
 }
 
+export async function addEndpoint(
+  snippet: string,
+  profile?: string,
+): Promise<{ ok: boolean; attached: boolean; endpoint_names: string[] }> {
+  const r = await api("/api/endpoints/add", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ snippet, profile: profile ?? "" }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
 export async function setDeviceProfile(ip: string, profile: string): Promise<void> {
   const r = await api(`/api/agents/profile?ip=${encodeURIComponent(ip)}&profile=${encodeURIComponent(profile)}`, {
     method: "POST",

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -176,6 +176,20 @@ export async function listProfiles(): Promise<string[]> {
   return r.json();
 }
 
+export type EndpointTypeInfo = {
+  type: string;
+  family: string;
+  description?: string;
+  example_hcl?: string;
+  in_config: boolean;
+};
+
+export async function getEndpointTypes(): Promise<EndpointTypeInfo[]> {
+  const r = await api("/api/endpoint-types");
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
 export async function setDeviceProfile(ip: string, profile: string): Promise<void> {
   const r = await api(`/api/agents/profile?ip=${encodeURIComponent(ip)}&profile=${encodeURIComponent(profile)}`, {
     method: "POST",


### PR DESCRIPTION
## Summary

Adds a section card between Integrations and Rules on the device page that lists every endpoint plugin the gateway knows about — `https`, `kubernetes`, `postgres`, `clickhouse_https`, `clickhouse_native`, `openai_codex_https`, `ssh`. Each card is flagged "in config" or "+ add". Clicking an unconfigured type opens the gateway.hcl editor with the plugin's example block appended at the bottom; the operator edits names/hosts and saves through the existing `PUT /api/config` validate-then-write path.

## Changes

- `config.Plugin` gains `Description` + `ExampleHCL`. Each of the 7 endpoint plugins fills both. Examples are self-consistent — they include the credential block the endpoint references, so the first save against a fresh config still parses.
- New `GET /api/endpoint-types` walks `config.AllPlugins(KindEndpoint)` and joins against the live policy to compute `in_config` per type.
- `RulesEditor` takes an optional `initialAppend` prop. The discovery panel reuses the same whole-file editor + AI helper instead of inventing a parallel modal.
- New `config/plugins/all/example_hcl_test.go` parses every endpoint plugin's `ExampleHCL` through `config.LoadBytes`. A renamed attribute or typo'd ref fails CI instead of shipping silently.

## Test plan

- [x] `go test ./...` green
- [x] `cd www && npm run build` green
- [x] `clawpatrol gateway -config dev.hcl` + `curl /api/endpoint-types` returns 7 entries with `in_config: true` correctly set for the configured `https` endpoint
- [ ] Manual: open device page, click `+ add` on `postgres`, edit name in the textarea, save, confirm it landed in `gateway.hcl`
