### PR TITLE
chore: add oxc for frontend format and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: cd www && npm ci && npm run build
+      - run: cd www && npm ci && npm run format:check && npm run lint:github && npm run build
       - run: gofmt -l . && test -z "$(gofmt -l .)"
       - run: go test ./...

--- a/www/.oxfmtrc.json
+++ b/www/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/www/.oxlintrc.json
+++ b/www/.oxlintrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "oxc",
+    "react"
+  ],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {},
+  "env": {
+    "builtin": true
+  }
+}

--- a/www/login.html
+++ b/www/login.html
@@ -1,78 +1,90 @@
 <!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>clawpatrol</title>
-  <style>
-    body {
-      font: 14px -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #fafafa;
-      color: #171717;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-      margin: 0;
-    }
-    form {
-      background: #fff;
-      border: 1px solid #e5e5e5;
-      border-radius: 6px;
-      padding: 24px;
-      width: 320px;
-    }
-    h1 {
-      font-family: Georgia, serif;
-      font-size: 28px;
-      font-weight: 400;
-      margin: 0 0 16px;
-      letter-spacing: -0.01em;
-    }
-    label {
-      display: block;
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: .09em;
-      color: #a3a3a3;
-      margin: 0 0 6px;
-    }
-    input {
-      width: 100%;
-      box-sizing: border-box;
-      padding: 8px 10px;
-      border: 1px solid #e5e5e5;
-      border-radius: 4px;
-      font: 13px ui-monospace, SFMono-Regular, monospace;
-      outline: none;
-    }
-    input:focus { border-color: #171717; }
-    button {
-      margin-top: 12px;
-      width: 100%;
-      padding: 8px;
-      background: #171717;
-      color: #fff;
-      border: 0;
-      border-radius: 4px;
-      font-size: 12px;
-      cursor: pointer;
-    }
-    button:hover { background: #000; }
-    .err {
-      color: #dc2626;
-      font-size: 12px;
-      margin: 0 0 12px;
-    }
-  </style>
-</head>
-<body>
-  <form method="POST" action="/__login?next={{.Next}}">
-    <h1>clawpatrol</h1>
-    {{if .Error}}<p class="err">{{.Error}}</p>{{end}}
-    <label>secret</label>
-    <input type="password" name="secret" autofocus required>
-    <button type="submit">unlock</button>
-  </form>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>clawpatrol</title>
+    <style>
+      body {
+        font:
+          14px -apple-system,
+          BlinkMacSystemFont,
+          sans-serif;
+        background: #fafafa;
+        color: #171717;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+      }
+      form {
+        background: #fff;
+        border: 1px solid #e5e5e5;
+        border-radius: 6px;
+        padding: 24px;
+        width: 320px;
+      }
+      h1 {
+        font-family: Georgia, serif;
+        font-size: 28px;
+        font-weight: 400;
+        margin: 0 0 16px;
+        letter-spacing: -0.01em;
+      }
+      label {
+        display: block;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        color: #a3a3a3;
+        margin: 0 0 6px;
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px 10px;
+        border: 1px solid #e5e5e5;
+        border-radius: 4px;
+        font:
+          13px ui-monospace,
+          SFMono-Regular,
+          monospace;
+        outline: none;
+      }
+      input:focus {
+        border-color: #171717;
+      }
+      button {
+        margin-top: 12px;
+        width: 100%;
+        padding: 8px;
+        background: #171717;
+        color: #fff;
+        border: 0;
+        border-radius: 4px;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #000;
+      }
+      .err {
+        color: #dc2626;
+        font-size: 12px;
+        margin: 0 0 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <form method="POST" action="/__login?next={{.Next}}">
+      <h1>clawpatrol</h1>
+      {{if .Error}}
+      <p class="err">{{.Error}}</p>
+      {{end}}
+      <label>secret</label>
+      <input type="password" name="secret" autofocus required />
+      <button type="submit">unlock</button>
+    </form>
+  </body>
 </html>

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -20,6 +20,8 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.19",
+        "oxfmt": "^0.48.0",
+        "oxlint": "^1.63.0",
         "postcss": "^8.4.39",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.5.3",
@@ -70,7 +72,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -815,6 +816,652 @@
         "node": ">=12"
       }
     },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.48.0.tgz",
+      "integrity": "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.48.0.tgz",
+      "integrity": "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.48.0.tgz",
+      "integrity": "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.48.0.tgz",
+      "integrity": "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.48.0.tgz",
+      "integrity": "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.48.0.tgz",
+      "integrity": "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.48.0.tgz",
+      "integrity": "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.48.0.tgz",
+      "integrity": "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.48.0.tgz",
+      "integrity": "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.48.0.tgz",
+      "integrity": "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.48.0.tgz",
+      "integrity": "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.48.0.tgz",
+      "integrity": "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.48.0.tgz",
+      "integrity": "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.48.0.tgz",
+      "integrity": "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.48.0.tgz",
+      "integrity": "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.48.0.tgz",
+      "integrity": "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.48.0.tgz",
+      "integrity": "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.48.0.tgz",
+      "integrity": "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.48.0.tgz",
+      "integrity": "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.63.0.tgz",
+      "integrity": "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.63.0.tgz",
+      "integrity": "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.63.0.tgz",
+      "integrity": "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.63.0.tgz",
+      "integrity": "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.63.0.tgz",
+      "integrity": "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.63.0.tgz",
+      "integrity": "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.63.0.tgz",
+      "integrity": "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.63.0.tgz",
+      "integrity": "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.63.0.tgz",
+      "integrity": "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.63.0.tgz",
+      "integrity": "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.63.0.tgz",
+      "integrity": "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.63.0.tgz",
+      "integrity": "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.63.0.tgz",
+      "integrity": "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.63.0.tgz",
+      "integrity": "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.63.0.tgz",
+      "integrity": "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.63.0.tgz",
+      "integrity": "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.63.0.tgz",
+      "integrity": "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.63.0.tgz",
+      "integrity": "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.63.0.tgz",
+      "integrity": "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1243,7 +1890,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1410,7 +2056,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1857,7 +2502,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2281,7 +2925,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2459,6 +3102,91 @@
         "node": ">= 6"
       }
     },
