### PR TITLE
test: cover k8s parser edge cases

### DIFF
--- a/config/match/match_test.go
+++ b/config/match/match_test.go
@@ -162,6 +162,31 @@ func TestK8sMatcherParams(t *testing.T) {
 	}
 }
 
+func TestK8sMatcherWatchVerbAndParams(t *testing.T) {
+	m, err := match.New("k8s", map[string]any{
+		"verb":     "watch",
+		"resource": "pods",
+		"params":   map[string]any{"watch": "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &match.Request{
+		Family: "k8s",
+		K8s: &match.K8sMeta{
+			Verb: "watch", Resource: "pods", Params: map[string]string{"watch": "true"},
+		},
+	}
+	if !m.Match(req) {
+		t.Errorf("expected watch pod list to match")
+	}
+	req.K8s.Verb = "list"
+	if m.Match(req) {
+		t.Errorf("expected plain list to miss watch rule")
+	}
+}
+
 func TestSQLMatcherVerbAndTables(t *testing.T) {
 	m, err := match.New("sql", map[string]any{
 		"verb":   "select",

--- a/config/runtime/k8s_parse.go
+++ b/config/runtime/k8s_parse.go
@@ -20,9 +20,10 @@ import (
 //	/api/v1/namespaces/<ns>/<resource>/<name>/<sub> → subresource (exec / portforward / etc.)
 //	/apis/<group>/<v>/...                           → same shapes under named groups
 //
-// Verb derives from the HTTP method (GET → list/get, POST → create,
-// PUT → update, PATCH → patch, DELETE → delete) — kubectl uses POST
-// to /api/v1/.../<name>/exec so the matcher relies on Resource ending
+// Verb derives from the HTTP method (GET → list/get/watch, POST → create,
+// PUT → update, PATCH → patch, DELETE → delete). GET requests with
+// watch=true are normalized to watch. kubectl uses POST to
+// /api/v1/.../<name>/exec so the matcher relies on Resource ending
 // in "/exec" rather than special-casing the verb.
 func ParseK8sPath(method, rawURL string) *match.K8sMeta {
 	u, err := url.Parse(rawURL)
@@ -87,6 +88,9 @@ func ParseK8sPath(method, rawURL string) *match.K8sMeta {
 				m.Params[k] = v[0]
 			}
 		}
+	}
+	if strings.EqualFold(method, "GET") && strings.EqualFold(m.Params["watch"], "true") {
+		m.Verb = "watch"
 	}
 	return m
 }

--- a/config/runtime/k8s_parse_test.go
+++ b/config/runtime/k8s_parse_test.go
@@ -1,0 +1,96 @@
+package runtime_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/match"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestParseK8sPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		rawURL string
+		want   *match.K8sMeta
+	}{
+		{
+			name:   "core namespaced pod get",
+			method: "GET",
+			rawURL: "/api/v1/namespaces/default/pods/nginx",
+			want: &match.K8sMeta{
+				Verb: "get", Resource: "pods", Namespace: "default", Name: "nginx",
+			},
+		},
+		{
+			name:   "pod logs subresource",
+			method: "GET",
+			rawURL: "/api/v1/namespaces/default/pods/nginx/log?container=app",
+			want: &match.K8sMeta{
+				Verb:      "get",
+				Resource:  "pods/log",
+				Namespace: "default",
+				Name:      "nginx",
+				Params:    map[string]string{"container": "app"},
+			},
+		},
+		{
+			name:   "interactive exec subresource preserves params",
+			method: "POST",
+			rawURL: "/api/v1/namespaces/default/pods/nginx/exec?stdin=true&tty=true&command=sh",
+			want: &match.K8sMeta{
+				Verb:      "create",
+				Resource:  "pods/exec",
+				Namespace: "default",
+				Name:      "nginx",
+				Params:    map[string]string{"stdin": "true", "tty": "true", "command": "sh"},
+			},
+		},
+		{
+			name:   "portforward subresource",
+			method: "POST",
+			rawURL: "/api/v1/namespaces/default/pods/nginx/portforward?ports=5432",
+			want: &match.K8sMeta{
+				Verb:      "create",
+				Resource:  "pods/portforward",
+				Namespace: "default",
+				Name:      "nginx",
+				Params:    map[string]string{"ports": "5432"},
+			},
+		},
+		{
+			name:   "named API group deployment",
+			method: "PATCH",
+			rawURL: "/apis/apps/v1/namespaces/default/deployments/web",
+			want: &match.K8sMeta{
+				Verb: "patch", Resource: "deployments", Namespace: "default", Name: "web",
+			},
+		},
+		{
+			name:   "cluster scoped list with watch param is watch verb",
+			method: "GET",
+			rawURL: "/api/v1/pods?watch=true&resourceVersion=123",
+			want: &match.K8sMeta{
+				Verb:     "watch",
+				Resource: "pods",
+				Params:   map[string]string{"watch": "true", "resourceVersion": "123"},
+			},
+		},
+		{
+			name:   "non k8s path returns nil",
+			method: "GET",
+			rawURL: "/healthz",
+			want:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runtime.ParseK8sPath(tc.method, tc.rawURL)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ParseK8sPath(%q, %q) = %#v, want %#v", tc.method, tc.rawURL, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add table-driven coverage for Kubernetes API path parsing, including subresources and named API groups
- Normalize `GET ...?watch=true` requests to k8s verb `watch`
- Add matcher coverage for watch verb + query params

## Test Plan
- `go test ./config/runtime ./config/match -v`
- `cd www && npm ci && npm run build`
- `go test ./...`
