### PR TITLE
site: fix ProtocolDepth section to show real HCL rules

### DIFF
--- a/site/src/components/HclCode.tsx
+++ b/site/src/components/HclCode.tsx
@@ -1,0 +1,93 @@
+/* Tiny HCL tokenizer. Just enough to colorize the `rule { ... }`
+   snippets on the landing page — not a real parser. Palette matches
+   the hand-tinted block in RulesSection. */
+
+type Tok = {
+  kind: "kw" | "str" | "cmt" | "key" | "txt";
+  text: string;
+};
+
+const KEYWORDS = new Set([
+  "rule",
+  "endpoint",
+  "endpoints",
+  "credential",
+  "credentials",
+  "approver",
+  "policy",
+  "profile",
+  "match",
+  "verdict",
+  "approve",
+  "reason",
+  "priority",
+  "disabled",
+  "defaults",
+]);
+
+function tokenize(src: string): Tok[] {
+  const out: Tok[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "#") {
+      const end = src.indexOf("\n", i);
+      const stop = end < 0 ? src.length : end;
+      out.push({ kind: "cmt", text: src.slice(i, stop) });
+      i = stop;
+      continue;
+    }
+    if (c === '"') {
+      let j = i + 1;
+      while (j < src.length && src[j] !== '"') {
+        if (src[j] === "\\") j++;
+        j++;
+      }
+      out.push({ kind: "str", text: src.slice(i, j + 1) });
+      i = j + 1;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(c)) {
+      let j = i + 1;
+      while (j < src.length && /[A-Za-z0-9_-]/.test(src[j])) j++;
+      const word = src.slice(i, j);
+      let k = j;
+      while (k < src.length && (src[k] === " " || src[k] === "\t")) k++;
+      const isKey = src[k] === "=";
+      out.push({
+        kind: KEYWORDS.has(word) ? "kw" : isKey ? "key" : "txt",
+        text: word,
+      });
+      i = j;
+      continue;
+    }
+    let j = i;
+    while (j < src.length && !/[A-Za-z_#"]/.test(src[j])) j++;
+    out.push({ kind: "txt", text: src.slice(i, j) });
+    i = j;
+  }
+  return out;
+}
+
+const CLASS: Record<Tok["kind"], string> = {
+  kw: "text-rust-300",
+  str: "text-butter-300",
+  cmt: "text-canvas/40",
+  key: "text-canvas/70",
+  txt: "",
+};
+
+export function HclCode(
+  { source, class: cls }: { source: string; class?: string },
+) {
+  const toks = tokenize(source);
+  return (
+    <pre class={cls ?? ""}>
+      <code>
+        {toks.map((t, i) => (
+          <span key={i} class={CLASS[t.kind]}>{t.text}</span>
+        ))}
+      </code>
+    </pre>
+  );
+}

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from "preact";
 import { SectionLabel } from "../components/SectionLabel";
+import { HclCode } from "../components/HclCode";
 
 /* ──────────────────────────────────────────────────────────────────────
    Approvers — deepens the `require_llm` and `require_human` verdicts
@@ -145,9 +146,10 @@ function ApproverCard({
           <code class="text-[10px] font-mono text-text-subtle">{verdict}</code>
         </header>
         <p class="text-sm  text-text-muted">{pitch}</p>
-        <pre class="text-[12px]  font-mono bg-console-dark text-canvas/85 squircle-sm p-4 overflow-x-auto whitespace-pre">
-          {config}
-        </pre>
+        <HclCode
+          source={config}
+          class="text-[12px]  font-mono bg-console-dark text-canvas/85 squircle-sm p-4 overflow-x-auto whitespace-pre"
+        />
         {diagram}
       </div>
     </article>

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -85,7 +85,7 @@ function LlmDiagram() {
   );
 }
 
-/* ── Human review: Slack ping → human reply → verdict ──────────────── */
+/* ── Human In The Loop: Slack ping → human reply → verdict ─────────── */
 
 function HumanDiagram() {
   return (
@@ -194,7 +194,7 @@ export function ApproversSection() {
           />
           <OrDivider />
           <ApproverCard
-            title="Human review"
+            title="Human In The Loop"
             verdict="require_human"
             pitch="A person votes in Slack, the dashboard, or your own webhook. Times out closed if no one's home."
             config={HUMAN_CONFIG}

--- a/site/src/sections/ProtocolDepthSection.tsx
+++ b/site/src/sections/ProtocolDepthSection.tsx
@@ -1,4 +1,5 @@
 import { SectionLabel } from "../components/SectionLabel";
+import { HclCode } from "../components/HclCode";
 
 /* ──────────────────────────────────────────────────────────────────────
    Multi-protocol depth — sells the idea that the gateway doesn't just
@@ -82,13 +83,12 @@ export function ProtocolDepthSection() {
                 {p.name}
               </h4>
               <p class="text-sm  text-canvas/70">{p.body}</p>
-              <pre
-                class="block text-[12px] mt-4  font-mono
-                  bg-navy-950 text-rust-200 px-3 py-2 rounded-sm
+              <HclCode
+                source={p.example}
+                class="block text-[12px] mt-2 font-mono
+                  bg-navy-950 text-canvas/85 px-3 py-2 rounded-sm
                   whitespace-pre-wrap break-words"
-              >
-                {p.example}
-              </pre>
+              />
             </li>
           ))}
         </ul>

--- a/site/src/sections/ProtocolDepthSection.tsx
+++ b/site/src/sections/ProtocolDepthSection.tsx
@@ -1,10 +1,10 @@
 import { SectionLabel } from "../components/SectionLabel";
 
 /* ──────────────────────────────────────────────────────────────────────
-   Multi-protocol depth — sells the idea that the proxy doesn't just
-   sniff HTTP, it actually parses each protocol so rules can match on
-   meaningful fields. Dark navy band — first major palette break of
-   the page after the cream + canvas-muted runs.
+   Multi-protocol depth — sells the idea that the gateway doesn't just
+   sniff HTTP, it parses each protocol (HTTP, SQL, Kubernetes) so rules
+   can match on meaningful fields of every action. Dark navy band —
+   first major palette break after the cream / canvas-muted runs.
    ──────────────────────────────────────────────────────────────────── */
 
 const PROTOCOLS: {
@@ -15,13 +15,13 @@ const PROTOCOLS: {
   {
     name: "HTTPS",
     body:
-      "Method, URL, headers, body. Any host, any service. " +
-      "Plugins add per-service facets — github.repo, slack.channel.",
-    example: `{
-  "http.method": "DELETE",
-  "http.url": {
-    "contains": "/repos/"
-  }
+      "Method, path, headers, body. Any host, any service. " +
+      "Hostname matching is implicit via the endpoint scope.",
+    example: `rule "http_rule" "github-no-repo-delete" {
+  endpoint = github-api
+  match    = { method = "DELETE", path = "/repos/*" }
+  verdict  = "deny"
+  reason   = "deleting repos is not allowed"
 }`,
   },
   {
@@ -29,21 +29,11 @@ const PROTOCOLS: {
     body:
       "Postgres and ClickHouse traffic parsed verb-by-verb. " +
       "Match SELECT, INSERT, DROP. Inspect tables and statement text.",
-    example: `{
-  "sql.verb": {
-    "in": ["DROP", "TRUNCATE"]
-  }
-}`,
-  },
-  {
-    name: "SSH",
-    body:
-      "Commands sent over interactive shells and exec sessions. " +
-      "Block rm -rf. Approve sudo. Audit every keystroke.",
-    example: `{
-  "ssh.command": {
-    "contains": "rm -rf"
-  }
+    example: `rule "sql_rule" "no-ddl" {
+  endpoint = pg-writer
+  match    = { verb = ["drop", "truncate", "alter"] }
+  verdict  = "deny"
+  reason   = "no DDL"
 }`,
   },
   {
@@ -51,19 +41,11 @@ const PROTOCOLS: {
     body:
       "API calls to kube-apiserver. Match by namespace, resource, " +
       "and verb — protect prod from accidental kubectl delete.",
-    example: `{
-  "k8s.namespace": "prod",
-  "k8s.verb": "delete"
-}`,
-  },
-  {
-    name: "Plugins",
-    body:
-      "Write a plugin in TypeScript and emit your own facets. " +
-      "Rules can match on whatever you surface.",
-    example: `{
-  "myplugin.action": "transfer",
-  "myplugin.amount_tier": "high"
+    example: `rule "k8s_rule" "no-secrets" {
+  endpoints = [k8s-dev-ams, k8s-dev-ord]
+  match     = { resource = "secrets" }
+  verdict   = "deny"
+  reason    = "Secret values must not leave the cluster"
 }`,
   },
 ];
@@ -76,17 +58,18 @@ export function ProtocolDepthSection() {
 
         <div class="max-w-3xl mx-auto text-center mb-16">
           <h3 class="text-3xl sm:text-4xl md:text-5xl font-display font-extrabold  mb-5">
-            Rules dive into <span class="text-rust">every request.</span>
+            Rules dive into <span class="text-rust">every action.</span>
           </h3>
           <p class="text-base  text-canvas/70">
-            Most gateways stop at HTTP method and URL. Claw Patrol parses each
-            protocol — so you can write rules that mean something. Block
-            destructive SQL. Gate sudo over SSH. Quarantine prod kubectl.
+            Most gateways stop at HTTP method and URL. Claw Patrol parses
+            each protocol — so you can write rules that mean something.
+            Block destructive SQL. Quarantine prod kubectl. Gate writes
+            to GitHub.
           </p>
         </div>
 
         <p class="text-xs uppercase tracking-[0.25em] font-display font-extrabold text-rust-300 mb-5 text-center">
-          Match anything in the request
+          Match anything in the action
         </p>
         <ul class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           {PROTOCOLS.map((p) => (

--- a/site/src/sections/ProtocolDepthSection.tsx
+++ b/site/src/sections/ProtocolDepthSection.tsx
@@ -64,8 +64,8 @@ export function ProtocolDepthSection() {
           <p class="text-base  text-canvas/70">
             Most gateways stop at HTTP method and URL. Claw Patrol parses
             each protocol — so you can write rules that mean something.
-            Block destructive SQL. Quarantine prod kubectl. Gate writes
-            to GitHub.
+            Block destructive SQL. Quarantine prod kubectl. Gate
+            specific ssh commands.
           </p>
         </div>
 

--- a/site/src/sections/ProtocolDepthSection.tsx
+++ b/site/src/sections/ProtocolDepthSection.tsx
@@ -87,7 +87,7 @@ export function ProtocolDepthSection() {
                 source={p.example}
                 class="block text-[12px] mt-2 font-mono
                   bg-navy-950 text-canvas/85 px-3 py-2 rounded-sm
-                  whitespace-pre-wrap break-words"
+                  whitespace-pre overflow-x-auto"
               />
             </li>
           ))}

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -29,7 +29,7 @@ const DECISIONS: { label: string; verdict: string; body: string }[] = [
       "with your custom prompt — it reads the payload and votes.",
   },
   {
-    label: "Human review",
+    label: "Human In The Loop",
     verdict: "require_human",
     body:
       "Park the request. Ping Slack, the dashboard, or your own " +


### PR DESCRIPTION
## Summary
- Replace the JSON facet mock-ups in the "Not just HTTP" section with real HCL `rule` blocks that mirror `config/testdata/full.hcl`.
- Drop the SSH and Plugins cards: SSH protocol decode and plugin-defined match facets aren't supported by the gateway today.
- "request" → "action" throughout the section, since not every gated action is an HTTP request.

## Test plan
- [ ] `cd site && npm run build` (passes locally)
- [ ] Visual check at `/` — three cards (HTTPS, SQL, Kubernetes), each showing an HCL rule block
