### PR TITLE
remove OAuthInjectAny. LLM approver must use per-profile credentials only

### DIFF
--- a/config/plugins/approvers/llm.go
+++ b/config/plugins/approvers/llm.go
@@ -83,34 +83,17 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "unknown model family: " + a.Model}, nil
 	}
 
-	// Try OAuth registry first (claude/codex OAuth — no API key needed).
-	// Fall back to per-profile secret store (anthropic_manual_key, bearer_token, etc.).
-	// Silently fall through when credential isn't an OAuth type or no owner is connected.
-	injected := false
-	if req.OAuthInjectAny != nil {
-		if ok, _ := req.OAuthInjectAny(a.Credential, hreq); ok {
-			injected = true
-			// Claude OAuth tokens require this beta header in addition to Bearer.
-			// reg.Inject only stamps the token; the credential plugin's InjectHTTP
-			// would add it, but OAuthInjectAny bypasses that path.
-			if strings.HasPrefix(a.Model, "claude-") {
-				hreq.Header.Set("anthropic-beta", "oauth-2025-04-20")
-			}
-		}
+	credEnt := req.Policy.Credentials[a.Credential]
+	injector, ok := credEnt.Body.(runtime.HTTPCredentialRuntime)
+	if !ok {
+		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential " + a.Credential + " does not satisfy HTTPCredentialRuntime"}, nil
 	}
-	if !injected {
-		credEnt := req.Policy.Credentials[a.Credential]
-		injector, ok := credEnt.Body.(runtime.HTTPCredentialRuntime)
-		if !ok {
-			return runtime.ApproveVerdict{Decision: "deny", Reason: "credential " + a.Credential + " does not satisfy HTTPCredentialRuntime"}, nil
-		}
-		sec, err := req.Secrets.Get(a.Credential, req.Profile)
-		if err != nil {
-			return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
-		}
-		if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
-			return runtime.ApproveVerdict{Decision: "deny", Reason: "credential inject: " + err.Error()}, nil
-		}
+	sec, err := req.Secrets.Get(a.Credential, req.Profile)
+	if err != nil {
+		return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
+	}
+	if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
+		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential inject: " + err.Error()}, nil
 	}
 	c := &http.Client{Timeout: 30 * time.Second}
 	resp, err := c.Do(hreq)

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -283,11 +283,6 @@ type ApproveRequest struct {
 	// Secrets fetches the bot token / API key the approver needs to
 	// post a notification or call an LLM judge.
 	Secrets SecretStore
-	// OAuthInjectAny stamps the Authorization header for the named
-	// OAuth credential using any currently-connected owner's token.
-	// Nil when the gateway has no OAuth registry (tests). LLM approvers
-	// use this to call claude/codex without a separate API key in the DB.
-	OAuthInjectAny func(id string, req *http.Request) (bool, error)
 	// DashboardURL is the operator-facing dashboard origin used for
 	// deep links in Slack messages and similar notifications.
 	DashboardURL string

--- a/main.go
+++ b/main.go
@@ -1983,14 +1983,6 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			ThreadTS:     c.ThreadTS,
 			Pool:         g.hitl,
 			Secrets:      g.secrets,
-			OAuthInjectAny: func(id string, hr *http.Request) (bool, error) {
-				for _, owner := range g.oauth.Owners(id) {
-					if ok, err := g.oauth.Inject(id, owner, hr); ok {
-						return true, err
-					}
-				}
-				return false, fmt.Errorf("no connected owner for oauth credential %q", id)
-			},
 			DashboardURL: g.cfg.PublicURL,
 			Policy:       policy,
 		}


### PR DESCRIPTION
## Summary

- Removes `OAuthInjectAny` from `ApproveRequest` and the LLM approver introduced in #132
- Removes the gateway wiring in `main.go`

## Why

`OAuthInjectAny` picked any connected operator's OAuth token regardless of which profile triggered the LLM proctor. An `dev2` exec call would silently bill the admin's Anthropic subscription — profile isolation was completely broken.

Credentials must always be scoped to the requesting profile. The LLM approver reverts to the SecretStore-only path: `Secrets.Get(credential, profile)` which looks up `(credential, profile)` in `credential_secrets`. If no key is configured for that profile, it denies with a clear error rather than borrowing someone else's token.

## Migration

Operators using `llm_approver` must store a credential secret for their profile:

```python
# anthropic_manual_key credential
con.execute("INSERT OR REPLACE INTO credential_secrets VALUES (?,?,?,?,?)",
    ("my-llm-cred", "my-profile", "", "sk-ant-...", time.time_ns()))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)