### PR TITLE
Add safe gateway.hcl save review flow

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -842,14 +842,15 @@ type RuleSummary struct {
 // emit one row per endpoint so the operator sees each attachment
 // site individually.
 //
-// Read-only. Edits go through PUT /api/config (whole-file HCL via
-// the new typed-block validator).
+// Read-only. Dashboard edits go through the whole-file gateway.hcl
+// preview/save flow so operators review the formatted diff before the
+// typed-block validator persists changes.
 func (w *webMux) apiRules(rw http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		writeJSON(rw, w.collectRuleSummaries(""))
 	default:
-		http.Error(rw, "edit rules through PUT /api/config", http.StatusNotImplemented)
+		http.Error(rw, "edit rules through the gateway.hcl preview/save flow", http.StatusNotImplemented)
 	}
 }
 

--- a/ai.go
+++ b/ai.go
@@ -251,7 +251,8 @@ func extractRefusal(s string) (string, string) {
 }
 
 // validateHCLSyntax confirms the output parses as HCL. We only care
-// about syntax here — full type-check happens on PUT /api/config.
+// about syntax here — full type-check happens during the gateway.hcl
+// preview/save flow.
 func validateHCLSyntax(s string) error {
 	parser := hclparse.NewParser()
 	_, diags := parser.ParseHCL([]byte(s), "ai.hcl")

--- a/web.go
+++ b/web.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"database/sql"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"html/template"
@@ -22,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -38,6 +41,8 @@ var loginHTML string
 
 var loginTpl = template.Must(template.New("login").Parse(loginHTML))
 
+var errConfigRevisionConflict = errors.New("config revision conflict")
+
 type webMux struct {
 	g         *Gateway
 	caDir     string
@@ -46,6 +51,7 @@ type webMux struct {
 	mu        sync.Mutex
 	sessions  map[string]*oauthSession
 	onboard   *onboardRegistry
+	previews  map[string]configPreviewToken
 
 	// stateCache: per-caller TTL'd memo for /api/state. RWMutex
 	// because reads vastly outnumber writes — every dashboard tab
@@ -55,8 +61,13 @@ type webMux struct {
 	stateCache   map[string]stateCacheEntry
 }
 
+type configPreviewToken struct {
+	revision    string
+	contentHash string
+}
+
 func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Handler {
-	w := &webMux{g: g, caDir: caDir, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard}
+	w := &webMux{g: g, caDir: caDir, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/info", w.serveInfo)
 	mux.HandleFunc("/ca.crt", w.serveCA)
@@ -711,9 +722,8 @@ func lookupOAuthFlow(policy *config.CompiledPolicy, name string) *config.OAuthIn
 
 // apiConfig serves the entire gateway.hcl for the global settings
 // editor. GET returns the file as-is (preserves operator comments).
-// Writes must go through /api/config/preview + /api/config/save (or
-// include If-Match/X-Config-Revision on legacy PUT) so operators can
-// review the formatted diff before the atomic write.
+// Writes must go through /api/config/preview + /api/config/save so
+// operators can review the formatted diff before the atomic write.
 func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
@@ -728,40 +738,7 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = rw.Write(b)
 	case "PUT":
-		expectedRev := strings.Trim(r.Header.Get("If-Match"), `"`)
-		if expectedRev == "" {
-			expectedRev = r.Header.Get("X-Config-Revision")
-		}
-		if expectedRev == "" {
-			http.Error(rw, "If-Match or X-Config-Revision required; use /api/config/preview then /api/config/save", http.StatusPreconditionRequired)
-			return
-		}
-		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
-		if err != nil {
-			http.Error(rw, err.Error(), 400)
-			return
-		}
-		formatted, err := validateAndFormatConfig(body)
-		if err != nil {
-			http.Error(rw, err.Error(), 400)
-			return
-		}
-		w.mu.Lock()
-		defer w.mu.Unlock()
-		currentRev, err := fileRevision(w.g.cfgPath)
-		if err != nil {
-			http.Error(rw, err.Error(), 500)
-			return
-		}
-		if expectedRev != currentRev {
-			http.Error(rw, "gateway.hcl changed since read; reload before saving", http.StatusConflict)
-			return
-		}
-		if err := writeConfigAtomically(w.g.cfgPath, formatted); err != nil {
-			http.Error(rw, err.Error(), 500)
-			return
-		}
-		writeJSON(rw, map[string]any{"ok": true, "bytes": len(formatted), "revision": revisionForBytes(formatted)})
+		http.Error(rw, "use /api/config/preview then /api/config/save", http.StatusMethodNotAllowed)
 	default:
 		http.Error(rw, "GET or PUT", http.StatusMethodNotAllowed)
 	}
@@ -769,7 +746,7 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 
 func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
@@ -783,32 +760,50 @@ func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.mu.Lock()
-	current, err := os.ReadFile(w.g.cfgPath)
-	if err != nil {
+	var current []byte
+	var rev string
+	var token string
+	if err := withConfigFileLock(w.g.cfgPath, func() error {
+		current, err = os.ReadFile(w.g.cfgPath)
+		if err != nil {
+			return err
+		}
+		rev = revisionForBytes(current)
+		token, err = newConfigPreviewToken()
+		if err != nil {
+			return err
+		}
+		w.configPreviewTokens()[token] = configPreviewToken{
+			revision:    rev,
+			contentHash: revisionForBytes(formatted),
+		}
+		return nil
+	}); err != nil {
 		w.mu.Unlock()
 		http.Error(rw, err.Error(), 500)
 		return
 	}
-	rev := revisionForBytes(current)
 	w.mu.Unlock()
 	writeJSON(rw, map[string]any{
-		"ok":        true,
-		"formatted": string(formatted),
-		"diff":      unifiedDiff("gateway.hcl", "formatted draft", string(current), string(formatted)),
-		"changed":   !bytes.Equal(current, formatted),
-		"bytes":     len(formatted),
-		"revision":  rev,
+		"ok":            true,
+		"formatted":     string(formatted),
+		"diff":          unifiedDiff("gateway.hcl", "formatted draft", string(current), string(formatted)),
+		"changed":       !bytes.Equal(current, formatted),
+		"bytes":         len(formatted),
+		"revision":      rev,
+		"preview_token": token,
 	})
 }
 
 func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(rw, "POST", 405)
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
 	}
 	var body struct {
 		Content          string `json:"content"`
 		ExpectedRevision string `json:"expected_revision"`
+		PreviewToken     string `json:"preview_token"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
 		http.Error(rw, err.Error(), 400)
@@ -818,15 +813,8 @@ func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "expected_revision required", 400)
 		return
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	currentRev, err := fileRevision(w.g.cfgPath)
-	if err != nil {
-		http.Error(rw, err.Error(), 500)
-		return
-	}
-	if body.ExpectedRevision != currentRev {
-		http.Error(rw, "gateway.hcl changed since preview; reload before saving", http.StatusConflict)
+	if body.PreviewToken == "" {
+		http.Error(rw, "preview_token required", 400)
 		return
 	}
 	formatted, err := validateAndFormatConfig([]byte(body.Content))
@@ -834,7 +822,35 @@ func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, err.Error(), 400)
 		return
 	}
-	if err := writeConfigAtomically(w.g.cfgPath, formatted); err != nil {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	preview, ok := w.configPreviewTokens()[body.PreviewToken]
+	if !ok {
+		http.Error(rw, "preview token not found; review changes before saving", http.StatusPreconditionRequired)
+		return
+	}
+	if preview.revision != body.ExpectedRevision || preview.contentHash != revisionForBytes(formatted) {
+		http.Error(rw, "preview token does not match reviewed content", http.StatusPreconditionFailed)
+		return
+	}
+	if err := withConfigFileLock(w.g.cfgPath, func() error {
+		currentRev, err := fileRevision(w.g.cfgPath)
+		if err != nil {
+			return err
+		}
+		if body.ExpectedRevision != currentRev {
+			return errConfigRevisionConflict
+		}
+		if err := writeConfigAtomically(w.g.cfgPath, formatted); err != nil {
+			return err
+		}
+		delete(w.previews, body.PreviewToken)
+		return nil
+	}); err != nil {
+		if errors.Is(err, errConfigRevisionConflict) {
+			http.Error(rw, "gateway.hcl changed since preview; reload before saving", http.StatusConflict)
+			return
+		}
 		http.Error(rw, err.Error(), 500)
 		return
 	}
@@ -852,26 +868,53 @@ func validateAndFormatConfig(body []byte) ([]byte, error) {
 	return formatted, nil
 }
 
+func withConfigFileLock(configPath string, fn func() error) error {
+	lockPath := configPath + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }()
+	return fn()
+}
+
 func writeConfigAtomically(path string, body []byte) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	mode := os.FileMode(0o600)
+	if st, err := os.Stat(path); err == nil {
+		mode = st.Mode().Perm()
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 	if _, err := tmp.Write(body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("write: %w", err)
 	}
-	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
 		return fmt.Errorf("chmod: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("rename: %w", err)
+	}
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
 	}
 	return nil
 }
@@ -889,6 +932,28 @@ func revisionForBytes(b []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func (w *webMux) configPreviewTokens() map[string]configPreviewToken {
+	if w.previews == nil {
+		w.previews = map[string]configPreviewToken{}
+	}
+	return w.previews
+}
+
+func newConfigPreviewToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("preview token: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+type diffOp struct {
+	prefix  byte
+	line    string
+	oldLine int
+	newLine int
+}
+
 func unifiedDiff(oldName, newName, oldText, newText string) string {
 	if oldText == newText {
 		return ""
@@ -897,7 +962,21 @@ func unifiedDiff(oldName, newName, oldText, newText string) string {
 	newLines := splitDiffLines(newText)
 	var b strings.Builder
 	fmt.Fprintf(&b, "--- %s\n+++ %s\n", oldName, newName)
-	fmt.Fprintf(&b, "@@ -1,%d +1,%d @@\n", len(oldLines), len(newLines))
+
+	if len(oldLines) > 0 && len(newLines) > 0 && len(oldLines) > 250000/len(newLines) {
+		fmt.Fprintf(&b, "@@ -1,%d +1,%d @@\n", len(oldLines), len(newLines))
+		for _, line := range oldLines {
+			b.WriteByte('-')
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		for _, line := range newLines {
+			b.WriteByte('+')
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		return b.String()
+	}
 
 	dp := make([][]int, len(oldLines)+1)
 	for i := range dp {
@@ -915,27 +994,85 @@ func unifiedDiff(oldName, newName, oldText, newText string) string {
 		}
 	}
 
+	ops := make([]diffOp, 0, len(oldLines)+len(newLines))
 	for i, j := 0, 0; i < len(oldLines) || j < len(newLines); {
 		switch {
 		case i < len(oldLines) && j < len(newLines) && oldLines[i] == newLines[j]:
-			b.WriteByte(' ')
-			b.WriteString(oldLines[i])
-			b.WriteByte('\n')
+			ops = append(ops, diffOp{prefix: ' ', line: oldLines[i], oldLine: i + 1, newLine: j + 1})
 			i++
 			j++
-		case j < len(newLines) && (i == len(oldLines) || dp[i][j+1] >= dp[i+1][j]):
-			b.WriteByte('+')
-			b.WriteString(newLines[j])
-			b.WriteByte('\n')
-			j++
-		case i < len(oldLines):
-			b.WriteByte('-')
-			b.WriteString(oldLines[i])
-			b.WriteByte('\n')
+		case i < len(oldLines) && (j == len(newLines) || dp[i+1][j] >= dp[i][j+1]):
+			ops = append(ops, diffOp{prefix: '-', line: oldLines[i], oldLine: i + 1, newLine: j + 1})
 			i++
+		case j < len(newLines):
+			ops = append(ops, diffOp{prefix: '+', line: newLines[j], oldLine: i + 1, newLine: j + 1})
+			j++
 		}
 	}
+
+	const contextLines = 3
+	for start := 0; start < len(ops); {
+		for start < len(ops) && ops[start].prefix == ' ' {
+			start++
+		}
+		if start >= len(ops) {
+			break
+		}
+
+		hunkStart := max(start-contextLines, 0)
+		lastChange := start
+		end := min(start+contextLines+1, len(ops))
+		for scan := start + 1; scan < len(ops); scan++ {
+			if ops[scan].prefix == ' ' {
+				continue
+			}
+			if scan > end+contextLines {
+				break
+			}
+			lastChange = scan
+			end = min(scan+contextLines+1, len(ops))
+		}
+
+		writeDiffHunk(&b, ops[hunkStart:end])
+		start = lastChange + 1
+	}
+
 	return b.String()
+}
+
+func writeDiffHunk(b *strings.Builder, ops []diffOp) {
+	if len(ops) == 0 {
+		return
+	}
+	oldStart, newStart := 0, 0
+	oldCount, newCount := 0, 0
+	for _, op := range ops {
+		if oldStart == 0 && op.prefix != '+' {
+			oldStart = op.oldLine
+		}
+		if newStart == 0 && op.prefix != '-' {
+			newStart = op.newLine
+		}
+		if op.prefix != '+' {
+			oldCount++
+		}
+		if op.prefix != '-' {
+			newCount++
+		}
+	}
+	if oldStart == 0 {
+		oldStart = ops[0].oldLine
+	}
+	if newStart == 0 {
+		newStart = ops[0].newLine
+	}
+
+	fmt.Fprintf(b, "@@ -%d,%d +%d,%d @@\n", oldStart, oldCount, newStart, newCount)
+	for _, op := range ops {
+		b.WriteByte(op.prefix)
+		b.WriteString(op.line)
+		b.WriteByte('\n')
+	}
 }
 
 func splitDiffLines(s string) []string {

--- a/web.go
+++ b/web.go
@@ -16,12 +16,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/runtime"
@@ -71,6 +74,8 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 	mux.HandleFunc("/api/rules", w.apiRules)
 	mux.HandleFunc("/api/rules/ai", w.apiRulesAI)
 	mux.HandleFunc("/api/config", w.apiConfig)
+	mux.HandleFunc("/api/config/preview", w.apiConfigPreview)
+	mux.HandleFunc("/api/config/save", w.apiConfigSave)
 	mux.HandleFunc("/api/hitl/pending", w.apiHITLPending)
 	mux.HandleFunc("/api/hitl/decide", w.apiHITLDecide)
 	w.mountCredentialWebhooks(mux)
@@ -706,8 +711,9 @@ func lookupOAuthFlow(policy *config.CompiledPolicy, name string) *config.OAuthIn
 
 // apiConfig serves the entire gateway.hcl for the global settings
 // editor. GET returns the file as-is (preserves operator comments).
-// PUT validates by re-parsing + writing through writeConfigHCL so
-// hot-reload picks up the change.
+// Writes must go through /api/config/preview + /api/config/save (or
+// include If-Match/X-Config-Revision on legacy PUT) so operators can
+// review the formatted diff before the atomic write.
 func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
@@ -716,35 +722,228 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 			http.Error(rw, err.Error(), 500)
 			return
 		}
+		rev := revisionForBytes(b)
+		rw.Header().Set("ETag", `"`+rev+`"`)
+		rw.Header().Set("X-Config-Revision", rev)
 		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = rw.Write(b)
 	case "PUT":
+		expectedRev := strings.Trim(r.Header.Get("If-Match"), `"`)
+		if expectedRev == "" {
+			expectedRev = r.Header.Get("X-Config-Revision")
+		}
+		if expectedRev == "" {
+			http.Error(rw, "If-Match or X-Config-Revision required; use /api/config/preview then /api/config/save", http.StatusPreconditionRequired)
+			return
+		}
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
 			http.Error(rw, err.Error(), 400)
 			return
 		}
-		// Validate via the new typed-block loader before persisting —
-		// rejects unknown attributes / dangling references / kind
-		// mismatches with precise diagnostics.
-		if _, diags := config.LoadBytes(body, "gateway.hcl"); diags.HasErrors() {
-			http.Error(rw, "hcl: "+diags.Error(), 400)
+		formatted, err := validateAndFormatConfig(body)
+		if err != nil {
+			http.Error(rw, err.Error(), 400)
 			return
 		}
-		// atomic write — mtime watcher reloads + applies.
-		tmp := w.g.cfgPath + ".tmp"
-		if err := os.WriteFile(tmp, body, 0o600); err != nil {
-			http.Error(rw, "write: "+err.Error(), 500)
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		currentRev, err := fileRevision(w.g.cfgPath)
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
 			return
 		}
-		if err := os.Rename(tmp, w.g.cfgPath); err != nil {
-			http.Error(rw, "rename: "+err.Error(), 500)
+		if expectedRev != currentRev {
+			http.Error(rw, "gateway.hcl changed since read; reload before saving", http.StatusConflict)
 			return
 		}
-		writeJSON(rw, map[string]any{"ok": true, "bytes": len(body)})
+		if err := writeConfigAtomically(w.g.cfgPath, formatted); err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		writeJSON(rw, map[string]any{"ok": true, "bytes": len(formatted), "revision": revisionForBytes(formatted)})
 	default:
 		http.Error(rw, "GET or PUT", http.StatusMethodNotAllowed)
 	}
+}
+
+func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", 405)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(rw, err.Error(), 400)
+		return
+	}
+	formatted, err := validateAndFormatConfig(body)
+	if err != nil {
+		http.Error(rw, err.Error(), 400)
+		return
+	}
+	w.mu.Lock()
+	current, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		w.mu.Unlock()
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	rev := revisionForBytes(current)
+	w.mu.Unlock()
+	writeJSON(rw, map[string]any{
+		"ok":        true,
+		"formatted": string(formatted),
+		"diff":      unifiedDiff("gateway.hcl", "formatted draft", string(current), string(formatted)),
+		"changed":   !bytes.Equal(current, formatted),
+		"bytes":     len(formatted),
+		"revision":  rev,
+	})
+}
+
+func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", 405)
+		return
+	}
+	var body struct {
+		Content          string `json:"content"`
+		ExpectedRevision string `json:"expected_revision"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), 400)
+		return
+	}
+	if body.ExpectedRevision == "" {
+		http.Error(rw, "expected_revision required", 400)
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	currentRev, err := fileRevision(w.g.cfgPath)
+	if err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	if body.ExpectedRevision != currentRev {
+		http.Error(rw, "gateway.hcl changed since preview; reload before saving", http.StatusConflict)
+		return
+	}
+	formatted, err := validateAndFormatConfig([]byte(body.Content))
+	if err != nil {
+		http.Error(rw, err.Error(), 400)
+		return
+	}
+	if err := writeConfigAtomically(w.g.cfgPath, formatted); err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	writeJSON(rw, map[string]any{"ok": true, "bytes": len(formatted), "revision": revisionForBytes(formatted)})
+}
+
+func validateAndFormatConfig(body []byte) ([]byte, error) {
+	if _, diags := config.LoadBytes(body, "gateway.hcl"); diags.HasErrors() {
+		return nil, fmt.Errorf("hcl: %s", diags.Error())
+	}
+	formatted := hclwrite.Format(body)
+	if _, diags := config.LoadBytes(formatted, "gateway.hcl"); diags.HasErrors() {
+		return nil, fmt.Errorf("formatted hcl: %s", diags.Error())
+	}
+	return formatted, nil
+}
+
+func writeConfigAtomically(path string, body []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+func fileRevision(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return revisionForBytes(b), nil
+}
+
+func revisionForBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func unifiedDiff(oldName, newName, oldText, newText string) string {
+	if oldText == newText {
+		return ""
+	}
+	oldLines := splitDiffLines(oldText)
+	newLines := splitDiffLines(newText)
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- %s\n+++ %s\n", oldName, newName)
+	fmt.Fprintf(&b, "@@ -1,%d +1,%d @@\n", len(oldLines), len(newLines))
+
+	dp := make([][]int, len(oldLines)+1)
+	for i := range dp {
+		dp[i] = make([]int, len(newLines)+1)
+	}
+	for i := len(oldLines) - 1; i >= 0; i-- {
+		for j := len(newLines) - 1; j >= 0; j-- {
+			if oldLines[i] == newLines[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+
+	for i, j := 0, 0; i < len(oldLines) || j < len(newLines); {
+		switch {
+		case i < len(oldLines) && j < len(newLines) && oldLines[i] == newLines[j]:
+			b.WriteByte(' ')
+			b.WriteString(oldLines[i])
+			b.WriteByte('\n')
+			i++
+			j++
+		case j < len(newLines) && (i == len(oldLines) || dp[i][j+1] >= dp[i+1][j]):
+			b.WriteByte('+')
+			b.WriteString(newLines[j])
+			b.WriteByte('\n')
+			j++
+		case i < len(oldLines):
+			b.WriteByte('-')
+			b.WriteString(oldLines[i])
+			b.WriteByte('\n')
+			i++
+		}
+	}
+	return b.String()
+}
+
+func splitDiffLines(s string) []string {
+	trimmed := strings.TrimSuffix(s, "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
 }
 
 // apiRulesAI translates a natural-language request into an HCL rule

--- a/web_config_test.go
+++ b/web_config_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAPIConfigPreviewFormatsAndDiffsWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	original := []byte("insecure_no_dashboard_secret = true\n")
+	if err := os.WriteFile(cfgPath, original, 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+	req := httptest.NewRequest(http.MethodPost, "/api/config/preview", strings.NewReader("insecure_no_dashboard_secret=false\n"))
+	rr := httptest.NewRecorder()
+
+	w.apiConfigPreview(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		OK        bool   `json:"ok"`
+		Formatted string `json:"formatted"`
+		Diff      string `json:"diff"`
+		Bytes     int    `json:"bytes"`
+		Revision  string `json:"revision"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if !got.OK {
+		t.Fatalf("ok = false")
+	}
+	if got.Formatted != "insecure_no_dashboard_secret = false\n" {
+		t.Fatalf("formatted = %q", got.Formatted)
+	}
+	if got.Bytes != len(got.Formatted) {
+		t.Fatalf("bytes = %d, want %d", got.Bytes, len(got.Formatted))
+	}
+	if got.Revision == "" {
+		t.Fatalf("revision is empty")
+	}
+	for _, want := range []string{"--- gateway.hcl", "+++ formatted draft", "-insecure_no_dashboard_secret = true", "+insecure_no_dashboard_secret = false"} {
+		if !strings.Contains(got.Diff, want) {
+			t.Fatalf("diff missing %q:\n%s", want, got.Diff)
+		}
+	}
+	contents, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read cfg: %v", err)
+	}
+	if !bytes.Equal(contents, original) {
+		t.Fatalf("preview wrote file: %q", contents)
+	}
+}
+
+func TestAPIConfigSaveRequiresExpectedRevisionAndWritesFormattedHCL(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	if err := os.WriteFile(cfgPath, []byte("insecure_no_dashboard_secret = true\n"), 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+	rev, err := fileRevision(cfgPath)
+	if err != nil {
+		t.Fatalf("revision: %v", err)
+	}
+
+	payload := `{"content":"insecure_no_dashboard_secret=false\n","expected_revision":"` + rev + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
+	rr := httptest.NewRecorder()
+
+	w.apiConfigSave(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	contents, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read cfg: %v", err)
+	}
+	if got, want := string(contents), "insecure_no_dashboard_secret = false\n"; got != want {
+		t.Fatalf("saved content = %q, want %q", got, want)
+	}
+}
+
+func TestAPIConfigSaveRejectsStaleRevision(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	original := []byte("insecure_no_dashboard_secret = true\n")
+	if err := os.WriteFile(cfgPath, original, 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+
+	payload := `{"content":"insecure_no_dashboard_secret=false\n","expected_revision":"stale"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
+	rr := httptest.NewRecorder()
+
+	w.apiConfigSave(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body = %s", rr.Code, rr.Body.String())
+	}
+	contents, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read cfg: %v", err)
+	}
+	if !bytes.Equal(contents, original) {
+		t.Fatalf("stale save wrote file: %q", contents)
+	}
+}
+
+func TestAPIConfigPutRequiresRevision(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	original := []byte("insecure_no_dashboard_secret = true\n")
+	if err := os.WriteFile(cfgPath, original, 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader("insecure_no_dashboard_secret=false\n"))
+	rr := httptest.NewRecorder()
+
+	w.apiConfig(rr, req)
+
+	if rr.Code != http.StatusPreconditionRequired {
+		t.Fatalf("status = %d, want 428, body = %s", rr.Code, rr.Body.String())
+	}
+	contents, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read cfg: %v", err)
+	}
+	if !bytes.Equal(contents, original) {
+		t.Fatalf("put without revision wrote file: %q", contents)
+	}
+}

--- a/web_config_test.go
+++ b/web_config_test.go
@@ -29,11 +29,12 @@ func TestAPIConfigPreviewFormatsAndDiffsWithoutWriting(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
 	}
 	var got struct {
-		OK        bool   `json:"ok"`
-		Formatted string `json:"formatted"`
-		Diff      string `json:"diff"`
-		Bytes     int    `json:"bytes"`
-		Revision  string `json:"revision"`
+		OK           bool   `json:"ok"`
+		Formatted    string `json:"formatted"`
+		Diff         string `json:"diff"`
+		Bytes        int    `json:"bytes"`
+		Revision     string `json:"revision"`
+		PreviewToken string `json:"preview_token"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
 		t.Fatalf("json: %v", err)
@@ -50,6 +51,9 @@ func TestAPIConfigPreviewFormatsAndDiffsWithoutWriting(t *testing.T) {
 	if got.Revision == "" {
 		t.Fatalf("revision is empty")
 	}
+	if got.PreviewToken == "" {
+		t.Fatalf("preview token is empty")
+	}
 	for _, want := range []string{"--- gateway.hcl", "+++ formatted draft", "-insecure_no_dashboard_secret = true", "+insecure_no_dashboard_secret = false"} {
 		if !strings.Contains(got.Diff, want) {
 			t.Fatalf("diff missing %q:\n%s", want, got.Diff)
@@ -64,19 +68,76 @@ func TestAPIConfigPreviewFormatsAndDiffsWithoutWriting(t *testing.T) {
 	}
 }
 
-func TestAPIConfigSaveRequiresExpectedRevisionAndWritesFormattedHCL(t *testing.T) {
+func TestUnifiedDiffSplitsDistantChangesIntoSeparateHunks(t *testing.T) {
+	oldText := strings.Join([]string{
+		"line 01",
+		"line 02",
+		"line 03",
+		"line 04",
+		"line 05",
+		"line 06",
+		"line 07",
+		"line 08",
+		"line 09",
+		"line 10",
+		"line 11",
+		"line 12",
+		"line 13",
+		"line 14",
+		"line 15",
+	}, "\n") + "\n"
+	newText := strings.Join([]string{
+		"line 01",
+		"line 02 changed",
+		"line 03",
+		"line 04",
+		"line 05",
+		"line 06",
+		"line 07",
+		"line 08",
+		"line 09",
+		"line 10",
+		"line 11",
+		"line 12",
+		"line 13 changed",
+		"line 14",
+		"line 15",
+	}, "\n") + "\n"
+
+	diff := unifiedDiff("gateway.hcl", "formatted draft", oldText, newText)
+
+	for _, want := range []string{
+		"--- gateway.hcl",
+		"+++ formatted draft",
+		"@@ -1,5 +1,5 @@",
+		"@@ -10,6 +10,6 @@",
+		"-line 02",
+		"+line 02 changed",
+		"-line 13",
+		"+line 13 changed",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("diff missing %q:\n%s", want, diff)
+		}
+	}
+	if strings.Count(diff, "@@") != 4 {
+		t.Fatalf("hunk header count = %d, want 2 headers:\n%s", strings.Count(diff, "@@")/2, diff)
+	}
+	if strings.Contains(diff, " line 07\n") {
+		t.Fatalf("diff included distant unchanged middle context:\n%s", diff)
+	}
+}
+
+func TestAPIConfigSaveRequiresPreviewTokenAndWritesFormattedHCL(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "gateway.hcl")
 	if err := os.WriteFile(cfgPath, []byte("insecure_no_dashboard_secret = true\n"), 0o600); err != nil {
 		t.Fatalf("write cfg: %v", err)
 	}
 	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
-	rev, err := fileRevision(cfgPath)
-	if err != nil {
-		t.Fatalf("revision: %v", err)
-	}
 
-	payload := `{"content":"insecure_no_dashboard_secret=false\n","expected_revision":"` + rev + `"}`
+	preview := previewConfigForTest(t, w, "insecure_no_dashboard_secret=false\n")
+	payload := `{"content":"` + jsonEscape(preview.Formatted) + `","expected_revision":"` + preview.Revision + `","preview_token":"` + preview.PreviewToken + `"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
 	rr := httptest.NewRecorder()
 
@@ -102,8 +163,12 @@ func TestAPIConfigSaveRejectsStaleRevision(t *testing.T) {
 		t.Fatalf("write cfg: %v", err)
 	}
 	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+	preview := previewConfigForTest(t, w, "insecure_no_dashboard_secret=false\n")
+	if err := os.WriteFile(cfgPath, []byte("insecure_no_dashboard_secret = false\n"), 0o600); err != nil {
+		t.Fatalf("concurrent write: %v", err)
+	}
 
-	payload := `{"content":"insecure_no_dashboard_secret=false\n","expected_revision":"stale"}`
+	payload := `{"content":"` + jsonEscape(preview.Formatted) + `","expected_revision":"` + preview.Revision + `","preview_token":"` + preview.PreviewToken + `"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
 	rr := httptest.NewRecorder()
 
@@ -116,12 +181,40 @@ func TestAPIConfigSaveRejectsStaleRevision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cfg: %v", err)
 	}
-	if !bytes.Equal(contents, original) {
-		t.Fatalf("stale save wrote file: %q", contents)
+	if got, want := string(contents), "insecure_no_dashboard_secret = false\n"; got != want {
+		t.Fatalf("stale save changed file: %q", contents)
 	}
 }
 
-func TestAPIConfigPutRequiresRevision(t *testing.T) {
+func TestAPIConfigSaveRejectsUnpreviewedContent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	original := []byte("insecure_no_dashboard_secret = true\n")
+	if err := os.WriteFile(cfgPath, original, 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+	preview := previewConfigForTest(t, w, "insecure_no_dashboard_secret=false\n")
+
+	payload := `{"content":"insecure_no_dashboard_secret = true\n","expected_revision":"` + preview.Revision + `","preview_token":"` + preview.PreviewToken + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
+	rr := httptest.NewRecorder()
+
+	w.apiConfigSave(rr, req)
+
+	if rr.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status = %d, want 412, body = %s", rr.Code, rr.Body.String())
+	}
+	contents, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read cfg: %v", err)
+	}
+	if !bytes.Equal(contents, original) {
+		t.Fatalf("unpreviewed save wrote file: %q", contents)
+	}
+}
+
+func TestAPIConfigPutIsReadOnly(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "gateway.hcl")
 	original := []byte("insecure_no_dashboard_secret = true\n")
@@ -135,8 +228,8 @@ func TestAPIConfigPutRequiresRevision(t *testing.T) {
 
 	w.apiConfig(rr, req)
 
-	if rr.Code != http.StatusPreconditionRequired {
-		t.Fatalf("status = %d, want 428, body = %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405, body = %s", rr.Code, rr.Body.String())
 	}
 	contents, err := os.ReadFile(cfgPath)
 	if err != nil {
@@ -145,4 +238,36 @@ func TestAPIConfigPutRequiresRevision(t *testing.T) {
 	if !bytes.Equal(contents, original) {
 		t.Fatalf("put without revision wrote file: %q", contents)
 	}
+}
+
+type configPreviewForTest struct {
+	Formatted    string `json:"formatted"`
+	Revision     string `json:"revision"`
+	PreviewToken string `json:"preview_token"`
+}
+
+func previewConfigForTest(t *testing.T, w *webMux, body string) configPreviewForTest {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/config/preview", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	w.apiConfigPreview(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preview status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var got configPreviewForTest
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("preview json: %v", err)
+	}
+	if got.Formatted == "" || got.Revision == "" || got.PreviewToken == "" {
+		t.Fatalf("incomplete preview: %+v", got)
+	}
+	return got
+}
+
+func jsonEscape(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b[1 : len(b)-1])
 }

--- a/www/src/components/ConfigSaveReview.tsx
+++ b/www/src/components/ConfigSaveReview.tsx
@@ -1,0 +1,63 @@
+import type { ConfigSavePreview } from "../lib/api";
+
+export function ConfigSaveReview({
+  preview,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  preview: ConfigSavePreview;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[60]">
+      <div className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[920px] max-w-[96vw] max-h-[88vh]">
+        <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
+          <div>
+            <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
+              REVIEW GATEWAY.HCL CHANGES
+            </div>
+            <div className="text-[12px] text-[#737373] mt-1">
+              HCL parsed successfully · formatting applied · {preview.bytes} bytes will be saved
+            </div>
+          </div>
+          <button
+            onClick={onCancel}
+            disabled={busy}
+            className="ml-auto text-[11px] px-2 py-1 text-[#a3a3a3] hover:text-[#171717] disabled:opacity-40"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-4 py-3 border-b border-[#e5e5e5] bg-[#fafafa] text-[12px] text-[#404040]">
+          Confirming writes the <span className="font-mono">formatted</span> draft below to disk.
+          If <span className="font-mono">gateway.hcl</span> changed since this preview, the save is rejected.
+        </div>
+
+        <pre className="flex-1 overflow-auto m-0 p-4 text-[12px] leading-5 font-mono bg-[#0a0a0a] text-[#e5e5e5] whitespace-pre-wrap">
+          {preview.diff || "No file content changes after formatting."}
+        </pre>
+
+        <div className="flex items-center gap-2 px-4 py-3 border-t border-[#e5e5e5]">
+          <button
+            onClick={onCancel}
+            disabled={busy}
+            className="ml-auto text-[11px] px-3 py-1.5 border border-[#e5e5e5] text-[#737373] rounded hover:border-[#a3a3a3] disabled:opacity-40"
+          >
+            back to editor
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={busy || !preview.changed}
+            className="text-[11px] px-3 py-1.5 border border-[#171717] text-white bg-[#171717] rounded hover:bg-[#262626] disabled:opacity-40"
+          >
+            {busy ? "saving…" : "save changes"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/www/src/components/ConfigSaveReview.tsx
+++ b/www/src/components/ConfigSaveReview.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import type { ConfigSavePreview } from "../lib/api";
+import { highlightDiff } from "../lib/diffHighlight";
 
 export function ConfigSaveReview({
   preview,
@@ -11,6 +13,11 @@ export function ConfigSaveReview({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  const diffHtml = useMemo(
+    () => highlightDiff(preview.diff || "No file content changes after formatting."),
+    [preview.diff],
+  );
+
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[60]">
       <div className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[920px] max-w-[96vw] max-h-[88vh]">
@@ -33,12 +40,16 @@ export function ConfigSaveReview({
         </div>
 
         <div className="px-4 py-3 border-b border-[#e5e5e5] bg-[#fafafa] text-[12px] text-[#404040]">
-          Confirming writes the <span className="font-mono">formatted</span> draft below to disk.
-          If <span className="font-mono">gateway.hcl</span> changed since this preview, the save is rejected.
+          Confirming writes the <span className="font-mono">formatted</span> draft below to disk. If{" "}
+          <span className="font-mono">gateway.hcl</span> changed since this preview, the save is
+          rejected.
         </div>
 
-        <pre className="flex-1 overflow-auto m-0 p-4 text-[12px] leading-5 font-mono bg-[#0a0a0a] text-[#e5e5e5] whitespace-pre-wrap">
-          {preview.diff || "No file content changes after formatting."}
+        <pre className="config-diff-view flex-1 overflow-auto m-0 p-4 text-[12px] leading-5 font-mono whitespace-pre-wrap language-diff diff-highlight">
+          <code
+            className="config-diff-view language-diff diff-highlight"
+            dangerouslySetInnerHTML={{ __html: diffHtml }}
+          />
         </pre>
 
         <div className="flex items-center gap-2 px-4 py-3 border-t border-[#e5e5e5]">

--- a/www/src/components/RulesEditor.tsx
+++ b/www/src/components/RulesEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { aiEditRules, getConfigHCL, putConfigHCL } from "../lib/api";
+import { aiEditRules, getConfigHCL, previewConfigHCL, saveConfigHCL, type ConfigSavePreview } from "../lib/api";
+import { ConfigSaveReview } from "./ConfigSaveReview";
 import { HCLEditor } from "./HCLEditor";
 
 // RulesEditor edits the whole gateway.hcl file. Validation runs
@@ -10,6 +11,7 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [okMsg, setOkMsg] = useState<string | null>(null);
+  const [preview, setPreview] = useState<ConfigSavePreview | null>(null);
   const [aiPrompt, setAIPrompt] = useState("");
   const [aiBusy, setAIBusy] = useState(false);
 
@@ -27,11 +29,29 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
     setErr(null);
     setOkMsg(null);
     try {
-      const r = await putConfigHCL(text);
+      const p = await previewConfigHCL(text);
+      setPreview(p);
+    } catch (e: any) {
+      setErr(String(e.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function confirmSave() {
+    if (!preview) return;
+    setBusy(true);
+    setErr(null);
+    setOkMsg(null);
+    try {
+      const r = await saveConfigHCL(preview.formatted, preview.revision);
+      setText(preview.formatted);
+      setOriginal(preview.formatted);
+      setPreview(null);
       setOkMsg(`saved · ${r.bytes} bytes`);
-      setOriginal(text);
       onSaved();
     } catch (e: any) {
+      setPreview(null);
       setErr(String(e.message ?? e));
     } finally {
       setBusy(false);
@@ -61,7 +81,8 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
   const dirty = text !== original;
 
   return (
-    <div
+    <>
+      <div
       className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
       onClick={onClose}
     >
@@ -129,6 +150,15 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
           </button>
         </div>
       </div>
-    </div>
+      </div>
+      {preview && (
+        <ConfigSaveReview
+          preview={preview}
+          busy={busy}
+          onCancel={() => setPreview(null)}
+          onConfirm={confirmSave}
+        />
+      )}
+    </>
   );
 }

--- a/www/src/components/RulesEditor.tsx
+++ b/www/src/components/RulesEditor.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { aiEditRules, getConfigHCL, previewConfigHCL, saveConfigHCL, type ConfigSavePreview } from "../lib/api";
+import {
+  aiEditRules,
+  getConfigHCL,
+  previewConfigHCL,
+  saveConfigHCL,
+  type ConfigSavePreview,
+} from "../lib/api";
 import { ConfigSaveReview } from "./ConfigSaveReview";
 import { HCLEditor } from "./HCLEditor";
 
@@ -44,7 +50,7 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
     setErr(null);
     setOkMsg(null);
     try {
-      const r = await saveConfigHCL(preview.formatted, preview.revision);
+      const r = await saveConfigHCL(preview.formatted, preview.revision, preview.preview_token);
       setText(preview.formatted);
       setOriginal(preview.formatted);
       setPreview(null);
@@ -83,73 +89,73 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
   return (
     <>
       <div
-      className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
-      onClick={onClose}
-    >
-      <div
-        className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[820px] max-w-full max-h-[85vh]"
-        onClick={(e) => e.stopPropagation()}
+        className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        onClick={onClose}
       >
-        <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
-          <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
-            EDIT GATEWAY.HCL
-          </div>
-          <button
-            onClick={onClose}
-            className="ml-auto text-[11px] px-2 py-1 text-[#a3a3a3] hover:text-[#171717]"
-          >
-            ✕
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-auto">
-          <HCLEditor value={text} onChange={setText} minHeight={320} />
-        </div>
-
-        <form
-          onSubmit={runAI}
-          className="flex items-center gap-2 px-4 py-2.5 border-t border-[#e5e5e5] bg-white"
+        <div
+          className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[820px] max-w-full max-h-[85vh]"
+          onClick={(e) => e.stopPropagation()}
         >
-          <span className="text-[10px] uppercase tracking-[.09em] text-[#a3a3a3]">AI</span>
-          <input
-            type="text"
-            value={aiPrompt}
-            onChange={(e) => setAIPrompt(e.target.value)}
-            placeholder='e.g. "deny POSTs to api.github.com" — uses connected Claude/Codex'
-            className="flex-1 text-[12px] border border-[#e5e5e5] rounded px-2 py-1.5 focus:outline-none focus:border-[#171717] transition-colors"
-          />
-          <button
-            type="submit"
-            disabled={aiBusy || !aiPrompt.trim()}
-            className="text-[11px] px-3 py-1.5 border border-[#171717] text-[#171717] rounded hover:bg-[#171717] hover:text-white disabled:opacity-40"
-          >
-            {aiBusy ? "thinking…" : "apply"}
-          </button>
-        </form>
+          <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
+            <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
+              EDIT GATEWAY.HCL
+            </div>
+            <button
+              onClick={onClose}
+              className="ml-auto text-[11px] px-2 py-1 text-[#a3a3a3] hover:text-[#171717]"
+            >
+              ✕
+            </button>
+          </div>
 
-        <div className="flex items-center px-4 py-3 border-t border-[#e5e5e5] gap-3">
-          {err && <span className="text-[11px] text-red-600 break-all flex-1">{err}</span>}
-          {okMsg && <span className="text-[11px] text-[#16a34a] flex-1">{okMsg}</span>}
-          {!err && !okMsg && (
-            <span className="text-[11px] text-[#a3a3a3] flex-1">
-              {dirty ? "unsaved changes" : "no changes"}
-            </span>
-          )}
-          <button
-            onClick={onClose}
-            className="text-[11px] px-3 py-1.5 border border-[#e5e5e5] text-[#737373] rounded hover:border-[#a3a3a3]"
+          <div className="flex-1 overflow-auto">
+            <HCLEditor value={text} onChange={setText} minHeight={320} />
+          </div>
+
+          <form
+            onSubmit={runAI}
+            className="flex items-center gap-2 px-4 py-2.5 border-t border-[#e5e5e5] bg-white"
           >
-            close
-          </button>
-          <button
-            onClick={save}
-            disabled={!dirty || busy}
-            className="text-[11px] px-3 py-1.5 border border-[#171717] text-white bg-[#171717] rounded hover:bg-[#262626] disabled:opacity-40"
-          >
-            {busy ? "saving…" : "save"}
-          </button>
+            <span className="text-[10px] uppercase tracking-[.09em] text-[#a3a3a3]">AI</span>
+            <input
+              type="text"
+              value={aiPrompt}
+              onChange={(e) => setAIPrompt(e.target.value)}
+              placeholder='e.g. "deny POSTs to api.github.com" — uses connected Claude/Codex'
+              className="flex-1 text-[12px] border border-[#e5e5e5] rounded px-2 py-1.5 focus:outline-none focus:border-[#171717] transition-colors"
+            />
+            <button
+              type="submit"
+              disabled={aiBusy || !aiPrompt.trim()}
+              className="text-[11px] px-3 py-1.5 border border-[#171717] text-[#171717] rounded hover:bg-[#171717] hover:text-white disabled:opacity-40"
+            >
+              {aiBusy ? "thinking…" : "apply"}
+            </button>
+          </form>
+
+          <div className="flex items-center px-4 py-3 border-t border-[#e5e5e5] gap-3">
+            {err && <span className="text-[11px] text-red-600 break-all flex-1">{err}</span>}
+            {okMsg && <span className="text-[11px] text-[#16a34a] flex-1">{okMsg}</span>}
+            {!err && !okMsg && (
+              <span className="text-[11px] text-[#a3a3a3] flex-1">
+                {dirty ? "unsaved changes" : "no changes"}
+              </span>
+            )}
+            <button
+              onClick={onClose}
+              className="text-[11px] px-3 py-1.5 border border-[#e5e5e5] text-[#737373] rounded hover:border-[#a3a3a3]"
+            >
+              close
+            </button>
+            <button
+              onClick={save}
+              disabled={!dirty || busy}
+              className="text-[11px] px-3 py-1.5 border border-[#171717] text-white bg-[#171717] rounded hover:bg-[#262626] disabled:opacity-40"
+            >
+              {busy ? "saving…" : "save"}
+            </button>
+          </div>
         </div>
-      </div>
       </div>
       {preview && (
         <ConfigSaveReview

--- a/www/src/components/SettingsModal.tsx
+++ b/www/src/components/SettingsModal.tsx
@@ -3,7 +3,8 @@
 // hot-reloads rules / profiles / approvers without a restart.
 
 import { useEffect, useState } from "react";
-import { getConfigHCL, putConfigHCL } from "../lib/api";
+import { getConfigHCL, previewConfigHCL, saveConfigHCL, type ConfigSavePreview } from "../lib/api";
+import { ConfigSaveReview } from "./ConfigSaveReview";
 import { HCLEditor } from "./HCLEditor";
 
 export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
@@ -12,6 +13,7 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
   const [err, setErr] = useState<string | null>(null);
   const [okMsg, setOkMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [preview, setPreview] = useState<ConfigSavePreview | null>(null);
 
   useEffect(() => {
     getConfigHCL()
@@ -27,11 +29,29 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
     setErr(null);
     setOkMsg(null);
     try {
-      const r = await putConfigHCL(text);
+      const p = await previewConfigHCL(text);
+      setPreview(p);
+    } catch (e: any) {
+      setErr(String(e.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function confirmSave() {
+    if (!preview) return;
+    setBusy(true);
+    setErr(null);
+    setOkMsg(null);
+    try {
+      const r = await saveConfigHCL(preview.formatted, preview.revision);
+      setText(preview.formatted);
+      setOriginal(preview.formatted);
+      setPreview(null);
       setOkMsg(`saved · ${r.bytes} bytes`);
-      setOriginal(text);
       onSaved();
     } catch (e: any) {
+      setPreview(null);
       setErr(String(e.message ?? e));
     } finally {
       setBusy(false);
@@ -41,7 +61,8 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
   const dirty = text !== original;
 
   return (
-    <div
+    <>
+      <div
       className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
       onClick={onClose}
     >
@@ -77,6 +98,15 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
           </button>
         </div>
       </div>
-    </div>
+      </div>
+      {preview && (
+        <ConfigSaveReview
+          preview={preview}
+          busy={busy}
+          onCancel={() => setPreview(null)}
+          onConfirm={confirmSave}
+        />
+      )}
+    </>
   );
 }

--- a/www/src/components/SettingsModal.tsx
+++ b/www/src/components/SettingsModal.tsx
@@ -44,7 +44,7 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
     setErr(null);
     setOkMsg(null);
     try {
-      const r = await saveConfigHCL(preview.formatted, preview.revision);
+      const r = await saveConfigHCL(preview.formatted, preview.revision, preview.preview_token);
       setText(preview.formatted);
       setOriginal(preview.formatted);
       setPreview(null);
@@ -63,41 +63,41 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
   return (
     <>
       <div
-      className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
-      onClick={onClose}
-    >
-      <div
-        className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[820px] max-w-full max-h-[85vh]"
-        onClick={(e) => e.stopPropagation()}
+        className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        onClick={onClose}
       >
-        <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
-          <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
-            GATEWAY SETTINGS · gateway.hcl
+        <div
+          className="bg-white border border-[#e5e5e5] rounded-md shadow-2xl flex flex-col w-[820px] max-w-full max-h-[85vh]"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
+            <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
+              GATEWAY SETTINGS · gateway.hcl
+            </div>
+            <button
+              onClick={onClose}
+              className="ml-auto text-[11px] px-2 py-1 text-[#a3a3a3] hover:text-[#171717]"
+            >
+              ✕
+            </button>
           </div>
-          <button
-            onClick={onClose}
-            className="ml-auto text-[11px] px-2 py-1 text-[#a3a3a3] hover:text-[#171717]"
-          >
-            ✕
-          </button>
-        </div>
 
-        <div className="flex-1 overflow-auto">
-          <HCLEditor value={text} onChange={setText} minHeight={420} />
-        </div>
+          <div className="flex-1 overflow-auto">
+            <HCLEditor value={text} onChange={setText} minHeight={420} />
+          </div>
 
-        <div className="flex items-center gap-2 px-4 py-3 border-t border-[#e5e5e5]">
-          {err && <div className="text-[11px] text-red-600 truncate">{err}</div>}
-          {okMsg && <div className="text-[11px] text-green-700 truncate">{okMsg}</div>}
-          <button
-            onClick={save}
-            disabled={!dirty || busy}
-            className="ml-auto text-[11px] px-3 py-1 bg-black text-white rounded disabled:opacity-40 hover:bg-[#171717]"
-          >
-            {busy ? "saving…" : "save"}
-          </button>
+          <div className="flex items-center gap-2 px-4 py-3 border-t border-[#e5e5e5]">
+            {err && <div className="text-[11px] text-red-600 truncate">{err}</div>}
+            {okMsg && <div className="text-[11px] text-green-700 truncate">{okMsg}</div>}
+            <button
+              onClick={save}
+              disabled={!dirty || busy}
+              className="ml-auto text-[11px] px-3 py-1 bg-black text-white rounded disabled:opacity-40 hover:bg-[#171717]"
+            >
+              {busy ? "saving…" : "save"}
+            </button>
+          </div>
         </div>
-      </div>
       </div>
       {preview && (
         <ConfigSaveReview

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -30,3 +30,41 @@ body {
   background: #d4d4d4;
   border-radius: 2px;
 }
+
+.config-diff-view,
+pre.config-diff-view[class*="language-"],
+code.config-diff-view[class*="language-"] {
+  background: #020617;
+  color: #e2e8f0;
+  text-shadow: none;
+}
+
+pre.config-diff-view.diff-highlight > code .token.inserted:not(.prefix),
+pre > code.config-diff-view.diff-highlight .token.inserted:not(.prefix) {
+  background: rgba(34, 197, 94, 0.18);
+  color: #dcfce7;
+}
+
+pre.config-diff-view.diff-highlight > code .token.deleted:not(.prefix),
+pre > code.config-diff-view.diff-highlight .token.deleted:not(.prefix) {
+  background: rgba(239, 68, 68, 0.2);
+  color: #fee2e2;
+}
+
+.config-diff-view .token.inserted {
+  color: #86efac;
+}
+
+.config-diff-view .token.deleted {
+  color: #fca5a5;
+}
+
+.config-diff-view .token.coord {
+  color: #93c5fd;
+}
+
+.config-diff-view .token.prefix.inserted,
+.config-diff-view .token.prefix.deleted {
+  color: #f8fafc;
+  user-select: none;
+}

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -162,11 +162,36 @@ export async function getConfigHCL(): Promise<string> {
   return r.text();
 }
 
-export async function putConfigHCL(hcl: string): Promise<{ ok: boolean; bytes: number }> {
-  const r = await api("/api/config", {
-    method: "PUT",
+export type ConfigSavePreview = {
+  ok: boolean;
+  formatted: string;
+  diff: string;
+  changed: boolean;
+  bytes: number;
+  revision: string;
+};
+
+export type ConfigSaveResult = {
+  ok: boolean;
+  bytes: number;
+  revision: string;
+};
+
+export async function previewConfigHCL(hcl: string): Promise<ConfigSavePreview> {
+  const r = await api("/api/config/preview", {
+    method: "POST",
     headers: { "Content-Type": "text/plain" },
     body: hcl,
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+export async function saveConfigHCL(content: string, expectedRevision: string): Promise<ConfigSaveResult> {
+  const r = await api("/api/config/save", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content, expected_revision: expectedRevision }),
   });
   if (!r.ok) throw new Error(await r.text());
   return r.json();

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -169,6 +169,7 @@ export type ConfigSavePreview = {
   changed: boolean;
   bytes: number;
   revision: string;
+  preview_token: string;
 };
 
 export type ConfigSaveResult = {
@@ -187,11 +188,19 @@ export async function previewConfigHCL(hcl: string): Promise<ConfigSavePreview> 
   return r.json();
 }
 
-export async function saveConfigHCL(content: string, expectedRevision: string): Promise<ConfigSaveResult> {
+export async function saveConfigHCL(
+  content: string,
+  expectedRevision: string,
+  previewToken: string,
+): Promise<ConfigSaveResult> {
   const r = await api("/api/config/save", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ content, expected_revision: expectedRevision }),
+    body: JSON.stringify({
+      content,
+      expected_revision: expectedRevision,
+      preview_token: previewToken,
+    }),
   });
   if (!r.ok) throw new Error(await r.text());
   return r.json();

--- a/www/src/lib/diffHighlight.ts
+++ b/www/src/lib/diffHighlight.ts
@@ -1,0 +1,10 @@
+import Prism from "prismjs";
+import "prismjs/components/prism-diff";
+import "prismjs/plugins/diff-highlight/prism-diff-highlight";
+import "prismjs/plugins/diff-highlight/prism-diff-highlight.css";
+
+// Prism.highlight returns escaped token HTML. ConfigSaveReview injects this
+// string into a read-only <code> element so Prism can style diff tokens.
+export function highlightDiff(diff: string): string {
+  return Prism.highlight(diff, Prism.languages.diff, "diff");
+}


### PR DESCRIPTION
## Summary

Adds a safer dashboard save flow for `gateway.hcl`.

- Adds a preview endpoint that validates, formats, and diffs the edited config before writing
- Adds a confirmation modal in the dashboard so users can review the formatted diff before saving
- Rejects saves when `gateway.hcl` changed after the preview was generated
- Writes config changes atomically
- Highlights the diff view with Prism, including clearer inserted/deleted line styling
 
![image](https://github.com/user-attachments/assets/4d3de993-f24d-4f8d-a965-f1e2c5cf3f01)


## Test Plan

- `go test ./...`
- `npm run build`
- `git diff --check`
- Manual dashboard check with the `gateway.hcl` review modal
