### PR TITLE
fix: request body truncation >1MiB + stale idle connections

### DIFF
--- a/main.go
+++ b/main.go
@@ -292,7 +292,7 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 			return g.dialUpstream(ctx, network, addr, h, ep, profile)
 		},
 		ForceAttemptHTTP2:   false,
-		IdleConnTimeout:     30 * time.Second,
+		IdleConnTimeout:     5 * time.Second,
 		MaxIdleConns:        128,
 		MaxIdleConnsPerHost: 8,
 	}
@@ -1621,13 +1621,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		var matchBody []byte
 		if req.Body != nil && (req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH") {
 			b, rdErr := io.ReadAll(io.LimitReader(req.Body, 1<<20))
-			req.Body.Close()
 			if rdErr == nil {
 				matchBody = b
-				req.Body = io.NopCloser(bytes.NewReader(b))
-				if req.ContentLength > 0 {
-					req.ContentLength = int64(len(b))
-				}
+				// Re-attach: buffered prefix + rest of original stream.
+				// Do not close req.Body — it still holds bytes beyond 1 MiB.
+				req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(b), req.Body))
 			}
 		}
 
@@ -1817,12 +1815,10 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		var trackedReqBody []byte
 		if trackKind != "" && req.Body != nil {
 			b, _ := io.ReadAll(io.LimitReader(req.Body, 1<<20))
-			req.Body.Close()
 			trackedReqBody = b
-			req.Body = io.NopCloser(bytes.NewReader(b))
-			if req.ContentLength > 0 {
-				req.ContentLength = int64(len(b))
-			}
+			// Re-attach: buffered prefix + rest of original stream.
+			// Do not close req.Body — it still holds bytes beyond 1 MiB.
+			req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(b), req.Body))
 		}
 		// Pre-create session from the request body so streaming SSE
 		// responses (codex /backend-api/codex/responses, anthropic


### PR DESCRIPTION
## Summary

- **Body truncation bug**: `body_json`/`body_contains` match path and LLM tracking path both read up to 1 MiB with `io.LimitReader` then closed the original body and replaced `req.Body` with only the buffered prefix. Requests >1 MiB (e.g. Anthropic API calls with long conversation context) were forwarded with incomplete JSON → 400 from upstream.
- **Fix**: `io.MultiReader(bytes.NewReader(buf), req.Body)` re-attaches the buffered prefix ahead of the still-open original stream. `ContentLength` left unchanged.
- **Stale idle connections**: `IdleConnTimeout` was 30s; GitHub closes idle connections faster, causing intermittent `connection reset by peer` when the pool reuses a dead connection. Reduced to 5s.

## Reproduces as

```
API Error: 400 The request body is not valid JSON: unexpected end of data: line 1 column 1047755 (char 1047754)
```

Truncation always at ~1 MiB (1,048,576 bytes) boundary. Restarting gateway clears the body state and appears to fix it temporarily (actually fixes it because fresh requests are smaller or hit a fresh pool).

## Test plan

- [ ] Send Anthropic API request with conversation context >1 MiB through gateway — verify no 400
- [ ] Verify `body_json` match rules still work on requests <1 MiB
- [ ] Let agent run idle for >15s then make GitHub API call — verify no ECONNRESET

🤖 Generated with [Claude Code](https://claude.com/claude-code)