### PR TITLE
site: reframe landing page around production access

### DIFF
--- a/site/src/components/InstallTerminal.tsx
+++ b/site/src/components/InstallTerminal.tsx
@@ -1,0 +1,49 @@
+import { useState } from "preact/hooks";
+
+export const INSTALL_CMD =
+  "curl -fsSL https://clawpatrol.dev/install.sh | sh";
+
+// Flat install pill for the hero. The dramatic CRT lives in the CTA
+// section at the bottom; up here we want a single-line code line with
+// a copy button, sized to its contents and matching the cream/dark
+// page palette rather than competing with the heading.
+export function InstallTerminal() {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(INSTALL_CMD);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // clipboard unavailable (insecure context); leave the text
+      // selectable so the operator can still copy by hand.
+    }
+  }
+
+  return (
+    <div
+      class="squircle-lg bg-console-dark inline-flex items-center
+        gap-3 pl-4 pr-3 py-3 max-w-full shadow-sm"
+    >
+      <pre
+        class="font-mono text-sm text-canvas flex-1 min-w-0
+          overflow-x-auto whitespace-nowrap leading-none
+          [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        <span class="text-crt-dim">$ </span>{INSTALL_CMD}
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy install command"
+        class="font-mono text-[11px] uppercase tracking-wider
+          shrink-0 transition-colors px-2 py-1
+          text-rust-300 hover:text-rust-200
+          focus:outline-none focus-visible:text-rust-200"
+      >
+        {copied ? "copied" : "copy"}
+      </button>
+    </div>
+  );
+}

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -16,7 +16,7 @@ import { HclCode } from "../components/HclCode";
 
 const LLM_CONFIG = `approver "llm_approver" "secret-judge" {
   model       = "claude-haiku-4-5"
-  policy      = "deny if SELECT touches secret/token columns"
+  policy      = "reject changes with bad words"
   cache_ttl   = 300
   fail_closed = true
 }`;
@@ -67,7 +67,9 @@ function LlmDiagram() {
         <div class="text-text-subtle text-[10px] uppercase tracking-[0.18em] mb-1">
           incoming
         </div>
-        <code class="text-text">SELECT password FROM users</code>
+        <code class="text-text">
+          POST /tickets/reply {"{ "}body: "RTFM you moron"{" }"}
+        </code>
       </div>
 
       <div class="flex items-start gap-2">
@@ -75,8 +77,8 @@ function LlmDiagram() {
           AI
         </div>
         <div class="bg-canvas border border-rust-100 squircle-sm px-3 py-2 text-[12px]  text-text-muted">
-          Column <code class="text-text font-mono">password</code> matches the
-          secret-token policy.
+          Reply body contains banned term{" "}
+          <code class="text-text font-mono">moron</code>.
         </div>
       </div>
 

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -1,4 +1,5 @@
 import { Button } from "../components/Button";
+import { InstallTerminal } from "../components/InstallTerminal";
 
 export function HeroSection() {
   return (
@@ -17,22 +18,26 @@ export function HeroSection() {
                mb-8 font-display text-balance
               text-text"
           >
-            Your control plane for AI agents
+            Let your agents into production.
           </h1>
           <p
             class="mb-10 max-w-lg
             text-text-muted"
           >
-            Decide what your agents can do — before they do it. Claw Patrol is a
-            forward proxy that intercepts every outbound request, runs it
-            against rules you write, and routes the risky ones to a human or an
-            LLM judge for approval. Secrets stay out of the agent. Every
-            decision is logged. Works with Claude Code, Codex, or any agent — no
-            code changes.
+            An agent stuck in a sandbox is a toy. Handing it your prod
+            keys is reckless. Claw Patrol sits at the only universal
+            checkpoint — the network — between your agents and real
+            systems. Every outbound action runs against rules you write
+            in HCL. Risky ones get a human in Slack or an LLM judge.
+            Secrets live in the proxy, not the agent. Works with Claude
+            Code, Codex, or any agent — no code changes.
           </p>
           <Button href="https://github.com/denoland/clawpatrol" size="lg">
             Get Started
           </Button>
+          <div class="mt-5 max-w-lg">
+            <InstallTerminal />
+          </div>
         </div>
 
         <div class="flex justify-center">

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -2,25 +2,28 @@ import { SectionLabel } from "../components/SectionLabel";
 
 const PROBLEMS = [
   {
-    title: "No way to gate writes",
+    title: "Agents are stuck without access",
     body:
-      "Your agent can DROP TABLE, force-push, send the email, delete the " +
-      "repo. By the time you notice, the action's already shipped. " +
-      "There's no checkpoint between intent and damage.",
+      "An agent that can only edit files in a sandbox is a toy. The " +
+      "work that matters — running a migration, replying to a " +
+      "customer, fixing a deploy — lives behind API calls. But every " +
+      "credential you hand the agent is one you've given away.",
   },
   {
-    title: "No audit trail",
+    title: "Prompt injection turns every input into instructions",
     body:
-      "When something goes wrong, you can't reconstruct who decided what. " +
-      "No record of which model called which API, no record of who — or " +
-      "what — approved the destructive action.",
+      "Tool outputs, RAG hits, MCP responses, file contents the agent " +
+      "reads — any of it can hide instructions the model will follow. " +
+      "You can't audit the model's intent. The only thing you can " +
+      "constrain is what leaves the machine.",
   },
   {
-    title: "Secrets in plaintext",
+    title: "Today's options are no-access or YOLO",
     body:
-      "Every API key in the agent's environment is one prompt injection " +
-      "away from exfiltration. The agent doesn't need to see your " +
-      "credentials to use them — but right now it does.",
+      "API keys in env vars, broad OAuth scopes, no checkpoint " +
+      "between intent and damage. By the time you notice the agent " +
+      "ran DROP TABLE on prod, the table is gone — and you have no " +
+      "record of who decided what.",
   },
 ];
 

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -108,7 +108,7 @@ function RuleCodeBlock() {
         <span class="text-rust-300">policy</span>
         {" = "}
         <span class="text-butter-300">
-          "deny if SELECT touches secret/token columns"
+          "reject changes with bad words"
         </span>
         {"\n}"}
       </code>


### PR DESCRIPTION
## Summary
- **Hero**: replaces the generic "Your control plane for AI agents" with **Let your agents into production.** Blurb now leads with the upside (sandbox = toy, prod keys = reckless), names the architectural argument (network-layer checkpoint), and calls out HCL.
- **Problem section**: reorders to match. New #1 is *Agents are stuck without access*. #2 is *Prompt injection turns every input into instructions*. #3 is *Today's options are no-access or YOLO* — collapses the old "audit trail" + "secrets in plaintext" cards into a single broken-current-state framing.
- **Install pill**: new `InstallTerminal` component (single-line `curl | sh` with copy button) wired into the hero below Get Started. Fixes two undefined Tailwind classes that were silently no-op'ing (`text-cream-light` → `text-canvas`, `text-accent` → `text-rust-300`).
- **Approver policy text**: `deny if SELECT touches secret/token columns` → `reject changes with bad words`. LLM-judge diagram updated to match (POST /tickets/reply with a banned term).

## Test plan
- [x] `cd site && npm run build` passes locally
- [ ] Visual check at `/` — hero h1, install pill renders with light text on dark pill, problem section reads cleanly, LLM diagram shows the new content example
