### PR TITLE
fix: add SecretSlots to notion_oauth so dashboard shows token input

### DIFF
--- a/config/plugins/credentials/notion.go
+++ b/config/plugins/credentials/notion.go
@@ -24,6 +24,10 @@ func (n *NotionOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runti
 	return nil
 }
 
+func (*NotionOAuth) SecretSlots() []config.SecretSlot {
+	return []config.SecretSlot{{Label: "Notion OAuth access token", Description: "secret_… integration token or OAuth access_token. Stamped as Authorization: Bearer + Notion-Version header."}}
+}
+
 func init() {
 	var _ runtime.HTTPCredentialRuntime = (*NotionOAuth)(nil)
 	config.Register(&config.Plugin{


### PR DESCRIPTION
## Summary

- `notion_oauth` credential had no `SecretSlots()` implementation
- Dashboard requires `SecretSlots()` to render a token-entry UI — without it the credential appears in the list but clicking does nothing ("unclickable")
- Added a single slot matching the `bearer_token` pattern: paste the Notion integration token (`secret_…`) or OAuth `access_token`
- Also injects `Notion-Version: 2022-06-28` header automatically (existing behavior)

## Test plan

- [ ] Open dashboard → dev2 profile → click `notion-oauth-dev2` credential → should show token input dialog
- [ ] Paste Notion integration token → save → `curl https://api.notion.com/v1/users/me` from dev2 VM should return workspace user

🤖 Generated with [Claude Code](https://claude.com/claude-code)