### PR TITLE
docs: auto-generated HCL config reference page

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -3,10 +3,20 @@
 `config/` is clawpatrol's HCL policy loader. The grammar is a typed-
 block dialect — every named entity declares its kind + type via two
 labels, and operators reference entities by bare name. This README
-is the canonical syntax reference; the runtime semantics live in
-`config/runtime/` and the per-plugin schemas in `config/plugins/`.
+is the human-curated narrative reference; the runtime semantics live
+in `config/runtime/` and the per-plugin schemas in `config/plugins/`.
 
 A complete example fixture lives at [`testdata/full.hcl`](testdata/full.hcl).
+The auto-generated, exhaustive field reference lives at
+[`site/doc/15-config-reference.md`](../site/doc/15-config-reference.md) —
+regenerate it with:
+
+```
+go run ./tools/docgen -out site/doc/15-config-reference.md
+```
+
+(equivalently: `go generate ./tools/docgen`). A `go test ./tools/docgen/...`
+drift check fails CI if the committed file goes stale.
 
 ## Top-level structure
 

--- a/site/doc/15-config-reference.md
+++ b/site/doc/15-config-reference.md
@@ -1,0 +1,662 @@
+# Configuration reference
+
+Auto-generated from the source of truth in `config/plugins/`.
+Do not hand-edit; run `go run ./tools/docgen -out site/doc/15-config-reference.md` to regenerate.
+
+A clawpatrol gateway loads one HCL file (typically `/etc/clawpatrol/gateway.hcl`).
+The file mixes **operational** fields (gateway plumbing) with **policy** blocks. Operational
+fields decode statically; policy blocks dispatch to plugins by their first label. References
+between named entities are bare names — no kind prefix, no type prefix — and the namespace
+is flat.
+
+For a worked tour of the grammar, see `config/README.md`; this page is the
+exhaustive field reference.
+
+## Top-level fields
+
+Gateway is the fully-loaded clawpatrol gateway config: operational fields at the top, plus a resolved policy.
+
+Operational fields are still decoded via plain gohcl struct tags — they're not pluggable. Anything below `tailscale {}` is dispatched to the plugin registry.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `listen` | string | no |  |
+| `info_listen` | string | no |  |
+| `public_url` | string | no |  |
+| `admin_email` | string | no |  |
+| `ca_dir` | string | no |  |
+| `resolver` | string | no |  |
+| `log_path` | string | no |  |
+| `oauth_dir` | string | no |  |
+| `dashboard_secret` | string | no |  |
+| `insecure_no_dashboard_secret` | bool | no | InsecureNoDashboardSecret opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
+| `session_keep` | string | no | SessionKeep is the hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
+
+### `gateway {}` block
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `authkey` | string | no |  |
+| `control_url` | string | no |  |
+| `hostname` | string | no |  |
+| `state_dir` | string | no |  |
+| `control` | string | no |  |
+| `oauth_client_id` | string | no |  |
+| `oauth_client_secret` | string | no |  |
+| `tags` | list of string | no |  |
+| `wg_interface` | string | no |  |
+| `wg_endpoint` | string | no |  |
+| `wg_server_pub` | string | no |  |
+| `wg_subnet_cidr` | string | no |  |
+
+## `defaults {}`
+
+Defaults captures the singleton defaults {} block.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `unknown_host` | string | no |  |
+| `llm_fail_mode` | string | no |  |
+| `llm_cache_ttl` | number | no |  |
+| `human_timeout` | number | no |  |
+| `human_on_timeout` | string | no |  |
+
+Example:
+
+```hcl
+defaults {
+  unknown_host       = "<value>"
+  llm_fail_mode      = "<value>"
+  llm_cache_ttl      = 0
+  human_timeout      = 0
+  human_on_timeout   = "<value>"
+}
+```
+
+## `policy "<name>" {}`
+
+Reusable LLM proctor prompt. Referenced by name from `approver` blocks (LLM judges) and `rule` `approve` chains. Heredoc-friendly.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `text` | string | yes |  |
+
+Example:
+
+```hcl
+policy "k8s-exec-content" {
+  text = <<-EOT
+    Inspect the kubectl exec command (each ?command= argv element).
+    Deny if it dumps env vars, reads sensitive host-mount files...
+  EOT
+}
+```
+
+## `profile "<name>" {}`
+
+Endpoint membership list. A device's profile gets exactly the endpoints its profile names; rules ride along automatically because they're attached to endpoints.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `endpoints` | list of string | yes | Bare-name references to declared endpoints. |
+
+Example:
+
+```hcl
+profile "kaju" {
+  endpoints = [github-kaju, slack-kaju, grafana]
+}
+```
+
+## `device "<ip>" {}`
+
+Per-device rule overrides. Nested `rule "<type>" "<name>"` blocks decode through the same plugin pipeline as top-level rules; the compiler pins each rule to the device IP automatically and adds a +1000 priority bump so device overrides win against profile rules at the same explicit priority.
+
+- Nested rules reference the device's IP implicitly. Do **not** add `peer_ip = ...` — the dispatcher handles peer scoping.
+- An endpoint referenced by a device rule is auto-added to every profile's HostIndex so dispatch finds it. Other devices' traffic to those hosts gets MITM'd but no rule fires.
+- The dashboard's per-device editor accepts `device {}` blocks alongside `endpoint`, `credential`, `approver`, and `policy` blocks.
+
+Example:
+
+```hcl
+device "10.55.0.2" {
+  rule "http_rule" "deny-tinyclouds" {
+    endpoint = github-api
+    match    = { path = "/tinyclouds/*" }
+    verdict  = "deny"
+    reason   = "this device shouldn't reach tinyclouds"
+  }
+}
+```
+
+## Approvers
+
+Who arbitrates `approve = [...]` chains. Reference an approver by its bare name from a rule's `approve` list. The built-in `dashboard` approver does not require a block — `approve = [dashboard]` resolves to the built-in.
+
+### `approver "human_approver" "<name>"`
+
+HumanApprover targets one channel. Timeout / require_approvers override the global defaults block on a per-approver basis.
+
+Credential references a credential whose body satisfies HITLNotifier (slack_tokens today; future Discord / Telegram / SMTP credentials). Leave empty for a dashboard-only approver (no channel notification; operator clicks approve/deny on the dashboard).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `channel` | string | yes |  |
+| `credential` | string | no |  |
+| `timeout` | number | no |  |
+| `require_approvers` | number | no |  |
+| `interactive` | bool | no | Interactive toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
+
+Example:
+
+```hcl
+approver "human_approver" "<name>" {
+  channel      = "<value>"
+}
+```
+
+### `approver "llm_approver" "<name>"`
+
+LLMApprover carries the model + the credential used to authenticate the call to the model API + the policy text the model judges against. Inline `policy` is a bare-name reference to a `policy "<name>" { text = ... }` block — operator declares the prompt once and reuses across multiple judges.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `model` | string | yes |  |
+| `credential` | string | yes |  |
+| `policy` | string | no |  |
+
+Example:
+
+```hcl
+approver "llm_approver" "<name>" {
+  model        = "<value>"
+  credential   = "<value>"
+}
+```
+
+## Credentials
+
+Typed handle to a secret. The actual secret bytes live in the gateway's secret store (env vars by default, keyed by `CLAWPATROL_SECRET_<UPPER_NAME>`); the credential block carries only how-to-inject parameters.
+
+### `credential "anthropic_manual_key" "<name>"`
+
+anthropic_manual_key: Anthropic API key stamped into the `x-api-key` header (Anthropic's bearer-style header for direct API keys; OAuth subscriptions use Authorization, see anthropic_oauth.go).
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "anthropic_manual_key" "<name>" {}
+```
+
+### `credential "anthropic_oauth_subscription" "<name>"`
+
+anthropic_oauth_subscription: claude.ai → console.anthropic.com OAuth flow. Stamps the bearer + the beta header that gates Anthropic's OAuth-backed access.
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "anthropic_oauth_subscription" "<name>" {}
+```
+
+### `credential "aws_eks_credential" "<name>"`
+
+aws_eks_credential: the kubernetes endpoint plugin runs `aws eks get-token` at request time using these parameters and uses the resulting bearer as the Authorization header. Configured via mTLS / IAM at the cluster level — no paste-secret slots, no env pushdown.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `cluster` | string | yes |  |
+| `region` | string | yes |  |
+| `profile` | string | no |  |
+
+Example:
+
+```hcl
+credential "aws_eks_credential" "<name>" {
+  cluster      = "<value>"
+  region       = "<value>"
+}
+```
+
+### `credential "bearer_token" "<name>"`
+
+bearer_token: Authorization: Bearer <secret>. Optional idempotency_key flag stamps a derived Idempotency-Key header on writes when the agent didn't already.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `idempotency_key` | bool | no |  |
+
+Example:
+
+```hcl
+credential "bearer_token" "<name>" {}
+```
+
+### `credential "clickhouse_credential" "<name>"`
+
+clickhouse_credential: HTTPS API takes user + password as query params (?user=…&password=…) or basic-auth header. We populate both — basic-auth handles default-auth ClickHouse setups, query params handle setups that disable header auth.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | no |  |
+
+Example:
+
+```hcl
+credential "clickhouse_credential" "<name>" {}
+```
+
+### `credential "cookie_token" "<name>"`
+
+cookie_token: stamp the secret as an HTTP cookie under the configured name.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `cookie_name` | string | no |  |
+
+Example:
+
+```hcl
+credential "cookie_token" "<name>" {}
+```
+
+### `credential "gemini_api_key" "<name>"`
+
+gemini_api_key: Google Gemini accepts the API key in either the `x-goog-api-key` header or the `?key=` query parameter. Always overwrite both — agents that send placeholder values get them swapped; agents that don't send anything get the real key stamped in.
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "gemini_api_key" "<name>" {}
+```
+
+### `credential "github_oauth" "<name>"`
+
+github_oauth: bearer token from gh's device-flow OAuth. Used by gh CLI + the GitHub REST API (api.github.com / raw.githubusercontent.com).
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "github_oauth" "<name>" {}
+```
+
+### `credential "header_token" "<name>"`
+
+header_token: stamp the secret onto an arbitrary header, optionally prefixed (e.g. "Bearer ", "Token ").
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `header` | string | yes |  |
+| `prefix` | string | no |  |
+
+Example:
+
+```hcl
+credential "header_token" "<name>" {
+  header       = "<value>"
+}
+```
+
+### `credential "mtls_credential" "<name>"`
+
+mtls_credential: client cert + key (+ optional CA bundle) for mTLS-authenticated upstreams (k8s API servers, internal CAs). Configures the upstream tls.Config rather than stamping a header.
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "mtls_credential" "<name>" {}
+```
+
+### `credential "notion_oauth" "<name>"`
+
+notion_oauth: Bearer token in Authorization + Notion-Version header (Notion's API requires the version, defaults to a recent stable).
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "notion_oauth" "<name>" {}
+```
+
+### `credential "openai_codex_oauth" "<name>"`
+
+openai_codex_oauth: bearer token for the codex CLI's OAuth flow. api.openai.com + chatgpt.com both accept Authorization: Bearer.
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "openai_codex_oauth" "<name>" {}
+```
+
+### `credential "postgres_credential" "<name>"`
+
+postgres_credential: the wire-protocol user the runtime uses when terminating upstream auth on the agent's behalf. User is the HCL field; password lives in the secret store under the credential's bare name (operator pastes via the dashboard's Postgres slot).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | no |  |
+
+Example:
+
+```hcl
+credential "postgres_credential" "<name>" {}
+```
+
+### `credential "slack_tokens" "<name>"`
+
+slack_tokens: bot + app token pair plus the optional signing secret. Implements:
+
+  - HTTPCredentialRuntime — pick the right token per Slack endpoint
+    and stamp Authorization: Bearer.
+  - HITLNotifier          — post Block Kit approval prompts to a
+    channel; powers the human_approver plugin without approvers
+    having to know anything Slack-specific.
+  - WebhookProvider       — handle Slack's interactive (button-click)
+    callback. Mounted by main at /api/cred/<credName>/interactive.
+
+Adding another notification channel (Discord, Telegram, SMTP) is a new credential plugin with its own NotifyHITL — no human_approver / runtime.go changes.
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "slack_tokens" "<name>" {}
+```
+
+### `credential "ssh" "<name>"`
+
+ssh credential: the auth material the SSH endpoint runtime replays upstream on the agent's behalf. The credential carries only key / password / host-pubkey-pin — the username sent upstream is the one the agent typed, passed through verbatim. Per-username dispatch (e.g. `ssh root@host` vs `ssh deploy@host` picking different keys) lives on the endpoint via the `credentials = [{user=..., credential=...}]` list, mirroring postgres' placeholder-based dispatch.
+
+Material is split across slots so operators can paste a multi-line PEM into one textarea and a single-line passphrase into another:
+
+  private_key  multi-line   OpenSSH / PKCS#8 / PKCS#1 PEM
+  passphrase   single-line  optional, decrypts private_key
+  password     single-line  optional, used when no key is set
+  host_pubkey  single-line  optional, ssh-keyscan-style line for
+                            upstream host pinning
+
+At least one of (private_key, password) must be filled at runtime — the endpoint surfaces a clear error to the agent if both are empty.
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "ssh" "<name>" {}
+```
+
+### `credential "telegram_bot_token" "<name>"`
+
+telegram_bot_token: bot token lives in the URL path (/bot<TOKEN>/<METHOD>) and sometimes in the request body (setWebhook posts a URL containing the token). We swap every occurrence of the operator-emitted placeholder with the real secret — operator's CLI uses the placeholder verbatim; gateway substitutes globally so the token never hits the upstream as the placeholder and never leaks to logs.
+
+Telegram doesn't appear in `clawpatrol env` because Telegram SDKs take the token as an explicit argument rather than reading it from the env, so there's nothing to "push down".
+
+_No body attributes._
+
+Example:
+
+```hcl
+credential "telegram_bot_token" "<name>" {}
+```
+
+## Endpoints
+
+Typed upstream binding. Each endpoint type maps to a protocol family (`https`, `sql`, `k8s`, `ssh`); rules constrain themselves to a matching family.
+
+### `endpoint "clickhouse_https" "<name>"`
+
+**Family:** `sql`.
+
+clickhouse_https endpoint: HTTPS API surface for ClickHouse. Pairs with clickhouse_native (same upstream cluster, different protocol) so rules can target both via `endpoints = [ch-https, ch-native]`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `hosts` | list of string | yes |  |
+| `credential` | string | no |  |
+
+Example:
+
+```hcl
+endpoint "clickhouse_https" "<name>" {
+  hosts        = ["<value>"]
+}
+```
+
+### `endpoint "clickhouse_native" "<name>"`
+
+**Family:** `sql`.
+
+ClickhouseNativeEndpoint addresses one ClickHouse server reachable via the binary native protocol. Operators bind a single clickhouse_credential; the runtime parses the agent's Hello and substitutes the credential's (user, password) where the agent embedded a placeholder.
+
+TLS toggles TLS on both hops: the gateway terminates the agent's TLS using a leaf minted off the gateway CA, parses the Hello in plaintext, then re-wraps to upstream. The wrapped client therefore keeps speaking native-over-TLS exactly as it would against the real cloud ClickHouse — `clawpatrol run` is transparent to its TLS posture. Default false: WG-only deployments where the operator wants plaintext on the inner hop (typical self-hosted ClickHouse on 9000 behind a private network) leave it off.
+
+AcceptInvalidCertificate mirrors clickhouse-client's flag of the same name: when true and tls is on, the gateway skips upstream cert validation. Use for self-hosted ClickHouse fronted by a private CA. Default false keeps full validation against system roots.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `hosts` | list of string | yes |  |
+| `port` | number | no |  |
+| `tls` | bool | no |  |
+| `accept_invalid_certificate` | bool | no |  |
+| `credential` | string | no |  |
+
+Example:
+
+```hcl
+endpoint "clickhouse_native" "<name>" {
+  hosts        = ["<value>"]
+}
+```
+
+### `endpoint "https" "<name>"`
+
+**Family:** `https`.
+
+https endpoint: anything that speaks TLS-wrapped HTTP. Covers most API-style upstreams. The kubernetes endpoint is HTTPS underneath too but ships as its own type because it carries server / ca_cert metadata HTTPS doesn't.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `hosts` | list of string | yes |  |
+| `credential` | string | no |  |
+| `credentials` | list of object | no |  |
+
+Example:
+
+```hcl
+endpoint "https" "<name>" {
+  hosts        = ["<value>"]
+}
+```
+
+### `endpoint "kubernetes" "<name>"`
+
+**Family:** `k8s`.
+
+kubernetes endpoint: self-hosted clusters (server + ca_cert) and managed clusters (hosts + EKS-style credential resolved at request time).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `hosts` | list of string | no |  |
+| `server` | string | no |  |
+| `ca_cert` | string | no |  |
+| `description` | string | no |  |
+| `credential` | string | no |  |
+
+Example:
+
+```hcl
+endpoint "kubernetes" "<name>" {}
+```
+
+### `endpoint "openai_codex_https" "<name>"`
+
+**Family:** `https`.
+
+openai_codex_https endpoint: chatgpt.com path for codex-cli's subscription auth flow. Pushes a synthesized Agent Identity JWT down via env (CODEX_ACCESS_TOKEN / CODEX_AGENT_IDENTITY) so codex enters AgentIdentity mode and routes to chatgpt.com on its own. At MITM time we serve the matching JWKS at `/backend-api/wham/agent-identities/jwks` and stub the agent-task registration POST. Codex's Authorization gets overwritten by the bound credential plugin (openai_codex_oauth) before forwarding upstream, so the AgentAssertion never has to validate against OpenAI's real identity service.
+
+Sample HCL:
+
+	credential "openai_codex_oauth" "codex" {}
+
+	endpoint "openai_codex_https" "codex" {
+	  hosts      = ["chatgpt.com"]
+	  credential = codex
+	}
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `hosts` | list of string | yes |  |
+| `credential` | string | no |  |
+| `credentials` | list of object | no |  |
+
+Example:
+
+```hcl
+endpoint "openai_codex_https" "<name>" {
+  hosts        = ["<value>"]
+}
+```
+
+### `endpoint "postgres" "<name>"`
+
+**Family:** `sql`.
+
+PostgresEndpoint addresses a single RDS-or-equivalent server. Tunnel topologies (kubectl-portforward-ssh and friends) aren't supported in this iteration — operators run the gateway with network reachability already arranged.
+
+SSLMode mirrors libpq's sslmode names — "disable" / "prefer" / "require" / "verify-full". Default "prefer": try TLS, fall back to plain when the upstream replies 'N'. "require" hard-fails on 'N'. "verify-full" additionally validates the upstream cert against Host. "disable" skips the SSLRequest probe entirely — fine for self-hosted pg on a private network where WG already encrypts the path.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `host` | string | yes |  |
+| `database` | string | yes |  |
+| `sslmode` | string | no |  |
+| `credential` | string | no |  |
+| `credentials` | list of object | no |  |
+
+Example:
+
+```hcl
+endpoint "postgres" "<name>" {
+  host         = "<value>"
+  database     = "<value>"
+}
+```
+
+### `endpoint "ssh" "<name>"`
+
+**Family:** `ssh`.
+
+SSHEndpoint binds one or more host:port tuples to one or more SSH credentials. The agent's username is the discriminator for per-username dispatch (mirrors postgres' placeholder-based dispatch, just spelled `user` because that's what SSH calls it):
+
+	credential = X                                  // any user → X
+	credentials = [{ user = "root",   credential = X },
+	               { user = "deploy", credential = Y },
+	               { credential = Z }]              // fallback
+
+The agent's username is also passed through verbatim as the upstream SSH user — credentials carry only auth material (key / password / host_pubkey), never a username override.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `hosts` | list of string | yes |  |
+| `credential` | string | no |  |
+| `credentials` | list of object | no |  |
+
+Example:
+
+```hcl
+endpoint "ssh" "<name>" {
+  hosts        = ["<value>"]
+}
+```
+
+## Rules
+
+One policy decision targeting one or more endpoints. Each rule type is constrained to a matching endpoint family. The shared `RuleBody` schema below applies to all rule types; the per-family match keys are listed under each type.
+
+### `rule "http_rule" "<name>"`
+
+**Endpoint families:** `https`.
+
+RuleBody is the shared shape across all three rule types. The match keys vary by family (interpreted in Build), but the outer frame is identical: endpoint targeting, priority, outcome.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `endpoint` | string | no |  |
+| `endpoints` | list of string | no |  |
+| `priority` | number | no |  |
+| `disabled` | bool | no |  |
+| `match` | object | no | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | string | no | Outcome: exactly one of verdict / approve. |
+| `reason` | string | no |  |
+| `approve` | list | no |  |
+
+**`match` keys (http_rule):** `body_contains`, `body_json`, `credential`, `headers`, `method`, `path`, `query`. Each value accepts a single string or a list (any-of). Strings starting with `!` are negated.
+
+Example:
+
+```hcl
+rule "http_rule" "<name>" {}
+```
+
+### `rule "k8s_rule" "<name>"`
+
+**Endpoint families:** `k8s`.
+
+RuleBody is the shared shape across all three rule types. The match keys vary by family (interpreted in Build), but the outer frame is identical: endpoint targeting, priority, outcome.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `endpoint` | string | no |  |
+| `endpoints` | list of string | no |  |
+| `priority` | number | no |  |
+| `disabled` | bool | no |  |
+| `match` | object | no | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | string | no | Outcome: exactly one of verdict / approve. |
+| `reason` | string | no |  |
+| `approve` | list | no |  |
+
+**`match` keys (k8s_rule):** `credential`, `name`, `namespace`, `params`, `resource`, `verb`. Each value accepts a single string or a list (any-of). Strings starting with `!` are negated.
+
+Example:
+
+```hcl
+rule "k8s_rule" "<name>" {}
+```
+
+### `rule "sql_rule" "<name>"`
+
+**Endpoint families:** `sql`.
+
+RuleBody is the shared shape across all three rule types. The match keys vary by family (interpreted in Build), but the outer frame is identical: endpoint targeting, priority, outcome.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `endpoint` | string | no |  |
+| `endpoints` | list of string | no |  |
+| `priority` | number | no |  |
+| `disabled` | bool | no |  |
+| `match` | object | no | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | string | no | Outcome: exactly one of verdict / approve. |
+| `reason` | string | no |  |
+| `approve` | list | no |  |
+
+**`match` keys (sql_rule):** `credential`, `function`, `statement`, `statement_regex`, `tables`, `verb`. Each value accepts a single string or a list (any-of). Strings starting with `!` are negated.
+
+Example:
+
+```hcl
+rule "sql_rule" "<name>" {}
+```

--- a/tools/docgen/docgen_test.go
+++ b/tools/docgen/docgen_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDocReferenceUpToDate fails when site/doc/15-config-reference.md
+// drifts from what docgen produces against the current source. Run
+// `go run ./tools/docgen -out site/doc/15-config-reference.md` to fix.
+func TestDocReferenceUpToDate(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+
+	idx, err := indexDocs(root)
+	if err != nil {
+		t.Fatalf("indexDocs: %v", err)
+	}
+	got, err := render(idx)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	want, err := os.ReadFile(filepath.Join(root, "site/doc/15-config-reference.md"))
+	if err != nil {
+		t.Fatalf("read committed reference: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf(`site/doc/15-config-reference.md is stale.
+
+Run:
+    go run ./tools/docgen -out site/doc/15-config-reference.md
+
+then commit the result.`)
+	}
+}
+
+// repoRoot walks up from the test's working directory until it finds
+// a go.mod. tools/docgen lives at <root>/tools/docgen so the parent
+// of cwd's parent is the root, but walking up is robust to refactors.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}

--- a/tools/docgen/gen.go
+++ b/tools/docgen/gen.go
@@ -1,0 +1,13 @@
+// Package main hosts the docgen generator and its drift-check test.
+//
+// Regenerate the committed config reference page from anywhere in the
+// repo:
+//
+//	go run ./tools/docgen -out site/doc/15-config-reference.md
+//
+// The drift check (`go test ./tools/docgen/...`) fails CI when the
+// committed file no longer matches what the generator produces against
+// the current plugin sources.
+package main
+
+//go:generate go run . -root ../.. -out ../../site/doc/15-config-reference.md

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -1,0 +1,685 @@
+// docgen renders site/doc/15-config-reference.md from the live plugin
+// registry. Run via `go run ./tools/docgen -out site/doc/15-config-reference.md`
+// (or `go generate ./...` — see tools/docgen/gen.go).
+//
+// Why a hand-rolled generator (and not terraform-docs / gomarkdoc / hcldec):
+//
+//   - terraform-docs is wired to Terraform's variable / output / resource
+//     shape. Clawpatrol's grammar is a typed-block dialect with custom
+//     two-label kinds (`endpoint "<type>" "<name>"`, `credential "<type>"
+//     "<name>"`, etc.) dispatched to plugins by their first label. There's
+//     no template hook in terraform-docs that lets you re-shape that.
+//   - gomarkdoc renders Go package API docs. It can't see HCL field tags,
+//     and the output (a Go-API reference) isn't what a config author wants.
+//   - hcldec is a runtime spec library; nothing in the HCL ecosystem
+//     ships a maintained doc generator that consumes plugin-dispatched
+//     custom block kinds.
+//   - terraform-plugin-docs is hard-coded to Terraform provider schemas.
+//     Wrong shape.
+//
+// The plugin registry already has every fact we need: each plugin's
+// `New() any` returns a struct whose fields carry `hcl:"..."` tags, and
+// the file's Go doc comments describe the block. Reflection + go/parser
+// is the smallest faithful path; emitting our own Markdown costs ~400
+// lines and stays in lock-step with the source of truth.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+func main() {
+	out := flag.String("out", "", "output file (defaults to stdout)")
+	root := flag.String("root", ".", "repo root (must contain go.mod)")
+	flag.Parse()
+
+	rootAbs, err := filepath.Abs(*root)
+	if err != nil {
+		die("resolve root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootAbs, "go.mod")); err != nil {
+		die("root %q does not contain go.mod: %v", rootAbs, err)
+	}
+
+	idx, err := indexDocs(rootAbs)
+	if err != nil {
+		die("index docs: %v", err)
+	}
+
+	md, err := render(idx)
+	if err != nil {
+		die("render: %v", err)
+	}
+
+	if *out == "" {
+		os.Stdout.Write(md)
+		return
+	}
+	if err := os.WriteFile(*out, md, 0o644); err != nil {
+		die("write %s: %v", *out, err)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "docgen: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+// ---------------------------------------------------------------------
+// Doc index — built from go/parser AST traversal of source dirs.
+// ---------------------------------------------------------------------
+
+type structDoc struct {
+	GoTypeName  string
+	PackagePath string
+	Description string                  // doc comment immediately above the struct
+	FileLead    string                  // file-level lead comment (used as fallback)
+	Fields      map[string]fieldDocText // keyed by Go field name
+}
+
+type fieldDocText struct {
+	Name        string
+	Description string
+}
+
+// docIndex maps `<pkgPath>.<TypeName>` → structDoc.
+type docIndex struct {
+	structs map[string]structDoc
+}
+
+// dirsToIndex returns every source directory we need to read comments
+// from. Tied to where plugins live + where the operational structs live.
+var dirsToIndex = []string{
+	"config",
+	"config/plugins/credentials",
+	"config/plugins/endpoints",
+	"config/plugins/approvers",
+	"config/plugins/rules",
+}
+
+func indexDocs(root string) (*docIndex, error) {
+	idx := &docIndex{structs: map[string]structDoc{}}
+	for _, rel := range dirsToIndex {
+		dir := filepath.Join(root, rel)
+		fset := token.NewFileSet()
+		pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+			// Skip _test.go — they don't carry config schema.
+			return !strings.HasSuffix(fi.Name(), "_test.go")
+		}, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", rel, err)
+		}
+		// Map dir → import path. We rely on the project layout
+		// (rel path under module = import path under module path).
+		for _, pkg := range pkgs {
+			pkgPath := "github.com/denoland/clawpatrol/" + filepath.ToSlash(rel)
+			collectStructs(idx, pkg, pkgPath)
+		}
+	}
+	return idx, nil
+}
+
+func collectStructs(idx *docIndex, pkg *ast.Package, pkgPath string) {
+	for _, file := range pkg.Files {
+		fileLead := fileLeadComment(file)
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			// A GenDecl can hold one or more TypeSpecs. The doc lives
+			// on the GenDecl when it has a single spec, on the spec
+			// otherwise.
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				doc := ts.Doc
+				if doc == nil && len(gd.Specs) == 1 {
+					doc = gd.Doc
+				}
+				sd := structDoc{
+					GoTypeName:  ts.Name.Name,
+					PackagePath: pkgPath,
+					Description: textFromCommentGroup(doc),
+					FileLead:    fileLead,
+					Fields:      map[string]fieldDocText{},
+				}
+				for _, f := range st.Fields.List {
+					if len(f.Names) == 0 {
+						continue
+					}
+					for _, n := range f.Names {
+						sd.Fields[n.Name] = fieldDocText{
+							Name:        n.Name,
+							Description: textFromCommentGroup(f.Doc),
+						}
+					}
+				}
+				idx.structs[pkgPath+"."+ts.Name.Name] = sd
+			}
+		}
+	}
+}
+
+// fileLeadComment returns the first orphan comment group in a file —
+// the comment that sits between the package clause and the first
+// declaration, conventionally describing what the file is about. Used
+// as a fallback when a struct has no doc comment of its own (the
+// pattern in config/plugins/*/<name>.go).
+func fileLeadComment(file *ast.File) string {
+	if len(file.Comments) == 0 {
+		return ""
+	}
+	pkgEnd := file.Name.End()
+	var firstDeclStart token.Pos
+	if len(file.Decls) > 0 {
+		firstDeclStart = file.Decls[0].Pos()
+	}
+	for _, cg := range file.Comments {
+		if cg.Pos() <= pkgEnd {
+			continue
+		}
+		if firstDeclStart != token.NoPos && cg.End() >= firstDeclStart {
+			return ""
+		}
+		return textFromCommentGroup(cg)
+	}
+	return ""
+}
+
+func textFromCommentGroup(g *ast.CommentGroup) string {
+	if g == nil {
+		return ""
+	}
+	var lines []string
+	for _, c := range g.List {
+		t := c.Text
+		switch {
+		case strings.HasPrefix(t, "// "):
+			lines = append(lines, t[3:])
+		case strings.HasPrefix(t, "//"):
+			lines = append(lines, t[2:])
+		case strings.HasPrefix(t, "/*"):
+			t = strings.TrimPrefix(t, "/*")
+			t = strings.TrimSuffix(t, "*/")
+			lines = append(lines, strings.TrimSpace(t))
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// ---------------------------------------------------------------------
+// HCL tag parsing.
+// ---------------------------------------------------------------------
+
+type hclTag struct {
+	Name     string
+	Optional bool
+	Block    bool
+	Label    bool
+	Remain   bool
+	Skip     bool
+}
+
+func parseHCLTag(tag reflect.StructTag) (hclTag, bool) {
+	raw, ok := tag.Lookup("hcl")
+	if !ok {
+		return hclTag{}, false
+	}
+	parts := strings.Split(raw, ",")
+	t := hclTag{Name: parts[0]}
+	for _, p := range parts[1:] {
+		switch strings.TrimSpace(p) {
+		case "optional":
+			t.Optional = true
+		case "block":
+			t.Block = true
+		case "label":
+			t.Label = true
+		case "remain":
+			t.Remain = true
+		}
+	}
+	if t.Name == "-" || (t.Name == "" && !t.Remain) {
+		t.Skip = true
+	}
+	return t, true
+}
+
+// ---------------------------------------------------------------------
+// Field rendering.
+// ---------------------------------------------------------------------
+
+type renderedField struct {
+	HCLName     string
+	HCLType     string
+	Required    bool
+	Description string
+}
+
+func describeStruct(idx *docIndex, st reflect.Type) (description string, fields []renderedField, blockFields []blockSubField) {
+	if st.Kind() == reflect.Pointer {
+		st = st.Elem()
+	}
+	key := st.PkgPath() + "." + st.Name()
+	sd, ok := idx.structs[key]
+	if ok {
+		description = sd.Description
+		if description == "" {
+			description = sd.FileLead
+		}
+	}
+	for i := 0; i < st.NumField(); i++ {
+		f := st.Field(i)
+		tag, ok := parseHCLTag(f.Tag)
+		if !ok || tag.Skip || tag.Remain || tag.Label {
+			continue
+		}
+		fdoc := ""
+		if sd.Fields != nil {
+			if d, ok := sd.Fields[f.Name]; ok {
+				fdoc = d.Description
+			}
+		}
+		if tag.Block {
+			blockFields = append(blockFields, blockSubField{
+				HCLName:     tag.Name,
+				StructType:  f.Type,
+				Description: fdoc,
+			})
+			continue
+		}
+		fields = append(fields, renderedField{
+			HCLName:     tag.Name,
+			HCLType:     hclTypeName(f.Type, tag.Name),
+			Required:    !tag.Optional,
+			Description: fdoc,
+		})
+	}
+	return description, fields, blockFields
+}
+
+type blockSubField struct {
+	HCLName     string
+	StructType  reflect.Type
+	Description string
+}
+
+// hclTypeName renders a Go type as an HCL-friendly type label. cty.Value
+// fields are deliberately heterogeneous and surface as "object" or "list"
+// based on how the plugin uses them; we look at a small number of known
+// HCL field names to give a useful hint instead of "value".
+func hclTypeName(t reflect.Type, hclName string) string {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.PkgPath() == "github.com/zclconf/go-cty/cty" && t.Name() == "Value" {
+		switch hclName {
+		case "match":
+			return "object"
+		case "approve":
+			return "list"
+		case "credentials":
+			return "list of object"
+		}
+		return "value"
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "bool"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "number"
+	case reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Slice:
+		return "list of " + hclTypeName(t.Elem(), "")
+	case reflect.Map:
+		return fmt.Sprintf("map[%s]%s", hclTypeName(t.Key(), ""), hclTypeName(t.Elem(), ""))
+	case reflect.Struct:
+		return "block"
+	}
+	return strings.ToLower(t.Kind().String())
+}
+
+// ---------------------------------------------------------------------
+// Markdown rendering.
+// ---------------------------------------------------------------------
+
+func render(idx *docIndex) ([]byte, error) {
+	var b strings.Builder
+
+	b.WriteString(`# Configuration reference
+
+Auto-generated from the source of truth in ` + "`config/plugins/`" + `.
+Do not hand-edit; run ` + "`go run ./tools/docgen -out site/doc/15-config-reference.md`" + ` to regenerate.
+
+A clawpatrol gateway loads one HCL file (typically ` + "`/etc/clawpatrol/gateway.hcl`" + `).
+The file mixes **operational** fields (gateway plumbing) with **policy** blocks. Operational
+fields decode statically; policy blocks dispatch to plugins by their first label. References
+between named entities are bare names — no kind prefix, no type prefix — and the namespace
+is flat.
+
+For a worked tour of the grammar, see ` + "`config/README.md`" + `; this page is the
+exhaustive field reference.
+
+`)
+
+	b.WriteString("## Top-level fields\n\n")
+	gwType := reflect.TypeOf(config.Gateway{})
+	desc, fields, blocks := describeStruct(idx, gwType)
+	if desc != "" {
+		b.WriteString(paragraphify(desc) + "\n\n")
+	}
+	writeFieldTable(&b, fields)
+
+	for _, sub := range blocks {
+		b.WriteString(fmt.Sprintf("\n### `%s {}` block\n\n", sub.HCLName))
+		if sub.Description != "" {
+			b.WriteString(paragraphify(sub.Description) + "\n\n")
+		}
+		_, subFields, _ := describeStruct(idx, sub.StructType)
+		writeFieldTable(&b, subFields)
+	}
+
+	// defaults {}
+	b.WriteString("\n## `defaults {}`\n\n")
+	defType := reflect.TypeOf(config.Defaults{})
+	defDesc, defFields, _ := describeStruct(idx, defType)
+	if defDesc != "" {
+		b.WriteString(paragraphify(defDesc) + "\n\n")
+	}
+	writeFieldTable(&b, defFields)
+	b.WriteString("\nExample:\n\n```hcl\n")
+	b.WriteString(synthExampleSimple("defaults", "", defFields))
+	b.WriteString("```\n")
+
+	// policy "<name>" {}
+	b.WriteString("\n## `policy \"<name>\" {}`\n\n")
+	b.WriteString("Reusable LLM proctor prompt. Referenced by name from `approver` blocks (LLM judges) and `rule` `approve` chains. Heredoc-friendly.\n\n")
+	ptType := reflect.TypeOf(config.PolicyText{})
+	_, ptFields, _ := describeStruct(idx, ptType)
+	writeFieldTable(&b, ptFields)
+	b.WriteString("\nExample:\n\n```hcl\npolicy \"k8s-exec-content\" {\n  text = <<-EOT\n    Inspect the kubectl exec command (each ?command= argv element).\n    Deny if it dumps env vars, reads sensitive host-mount files...\n  EOT\n}\n```\n")
+
+	// profile "<name>" {}
+	b.WriteString("\n## `profile \"<name>\" {}`\n\n")
+	b.WriteString("Endpoint membership list. A device's profile gets exactly the endpoints its profile names; rules ride along automatically because they're attached to endpoints.\n\n")
+	b.WriteString("| Field | Type | Required | Description |\n|---|---|---|---|\n")
+	b.WriteString("| `endpoints` | list of string | yes | Bare-name references to declared endpoints. |\n")
+	b.WriteString("\nExample:\n\n```hcl\nprofile \"kaju\" {\n  endpoints = [github-kaju, slack-kaju, grafana]\n}\n```\n")
+
+	// device "<ip>" {}
+	b.WriteString("\n## `device \"<ip>\" {}`\n\n")
+	b.WriteString("Per-device rule overrides. Nested `rule \"<type>\" \"<name>\"` blocks decode through the same plugin pipeline as top-level rules; the compiler pins each rule to the device IP automatically and adds a +1000 priority bump so device overrides win against profile rules at the same explicit priority.\n\n")
+	b.WriteString("- Nested rules reference the device's IP implicitly. Do **not** add `peer_ip = ...` — the dispatcher handles peer scoping.\n")
+	b.WriteString("- An endpoint referenced by a device rule is auto-added to every profile's HostIndex so dispatch finds it. Other devices' traffic to those hosts gets MITM'd but no rule fires.\n")
+	b.WriteString("- The dashboard's per-device editor accepts `device {}` blocks alongside `endpoint`, `credential`, `approver`, and `policy` blocks.\n\n")
+	b.WriteString("Example:\n\n```hcl\ndevice \"10.55.0.2\" {\n  rule \"http_rule\" \"deny-tinyclouds\" {\n    endpoint = github-api\n    match    = { path = \"/tinyclouds/*\" }\n    verdict  = \"deny\"\n    reason   = \"this device shouldn't reach tinyclouds\"\n  }\n}\n```\n")
+
+	// Per-kind plugin sections.
+	type kindSection struct {
+		Heading  string
+		Kind     config.Kind
+		Labels   string // e.g. `"<type>" "<name>"`
+		Preamble string
+	}
+	sections := []kindSection{
+		{
+			Heading:  "Approvers",
+			Kind:     config.KindApprover,
+			Labels:   `"<type>" "<name>"`,
+			Preamble: "Who arbitrates `approve = [...]` chains. Reference an approver by its bare name from a rule's `approve` list. The built-in `dashboard` approver does not require a block — `approve = [dashboard]` resolves to the built-in.",
+		},
+		{
+			Heading:  "Credentials",
+			Kind:     config.KindCredential,
+			Labels:   `"<type>" "<name>"`,
+			Preamble: "Typed handle to a secret. The actual secret bytes live in the gateway's secret store (env vars by default, keyed by `CLAWPATROL_SECRET_<UPPER_NAME>`); the credential block carries only how-to-inject parameters.",
+		},
+		{
+			Heading:  "Endpoints",
+			Kind:     config.KindEndpoint,
+			Labels:   `"<type>" "<name>"`,
+			Preamble: "Typed upstream binding. Each endpoint type maps to a protocol family (`https`, `sql`, `k8s`, `ssh`); rules constrain themselves to a matching family.",
+		},
+		{
+			Heading:  "Rules",
+			Kind:     config.KindRule,
+			Labels:   `"<type>" "<name>"`,
+			Preamble: "One policy decision targeting one or more endpoints. Each rule type is constrained to a matching endpoint family. The shared `RuleBody` schema below applies to all rule types; the per-family match keys are listed under each type.",
+		},
+	}
+
+	for _, sec := range sections {
+		b.WriteString("\n## " + sec.Heading + "\n\n")
+		b.WriteString(sec.Preamble + "\n")
+		plugins := config.AllPlugins(sec.Kind)
+		for _, p := range plugins {
+			renderPlugin(&b, idx, p, string(sec.Kind), sec.Labels)
+		}
+	}
+
+	return []byte(b.String()), nil
+}
+
+func renderPlugin(b *strings.Builder, idx *docIndex, p *config.Plugin, kindWord, labels string) {
+	body := p.New()
+	t := reflect.TypeOf(body)
+	desc, fields, _ := describeStruct(idx, t)
+
+	header := fmt.Sprintf("\n### `%s \"%s\" \"<name>\"`\n\n", kindWord, p.Type)
+	if labels == `"<name>"` {
+		header = fmt.Sprintf("\n### `%s \"<name>\"` (type `%s`)\n\n", kindWord, p.Type)
+	}
+	b.WriteString(header)
+
+	var meta []string
+	if p.Family != "" {
+		meta = append(meta, fmt.Sprintf("**Family:** `%s`", p.Family))
+	}
+	if len(p.Families) > 0 {
+		meta = append(meta, fmt.Sprintf("**Endpoint families:** `%s`", strings.Join(p.Families, "`, `")))
+	}
+	if len(meta) > 0 {
+		b.WriteString(strings.Join(meta, ". ") + ".\n\n")
+	}
+
+	if desc != "" {
+		b.WriteString(paragraphify(desc) + "\n\n")
+	}
+
+	if len(fields) == 0 {
+		b.WriteString("_No body attributes._\n")
+	} else {
+		writeFieldTable(b, fields)
+	}
+
+	// Special-case the rules grammar: the rule body is `RuleBody` and
+	// the per-family `match` keys live in config/match. We surface
+	// match keys in a follow-up subsection rather than duplicating the
+	// shared field table per type.
+	if p.Kind == config.KindRule {
+		writeRuleMatchKeys(b, p)
+	}
+
+	b.WriteString("\nExample:\n\n```hcl\n")
+	b.WriteString(synthExample(kindWord, p.Type, fields))
+	b.WriteString("```\n")
+}
+
+// writeRuleMatchKeys lists the family-specific `match = { ... }` keys
+// the rule type accepts. Sourced from config/match's KnownKeys via the
+// rules plugin's plugin metadata.
+func writeRuleMatchKeys(b *strings.Builder, p *config.Plugin) {
+	keys := matchKeysForRule(p.Type)
+	if len(keys) == 0 {
+		return
+	}
+	b.WriteString(fmt.Sprintf("\n**`match` keys (%s):** ", p.Type))
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = "`" + k + "`"
+	}
+	b.WriteString(strings.Join(out, ", "))
+	b.WriteString(". Each value accepts a single string or a list (any-of). Strings starting with `!` are negated.\n")
+}
+
+func writeFieldTable(b *strings.Builder, fields []renderedField) {
+	if len(fields) == 0 {
+		b.WriteString("_No fields._\n\n")
+		return
+	}
+	b.WriteString("| Field | Type | Required | Description |\n|---|---|---|---|\n")
+	for _, f := range fields {
+		req := "no"
+		if f.Required {
+			req = "yes"
+		}
+		desc := strings.ReplaceAll(f.Description, "|", `\|`)
+		desc = strings.ReplaceAll(desc, "\n", " ")
+		b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n",
+			f.HCLName, f.HCLType, req, desc))
+	}
+}
+
+// synthExample emits a minimal HCL block populated with required-only
+// fields. Default values are placeholder idents — the goal is to teach
+// shape, not be valid out of the box.
+func synthExample(kindWord, typ string, fields []renderedField) string {
+	var b strings.Builder
+	if typ == "" {
+		fmt.Fprintf(&b, "%s {\n", kindWord)
+	} else {
+		fmt.Fprintf(&b, "%s %q \"<name>\" {\n", kindWord, typ)
+	}
+	hasReq := false
+	for _, f := range fields {
+		if !f.Required {
+			continue
+		}
+		fmt.Fprintf(&b, "  %-12s = %s\n", f.HCLName, exampleValue(f.HCLType))
+		hasReq = true
+	}
+	if !hasReq {
+		// Show one-line empty form — common for empty-struct credentials.
+		return strings.TrimRight(b.String(), "{\n") + "{}\n"
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func synthExampleSimple(kindWord, typ string, fields []renderedField) string {
+	var b strings.Builder
+	if typ == "" {
+		fmt.Fprintf(&b, "%s {\n", kindWord)
+	} else {
+		fmt.Fprintf(&b, "%s %q \"<name>\" {\n", kindWord, typ)
+	}
+	for _, f := range fields {
+		fmt.Fprintf(&b, "  %-18s = %s\n", f.HCLName, exampleValue(f.HCLType))
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func exampleValue(typ string) string {
+	switch typ {
+	case "string":
+		return `"<value>"`
+	case "bool":
+		return "false"
+	case "number":
+		return "0"
+	case "list of string":
+		return `["<value>"]`
+	case "object":
+		return "{}"
+	case "list", "list of object":
+		return "[]"
+	}
+	if strings.HasPrefix(typ, "list of ") {
+		return "[]"
+	}
+	return `"<value>"`
+}
+
+// paragraphify normalizes a block of "//" comment text: collapses
+// single-newline soft-wraps inside paragraphs but preserves blank-line
+// paragraph breaks. Indented blocks (start with two spaces) and lines
+// inside a fenced code block stay as-is.
+func paragraphify(s string) string {
+	s = strings.TrimSpace(s)
+	lines := strings.Split(s, "\n")
+	var out []string
+	var paragraph []string
+	flush := func() {
+		if len(paragraph) > 0 {
+			out = append(out, strings.Join(paragraph, " "))
+			paragraph = paragraph[:0]
+		}
+	}
+	for _, ln := range lines {
+		trim := strings.TrimSpace(ln)
+		switch {
+		case trim == "":
+			flush()
+			out = append(out, "")
+		case strings.HasPrefix(ln, "  ") || strings.HasPrefix(ln, "\t"):
+			flush()
+			out = append(out, ln)
+		default:
+			paragraph = append(paragraph, trim)
+		}
+	}
+	flush()
+	// Trim leading/trailing blanks
+	for len(out) > 0 && out[0] == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return strings.Join(out, "\n")
+}
+
+// matchKeysForRule returns the per-family `match` keys for a rule
+// type, sourced from config/match.KnownKeys (the same table the
+// matcher itself reads, so docs and validator can't drift).
+func matchKeysForRule(ruleType string) []string {
+	family := ruleTypeToFamily[ruleType]
+	if family == "" {
+		return nil
+	}
+	keys := match.KnownKeys(family)
+	out := append([]string(nil), keys...)
+	sort.Strings(out)
+	return out
+}
+
+var ruleTypeToFamily = map[string]string{
+	"http_rule": "https",
+	"sql_rule":  "sql",
+	"k8s_rule":  "k8s",
+}


### PR DESCRIPTION
## Summary

Adds an auto-generated config reference at `site/doc/15-config-reference.md` plus the generator that produces it.

- **Generator:** `tools/docgen/main.go`. Walks the plugin registry via `config.AllPlugins(kind)`, reflects each plugin's gohcl-tagged struct for fields/types/required-ness, and pulls descriptions via `go/parser` (struct doc comments + a per-file lead-comment fallback for the `// <type>: ...` convention used across `config/plugins/*`). Renders Markdown.
- **Drift check:** `tools/docgen/docgen_test.go` re-runs the generator and diffs against the committed file. CI's existing `go test ./...` step catches stale output. Also wired via `go generate ./tools/docgen` for regeneration ergonomics.
- **First generated output** committed at `site/doc/15-config-reference.md` (covers operational fields, the `gateway {}` block, `defaults`, `policy`, `profile`, `device`, every registered approver/credential/endpoint/rule plugin with field tables, family/families metadata, and per-rule match keys sourced from `config/match.KnownKeys`).

## Tool survey

Evaluated and rejected (rationale also in `tools/docgen/main.go` package doc):

- **terraform-docs** — wired to Terraform's `variable` / `output` / `resource` shape, no template hook for clawpatrol's two-label custom kinds dispatched to plugins.
- **gomarkdoc** — emits Go API docs; can't read HCL field tags, wrong audience.
- **hcldec / `awesome-hcl`** — `hcldec` is a runtime spec library; no maintained doc generator in the HCL ecosystem consumes plugin-dispatched custom block kinds.
- **terraform-plugin-docs** — hard-coded to Terraform provider schemas.
- **pkgsite / `go doc`** — produces Go API output, not an HCL reference.

The plugin registry already exposes everything needed; ~400 lines of reflection + `go/parser` keeps the doc in lock-step with the source.

## Test plan

- [x] `go test ./tools/docgen/...` (drift check passes against committed output)
- [x] Smoke-tested drift detection by mutating the committed file (test fails as expected)
- [x] `go run ./tools/docgen -out site/doc/15-config-reference.md` is idempotent
- [x] `go generate ./tools/docgen` produces identical output
- [x] `go test ./config/...` still green
- [x] `gofmt -l tools/docgen/` clean, `go vet` clean