### PR TITLE
fix: stable session ID for codex HTTP sessions

### DIFF
--- a/main.go
+++ b/main.go
@@ -565,6 +565,26 @@ func codexInputTitle(input []struct {
 	return ""
 }
 
+// codexInputFirstTitle returns the FIRST real user message from a Codex
+// input array — used as a stable session ID seed across turns (since the
+// full conversation history is resent every turn, the first message never
+// changes, giving a consistent shortHash).
+func codexInputFirstTitle(input []struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}) string {
+	for _, m := range input {
+		if m.Role != "user" {
+			continue
+		}
+		text := stripCodexWrappers(joinUserContent(m.Content))
+		if text != "" {
+			return truncate(text, 80)
+		}
+	}
+	return ""
+}
+
 // joinUserContent flattens a Codex/OpenAI message Content (string OR
 // array of typed blocks). Blocks are joined with newlines so a single
 // user message that mixes <environment_context> + the actual prompt
@@ -665,7 +685,9 @@ func (g *Gateway) preCreateLLMSession(c net.Conn, kind, path string, reqBody []b
 		if title == "" {
 			return
 		}
-		g.agents.recordLLMUsage(ip, "codex", "", title, codexRequestModel(reqBody), 0, 0)
+		firstTitle := codexResponsesRequestFirstTitle(reqBody)
+		sid := shortHash(firstTitle)
+		g.agents.recordLLMUsage(ip, "codex", sid, title, codexRequestModel(reqBody), 0, 0)
 	}
 }
 
@@ -737,10 +759,9 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
-		// Empty sid → reuse the latest codex session for this device
-		// (see findOrAddSession). Each codex CLI run shares a session on
-		// the same device; first call w/ a real prompt fills the title.
-		g.agents.recordLLMUsage(ip, "codex", "", title, model, in, out)
+		firstTitle := codexResponsesRequestFirstTitle(reqBody)
+		sid := shortHash(firstTitle)
+		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	}
 }
 
@@ -760,6 +781,21 @@ func codexResponsesRequestTitle(body []byte) string {
 		return ""
 	}
 	return codexInputTitle(req.Input)
+}
+
+// codexResponsesRequestFirstTitle returns the first real user message from
+// the request body — stable across turns, used as a session ID seed.
+func codexResponsesRequestFirstTitle(body []byte) string {
+	var req struct {
+		Input []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ""
+	}
+	return codexInputFirstTitle(req.Input)
 }
 
 func parseOpenAIResponse(body []byte) (model string, in, out int64) {

--- a/main.go
+++ b/main.go
@@ -646,7 +646,9 @@ func trackKindFor(host string) string {
 // before the SSE stream completes. Token counts arrive later via
 // trackLLMUsage. Mirrors trackLLMUsage's path/kind gating but skips
 // any work that depends on the response body.
-func (g *Gateway) preCreateLLMSession(c net.Conn, kind, path string, reqBody []byte) {
+// sessionHint is the value of the Session_id / Session-Id request header
+// when present — used as a stable session key for codex_ws_usage HTTP requests.
+func (g *Gateway) preCreateLLMSession(c net.Conn, kind, path string, reqBody []byte, sessionHint string) {
 	if g.agents == nil {
 		return
 	}
@@ -685,8 +687,10 @@ func (g *Gateway) preCreateLLMSession(c net.Conn, kind, path string, reqBody []b
 		if title == "" {
 			return
 		}
-		firstTitle := codexResponsesRequestFirstTitle(reqBody)
-		sid := shortHash(firstTitle)
+		sid := shortHash(sessionHint)
+		if sid == "" {
+			sid = shortHash(codexResponsesRequestFirstTitle(reqBody))
+		}
 		g.agents.recordLLMUsage(ip, "codex", sid, title, codexRequestModel(reqBody), 0, 0)
 	}
 }
@@ -707,7 +711,7 @@ func codexRequestModel(body []byte) string {
 // trackLLMUsage parses LLM API request/response bodies for session id,
 // title, model, and token usage. Only fires on actual model-invocation
 // endpoints; ignores heartbeat / event_logging / mcp / oauth probes.
-func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody []byte) {
+func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody []byte, sessionHint string) {
 	ip := peerIP(c)
 	switch kind {
 	case "claude_usage":
@@ -759,8 +763,10 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
-		firstTitle := codexResponsesRequestFirstTitle(reqBody)
-		sid := shortHash(firstTitle)
+		sid := shortHash(sessionHint)
+		if sid == "" {
+			sid = shortHash(codexResponsesRequestFirstTitle(reqBody))
+		}
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	}
 }
@@ -1807,8 +1813,12 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// turn-start, not at turn-end. trackLLMUsage below runs after
 		// resp.Write completes — which for codex can be minutes. WS
 		// reports per-frame; HTTP needs this kickoff so it doesn't lag.
+		sessionHint := req.Header.Get("Session_id")
+		if sessionHint == "" {
+			sessionHint = req.Header.Get("Session-Id")
+		}
 		if trackKind != "" && len(trackedReqBody) > 0 && g.agents != nil {
-			g.preCreateLLMSession(c, trackKind, req.URL.Path, trackedReqBody)
+			g.preCreateLLMSession(c, trackKind, req.URL.Path, trackedReqBody, sessionHint)
 		}
 		reqS := newSampler(4096)
 		if req.Body != nil {
@@ -1864,7 +1874,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					zr.Close()
 				}
 			}
-			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body)
+			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint)
 		}
 
 		if ev.Action == "" {


### PR DESCRIPTION
## Problem

`codex_ws_usage` (chatgpt.com `POST /backend-api/codex/responses`) was passing `""` as session ID to `recordLLMUsage`. `findOrAddSession` with empty id extends the most-recent same-type session, so multiple concurrent Codex CLI invocations merged into a single dashboard row.

## Fix

**Primary:** Pass the `Session_id` / `Session-Id` request header through `preCreateLLMSession` and `trackLLMUsage` as `sessionHint`. The WS upgrade path already reads these headers — HTTP requests from the same Codex CLI instance carry the same header, giving a stable per-run session key.

**Fallback (header absent):** `codexInputFirstTitle` walks the `input` array forward (vs `codexInputTitle`'s backward walk for display title) to get the first real user message — stable across turns since Codex resends full history every request. `shortHash(firstTitle)` used as sid.

`shortHash("")` returns `""`, so empty hint + empty first message falls back to old extend-latest behavior safely.

## Test plan

- [ ] Two separate Codex CLI sessions from same device appear as distinct rows in dashboard
- [ ] Within a single session, multiple turns update the same row
- [ ] WS-path sessions (`trackCodexWSUsage`) unaffected — already use `wsSessionID`-derived sids

🤖 Generated with [Claude Code](https://claude.com/claude-code)