### PR TITLE
ci: bump deploy health-check sleep 2→5s

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,6 @@ jobs:
             mv /opt/clawall/gateway.new /opt/clawall/gateway
             chmod +x /opt/clawall/gateway
             systemctl restart clawall-gateway
-            sleep 2
+            sleep 5
             systemctl is-active clawall-gateway
           '


### PR DESCRIPTION
Gateway needs >2s to start; `sleep 2` → `systemctl is-active` was a false-failure race. Bumping to 5s.