### PR TITLE
fix: kubectl exec/portforward through k8s mTLS endpoints

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -57,6 +57,12 @@ func endpointWantsClientCert(ep *config.CompiledEndpoint) bool {
 	return false
 }
 
+// profileCtxKey is the context key for the peer's profile name.
+// mitmHTTPS injects it into each request's context so DialTLSContext
+// can fetch per-profile mTLS credentials without the transport needing
+// to know about WireGuard peer → profile mapping.
+type profileCtxKey struct{}
+
 // servePorts is a no-op until the postgres / clickhouse_native
 // endpoint plugins land their wire-protocol runtime hooks.
 func (g *Gateway) servePorts() {}
@@ -67,11 +73,16 @@ func (g *Gateway) servePorts() {}
 // (currently mtls_credential) get the plugin a chance to add client
 // certs / replace RootCAs before the handshake.
 //
+// profile is the peer's profile name (e.g. "avocet2"); it is used to
+// fetch per-profile secrets from the dashboard DB. Callers that don't
+// have a profile may pass "" — secrets stored under "" or via env-var
+// still resolve correctly for non-profiled deployments.
+//
 // Empty TLS credential (cert/key not configured) logs a hint and
 // falls back to plain TLS — the request still flows but the
 // upstream rejects it on cert-required endpoints. Operators see
 // the misconfiguration in the dashboard event log.
-func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint) (net.Conn, error) {
+func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint, profile string) (net.Conn, error) {
 	cfg := &tls.Config{ServerName: serverName, NextProtos: []string{"http/1.1"}}
 
 	if ep != nil {
@@ -83,7 +94,7 @@ func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName st
 			if !ok {
 				continue
 			}
-			sec, err := g.secrets.Get(cc.Credential.Symbol.Name, "")
+			sec, err := g.secrets.Get(cc.Credential.Symbol.Name, profile)
 			if err != nil {
 				log.Printf("tls-secret %s: %v — dialing without client cert", cc.Credential.Symbol.Name, err)
 				break

--- a/main.go
+++ b/main.go
@@ -1796,6 +1796,19 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			return
 		}
 
+		// Generic HTTP upgrade (SPDY/3.1 for kubectl exec/attach/portforward,
+		// HTTP/2 cleartext, etc.). No frame parsing — raw bidirectional splice
+		// after the 101 handshake. Credentials already injected above.
+		if isHTTPUpgrade(req) {
+			log.Printf("http-upgrade %s %s %s", host, req.Header.Get("Upgrade"), req.URL.Path)
+			ev.Action = "upgrade"
+			g.handleHTTPUpgrade(tc, br, req, host, ep)
+			ev.Status = 101
+			ev.Ms = time.Since(start).Milliseconds()
+			g.emitEnd(ev)
+			return
+		}
+
 		trackKind := trackKindFor(host)
 		var trackedReqBody []byte
 		if trackKind != "" && req.Body != nil {

--- a/main.go
+++ b/main.go
@@ -1811,19 +1811,6 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			return
 		}
 
-		// Generic HTTP upgrade (SPDY/3.1 for kubectl exec/attach/portforward,
-		// HTTP/2 cleartext, etc.). No frame parsing — raw bidirectional splice
-		// after the 101 handshake. Credentials already injected above.
-		if isHTTPUpgrade(req) {
-			log.Printf("http-upgrade %s %s %s", host, req.Header.Get("Upgrade"), req.URL.Path)
-			ev.Action = "upgrade"
-			g.handleHTTPUpgrade(tc, br, req, host, ep)
-			ev.Status = 101
-			ev.Ms = time.Since(start).Milliseconds()
-			g.emitEnd(ev)
-			return
-		}
-
 		trackKind := trackKindFor(host)
 		var trackedReqBody []byte
 		if trackKind != "" && req.Body != nil {

--- a/main.go
+++ b/main.go
@@ -288,7 +288,8 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 			if needsBrowserTLS(h) && !endpointWantsClientCert(ep) {
 				return dialBrowserTLS(ctx, network, addr, h)
 			}
-			return g.dialUpstream(ctx, network, addr, h, ep)
+			profile, _ := ctx.Value(profileCtxKey{}).(string)
+			return g.dialUpstream(ctx, network, addr, h, ep, profile)
 		},
 		ForceAttemptHTTP2:   false,
 		IdleConnTimeout:     30 * time.Second,
@@ -1130,11 +1131,25 @@ func (g *Gateway) ownerForRequest(c net.Conn, _ *OAuthIntegration) string {
 	return ip
 }
 
-func (g *Gateway) handle(raw net.Conn) {
+func (g *Gateway) handle(raw net.Conn, dstIP string) {
 	defer raw.Close()
 	defer otelTrackConn("https_mitm")()
 	host, prefix, err := peekSNI(raw)
 	if err != nil {
+		// No SNI — fall back to direct-IP endpoint lookup for kubernetes/https
+		// endpoints whose `server` field is an IP literal (kubectl connects
+		// by IP and never sends SNI).
+		if dstIP != "" {
+			c := wrapPeek(raw, prefix)
+			pip := peerIP(c)
+			profile := g.profileFor(pip)
+			ep := runtime.HostEndpoint(g.Policy(), profile, dstIP)
+			if ep != nil && (ep.Family == "https" || ep.Family == "k8s") {
+				log.Printf("sni-fallback: %s → %s", dstIP, ep.Name)
+				g.mitmHTTPS(c, dstIP, ep)
+				return
+			}
+		}
 		log.Printf("sni: %v", err)
 		return
 	}
@@ -1789,7 +1804,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					Direction: direction,
 				})
 			}
-			g.handleWSUpgrade(tc, br, req, host, frameEmit)
+			g.handleWSUpgrade(tc, br, req, host, frameEmit, ep, profile)
 			ev.Status = 101
 			ev.Ms = time.Since(start).Milliseconds()
 			g.emitEnd(ev)
@@ -1839,7 +1854,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		}
 
 		rtStart := time.Now()
