### PR TITLE
fix: strip legacy body token for Slack so Authorization header takes precedence

### DIFF
--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -54,6 +55,24 @@ func (s *SlackTokens) InjectHTTP(_ context.Context, req *http.Request, sec runti
 		return nil
 	}
 	req.Header.Set("Authorization", "Bearer "+pick)
+	// Slack's legacy SDKs send `token=<value>` in the form body alongside
+	// the Authorization header. If the body token is a placeholder it
+	// reaches Slack unsubstituted and causes invalid_auth. Strip it so
+	// Slack uses only the Authorization header we just set.
+	if strings.Contains(req.Header.Get("Content-Type"), "application/x-www-form-urlencoded") && req.Body != nil {
+		raw, err := io.ReadAll(req.Body)
+		if err == nil {
+			vals, err := url.ParseQuery(string(raw))
+			if err == nil && vals.Get("token") != "" {
+				vals.Del("token")
+				encoded := vals.Encode()
+				req.Body = io.NopCloser(strings.NewReader(encoded))
+				req.ContentLength = int64(len(encoded))
+			} else {
+				req.Body = io.NopCloser(bytes.NewReader(raw))
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `@slack/web-api` sends `token=<value>` in both the `Authorization` header **and** the `application/x-www-form-urlencoded` body
- ref-impl-mini replaces the `Authorization` header with the real token but left the placeholder `token=` in the body
- Slack validates the body `token=` field and rejected with `invalid_auth`

This fix strips `token=` from the form body in `InjectHTTP` after setting the `Authorization` header, so Slack only sees the injected real token.

## Test plan

- [ ] Send a Slack message via dev2 — should respond without `invalid_auth`
- [ ] Verify `token=` is no longer sent in request body to `slack.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)