+    "node_modules/oxfmt": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.48.0.tgz",
+      "integrity": "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.48.0",
+        "@oxfmt/binding-android-arm64": "0.48.0",
+        "@oxfmt/binding-darwin-arm64": "0.48.0",
+        "@oxfmt/binding-darwin-x64": "0.48.0",
+        "@oxfmt/binding-freebsd-x64": "0.48.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.48.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.48.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.48.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.48.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-x64-musl": "0.48.0",
+        "@oxfmt/binding-openharmony-arm64": "0.48.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.48.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.48.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.48.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.63.0.tgz",
+      "integrity": "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.63.0",
+        "@oxlint/binding-android-arm64": "1.63.0",
+        "@oxlint/binding-darwin-arm64": "1.63.0",
+        "@oxlint/binding-darwin-x64": "1.63.0",
+        "@oxlint/binding-freebsd-x64": "1.63.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.63.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.63.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.63.0",
+        "@oxlint/binding-linux-arm64-musl": "1.63.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.63.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.63.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.63.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.63.0",
+        "@oxlint/binding-linux-x64-gnu": "1.63.0",
+        "@oxlint/binding-linux-x64-musl": "1.63.0",
+        "@oxlint/binding-openharmony-arm64": "1.63.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.63.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.63.0",
+        "@oxlint/binding-win32-x64-msvc": "1.63.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2526,7 +3254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2705,7 +3432,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2718,7 +3444,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3057,12 +3782,21 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3143,7 +3877,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/www/package.json
+++ b/www/package.json
@@ -1,11 +1,15 @@
 {
   "name": "clawpatrol-dashboard",
-  "private": true,
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b --noEmit && vite build"
+    "build": "tsc -b --noEmit && vite build",
+    "format": "oxfmt src index.html login.html package.json tsconfig.json vite.config.ts tailwind.config.js postcss.config.js",
+    "format:check": "oxfmt --check src index.html login.html package.json tsconfig.json vite.config.ts tailwind.config.js postcss.config.js",
+    "lint": "oxlint src vite.config.ts tailwind.config.js postcss.config.js",
+    "lint:github": "oxlint --format=github src vite.config.ts tailwind.config.js postcss.config.js"
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.17",
@@ -20,6 +24,8 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.19",
+    "oxfmt": "^0.48.0",
+    "oxlint": "^1.63.0",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.5.3",

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -9,13 +9,7 @@ import { RequestDetailPage } from "./components/RequestDetailPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
-import {
-  getState,
-  type Agent,
-  type Integration,
-  type UpdateBanner,
-  type Whoami,
-} from "./lib/api";
+import { getState, type Agent, type Integration, type UpdateBanner, type Whoami } from "./lib/api";
 
 type Route =
   | { name: "main" }
@@ -108,7 +102,16 @@ export default function App() {
               className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
               title="analytics"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <path d="M3 3v18h18" />
                 <path d="m7 16 4-8 4 4 4-6" />
               </svg>
@@ -118,7 +121,16 @@ export default function App() {
               className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
               title="settings (gateway.hcl)"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <circle cx="12" cy="12" r="3" />
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
               </svg>
@@ -156,7 +168,9 @@ export default function App() {
           onRefresh={refresh}
         />
       )}
-      {showAddDevice && <AddDeviceModal publicURL={whoami?.public_url} onClose={() => setShowAddDevice(false)} />}
+      {showAddDevice && (
+        <AddDeviceModal publicURL={whoami?.public_url} onClose={() => setShowAddDevice(false)} />
+      )}
       {showSettings && <SettingsModal onClose={() => setShowSettings(false)} onSaved={refresh} />}
       {connectId && (
         <ConnectModal
@@ -182,8 +196,7 @@ function UpdateNotice({ update }: { update: UpdateBanner | null }) {
   if (!update?.update_available) return null;
   const dismissKey = "clawpatrol:update-dismissed:" + update.latest;
   const [dismissed, setDismissed] = useState(
-    typeof localStorage !== "undefined" &&
-      localStorage.getItem(dismissKey) === "1",
+    typeof localStorage !== "undefined" && localStorage.getItem(dismissKey) === "1",
   );
   if (dismissed) return null;
   return (
@@ -199,11 +212,7 @@ function UpdateNotice({ update }: { update: UpdateBanner | null }) {
         >
           release notes
         </a>
-        {update.advisory && (
-          <span className="ml-2 text-[#92400e]">
-            ({update.advisory})
-          </span>
-        )}
+        {update.advisory && <span className="ml-2 text-[#92400e]">({update.advisory})</span>}
       </div>
       <button
         onClick={() => {

--- a/www/src/components/AddDeviceModal.tsx
+++ b/www/src/components/AddDeviceModal.tsx
@@ -1,19 +1,30 @@
 import { useState } from "react";
 
-export function AddDeviceModal({ publicURL, onClose }: { publicURL?: string; onClose: () => void }) {
+export function AddDeviceModal({
+  publicURL,
+  onClose,
+}: {
+  publicURL?: string;
+  onClose: () => void;
+}) {
   const url = publicURL || window.location.origin;
   const installCmd = "curl -fsSL https://clawpatrol.dev/install.sh | sh";
   const joinCmd = `clawpatrol join ${url}`;
 
   return (
-    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50" onClick={onClose}>
+    <div
+      className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
       <div
         className="bg-white border border-[#e5e5e5] rounded-md p-4 w-[600px] shadow-2xl space-y-3"
         onClick={(e) => e.stopPropagation()}
       >
         <div>
           <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">add device</div>
-          <h2 className="font-serif text-[22px] leading-none tracking-tight text-[#171717] mt-1">run on the new machine</h2>
+          <h2 className="font-serif text-[22px] leading-none tracking-tight text-[#171717] mt-1">
+            run on the new machine
+          </h2>
         </div>
 
         <Step n={1} label="install" cmd={installCmd} />
@@ -41,7 +52,7 @@ function Step({ n, label, cmd }: { n: number; label: string; cmd: string }) {
       </div>
       <div className="relative">
         <pre className="bg-[#fafafa] border border-[#e5e5e5] rounded px-2.5 py-1.5 text-[12px] font-mono text-[#171717] overflow-x-auto whitespace-pre">
-{cmd}
+          {cmd}
         </pre>
         <button
           onClick={copy}

--- a/www/src/components/AgentTypeIcon.tsx
+++ b/www/src/components/AgentTypeIcon.tsx
@@ -23,7 +23,15 @@ export function AgentTypeIcon({ type, className = "" }: { type?: string; classNa
     );
   if (t === "shell")
     return (
-      <svg className={className} viewBox="0 0 24 24" fill="none" stroke="#7c3aed" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        className={className}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#7c3aed"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M4 17l6-6-6-6" />
         <path d="M12 19h8" />
       </svg>

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -87,7 +87,12 @@ export function AgentsTable({
                 </div>
               </Td>
               <Td className="text-[11px] text-[#525252] tabular-nums text-right">{a.reqs}</Td>
-              <Td className="hidden lg:table-cell text-[11px] text-[#737373] tabular-nums truncate" title={[a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") || `wg ${a.ip}`}>
+              <Td
+                className="hidden lg:table-cell text-[11px] text-[#737373] tabular-nums truncate"
+                title={
+                  [a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") || `wg ${a.ip}`
+                }
+              >
                 {a.external_ipv4 || a.external_ipv6 || a.ip}
               </Td>
               <Td>
@@ -97,8 +102,7 @@ export function AgentsTable({
                     // Pick the owner row matching this device's profile
                     // so two profiles connected to different GH accounts
                     // surface distinct avatars in their respective rows.
-                    const owner = it?.owners?.find((o) => o.owner === a.profile)
-                      ?? it?.owners?.[0];
+                    const owner = it?.owners?.find((o) => o.owner === a.profile) ?? it?.owners?.[0];
                     return {
                       id,
                       type: it?.type,
@@ -138,7 +142,10 @@ function Td({
   title?: string;
 }) {
   return (
-    <td className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className} {...rest}>
+    <td
+      className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className}
+      {...rest}
+    >
       {children}
     </td>
   );

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -1,18 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as Plot from "@observablehq/plot";
 import { getAnalytics, type Agent, type EventRecord } from "../lib/api";
 
-
-const RANGES = [
-  "1m", "5m", "15m", "30m", "1h", "6h", "24h",
-] as const;
-type Range = typeof RANGES[number];
+const RANGES = ["1m", "5m", "15m", "30m", "1h", "6h", "24h"] as const;
+type Range = (typeof RANGES)[number];
 type ColorBy = "host" | "status" | "device";
 type Scale = "log" | "linear";
 
 const RANGE_MS: Record<Range, number> = {
-  "1m": 60e3, "5m": 300e3, "15m": 900e3,
-  "30m": 1800e3, "1h": 3600e3, "6h": 21600e3,
+  "1m": 60e3,
+  "5m": 300e3,
+  "15m": 900e3,
+  "30m": 1800e3,
+  "1h": 3600e3,
+  "6h": 21600e3,
   "24h": 86400e3,
 };
 
@@ -36,42 +37,36 @@ function qsSet(key: string, value: string) {
 }
 
 function useQS<T extends string>(
-  key: string, fallback: T, valid: readonly T[],
+  key: string,
+  fallback: T,
+  valid: readonly T[],
 ): [T, (v: T) => void] {
   const init = qsGet(key, fallback) as T;
-  const [val, setVal] = useState(
-    valid.includes(init) ? init : fallback,
-  );
-  const set = (v: T) => { setVal(v); qsSet(key, v); };
+  const [val, setVal] = useState(valid.includes(init) ? init : fallback);
+  const set = (v: T) => {
+    setVal(v);
+    qsSet(key, v);
+  };
   return [val, set];
 }
 
 // --- page ---
 
-export function AnalyticsPage({ ip, agents }: {
-  ip?: string;
-  agents: Agent[];
-}) {
-  const deviceName = ip
-    ? agents.find(a => a.ip === ip)?.hostname || ip
-    : undefined;
+export function AnalyticsPage({ ip, agents }: { ip?: string; agents: Agent[] }) {
+  const deviceName = ip ? agents.find((a) => a.ip === ip)?.hostname || ip : undefined;
   const [events, setEvents] = useState<EventRecord[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [errorCount, setErrorCount] = useState(0);
   type Counts = Array<{ key: string; count: number }>;
   const [byDevice, setByDevice] = useState<Counts>([]);
   const [byHost, setByHost] = useState<Counts>([]);
-  const [range, setRange] =
-    useQS("range", "1h" as Range, RANGES);
-  const [filterDevice, setFilterDevice] = useState<
-    string | null
-  >(null);
-  const [filterHost, setFilterHost] = useState<
-    string | null
-  >(null);
+  const [range, setRange] = useQS("range", "1h" as Range, RANGES);
+  const [filterDevice, setFilterDevice] = useState<string | null>(null);
+  const [filterHost, setFilterHost] = useState<string | null>(null);
   const isGlobal = !ip;
-  const agentNames = new Map(
-    agents.map(a => [a.ip, a.hostname || a.ip]),
+  const agentNames = useMemo(
+    () => new Map(agents.map((a) => [a.ip, a.hostname || a.ip])),
+    [agents],
   );
 
   // Skip setState (and thus the chart redraw) when the polled
@@ -102,23 +97,31 @@ export function AnalyticsPage({ ip, agents }: {
     // Auto-refresh only for short ranges. On 1h+ the data barely
     // shifts per poll and the redraw is mostly noise.
     if (RANGE_MS[range] >= 3600e3) {
-      return () => { cancelled = true; };
+      return () => {
+        cancelled = true;
+      };
     }
     const t = setInterval(load, 10000);
-    return () => { cancelled = true; clearInterval(t); };
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
   }, [ip, range]);
 
   // Client-side filters from bar chart clicks
-  const filtered = events.filter((e) => {
-    if (filterDevice && e.agent_ip !== filterDevice)
-      return false;
-    if (filterHost && e.host !== filterHost) return false;
-    return true;
-  });
+  const filtered = useMemo(
+    () =>
+      events.filter((e) => {
+        if (filterDevice && e.agent_ip !== filterDevice) return false;
+        if (filterHost && e.host !== filterHost) return false;
+        return true;
+      }),
+    [events, filterDevice, filterHost],
+  );
   const hasFilter = filterDevice || filterHost;
   const filterLabel = filterDevice
-    ? agentNames.get(filterDevice) ?? filterDevice
-    : filterHost ?? "";
+    ? (agentNames.get(filterDevice) ?? filterDevice)
+    : (filterHost ?? "");
 
   // --- summary stats ---
   // Counts (n, errPct) come from server-side aggregates so the
@@ -131,22 +134,18 @@ export function AnalyticsPage({ ip, agents }: {
       return { n: 0, avg: 0, p99: 0, errPct: 0, devices: 0 };
     }
     const lats = filtered
-      .map(e => e.ms).filter(m => m > 0)
+      .map((e) => e.ms)
+      .filter((m) => m > 0)
       .sort((a, b) => a - b);
-    const avg = lats.length
-      ? Math.round(lats.reduce((a, b) => a + b, 0) / lats.length) : 0;
-    const p99 = lats.length
-      ? lats[Math.min(Math.floor(lats.length * 0.99), lats.length - 1)] : 0;
-    const devices = new Set(
-      filtered.map(e => e.agent_ip).filter(Boolean),
-    ).size;
+    const avg = lats.length ? Math.round(lats.reduce((a, b) => a + b, 0) / lats.length) : 0;
+    const p99 = lats.length ? lats[Math.min(Math.floor(lats.length * 0.99), lats.length - 1)] : 0;
+    const devices = new Set(filtered.map((e) => e.agent_ip).filter(Boolean)).size;
     if (hasFilter) {
-      const errs = filtered.filter(e => (e.status ?? 0) >= 400).length;
+      const errs = filtered.filter((e) => (e.status ?? 0) >= 400).length;
       const errPct = sampleN > 0 ? (errs / sampleN) * 100 : 0;
       return { n: sampleN, avg, p99, errPct, devices };
     }
-    const errPct = totalCount > 0
-      ? (errorCount / totalCount) * 100 : 0;
+    const errPct = totalCount > 0 ? (errorCount / totalCount) * 100 : 0;
     return { n: totalCount, avg, p99, errPct, devices };
   })();
 
@@ -176,7 +175,10 @@ export function AnalyticsPage({ ip, agents }: {
           )}
           {hasFilter && (
             <button
-              onClick={() => { setFilterDevice(null); setFilterHost(null); }}
+              onClick={() => {
+                setFilterDevice(null);
+                setFilterHost(null);
+              }}
               className="ml-3 px-2 py-0.5 rounded text-[13px] border border-[#171717] bg-[#171717] text-white flex items-center gap-1.5 self-center"
             >
               {filterLabel}
@@ -184,27 +186,24 @@ export function AnalyticsPage({ ip, agents }: {
             </button>
           )}
         </div>
-        <Toggle
-          options={[...RANGES]}
-          value={range}
-          onChange={setRange}
-        />
+        <Toggle options={[...RANGES]} value={range} onChange={setRange} />
       </div>
 
-      <div className={
-        "bg-white border border-[#e5e5e5] rounded grid grid-cols-2 divide-x divide-[#e5e5e5] "
-        + (isGlobal ? "sm:grid-cols-4 lg:grid-cols-5" : "sm:grid-cols-4")
-      }>
+      <div
+        className={
+          "bg-white border border-[#e5e5e5] rounded grid grid-cols-2 divide-x divide-[#e5e5e5] " +
+          (isGlobal ? "sm:grid-cols-4 lg:grid-cols-5" : "sm:grid-cols-4")
+        }
+      >
         <Stat label="Requests" value={stats.n.toLocaleString()} />
         <Stat label="Avg" value={stats.avg ? fmtMs(stats.avg) : "—"} />
         <Stat label="p99" value={stats.p99 ? fmtMs(stats.p99) : "—"} />
-        <Stat label="Errors"
+        <Stat
+          label="Errors"
           value={stats.errPct ? stats.errPct.toFixed(1) + "%" : "0%"}
-          tone={stats.errPct >= 5 ? "warn" : undefined} />
-        {isGlobal && (
-          <Stat label="Devices"
-            value={stats.devices.toLocaleString()} />
-        )}
+          tone={stats.errPct >= 5 ? "warn" : undefined}
+        />
+        {isGlobal && <Stat label="Devices" value={stats.devices.toLocaleString()} />}
       </div>
 
       <div className={"grid gap-4 " + (isGlobal ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1")}>
@@ -233,12 +232,7 @@ export function AnalyticsPage({ ip, agents }: {
         />
       </div>
 
-      <LatencyChart
-        filtered={filtered}
-        isGlobal={isGlobal}
-        agents={agents}
-        range={range}
-      />
+      <LatencyChart filtered={filtered} isGlobal={isGlobal} agents={agents} range={range} />
 
       <TopRoutes events={filtered} />
     </main>
@@ -250,21 +244,16 @@ function fmtMs(ms: number): string {
   return ms + "ms";
 }
 
-
-function Stat({ label, value, tone }: {
-  label: string;
-  value: string;
-  tone?: "warn";
-}) {
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "warn" }) {
   return (
     <div className="flex flex-col gap-1.5 px-5 py-4">
-      <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
-        {label}
-      </span>
-      <span className={
-        "text-[22px] font-semibold leading-none tabular-nums tracking-tight "
-        + (tone === "warn" ? "text-[#b91c1c]" : "text-[#171717]")
-      }>
+      <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">{label}</span>
+      <span
+        className={
+          "text-[22px] font-semibold leading-none tabular-nums tracking-tight " +
+          (tone === "warn" ? "text-[#b91c1c]" : "text-[#171717]")
+        }
+      >
         {value}
       </span>
     </div>
@@ -273,13 +262,12 @@ function Stat({ label, value, tone }: {
 
 // --- event list (time-filtered) ---
 
-
 // --- stable color from string hash ---
 
 function stableIndex(s: string, n: number): number {
   let h = 0;
   for (let i = 0; i < s.length; i++) {
-    h = Math.imul(31, h) + s.charCodeAt(i) | 0;
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
   }
   return ((h % n) + n) % n;
 }
@@ -302,35 +290,39 @@ const PALETTE = [
 const hostColor = (s: string) => PALETTE[stableIndex(s, PALETTE.length)];
 // Offset by half the palette so the same string hashes to a maximally
 // different hue when used as a device vs. a host.
-const deviceColor = (s: string) =>
-  PALETTE[(stableIndex(s, PALETTE.length) + 5) % PALETTE.length];
+const deviceColor = (s: string) => PALETTE[(stableIndex(s, PALETTE.length) + 5) % PALETTE.length];
 
 // Status: Tailwind -700 (desaturated vs original -600). Used both in
 // scatter legend and EventRow status text.
 const STATUS_COLORS = {
-  "2xx": "#15803d", "3xx": "#a16207", "4xx": "#c2410c",
-  "5xx": "#b91c1c", "—": "#a3a3a3",
+  "2xx": "#15803d",
+  "3xx": "#a16207",
+  "4xx": "#c2410c",
+  "5xx": "#b91c1c",
+  "—": "#a3a3a3",
 } as const;
 
 // --- chart ---
 
-function LatencyChart({ filtered, isGlobal, agents, range }: {
+function LatencyChart({
+  filtered,
+  isGlobal,
+  agents,
+  range,
+}: {
   filtered: EventRecord[];
   isGlobal: boolean;
   agents: Agent[];
   range: Range;
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const colorOptions: ColorBy[] = isGlobal
-    ? ["device", "host", "status"]
-    : ["host", "status"];
-  const [colorBy, setColorBy] =
-    useQS("color", colorOptions[0], colorOptions);
-  const [scale, setScale] =
-    useQS("scale", "log" as Scale, ["log", "linear"]);
+  const colorOptions: ColorBy[] = isGlobal ? ["device", "host", "status"] : ["host", "status"];
+  const [colorBy, setColorBy] = useQS("color", colorOptions[0], colorOptions);
+  const [scale, setScale] = useQS("scale", "log" as Scale, ["log", "linear"]);
 
-  const agentNames = new Map(
-    agents.map(a => [a.ip, a.hostname || a.ip]),
+  const agentNames = useMemo(
+    () => new Map(agents.map((a) => [a.ip, a.hostname || a.ip])),
+    [agents],
   );
 
   useEffect(() => {
@@ -346,39 +338,38 @@ function LatencyChart({ filtered, isGlobal, agents, range }: {
         device: agentNames.get(e.agent_ip ?? "") ?? e.agent_ip ?? "?",
         statusCode: e.status ?? 0,
         status: e.status
-          ? e.status >= 500 ? "5xx"
-          : e.status >= 400 ? "4xx"
-          : e.status >= 300 ? "3xx"
-          : "2xx"
+          ? e.status >= 500
+            ? "5xx"
+            : e.status >= 400
+              ? "4xx"
+              : e.status >= 300
+                ? "3xx"
+                : "2xx"
           : "\u2014",
       }));
 
-    const colorField =
-      colorBy === "status" ? "status"
-      : colorBy === "device" ? "device"
-      : "host";
+    const colorField = colorBy === "status" ? "status" : colorBy === "device" ? "device" : "host";
 
-    const vals = [...new Set(dots.map(
-      d => d[colorField] as string,
-    ))];
+    const vals = [...new Set(dots.map((d) => d[colorField] as string))];
 
-    const colorCfg = colorBy === "status"
-      ? {
-          domain: ["2xx", "3xx", "4xx", "5xx", "\u2014"],
-          range: [
-            STATUS_COLORS["2xx"], STATUS_COLORS["3xx"],
-            STATUS_COLORS["4xx"], STATUS_COLORS["5xx"],
-            STATUS_COLORS["\u2014"],
-          ],
-          legend: true,
-        }
-      : {
-          domain: vals,
-          range: vals.map((v) =>
-            colorBy === "device" ? deviceColor(v) : hostColor(v),
-          ),
-          legend: true,
-        };
+    const colorCfg =
+      colorBy === "status"
+        ? {
+            domain: ["2xx", "3xx", "4xx", "5xx", "\u2014"],
+            range: [
+              STATUS_COLORS["2xx"],
+              STATUS_COLORS["3xx"],
+              STATUS_COLORS["4xx"],
+              STATUS_COLORS["5xx"],
+              STATUS_COLORS["\u2014"],
+            ],
+            legend: true,
+          }
+        : {
+            domain: vals,
+            range: vals.map((v) => (colorBy === "device" ? deviceColor(v) : hostColor(v))),
+            legend: true,
+          };
 
     const chart = Plot.plot({
       width: ref.current.clientWidth,
@@ -401,23 +392,16 @@ function LatencyChart({ filtered, isGlobal, agents, range }: {
         ...(scale === "log"
           ? {
               ticks: [1, 10, 100, 1000, 10000],
-              tickFormat: (v: number) =>
-                v >= 1000 ? `${v / 1000}k` : `${v}`,
+              tickFormat: (v: number) => (v >= 1000 ? `${v / 1000}k` : `${v}`),
             }
           : {
-              domain: [
-                0,
-                Math.max(100, ...dots.map(d => d.ms)) * 1.1,
-              ],
+              domain: [0, Math.max(100, ...dots.map((d) => d.ms)) * 1.1],
             }),
       },
       x: {
         type: "time",
         label: null,
-        domain: [
-          new Date(Date.now() - RANGE_MS[range]),
-          new Date(),
-        ],
+        domain: [new Date(Date.now() - RANGE_MS[range]), new Date()],
       },
       color: colorCfg,
       marks: [
@@ -435,17 +419,19 @@ function LatencyChart({ filtered, isGlobal, agents, range }: {
           fillOpacity: 0.75,
           stroke: "white",
           strokeWidth: 0.5,
-          href: (d: typeof dots[0]) =>
-            d.id ? `#/request/${d.id}` : undefined,
-          title: (d: typeof dots[0]) =>
+          href: (d: (typeof dots)[0]) => (d.id ? `#/request/${d.id}` : undefined),
+          title: (d: (typeof dots)[0]) =>
             `${d.host}\n${d.device}\n${d.statusCode || "\u2014"} \u2022 ${d.ms}ms`,
         }),
-        Plot.tip(dots, Plot.pointer({
-          x: "t",
-          y: "ms",
-          title: (d: typeof dots[0]) =>
-            `${d.host}\n${d.device}\n${d.statusCode || "\u2014"} \u2022 ${d.ms}ms`,
-        })),
+        Plot.tip(
+          dots,
+          Plot.pointer({
+            x: "t",
+            y: "ms",
+            title: (d: (typeof dots)[0]) =>
+              `${d.host}\n${d.device}\n${d.statusCode || "\u2014"} \u2022 ${d.ms}ms`,
+          }),
+        ),
       ],
     });
 
@@ -454,10 +440,8 @@ function LatencyChart({ filtered, isGlobal, agents, range }: {
     // handles them instead.
     chart.addEventListener("click", (evt) => {
       const a = (evt.target as Element).closest("a");
-      const href = a?.getAttribute("href")
-        ?? a?.getAttributeNS(
-          "http://www.w3.org/1999/xlink", "href",
-        );
+      const href =
+        a?.getAttribute("href") ?? a?.getAttributeNS("http://www.w3.org/1999/xlink", "href");
       if (href?.startsWith("#/request/")) {
         evt.preventDefault();
         window.location.hash = href;
@@ -472,65 +456,51 @@ function LatencyChart({ filtered, isGlobal, agents, range }: {
     // with an inner `<svg fill="...">` and the value as a text node —
     // there are no aria-labels, so we read the color straight off the
     // swatch's SVG (same scale as the dots use).
-    const dotEls = chart.querySelectorAll<SVGCircleElement>(
-      "g[aria-label='dot'] circle",
-    );
+    const dotEls = chart.querySelectorAll<SVGCircleElement>("g[aria-label='dot'] circle");
     const setHighlight = (target: string | null) => {
       if (!target) {
-        dotEls.forEach((c) => { c.style.opacity = ""; });
+        dotEls.forEach((c) => {
+          c.style.opacity = "";
+        });
         return;
       }
       dotEls.forEach((c) => {
-        c.style.opacity =
-          c.getAttribute("fill") === target ? "1" : "0.08";
+        c.style.opacity = c.getAttribute("fill") === target ? "1" : "0.08";
       });
     };
 
-    const nameToIP = colorBy === "device"
-      ? new Map(agents.map(a => [a.hostname || a.ip, a.ip]))
-      : null;
+    const nameToIP =
+      colorBy === "device" ? new Map(agents.map((a) => [a.hostname || a.ip, a.ip])) : null;
 
-    chart.querySelectorAll<HTMLElement>(
-      "[class*='-swatch']:not([class*='-swatches'])",
-    ).forEach((el) => {
-      const color = el.querySelector("svg")?.getAttribute("fill")
-        ?? null;
-      const label = el.textContent?.trim() ?? "";
-      el.addEventListener("mouseenter", () => setHighlight(color));
-      el.addEventListener("mouseleave", () => setHighlight(null));
-      if (nameToIP) {
-        const devIP = nameToIP.get(label);
-        if (!devIP) return;
-        el.style.cursor = "pointer";
-        el.addEventListener("click", (e) => {
-          e.stopPropagation();
-          window.location.hash =
-            `#/analytics/${encodeURIComponent(devIP)}`;
-        });
-      }
-    });
+    chart
+      .querySelectorAll<HTMLElement>("[class*='-swatch']:not([class*='-swatches'])")
+      .forEach((el) => {
+        const color = el.querySelector("svg")?.getAttribute("fill") ?? null;
+        const label = el.textContent?.trim() ?? "";
+        el.addEventListener("mouseenter", () => setHighlight(color));
+        el.addEventListener("mouseleave", () => setHighlight(null));
+        if (nameToIP) {
+          const devIP = nameToIP.get(label);
+          if (!devIP) return;
+          el.style.cursor = "pointer";
+          el.addEventListener("click", (e) => {
+            e.stopPropagation();
+            window.location.hash = `#/analytics/${encodeURIComponent(devIP)}`;
+          });
+        }
+      });
 
     ref.current.replaceChildren(chart);
     return () => chart.remove();
-  }, [filtered, colorBy, scale, range]);
+  }, [filtered, colorBy, scale, range, agents, agentNames]);
 
   return (
     <section className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
       <header className="flex items-center justify-between px-4 py-2.5 border-b border-[#e5e5e5]">
-        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
-          Latency
-        </span>
+        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">Latency</span>
         <div className="flex items-center gap-3">
-          <Toggle
-            options={colorOptions}
-            value={colorBy}
-            onChange={setColorBy}
-          />
-          <Toggle
-            options={["log", "linear"] as Scale[]}
-            value={scale}
-            onChange={setScale}
-          />
+          <Toggle options={colorOptions} value={colorBy} onChange={setColorBy} />
+          <Toggle options={["log", "linear"] as Scale[]} value={scale} onChange={setScale} />
         </div>
       </header>
       <div ref={ref} className="p-4 min-h-[320px]" />
@@ -541,7 +511,9 @@ function LatencyChart({ filtered, isGlobal, agents, range }: {
 // --- toggle ---
 
 function Toggle<T extends string>({
-  options, value, onChange,
+  options,
+  value,
+  onChange,
 }: {
   options: T[];
   value: T;
@@ -555,9 +527,7 @@ function Toggle<T extends string>({
           onClick={() => onChange(o)}
           className={
             "px-2 py-0.5 " +
-            (o === value
-              ? "bg-[#171717] text-white"
-              : "text-[#525252] hover:bg-[#fafafa]")
+            (o === value ? "bg-[#171717] text-white" : "text-[#525252] hover:bg-[#fafafa]")
           }
         >
           {o}
@@ -613,7 +583,8 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
       className="px-3 sm:px-[14px] py-[9px] text-right text-[10px] font-medium uppercase tracking-[.12em] text-[#a3a3a3] cursor-pointer hover:text-[#525252] select-none"
       onClick={() => setSortBy(field)}
     >
-      {label}{sortBy === field ? " \u25BE" : ""}
+      {label}
+      {sortBy === field ? " \u25BE" : ""}
     </th>
   );
 
@@ -636,25 +607,33 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
         </thead>
         <tbody>
           {rows.slice(0, 20).map((d) => {
-            const pct = maxCount > 0
-              ? (d.count / maxCount) * 100 : 0;
+            const pct = maxCount > 0 ? (d.count / maxCount) * 100 : 0;
             return (
               <tr
                 key={d.key}
                 className="border-b border-[#f5f5f5] hover:bg-[#f9f9f9] transition-colors"
               >
-                <td className="px-3 sm:px-[14px] py-[9px] font-mono align-middle break-all" title={`${d.method} ${d.host}${d.path}`}>
-                  <span className="text-[#a3a3a3]">{d.method}</span>{" "}{d.host}<span className="text-[#525252]">{d.path}</span>
+                <td
+                  className="px-3 sm:px-[14px] py-[9px] font-mono align-middle break-all"
+                  title={`${d.method} ${d.host}${d.path}`}
+                >
+                  <span className="text-[#a3a3a3]">{d.method}</span> {d.host}
+                  <span className="text-[#525252]">{d.path}</span>
                 </td>
                 <td className="px-3 sm:px-[14px] py-[9px] text-right whitespace-nowrap align-middle">
                   <div className="flex items-center justify-end gap-1.5">
                     <div className="w-12 h-1.5 bg-[#f5f5f5] rounded-full">
-                      <div className="h-full bg-[#a3a3a3] rounded-full" style={{ width: `${pct}%` }} />
+                      <div
+                        className="h-full bg-[#a3a3a3] rounded-full"
+                        style={{ width: `${pct}%` }}
+                      />
                     </div>
                     <span className="w-8 text-right tabular-nums">{d.count}</span>
                   </div>
                 </td>
-                <td className="px-3 sm:px-[14px] py-[9px] text-right text-[#525252] tabular-nums align-middle">{fmtMs(d.p99Ms)}</td>
+                <td className="px-3 sm:px-[14px] py-[9px] text-right text-[#525252] tabular-nums align-middle">
+                  {fmtMs(d.p99Ms)}
+                </td>
               </tr>
             );
           })}
@@ -674,7 +653,12 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
 // --- horizontal bar list ---
 
 function BarList({
-  title, items: rawItems, active, labelFn, onClickFn, colorFn,
+  title,
+  items: rawItems,
+  active,
+  labelFn,
+  onClickFn,
+  colorFn,
 }: {
   title: string;
   items: Array<{ key: string; count: number }>;
@@ -693,9 +677,7 @@ function BarList({
   return (
     <section className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
       <header className="px-4 py-2.5 border-b border-[#e5e5e5]">
-        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
-          {title}
-        </span>
+        <span className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">{title}</span>
       </header>
       <div className="p-3 space-y-0.5">
         {items.slice(0, 10).map((item) => {
@@ -703,17 +685,25 @@ function BarList({
           const isActive = active === item.key;
           const barColor = colorFn
             ? colorFn(item.key, item.label)
-            : (isActive ? "#171717" : "#525252");
+            : isActive
+              ? "#171717"
+              : "#525252";
           return (
             <div
               key={item.key}
               className={
-                "flex items-center gap-2 px-1 py-0.5 rounded cursor-pointer "
-                + (isActive ? "bg-[#f5f5f5]" : "hover:bg-[#fafafa]")
+                "flex items-center gap-2 px-1 py-0.5 rounded cursor-pointer " +
+                (isActive ? "bg-[#f5f5f5]" : "hover:bg-[#fafafa]")
               }
               onClick={onClickFn ? () => onClickFn(item.key) : undefined}
             >
-              <span className={"w-32 truncate text-[11px] " + (isActive ? "text-[#171717] font-semibold" : "text-[#525252]")} title={item.label}>
+              <span
+                className={
+                  "w-32 truncate text-[11px] " +
+                  (isActive ? "text-[#171717] font-semibold" : "text-[#525252]")
+                }
+                title={item.label}
+              >
                 {item.label}
               </span>
               <div className="flex-1 h-2 bg-[#f5f5f5] rounded-full">

--- a/www/src/components/Avatar.tsx
+++ b/www/src/components/Avatar.tsx
@@ -3,9 +3,7 @@
 
 import { useState } from "react";
 
-const PALETTE = [
-  "#a78bfa", "#f87171", "#fbbf24", "#34d399", "#60a5fa", "#f472b6", "#facc15",
-];
+const PALETTE = ["#a78bfa", "#f87171", "#fbbf24", "#34d399", "#60a5fa", "#f472b6", "#facc15"];
 
 function colorFor(s: string): string {
   let h = 0;

--- a/www/src/components/ConnectModal.tsx
+++ b/www/src/components/ConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   oauthDevicePoll,
   oauthExchange,
@@ -33,7 +33,7 @@ export function ConnectModal({
   const showsScopePicker = optionalGroups.length > 0;
   const [started, setStarted] = useState(!showsScopePicker);
   const [extras, setExtras] = useState<Set<string>>(() => new Set());
-  const baseSet = useMemo(() => new Set(baseScopes), [baseScopes]);
+  const baseSet = new Set(baseScopes);
 
   useEffect(() => {
     if (!started) return;
@@ -85,7 +85,7 @@ export function ConnectModal({
           setErr(`${r.error}: ${r.detail || ""}`);
           return;
         }
-      } catch (_) {
+      } catch {
         /* transient — keep polling */
       }
       if (!cancelled) timer = setTimeout(tick, intervalSec * 1000);
@@ -140,9 +140,8 @@ export function ConnectModal({
             <div className="text-[11px] text-[#737373] leading-relaxed">
               {baseScopes.length > 0 ? (
                 <>
-                  defaults (
-                  <code className="text-[#171717]">{baseScopes.join(", ")}</code>
-                  ) are always requested.
+                  defaults (<code className="text-[#171717]">{baseScopes.join(", ")}</code>) are
+                  always requested.
                 </>
               ) : (
                 <>no scopes are requested by default.</>
@@ -173,7 +172,9 @@ export function ConnectModal({
                             key={s.id}
                             className={
                               "flex items-center gap-2 text-[11px] py-0.5 px-1 rounded " +
-                              (isBase ? "text-[#a3a3a3]" : "text-[#171717] cursor-pointer hover:bg-white")
+                              (isBase
+                                ? "text-[#a3a3a3]"
+                                : "text-[#171717] cursor-pointer hover:bg-white")
                             }
                           >
                             <input
@@ -192,7 +193,9 @@ export function ConnectModal({
                             />
                             <code className="text-[11px]">{s.id}</code>
                             <span className="text-[#737373]">— {s.label}</span>
-                            {isBase && <span className="ml-auto text-[10px] text-[#a3a3a3]">default</span>}
+                            {isBase && (
+                              <span className="ml-auto text-[10px] text-[#a3a3a3]">default</span>
+                            )}
                           </label>
                         );
                       })}
@@ -224,7 +227,8 @@ export function ConnectModal({
         ) : start.flow === "device" ? (
           <div className="space-y-3">
             <div className="text-[11px] text-[#737373] leading-relaxed">
-              browser opened to <code className="text-[#171717]">{start.verification_uri}</code>. enter this code:
+              browser opened to <code className="text-[#171717]">{start.verification_uri}</code>.
+              enter this code:
             </div>
             <div className="font-mono text-[28px] tracking-[.18em] text-[#171717] text-center py-3 bg-[#fafafa] border border-[#e5e5e5] rounded select-all">
               {start.user_code}

--- a/www/src/components/CredentialSecretsModal.tsx
+++ b/www/src/components/CredentialSecretsModal.tsx
@@ -55,9 +55,7 @@ export function CredentialSecretsModal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
-          <div className="text-[14px] font-semibold text-[#171717]">
-            Connect {integration.name}
-          </div>
+          <div className="text-[14px] font-semibold text-[#171717]">Connect {integration.name}</div>
           <button
             onClick={onClose}
             className="text-[#a3a3a3] hover:text-[#171717] text-[14px] leading-none"

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { deleteAgent, getStatus, listProfiles, setDeviceProfile, type Agent, type Integration, type Whoami } from "../lib/api";
+import {
+  deleteAgent,
+  getStatus,
+  listProfiles,
+  setDeviceProfile,
+  type Agent,
+  type Integration,
+  type Whoami,
+} from "../lib/api";
 import { fmtBytes } from "../lib/format";
 import { DeviceIcon } from "./Logos";
 import { Sparkline } from "./Sparkline";
@@ -36,7 +44,9 @@ export function DevicePage({
   // case (legacy single-tenant configs).
   const [profileCreds, setProfileCreds] = useState<Integration[] | null>(null);
   useEffect(() => {
-    listProfiles().then(setProfiles).catch(() => setProfiles([]));
+    listProfiles()
+      .then(setProfiles)
+      .catch(() => setProfiles([]));
   }, []);
   const devProfile = a?.profile;
   useEffect(() => {
@@ -44,7 +54,9 @@ export function DevicePage({
       setProfileCreds(null);
       return;
     }
-    getStatus(devProfile).then(setProfileCreds).catch(() => setProfileCreds(null));
+    getStatus(devProfile)
+      .then(setProfileCreds)
+      .catch(() => setProfileCreds(null));
     // Re-fetch whenever the parent's integrations list changes too —
     // OAuth modal calls onRefresh on success, which updates parent state
     // but otherwise this effect would stay stale and the card wouldn't
@@ -54,7 +66,9 @@ export function DevicePage({
     return (
       <main className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-5">
         <nav className="text-[13px] text-[#a3a3a3] flex items-center gap-1.5 mb-3">
-          <a href="#/" className="hover:text-[#171717]">clawpatrol</a>
+          <a href="#/" className="hover:text-[#171717]">
+            clawpatrol
+          </a>
           <span>/</span>
           <span className="text-[#525252]">{ip}</span>
         </nav>
@@ -70,7 +84,12 @@ export function DevicePage({
   const allForUser = profileCreds ?? integrations;
 
   async function remove() {
-    if (!confirm(`Remove ${dev.hostname || dev.ip} from clawpatrol?\n\nThis clears the device's tracking + owner mapping. Tailscale node stays — remove from admin console if you want a hard kick.`)) return;
+    if (
+      !confirm(
+        `Remove ${dev.hostname || dev.ip} from clawpatrol?\n\nThis clears the device's tracking + owner mapping. Tailscale node stays — remove from admin console if you want a hard kick.`,
+      )
+    )
+      return;
     try {
       await deleteAgent(dev.ip);
       onBack();
@@ -84,7 +103,9 @@ export function DevicePage({
     <main className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-5 space-y-5">
       <div className="flex items-center justify-between">
         <nav className="text-[13px] text-[#a3a3a3] flex items-center gap-1.5">
-          <a href="#/" className="hover:text-[#171717]">clawpatrol</a>
+          <a href="#/" className="hover:text-[#171717]">
+            clawpatrol
+          </a>
           <span>/</span>
           <span className="text-[#525252]">{dev.hostname || dev.ip}</span>
         </nav>
@@ -113,7 +134,16 @@ export function DevicePage({
             title="analytics"
             className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M3 3v18h18" />
               <path d="m7 16 4-8 4 4 4-6" />
             </svg>
@@ -124,7 +154,16 @@ export function DevicePage({
             title="forget this device"
             className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#dc2626] hover:text-[#dc2626] transition-colors"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M3 6h18" />
               <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
               <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
@@ -138,12 +177,25 @@ export function DevicePage({
       {/* device header card */}
       <section className="bg-white border border-[#e5e5e5] rounded">
         <div className="flex items-center gap-3 px-5 py-4 border-b border-[#e5e5e5]">
-          <DeviceIcon os={a.os} hostname={a.hostname} ua={a.ua} className="w-[18px] h-[18px] text-[#525252]" />
+          <DeviceIcon
+            os={a.os}
+            hostname={a.hostname}
+            ua={a.ua}
+            className="w-[18px] h-[18px] text-[#525252]"
+          />
           <div className="min-w-0">
-            <div className="text-[15px] font-semibold text-[#171717] truncate">{a.hostname || a.ip}</div>
+            <div className="text-[15px] font-semibold text-[#171717] truncate">
+              {a.hostname || a.ip}
+            </div>
             <div className="text-[11px] text-[#737373] truncate">
-              {a.profile || "—"} · {[a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") || a.ip}
-              {a.os && <> · <span className="uppercase tracking-[.08em]">{a.os}</span></>}
+              {a.profile || "—"} ·{" "}
+              {[a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") || a.ip}
+              {a.os && (
+                <>
+                  {" "}
+                  · <span className="uppercase tracking-[.08em]">{a.os}</span>
+                </>
+              )}
             </div>
           </div>
           <div className="ml-auto flex items-center gap-3">
@@ -214,7 +266,16 @@ function ProfilePicker({
         title={`profile: ${current || "—"}`}
         className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors disabled:opacity-50"
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <path d="M12 2 2 7l10 5 10-5-10-5z" />
           <path d="M2 17l10 5 10-5" />
           <path d="M2 12l10 5 10-5" />

--- a/www/src/components/HITLBar.tsx
+++ b/www/src/components/HITLBar.tsx
@@ -57,33 +57,44 @@ export function HITLBar() {
             // "users-db UPDATE ..." rather than "users-dbUPDATE ...".
             const sep = p.path && !p.path.startsWith("/") ? " " : "";
             return (
-            <tr key={p.id} className="border-b border-[#f5f5f5] last:border-b-0 hover:bg-[#f9f9f9]">
-              <Td className="text-[11px] text-[#525252] tabular-nums truncate">{p.agent_ip}</Td>
-              <Td className="text-[11px] uppercase font-semibold text-[#9a3412]">{p.method}</Td>
-              <Td>
-                <span className="text-[12px] text-[#171717] truncate block" title={ep + sep + p.path}>
-                  <span className="text-[#737373]">{ep}{sep}</span>
-                  <span>{p.path}</span>
-                </span>
-                {p.reason && <div className="text-[10px] text-[#737373] truncate">{p.reason}</div>}
-              </Td>
-              <Td className="text-right">
-                <div className="flex gap-1.5 justify-end">
-                  <button
-                    onClick={() => decide(p.id, false)}
-                    className="text-[11px] px-3 py-1 border border-[#fecaca] text-[#991b1b] rounded hover:bg-[#fef2f2]"
+              <tr
+                key={p.id}
+                className="border-b border-[#f5f5f5] last:border-b-0 hover:bg-[#f9f9f9]"
+              >
+                <Td className="text-[11px] text-[#525252] tabular-nums truncate">{p.agent_ip}</Td>
+                <Td className="text-[11px] uppercase font-semibold text-[#9a3412]">{p.method}</Td>
+                <Td>
+                  <span
+                    className="text-[12px] text-[#171717] truncate block"
+                    title={ep + sep + p.path}
                   >
-                    deny
-                  </button>
-                  <button
-                    onClick={() => decide(p.id, true)}
-                    className="text-[11px] px-3 py-1 bg-[#171717] text-white rounded hover:bg-[#000]"
-                  >
-                    allow
-                  </button>
-                </div>
-              </Td>
-            </tr>
+                    <span className="text-[#737373]">
+                      {ep}
+                      {sep}
+                    </span>
+                    <span>{p.path}</span>
+                  </span>
+                  {p.reason && (
+                    <div className="text-[10px] text-[#737373] truncate">{p.reason}</div>
+                  )}
+                </Td>
+                <Td className="text-right">
+                  <div className="flex gap-1.5 justify-end">
+                    <button
+                      onClick={() => decide(p.id, false)}
+                      className="text-[11px] px-3 py-1 border border-[#fecaca] text-[#991b1b] rounded hover:bg-[#fef2f2]"
+                    >
+                      deny
+                    </button>
+                    <button
+                      onClick={() => decide(p.id, true)}
+                      className="text-[11px] px-3 py-1 bg-[#171717] text-white rounded hover:bg-[#000]"
+                    >
+                      allow
+                    </button>
+                  </div>
+                </Td>
+              </tr>
             );
           })}
         </tbody>

--- a/www/src/components/IntegrationStack.tsx
+++ b/www/src/components/IntegrationStack.tsx
@@ -32,11 +32,19 @@ export function IntegrationStack({
             zIndex: items.length - i,
           }}
         >
-          {it.avatar_url
-            ? <StackAvatar src={it.avatar_url} fallbackId={it.id} fallbackType={it.type} size={size} inner={inner} />
-            : <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
-                <IntegrationIcon id={it.id} type={it.type} className="w-full h-full" />
-              </span>}
+          {it.avatar_url ? (
+            <StackAvatar
+              src={it.avatar_url}
+              fallbackId={it.id}
+              fallbackType={it.type}
+              size={size}
+              inner={inner}
+            />
+          ) : (
+            <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
+              <IntegrationIcon id={it.id} type={it.type} className="w-full h-full" />
+            </span>
+          )}
         </span>
       ))}
     </div>
@@ -44,16 +52,25 @@ export function IntegrationStack({
 }
 
 function StackAvatar({
-  src, fallbackId, fallbackType, size, inner,
+  src,
+  fallbackId,
+  fallbackType,
+  size,
+  inner,
 }: {
-  src: string; fallbackId: string; fallbackType?: string;
-  size: number; inner: number;
+  src: string;
+  fallbackId: string;
+  fallbackType?: string;
+  size: number;
+  inner: number;
 }) {
   const [broken, setBroken] = React.useState(false);
   if (broken) {
-    return <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
-      <IntegrationIcon id={fallbackId} type={fallbackType} className="w-full h-full" />
-    </span>;
+    return (
+      <span style={{ width: inner, height: inner, display: "inline-flex", color: "#171717" }}>
+        <IntegrationIcon id={fallbackId} type={fallbackType} className="w-full h-full" />
+      </span>
+    );
   }
   return (
     <img

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -148,7 +148,13 @@ function OwnerAvatar({
 }) {
   const [broken, setBroken] = React.useState(false);
   if (broken) {
-    return <IntegrationIcon id={fallbackId} type={fallbackType} className="w-[16px] h-[16px] flex-shrink-0" />;
+    return (
+      <IntegrationIcon
+        id={fallbackId}
+        type={fallbackType}
+        className="w-[16px] h-[16px] flex-shrink-0"
+      />
+    );
   }
   return (
     <img
@@ -180,10 +186,10 @@ function Card({
       ? "expires " + fmtExpiry(me.expires_at)
       : "connected"
     : i.has_oauth
-    ? "click to connect"
-    : hasSlots
-    ? "paste secret"
-    : "api key only";
+      ? "click to connect"
+      : hasSlots
+        ? "paste secret"
+        : "api key only";
   return (
     <button
       disabled={!clickable && !connected}
@@ -193,15 +199,20 @@ function Card({
         (connected
           ? "border-[#bbf7d0] bg-[#f0fdf4]"
           : clickable
-          ? "border-[#e5e5e5] hover:border-[#171717] cursor-pointer"
-          : "border-[#e5e5e5] cursor-default")
+            ? "border-[#e5e5e5] hover:border-[#171717] cursor-pointer"
+            : "border-[#e5e5e5] cursor-default")
       }
     >
       <div className="flex items-center gap-2 w-full">
-        {connected && me?.avatar_url
-          ? <OwnerAvatar src={me.avatar_url} fallbackId={i.id} fallbackType={i.type} />
-          : <IntegrationIcon id={i.id} type={i.type} className="w-[16px] h-[16px] flex-shrink-0" />}
-        <span className="text-[12px] font-semibold text-[#171717] truncate" title={me?.display_name ?? i.id}>
+        {connected && me?.avatar_url ? (
+          <OwnerAvatar src={me.avatar_url} fallbackId={i.id} fallbackType={i.type} />
+        ) : (
+          <IntegrationIcon id={i.id} type={i.type} className="w-[16px] h-[16px] flex-shrink-0" />
+        )}
+        <span
+          className="text-[12px] font-semibold text-[#171717] truncate"
+          title={me?.display_name ?? i.id}
+        >
           {(() => {
             const label = TYPE_LABEL[i.type] ?? i.name;
             return me?.display_name ? `${label} (${me.display_name})` : label;
@@ -222,8 +233,7 @@ function Card({
           )}
           <span
             className={
-              "w-[6px] h-[6px] rounded-full " +
-              (connected ? "bg-[#22c55e]" : "bg-[#d4d4d4]")
+              "w-[6px] h-[6px] rounded-full " + (connected ? "bg-[#22c55e]" : "bg-[#d4d4d4]")
             }
           />
         </span>
@@ -236,8 +246,8 @@ function Card({
         {connected
           ? subtitle
           : TYPE_LABEL[i.type] && i.id !== (TYPE_LABEL[i.type] ?? "").toLowerCase()
-          ? i.id
-          : subtitle}
+            ? i.id
+            : subtitle}
       </div>
     </button>
   );

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -3,7 +3,11 @@ import { type EventRecord } from "../lib/api";
 
 type RowState = EventRecord & { frames?: { direction: string; frame: string; ts: string }[] };
 
-export function LiveRequests({ agentIP, max = 200, height }: {
+export function LiveRequests({
+  agentIP,
+  max = 200,
+  height,
+}: {
   agentIP?: string;
   max?: number;
   height?: string;
@@ -12,9 +16,7 @@ export function LiveRequests({ agentIP, max = 200, height }: {
 
   useEffect(() => {
     setEvents([]);
-    const url = agentIP
-      ? `/api/events?agent=${encodeURIComponent(agentIP)}`
-      : "/api/events";
+    const url = agentIP ? `/api/events?agent=${encodeURIComponent(agentIP)}` : "/api/events";
     const es = new EventSource(url);
 
     // Batched render: SSE can fire dozens of events per second on a
@@ -47,13 +49,17 @@ export function LiveRequests({ agentIP, max = 200, height }: {
           for (const ev of arr) next = mergeEvent(next, ev, max);
           return next;
         });
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     });
     es.onmessage = (e) => {
       try {
         pending.push(JSON.parse(e.data) as EventRecord);
         if (raf === 0) raf = requestAnimationFrame(flush);
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     };
     return () => {
       es.close();
@@ -62,7 +68,10 @@ export function LiveRequests({ agentIP, max = 200, height }: {
   }, [agentIP, max]);
 
   return (
-    <div className="flex flex-col bg-white border border-[#e5e5e5] rounded overflow-hidden" style={{ height: height ?? "420px" }}>
+    <div
+      className="flex flex-col bg-white border border-[#e5e5e5] rounded overflow-hidden"
+      style={{ height: height ?? "420px" }}
+    >
       <div className="flex items-center px-4 py-2.5 text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] border-b border-[#e5e5e5] flex-shrink-0">
         <span>LIVE REQUESTS</span>
         <span className="ml-2 text-[#22c55e] tabular-nums flex items-center gap-1">
@@ -74,12 +83,11 @@ export function LiveRequests({ agentIP, max = 200, height }: {
         {events.length === 0 ? (
           <div className="px-5 py-8 text-center text-[11px] text-[#a3a3a3] flex items-center justify-center gap-2">
             <span className="w-1.5 h-1.5 rounded-full bg-[#22c55e] animate-pulse" />
-            Waiting for requests<AnimatedDots />
+            Waiting for requests
+            <AnimatedDots />
           </div>
         ) : (
-          events.map((e, i) => (
-            <Row key={i} ev={e} />
-          ))
+          events.map((e, i) => <Row key={i} ev={e} />)
         )}
       </div>
     </div>
@@ -98,7 +106,13 @@ function mergeEvent(prev: RowState[], ev: EventRecord, max: number): RowState[] 
   if (ev.id && ev.phase === "frame") {
     return prev.map((r) =>
       r.id === ev.id
-        ? { ...r, frames: [...(r.frames ?? []), { direction: ev.direction ?? "", frame: ev.frame ?? "", ts: ev.ts }] }
+        ? {
+            ...r,
+            frames: [
+              ...(r.frames ?? []),
+              { direction: ev.direction ?? "", frame: ev.frame ?? "", ts: ev.ts },
+            ],
+          }
         : r,
     );
   }
@@ -129,21 +143,28 @@ function pathSeparator(path: string): string {
 
 function Row({ ev }: { ev: RowState }) {
   const onClick = ev.id
-    ? () => { window.location.hash = `#/request/${ev.id}`; }
+    ? () => {
+        window.location.hash = `#/request/${ev.id}`;
+      }
     : undefined;
   const t = new Date(ev.ts);
   const time =
-    t.toLocaleTimeString([], { hour12: false })
-    + "." + String(t.getMilliseconds()).padStart(3, "0");
+    t.toLocaleTimeString([], { hour12: false }) +
+    "." +
+    String(t.getMilliseconds()).padStart(3, "0");
   const inFlight = ev.phase === "start";
   const status = ev.status || 0;
   const statusColor = inFlight
     ? "text-[#a3a3a3]"
-    : status >= 500 ? "text-[#dc2626]"
-    : status >= 400 ? "text-[#ea580c]"
-    : status >= 300 ? "text-[#ca8a04]"
-    : status >= 200 ? "text-[#16a34a]"
-    : "text-[#737373]";
+    : status >= 500
+      ? "text-[#dc2626]"
+      : status >= 400
+        ? "text-[#ea580c]"
+        : status >= 300
+          ? "text-[#ca8a04]"
+          : status >= 200
+            ? "text-[#16a34a]"
+            : "text-[#737373]";
   const path = ev.path ?? "";
   const sep = pathSeparator(path);
   const hasFrames = (ev.frames?.length ?? 0) > 0;
@@ -152,21 +173,26 @@ function Row({ ev }: { ev: RowState }) {
       <div
         onClick={onClick}
         className={
-          "px-4 py-2 flex items-center gap-3 min-w-0 transition-colors"
-          + (onClick ? " cursor-pointer" : "")
-          + (inFlight ? " opacity-70" : "")
-          + " hover:bg-[#f9f9f9]"
+          "px-4 py-2 flex items-center gap-3 min-w-0 transition-colors" +
+          (onClick ? " cursor-pointer" : "") +
+          (inFlight ? " opacity-70" : "") +
+          " hover:bg-[#f9f9f9]"
         }
       >
         <span className="text-[10px] tabular-nums text-[#a3a3a3] flex-shrink-0">{time}</span>
         <ModeIcon mode={ev.mode} />
         {ev.method && (
-          <span className="text-[10px] uppercase font-semibold text-[#525252] flex-shrink-0 w-[44px]">{ev.method}</span>
+          <span className="text-[10px] uppercase font-semibold text-[#525252] flex-shrink-0 w-[44px]">
+            {ev.method}
+          </span>
         )}
         <span className={"text-[11px] tabular-nums flex-shrink-0 w-[36px] " + statusColor}>
-          {inFlight ? <InFlightSpinner /> : (status || "—")}
+          {inFlight ? <InFlightSpinner /> : status || "—"}
         </span>
-        <span className="text-[12px] text-[#171717] truncate flex-1 min-w-0" title={ev.host + sep + path}>
+        <span
+          className="text-[12px] text-[#171717] truncate flex-1 min-w-0"
+          title={ev.host + sep + path}
+        >
           <span className="text-[#737373]">{ev.host}</span>
           {sep && <span> </span>}
           <span>{path}</span>
@@ -180,7 +206,9 @@ function Row({ ev }: { ev: RowState }) {
           {ev.frames!.map((f, i) => (
             <div key={i} className="px-4 py-1 flex items-start gap-2 text-[10px] font-mono">
               <span className="text-[#a3a3a3] flex-shrink-0 w-[24px]">{f.direction}</span>
-              <span className="text-[#525252] truncate" title={f.frame}>{f.frame}</span>
+              <span className="text-[#525252] truncate" title={f.frame}>
+                {f.frame}
+              </span>
             </div>
           ))}
         </div>
@@ -220,7 +248,16 @@ function ModeIcon({ mode }: { mode: string }) {
   }
   return (
     <span title="Splice — gateway forwarded encrypted bytes untouched" className="flex-shrink-0">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#a3a3a3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#a3a3a3"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M5 12h14" />
         <path d="m13 6 6 6-6 6" />
       </svg>

--- a/www/src/components/Logos.tsx
+++ b/www/src/components/Logos.tsx
@@ -16,30 +16,27 @@ export function ClaudeLogo({ className = "" }: { className?: string }) {
 
 export function OpenAILogo({ className = "" }: { className?: string }) {
   return (
-    <img
-      src={ICON_BASE + "openai.svg"}
-      className={className}
-      alt="OpenAI"
-      draggable={false}
-    />
+    <img src={ICON_BASE + "openai.svg"} className={className} alt="OpenAI" draggable={false} />
   );
 }
 
 export function GithubLogo({ className = "" }: { className?: string }) {
   return (
-    <img
-      src={ICON_BASE + "github.svg"}
-      className={className}
-      alt="GitHub"
-      draggable={false}
-    />
+    <img src={ICON_BASE + "github.svg"} className={className} alt="GitHub" draggable={false} />
   );
 }
 
 export function ShellGlyph({ className = "" }: { className?: string }) {
   return (
     <svg width="14" height="14" viewBox="0 0 24 24" fill="#7c3aed" className={className}>
-      <path d="M4 17l6-6-6-6m8 14h8" stroke="#7c3aed" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M4 17l6-6-6-6m8 14h8"
+        stroke="#7c3aed"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   );
 }
@@ -50,19 +47,32 @@ export function ShellGlyph({ className = "" }: { className?: string }) {
 // ins where the bare name happens to match the brand. Unknown types
 // get a neutral key glyph rather than empty space, so dashboard rows
 // stay visually anchored.
-export function IntegrationIcon({ id, type, className = "" }: { id: string; type?: string; className?: string }) {
+export function IntegrationIcon({
+  id,
+  type,
+  className = "",
+}: {
+  id: string;
+  type?: string;
+  className?: string;
+}) {
   const t = type ?? "";
   if (t === "anthropic_oauth_subscription" || t === "anthropic_manual_key" || id === "claude")
     return <ClaudeLogo className={className} />;
   if (t === "openai_codex_oauth" || id === "codex") return <OpenAILogo className={className} />;
   if (t === "github_oauth" || id === "github") return <GithubLogo className={className} />;
-  if (t === "postgres_credential") return <BrandIcon name="postgresql" color="%23336791" className={className} />;
-  if (t === "clickhouse_credential") return <BrandIcon name="clickhouse" color="%23faff69" className={className} />;
+  if (t === "postgres_credential")
+    return <BrandIcon name="postgresql" color="%23336791" className={className} />;
+  if (t === "clickhouse_credential")
+    return <BrandIcon name="clickhouse" color="%23faff69" className={className} />;
   if (t === "slack_tokens") return <SlackGlyph className={className} />;
-  if (t === "telegram_bot_token") return <BrandIcon name="telegram" color="%2326a5e4" className={className} />;
-  if (t === "gemini_api_key") return <BrandIcon name="googlegemini" color="%238e75b2" className={className} />;
+  if (t === "telegram_bot_token")
+    return <BrandIcon name="telegram" color="%2326a5e4" className={className} />;
+  if (t === "gemini_api_key")
+    return <BrandIcon name="googlegemini" color="%238e75b2" className={className} />;
   if (t === "notion_oauth") return <BrandIcon name="notion" className={className} />;
-  if (t === "aws_eks_credential") return <BrandIcon name="amazoneks" color="%23ff9900" className={className} />;
+  if (t === "aws_eks_credential")
+    return <BrandIcon name="amazoneks" color="%23ff9900" className={className} />;
   if (t === "mtls_credential") return <KeyGlyph className={className} />;
   return <KeyGlyph className={className} />;
 }
@@ -74,22 +84,52 @@ export function IntegrationIcon({ id, type, className = "" }: { id: string; type
 function SlackGlyph({ className = "" }: { className?: string }) {
   return (
     <svg viewBox="70 70 130 130" xmlns="http://www.w3.org/2000/svg" className={className}>
-      <path fill="#E01E5A" d="M99.4 151.2c0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9v-32.3z" />
-      <path fill="#36C5F0" d="M118.8 99.4c-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9v12.9h-12.9zm0 6.5c7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9H86.5c-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9h32.3z" />
-      <path fill="#2EB67D" d="M170.6 118.8c0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9h-12.9v-12.9zm-6.5 0c0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9V86.5c0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9v32.3z" />
-      <path fill="#ECB22E" d="M151.2 170.6c7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9v-12.9h12.9zm0-6.5c-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9h32.3c7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9h-32.3z" />
+      <path
+        fill="#E01E5A"
+        d="M99.4 151.2c0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9v-32.3z"
+      />
+      <path
+        fill="#36C5F0"
+        d="M118.8 99.4c-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9v12.9h-12.9zm0 6.5c7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9H86.5c-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9h32.3z"
+      />
+      <path
+        fill="#2EB67D"
+        d="M170.6 118.8c0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9h-12.9v-12.9zm-6.5 0c0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9V86.5c0-7.1 5.8-12.9 12.9-12.9 7.1 0 12.9 5.8 12.9 12.9v32.3z"
+      />
+      <path
+        fill="#ECB22E"
+        d="M151.2 170.6c7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9-7.1 0-12.9-5.8-12.9-12.9v-12.9h12.9zm0-6.5c-7.1 0-12.9-5.8-12.9-12.9 0-7.1 5.8-12.9 12.9-12.9h32.3c7.1 0 12.9 5.8 12.9 12.9 0 7.1-5.8 12.9-12.9 12.9h-32.3z"
+      />
     </svg>
   );
 }
 
-function BrandIcon({ name, color = "", className = "" }: { name: string; color?: string; className?: string }) {
+function BrandIcon({
+  name,
+  color = "",
+  className = "",
+}: {
+  name: string;
+  color?: string;
+  className?: string;
+}) {
   const url = ICON_BASE + name + ".svg" + (color ? "?color=" + color : "");
   return <img src={url} className={className} alt={name} draggable={false} />;
 }
 
 function KeyGlyph({ className = "" }: { className?: string }) {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#737373" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#737373"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
     </svg>
   );
@@ -100,7 +140,17 @@ function KeyGlyph({ className = "" }: { className?: string }) {
 // like a set, not a mismatched grab-bag.
 export function EditGlyph({ className = "" }: { className?: string }) {
   return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
     </svg>
@@ -110,7 +160,11 @@ export function EditGlyph({ className = "" }: { className?: string }) {
 // ── device / OS icons (kept local) ─────────────────────────────────
 
 type IconProps = { className?: string };
-const baseProps = { viewBox: "0 0 24 24", fill: "currentColor", xmlns: "http://www.w3.org/2000/svg" };
+const baseProps = {
+  viewBox: "0 0 24 24",
+  fill: "currentColor",
+  xmlns: "http://www.w3.org/2000/svg",
+};
 
 function MacIcon({ className = "" }: IconProps) {
   return (
@@ -151,7 +205,16 @@ function WindowsIcon({ className = "" }: IconProps) {
 
 function DesktopIcon({ className = "" }: IconProps) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <rect width="20" height="14" x="2" y="3" rx="2" />
       <line x1="8" x2="16" y1="21" y2="21" />
       <line x1="12" x2="12" y1="17" y2="21" />
@@ -172,7 +235,8 @@ export function DeviceIcon({
 }) {
   const s = ((os || "") + " " + (hostname || "") + " " + (ua || "")).toLowerCase();
   if (/mac|darwin|os x|macbook|imac/.test(s)) return <MacIcon className={className} />;
-  if (/linux|ubuntu|debian|fedora|arch|rocky|alpine|nixos/.test(s)) return <LinuxIcon className={className} />;
+  if (/linux|ubuntu|debian|fedora|arch|rocky|alpine|nixos/.test(s))
+    return <LinuxIcon className={className} />;
   if (/windows|win\b|win32/.test(s)) return <WindowsIcon className={className} />;
   return <DesktopIcon className={className} />;
 }

--- a/www/src/components/OnboardPage.tsx
+++ b/www/src/components/OnboardPage.tsx
@@ -15,7 +15,9 @@ export function OnboardPage({ code, onBack }: { code: string; onBack: () => void
   async function approve() {
     setStatus("approving");
     try {
-      const r = await fetch("/api/onboard/approve?code=" + encodeURIComponent(code), { method: "POST" });
+      const r = await fetch("/api/onboard/approve?code=" + encodeURIComponent(code), {
+        method: "POST",
+      });
       if (!r.ok) {
         setErr(await r.text());
         setStatus("error");
@@ -33,7 +35,9 @@ export function OnboardPage({ code, onBack }: { code: string; onBack: () => void
       <button onClick={onBack} className="text-[11px] text-[#737373] hover:text-[#171717]">
         ← back
       </button>
-      <h1 className="font-serif text-[36px] leading-none tracking-tight text-[#171717]">add device</h1>
+      <h1 className="font-serif text-[36px] leading-none tracking-tight text-[#171717]">
+        add device
+      </h1>
 
       {!info && !err && <div className="text-[12px] text-[#737373]">loading…</div>}
       {err && <div className="text-[12px] text-[#dc2626]">{err}</div>}
@@ -41,8 +45,12 @@ export function OnboardPage({ code, onBack }: { code: string; onBack: () => void
       {info && (
         <div className="bg-white border border-[#e5e5e5] rounded p-6 space-y-4">
           <div>
-            <div className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">code from CLI</div>
-            <div className="font-mono text-[28px] tracking-[.18em] text-[#171717] mt-1">{info.user_code || code}</div>
+            <div className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3]">
+              code from CLI
+            </div>
+            <div className="font-mono text-[28px] tracking-[.18em] text-[#171717] mt-1">
+              {info.user_code || code}
+            </div>
           </div>
 
           <div className="text-[11px] text-[#737373]">

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -1,17 +1,7 @@
 import { useState, useEffect } from "react";
-import {
-  getAction,
-  type Agent,
-  type EventRecord,
-} from "../lib/api";
+import { getAction, type Agent, type EventRecord } from "../lib/api";
 
-export function RequestDetailPage({
-  id,
-  agents,
-}: {
-  id: string;
-  agents: Agent[];
-}) {
+export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] }) {
   const [ev, setEv] = useState<EventRecord | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
@@ -38,31 +28,34 @@ export function RequestDetailPage({
 
   const t = new Date(ev.ts);
   const time =
-    t.toLocaleDateString() + " " +
+    t.toLocaleDateString() +
+    " " +
     t.toLocaleTimeString([], { hour12: false }) +
-    "." + String(t.getMilliseconds()).padStart(3, "0");
+    "." +
+    String(t.getMilliseconds()).padStart(3, "0");
   const status = ev.status || 0;
   const statusColor =
-    status >= 500 ? "text-[#dc2626]"
-    : status >= 400 ? "text-[#ea580c]"
-    : status >= 300 ? "text-[#ca8a04]"
-    : status >= 200 ? "text-[#16a34a]"
-    : "text-[#737373]";
+    status >= 500
+      ? "text-[#dc2626]"
+      : status >= 400
+        ? "text-[#ea580c]"
+        : status >= 300
+          ? "text-[#ca8a04]"
+          : status >= 200
+            ? "text-[#16a34a]"
+            : "text-[#737373]";
   const path = ev.path ?? "";
-  const fullUrl = ev.host +
-    (path.startsWith("/") ? "" : " ") + path;
+  const fullUrl = ev.host + (path.startsWith("/") ? "" : " ") + path;
   const hasReq = !!ev.req_body;
   const hasResp = !!ev.resp_body;
-  const hasReqH = ev.req_headers &&
-    Object.keys(ev.req_headers).length > 0;
-  const hasRespH = ev.resp_headers &&
-    Object.keys(ev.resp_headers).length > 0;
+  const hasReqH = ev.req_headers && Object.keys(ev.req_headers).length > 0;
+  const hasRespH = ev.resp_headers && Object.keys(ev.resp_headers).length > 0;
   const hasSections = hasReq || hasResp || hasReqH || hasRespH;
 
   return (
     <Shell
       agentIP={ev.agent_ip}
-      agentName={agents.find(a => a.ip === ev.agent_ip)?.hostname}
+      agentName={agents.find((a) => a.ip === ev.agent_ip)?.hostname}
       requestId={ev.id}
     >
       {/* header */}
@@ -70,9 +63,7 @@ export function RequestDetailPage({
         <div className="flex items-center gap-3 flex-wrap">
           <ModeIcon mode={ev.mode} />
           {ev.method && (
-            <span className="text-[12px] uppercase font-semibold text-[#525252]">
-              {ev.method}
-            </span>
+            <span className="text-[12px] uppercase font-semibold text-[#525252]">{ev.method}</span>
           )}
           <span className={"text-[13px] tabular-nums font-semibold " + statusColor}>
             {status || "\u2014"}
@@ -89,18 +80,18 @@ export function RequestDetailPage({
         {(ev.action || ev.reason) && (
           <div className="flex items-center gap-2 text-[11px]">
             {ev.action && (
-              <span className={
-                "px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase " +
-                (ev.action === "deny"
-                  ? "bg-[#fef2f2] text-[#dc2626]"
-                  : "bg-[#f0fdf4] text-[#16a34a]")
-              }>
+              <span
+                className={
+                  "px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase " +
+                  (ev.action === "deny"
+                    ? "bg-[#fef2f2] text-[#dc2626]"
+                    : "bg-[#f0fdf4] text-[#16a34a]")
+                }
+              >
                 {ev.action}
               </span>
             )}
-            {ev.reason && (
-              <span className="text-[#737373]">{ev.reason}</span>
-            )}
+            {ev.reason && <span className="text-[#737373]">{ev.reason}</span>}
           </div>
         )}
       </div>
@@ -124,9 +115,7 @@ export function RequestDetailPage({
             </Section>
           )}
           {hasResp && (
-            <Section title={
-              `Response body${status ? ` (${status})` : ""}`
-            }>
+            <Section title={`Response body${status ? ` (${status})` : ""}`}>
               <HttpBody text={ev.resp_body!} />
             </Section>
           )}
@@ -140,12 +129,8 @@ export function RequestDetailPage({
 
       {/* footer */}
       <div className="flex items-center gap-6 text-[10px] text-[#a3a3a3] flex-wrap">
-        {(ev.in != null && ev.in > 0) && (
-          <span>in: {fmtBytes(ev.in)}</span>
-        )}
-        {(ev.out != null && ev.out > 0) && (
-          <span>out: {fmtBytes(ev.out)}</span>
-        )}
+        {ev.in != null && ev.in > 0 && <span>in: {fmtBytes(ev.in)}</span>}
+        {ev.out != null && ev.out > 0 && <span>out: {fmtBytes(ev.out)}</span>}
         {ev.req_sha && (
           <span className="font-mono" title={ev.req_sha}>
             req_sha: {ev.req_sha.slice(0, 12)}
@@ -163,7 +148,11 @@ export function RequestDetailPage({
 
 // --- layout ---
 
-function Breadcrumbs({ agentIP, agentName, requestId }: {
+function Breadcrumbs({
+  agentIP,
+  agentName,
+  requestId,
+}: {
   agentIP?: string;
   agentName?: string;
   requestId?: string;
@@ -187,16 +176,19 @@ function Breadcrumbs({ agentIP, agentName, requestId }: {
       {requestId && (
         <>
           <span className="text-[13px] text-[#a3a3a3]">/</span>
-          <span className="text-[13px] text-[#525252] font-mono">
-            {requestId.slice(0, 8)}
-          </span>
+          <span className="text-[13px] text-[#525252] font-mono">{requestId.slice(0, 8)}</span>
         </>
       )}
     </nav>
   );
 }
 
-function Shell({ children, agentIP, agentName, requestId }: {
+function Shell({
+  children,
+  agentIP,
+  agentName,
+  requestId,
+}: {
   children: React.ReactNode;
   agentIP?: string;
   agentName?: string;
@@ -210,18 +202,13 @@ function Shell({ children, agentIP, agentName, requestId }: {
   );
 }
 
-function Section({ title, children }: {
-  title: string;
-  children: React.ReactNode;
-}) {
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <details open>
       <summary className="cursor-pointer px-4 py-2.5 text-[10px] uppercase tracking-wider font-medium text-[#a3a3a3] hover:text-[#525252] select-none">
         {title}
       </summary>
-      <div className="border-t border-[#f5f5f5]">
-        {children}
-      </div>
+      <div className="border-t border-[#f5f5f5]">{children}</div>
     </details>
   );
 }
@@ -237,9 +224,11 @@ function Headers({ obj }: { obj: Record<string, string> }) {
         <div key={k}>
           <span className="font-semibold text-[#171717]">{k}</span>
           <span className="text-[#a3a3a3]">: </span>
-          {SENSITIVE.test(k)
-            ? <span className="text-[#a3a3a3]">{"*".repeat(Math.min(v.length, 24))}</span>
-            : <span className="text-[#525252]">{v}</span>}
+          {SENSITIVE.test(k) ? (
+            <span className="text-[#a3a3a3]">{"*".repeat(Math.min(v.length, 24))}</span>
+          ) : (
+            <span className="text-[#525252]">{v}</span>
+          )}
         </div>
       ))}
     </pre>
@@ -252,11 +241,14 @@ function Headers({ obj }: { obj: Record<string, string> }) {
 // the 4KB sampler cap) walks backward to find the last position
 // where closing all open containers yields valid JSON.
 function tryParseJSON(text: string): {
-  parsed: unknown; truncated: boolean;
+  parsed: unknown;
+  truncated: boolean;
 } | null {
   try {
     return { parsed: JSON.parse(text), truncated: false };
-  } catch { /* fall through */ }
+  } catch {
+    /* fall through */
+  }
   // Walk the string tracking container depth, ignoring string
   // interiors. At each position where we're outside a string
   // and just finished a complete value (after , or : or [ or {),
@@ -267,9 +259,18 @@ function tryParseJSON(text: string): {
   let lastGoodCut = -1;
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
-    if (esc) { esc = false; continue; }
-    if (ch === "\\") { esc = true; continue; }
-    if (ch === '"') { inStr = !inStr; continue; }
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === "\\") {
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      inStr = !inStr;
+      continue;
+    }
     if (inStr) continue;
     if (ch === "{") stack.push("}");
     else if (ch === "[") stack.push("]");
@@ -288,9 +289,18 @@ function tryParseJSON(text: string): {
     let es = false;
     for (let i = 0; i < cut; i++) {
       const c = text[i];
-      if (es) { es = false; continue; }
-      if (c === "\\") { es = true; continue; }
-      if (c === '"') { ins = !ins; continue; }
+      if (es) {
+        es = false;
+        continue;
+      }
+      if (c === "\\") {
+        es = true;
+        continue;
+      }
+      if (c === '"') {
+        ins = !ins;
+        continue;
+      }
       if (ins) continue;
       if (c === "{") st.push("}");
       else if (c === "[") st.push("]");
@@ -304,7 +314,9 @@ function tryParseJSON(text: string): {
     attempt += st.reverse().join("");
     try {
       return { parsed: JSON.parse(attempt), truncated: true };
-    } catch { continue; }
+    } catch {
+      continue;
+    }
   }
   return null;
 }
@@ -326,12 +338,13 @@ function parseSSE(text: string): SseEvent[] | null {
       const k = line.slice(0, idx);
       let v = line.slice(idx + 1);
       if (v.startsWith(" ")) v = v.slice(1);
-      if (k === "event") { ev.type = v; valid = true; }
-      else if (k === "data") {
+      if (k === "event") {
+        ev.type = v;
+        valid = true;
+      } else if (k === "data") {
         ev.data = ev.data ? ev.data + "\n" + v : v;
         valid = true;
-      }
-      else if (k === "id") ev.id = v;
+      } else if (k === "id") ev.id = v;
     }
     if (valid) events.push(ev);
   }
@@ -339,21 +352,13 @@ function parseSSE(text: string): SseEvent[] | null {
 }
 
 function HttpBody({ text }: { text: string }) {
-  if (!text) return (
-    <div className="px-4 py-3 text-[11px] text-[#a3a3a3]">
-      (empty)
-    </div>
-  );
+  if (!text) return <div className="px-4 py-3 text-[11px] text-[#a3a3a3]">(empty)</div>;
   const result = tryParseJSON(text);
   if (result) {
     return (
       <div className="overflow-auto px-4 py-3 font-mono text-[11px] leading-relaxed">
         <JsonNode value={result.parsed} />
-        {result.truncated && (
-          <div className="mt-2 text-[10px] text-[#a3a3a3]">
-            (truncated)
-          </div>
-        )}
+        {result.truncated && <div className="mt-2 text-[10px] text-[#a3a3a3]">(truncated)</div>}
       </div>
     );
   }
@@ -367,16 +372,15 @@ function HttpBody({ text }: { text: string }) {
             <div key={i}>
               {e.type && (
                 <div className="text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] mb-1">
-                  event: <span className="normal-case tracking-normal text-[#525252]">{e.type}</span>
+                  event:{" "}
+                  <span className="normal-case tracking-normal text-[#525252]">{e.type}</span>
                 </div>
               )}
               {dataJson ? (
                 <>
                   <JsonNode value={dataJson.parsed} />
                   {dataJson.truncated && (
-                    <div className="mt-1 text-[10px] text-[#a3a3a3]">
-                      (truncated)
-                    </div>
+                    <div className="mt-1 text-[10px] text-[#a3a3a3]">(truncated)</div>
                   )}
                 </>
               ) : (
@@ -425,16 +429,12 @@ function JsonNode({ value }: { value: unknown }) {
     );
   }
   if (typeof value === "object") {
-    const entries = Object.entries(
-      value as Record<string, unknown>,
-    );
+    const entries = Object.entries(value as Record<string, unknown>);
     return (
       <Collapsible bracket={["{", "}"]} count={entries.length}>
         {entries.map(([k, v], i) => (
           <div key={k} className="pl-5">
-            <span className="text-[#be123c]">
-              {JSON.stringify(k)}
-            </span>
+            <span className="text-[#be123c]">{JSON.stringify(k)}</span>
             {": "}
             <JsonNode value={v} />
             {i < entries.length - 1 && ","}
@@ -457,13 +457,8 @@ function StringNode({ value }: { value: string }) {
   if (!expanded) {
     return (
       <span>
-        <span className="text-[#15803d]">
-          {raw.slice(0, LONG_STRING)}
-        </span>
-        <button
-          onClick={() => setExpanded(true)}
-          className="ml-1 text-[#2563eb] hover:underline"
-        >
+        <span className="text-[#15803d]">{raw.slice(0, LONG_STRING)}</span>
+        <button onClick={() => setExpanded(true)} className="ml-1 text-[#2563eb] hover:underline">
           +{raw.length - LONG_STRING} more
         </button>
       </span>
@@ -486,45 +481,41 @@ function StringNode({ value }: { value: string }) {
         </span>
       ))}
       {'"'}
-      <button
-        onClick={() => setExpanded(false)}
-        className="ml-1 text-[#2563eb] hover:underline"
-      >
+      <button onClick={() => setExpanded(false)} className="ml-1 text-[#2563eb] hover:underline">
         less
       </button>
     </span>
   );
 }
 
-function Collapsible({ bracket, count, children }: {
+function Collapsible({
+  bracket,
+  count,
+  children,
+}: {
   bracket: [string, string];
   count: number;
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(true);
   if (count === 0) {
-    return <span>{bracket[0]}{bracket[1]}</span>;
+    return (
+      <span>
+        {bracket[0]}
+        {bracket[1]}
+      </span>
+    );
   }
   if (!open) {
     return (
-      <button
-        onClick={() => setOpen(true)}
-        className="text-[#a3a3a3] hover:text-[#525252]"
-      >
-        {bracket[0]}{" "}
-        <span className="text-[#2563eb]">
-          {count} items
-        </span>
-        {" "}{bracket[1]}
+      <button onClick={() => setOpen(true)} className="text-[#a3a3a3] hover:text-[#525252]">
+        {bracket[0]} <span className="text-[#2563eb]">{count} items</span> {bracket[1]}
       </button>
     );
   }
   return (
     <span>
-      <button
-        onClick={() => setOpen(false)}
-        className="hover:text-[#a3a3a3]"
-      >
+      <button onClick={() => setOpen(false)} className="hover:text-[#a3a3a3]">
         {bracket[0]}
       </button>
       {children}
@@ -553,7 +544,16 @@ function ModeIcon({ mode }: { mode: string }) {
   }
   return (
     <span title="Splice" className="flex-shrink-0">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#a3a3a3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#a3a3a3"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M5 12h14" />
         <path d="m13 6 6 6-6 6" />
       </svg>

--- a/www/src/components/RulesEditor.tsx
+++ b/www/src/components/RulesEditor.tsx
@@ -4,13 +4,7 @@ import { HCLEditor } from "./HCLEditor";
 
 // RulesEditor edits the whole gateway.hcl file. Validation runs
 // server-side; diagnostics surface in the err panel.
-export function RulesEditor({
-  onClose,
-  onSaved,
-}: {
-  onClose: () => void;
-  onSaved: () => void;
-}) {
+export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
   const [text, setText] = useState("");
   const [original, setOriginal] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -113,9 +107,7 @@ export function RulesEditor({
         </form>
 
         <div className="flex items-center px-4 py-3 border-t border-[#e5e5e5] gap-3">
-          {err && (
-            <span className="text-[11px] text-red-600 break-all flex-1">{err}</span>
-          )}
+          {err && <span className="text-[11px] text-red-600 break-all flex-1">{err}</span>}
           {okMsg && <span className="text-[11px] text-[#16a34a] flex-1">{okMsg}</span>}
           {!err && !okMsg && (
             <span className="text-[11px] text-[#a3a3a3] flex-1">

--- a/www/src/components/SessionsTable.tsx
+++ b/www/src/components/SessionsTable.tsx
@@ -46,14 +46,18 @@ export function SessionsTable({ sessions: all }: { sessions: Session[] }) {
                     <div className="text-[12px] text-[#171717] truncate" title={s.title}>
                       {s.title}
                     </div>
-                    {s.id && <div className="text-[10px] text-[#a3a3a3] tabular-nums truncate">{s.id}</div>}
+                    {s.id && (
+                      <div className="text-[10px] text-[#a3a3a3] tabular-nums truncate">{s.id}</div>
+                    )}
                   </div>
                 </div>
               </Td>
               <Td>
                 <Sparkline data={s.activity} width={100} height={16} />
               </Td>
-              <Td className="text-[11px] text-[#737373] tabular-nums text-right">{fmtAge(s.first_at)}</Td>
+              <Td className="text-[11px] text-[#737373] tabular-nums text-right">
+                {fmtAge(s.first_at)}
+              </Td>
               <Td className="text-[11px] text-[#525252] tabular-nums text-right">{s.reqs}</Td>
               <Td>
                 {s.model ? (
@@ -100,7 +104,9 @@ function ModelDonut({ session: s }: { session: Session }) {
           style={{ top: tip.top, left: tip.left }}
         >
           {fmtTokens(s.tokens_in)} in · {fmtTokens(s.tokens_out)} out
-          {s.ctx_max ? ` · ${fmtTokens(s.ctx_used)}/${fmtTokens(s.ctx_max)} (${pct.toFixed(0)}%)` : ""}
+          {s.ctx_max
+            ? ` · ${fmtTokens(s.ctx_used)}/${fmtTokens(s.ctx_max)} (${pct.toFixed(0)}%)`
+            : ""}
         </div>
       )}
     </div>
@@ -120,9 +126,20 @@ function Th({ children, className = "" }: { children: React.ReactNode; className
   );
 }
 
-function Td({ children, className = "", ...rest }: { children: React.ReactNode; className?: string; title?: string }) {
+function Td({
+  children,
+  className = "",
+  ...rest
+}: {
+  children: React.ReactNode;
+  className?: string;
+  title?: string;
+}) {
   return (
-    <td className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className} {...rest}>
+    <td
+      className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className}
+      {...rest}
+    >
       {children}
     </td>
   );

--- a/www/src/components/SettingsModal.tsx
+++ b/www/src/components/SettingsModal.tsx
@@ -6,13 +6,7 @@ import { useEffect, useState } from "react";
 import { getConfigHCL, putConfigHCL } from "../lib/api";
 import { HCLEditor } from "./HCLEditor";
 
-export function SettingsModal({
-  onClose,
-  onSaved,
-}: {
-  onClose: () => void;
-  onSaved: () => void;
-}) {
+export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
   const [text, setText] = useState("");
   const [original, setOriginal] = useState("");
   const [err, setErr] = useState<string | null>(null);

--- a/www/src/components/Sparkline.tsx
+++ b/www/src/components/Sparkline.tsx
@@ -28,14 +28,27 @@ export function Sparkline({
   const fillPath = linePath + ` L ${width},${height} L 0,${height} Z`;
 
   return (
-    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="block" preserveAspectRatio="none">
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="block"
+      preserveAspectRatio="none"
+    >
       <path d={fillPath} fill={color} opacity={0.15} />
-      <path d={linePath} fill="none" stroke={color} strokeWidth={1.25} strokeLinejoin="round" strokeLinecap="round" />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.25}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
     </svg>
   );
 }
 
 function padTo(a: number[], n: number): number[] {
   if (a.length >= n) return a.slice(-n);
-  return new Array(n - a.length).fill(0).concat(a);
+  return Array.from({ length: n - a.length }, () => 0).concat(a);
 }

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -2,14 +2,31 @@
 @tailwind components;
 @tailwind utilities;
 
-*, *::before, *::after { box-sizing: border-box; }
-html, body { height: 100%; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+html,
+body {
+  height: 100%;
+}
 body {
   background: #fafafa;
   color: #171717;
-  font: 13px/1.4 ui-monospace, "SF Mono", Menlo, monospace;
+  font:
+    13px/1.4 ui-monospace,
+    "SF Mono",
+    Menlo,
+    monospace;
   -webkit-font-smoothing: antialiased;
 }
 
-::-webkit-scrollbar { width: 4px; height: 4px; }
-::-webkit-scrollbar-thumb { background: #d4d4d4; border-radius: 2px; }
+::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+::-webkit-scrollbar-thumb {
+  background: #d4d4d4;
+  border-radius: 2px;
+}

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -185,9 +185,12 @@ export async function listProfiles(): Promise<string[]> {
 }
 
 export async function setDeviceProfile(ip: string, profile: string): Promise<void> {
-  const r = await api(`/api/agents/profile?ip=${encodeURIComponent(ip)}&profile=${encodeURIComponent(profile)}`, {
-    method: "POST",
-  });
+  const r = await api(
+    `/api/agents/profile?ip=${encodeURIComponent(ip)}&profile=${encodeURIComponent(profile)}`,
+    {
+      method: "POST",
+    },
+  );
   if (!r.ok) throw new Error(await r.text());
 }
 
@@ -298,9 +301,21 @@ export async function getState(): Promise<StateResp> {
 
 export type OAuthStartResp =
   | { flow?: "auth_code"; auth_url: string; state: string; owner: string }
-  | { flow: "device"; user_code: string; verification_uri: string; state: string; owner: string; interval: number; expires_in: number };
+  | {
+      flow: "device";
+      user_code: string;
+      verification_uri: string;
+      state: string;
+      owner: string;
+      interval: number;
+      expires_in: number;
+    };
 
-export async function oauthStart(id: string, profile?: string, extraScopes?: string[]): Promise<OAuthStartResp> {
+export async function oauthStart(
+  id: string,
+  profile?: string,
+  extraScopes?: string[],
+): Promise<OAuthStartResp> {
   let qs = `id=${encodeURIComponent(id)}`;
   if (profile) qs += `&profile=${encodeURIComponent(profile)}`;
   if (extraScopes && extraScopes.length > 0) {
@@ -311,8 +326,16 @@ export async function oauthStart(id: string, profile?: string, extraScopes?: str
   return r.json();
 }
 
-export async function oauthDevicePoll(state: string): Promise<{ connected?: boolean; owner?: string; error?: string; detail?: string; interval?: number }> {
-  const r = await api(`/api/oauth/device-poll?state=${encodeURIComponent(state)}`, { method: "POST" });
+export async function oauthDevicePoll(state: string): Promise<{
+  connected?: boolean;
+  owner?: string;
+  error?: string;
+  detail?: string;
+  interval?: number;
+}> {
+  const r = await api(`/api/oauth/device-poll?state=${encodeURIComponent(state)}`, {
+    method: "POST",
+  });
   if (!r.ok) throw new Error(await r.text());
   return r.json();
 }
@@ -377,7 +400,10 @@ export async function getAnalytics(params: {
   return r.json();
 }
 
-export async function oauthExchange(state: string, code: string): Promise<{ connected: boolean; owner: string; expires: number }> {
+export async function oauthExchange(
+  state: string,
+  code: string,
+): Promise<{ connected: boolean; owner: string; expires: number }> {
   const r = await api("/api/oauth/exchange", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/www/src/lib/format.ts
+++ b/www/src/lib/format.ts
@@ -1,8 +1,12 @@
 export function fmtBytes(n: number): string {
   if (!n) return "0";
   const u = ["B", "K", "M", "G"];
-  let i = 0, x = n;
-  while (x >= 1024 && i < u.length - 1) { x /= 1024; i++; }
+  let i = 0,
+    x = n;
+  while (x >= 1024 && i < u.length - 1) {
+    x /= 1024;
+    i++;
+  }
   return x.toFixed(x < 10 && i > 0 ? 1 : 0) + u[i];
 }
 

--- a/www/src/main.tsx
+++ b/www/src/main.tsx
@@ -5,4 +5,8 @@ import "./index.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("no root");
-createRoot(root).render(<React.StrictMode><App /></React.StrictMode>);
+createRoot(root).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/www/tailwind.config.js
+++ b/www/tailwind.config.js
@@ -4,7 +4,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        mono: ['ui-monospace', '"SF Mono"', 'Menlo', 'monospace'],
+        mono: ["ui-monospace", '"SF Mono"', "Menlo", "monospace"],
       },
       letterSpacing: {
         tight12: ".12em",


### PR DESCRIPTION
## Summary

- Add `oxfmt` and `oxlint` to the dashboard frontend toolchain
- Configure `oxlint` with TypeScript, Unicorn, Oxc, and React rules
- Run frontend format/lint checks in CI before the existing dashboard build
- Format the existing dashboard sources with `oxfmt`
- Fix the remaining `oxlint` findings, including React hook dependencies

## Test Plan

- `cd www && npm run format:check`
- `cd www && npm run lint:github`
- `cd www && npm run build`
- `git diff --check`
- `gofmt -l . && test -z "$(gofmt -l .)"`
- `go test ./...`