### PR TITLE
feat: HITL Slack thread context + OAuth credential reuse for LLM approver

### DIFF
--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -67,6 +67,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					Interactive:    h.Interactive,
 					PendingID:      id,
 					DashboardURL:   req.DashboardURL,
+					ThreadTS:       req.ThreadTS,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {

--- a/config/plugins/approvers/llm.go
+++ b/config/plugins/approvers/llm.go
@@ -64,17 +64,8 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 		}
 		policyText = pt.Text
 	}
-	credEnt, ok := req.Policy.Credentials[a.Credential]
-	if !ok {
+	if _, ok := req.Policy.Credentials[a.Credential]; !ok {
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential " + a.Credential + " not declared"}, nil
-	}
-	injector, ok := credEnt.Body.(runtime.HTTPCredentialRuntime)
-	if !ok {
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential " + a.Credential + " does not satisfy HTTPCredentialRuntime"}, nil
-	}
-	sec, err := req.Secrets.Get(a.Credential, req.Profile)
-	if err != nil {
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
 	}
 
 	user := buildJudgePrompt(req, policyText)
@@ -91,8 +82,29 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	default:
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "unknown model family: " + a.Model}, nil
 	}
-	if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential inject: " + err.Error()}, nil
+
+	// Try OAuth registry first (claude/codex OAuth — no API key needed).
+	// Fall back to per-profile secret store (anthropic_manual_key, bearer_token, etc.).
+	// Silently fall through when credential isn't an OAuth type or no owner is connected.
+	injected := false
+	if req.OAuthInjectAny != nil {
+		if ok, _ := req.OAuthInjectAny(a.Credential, hreq); ok {
+			injected = true
+		}
+	}
+	if !injected {
+		credEnt := req.Policy.Credentials[a.Credential]
+		injector, ok := credEnt.Body.(runtime.HTTPCredentialRuntime)
+		if !ok {
+			return runtime.ApproveVerdict{Decision: "deny", Reason: "credential " + a.Credential + " does not satisfy HTTPCredentialRuntime"}, nil
+		}
+		sec, err := req.Secrets.Get(a.Credential, req.Profile)
+		if err != nil {
+			return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
+		}
+		if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
+			return runtime.ApproveVerdict{Decision: "deny", Reason: "credential inject: " + err.Error()}, nil
+		}
 	}
 	c := &http.Client{Timeout: 30 * time.Second}
 	resp, err := c.Do(hreq)

--- a/config/plugins/approvers/llm.go
+++ b/config/plugins/approvers/llm.go
@@ -90,6 +90,12 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	if req.OAuthInjectAny != nil {
 		if ok, _ := req.OAuthInjectAny(a.Credential, hreq); ok {
 			injected = true
+			// Claude OAuth tokens require this beta header in addition to Bearer.
+			// reg.Inject only stamps the token; the credential plugin's InjectHTTP
+			// would add it, but OAuthInjectAny bypasses that path.
+			if strings.HasPrefix(a.Model, "claude-") {
+				hreq.Header.Set("anthropic-beta", "oauth-2025-04-20")
+			}
 		}
 	}
 	if !injected {

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -179,6 +179,9 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 		"text":    fmt.Sprintf("clawpatrol HITL: %s %s%s", req.Method, req.Host, req.Path),
 		"blocks":  blocks,
 	}
