### PR TITLE
ci: add golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: cd www && npm ci && npm run build
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - bodyclose
+    - durationcheck
+    - errcheck
+    - errorlint
+    - govet
+    - ineffassign
+    - misspell
+    - nilerr
+    - nilnil
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - unused
+
+formatters:
+  enable:
+    - gofmt

--- a/agents.go
+++ b/agents.go
@@ -1,3 +1,4 @@
+// Package main implements clawpatrol main support.
 package main
 
 import (
@@ -85,22 +86,6 @@ func (a *Agent) findOrAddSession(t, id, title string) *Session {
 	s := &Session{ID: id, Title: title, Type: t, FirstAt: now, LastAt: now, Reqs: 1}
 	a.Sessions = append(a.Sessions, s)
 	return s
-}
-
-func detectAgentType(ua string) string {
-	u := strings.ToLower(ua)
-	switch {
-	case strings.Contains(u, "claude-code") || strings.Contains(u, "anthropic"):
-		return "claude"
-	case strings.Contains(u, "codex") || strings.Contains(u, "openai"):
-		return "codex"
-	case strings.Contains(u, "curl/") || strings.Contains(u, "wget/") || strings.Contains(u, "httpie"):
-		return "shell"
-	case u == "":
-		return ""
-	default:
-		return "other"
-	}
 }
 
 // detectAgentTypeFromHost infers type from destination host (used for
@@ -321,8 +306,8 @@ func printDashboardURL(listen string) {
 		return
 	}
 	hostName := st.Self.HostName
-	if st.MagicDNSSuffix != "" && hostName != "" {
-		log.Printf("dashboard: http://%s.%s%s", hostName, st.MagicDNSSuffix, port)
+	if st.CurrentTailnet != nil && st.CurrentTailnet.MagicDNSSuffix != "" && hostName != "" {
+		log.Printf("dashboard: http://%s.%s%s", hostName, st.CurrentTailnet.MagicDNSSuffix, port)
 	}
 	if len(st.Self.TailscaleIPs) > 0 {
 		log.Printf("dashboard: http://%s%s", st.Self.TailscaleIPs[0], port)
@@ -481,7 +466,7 @@ func (r *AgentRegistry) LoadSessions(db *sql.DB) {
 		log.Printf("sessions: load: %v", err)
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for rows.Next() {
@@ -512,6 +497,9 @@ func (r *AgentRegistry) LoadSessions(db *sql.DB) {
 			Reqs: reqs, FirstAt: time.Unix(0, fa), LastAt: time.Unix(0, la),
 		}
 		a.Sessions = append(a.Sessions, s)
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("sessions: load rows: %v", err)
 	}
 }
 
@@ -775,7 +763,7 @@ func (w *webMux) agentsList() []*Agent {
 // that from the Tailscale admin console.
 func (w *webMux) apiAgentDelete(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	ip := r.URL.Query().Get("ip")
@@ -801,7 +789,7 @@ func (w *webMux) apiAgentDelete(rw http.ResponseWriter, r *http.Request) {
 // time, so rule scoping switches over immediately.
 func (w *webMux) apiAgentProfile(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	ip := r.URL.Query().Get("ip")

--- a/ai.go
+++ b/ai.go
@@ -202,7 +202,7 @@ func generateRuleHCL(ctx context.Context, g *Gateway, agent, owner, prompt, curr
 		return "", refusal, nil
 	}
 	if perr := validateHCLSyntax(out); perr != nil {
-		return "", "", fmt.Errorf("AI returned invalid HCL — %v", perr)
+		return "", "", fmt.Errorf("AI returned invalid HCL — %w", perr)
 	}
 	return out, "", nil
 }
@@ -322,7 +322,7 @@ func callClaude(ctx context.Context, reg *OAuthRegistry, owner, user string) (st
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	rb, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("anthropic %d: %s", resp.StatusCode, truncate(string(rb), 400))
@@ -368,7 +368,7 @@ func callCodex(ctx context.Context, reg *OAuthRegistry, owner, user string) (str
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	rb, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("openai %d: %s", resp.StatusCode, truncate(string(rb), 400))

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -24,6 +24,7 @@ import (
 // collisions across the flat namespace.
 type Kind string
 
+// Plugin kind constants enumerate supported config block kinds.
 const (
 	KindEndpoint   Kind = "endpoint"
 	KindCredential Kind = "credential"

--- a/config/plugins/all/all.go
+++ b/config/plugins/all/all.go
@@ -4,7 +4,7 @@
 package all
 
 import (
-	_ "github.com/denoland/clawpatrol/config/plugins/approvers"
+	_ "github.com/denoland/clawpatrol/config/plugins/approvers" // register built-in plugin
 	_ "github.com/denoland/clawpatrol/config/plugins/credentials"
 	_ "github.com/denoland/clawpatrol/config/plugins/endpoints"
 	_ "github.com/denoland/clawpatrol/config/plugins/rules"

--- a/config/plugins/approvers/dashboard.go
+++ b/config/plugins/approvers/dashboard.go
@@ -12,8 +12,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// DashboardApprover is part of the clawpatrol plugin API.
 type DashboardApprover struct{}
 
+// Approve is part of the clawpatrol plugin API.
 func (DashboardApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
 	if req.Pool == nil {
 		return runtime.ApproveVerdict{}, fmt.Errorf("dashboard approver: no pool")

--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -45,10 +45,15 @@ type HumanApprover struct {
 // HumanApproverChannel + HumanApproverCredential expose the fields
 // the gateway's HITL wiring needs without main importing this package
 // — main does an anonymous-interface type-assert on ent.Body.
-func (h *HumanApprover) HumanApproverChannel() string    { return h.Channel }
-func (h *HumanApprover) HumanApproverCredential() string { return h.Credential }
-func (h *HumanApprover) HumanApproverInteractive() bool  { return h.Interactive }
+func (h *HumanApprover) HumanApproverChannel() string { return h.Channel }
 
+// HumanApproverCredential is part of the clawpatrol plugin API.
+func (h *HumanApprover) HumanApproverCredential() string { return h.Credential }
+
+// HumanApproverInteractive is part of the clawpatrol plugin API.
+func (h *HumanApprover) HumanApproverInteractive() bool { return h.Interactive }
+
+// Approve is part of the clawpatrol plugin API.
 func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
 	if req.Pool == nil {
 		return runtime.ApproveVerdict{}, fmt.Errorf("human approver %q: no pool", req.ApproverName)

--- a/config/plugins/approvers/llm.go
+++ b/config/plugins/approvers/llm.go
@@ -46,6 +46,7 @@ type LLMApprover struct {
 	Policy     string `hcl:"policy,optional"`
 }
 
+// Approve is part of the clawpatrol plugin API.
 func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
 	if a.Model == "" {
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "llm approver has no model"}, nil
@@ -100,7 +101,7 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	if err != nil {
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "llm call: " + err.Error()}, nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return runtime.ApproveVerdict{Decision: "deny", Reason: fmt.Sprintf("llm http %d: %s", resp.StatusCode, string(body))}, nil

--- a/config/plugins/credentials/anthropic_manual_key.go
+++ b/config/plugins/credentials/anthropic_manual_key.go
@@ -1,3 +1,4 @@
+// Package credentials implements clawpatrol credentials support.
 package credentials
 
 // anthropic_manual_key: Anthropic API key stamped into the
@@ -12,8 +13,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// AnthropicManualKey is part of the clawpatrol plugin API.
 type AnthropicManualKey struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (a *AnthropicManualKey) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
 		return nil
@@ -22,6 +25,7 @@ func (a *AnthropicManualKey) InjectHTTP(_ context.Context, req *http.Request, se
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*AnthropicManualKey) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Anthropic API key", Description: "sk-ant-…"}}
 }

--- a/config/plugins/credentials/anthropic_oauth.go
+++ b/config/plugins/credentials/anthropic_oauth.go
@@ -12,8 +12,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// AnthropicOAuthSubscription is part of the clawpatrol plugin API.
 type AnthropicOAuthSubscription struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (a *AnthropicOAuthSubscription) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
 		return nil
@@ -23,6 +25,7 @@ func (a *AnthropicOAuthSubscription) InjectHTTP(_ context.Context, req *http.Req
 	return nil
 }
 
+// EnvVars is part of the clawpatrol plugin API.
 func (*AnthropicOAuthSubscription) EnvVars() []config.EnvVar {
 	return []config.EnvVar{
 		{Name: "ANTHROPIC_AUTH_TOKEN", Value: phClaude, Description: "Claude Code / Anthropic SDKs"},

--- a/config/plugins/credentials/aws_eks.go
+++ b/config/plugins/credentials/aws_eks.go
@@ -13,6 +13,7 @@ import (
 	"github.com/denoland/clawpatrol/config"
 )
 
+// AWSEKSCredential is part of the clawpatrol plugin API.
 type AWSEKSCredential struct {
 	Cluster string `hcl:"cluster"`
 	Region  string `hcl:"region"`

--- a/config/plugins/credentials/bearer_token.go
+++ b/config/plugins/credentials/bearer_token.go
@@ -15,10 +15,12 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// BearerToken is part of the clawpatrol plugin API.
 type BearerToken struct {
 	IdempotencyKey bool `hcl:"idempotency_key,optional"`
 }
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (b *BearerToken) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
 		return nil
@@ -45,6 +47,7 @@ func idempotencyKeyFor(req *http.Request) string {
 	return req.URL.Path + "@" + req.Method
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*BearerToken) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Bearer token", Description: "Stamped as `Authorization: Bearer …`."}}
 }

--- a/config/plugins/credentials/clickhouse.go
+++ b/config/plugins/credentials/clickhouse.go
@@ -16,10 +16,12 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// ClickhouseCredential is part of the clawpatrol plugin API.
 type ClickhouseCredential struct {
 	User string `hcl:"user,optional"`
 }
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (c *ClickhouseCredential) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if c.User == "" || len(sec.Bytes) == 0 || req.URL == nil {
 		return nil
@@ -40,6 +42,7 @@ func (c *ClickhouseCredential) ClickhouseAuth(sec runtime.Secret) (string, strin
 	return c.User, string(sec.Bytes)
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*ClickhouseCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "ClickHouse password"}}
 }

--- a/config/plugins/credentials/cookie_token.go
+++ b/config/plugins/credentials/cookie_token.go
@@ -14,10 +14,12 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// CookieToken is part of the clawpatrol plugin API.
 type CookieToken struct {
 	CookieName string `hcl:"cookie_name,optional"`
 }
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (c *CookieToken) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if c.CookieName == "" || len(sec.Bytes) == 0 {
 		return nil
@@ -26,6 +28,7 @@ func (c *CookieToken) InjectHTTP(_ context.Context, req *http.Request, sec runti
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*CookieToken) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Cookie value"}}
 }

--- a/config/plugins/credentials/gemini.go
+++ b/config/plugins/credentials/gemini.go
@@ -14,8 +14,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// GeminiAPIKey is part of the clawpatrol plugin API.
 type GeminiAPIKey struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (g *GeminiAPIKey) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 || req.URL == nil {
 		return nil
@@ -33,10 +35,12 @@ func (g *GeminiAPIKey) InjectHTTP(_ context.Context, req *http.Request, sec runt
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*GeminiAPIKey) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Gemini API key"}}
 }
 
+// EnvVars is part of the clawpatrol plugin API.
 func (*GeminiAPIKey) EnvVars() []config.EnvVar {
 	return []config.EnvVar{
 		{Name: "GOOGLE_API_KEY", Value: phGemini, Description: "Gemini SDKs"},

--- a/config/plugins/credentials/github.go
+++ b/config/plugins/credentials/github.go
@@ -11,8 +11,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// GitHubOAuth is part of the clawpatrol plugin API.
 type GitHubOAuth struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (g *GitHubOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
 		return nil
@@ -21,6 +23,7 @@ func (g *GitHubOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runti
 	return nil
 }
 
+// EnvVars is part of the clawpatrol plugin API.
 func (*GitHubOAuth) EnvVars() []config.EnvVar {
 	return []config.EnvVar{
 		{Name: "GH_TOKEN", Value: phGitHub, Description: "gh CLI"},

--- a/config/plugins/credentials/header_token.go
+++ b/config/plugins/credentials/header_token.go
@@ -14,11 +14,13 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// HeaderToken is part of the clawpatrol plugin API.
 type HeaderToken struct {
 	Header string `hcl:"header"`
 	Prefix string `hcl:"prefix,optional"`
 }
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (h *HeaderToken) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if h.Header == "" || len(sec.Bytes) == 0 {
 		return nil
@@ -27,6 +29,7 @@ func (h *HeaderToken) InjectHTTP(_ context.Context, req *http.Request, sec runti
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*HeaderToken) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Header value"}}
 }

--- a/config/plugins/credentials/mtls.go
+++ b/config/plugins/credentials/mtls.go
@@ -14,8 +14,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// MTLSCredential is part of the clawpatrol plugin API.
 type MTLSCredential struct{}
 
+// ConfigureUpstreamTLS is part of the clawpatrol plugin API.
 func (m *MTLSCredential) ConfigureUpstreamTLS(cfg *tls.Config, sec runtime.Secret) error {
 	certPEM := []byte(sec.Extras["cert"])
 	keyPEM := []byte(sec.Extras["key"])
@@ -37,6 +39,7 @@ func (m *MTLSCredential) ConfigureUpstreamTLS(cfg *tls.Config, sec runtime.Secre
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*MTLSCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{
 		{Name: "cert", Label: "Client cert (PEM)", Multiline: true},

--- a/config/plugins/credentials/notion.go
+++ b/config/plugins/credentials/notion.go
@@ -11,8 +11,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// NotionOAuth is part of the clawpatrol plugin API.
 type NotionOAuth struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (n *NotionOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
 		return nil
@@ -24,6 +26,7 @@ func (n *NotionOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runti
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*NotionOAuth) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Notion OAuth access token", Description: "secret_… integration token or OAuth access_token. Stamped as Authorization: Bearer + Notion-Version header."}}
 }

--- a/config/plugins/credentials/openai_codex.go
+++ b/config/plugins/credentials/openai_codex.go
@@ -14,8 +14,10 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// OpenAICodexOAuth is part of the clawpatrol plugin API.
 type OpenAICodexOAuth struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (a *OpenAICodexOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
 		return nil
@@ -80,6 +82,7 @@ func chatgptAccountID(jwt string) string {
 //	}
 func (*OpenAICodexOAuth) EnvVars() []config.EnvVar { return nil }
 
+// OAuthFlow is part of the clawpatrol plugin API.
 func (a *OpenAICodexOAuth) OAuthFlow() *config.OAuthIntegration {
 	return &config.OAuthIntegration{
 		Type:   "oauth2",

--- a/config/plugins/credentials/postgres.go
+++ b/config/plugins/credentials/postgres.go
@@ -13,6 +13,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// PostgresCredential is part of the clawpatrol plugin API.
 type PostgresCredential struct {
 	User string `hcl:"user,optional"`
 }
@@ -24,6 +25,7 @@ func (p *PostgresCredential) PostgresAuth(sec runtime.Secret) (string, string) {
 	return p.User, string(sec.Bytes)
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*PostgresCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Postgres password"}}
 }

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -35,6 +35,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// SlackTokens is part of the clawpatrol plugin API.
 type SlackTokens struct{}
 
 // InjectHTTP defaults to the bot token (xoxb-…) for chat.postMessage
@@ -85,6 +86,7 @@ func slackPathPrefersApp(path string) bool {
 	return false
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*SlackTokens) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{
 		{Name: "bot", Label: "Bot token", Description: "xoxb-…"},
@@ -209,7 +211,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	var result struct {
 		OK    bool   `json:"ok"`
@@ -250,7 +252,7 @@ func (*SlackTokens) WebhookRoutes() []runtime.WebhookRoute {
 // payload, and decides the matching pending HITL entry.
 func slackInteractive(ctx runtime.WebhookCtx, rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
@@ -261,12 +263,12 @@ func slackInteractive(ctx runtime.WebhookCtx, rw http.ResponseWriter, r *http.Re
 	ts := r.Header.Get("X-Slack-Request-Timestamp")
 	sig := r.Header.Get("X-Slack-Signature")
 	if ts == "" || sig == "" {
-		http.Error(rw, "missing slack signature headers", 401)
+		http.Error(rw, "missing slack signature headers", http.StatusUnauthorized)
 		return
 	}
 	// Replay protection: timestamp within 5 minutes.
 	if tsi, _ := strconv.ParseInt(ts, 10, 64); tsi == 0 || time.Since(time.Unix(tsi, 0)) > 5*time.Minute {
-		http.Error(rw, "stale slack signature", 401)
+		http.Error(rw, "stale slack signature", http.StatusUnauthorized)
 		return
 	}
 
@@ -289,7 +291,7 @@ func slackInteractive(ctx runtime.WebhookCtx, rw http.ResponseWriter, r *http.Re
 		}
 	}
 	if !verified {
-		http.Error(rw, "slack signature verification failed", 401)
+		http.Error(rw, "slack signature verification failed", http.StatusUnauthorized)
 		return
 	}
 
@@ -385,7 +387,7 @@ func postSlackResponseURL(url, text string, blocks []map[string]any) {
 		log.Printf("slack response_url: post: %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 400 {
 		log.Printf("slack response_url: status=%d", resp.StatusCode)
 	}

--- a/config/plugins/credentials/ssh.go
+++ b/config/plugins/credentials/ssh.go
@@ -28,6 +28,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// SSHCredential is part of the clawpatrol plugin API.
 type SSHCredential struct{}
 
 // SSHAuth implements sshproto.AuthCredential. Returns the raw
@@ -51,6 +52,7 @@ func (s *SSHCredential) SSHAuth(sec runtime.Secret) (sshproto.Creds, error) {
 	return creds, nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*SSHCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{
 		{

--- a/config/plugins/credentials/telegram.go
+++ b/config/plugins/credentials/telegram.go
@@ -27,15 +27,17 @@ import (
 // their SDK config / URL when running through the gateway.
 const telegramPlaceholder = "0000000000:clawpatrol-placeholder-do-not-use"
 
+// TelegramBotToken is part of the clawpatrol plugin API.
 type TelegramBotToken struct{}
 
+// InjectHTTP is part of the clawpatrol plugin API.
 func (t *TelegramBotToken) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 || req.URL == nil {
 		return nil
 	}
-	real := string(sec.Bytes)
+	actualToken := string(sec.Bytes)
 	swap := func(s string) string {
-		return strings.ReplaceAll(s, telegramPlaceholder, real)
+		return strings.ReplaceAll(s, telegramPlaceholder, actualToken)
 	}
 
 	if strings.Contains(req.URL.Path, telegramPlaceholder) {
@@ -62,6 +64,7 @@ func (t *TelegramBotToken) InjectHTTP(_ context.Context, req *http.Request, sec 
 	return nil
 }
 
+// SecretSlots is part of the clawpatrol plugin API.
 func (*TelegramBotToken) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Telegram bot token"}}
 }

--- a/config/plugins/endpoints/clickhouse_https.go
+++ b/config/plugins/endpoints/clickhouse_https.go
@@ -10,12 +10,16 @@ import (
 	"github.com/denoland/clawpatrol/config"
 )
 
+// ClickhouseHTTPSEndpoint is part of the clawpatrol plugin API.
 type ClickhouseHTTPSEndpoint struct {
 	Hosts      []string `hcl:"hosts"`
 	Credential string   `hcl:"credential,optional"`
 }
 
+// EndpointHosts is part of the clawpatrol plugin API.
 func (e *ClickhouseHTTPSEndpoint) EndpointHosts() []string { return e.Hosts }
+
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *ClickhouseHTTPSEndpoint) EndpointCredentials() []config.CredBinding {
 	return singleBinding(e.Credential)
 }

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -69,6 +69,8 @@ func (e *ClickhouseNativeEndpoint) EndpointHosts() []string {
 	}
 	return out
 }
+
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
 	return singleBinding(e.Credential)
 }

--- a/config/plugins/endpoints/clickhouse_native_protocol.go
+++ b/config/plugins/endpoints/clickhouse_native_protocol.go
@@ -19,25 +19,10 @@ package endpoints
 // effect: LZ4/ZSTD stays out of the gateway entirely.
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
 	chgoproto "github.com/ClickHouse/ch-go/proto"
-)
-
-// Local aliases of the ch-go packet codes — keeps the runtime's
-// switch statements readable without leaking the dependency name
-// everywhere.
-const (
-	chClientPacketHello  = chgoproto.ClientCodeHello
-	chClientPacketQuery  = chgoproto.ClientCodeQuery
-	chClientPacketData   = chgoproto.ClientCodeData
-	chClientPacketCancel = chgoproto.ClientCodeCancel
-	chClientPacketPing   = chgoproto.ClientCodePing
-
-	chServerPacketHello     = chgoproto.ServerCodeHello
-	chServerPacketException = chgoproto.ServerCodeException
 )
 
 // chMaxProtocolRev caps the protocol revision the gateway is willing
@@ -231,8 +216,3 @@ func chEncodeException(displayText string) []byte {
 	exc.EncodeAware(&b, 0)
 	return b.Buf
 }
-
-// chErrShortBuffer is returned by helpers that try-decode out of a
-// fixed buffer. With ch-go/proto the runtime always reads from a live
-// io.Reader so this surfaces only from buffer-backed unit tests.
-var chErrShortBuffer = errors.New("clickhouse: short buffer")

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -103,7 +103,7 @@ func chValidCompressedMethod(b byte) bool {
 //     the path). Cancel/Ping forward as-is. Server → agent stays a
 //     pure copy past the Hello.
 func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
-	defer ch.Conn.Close()
+	defer func() { _ = ch.Conn.Close() }()
 	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
 		err := fmt.Errorf("clickhouse_native runtime invoked on non-sql endpoint %v", ch.Endpoint)
 		chEmitError(ch, "wrong-family", "")
@@ -199,7 +199,7 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 		chEmitError(ch, "dial-upstream", fmt.Sprintf("%s: %v", upstreamAddr, err))
 		return fmt.Errorf("dial upstream %s: %w", upstreamAddr, err)
 	}
-	defer upstream.Close()
+	defer func() { _ = upstream.Close() }()
 
 	if chEp.TLS {
 		host := upstreamAddr

--- a/config/plugins/endpoints/clickhouse_native_sql.go
+++ b/config/plugins/endpoints/clickhouse_native_sql.go
@@ -224,7 +224,7 @@ func chStripSQLComments(s string) string {
 		case '/':
 			if i+1 < len(s) && s[i+1] == '*' {
 				i += 2
-				for i+1 < len(s) && !(s[i] == '*' && s[i+1] == '/') {
+				for i+1 < len(s) && (s[i] != '*' || s[i+1] != '/') {
 					i++
 				}
 				if i+1 < len(s) {

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -449,7 +449,7 @@ func TestChEvaluateSQLAllowsSelectDeniesInsert(t *testing.T) {
 // the approve-chain branch can be exercised without spinning up the
 // HITL machinery.
 func chMockApprove(decision, reason string) func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
-	return func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
+	return func(_ runtime.ApproveCallRequest) runtime.ApproveVerdict {
 		return runtime.ApproveVerdict{Decision: decision, Reason: reason, By: "test"}
 	}
 }
@@ -518,7 +518,7 @@ func TestChAgentToServerForwardsQuery(t *testing.T) {
 	const revision = 54448
 
 	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
-	defer mock.Conn.Close()
+	defer func() { _ = mock.Conn.Close() }()
 
 	q := chgoproto.Query{
 		ID:          "qid-1",
@@ -593,7 +593,7 @@ func chBuildSampleBlock(t *testing.T) *chproto.Block {
 func TestChHandleDataUncompressed(t *testing.T) {
 	const revision = 54448
 	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
-	defer mock.Conn.Close()
+	defer func() { _ = mock.Conn.Close() }()
 
 	block := chBuildSampleBlock(t)
 	var agentBuf chgoproto.Buffer
@@ -643,7 +643,7 @@ func TestChHandleDataUncompressed(t *testing.T) {
 func TestChHandleDataCompressedForwardsOpaquely(t *testing.T) {
 	const revision = 54448
 	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
-	defer mock.Conn.Close()
+	defer func() { _ = mock.Conn.Close() }()
 
 	// Build the Query packet (Compression=Enabled).
 	q := chgoproto.Query{
@@ -763,7 +763,7 @@ func chCompressedDataEventSummary(t *testing.T, events []runtime.ConnEvent) stri
 func TestChCompressedDataEventDropsRowsCols(t *testing.T) {
 	const revision = 54448
 	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
-	defer mock.Conn.Close()
+	defer func() { _ = mock.Conn.Close() }()
 
 	q := chgoproto.Query{
 		ID: "qid-1", Body: "SELECT 1",
@@ -818,7 +818,7 @@ func TestChCompressedDataEventDropsRowsCols(t *testing.T) {
 func TestChProbeForwardsMultiChunkBlock(t *testing.T) {
 	const revision = 54448
 	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
-	defer mock.Conn.Close()
+	defer func() { _ = mock.Conn.Close() }()
 
 	q := chgoproto.Query{
 		ID: "qid-1", Body: "SELECT 1",
@@ -889,7 +889,7 @@ func TestChProbeForwardsMultiChunkBlock(t *testing.T) {
 func TestChProbeRewindsToNextQuery(t *testing.T) {
 	const revision = 54448
 	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
-	defer mock.Conn.Close()
+	defer func() { _ = mock.Conn.Close() }()
 
 	mkQuery := func(id, body string, comp chgoproto.Compression) chgoproto.Query {
 		return chgoproto.Query{
@@ -984,8 +984,8 @@ func TestChAgentToServerDeniesQuery(t *testing.T) {
 		map[string]any{"verb": []any{"insert"}}, "deny", "writes blocked", 100)
 	ep := chBuildEndpoint(t, rule)
 	mock, agentSide := chNewMockHandle(t, ep)
-	defer agentSide.Close()
-	defer mock.Conn.Close()
+	defer func() { _ = agentSide.Close() }()
+	defer func() { _ = mock.Conn.Close() }()
 
 	q := chgoproto.Query{
 		ID: "qid-1", Body: sql,
@@ -1037,8 +1037,8 @@ func TestChAgentToServerMultiQueryDenyContinues(t *testing.T) {
 		map[string]any{"verb": []any{"drop"}}, "deny", "drops blocked", 100)
 	ep := chBuildEndpoint(t, rule)
 	mock, agentSide := chNewMockHandle(t, ep)
-	defer agentSide.Close()
-	defer mock.Conn.Close()
+	defer func() { _ = agentSide.Close() }()
+	defer func() { _ = mock.Conn.Close() }()
 
 	mkQuery := func(id, body string) []byte {
 		q := chgoproto.Query{

--- a/config/plugins/endpoints/https.go
+++ b/config/plugins/endpoints/https.go
@@ -15,6 +15,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// HTTPSEndpoint is part of the clawpatrol plugin API.
 type HTTPSEndpoint struct {
 	Hosts          []string  `hcl:"hosts"`
 	Credential     string    `hcl:"credential,optional"`
@@ -25,7 +26,10 @@ type HTTPSEndpoint struct {
 	Credentials []CredentialEntry `json:"Credentials,omitempty"`
 }
 
+// EndpointHosts is part of the clawpatrol plugin API.
 func (e *HTTPSEndpoint) EndpointHosts() []string { return e.Hosts }
+
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *HTTPSEndpoint) EndpointCredentials() []config.CredBinding {
 	return bindings(e.Credential, e.Credentials)
 }
@@ -43,6 +47,7 @@ func (e *HTTPSEndpoint) setCredentialEntries(es []CredentialEntry) { e.Credentia
 // the auth scheme.
 type HTTPSEndpointRuntime struct{}
 
+// DetectPlaceholder is part of the clawpatrol plugin API.
 func (HTTPSEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidates []string) string {
 	if req == nil || req.Headers == nil {
 		return ""

--- a/config/plugins/endpoints/kubernetes.go
+++ b/config/plugins/endpoints/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/denoland/clawpatrol/config"
 )
 
+// KubernetesEndpoint is part of the clawpatrol plugin API.
 type KubernetesEndpoint struct {
 	Hosts       []string `hcl:"hosts,optional"`
 	Server      string   `hcl:"server,optional"`
@@ -19,6 +20,7 @@ type KubernetesEndpoint struct {
 	Credential  string   `hcl:"credential,optional"`
 }
 
+// EndpointHosts is part of the clawpatrol plugin API.
 func (e *KubernetesEndpoint) EndpointHosts() []string {
 	if len(e.Hosts) > 0 {
 		return e.Hosts
@@ -38,6 +40,7 @@ func (e *KubernetesEndpoint) FileIncludeFields() []config.FileIncludeField {
 	}
 }
 
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *KubernetesEndpoint) EndpointCredentials() []config.CredBinding {
 	return singleBinding(e.Credential)
 }

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -47,6 +47,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// OpenAICodexHTTPSEndpoint is part of the clawpatrol plugin API.
 type OpenAICodexHTTPSEndpoint struct {
 	Hosts          []string  `hcl:"hosts"`
 	Credential     string    `hcl:"credential,optional"`
@@ -55,7 +56,10 @@ type OpenAICodexHTTPSEndpoint struct {
 	Credentials []CredentialEntry `json:"Credentials,omitempty"`
 }
 
+// EndpointHosts is part of the clawpatrol plugin API.
 func (e *OpenAICodexHTTPSEndpoint) EndpointHosts() []string { return e.Hosts }
+
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *OpenAICodexHTTPSEndpoint) EndpointCredentials() []config.CredBinding {
 	return bindings(e.Credential, e.Credentials)
 }
@@ -99,6 +103,7 @@ func (e *OpenAICodexHTTPSEndpoint) EnvVars() []config.EnvVar {
 	}
 }
 
+// OpenAICodexHTTPSEndpointRuntime is part of the clawpatrol plugin API.
 type OpenAICodexHTTPSEndpointRuntime struct{}
 
 // DetectPlaceholder mirrors the default https endpoint — agent

--- a/config/plugins/endpoints/openai_codex_https_test.go
+++ b/config/plugins/endpoints/openai_codex_https_test.go
@@ -212,6 +212,7 @@ func TestCodexRespondHTTP(t *testing.T) {
 			if !handled {
 				return
 			}
+			defer func() { _ = resp.Body.Close() }()
 			if resp.StatusCode != c.want {
 				t.Fatalf("status=%d want %d", resp.StatusCode, c.want)
 			}
@@ -253,6 +254,7 @@ func TestCodexSynthRoundTripOverHTTP(t *testing.T) {
 				w.Header().Add(k, v)
 			}
 		}
+		defer func() { _ = resp.Body.Close() }()
 		w.WriteHeader(resp.StatusCode)
 		_, _ = io.Copy(w, resp.Body)
 	}))
@@ -262,7 +264,7 @@ func TestCodexSynthRoundTripOverHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get jwks: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		t.Fatalf("status %d", resp.StatusCode)
 	}

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -77,7 +77,10 @@ type PostgresEndpoint struct {
 	Credentials []CredentialEntry `json:"Credentials,omitempty"`
 }
 
+// EndpointHosts is part of the clawpatrol plugin API.
 func (e *PostgresEndpoint) EndpointHosts() []string { return []string{e.Host} }
+
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *PostgresEndpoint) EndpointCredentials() []config.CredBinding {
 	return bindings(e.Credential, e.Credentials)
 }
@@ -100,6 +103,7 @@ func (e *PostgresEndpoint) setCredentialEntries(es []CredentialEntry) { e.Creden
 // password verbatim before injection.
 type PostgresEndpointRuntime struct{}
 
+// DetectPlaceholder is part of the clawpatrol plugin API.
 func (PostgresEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidates []string) string {
 	if req == nil || req.SQL == nil {
 		return ""
@@ -155,7 +159,7 @@ const sslRequestCode = 80877103
 //     post-auth frames so agent proceeds as if it just authed.
 //  7. Bidirectional pump with per-query inspection.
 func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
-	defer ch.Conn.Close()
+	defer func() { _ = ch.Conn.Close() }()
 	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
 		return fmt.Errorf("postgres runtime invoked on non-sql endpoint %v", ch.Endpoint)
 	}
@@ -233,7 +237,7 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 		pgWriteError(ch.Conn, "dial upstream: "+err.Error())
 		return fmt.Errorf("dial %s: %w", upstreamAddr, err)
 	}
-	defer upstream.Close()
+	defer func() { _ = upstream.Close() }()
 
 	pgEp, _ := ch.Endpoint.Body.(*PostgresEndpoint)
 	sslmode := "prefer"
@@ -347,7 +351,7 @@ func pgStartupParam(body []byte, key string) string {
 
 // pgClientToServer pumps the agent's outbound message stream to the
 // upstream, inspecting Query / Parse for policy.
-func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.Conn, credName string) {
+func pgClientToServer(_ context.Context, ch *runtime.ConnHandle, upstream net.Conn, credName string) {
 	buf := make([]byte, 0, 64*1024)
 	tmp := make([]byte, 32*1024)
 	for {
@@ -381,7 +385,6 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 			return
 		}
 	}
-	_ = ctx
 }
 
 // pgEvaluate runs the SQL through the endpoint's compiled rules and
@@ -711,7 +714,7 @@ func pgUpgradeSSL(upstream net.Conn, pgEp *PostgresEndpoint, sslmode string) (ne
 		if sslmode == "require" || sslmode == "verify-full" {
 			return nil, fmt.Errorf("upstream refused TLS but sslmode=%q requires it", sslmode)
 		}
-		return nil, nil // continue plaintext
+		return upstream, nil // continue plaintext
 	default:
 		return nil, fmt.Errorf("unexpected SSLRequest reply byte %q", reply[0])
 	}

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -75,7 +75,10 @@ type SSHEndpoint struct {
 	Credentials []CredentialEntry `json:"Credentials,omitempty"`
 }
 
+// EndpointHosts is part of the clawpatrol plugin API.
 func (e *SSHEndpoint) EndpointHosts() []string { return e.Hosts }
+
+// EndpointCredentials is part of the clawpatrol plugin API.
 func (e *SSHEndpoint) EndpointCredentials() []config.CredBinding {
 	return bindings(e.Credential, e.Credentials)
 }
@@ -140,8 +143,9 @@ var (
 
 // ── HandleConn ────────────────────────────────────────────────────────
 
+// HandleConn is part of the clawpatrol plugin API.
 func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
-	defer ch.Conn.Close()
+	defer func() { _ = ch.Conn.Close() }()
 	if ch.Endpoint == nil || ch.Endpoint.Family != "ssh" {
 		return fmt.Errorf("ssh runtime invoked on non-ssh endpoint %v", ch.Endpoint)
 	}
@@ -196,7 +200,7 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	if err != nil {
 		return fmt.Errorf("ssh server handshake: %w", err)
 	}
-	defer srvConn.Close()
+	defer func() { _ = srvConn.Close() }()
 
 	agentUser := srvConn.User()
 	if agentUser == "" {
@@ -227,13 +231,13 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	if err != nil {
 		return fmt.Errorf("dial upstream %s: %w", upstreamAddr, err)
 	}
-	defer upConn.Close()
+	defer func() { _ = upConn.Close() }()
 
 	clientConn, clientChans, clientReqs, err := ssh.NewClientConn(upConn, upstreamAddr, upstreamCfg)
 	if err != nil {
 		return fmt.Errorf("ssh client handshake to %s: %w", upstreamAddr, err)
 	}
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 
 	if ch.Emit != nil {
 		ch.Emit(runtime.ConnEvent{
@@ -269,8 +273,8 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	// the time chans.Wait() returns every byte that was going to flow
 	// has flowed.
 	chans.Wait()
-	srvConn.Close()
-	clientConn.Close()
+	_ = srvConn.Close()
+	_ = clientConn.Close()
 	dispatch.Wait()
 	return nil
 }
@@ -368,7 +372,7 @@ func buildHostKeyCallback(hostPubkey, endpointName string) (ssh.HostKeyCallback,
 		return nil, err
 	}
 	pinned := pubkey.Marshal()
-	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+	return func(hostname string, _ net.Addr, key ssh.PublicKey) error {
 		if !bytes.Equal(key.Marshal(), pinned) {
 			return fmt.Errorf("upstream host key for %s does not match credential's pin", hostname)
 		}
@@ -405,7 +409,7 @@ func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel, wg *sync.WaitGr
 		}
 		sourceCh, sourceReqs, err := newCh.Accept()
 		if err != nil {
-			targetCh.Close()
+			_ = targetCh.Close()
 			continue
 		}
 		wg.Add(1)
@@ -588,17 +592,17 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if err := tmp.Chmod(perm); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return err
 	}
 	return os.Rename(tmpName, path)

--- a/config/plugins/tunnels/kubernetes_port_forward.go
+++ b/config/plugins/tunnels/kubernetes_port_forward.go
@@ -84,6 +84,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// KubernetesPortForwardTunnel configures the tunnel runtime.
 type KubernetesPortForwardTunnel struct {
 	Context   string `hcl:"context,optional"`
 	Namespace string `hcl:"namespace,optional"`
@@ -112,6 +113,7 @@ type KubernetesPortForwardTunnel struct {
 	Credential string `hcl:"credential,optional"`
 }
 
+// TunnelCommon returns shared tunnel settings.
 func (t *KubernetesPortForwardTunnel) TunnelCommon() config.TunnelCommon {
 	return config.TunnelCommon{
 		Share:      t.Share,

--- a/config/plugins/tunnels/local_command.go
+++ b/config/plugins/tunnels/local_command.go
@@ -43,6 +43,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// LocalCommandTunnel configures the tunnel runtime.
 type LocalCommandTunnel struct {
 	Command      []string          `hcl:"command"`
 	Listen       string            `hcl:"listen"`
@@ -59,6 +60,7 @@ type LocalCommandTunnel struct {
 	Credential string `hcl:"credential,optional"`
 }
 
+// TunnelCommon returns shared tunnel settings.
 func (t *LocalCommandTunnel) TunnelCommon() config.TunnelCommon {
 	return config.TunnelCommon{
 		Share:      t.Share,
@@ -135,7 +137,7 @@ func (t *LocalCommandTunnel) Open(ctx context.Context, host runtime.TunnelHost, 
 		probeCtx, cancel := context.WithTimeout(ctx, readyTimeout)
 		defer cancel()
 		if err := readinessTCP(probeCtx, t.Listen, 200*time.Millisecond); err != nil {
-			rt.Close()
+			_ = rt.Close()
 			return nil, fmt.Errorf("local_command/%s: %w", host.Name, err)
 		}
 	}

--- a/config/plugins/tunnels/local_command_test.go
+++ b/config/plugins/tunnels/local_command_test.go
@@ -25,7 +25,7 @@ func TestLocalCommandSpawn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	listenAddr := l.Addr().String()
 
 	// Accept-and-discard in the background so Dial succeeds.
@@ -35,7 +35,7 @@ func TestLocalCommandSpawn(t *testing.T) {
 			if err != nil {
 				return
 			}
-			c.Close()
+			_ = c.Close()
 		}
 	}()
 
@@ -61,7 +61,7 @@ func TestLocalCommandSpawn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	// Close terminates the spawned `sleep`; the test would hang
 	// for 30s if SIGTERM weren't routed to the process group.

--- a/config/plugins/tunnels/ssh_port_forward.go
+++ b/config/plugins/tunnels/ssh_port_forward.go
@@ -42,6 +42,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// SSHPortForwardTunnel configures the tunnel runtime.
 type SSHPortForwardTunnel struct {
 	Bastion string `hcl:"bastion,optional"` // host:port; required when Via is unset
 	User    string `hcl:"user"`
@@ -53,6 +54,7 @@ type SSHPortForwardTunnel struct {
 	Credential string `hcl:"credential"`
 }
 
+// TunnelCommon returns shared tunnel settings.
 func (t *SSHPortForwardTunnel) TunnelCommon() config.TunnelCommon {
 	return config.TunnelCommon{
 		Share:      t.Share,
@@ -136,7 +138,7 @@ func (t *SSHPortForwardTunnel) Open(ctx context.Context, host runtime.TunnelHost
 	}
 	clientConn, chans, reqs, err := ssh.NewClientConn(netConn, bastionAddr, clientCfg)
 	if err != nil {
-		netConn.Close()
+		_ = netConn.Close()
 		return nil, fmt.Errorf("ssh_port_forward: handshake to %q: %w", bastionAddr, err)
 	}
 	client := ssh.NewClient(clientConn, chans, reqs)

--- a/config/plugins/tunnels/ssh_port_forward_test.go
+++ b/config/plugins/tunnels/ssh_port_forward_test.go
@@ -71,13 +71,13 @@ func inProcessSSHServer(t *testing.T, pubKey ssh.PublicKey, hostSigner ssh.Signe
 		}
 	}()
 	return l.Addr().String(), func() {
-		l.Close()
+		_ = l.Close()
 		<-done
 	}
 }
 
 func serveSSH(rawConn net.Conn, cfg *ssh.ServerConfig) {
-	defer rawConn.Close()
+	defer func() { _ = rawConn.Close() }()
 	_, chans, reqs, err := ssh.NewServerConn(rawConn, cfg)
 	if err != nil {
 		return
@@ -85,7 +85,7 @@ func serveSSH(rawConn net.Conn, cfg *ssh.ServerConfig) {
 	go ssh.DiscardRequests(reqs)
 	for newChan := range chans {
 		if newChan.ChannelType() != "direct-tcpip" {
-			newChan.Reject(ssh.UnknownChannelType, "unsupported")
+			_ = newChan.Reject(ssh.UnknownChannelType, "unsupported")
 			continue
 		}
 		// direct-tcpip extra data is RFC 4254 §7.2:
@@ -100,7 +100,7 @@ func serveSSH(rawConn net.Conn, cfg *ssh.ServerConfig) {
 			OriginPort uint32
 		}
 		if err := ssh.Unmarshal(newChan.ExtraData(), &payload); err != nil {
-			newChan.Reject(ssh.ConnectionFailed, "bad payload")
+			_ = newChan.Reject(ssh.ConnectionFailed, "bad payload")
 			continue
 		}
 		ch, chReqs, err := newChan.Accept()
@@ -112,7 +112,7 @@ func serveSSH(rawConn net.Conn, cfg *ssh.ServerConfig) {
 		target := net.JoinHostPort(payload.Target, itoaPort(int(payload.TargetPort)))
 		up, err := net.DialTimeout("tcp", target, 5*time.Second)
 		if err != nil {
-			ch.Close()
+			_ = ch.Close()
 			continue
 		}
 		go bridge(ch, up)
@@ -122,8 +122,8 @@ func serveSSH(rawConn net.Conn, cfg *ssh.ServerConfig) {
 func bridge(a, b io.ReadWriteCloser) {
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); io.Copy(a, b); a.Close() }()
-	go func() { defer wg.Done(); io.Copy(b, a); b.Close() }()
+	go func() { defer wg.Done(); _, _ = io.Copy(a, b); _ = a.Close() }()
+	go func() { defer wg.Done(); _, _ = io.Copy(b, a); _ = b.Close() }()
 	wg.Wait()
 }
 
@@ -177,15 +177,15 @@ func TestSSHPortForward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("target listen: %v", err)
 	}
-	defer targetL.Close()
+	defer func() { _ = targetL.Close() }()
 	go func() {
 		for {
 			c, err := targetL.Accept()
 			if err != nil {
 				return
 			}
-			c.Write([]byte("hello"))
-			c.Close()
+			_, _ = c.Write([]byte("hello"))
+			_ = c.Close()
 		}
 	}()
 
@@ -225,7 +225,7 @@ func TestSSHPortForward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer rt.Close()
+	defer func() { _ = rt.Close() }()
 
 	// Dial via SSH session — uses the bastion's `direct-tcpip`
 	// channel to reach our target listener. Use `clientSigner`
@@ -235,7 +235,7 @@ func TestSSHPortForward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	buf := make([]byte, 5)
 	n, err := io.ReadFull(conn, buf)
 	if err != nil {

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -46,6 +46,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+// TailscaleTunnel configures the tunnel runtime.
 type TailscaleTunnel struct {
 	AuthKey    string   `hcl:"authkey,optional"`
 	ControlURL string   `hcl:"control_url,optional"`
@@ -60,6 +61,7 @@ type TailscaleTunnel struct {
 	Credential string `hcl:"credential,optional"`
 }
 
+// TunnelCommon returns shared tunnel settings.
 func (t *TailscaleTunnel) TunnelCommon() config.TunnelCommon {
 	return config.TunnelCommon{
 		Share:      t.Share,

--- a/config/plugins/tunnels/util.go
+++ b/config/plugins/tunnels/util.go
@@ -70,7 +70,7 @@ func readinessTCP(ctx context.Context, dst string, interval time.Duration) error
 	for {
 		c, err := (&net.Dialer{Timeout: interval}).DialContext(ctx, "tcp", dst)
 		if err == nil {
-			c.Close()
+			_ = c.Close()
 			return nil
 		}
 		select {

--- a/config/runtime/secrets.go
+++ b/config/runtime/secrets.go
@@ -38,7 +38,8 @@ type SecretStore interface {
 // per-owner extension would key on `_<OWNER>` suffix.
 type EnvSecretStore struct{}
 
-func (EnvSecretStore) Get(name, owner string) (Secret, error) {
+// Get is part of the clawpatrol plugin API.
+func (EnvSecretStore) Get(name, _ string) (Secret, error) {
 	if name == "" {
 		return Secret{}, fmt.Errorf("empty credential name")
 	}

--- a/config/runtime/tunnel.go
+++ b/config/runtime/tunnel.go
@@ -44,19 +44,19 @@ type TunnelRuntime interface {
 type TunnelSharing = string
 
 const (
-	// TunnelShareSingleton: one runtime instance per tunnel name.
+	// TunnelShareSingleton creates one runtime instance per tunnel name.
 	// All endpoints, all connections, share the same Tunnel. Idle
 	// teardown is shared too. Right default for tailscale (one node
 	// in the tailnet) and singleton local listeners (cloud_sql_proxy).
 	TunnelShareSingleton TunnelSharing = "singleton"
 
-	// TunnelSharePerEndpoint: one runtime instance per (tunnel,
+	// TunnelSharePerEndpoint creates one runtime instance per (tunnel,
 	// endpoint) pair. Right default for kubernetes_port_forward,
 	// where each endpoint allocates its own ephemeral local port
 	// and two endpoints can't share the same forwarder.
 	TunnelSharePerEndpoint TunnelSharing = "per_endpoint"
 
-	// TunnelSharePerConn: a fresh instance per inbound connection,
+	// TunnelSharePerConn creates a fresh instance per inbound connection,
 	// torn down on conn close. Niche but useful for stateless
 	// "tunnels" whose lifetime should track a single request.
 	TunnelSharePerConn TunnelSharing = "per_conn"

--- a/db.go
+++ b/db.go
@@ -41,11 +41,11 @@ func OpenDB(path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("sqlite open %s: %w", path, err)
 	}
 	if err := db.Ping(); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("sqlite ping: %w", err)
 	}
 	if err := migrate(db); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return db, nil

--- a/dial.go
+++ b/dial.go
@@ -113,24 +113,7 @@ func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName st
 	}
 	tc := tls.Client(raw, cfg)
 	if err := tc.HandshakeContext(ctx); err != nil {
-		raw.Close()
-		return nil, err
-	}
-	return tc, nil
-}
-
-// dialUpstreamTLS opens a TCP connection and runs stdlib TLS with
-// ALPN forced to http/1.1 (our http.Transport is HTTP/1.1 only).
-// Used for normal HTTP-mode upstreams.
-func dialUpstreamTLS(ctx context.Context, network, addr, serverName string) (net.Conn, error) {
-	d := &net.Dialer{}
-	raw, err := d.DialContext(ctx, network, addr)
-	if err != nil {
-		return nil, err
-	}
-	tc := tls.Client(raw, &tls.Config{ServerName: serverName, NextProtos: []string{"http/1.1"}})
-	if err := tc.HandshakeContext(ctx); err != nil {
-		raw.Close()
+		_ = raw.Close()
 		return nil, err
 	}
 	return tc, nil
@@ -157,7 +140,7 @@ func dialBrowserTLS(ctx context.Context, network, addr, serverName string) (net.
 	c := utls.UClient(raw, &utls.Config{ServerName: serverName}, utls.HelloCustom)
 	spec, err := utls.UTLSIdToSpec(utls.HelloChrome_Auto)
 	if err != nil {
-		raw.Close()
+		_ = raw.Close()
 		return nil, err
 	}
 	for _, ext := range spec.Extensions {
@@ -166,11 +149,11 @@ func dialBrowserTLS(ctx context.Context, network, addr, serverName string) (net.
 		}
 	}
 	if err := c.ApplyPreset(&spec); err != nil {
-		raw.Close()
+		_ = raw.Close()
 		return nil, err
 	}
 	if err := c.HandshakeContext(ctx); err != nil {
-		raw.Close()
+		_ = raw.Close()
 		return nil, err
 	}
 	return c, nil

--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -202,12 +202,12 @@ func (a *Allocator) persistLocked() error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(buf); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return err
 	}
 	return os.Rename(tmpName, a.statePath)
@@ -351,7 +351,7 @@ func collectRequiredHosts(policy *config.CompiledPolicy) map[string][]EndpointHi
 			if net.ParseIP(host) != nil {
 				continue
 			}
-			var port uint16 = defaultPortFor(ep)
+			var port = defaultPortFor(ep)
 			if portStr != "" {
 				var p uint16
 				if _, err := fmt.Sscanf(portStr, "%d", &p); err == nil {
@@ -456,7 +456,7 @@ func (a *Allocator) VIPsFor(hostname string) (netip.Addr, netip.Addr) {
 // existing DNS configuration keeps working — the gateway hijacks
 // only the names it has policy for.
 func (a *Allocator) ServeUDP(c net.Conn, dstIP string) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	buf := make([]byte, 4096)
 	for {
 		_ = c.SetReadDeadline(time.Now().Add(60 * time.Second))
@@ -476,7 +476,7 @@ func (a *Allocator) ServeUDP(c net.Conn, dstIP string) {
 // netstack gives us one TCP conn per agent flow; we loop until the
 // agent closes (DNS-over-TCP supports pipelining).
 func (a *Allocator) ServeTCP(c net.Conn, dstIP string) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	hdr := make([]byte, 2)
 	for {
 		_ = c.SetReadDeadline(time.Now().Add(60 * time.Second))

--- a/integrations.go
+++ b/integrations.go
@@ -109,7 +109,7 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("fetch %s: status %d", url, resp.StatusCode)
 	}
@@ -253,17 +253,19 @@ func (f *flexInt) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		var n int64
-		if _, err := fmt.Sscan(s, &n); err != nil {
-			return nil // leave as 0
+		if _, scanErr := fmt.Sscan(s, &n); scanErr == nil {
+			*f = flexInt(n)
+		} else {
+			*f = 0
 		}
-		*f = flexInt(n)
 		return nil
 	}
 	var n int64
-	if err := json.Unmarshal(b, &n); err != nil {
-		return nil
+	if json.Unmarshal(b, &n) == nil {
+		*f = flexInt(n)
+	} else {
+		*f = 0
 	}
-	*f = flexInt(n)
 	return nil
 }
 
@@ -297,7 +299,7 @@ func (m *modelDB) fetch() error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var raw map[string]modelInfo
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return err

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -99,7 +99,7 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 			t.Fatalf("listen: %v", err)
 		}
 		addr := l.Addr().String()
-		l.Close()
+		_ = l.Close()
 		_ = os.WriteFile(filepath.Join(dir, "gateway"), []byte("http://"+addr), 0o644)
 		_ = os.WriteFile(filepath.Join(dir, "api-token"), []byte("t"), 0o600)
 		if _, err := fetchEnvPushdownFromGateway(dir); err == nil {
@@ -113,7 +113,7 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 // vars (client-side) plus the server-supplied ones in a single
 // flat list.
 func TestEnvPushdownVarsServerDriven(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"vars": []map[string]string{{"name": "CODEX_ACCESS_TOKEN", "value": "from-server"}},
 		})

--- a/login.go
+++ b/login.go
@@ -138,7 +138,7 @@ func fetchCAHTTP(gateway, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("status %d", resp.StatusCode)
 	}
@@ -271,7 +271,7 @@ func installShellRC() error {
 			return err
 		}
 		if _, err := f.WriteString(block); err != nil {
-			f.Close()
+			_ = f.Close()
 			return err
 		}
 		return f.Close()
@@ -410,7 +410,7 @@ func fetchCA(ip, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("status %d from %s", resp.StatusCode, url)
 	}
@@ -596,7 +596,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	if err != nil {
 		return false, fmt.Errorf("start: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		b, _ := io.ReadAll(resp.Body)
 		return false, fmt.Errorf("start: %d %s", resp.StatusCode, string(b))
@@ -647,7 +647,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		}
 		var pv map[string]string
 		_ = json.NewDecoder(pr.Body).Decode(&pv)
-		pr.Body.Close()
+		_ = pr.Body.Close()
 		if k, ok := pv["auth_key"]; ok && k != "" {
 			authKey = k
 			loginServer = pv["login_server"]
@@ -701,7 +701,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				claimURL += "&ip=" + neturl.QueryEscape(wgIP)
 			}
 			if cr, err := cli.Post(claimURL, "application/json", nil); err == nil {
-				cr.Body.Close()
+				_ = cr.Body.Close()
 			}
 		}
 		// Always persist a user-readable copy at ~/.config/clawpatrol/
@@ -797,7 +797,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		fmt.Fprintf(os.Stderr, "⚠ onboard claim failed: %v\n", err)
 		return false, nil
 	}
-	defer cr.Body.Close()
+	defer func() { _ = cr.Body.Close() }()
 	if cr.StatusCode != 200 {
 		body, _ := io.ReadAll(io.LimitReader(cr.Body, 400))
 		fmt.Fprintf(os.Stderr, "⚠ onboard claim %d: %s\n", cr.StatusCode, string(body))
@@ -881,8 +881,8 @@ func wgQuickUp(iface, conf string) error {
 	if _, err := tmp.WriteString(conf); err != nil {
 		return err
 	}
-	tmp.Close()
-	defer os.Remove(tmp.Name())
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	if err := runAsRoot("install", "-m", "0600", tmp.Name(), dst).Run(); err != nil {
 		return fmt.Errorf("install conf: %w", err)
 	}
@@ -1131,7 +1131,7 @@ func detectPublicIP() string {
 			continue
 		}
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 64))
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		ip := strings.TrimSpace(string(b))
 		if isIPv4(ip) {
 			return ip
@@ -1379,7 +1379,7 @@ func wgEndpointFromConf(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
@@ -1400,6 +1400,6 @@ func pingGateway(endpoint string) bool {
 	if err != nil {
 		return false
 	}
-	c.Close()
+	_ = c.Close()
 	return true
 }

--- a/mac_helper_stub.go
+++ b/mac_helper_stub.go
@@ -6,7 +6,7 @@ package main
 // login.go's runJoin guards the call with `runtime.GOOS == "darwin"`
 // already, but Go still needs the symbol resolvable at compile time
 // on every build.
-func macHelperInstall(wholeMachine bool) error { return nil }
+func macHelperInstall(_ bool) error { return nil }
 
 // macHelperPath alias for cross-platform builds. On non-darwin, the
 // path doesn't exist (uninstall + status guard with os.Stat); the

--- a/main.go
+++ b/main.go
@@ -135,8 +135,8 @@ func orderedProfileNames(p *config.Policy) []string {
 }
 
 func peekSNI(c net.Conn) (string, []byte, error) {
-	c.SetReadDeadline(time.Now().Add(10 * time.Second))
-	defer c.SetReadDeadline(time.Time{})
+	_ = c.SetReadDeadline(time.Now().Add(10 * time.Second))
+	defer func() { _ = c.SetReadDeadline(time.Time{}) }()
 
 	hdr := make([]byte, 5)
 	if _, err := io.ReadFull(c, hdr); err != nil {
@@ -1051,18 +1051,18 @@ func stripSystemReminders(s string) string {
 func stripXMLBlocks(s string, tags ...string) string {
 	for _, tag := range tags {
 		open := "<" + tag + ">"
-		close := "</" + tag + ">"
+		closing := "</" + tag + ">"
 		for {
 			i := strings.Index(s, open)
 			if i < 0 {
 				break
 			}
-			j := strings.Index(s[i:], close)
+			j := strings.Index(s[i:], closing)
 			if j < 0 {
 				s = s[:i]
 				break
 			}
-			s = s[:i] + s[i+j+len(close):]
+			s = s[:i] + s[i+j+len(closing):]
 		}
 	}
 	return strings.TrimSpace(s)
@@ -1109,39 +1109,8 @@ func truncate(s string, n int) string {
 	return s
 }
 
-// ownerForRequest returns the credential-bucket key for a peer. With
-// the profile-as-tenant model, that's the device's assigned profile
-// name (devices.profile). Falls back to the peer's onboard-mapped
-// owner email and finally peer IP for un-onboarded clients — both
-// preserve compatibility with credentials saved before the profile
-// migration. Whois lookup remains in place for tailscale-control mode
-// where the dashboard still binds creds to the human's login.
-func (g *Gateway) ownerForRequest(c net.Conn, _ *OAuthIntegration) string {
-	ip := peerIP(c)
-	if g.onboard != nil {
-		if profile := g.onboard.ProfileForIP(ip); profile != "" {
-			return profile
-		}
-	}
-	login := ""
-	if g.agents != nil && g.agents.lc != nil {
-		if who := g.agents.lookupWhois(ip); who != nil && !who.UserProfile.IsZero() {
-			login = who.UserProfile.LoginName
-		}
-	}
-	if (login == "" || login == "tagged-devices") && g.onboard != nil {
-		if owner := g.onboard.OwnerForIP(ip); owner != "" {
-			return owner
-		}
-	}
-	if login != "" {
-		return login
-	}
-	return ip
-}
-
 func (g *Gateway) handle(raw net.Conn, dstIP string) {
-	defer raw.Close()
+	defer func() { _ = raw.Close() }()
 	defer otelTrackConn("https_mitm")()
 	host, prefix, err := peekSNI(raw)
 	if err != nil {
@@ -1198,7 +1167,7 @@ func (g *Gateway) handle(raw net.Conn, dstIP string) {
 // passthrough fallback when no endpoint applies, mirroring the
 // HTTPS handler's `unknown_host = passthrough` default.
 func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	defer otelTrackConn("pg_relay")()
 	pip := peerIP(c)
 	profile := g.profileFor(pip)
@@ -1240,7 +1209,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 		Profile:  profile,
 		PeerIP:   pip,
 		Secrets:  g.secrets,
-		DialUpstream: func(ctx context.Context, network, addr string) (net.Conn, error) {
+		DialUpstream: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			// Plugin asks for ep.Hosts[0]:port; we bypass DNS by
 			// dialing the original upstream IP the WG forwarder
 			// gave us. Plugin-supplied addr is ignored when it's
@@ -1249,9 +1218,6 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 			// has no tunnel; this path is used by non-tunneled
 			// postgres endpoints today (tunneled ones land in the
 			// VIP dispatch path, not here).
-			if addr == "" {
-				addr = upstreamAddr
-			}
 			return g.dialThrough(ctx, ep, network, upstreamAddr)
 		},
 		Emit: func(ev runtime.ConnEvent) {
@@ -1290,7 +1256,7 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 	hostname, hits := g.dnsvip.LookupVIP(dstIP)
 	if hostname == "" || len(hits) == 0 {
 		log.Printf("vip %s:%d: VIP allocated but no endpoint binding (stale?); dropping", dstIP, dstPort)
-		c.Close()
+		_ = c.Close()
 		return
 	}
 	pip := peerIP(c)
@@ -1321,7 +1287,7 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 	}
 	if ep == nil {
 		log.Printf("vip %s:%d (host %q): no endpoint matches profile %q + port", dstIP, dstPort, hostname, profile)
-		c.Close()
+		_ = c.Close()
 		return
 	}
 	g.dispatchConnEndpoint(c, dstIP, matchedPort, ep, hostname)
@@ -1370,7 +1336,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 	connRT, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime)
 	if !ok {
 		log.Printf("conn dispatch: endpoint %q plugin lacks ConnEndpointRuntime", ep.Name)
-		c.Close()
+		_ = c.Close()
 		return
 	}
 	pip := peerIP(c)
@@ -1507,25 +1473,12 @@ func (g *Gateway) splice(c net.Conn, host string) {
 		g.emit(Event{Mode: "splice", Host: host, AgentIP: peerIP(c), Action: "error", Reason: err.Error(), Ms: time.Since(start).Milliseconds()})
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	agentAddr := peerIP(c) // capture BEFORE pipe — RemoteAddr() goes nil once netstack closes the conn
 	in, out := pipeProgress(c, up, g.streamTracker(agentAddr, host))
 	g.emit(Event{Mode: "splice", Host: host, AgentIP: agentAddr, Action: "allow", In: in, Out: out, Ms: time.Since(start).Milliseconds()})
 }
 
-// pipe shuttles bytes both ways between two conns. Returns (a-rx, a-tx)
-// = (bytes received from up into a, bytes sent from a to up). Sends
-// CloseWrite half-shutdown on each side after its copy finishes.
-func pipe(a, b net.Conn) (rx, tx int64) {
-	return pipeProgress(a, b, nil)
-}
-
-// pipeProgress is pipe with an optional onTick callback fired every
-// second w/ cumulative (rx, tx) snapshots. Lets callers feed the
-// per-agent activity sparkline DURING a long-lived flow (ssh clone,
-// websocket) instead of only after the conn closes — sampleLoop runs
-// at 1s and wants per-second deltas, so a flow that lasts 10 minutes
-// would otherwise paint a single bar at end-of-life.
 func pipeProgress(a, b net.Conn, onTick func(rx, tx int64)) (rx, tx int64) {
 	var rxC, txC atomic.Int64
 	done := make(chan struct{}, 2)
@@ -1533,7 +1486,7 @@ func pipeProgress(a, b net.Conn, onTick func(rx, tx int64)) (rx, tx int64) {
 		buf := make([]byte, 256<<10)
 		_, _ = io.CopyBuffer(&countWriter{Writer: b, n: &txC}, a, buf)
 		if cw, ok := b.(interface{ CloseWrite() error }); ok {
-			cw.CloseWrite()
+			_ = cw.CloseWrite()
 		}
 		done <- struct{}{}
 	}()
@@ -1541,7 +1494,7 @@ func pipeProgress(a, b net.Conn, onTick func(rx, tx int64)) (rx, tx int64) {
 		buf := make([]byte, 256<<10)
 		_, _ = io.CopyBuffer(&countWriter{Writer: a, n: &rxC}, b, buf)
 		if cw, ok := a.(interface{ CloseWrite() error }); ok {
-			cw.CloseWrite()
+			_ = cw.CloseWrite()
 		}
 		done <- struct{}{}
 	}()
@@ -1605,7 +1558,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		log.Printf("mitm tls handshake %s: %v", host, err)
 		return
 	}
-	defer tc.Close()
+	defer func() { _ = tc.Close() }()
 
 	// transport is shared across all requests for this endpoint.
 	// Old path allocated a fresh http.Transport per mitmHTTPS call,
@@ -1616,15 +1569,15 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 
 	br := bufio.NewReader(tc)
 	for {
-		tc.SetReadDeadline(time.Now().Add(60 * time.Second))
+		_ = tc.SetReadDeadline(time.Now().Add(60 * time.Second))
 		req, err := http.ReadRequest(br)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				log.Printf("mitm read req %s: %v", host, err)
 			}
 			return
 		}
-		tc.SetReadDeadline(time.Time{})
+		_ = tc.SetReadDeadline(time.Time{})
 
 		start := time.Now()
 		pip := peerIP(c)
@@ -1690,7 +1643,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					reason = "denied by approver"
 				}
 				log.Printf("hitl-deny %s %s %s: %s (by %s)", host, req.Method, req.URL.Path, reason, v.By)
-				fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
+				_, _ = fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
 				ev.Status = 403
 				ev.Action = "hitl_deny"
 				ev.Reason = reason
@@ -1709,7 +1662,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				reason = "denied by policy"
 			}
 			log.Printf("deny %s %s %s: %s (rule %q)", host, req.Method, req.URL.Path, reason, cr.Name)
-			fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
+			_, _ = fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
 			ev.Status = 403
 			ev.Action = "deny"
 			ev.Reason = reason
@@ -1753,6 +1706,9 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			if r, handled, err := responder.RespondHTTP(req.Context(), req); err != nil {
 				log.Printf("respond %s: %v", ep.Name, err)
 			} else if handled {
+				if r.Body != nil {
+					defer func() { _ = r.Body.Close() }()
+				}
 				ev.Status = r.StatusCode
 				ev.Action = "synth"
 				if err := r.Write(tc); err != nil {
@@ -1859,7 +1815,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		rtDur := time.Since(rtStart)
 		if err != nil {
 			log.Printf("mitm upstream %s %s: %v", host, req.URL.Path, err)
-			fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+			_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 			ev.Status = 502
 			ev.Action = "error"
 			ev.Reason = err.Error()
@@ -1892,7 +1848,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		}
 		writeErr := resp.Write(tc)
 		_ = rtDur
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if trackBuf != nil && g.agents != nil {
 			body := trackBuf.Bytes()
 			if strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
@@ -1900,7 +1856,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					if d, err := io.ReadAll(zr); err == nil {
 						body = d
 					}
-					zr.Close()
+					_ = zr.Close()
 				}
 			}
 			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint)
@@ -2024,13 +1980,6 @@ func ifNotEmpty(r *config.CompiledRule, f func(*config.CompiledRule) string) str
 		return ""
 	}
 	return f(r)
-}
-
-func defaultHITLTimeout(p *config.CompiledPolicy) time.Duration {
-	if p != nil && p.Defaults.HumanTimeout > 0 {
-		return time.Duration(p.Defaults.HumanTimeout) * time.Second
-	}
-	return 60 * time.Second
 }
 
 func main() {
@@ -2247,13 +2196,16 @@ func runGateway(args []string) {
 	// will be re-seeded below.
 	_, _ = db.Exec("DELETE FROM devices WHERE id LIKE 'fd77:%'")
 	if rows, err := db.Query("SELECT id FROM devices"); err == nil {
+		defer func() { _ = rows.Close() }()
 		for rows.Next() {
 			var ip string
 			if rows.Scan(&ip) == nil {
 				g.agents.Seed(canonicalPeerIP(ip))
 			}
 		}
-		rows.Close()
+		if err := rows.Err(); err != nil {
+			log.Printf("seed devices: %v", err)
+		}
 	}
 
 	// Sessions: rehydrate persisted rows + start the sweeper.
@@ -2277,11 +2229,11 @@ func runGateway(args []string) {
 	if cfg.InfoListen != "" {
 		mux := newWebMux(g, cfg.CADir, *cfg.Tailscale, cfg.PublicURL)
 		go func() {
-			http.ListenAndServe(cfg.InfoListen, mux)
+			_ = http.ListenAndServe(cfg.InfoListen, mux)
 		}()
 		printDashboardURL(cfg.InfoListen)
 	}
-	go http.ListenAndServe("127.0.0.1:6060", nil)
+	go func() { _ = http.ListenAndServe("127.0.0.1:6060", nil) }()
 	go g.servePorts()
 
 	// Embedded userspace WireGuard server. When operator sets
@@ -2422,7 +2374,7 @@ func (l *oneShotListener) Addr() net.Addr {
 // dashboard request history alongside MITM traffic — without this,
 // ssh / git-over-ssh / arbitrary-port connections went silent.
 func (g *Gateway) wgRelay(c net.Conn, dstIP string, dstPort int) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	pip := peerIP(c)
 	profile := g.profileFor(pip)
 	host := fmt.Sprintf("%s:%d", dstIP, dstPort)
@@ -2436,7 +2388,7 @@ func (g *Gateway) wgRelay(c net.Conn, dstIP string, dstPort int) {
 		})
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	rx, tx := pipeProgress(c, up, g.streamTracker(pip, host))
 	g.sink.Emit(Event{
 		Mode: "relay", AgentIP: pip, Agent: profile,

--- a/oauth.go
+++ b/oauth.go
@@ -30,13 +30,6 @@ type (
 	OAuthIntegration = config.OAuthIntegration
 )
 
-type tokenStore struct {
-	AccessToken  string    `json:"access_token"`
-	TokenType    string    `json:"token_type"`
-	RefreshToken string    `json:"refresh_token"`
-	Expiry       time.Time `json:"expiry"`
-}
-
 // oauthState is one credential: tokens for a single (integration, owner).
 // Persisted in the credentials table; one row per (id, owner).
 type oauthState struct {
@@ -255,7 +248,7 @@ func fetchOAuthProfile(id, accessToken string) (string, string) {
 		if err != nil {
 			return "", ""
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != 200 {
 			return "", ""
 		}
@@ -353,7 +346,7 @@ func (a *anthropicRefreshSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("anthropic refresh %d: %s", resp.StatusCode, string(respBytes))
@@ -458,7 +451,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var (
 			id, owner           string
@@ -547,7 +540,7 @@ func validOAuthScope(s string) bool {
 
 func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	id := r.URL.Query().Get("id")
@@ -608,7 +601,7 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 
 func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {
@@ -667,13 +660,13 @@ func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthInt
 	req.Header.Set("Accept", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		http.Error(rw, "device-code: "+err.Error(), 502)
+		http.Error(rw, "device-code: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		http.Error(rw, fmt.Sprintf("device-code %d: %s", resp.StatusCode, string(body)), 502)
+		http.Error(rw, fmt.Sprintf("device-code %d: %s", resp.StatusCode, string(body)), http.StatusBadGateway)
 		return
 	}
 	var dr struct {
@@ -684,7 +677,7 @@ func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthInt
 		Interval        int    `json:"interval"`
 	}
 	if err := json.Unmarshal(body, &dr); err != nil {
-		http.Error(rw, "device-code parse: "+err.Error(), 502)
+		http.Error(rw, "device-code parse: "+err.Error(), http.StatusBadGateway)
 		return
 	}
 	state := randomString(32)
@@ -728,13 +721,13 @@ func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OA
 	req.Header.Set("User-Agent", "clawpatrol/1.0")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		http.Error(rw, "openai deviceauth: "+err.Error(), 502)
+		http.Error(rw, "openai deviceauth: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		http.Error(rw, fmt.Sprintf("openai deviceauth %d: %s", resp.StatusCode, string(respBody)), 502)
+		http.Error(rw, fmt.Sprintf("openai deviceauth %d: %s", resp.StatusCode, string(respBody)), http.StatusBadGateway)
 		return
 	}
 	// OpenAI ships `interval` as a quoted string ("5") rather than a
@@ -745,7 +738,7 @@ func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OA
 		Interval     json.Number `json:"interval"`
 	}
 	if err := json.Unmarshal(respBody, &dr); err != nil || dr.DeviceAuthID == "" || dr.UserCode == "" {
-		http.Error(rw, "openai deviceauth parse: "+string(respBody), 502)
+		http.Error(rw, "openai deviceauth parse: "+string(respBody), http.StatusBadGateway)
 		return
 	}
 	state := randomString(32)
@@ -808,10 +801,10 @@ func (w *webMux) pollOpenAIDeviceFlow(rw http.ResponseWriter, sess *oauthSession
 	req.Header.Set("User-Agent", "clawpatrol/1.0")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		http.Error(rw, "openai poll: "+err.Error(), 502)
+		http.Error(rw, "openai poll: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == 202 || resp.StatusCode == 204 {
 		writeJSON(rw, map[string]string{"error": "authorization_pending"})
 		return
@@ -838,13 +831,13 @@ func (w *webMux) pollOpenAIDeviceFlow(rw http.ResponseWriter, sess *oauthSession
 	exReq.Header.Set("Accept", "application/json")
 	exResp, err := http.DefaultClient.Do(exReq)
 	if err != nil {
-		http.Error(rw, "openai exchange: "+err.Error(), 502)
+		http.Error(rw, "openai exchange: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer exResp.Body.Close()
+	defer func() { _ = exResp.Body.Close() }()
 	exBody, _ := io.ReadAll(exResp.Body)
 	if exResp.StatusCode != 200 {
-		http.Error(rw, fmt.Sprintf("openai exchange %d: %s", exResp.StatusCode, string(exBody)), 502)
+		http.Error(rw, fmt.Sprintf("openai exchange %d: %s", exResp.StatusCode, string(exBody)), http.StatusBadGateway)
 		return
 	}
 	var tr struct {
@@ -855,7 +848,7 @@ func (w *webMux) pollOpenAIDeviceFlow(rw http.ResponseWriter, sess *oauthSession
 		ExpiresIn    int64  `json:"expires_in"`
 	}
 	if err := json.Unmarshal(exBody, &tr); err != nil || tr.AccessToken == "" {
-		http.Error(rw, "openai exchange parse", 502)
+		http.Error(rw, "openai exchange parse", http.StatusBadGateway)
 		return
 	}
 	tok := &oauth2.Token{
@@ -888,10 +881,10 @@ func (w *webMux) pollDeviceFlow(rw http.ResponseWriter, sess *oauthSession) {
 	req.Header.Set("Accept", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		http.Error(rw, "device poll: "+err.Error(), 502)
+		http.Error(rw, "device poll: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	// Don't log the body verbatim — on success it carries access_token.
 	var tr struct {
@@ -905,7 +898,7 @@ func (w *webMux) pollDeviceFlow(rw http.ResponseWriter, sess *oauthSession) {
 		Interval         int    `json:"interval"`
 	}
 	if err := json.Unmarshal(body, &tr); err != nil {
-		http.Error(rw, "device poll parse: "+err.Error(), 502)
+		http.Error(rw, "device poll parse: "+err.Error(), http.StatusBadGateway)
 		return
 	}
 	if tr.Error != "" {
@@ -978,7 +971,7 @@ func exchangeAnthropicCode(ctx context.Context, sess *oauthSession, code, state 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("anthropic %d: %s", resp.StatusCode, string(respBytes))
@@ -1005,7 +998,7 @@ func exchangeAnthropicCode(ctx context.Context, sess *oauthSession, code, state 
 
 func (w *webMux) apiOAuthDevicePoll(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	state := r.URL.Query().Get("state")
@@ -1029,7 +1022,7 @@ func (w *webMux) apiOAuthDevicePoll(rw http.ResponseWriter, r *http.Request) {
 
 func (w *webMux) apiOAuthRevoke(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -16,8 +16,8 @@ func TestExchangeAnthropicSendsJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			gotCT = r.Header.Get("Content-Type")
-			json.NewDecoder(r.Body).Decode(&gotBody)
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"access_token": "tok",
 				"token_type":   "bearer",
 				"expires_in":   3600,
@@ -71,7 +71,7 @@ func TestExchangeNonAnthropicUsesFormEncoded(t *testing.T) {
 			// the key assertion is what Content-Type the
 			// *request* used.
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"access_token": "tok",
 				"token_type":   "bearer",
 				"expires_in":   3600,

--- a/onboard.go
+++ b/onboard.go
@@ -146,7 +146,7 @@ func (r *onboardRegistry) Load(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var (
 			ip      string
@@ -396,7 +396,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts Tailscale) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("tailscale oauth: %w", err)
 	}
-	defer tokResp.Body.Close()
+	defer func() { _ = tokResp.Body.Close() }()
 	if tokResp.StatusCode != 200 {
 		body, _ := io.ReadAll(io.LimitReader(tokResp.Body, 1024))
 		return "", fmt.Errorf("tailscale oauth %d: %s", tokResp.StatusCode, string(body))
@@ -438,7 +438,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts Tailscale) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer keyResp.Body.Close()
+	defer func() { _ = keyResp.Body.Close() }()
 	if keyResp.StatusCode != 200 {
 		body, _ := io.ReadAll(io.LimitReader(keyResp.Body, 1024))
 		return "", fmt.Errorf("tailscale key %d: %s", keyResp.StatusCode, string(body))
@@ -456,7 +456,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts Tailscale) (string, error) {
 }
 func (w *webMux) apiOnboardStart(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	s := w.onboard.start()
@@ -521,12 +521,12 @@ func (w *webMux) apiOnboardLookup(rw http.ResponseWriter, r *http.Request) {
 // gates onboarding behind an existing trusted user.
 func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	owner, _ := w.ownerForCaller(r)
 	if owner == "" {
-		http.Error(rw, "approval requires an authenticated tailnet caller (or set admin_email in gateway.hcl)", 403)
+		http.Error(rw, "approval requires an authenticated tailnet caller (or set admin_email in gateway.hcl)", http.StatusForbidden)
 		return
 	}
 	code := r.URL.Query().Get("code")
@@ -614,7 +614,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 // whois result.
 func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	dc := r.URL.Query().Get("device_code")
@@ -648,7 +648,7 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 // approved. Uses standard device-flow status codes via JSON.
 func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	dc := r.URL.Query().Get("device_code")
@@ -678,5 +678,3 @@ func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 		"login_server": s.loginServer, // empty = Tailscale Inc default
 	})
 }
-
-var displayOrder = []string{"claude", "codex", "github"}

--- a/otel.go
+++ b/otel.go
@@ -78,7 +78,7 @@ func StartOtel(g *Gateway) (func(context.Context) error, error) {
 		return noop, fmt.Errorf("register gauges: %w", err)
 	}
 
-	var tpShutdown func(context.Context) error = noop
+	var tpShutdown = noop
 	texp, err := otlptracehttp.New(context.Background())
 	if err != nil {
 		log.Printf("otel: otlp trace exporter: %v (continuing without traces)", err)

--- a/peer_api_tokens_test.go
+++ b/peer_api_tokens_test.go
@@ -14,7 +14,7 @@ func TestPeerAPITokenRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	token, err := mintAndPersistPeerAPIToken(db, "10.55.0.42")
 	if err != nil {
@@ -50,7 +50,7 @@ func TestForgetPeerAPITokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	t1, _ := mintAndPersistPeerAPIToken(db, "10.55.0.1")
 	t2, _ := mintAndPersistPeerAPIToken(db, "10.55.0.1")

--- a/run_linux.go
+++ b/run_linux.go
@@ -23,6 +23,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -82,7 +83,7 @@ func runRun(args []string) {
 	}
 	pSock := os.NewFile(uintptr(sp[0]), "parent-sock")
 	cSock := os.NewFile(uintptr(sp[1]), "child-sock")
-	defer pSock.Close()
+	defer func() { _ = pSock.Close() }()
 	wgUpR, wgUpW, err := os.Pipe()
 	if err != nil {
 		fail("pipe: %v", err)
@@ -117,8 +118,8 @@ func runRun(args []string) {
 	if err := child.Start(); err != nil {
 		fail("clone: %v\n  hint: this distro may have unprivileged user namespaces disabled.\n  enable: sudo sysctl -w kernel.unprivileged_userns_clone=1", err)
 	}
-	cSock.Close()
-	wgUpR.Close()
+	_ = cSock.Close()
+	_ = wgUpR.Close()
 
 	tunFd, err := recvFD(pSock)
 	if err != nil {
@@ -139,8 +140,8 @@ func runRun(args []string) {
 	}
 	defer dev.Close()
 
-	wgUpW.Write([]byte{1})
-	wgUpW.Close()
+	_, _ = wgUpW.Write([]byte{1})
+	_ = wgUpW.Close()
 
 	sigCh := make(chan os.Signal, 4)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
@@ -151,7 +152,8 @@ func runRun(args []string) {
 	}()
 
 	if err := child.Wait(); err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			os.Exit(ee.ExitCode())
 		}
 		fail("wait: %v", err)
@@ -178,14 +180,14 @@ func runRunChild() {
 	if err := sendFD(cSock, tunFd); err != nil {
 		fail("send tun fd: %v", err)
 	}
-	cSock.Close()
-	unix.Close(tunFd)
+	_ = cSock.Close()
+	_ = unix.Close(tunFd)
 
 	one := make([]byte, 1)
 	if _, err := io.ReadFull(wgUpR, one); err != nil {
 		fail("wait wg-up: %v", err)
 	}
-	wgUpR.Close()
+	_ = wgUpR.Close()
 
 	cfg := mustParseRunConf(os.Getenv("CLAWPATROL_RUN_CONF"))
 	// Address may carry both v4 and v6 separated by ", " — gateway-emitted
@@ -285,7 +287,7 @@ func parseRunConf(path string) (*runConf, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	c := &runConf{}
 	section := ""
 	sc := bufio.NewScanner(f)
@@ -321,7 +323,7 @@ func parseRunConf(path string) (*runConf, error) {
 	if c.PrivateKey == "" || c.Address == "" || c.PeerPubKey == "" || c.Endpoint == "" {
 		return nil, fmt.Errorf("missing PrivateKey/Address/PublicKey/Endpoint")
 	}
-	os.Setenv("CLAWPATROL_RUN_CONF", path)
+	_ = os.Setenv("CLAWPATROL_RUN_CONF", path)
 	return c, nil
 }
 
@@ -385,8 +387,8 @@ func openTUN(name string) (int, error) {
 	copy(req.Name[:], name)
 	req.Flags = iffTun | iffNoPi
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), tunsetiff, uintptr(unsafe.Pointer(&req))); errno != 0 {
-		unix.Close(fd)
-		return -1, fmt.Errorf("TUNSETIFF: %v", errno)
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("TUNSETIFF: %w", errno)
 	}
 	return fd, nil
 }
@@ -425,7 +427,7 @@ func recvFD(s *os.File) (int, error) {
 		fds, err := unix.ParseUnixRights(&cmsg)
 		if err == nil && len(fds) > 0 {
 			for _, x := range fds[1:] {
-				unix.Close(x)
+				_ = unix.Close(x)
 			}
 			return fds[0], nil
 		}
@@ -439,10 +441,10 @@ func bindResolv(body string) error {
 		return err
 	}
 	if _, err := tmp.WriteString(body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
-	tmp.Close()
+	_ = tmp.Close()
 	return unix.Mount(tmp.Name(), "/etc/resolv.conf", "", unix.MS_BIND, "")
 }
 

--- a/secrets.go
+++ b/secrets.go
@@ -65,15 +65,15 @@ func readCredentialSecrets(db *sql.DB, credential, profile string) (runtime.Secr
 	if err != nil {
 		return runtime.Secret{}, false, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	sec := runtime.Secret{Kind: "dashboard"}
-	any := false
+	found := false
 	for rows.Next() {
 		var slot, value string
 		if err := rows.Scan(&slot, &value); err != nil {
 			return runtime.Secret{}, false, err
 		}
-		any = true
+		found = true
 		if slot == "" {
 			sec.Bytes = []byte(value)
 			continue
@@ -83,7 +83,7 @@ func readCredentialSecrets(db *sql.DB, credential, profile string) (runtime.Secr
 		}
 		sec.Extras[slot] = value
 	}
-	return sec, any, rows.Err()
+	return sec, found, rows.Err()
 }
 
 // setCredentialSlot upserts one (credential, profile, slot) row.
@@ -130,7 +130,7 @@ func credentialSlotPresence(db *sql.DB, credential, profile string) (map[string]
 	if err != nil {
 		return out, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var slot string
 		if err := rows.Scan(&slot); err != nil {
@@ -164,9 +164,9 @@ func registerOAuthCredentials(reg *OAuthRegistry, policy *config.CompiledPolicy)
 		if flow == nil {
 			continue
 		}
-		copy := *flow
-		copy.ID = name
-		reg.Register(name, copy)
+		copied := *flow
+		copied.ID = name
+		reg.Register(name, copied)
 	}
 	if err := reg.LoadFromDB(); err != nil {
 		log.Printf("oauth: rehydrate from db: %v", err)

--- a/telemetry.go
+++ b/telemetry.go
@@ -166,7 +166,7 @@ func postTelemetry(payload []byte) (*telemetryResp, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
 			"telemetry: server status %d", resp.StatusCode,

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -24,7 +24,7 @@ type fakeTunnel struct {
 
 func (f *fakeTunnel) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
 
-func (f *fakeTunnel) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
+func (f *fakeTunnel) Open(_ context.Context, _ runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
 	f.openCount.Add(1)
 	if f.openDelay > 0 {
 		time.Sleep(f.openDelay)

--- a/web.go
+++ b/web.go
@@ -157,7 +157,7 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 		}
 		// API callers see 401; browsers get redirected to the login form.
 		if strings.HasPrefix(r.URL.Path, "/api/") {
-			http.Error(rw, "dashboard secret required", 401)
+			http.Error(rw, "dashboard secret required", http.StatusUnauthorized)
 			return
 		}
 		http.Redirect(rw, r, "/__login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
@@ -173,7 +173,7 @@ func renderDashboardMisconfigured(rw http.ResponseWriter, r *http.Request) {
 	}
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
 	rw.WriteHeader(http.StatusServiceUnavailable)
-	fmt.Fprintf(rw, `<!doctype html>
+	_, _ = fmt.Fprintf(rw, `<!doctype html>
 <html><head><meta charset="utf-8"><title>clawpatrol — dashboard disabled</title>
 <style>body{font:14px/1.5 -apple-system,system-ui,sans-serif;max-width:42em;margin:6em auto;padding:0 1em;color:#222}code{background:#f3f3f3;padding:.1em .3em;border-radius:3px}h1{font-size:1.4em}</style>
 </head><body>
@@ -308,7 +308,7 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 			login = r.Header.Get("Tailscale-User-Login")
 		}
 		if login == "" {
-			http.Error(rw, "tailnet access required — onboard via `clawpatrol join <gateway>`", 403)
+			http.Error(rw, "tailnet access required — onboard via `clawpatrol join <gateway>`", http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(rw, r)
@@ -443,7 +443,7 @@ func (w *webMux) serveCA(rw http.ResponseWriter, r *http.Request) {
 
 func (w *webMux) serveInfo(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(rw, `{"clawpatrol":true,"version":"0.1"}`+"\n")
+	_, _ = fmt.Fprintf(rw, `{"clawpatrol":true,"version":"0.1"}`+"\n")
 }
 
 // callerIdentity resolves the (user, device) of the request peer via
@@ -578,7 +578,7 @@ func serveState(rw http.ResponseWriter, r *http.Request, body []byte, tag string
 	rw.Header().Set("ETag", tag)
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set("Cache-Control", "no-cache")
-	rw.Write(body)
+	_, _ = rw.Write(body)
 }
 
 // apiStatus returns the credentials list for the dashboard. Filters
@@ -595,7 +595,7 @@ func serveState(rw http.ResponseWriter, r *http.Request, body []byte, tag string
 // Empty values clear the slot.
 func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {
@@ -661,7 +661,7 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 // button on the dashboard.
 func (w *webMux) apiCredentialsClear(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {
@@ -717,7 +717,7 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		rw.Write(b)
+		_, _ = rw.Write(b)
 	case "PUT":
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
@@ -743,7 +743,7 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(rw, map[string]any{"ok": true, "bytes": len(body)})
 	default:
-		http.Error(rw, "GET or PUT", 405)
+		http.Error(rw, "GET or PUT", http.StatusMethodNotAllowed)
 	}
 }
 
@@ -757,7 +757,7 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 // builds — the contents are HCL.)
 func (w *webMux) apiRulesAI(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {
@@ -776,12 +776,12 @@ func (w *webMux) apiRulesAI(rw http.ResponseWriter, r *http.Request) {
 	}
 	owner, _ := w.ownerForCaller(r)
 	if owner == "" {
-		http.Error(rw, "tailnet identity required", 403)
+		http.Error(rw, "tailnet identity required", http.StatusForbidden)
 		return
 	}
 	out, refused, err := generateRuleHCL(r.Context(), w.g, body.Agent, owner, body.Prompt, body.CurrentYAML, body.Scope)
 	if err != nil {
-		http.Error(rw, "ai: "+err.Error(), 502)
+		http.Error(rw, "ai: "+err.Error(), http.StatusBadGateway)
 		return
 	}
 	resp := map[string]string{"yaml": out}
@@ -797,7 +797,7 @@ func (w *webMux) apiHITLPending(rw http.ResponseWriter, _ *http.Request) {
 
 func (w *webMux) apiHITLDecide(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {
@@ -832,14 +832,14 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 	wantIP := r.URL.Query().Get("agent")
 
 	if w.g.sink == nil {
-		fmt.Fprintf(rw, ": no sink\n\n")
+		_, _ = fmt.Fprintf(rw, ": no sink\n\n")
 		flusher.Flush()
 		return
 	}
 	backlog, ch, cancel := w.g.sink.RecentAndSubscribe()
 	defer cancel()
 
-	fmt.Fprint(rw, ": connected\n\n")
+	_, _ = fmt.Fprint(rw, ": connected\n\n")
 	// Backlog ships as a single `event: backlog` SSE message carrying
 	// the whole array. Client renders that batch in one commit (no
 	// per-event rAF flood), then switches to per-event live streaming.
@@ -857,7 +857,7 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 		if len(filtered) > 0 {
 			b, err := json.Marshal(filtered)
 			if err == nil {
-				fmt.Fprintf(rw, "event: backlog\ndata: %s\n\n", b)
+				_, _ = fmt.Fprintf(rw, "event: backlog\ndata: %s\n\n", b)
 			}
 		}
 	}
@@ -871,7 +871,7 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 		case <-r.Context().Done():
 			return
 		case <-keepalive.C:
-			fmt.Fprint(rw, ": ka\n\n")
+			_, _ = fmt.Fprint(rw, ": ka\n\n")
 			flusher.Flush()
 		case pkt, ok := <-ch:
 			if !ok {
@@ -880,7 +880,7 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 			if wantIP != "" && pkt.ev.AgentIP != wantIP {
 				continue
 			}
-			fmt.Fprintf(rw, "data: %s\n\n", pkt.raw)
+			_, _ = fmt.Fprintf(rw, "data: %s\n\n", pkt.raw)
 			flusher.Flush()
 		}
 	}
@@ -1032,7 +1032,7 @@ func (w *webMux) apiAnalytics(
 		http.Error(rw, err.Error(), 500)
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make([]Event, 0, 256)
 	for rows.Next() {
 		var (
@@ -1070,6 +1070,10 @@ func (w *webMux) apiAnalytics(
 		e.Action = action.String
 		e.Reason = reason.String
 		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
 	}
 
 	// Real (non-sampled) totals so the top stats reflect the actual
@@ -1113,7 +1117,7 @@ func groupCount(db *sql.DB, q string, args []any) []map[string]any {
 	if err != nil {
 		return out
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var k sql.NullString
 		var c int64
@@ -1124,19 +1128,16 @@ func groupCount(db *sql.DB, q string, args []any) []map[string]any {
 			"key": k.String, "count": c,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return []map[string]any{}
+	}
 	return out
 }
 
 func writeJSON(rw http.ResponseWriter, v any) {
 	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(v)
+	_ = json.NewEncoder(rw).Encode(v)
 }
-
-// apiOnboardStart begins device-flow onboarding. Public (no auth)
-// since this IS how a brand-new client first contacts the gateway.
-// The returned user_code must still be approved by an existing tailnet
-// member on the dashboard.
-func allIntegrationKeys() []string { return displayOrder }
 
 // Event sink + sampling helpers (fed by g.handle/mitm/splice; consumed
 // by the dashboard SSE stream and the on-disk event log).
@@ -1226,7 +1227,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make([]Event, 0, n)
 	for rows.Next() {
 		var (
@@ -1317,7 +1318,7 @@ func (s *Sink) drain() {
 			if len(e.RespHeaders) > 0 {
 				rshJSON, _ = json.Marshal(e.RespHeaders)
 			}
-			s.db.Exec(`
+			_, _ = s.db.Exec(`
 				INSERT INTO actions
 				 (action_id, ts_ns, mode, agent_ip, host,
 				  method, path, status, bytes_in, bytes_out,

--- a/web_sink_test.go
+++ b/web_sink_test.go
@@ -44,7 +44,7 @@ func TestSinkPersistsGeneratedID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	s, err := NewSink(db, 4)
 	if err != nil {

--- a/wireguard.go
+++ b/wireguard.go
@@ -300,7 +300,7 @@ func StartWGServer(ts Tailscale, stateDir string) (*WGServer, error) {
 	listenPort := 51820
 	if ts.WGEndpoint != "" {
 		if _, p, err := net.SplitHostPort(ts.WGEndpoint); err == nil {
-			fmt.Sscanf(p, "%d", &listenPort)
+			_, _ = fmt.Sscanf(p, "%d", &listenPort)
 		}
 	}
 
@@ -361,6 +361,7 @@ func (s *WGServer) AddPeer(pubkeyHex, peerIP string) error {
 	if s.db != nil {
 		rows, err := s.db.Query("SELECT pubkey FROM wg_peers WHERE ip = ? AND pubkey != ?", peerIP, pubkeyHex)
 		if err == nil {
+			defer func() { _ = rows.Close() }()
 			var stale []string
 			for rows.Next() {
 				var k string
@@ -368,7 +369,9 @@ func (s *WGServer) AddPeer(pubkeyHex, peerIP string) error {
 					stale = append(stale, k)
 				}
 			}
-			rows.Close()
+			if err := rows.Err(); err != nil {
+				stale = nil
+			}
 			for _, k := range stale {
 				_ = s.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", k))
 				_, _ = s.db.Exec("DELETE FROM wg_peers WHERE pubkey = ?", k)
@@ -550,7 +553,7 @@ var udpRelayBufPool = sync.Pool{
 // and the real upstream over the host's network. Both directions run
 // until one half closes.
 func relayUDP(c net.Conn, dstIP string, dstPort uint16) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(dstIP, fmt.Sprintf("%d", dstPort)))
 	if err != nil {
 		return
@@ -559,7 +562,7 @@ func relayUDP(c net.Conn, dstIP string, dstPort uint16) {
 	if err != nil {
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	done := make(chan struct{}, 2)
 	go func() {
 		bp := udpRelayBufPool.Get().(*[]byte)
@@ -603,12 +606,15 @@ func (s *WGServer) loadPeers() map[string]string {
 	if err != nil {
 		return out
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var k, ip string
 		if rows.Scan(&k, &ip) == nil {
 			out[k] = ip
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return map[string]string{}
 	}
 	return out
 }
@@ -625,6 +631,7 @@ func (s *WGServer) RevokePeerByIP(ip string) {
 	if err != nil {
 		return
 	}
+	defer func() { _ = rows.Close() }()
 	var keys []string
 	for rows.Next() {
 		var k string
@@ -632,7 +639,9 @@ func (s *WGServer) RevokePeerByIP(ip string) {
 			keys = append(keys, k)
 		}
 	}
-	rows.Close()
+	if err := rows.Err(); err != nil {
+		keys = nil
+	}
 	for _, k := range keys {
 		_ = s.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", k))
 	}
@@ -711,12 +720,11 @@ func hexToB64(h string) (string, error) {
 }
 
 type wireguardOnboarder struct {
-	ts     Tailscale
-	server *WGServer // injected at gateway boot; set by setWGServer
-	mu     sync.Mutex
+	ts Tailscale
+	mu sync.Mutex
 }
 
-func (w *wireguardOnboarder) MintKey(ctx context.Context, reuseIP string) (string, string, string, error) {
+func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string) (string, string, string, error) {
 	if w.ts.WGEndpoint == "" || w.ts.WGSubnetCIDR == "" {
 		return "", "", "", fmt.Errorf("wireguard not configured (set tailscale.wg_endpoint, wg_subnet_cidr)")
 	}
@@ -789,13 +797,16 @@ func (w *wireguardOnboarder) allocateIP() (string, error) {
 	if globalDB != nil {
 		rows, err := globalDB.Query("SELECT ip FROM wg_peers")
 		if err == nil {
+			defer func() { _ = rows.Close() }()
 			for rows.Next() {
 				var ip string
 				if rows.Scan(&ip) == nil {
 					used[ip] = true
 				}
 			}
-			rows.Close()
+			if err := rows.Err(); err != nil {
+				used = map[string]bool{}
+			}
 		}
 	}
 	_, cidr, err := net.ParseCIDR(w.ts.WGSubnetCIDR)

--- a/ws.go
+++ b/ws.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -98,11 +99,11 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 		up, err = dialBrowserTLS(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream)
 	}
 	if err != nil {
-		fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+		_, _ = fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 		log.Printf("ws dial %s: %v", upstream, err)
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 
 	// Build raw HTTP/1.1 upgrade request — Go's http.Request.Write +
 	// http.ReadResponse + http.Response.Write round-trip mangles
@@ -146,8 +147,8 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 	if !strings.Contains(statusLine, " 101 ") {
 		log.Printf("ws upgrade non-101 host=%s status=%q", upstream, statusLine)
 		body, _ := io.ReadAll(io.LimitReader(upBR, 2048))
-		client.Write(headerBytes)
-		client.Write(body)
+		_, _ = client.Write(headerBytes)
+		_, _ = client.Write(body)
 		return
 	}
 	if _, err := client.Write(headerBytes); err != nil {
@@ -332,12 +333,12 @@ func (w *wsInflater) decompress(payload []byte, noTakeover bool) []byte {
 	src.Write(payload)
 	src.Write(deflateTrailer)
 	fr := flate.NewReaderDict(&src, dict)
-	defer fr.Close()
+	defer func() { _ = fr.Close() }()
 	out, err := io.ReadAll(fr)
 	// io.ErrUnexpectedEOF is expected — permessage-deflate's trailer
 	// (00 00 ff ff) is a non-final SYNC block, so flate never sees a
 	// real EOF marker. We accept the bytes decoded up to that point.
-	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil
 	}
 	if !noTakeover && len(out) > 0 {


### PR DESCRIPTION
Run golangci-lint in CI with a pinned v2.12.2 toolchain after building the embedded dashboard assets. Enable the standard Go checks plus revive, misspell, and high-signal bug linters for HTTP bodies, error wrapping, nil returns, and SQL rows handling.

Clean up the existing findings so the new lint job starts green.