-		resp, err := transport.RoundTrip(req)
+		resp, err := transport.RoundTrip(req.WithContext(context.WithValue(req.Context(), profileCtxKey{}, profile)))
 		rtDur := time.Since(rtStart)
 		if err != nil {
 			log.Printf("mitm upstream %s %s: %v", host, req.URL.Path, err)
@@ -2279,7 +2294,7 @@ func runGateway(args []string) {
 			log.Printf("wg-fwd: %s:%d", dstIP, dstPort)
 			switch {
 			case dstPort == 443:
-				g.handle(c)
+				g.handle(c, dstIP)
 			case dstPort == 5432:
 				g.handlePostgresConn(c, dstIP)
 			case dstPort == 53:
@@ -2330,7 +2345,7 @@ func runGateway(args []string) {
 			log.Printf("accept: %v", err)
 			continue
 		}
-		go g.handle(c)
+		go g.handle(c, "")
 	}
 }
 

--- a/ws.go
+++ b/ws.go
@@ -79,7 +79,6 @@ func isWSUpgrade(req *http.Request) bool {
 	return strings.Contains(conn, "upgrade") && upg == "websocket"
 }
 
-
 // handleWSUpgrade swaps the http.Transport-driven request loop for a
 // raw byte bridge once the agent's request looks like a WS upgrade.
 // The connection stays alive until either side closes; pumpWS
@@ -400,4 +399,3 @@ func readFrameRaw(br *bufio.Reader) (raw []byte, b0 byte, op byte, compressed, m
 	raw = rawBuf.Bytes()
 	return
 }
-

--- a/ws.go
+++ b/ws.go
@@ -89,14 +89,20 @@ func isHTTPUpgrade(req *http.Request) bool {
 // raw byte bridge once the agent's request looks like a WS upgrade.
 // The connection stays alive until either side closes; pumpWS
 // observes text frames for codex usage tracking when applicable.
-func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string)) {
+func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string) {
 	agentAddr := peerIP(client) // capture before netstack races to nil
 
-	// Cloudflare flags non-browser TLS fingerprints on WS handshakes
-	// to chatgpt.com with "Attack attempt detected". Use uTLS Chrome
-	// fingerprint for every WS upstream — cheap, and only WS
-	// upgrades hit this path.
-	up, err := dialBrowserTLS(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream)
+	// Endpoints that require a client cert (e.g. kubernetes mTLS) must
+	// use dialUpstream so the credential plugin can inject the cert.
+	// All other upstreams use dialBrowserTLS — Cloudflare WAF rejects
+	// plain Go TLS fingerprints on WS handshakes to chatgpt.com.
+	var up net.Conn
+	var err error
+	if endpointWantsClientCert(ep) {
+		up, err = g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream, ep, profile)
+	} else {
+		up, err = dialBrowserTLS(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream)
+	}
 	if err != nil {
 		fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 		log.Printf("ws dial %s: %v", upstream, err)
@@ -408,7 +414,8 @@ func readFrameRaw(br *bufio.Reader) (raw []byte, b0 byte, op byte, compressed, m
 // invoked, so the request headers already carry any bearer token or
 // client cert that the endpoint requires.
 func (g *Gateway) handleHTTPUpgrade(client net.Conn, br *bufio.Reader, req *http.Request, host string, ep *config.CompiledEndpoint) {
-	up, err := g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(host, "443"), host, ep)
+	profile := g.profileFor(peerIP(client))
+	up, err := g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(host, "443"), host, ep, profile)
 	if err != nil {
 		fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 		log.Printf("http-upgrade dial %s: %v", host, err)

--- a/ws.go
+++ b/ws.go
@@ -79,11 +79,6 @@ func isWSUpgrade(req *http.Request) bool {
 	return strings.Contains(conn, "upgrade") && upg == "websocket"
 }
 
-// isHTTPUpgrade returns true for non-WebSocket HTTP upgrade requests —
-// e.g. SPDY/3.1 used by kubectl exec/attach/portforward.
-func isHTTPUpgrade(req *http.Request) bool {
-	return !isWSUpgrade(req) && req.Header.Get("Upgrade") != ""
-}
 
 // handleWSUpgrade swaps the http.Transport-driven request loop for a
 // raw byte bridge once the agent's request looks like a WS upgrade.
@@ -406,80 +401,3 @@ func readFrameRaw(br *bufio.Reader) (raw []byte, b0 byte, op byte, compressed, m
 	return
 }
 
-// handleHTTPUpgrade handles non-WebSocket HTTP upgrade requests such as
-// SPDY/3.1 (kubectl exec / attach / portforward). Unlike the WebSocket
-// path it needs no frame parsing — bidirectional raw splice suffices.
-//
-// Credentials are injected by the caller (mitmHTTPS) before this is
-// invoked, so the request headers already carry any bearer token or
-// client cert that the endpoint requires.
-func (g *Gateway) handleHTTPUpgrade(client net.Conn, br *bufio.Reader, req *http.Request, host string, ep *config.CompiledEndpoint) {
-	profile := g.profileFor(peerIP(client))
-	up, err := g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(host, "443"), host, ep, profile)
-	if err != nil {
-		fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-		log.Printf("http-upgrade dial %s: %v", host, err)
-		return
-	}
-	defer up.Close()
-
-	var reqBuf bytes.Buffer
-	fmt.Fprintf(&reqBuf, "%s %s HTTP/1.1\r\n", req.Method, req.URL.RequestURI())
-	h := req.Host
-	if h == "" {
-		h = host
-	}
-	fmt.Fprintf(&reqBuf, "Host: %s\r\n", h)
-	for name, values := range req.Header {
-		if strings.EqualFold(name, "Host") {
-			continue
-		}
-		for _, v := range values {
-			fmt.Fprintf(&reqBuf, "%s: %s\r\n", name, v)
-		}
-	}
-	reqBuf.WriteString("\r\n")
-	if _, err := up.Write(reqBuf.Bytes()); err != nil {
-		log.Printf("http-upgrade req write %s: %v", host, err)
-		return
-	}
-
-	upBR := bufio.NewReader(up)
-	headerBytes, err := readHTTPHeader(upBR)
-	if err != nil {
-		log.Printf("http-upgrade read resp %s: %v", host, err)
-		return
-	}
-	statusLine := ""
-	if i := bytes.Index(headerBytes, []byte("\r\n")); i >= 0 {
-		statusLine = string(headerBytes[:i])
-	}
-	if !strings.Contains(statusLine, " 101 ") {
-		body, _ := io.ReadAll(io.LimitReader(upBR, 4096))
-		client.Write(headerBytes)
-		client.Write(body)
-		log.Printf("http-upgrade non-101 %s: %s", host, statusLine)
-		return
-	}
-	if _, err := client.Write(headerBytes); err != nil {
-		return
-	}
-
-	done := make(chan struct{}, 2)
-	go func() {
-		io.Copy(client, upBR)
-		if cw, ok := client.(interface{ CloseWrite() error }); ok {
-			cw.CloseWrite()
-		}
-		done <- struct{}{}
-	}()
-	go func() {
-		io.Copy(up, br)
-		if cw, ok := up.(interface{ CloseWrite() error }); ok {
-			cw.CloseWrite()
-		}
-		done <- struct{}{}
-	}()
-	<-done
-	<-done
-}

--- a/ws.go
+++ b/ws.go
@@ -30,6 +30,8 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/denoland/clawpatrol/config"
 )
 
 const (
@@ -75,6 +77,12 @@ func isWSUpgrade(req *http.Request) bool {
 	conn := strings.ToLower(req.Header.Get("Connection"))
 	upg := strings.ToLower(req.Header.Get("Upgrade"))
 	return strings.Contains(conn, "upgrade") && upg == "websocket"
+}
+
+// isHTTPUpgrade returns true for non-WebSocket HTTP upgrade requests —
+// e.g. SPDY/3.1 used by kubectl exec/attach/portforward.
+func isHTTPUpgrade(req *http.Request) bool {
+	return !isWSUpgrade(req) && req.Header.Get("Upgrade") != ""
 }
 
 // handleWSUpgrade swaps the http.Transport-driven request loop for a
@@ -390,4 +398,81 @@ func readFrameRaw(br *bufio.Reader) (raw []byte, b0 byte, op byte, compressed, m
 	rawBuf.Write(payload)
 	raw = rawBuf.Bytes()
 	return
+}
+
+// handleHTTPUpgrade handles non-WebSocket HTTP upgrade requests such as
+// SPDY/3.1 (kubectl exec / attach / portforward). Unlike the WebSocket
+// path it needs no frame parsing — bidirectional raw splice suffices.
+//
+// Credentials are injected by the caller (mitmHTTPS) before this is
+// invoked, so the request headers already carry any bearer token or
+// client cert that the endpoint requires.
+func (g *Gateway) handleHTTPUpgrade(client net.Conn, br *bufio.Reader, req *http.Request, host string, ep *config.CompiledEndpoint) {
+	up, err := g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(host, "443"), host, ep)
+	if err != nil {
+		fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+		log.Printf("http-upgrade dial %s: %v", host, err)
+		return
+	}
+	defer up.Close()
+
+	var reqBuf bytes.Buffer
+	fmt.Fprintf(&reqBuf, "%s %s HTTP/1.1\r\n", req.Method, req.URL.RequestURI())
+	h := req.Host
+	if h == "" {
+		h = host
+	}
+	fmt.Fprintf(&reqBuf, "Host: %s\r\n", h)
+	for name, values := range req.Header {
+		if strings.EqualFold(name, "Host") {
+			continue
+		}
+		for _, v := range values {
+			fmt.Fprintf(&reqBuf, "%s: %s\r\n", name, v)
+		}
+	}
+	reqBuf.WriteString("\r\n")
+	if _, err := up.Write(reqBuf.Bytes()); err != nil {
+		log.Printf("http-upgrade req write %s: %v", host, err)
+		return
+	}
+
+	upBR := bufio.NewReader(up)
+	headerBytes, err := readHTTPHeader(upBR)
+	if err != nil {
+		log.Printf("http-upgrade read resp %s: %v", host, err)
+		return
+	}
+	statusLine := ""
+	if i := bytes.Index(headerBytes, []byte("\r\n")); i >= 0 {
+		statusLine = string(headerBytes[:i])
+	}
+	if !strings.Contains(statusLine, " 101 ") {
+		body, _ := io.ReadAll(io.LimitReader(upBR, 4096))
+		client.Write(headerBytes)
+		client.Write(body)
+		log.Printf("http-upgrade non-101 %s: %s", host, statusLine)
+		return
+	}
+	if _, err := client.Write(headerBytes); err != nil {
+		return
+	}
+
+	done := make(chan struct{}, 2)
+	go func() {
+		io.Copy(client, upBR)
+		if cw, ok := client.(interface{ CloseWrite() error }); ok {
+			cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	go func() {
+		io.Copy(up, br)
+		if cw, ok := up.(interface{ CloseWrite() error }); ok {
+			cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
 }


### PR DESCRIPTION
## Problem

`kubectl exec` and `kubectl portforward` against self-hosted k8s endpoints configured with `mtls_credential` were failing silently — traffic reached the gateway but was dropped or forwarded without the client cert.

Three bugs:

**1. No SNI for IP-addressed k8s servers**
kubectl connects directly to the cluster IP (`server = "209.250.247.66"`). TLS clients don't send SNI when connecting by IP, so the gateway saw `sni: no SNI` and dropped the connection.

**2. Profile-blind mTLS secret lookup**
`dialUpstream` called `secrets.Get(name, "")` (empty profile). Secrets stored under `"dev2"` were never found, so the mTLS client cert was never loaded.

**3. WS upgrade path used wrong dialer**
kubectl ≥1.30 uses WebSocket (not SPDY) for exec/portforward. `handleWSUpgrade` always called `dialBrowserTLS` (uTLS Chrome fingerprint), which has no mTLS support.

## Fix

- **SNI fallback** (`main.go`): `handle(c, dstIP)` — on no-SNI, try `HostEndpoint(policy, profile, dstIP)`. k8s `server` field ends up in `HostIndex`, so the endpoint is found and `mitmHTTPS` runs with the IP as host. `mint()` already handles IP SANs.

- **Profile-aware dial** (`dial.go`): added `profileCtxKey` — `mitmHTTPS` injects profile into each request's context before `RoundTrip`; `DialTLSContext` extracts it and passes to `dialUpstream`, which now fetches secrets under the correct profile.

- **mTLS-aware WS upgrade** (`ws.go`): `handleWSUpgrade` now checks `endpointWantsClientCert(ep)` — if true, uses `g.dialUpstream` (stdlib TLS + client cert) instead of `dialBrowserTLS` (uTLS, no client cert support).

Note: initial branch included a SPDY splice (`handleHTTPUpgrade`) — removed after confirming kubectl 1.35 uses WebSocket for both exec and portforward.

## Test plan

- [x] `kubectl get pods` works through gateway (mTLS injected, IP SNI fallback)
- [x] `kubectl exec <pod> -- echo ok` works end-to-end (WS upgrade + mTLS)
- [x] `kubectl port-forward` works end-to-end (WS upgrade + mTLS)
- [x] Existing WS endpoints (codex) unaffected — `dialBrowserTLS` still used when `endpointWantsClientCert` is false
- [x] All tests pass