+	if target.ThreadTS != "" {
+		body["thread_ts"] = target.ThreadTS
+	}
 	buf, _ := json.Marshal(body)
 	hreq, err := http.NewRequest("POST", "https://slack.com/api/chat.postMessage", bytes.NewReader(buf))
 	if err != nil {

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -231,6 +231,7 @@ type HITLTarget struct {
 	Interactive    bool   // approve/deny buttons vs. dashboard-only
 	PendingID      string // pool's pending entry id
 	DashboardURL   string // for fallback dashboard link in non-interactive mode
+	ThreadTS       string // if set, post as a reply in this Slack thread
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.
@@ -269,6 +270,10 @@ type ApproveRequest struct {
 	UA         string
 	BodySample string
 	Reason     string
+	// ThreadTS, when set, asks HITL notifiers to post the approval
+	// prompt as a reply in this Slack thread rather than top-level.
+	// Populated from the X-HITL-Thread-TS request header.
+	ThreadTS string
 
 	// Pool exposes the gateway's shared pending-approval list — the
 	// dashboard / Slack approvers use it to publish a pending entry
@@ -278,6 +283,11 @@ type ApproveRequest struct {
 	// Secrets fetches the bot token / API key the approver needs to
 	// post a notification or call an LLM judge.
 	Secrets SecretStore
+	// OAuthInjectAny stamps the Authorization header for the named
+	// OAuth credential using any currently-connected owner's token.
+	// Nil when the gateway has no OAuth registry (tests). LLM approvers
+	// use this to call claude/codex without a separate API key in the DB.
+	OAuthInjectAny func(id string, req *http.Request) (bool, error)
 	// DashboardURL is the operator-facing dashboard origin used for
 	// deep links in Slack messages and similar notifications.
 	DashboardURL string

--- a/main.go
+++ b/main.go
@@ -1665,7 +1665,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// allow; first deny short-circuits.
 		if cr != nil && len(cr.Outcome.Approve) > 0 {
 			v := g.runApproveChain(req.Context(), cr.Outcome.Approve, runApproveCtx{
-				AgentIP: pip, Host: host, Method: req.Method, Path: req.URL.Path,
+				AgentIP: pip, Host: host, Method: req.Method, Path: req.URL.RequestURI(),
 				UA: req.Header.Get("User-Agent"), Reason: cr.Outcome.Reason,
 				ThreadTS: req.Header.Get("X-HITL-Thread-TS"),
 				Endpoint: ep, Rule: cr, Profile: profile,

--- a/main.go
+++ b/main.go
@@ -1667,6 +1667,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			v := g.runApproveChain(req.Context(), cr.Outcome.Approve, runApproveCtx{
 				AgentIP: pip, Host: host, Method: req.Method, Path: req.URL.Path,
 				UA: req.Header.Get("User-Agent"), Reason: cr.Outcome.Reason,
+				ThreadTS: req.Header.Get("X-HITL-Thread-TS"),
 				Endpoint: ep, Rule: cr, Profile: profile,
 			})
 			if v.Decision != "allow" {
@@ -1721,6 +1722,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				"Proxy-Authorization", "Te", "Trailers", "Transfer-Encoding", "Upgrade",
 				"Cf-Worker", "Cf-Ray", "Cf-Ew-Via", "Cf-Connecting-Ip", "Cdn-Loop",
 				"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "Via",
+				"X-HITL-Thread-TS",
 			} {
 				req.Header.Del(h)
 			}
@@ -1940,6 +1942,7 @@ type runApproveCtx struct {
 	UA         string
 	BodySample string
 	Reason     string
+	ThreadTS   string
 	Endpoint   *config.CompiledEndpoint
 	Rule       *config.CompiledRule
 	Profile    string
@@ -1977,8 +1980,17 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			UA:           c.UA,
 			BodySample:   c.BodySample,
 			Reason:       c.Reason,
+			ThreadTS:     c.ThreadTS,
 			Pool:         g.hitl,
 			Secrets:      g.secrets,
+			OAuthInjectAny: func(id string, hr *http.Request) (bool, error) {
+				for _, owner := range g.oauth.Owners(id) {
+					if ok, err := g.oauth.Inject(id, owner, hr); ok {
+						return true, err
+					}
+				}
+				return false, fmt.Errorf("no connected owner for oauth credential %q", id)
+			},
 			DashboardURL: g.cfg.PublicURL,
 			Policy:       policy,
 		}


### PR DESCRIPTION
## Summary

- **X-HITL-Thread-TS header**: When an agent sets `X-HITL-Thread-TS` on a proxied request, the gateway threads the HITL approval prompt into that Slack conversation instead of posting top-level. Header is stripped before forwarding upstream.
  - `ApproveRequest.ThreadTS` + `HITLTarget.ThreadTS` carry it through the chain
  - `SlackTokens.NotifyHITL` adds `thread_ts` to `chat.postMessage` when set
  - `human_approver` passes it to `HITLTarget`

- **OAuth credential reuse for LLM approver**: `llm_approver` now tries `OAuthInjectAny` (the gateway's OAuth registry) before falling back to `SecretStore`. Operators can point `credential = codex` or `credential = claude` at their existing connected OAuth credential — no separate API key row in `credential_secrets` needed.

## Test plan

- [ ] `markAsSpam` / `replyOnBehalf` from an agent Slack thread → HITL prompt appears as reply in that thread
- [ ] `kubectl exec` routed through LLM proctor with `credential = codex` → proctor calls OpenAI via connected OAuth token, no API key in DB required
- [ ] LLM approver with a `bearer_token` / `anthropic_manual_key` credential still works (SecretStore fallback path)
- [ ] No `X-HITL-Thread-TS` set → HITL prompt posts top-level (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)