### PR TITLE
docs: auto-generated HCL config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ If you'd rather route every packet on the host through the gateway, pass `--whol
 
 Policy lives in `gateway.hcl`. You declare credentials, the endpoints they unlock, and the rules that decide what's allowed. References are bare names — no quotes, no kind prefix.
 
+The full per-block field reference lives at [`site/doc/15-config-reference.md`](site/doc/15-config-reference.md). It is auto-generated from the plugin registry under `config/plugins/`; regenerate after adding a plugin or changing an `hcl:"..."` tag:
+
+```
+go generate ./config/plugins/all/
+# or directly:
+go run ./tools/docgen
+```
+
+A `go test ./tools/docgen/...` drift check fails when the committed reference disagrees with the live schema.
+
 ```hcl
 credential "anthropic_oauth_subscription" "claude" {}
 credential "github_oauth"                 "github" {}

--- a/config/config.go
+++ b/config/config.go
@@ -135,7 +135,9 @@ func (f FrameworkAttrs) Ref(name string) string {
 	return f.Refs[name]
 }
 
-// Defaults captures the singleton defaults {} block.
+// Defaults holds gateway-wide fallbacks used when an `approver` block
+// or other policy entity does not pin its own value. Exactly one
+// `defaults {}` block per config.
 type Defaults struct {
 	UnknownHost    string `hcl:"unknown_host,optional"`
 	LLMFailMode    string `hcl:"llm_fail_mode,optional"`
@@ -144,8 +146,9 @@ type Defaults struct {
 	HumanOnTimeout string `hcl:"human_on_timeout,optional"`
 }
 
-// PolicyText is the lowered shape of a policy "<name>" {} block:
-// the heredoc text plus its source range for diagnostic messages.
+// PolicyText defines a named, reusable chunk of policy prose that
+// `llm_approver` blocks reference by name. The single `text` attribute
+// is typically a heredoc.
 type PolicyText struct {
 	Name string
 	Text string `hcl:"text"`

--- a/config/plugins/all/all.go
+++ b/config/plugins/all/all.go
@@ -3,6 +3,8 @@
 // the Terraform provider blank-import pattern and lib/pq drivers.
 package all
 
+//go:generate go run ../../../tools/docgen -o ../../../site/doc/15-config-reference.md
+
 import (
 	_ "github.com/denoland/clawpatrol/config/plugins/approvers" // register built-in plugin
 	_ "github.com/denoland/clawpatrol/config/plugins/credentials"

--- a/config/plugins/rules/rules.go
+++ b/config/plugins/rules/rules.go
@@ -29,24 +29,30 @@ import (
 	"github.com/denoland/clawpatrol/config/facet"
 )
 
-// RuleBody is the shared shape across all three rule types. The
-// match keys vary by family (interpreted in Build), but the outer
-// frame is identical: endpoint targeting, priority, outcome.
+// RuleBody is the shared body shape across the three rule types
+// (`http_rule`, `sql_rule`, `k8s_rule`). The available keys inside the
+// `match` block depend on the rule's family (listed per kind below);
+// the outer frame is identical: endpoint targeting, priority, outcome.
 type RuleBody struct {
 	Endpoint  string   `hcl:"endpoint,optional"`
 	Endpoints []string `hcl:"endpoints,optional"`
 	Priority  int      `hcl:"priority,optional"`
 	Disabled  bool     `hcl:"disabled,optional"`
 
-	// Match is decoded raw and interpreted per family in Build. An
-	// absent match block matches everything — the v14 catch-all
-	// pattern (`rule "..." "X-default" { priority = -100; verdict =
-	// "deny" }`) relies on this.
+	// Match is a free-form block whose keys depend on the rule
+	// family. Each value is either a single string or a list of
+	// strings. Omitting `match` matches every request — the
+	// catch-all pattern (`rule "..." "X-default" { priority = -100;
+	// verdict = "deny" }`) relies on this.
 	Match cty.Value `hcl:"match,optional"`
 
-	// Outcome: exactly one of verdict / approve.
-	Verdict string    `hcl:"verdict,optional"`
-	Reason  string    `hcl:"reason,optional"`
+	// Verdict is the outcome when the rule matches. Set exactly one
+	// of `verdict` (`"allow"` / `"deny"`) or `approve`.
+	Verdict string `hcl:"verdict,optional"`
+	Reason  string `hcl:"reason,optional"`
+	// Approve is a list of bare-name approver references. The
+	// approvers run in order; the request is allowed only if every
+	// stage approves. Set this *or* `verdict`, not both.
 	Approve cty.Value `hcl:"approve,optional"`
 }
 

--- a/site/doc/15-config-reference.md
+++ b/site/doc/15-config-reference.md
@@ -1,0 +1,609 @@
+# HCL config reference
+
+> **This page is auto-generated** from the plugin registry under
+> `config/plugins/` and the operational structs in `config/`.
+> Do not hand-edit. Re-run `go run ./tools/docgen` after changing any
+> `hcl:"..."` tag, plugin registration, or struct field comment.
+
+A clawpatrol gateway config mixes **operational** fields (top-level
+plumbing) with **policy** blocks. Operational fields decode statically
+into `config.Gateway`; policy blocks dispatch to plugins by their
+first label.
+
+For prose context (references, namespaces, design rationale) see
+[`config/README.md`](https://github.com/denoland/clawpatrol/blob/main/config/README.md);
+the page you're reading is the field-by-field reference.
+
+## How to read this page
+
+Each block section lists the attributes the loader accepts, with:
+
+- **Type** — Go type after HCL decode. `string`, `bool`, `int` map to
+  the obvious HCL kinds; `[]string` is an HCL list of strings;
+  `object` denotes a nested block / object whose shape is
+  described inline.
+- **Required** — `yes` if the loader rejects the block when the
+  attribute is missing.
+- **Reference** — when set, the value is a bare-name reference to
+  another block of the named kind (e.g. `credential = github-pat`).
+
+Plugin-dispatched kinds (`approver`, `credential`, `endpoint`, `rule`)
+list one subsection per registered type.
+
+## Top-level operational fields
+
+Gateway is the fully-loaded clawpatrol gateway config: operational
+fields at the top, plus a resolved policy.
+
+Operational fields are still decoded via plain gohcl struct tags —
+they're not pluggable. Anything below `tailscale {}` is dispatched
+to the plugin registry.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `listen` | `string` | no | — |  |
+| `info_listen` | `string` | no | — |  |
+| `public_url` | `string` | no | — |  |
+| `admin_email` | `string` | no | — |  |
+| `ca_dir` | `string` | no | — |  |
+| `resolver` | `string` | no | — |  |
+| `log_path` | `string` | no | — |  |
+| `oauth_dir` | `string` | no | — |  |
+| `dashboard_secret` | `string` | no | — |  |
+| `insecure_no_dashboard_secret` | `bool` | no | — | InsecureNoDashboardSecret opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
+| `session_keep` | `string` | no | — | SessionKeep is the hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
+| `gateway` | `block` | yes | — |  |
+
+### `gateway {}` block
+
+Tailscale mirrors main.go's existing block layout. Kept here so
+config.Gateway is self-contained; the operational runtime can read
+from this type after Load.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `authkey` | `string` | no | — |  |
+| `control_url` | `string` | no | — |  |
+| `hostname` | `string` | no | — |  |
+| `state_dir` | `string` | no | — |  |
+| `control` | `string` | no | — |  |
+| `oauth_client_id` | `string` | no | — |  |
+| `oauth_client_secret` | `string` | no | — |  |
+| `tags` | `[]string` | no | — |  |
+| `wg_interface` | `string` | no | — |  |
+| `wg_endpoint` | `string` | no | — |  |
+| `wg_server_pub` | `string` | no | — |  |
+| `wg_subnet_cidr` | `string` | no | — |  |
+
+## `defaults {}`
+
+Defaults captures the singleton defaults {} block.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `unknown_host` | `string` | no | — |  |
+| `llm_fail_mode` | `string` | no | — |  |
+| `llm_cache_ttl` | `int` | no | — |  |
+| `human_timeout` | `int` | no | — |  |
+| `human_on_timeout` | `string` | no | — |  |
+
+```hcl
+defaults {}
+```
+
+## `policy "<name>" { ... }`
+
+PolicyText is the lowered shape of a policy "<name>" {} block:
+the heredoc text plus its source range for diagnostic messages.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `text` | `string` | yes | — |  |
+
+```hcl
+policy "example" {
+  text = <<-EOT
+    Example policy text.
+  EOT
+}
+```
+
+## `profile "<name>" { ... }`
+
+Names a set of endpoints. Profiles bind to dashboard owners; an owner's profile determines which endpoints their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `endpoints` | `[]string` | yes | endpoint | Bare-name endpoint references included in this profile. |
+
+```hcl
+profile "default" {
+  endpoints = [github, postgres-prod]
+}
+```
+
+## `approver` blocks
+
+Block syntax: `approver "<type>" "<name>" { ... }`
+
+Registered types: [`human_approver`](#approver-humanapprover), [`llm_approver`](#approver-llmapprover).
+
+### `approver "human_approver"`
+
+HumanApprover targets one channel. Timeout / require_approvers
+override the global defaults block on a per-approver basis.
+
+Credential references a credential whose body satisfies HITLNotifier
+(slack_tokens today; future Discord / Telegram / SMTP credentials).
+Leave empty for a dashboard-only approver (no channel notification;
+operator clicks approve/deny on the dashboard).
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `channel` | `string` | yes | — |  |
+| `credential` | `string` | no | credential |  |
+| `timeout` | `int` | no | — |  |
+| `require_approvers` | `int` | no | — |  |
+| `interactive` | `bool` | no | — | Interactive toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+approver "human_approver" "example" {
+  channel = "#approvals"
+}
+```
+
+### `approver "llm_approver"`
+
+LLMApprover carries the model + the credential used to authenticate
+the call to the model API + the policy text the model judges
+against. Inline `policy` is a bare-name reference to a `policy
+"<name>" { text = ... }` block — operator declares the prompt once
+and reuses across multiple judges.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `model` | `string` | yes | — |  |
+| `credential` | `string` | yes | credential |  |
+| `policy` | `string` | no | policy |  |
+
+**References:** `Credential` → credential; `Policy` → policy (optional).
+
+```hcl
+approver "llm_approver" "example" {
+  model = "claude-haiku-4-5-20251001"
+  credential = example-credential
+}
+```
+
+## `credential` blocks
+
+Block syntax: `credential "<type>" "<name>" { ... }`
+
+Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_eks_credential`](#credential-awsekscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`telegram_bot_token`](#credential-telegrambottoken).
+
+### `credential "anthropic_manual_key"`
+
+_No configurable attributes._
+
+```hcl
+credential "anthropic_manual_key" "example" {}
+```
+
+### `credential "anthropic_oauth_subscription"`
+
+_No configurable attributes._
+
+```hcl
+credential "anthropic_oauth_subscription" "example" {}
+```
+
+### `credential "aws_eks_credential"`
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `cluster` | `string` | yes | — |  |
+| `region` | `string` | yes | — |  |
+| `profile` | `string` | no | — |  |
+
+```hcl
+credential "aws_eks_credential" "example" {
+  cluster = "example"
+  region = "example"
+}
+```
+
+### `credential "bearer_token"`
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `idempotency_key` | `bool` | no | — |  |
+
+```hcl
+credential "bearer_token" "example" {}
+```
+
+### `credential "clickhouse_credential"`
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `user` | `string` | no | — |  |
+
+```hcl
+credential "clickhouse_credential" "example" {}
+```
+
+### `credential "cookie_token"`
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `cookie_name` | `string` | no | — |  |
+
+```hcl
+credential "cookie_token" "example" {}
+```
+
+### `credential "gemini_api_key"`
+
+_No configurable attributes._
+
+```hcl
+credential "gemini_api_key" "example" {}
+```
+
+### `credential "github_oauth"`
+
+_No configurable attributes._
+
+```hcl
+credential "github_oauth" "example" {}
+```
+
+### `credential "header_token"`
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `header` | `string` | yes | — |  |
+| `prefix` | `string` | no | — |  |
+
+```hcl
+credential "header_token" "example" {
+  header = "X-API-Key"
+}
+```
+
+### `credential "mtls_credential"`
+
+_No configurable attributes._
+
+```hcl
+credential "mtls_credential" "example" {}
+```
+
+### `credential "notion_oauth"`
+
+_No configurable attributes._
+
+```hcl
+credential "notion_oauth" "example" {}
+```
+
+### `credential "openai_codex_oauth"`
+
+_No configurable attributes._
+
+```hcl
+credential "openai_codex_oauth" "example" {}
+```
+
+### `credential "postgres_credential"`
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `user` | `string` | no | — |  |
+
+```hcl
+credential "postgres_credential" "example" {}
+```
+
+### `credential "slack_tokens"`
+
+_No configurable attributes._
+
+```hcl
+credential "slack_tokens" "example" {}
+```
+
+### `credential "ssh"`
+
+_No configurable attributes._
+
+```hcl
+credential "ssh" "example" {}
+```
+
+### `credential "telegram_bot_token"`
+
+_No configurable attributes._
+
+```hcl
+credential "telegram_bot_token" "example" {}
+```
+
+## `endpoint` blocks
+
+Block syntax: `endpoint "<type>" "<name>" { ... }`
+
+Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
+
+### `endpoint "clickhouse_https"`
+
+Family: `sql`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `hosts` | `[]string` | yes | — |  |
+| `credential` | `string` | no | credential |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "clickhouse_https" "example" {
+  hosts = ["api.example.com"]
+}
+```
+
+### `endpoint "clickhouse_native"`
+
+ClickhouseNativeEndpoint addresses one ClickHouse server reachable
+via the binary native protocol. Operators bind a single
+clickhouse_credential; the runtime parses the agent's Hello and
+substitutes the credential's (user, password) where the agent
+embedded a placeholder.
+
+TLS toggles TLS on both hops: the gateway terminates the agent's
+TLS using a leaf minted off the gateway CA, parses the Hello in
+plaintext, then re-wraps to upstream. The wrapped client therefore
+keeps speaking native-over-TLS exactly as it would against the
+real cloud ClickHouse — `clawpatrol run` is transparent to its
+TLS posture. Default false: WG-only deployments where the operator
+wants plaintext on the inner hop (typical self-hosted ClickHouse
+on 9000 behind a private network) leave it off.
+
+AcceptInvalidCertificate mirrors clickhouse-client's flag of the
+same name: when true and tls is on, the gateway skips upstream cert
+validation. Use for self-hosted ClickHouse fronted by a private CA.
+Default false keeps full validation against system roots.
+
+Family: `sql`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `hosts` | `[]string` | yes | — |  |
+| `port` | `int` | no | — |  |
+| `tls` | `bool` | no | — |  |
+| `accept_invalid_certificate` | `bool` | no | — |  |
+| `credential` | `string` | no | credential |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "clickhouse_native" "example" {
+  hosts = ["api.example.com"]
+}
+```
+
+### `endpoint "https"`
+
+Family: `https`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `hosts` | `[]string` | yes | — |  |
+| `credential` | `string` | no | credential |  |
+| `credentials` | `object` | no | — |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "https" "example" {
+  hosts = ["api.example.com"]
+}
+```
+
+### `endpoint "kubernetes"`
+
+Family: `k8s`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `hosts` | `[]string` | no | — |  |
+| `server` | `string` | no | — |  |
+| `ca_cert` | `string` | no | — |  |
+| `description` | `string` | no | — |  |
+| `credential` | `string` | no | credential |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "kubernetes" "example" {}
+```
+
+### `endpoint "openai_codex_https"`
+
+Family: `https`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `hosts` | `[]string` | yes | — |  |
+| `credential` | `string` | no | credential |  |
+| `credentials` | `object` | no | — |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "openai_codex_https" "example" {
+  hosts = ["api.example.com"]
+}
+```
+
+### `endpoint "postgres"`
+
+PostgresEndpoint addresses a single RDS-or-equivalent server.
+Tunnel topologies (kubectl-portforward-ssh and friends) aren't
+supported in this iteration — operators run the gateway with
+network reachability already arranged.
+
+SSLMode mirrors libpq's sslmode names — "disable" / "prefer" /
+"require" / "verify-full". Default "prefer": try TLS, fall back
+to plain when the upstream replies 'N'. "require" hard-fails on
+'N'. "verify-full" additionally validates the upstream cert
+against Host. "disable" skips the SSLRequest probe entirely —
+fine for self-hosted pg on a private network where WG already
+encrypts the path.
+
+Family: `sql`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `host` | `string` | yes | — |  |
+| `database` | `string` | yes | — |  |
+| `sslmode` | `string` | no | — |  |
+| `credential` | `string` | no | credential |  |
+| `credentials` | `object` | no | — |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "postgres" "example" {
+  host = "db.internal:5432"
+  database = "appdb"
+}
+```
+
+### `endpoint "ssh"`
+
+SSHEndpoint binds one or more host:port tuples to one or more SSH
+credentials. The agent's username is the discriminator for
+per-username dispatch (mirrors postgres' placeholder-based dispatch,
+just spelled `user` because that's what SSH calls it):
+
+	credential = X                                  // any user → X
+	credentials = [{ user = "root",   credential = X },
+	               { user = "deploy", credential = Y },
+	               { credential = Z }]              // fallback
+
+The agent's username is also passed through verbatim as the upstream
+SSH user — credentials carry only auth material (key / password /
+host_pubkey), never a username override.
+
+Family: `ssh`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `hosts` | `[]string` | yes | — |  |
+| `credential` | `string` | no | credential |  |
+| `credentials` | `object` | no | — |  |
+
+**References:** `Credential` → credential (optional).
+
+```hcl
+endpoint "ssh" "example" {
+  hosts = ["api.example.com"]
+}
+```
+
+## `rule` blocks
+
+Block syntax: `rule "<type>" "<name>" { ... }`
+
+Registered types: [`http_rule`](#rule-httprule), [`k8s_rule`](#rule-k8srule), [`sql_rule`](#rule-sqlrule).
+
+### `rule "http_rule"`
+
+RuleBody is the shared shape across all three rule types. The
+match keys vary by family (interpreted in Build), but the outer
+frame is identical: endpoint targeting, priority, outcome.
+
+Targets endpoints of family: `https`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `endpoint` | `string` | no | endpoint |  |
+| `endpoints` | `[]string` | no | endpoint |  |
+| `priority` | `int` | no | — |  |
+| `disabled` | `bool` | no | — |  |
+| `match` | `object` | no | — | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | `string` | no | — | Outcome: exactly one of verdict / approve. |
+| `reason` | `string` | no | — |  |
+| `approve` | `object` | no | — |  |
+
+**References:** `Endpoint` → endpoint (optional); `Endpoints[*]` → endpoint (optional).
+
+**`match` keys** (single string or list of strings each):
+
+- family `https`: `method`, `path`, `query`, `headers`, `body_json`, `body_contains`, `credential`
+
+```hcl
+rule "http_rule" "example" {}
+```
+
+### `rule "k8s_rule"`
+
+RuleBody is the shared shape across all three rule types. The
+match keys vary by family (interpreted in Build), but the outer
+frame is identical: endpoint targeting, priority, outcome.
+
+Targets endpoints of family: `k8s`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `endpoint` | `string` | no | endpoint |  |
+| `endpoints` | `[]string` | no | endpoint |  |
+| `priority` | `int` | no | — |  |
+| `disabled` | `bool` | no | — |  |
+| `match` | `object` | no | — | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | `string` | no | — | Outcome: exactly one of verdict / approve. |
+| `reason` | `string` | no | — |  |
+| `approve` | `object` | no | — |  |
+
+**References:** `Endpoint` → endpoint (optional); `Endpoints[*]` → endpoint (optional).
+
+**`match` keys** (single string or list of strings each):
+
+- family `k8s`: `resource`, `verb`, `namespace`, `name`, `params`, `credential`
+
+```hcl
+rule "k8s_rule" "example" {}
+```
+
+### `rule "sql_rule"`
+
+RuleBody is the shared shape across all three rule types. The
+match keys vary by family (interpreted in Build), but the outer
+frame is identical: endpoint targeting, priority, outcome.
+
+Targets endpoints of family: `sql`.
+
+| Attribute | Type | Required | Reference | Description |
+|-----------|------|----------|-----------|-------------|
+| `endpoint` | `string` | no | endpoint |  |
+| `endpoints` | `[]string` | no | endpoint |  |
+| `priority` | `int` | no | — |  |
+| `disabled` | `bool` | no | — |  |
+| `match` | `object` | no | — | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | `string` | no | — | Outcome: exactly one of verdict / approve. |
+| `reason` | `string` | no | — |  |
+| `approve` | `object` | no | — |  |
+
+**References:** `Endpoint` → endpoint (optional); `Endpoints[*]` → endpoint (optional).
+
+**`match` keys** (single string or list of strings each):
+
+- family `sql`: `verb`, `tables`, `function`, `statement`, `statement_regex`, `credential`
+
+```hcl
+rule "sql_rule" "example" {}
+```
+

--- a/site/doc/15-config-reference.md
+++ b/site/doc/15-config-reference.md
@@ -503,7 +503,7 @@ Targets endpoints of family: `https`.
 | `endpoints` | `[]ref(endpoint)` | no |  |
 | `priority` | `int` | no |  |
 | `disabled` | `bool` | no |  |
-| `match` | `object` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `match` | `block` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
 | `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
 | `reason` | `string` | no |  |
 | `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |
@@ -531,7 +531,7 @@ Targets endpoints of family: `k8s`.
 | `endpoints` | `[]ref(endpoint)` | no |  |
 | `priority` | `int` | no |  |
 | `disabled` | `bool` | no |  |
-| `match` | `object` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `match` | `block` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
 | `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
 | `reason` | `string` | no |  |
 | `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |
@@ -559,7 +559,7 @@ Targets endpoints of family: `sql`.
 | `endpoints` | `[]ref(endpoint)` | no |  |
 | `priority` | `int` | no |  |
 | `disabled` | `bool` | no |  |
-| `match` | `object` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `match` | `block` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
 | `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
 | `reason` | `string` | no |  |
 | `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |

--- a/site/doc/15-config-reference.md
+++ b/site/doc/15-config-reference.md
@@ -1,91 +1,76 @@
 # HCL config reference
 
-> **This page is auto-generated** from the plugin registry under
-> `config/plugins/` and the operational structs in `config/`.
-> Do not hand-edit. Re-run `go run ./tools/docgen` after changing any
-> `hcl:"..."` tag, plugin registration, or struct field comment.
-
 A clawpatrol gateway config mixes **operational** fields (top-level
-plumbing) with **policy** blocks. Operational fields decode statically
-into `config.Gateway`; policy blocks dispatch to plugins by their
-first label.
-
-For prose context (references, namespaces, design rationale) see
-[`config/README.md`](https://github.com/denoland/clawpatrol/blob/main/config/README.md);
-the page you're reading is the field-by-field reference.
+plumbing) with **policy** blocks. Operational fields are top-level
+attributes; policy blocks (`approver`, `credential`, `endpoint`, `rule`)
+dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
 
 Each block section lists the attributes the loader accepts, with:
 
-- **Type** — Go type after HCL decode. `string`, `bool`, `int` map to
-  the obvious HCL kinds; `[]string` is an HCL list of strings;
-  `object` denotes a nested block / object whose shape is
-  described inline.
+- **Type** — the HCL value type. `string`, `bool`, `int` are scalar
+  literals; `[]string` is a list of strings; `ref(<kind>)` is a
+  bare-name reference to another block of that kind (e.g.
+  `credential = github-pat`); `[]ref(<kind>)` is a list of such
+  references; nested blocks have their shape described inline.
 - **Required** — `yes` if the loader rejects the block when the
   attribute is missing.
-- **Reference** — when set, the value is a bare-name reference to
-  another block of the named kind (e.g. `credential = github-pat`).
 
 Plugin-dispatched kinds (`approver`, `credential`, `endpoint`, `rule`)
 list one subsection per registered type.
 
 ## Top-level operational fields
 
-Gateway is the fully-loaded clawpatrol gateway config: operational
-fields at the top, plus a resolved policy.
+These are the attributes you set directly at the top of `gateway.hcl`. Anything below `gateway {}` (defaults, policy, profile, approver, credential, endpoint, rule) is a separate block documented in its own section.
 
-Operational fields are still decoded via plain gohcl struct tags —
-they're not pluggable. Anything below `tailscale {}` is dispatched
-to the plugin registry.
-
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `listen` | `string` | no | — |  |
-| `info_listen` | `string` | no | — |  |
-| `public_url` | `string` | no | — |  |
-| `admin_email` | `string` | no | — |  |
-| `ca_dir` | `string` | no | — |  |
-| `resolver` | `string` | no | — |  |
-| `log_path` | `string` | no | — |  |
-| `oauth_dir` | `string` | no | — |  |
-| `dashboard_secret` | `string` | no | — |  |
-| `insecure_no_dashboard_secret` | `bool` | no | — | InsecureNoDashboardSecret opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
-| `session_keep` | `string` | no | — | SessionKeep is the hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
-| `gateway` | `block` | yes | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `listen` | `string` | no |  |
+| `info_listen` | `string` | no |  |
+| `public_url` | `string` | no |  |
+| `admin_email` | `string` | no |  |
+| `ca_dir` | `string` | no |  |
+| `resolver` | `string` | no |  |
+| `log_path` | `string` | no |  |
+| `oauth_dir` | `string` | no |  |
+| `dashboard_secret` | `string` | no |  |
+| `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
+| `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
+| `gateway` | `block` | yes |  |
 
 ### `gateway {}` block
 
-Tailscale mirrors main.go's existing block layout. Kept here so
-config.Gateway is self-contained; the operational runtime can read
-from this type after Load.
+Singleton block configuring how the gateway joins the operator's tailnet (or a self-hosted control plane) and the WireGuard tunnel that carries agent traffic.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `authkey` | `string` | no | — |  |
-| `control_url` | `string` | no | — |  |
-| `hostname` | `string` | no | — |  |
-| `state_dir` | `string` | no | — |  |
-| `control` | `string` | no | — |  |
-| `oauth_client_id` | `string` | no | — |  |
-| `oauth_client_secret` | `string` | no | — |  |
-| `tags` | `[]string` | no | — |  |
-| `wg_interface` | `string` | no | — |  |
-| `wg_endpoint` | `string` | no | — |  |
-| `wg_server_pub` | `string` | no | — |  |
-| `wg_subnet_cidr` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | `string` | no |  |
+| `control_url` | `string` | no |  |
+| `hostname` | `string` | no |  |
+| `state_dir` | `string` | no |  |
+| `control` | `string` | no |  |
+| `oauth_client_id` | `string` | no |  |
+| `oauth_client_secret` | `string` | no |  |
+| `tags` | `[]string` | no |  |
+| `wg_interface` | `string` | no |  |
+| `wg_endpoint` | `string` | no |  |
+| `wg_server_pub` | `string` | no |  |
+| `wg_subnet_cidr` | `string` | no |  |
 
 ## `defaults {}`
 
-Defaults captures the singleton defaults {} block.
+Holds gateway-wide fallbacks used when an `approver` block
+or other policy entity does not pin its own value. Exactly one
+`defaults {}` block per config.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `unknown_host` | `string` | no | — |  |
-| `llm_fail_mode` | `string` | no | — |  |
-| `llm_cache_ttl` | `int` | no | — |  |
-| `human_timeout` | `int` | no | — |  |
-| `human_on_timeout` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `unknown_host` | `string` | no |  |
+| `llm_fail_mode` | `string` | no |  |
+| `llm_cache_ttl` | `int` | no |  |
+| `human_timeout` | `int` | no |  |
+| `human_on_timeout` | `string` | no |  |
 
 ```hcl
 defaults {}
@@ -93,12 +78,13 @@ defaults {}
 
 ## `policy "<name>" { ... }`
 
-PolicyText is the lowered shape of a policy "<name>" {} block:
-the heredoc text plus its source range for diagnostic messages.
+Defines a named, reusable chunk of policy prose that
+`llm_approver` blocks reference by name. The single `text` attribute
+is typically a heredoc.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `text` | `string` | yes | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | `string` | yes |  |
 
 ```hcl
 policy "example" {
@@ -112,9 +98,9 @@ policy "example" {
 
 Names a set of endpoints. Profiles bind to dashboard owners; an owner's profile determines which endpoints their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `endpoints` | `[]string` | yes | endpoint | Bare-name endpoint references included in this profile. |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoints` | `[]ref(endpoint)` | yes | Bare-name endpoint references included in this profile. |
 
 ```hcl
 profile "default" {
@@ -128,9 +114,9 @@ Block syntax: `approver "<type>" "<name>" { ... }`
 
 Registered types: [`human_approver`](#approver-humanapprover), [`llm_approver`](#approver-llmapprover).
 
-### `approver "human_approver"`
+### `approver "human_approver" "<name>"`
 
-HumanApprover targets one channel. Timeout / require_approvers
+Targets one channel. Timeout / require_approvers
 override the global defaults block on a per-approver basis.
 
 Credential references a credential whose body satisfies HITLNotifier
@@ -138,15 +124,13 @@ Credential references a credential whose body satisfies HITLNotifier
 Leave empty for a dashboard-only approver (no channel notification;
 operator clicks approve/deny on the dashboard).
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `channel` | `string` | yes | — |  |
-| `credential` | `string` | no | credential |  |
-| `timeout` | `int` | no | — |  |
-| `require_approvers` | `int` | no | — |  |
-| `interactive` | `bool` | no | — | Interactive toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `channel` | `string` | yes |  |
+| `credential` | `ref(credential)` | no |  |
+| `timeout` | `int` | no |  |
+| `require_approvers` | `int` | no |  |
+| `interactive` | `bool` | no | Toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
 
 ```hcl
 approver "human_approver" "example" {
@@ -154,21 +138,19 @@ approver "human_approver" "example" {
 }
 ```
 
-### `approver "llm_approver"`
+### `approver "llm_approver" "<name>"`
 
-LLMApprover carries the model + the credential used to authenticate
+Carries the model + the credential used to authenticate
 the call to the model API + the policy text the model judges
 against. Inline `policy` is a bare-name reference to a `policy
 "<name>" { text = ... }` block — operator declares the prompt once
 and reuses across multiple judges.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `model` | `string` | yes | — |  |
-| `credential` | `string` | yes | credential |  |
-| `policy` | `string` | no | policy |  |
-
-**References:** `Credential` → credential; `Policy` → policy (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `model` | `string` | yes |  |
+| `credential` | `ref(credential)` | yes |  |
+| `policy` | `ref(policy)` | no |  |
 
 ```hcl
 approver "llm_approver" "example" {
@@ -183,7 +165,7 @@ Block syntax: `credential "<type>" "<name>" { ... }`
 
 Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_eks_credential`](#credential-awsekscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`telegram_bot_token`](#credential-telegrambottoken).
 
-### `credential "anthropic_manual_key"`
+### `credential "anthropic_manual_key" "<name>"`
 
 _No configurable attributes._
 
@@ -191,7 +173,7 @@ _No configurable attributes._
 credential "anthropic_manual_key" "example" {}
 ```
 
-### `credential "anthropic_oauth_subscription"`
+### `credential "anthropic_oauth_subscription" "<name>"`
 
 _No configurable attributes._
 
@@ -199,13 +181,13 @@ _No configurable attributes._
 credential "anthropic_oauth_subscription" "example" {}
 ```
 
-### `credential "aws_eks_credential"`
+### `credential "aws_eks_credential" "<name>"`
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `cluster` | `string` | yes | — |  |
-| `region` | `string` | yes | — |  |
-| `profile` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `cluster` | `string` | yes |  |
+| `region` | `string` | yes |  |
+| `profile` | `string` | no |  |
 
 ```hcl
 credential "aws_eks_credential" "example" {
@@ -214,37 +196,37 @@ credential "aws_eks_credential" "example" {
 }
 ```
 
-### `credential "bearer_token"`
+### `credential "bearer_token" "<name>"`
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `idempotency_key` | `bool` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `idempotency_key` | `bool` | no |  |
 
 ```hcl
 credential "bearer_token" "example" {}
 ```
 
-### `credential "clickhouse_credential"`
+### `credential "clickhouse_credential" "<name>"`
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `user` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user` | `string` | no |  |
 
 ```hcl
 credential "clickhouse_credential" "example" {}
 ```
 
-### `credential "cookie_token"`
+### `credential "cookie_token" "<name>"`
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `cookie_name` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `cookie_name` | `string` | no |  |
 
 ```hcl
 credential "cookie_token" "example" {}
 ```
 
-### `credential "gemini_api_key"`
+### `credential "gemini_api_key" "<name>"`
 
 _No configurable attributes._
 
@@ -252,7 +234,7 @@ _No configurable attributes._
 credential "gemini_api_key" "example" {}
 ```
 
-### `credential "github_oauth"`
+### `credential "github_oauth" "<name>"`
 
 _No configurable attributes._
 
@@ -260,12 +242,12 @@ _No configurable attributes._
 credential "github_oauth" "example" {}
 ```
 
-### `credential "header_token"`
+### `credential "header_token" "<name>"`
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `header` | `string` | yes | — |  |
-| `prefix` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `header` | `string` | yes |  |
+| `prefix` | `string` | no |  |
 
 ```hcl
 credential "header_token" "example" {
@@ -273,7 +255,7 @@ credential "header_token" "example" {
 }
 ```
 
-### `credential "mtls_credential"`
+### `credential "mtls_credential" "<name>"`
 
 _No configurable attributes._
 
@@ -281,7 +263,7 @@ _No configurable attributes._
 credential "mtls_credential" "example" {}
 ```
 
-### `credential "notion_oauth"`
+### `credential "notion_oauth" "<name>"`
 
 _No configurable attributes._
 
@@ -289,7 +271,7 @@ _No configurable attributes._
 credential "notion_oauth" "example" {}
 ```
 
-### `credential "openai_codex_oauth"`
+### `credential "openai_codex_oauth" "<name>"`
 
 _No configurable attributes._
 
@@ -297,17 +279,17 @@ _No configurable attributes._
 credential "openai_codex_oauth" "example" {}
 ```
 
-### `credential "postgres_credential"`
+### `credential "postgres_credential" "<name>"`
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `user` | `string` | no | — |  |
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user` | `string` | no |  |
 
 ```hcl
 credential "postgres_credential" "example" {}
 ```
 
-### `credential "slack_tokens"`
+### `credential "slack_tokens" "<name>"`
 
 _No configurable attributes._
 
@@ -315,7 +297,7 @@ _No configurable attributes._
 credential "slack_tokens" "example" {}
 ```
 
-### `credential "ssh"`
+### `credential "ssh" "<name>"`
 
 _No configurable attributes._
 
@@ -323,7 +305,7 @@ _No configurable attributes._
 credential "ssh" "example" {}
 ```
 
-### `credential "telegram_bot_token"`
+### `credential "telegram_bot_token" "<name>"`
 
 _No configurable attributes._
 
@@ -337,16 +319,14 @@ Block syntax: `endpoint "<type>" "<name>" { ... }`
 
 Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
 
-### `endpoint "clickhouse_https"`
+### `endpoint "clickhouse_https" "<name>"`
 
 Family: `sql`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `hosts` | `[]string` | yes | — |  |
-| `credential` | `string` | no | credential |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | yes |  |
+| `credential` | `ref(credential)` | no |  |
 
 ```hcl
 endpoint "clickhouse_https" "example" {
@@ -354,9 +334,9 @@ endpoint "clickhouse_https" "example" {
 }
 ```
 
-### `endpoint "clickhouse_native"`
+### `endpoint "clickhouse_native" "<name>"`
 
-ClickhouseNativeEndpoint addresses one ClickHouse server reachable
+Addresses one ClickHouse server reachable
 via the binary native protocol. Operators bind a single
 clickhouse_credential; the runtime parses the agent's Hello and
 substitutes the credential's (user, password) where the agent
@@ -378,15 +358,13 @@ Default false keeps full validation against system roots.
 
 Family: `sql`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `hosts` | `[]string` | yes | — |  |
-| `port` | `int` | no | — |  |
-| `tls` | `bool` | no | — |  |
-| `accept_invalid_certificate` | `bool` | no | — |  |
-| `credential` | `string` | no | credential |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | yes |  |
+| `port` | `int` | no |  |
+| `tls` | `bool` | no |  |
+| `accept_invalid_certificate` | `bool` | no |  |
+| `credential` | `ref(credential)` | no |  |
 
 ```hcl
 endpoint "clickhouse_native" "example" {
@@ -394,17 +372,15 @@ endpoint "clickhouse_native" "example" {
 }
 ```
 
-### `endpoint "https"`
+### `endpoint "https" "<name>"`
 
 Family: `https`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `hosts` | `[]string` | yes | — |  |
-| `credential` | `string` | no | credential |  |
-| `credentials` | `object` | no | — |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | yes |  |
+| `credential` | `ref(credential)` | no |  |
+| `credentials` | `[]credential` | no |  |
 
 ```hcl
 endpoint "https" "example" {
@@ -412,35 +388,31 @@ endpoint "https" "example" {
 }
 ```
 
-### `endpoint "kubernetes"`
+### `endpoint "kubernetes" "<name>"`
 
 Family: `k8s`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `hosts` | `[]string` | no | — |  |
-| `server` | `string` | no | — |  |
-| `ca_cert` | `string` | no | — |  |
-| `description` | `string` | no | — |  |
-| `credential` | `string` | no | credential |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | no |  |
+| `server` | `string` | no |  |
+| `ca_cert` | `string` | no |  |
+| `description` | `string` | no |  |
+| `credential` | `ref(credential)` | no |  |
 
 ```hcl
 endpoint "kubernetes" "example" {}
 ```
 
-### `endpoint "openai_codex_https"`
+### `endpoint "openai_codex_https" "<name>"`
 
 Family: `https`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `hosts` | `[]string` | yes | — |  |
-| `credential` | `string` | no | credential |  |
-| `credentials` | `object` | no | — |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | yes |  |
+| `credential` | `ref(credential)` | no |  |
+| `credentials` | `[]credential` | no |  |
 
 ```hcl
 endpoint "openai_codex_https" "example" {
@@ -448,9 +420,9 @@ endpoint "openai_codex_https" "example" {
 }
 ```
 
-### `endpoint "postgres"`
+### `endpoint "postgres" "<name>"`
 
-PostgresEndpoint addresses a single RDS-or-equivalent server.
+Addresses a single RDS-or-equivalent server.
 Tunnel topologies (kubectl-portforward-ssh and friends) aren't
 supported in this iteration — operators run the gateway with
 network reachability already arranged.
@@ -465,15 +437,13 @@ encrypts the path.
 
 Family: `sql`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `host` | `string` | yes | — |  |
-| `database` | `string` | yes | — |  |
-| `sslmode` | `string` | no | — |  |
-| `credential` | `string` | no | credential |  |
-| `credentials` | `object` | no | — |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `host` | `string` | yes |  |
+| `database` | `string` | yes |  |
+| `sslmode` | `string` | no |  |
+| `credential` | `ref(credential)` | no |  |
+| `credentials` | `[]credential` | no |  |
 
 ```hcl
 endpoint "postgres" "example" {
@@ -482,9 +452,9 @@ endpoint "postgres" "example" {
 }
 ```
 
-### `endpoint "ssh"`
+### `endpoint "ssh" "<name>"`
 
-SSHEndpoint binds one or more host:port tuples to one or more SSH
+Binds one or more host:port tuples to one or more SSH
 credentials. The agent's username is the discriminator for
 per-username dispatch (mirrors postgres' placeholder-based dispatch,
 just spelled `user` because that's what SSH calls it):
@@ -500,13 +470,11 @@ host_pubkey), never a username override.
 
 Family: `ssh`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `hosts` | `[]string` | yes | — |  |
-| `credential` | `string` | no | credential |  |
-| `credentials` | `object` | no | — |  |
-
-**References:** `Credential` → credential (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | yes |  |
+| `credential` | `ref(credential)` | no |  |
+| `credentials` | `[]credential` | no |  |
 
 ```hcl
 endpoint "ssh" "example" {
@@ -520,26 +488,25 @@ Block syntax: `rule "<type>" "<name>" { ... }`
 
 Registered types: [`http_rule`](#rule-httprule), [`k8s_rule`](#rule-k8srule), [`sql_rule`](#rule-sqlrule).
 
-### `rule "http_rule"`
+### `rule "http_rule" "<name>"`
 
-RuleBody is the shared shape across all three rule types. The
-match keys vary by family (interpreted in Build), but the outer
-frame is identical: endpoint targeting, priority, outcome.
+The shared body shape across the three rule types
+(`http_rule`, `sql_rule`, `k8s_rule`). The available keys inside the
+`match` block depend on the rule's family (listed per kind below);
+the outer frame is identical: endpoint targeting, priority, outcome.
 
 Targets endpoints of family: `https`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `endpoint` | `string` | no | endpoint |  |
-| `endpoints` | `[]string` | no | endpoint |  |
-| `priority` | `int` | no | — |  |
-| `disabled` | `bool` | no | — |  |
-| `match` | `object` | no | — | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
-| `verdict` | `string` | no | — | Outcome: exactly one of verdict / approve. |
-| `reason` | `string` | no | — |  |
-| `approve` | `object` | no | — |  |
-
-**References:** `Endpoint` → endpoint (optional); `Endpoints[*]` → endpoint (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoint` | `ref(endpoint)` | no |  |
+| `endpoints` | `[]ref(endpoint)` | no |  |
+| `priority` | `int` | no |  |
+| `disabled` | `bool` | no |  |
+| `match` | `object` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
+| `reason` | `string` | no |  |
+| `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |
 
 **`match` keys** (single string or list of strings each):
 
@@ -549,26 +516,25 @@ Targets endpoints of family: `https`.
 rule "http_rule" "example" {}
 ```
 
-### `rule "k8s_rule"`
+### `rule "k8s_rule" "<name>"`
 
-RuleBody is the shared shape across all three rule types. The
-match keys vary by family (interpreted in Build), but the outer
-frame is identical: endpoint targeting, priority, outcome.
+The shared body shape across the three rule types
+(`http_rule`, `sql_rule`, `k8s_rule`). The available keys inside the
+`match` block depend on the rule's family (listed per kind below);
+the outer frame is identical: endpoint targeting, priority, outcome.
 
 Targets endpoints of family: `k8s`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `endpoint` | `string` | no | endpoint |  |
-| `endpoints` | `[]string` | no | endpoint |  |
-| `priority` | `int` | no | — |  |
-| `disabled` | `bool` | no | — |  |
-| `match` | `object` | no | — | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
-| `verdict` | `string` | no | — | Outcome: exactly one of verdict / approve. |
-| `reason` | `string` | no | — |  |
-| `approve` | `object` | no | — |  |
-
-**References:** `Endpoint` → endpoint (optional); `Endpoints[*]` → endpoint (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoint` | `ref(endpoint)` | no |  |
+| `endpoints` | `[]ref(endpoint)` | no |  |
+| `priority` | `int` | no |  |
+| `disabled` | `bool` | no |  |
+| `match` | `object` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
+| `reason` | `string` | no |  |
+| `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |
 
 **`match` keys** (single string or list of strings each):
 
@@ -578,26 +544,25 @@ Targets endpoints of family: `k8s`.
 rule "k8s_rule" "example" {}
 ```
 
-### `rule "sql_rule"`
+### `rule "sql_rule" "<name>"`
 
-RuleBody is the shared shape across all three rule types. The
-match keys vary by family (interpreted in Build), but the outer
-frame is identical: endpoint targeting, priority, outcome.
+The shared body shape across the three rule types
+(`http_rule`, `sql_rule`, `k8s_rule`). The available keys inside the
+`match` block depend on the rule's family (listed per kind below);
+the outer frame is identical: endpoint targeting, priority, outcome.
 
 Targets endpoints of family: `sql`.
 
-| Attribute | Type | Required | Reference | Description |
-|-----------|------|----------|-----------|-------------|
-| `endpoint` | `string` | no | endpoint |  |
-| `endpoints` | `[]string` | no | endpoint |  |
-| `priority` | `int` | no | — |  |
-| `disabled` | `bool` | no | — |  |
-| `match` | `object` | no | — | Match is decoded raw and interpreted per family in Build. An absent match block matches everything — the v14 catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
-| `verdict` | `string` | no | — | Outcome: exactly one of verdict / approve. |
-| `reason` | `string` | no | — |  |
-| `approve` | `object` | no | — |  |
-
-**References:** `Endpoint` → endpoint (optional); `Endpoints[*]` → endpoint (optional).
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoint` | `ref(endpoint)` | no |  |
+| `endpoints` | `[]ref(endpoint)` | no |  |
+| `priority` | `int` | no |  |
+| `disabled` | `bool` | no |  |
+| `match` | `object` | no | A free-form block whose keys depend on the rule family. Each value is either a single string or a list of strings. Omitting `match` matches every request — the catch-all pattern (`rule "..." "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
+| `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
+| `reason` | `string` | no |  |
+| `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |
 
 **`match` keys** (single string or list of strings each):
 

--- a/site/doc/15-config-reference.md
+++ b/site/doc/15-config-reference.md
@@ -36,6 +36,7 @@ These are the attributes you set directly at the top of `gateway.hcl`. Anything 
 | `oauth_dir` | `string` | no |  |
 | `dashboard_secret` | `string` | no |  |
 | `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
+| `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
 | `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
 | `gateway` | `block` | yes |  |
 
@@ -167,6 +168,8 @@ Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`an
 
 ### `credential "anthropic_manual_key" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -175,6 +178,8 @@ credential "anthropic_manual_key" "example" {}
 
 ### `credential "anthropic_oauth_subscription" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -182,6 +187,8 @@ credential "anthropic_oauth_subscription" "example" {}
 ```
 
 ### `credential "aws_eks_credential" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -198,6 +205,8 @@ credential "aws_eks_credential" "example" {
 
 ### `credential "bearer_token" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `idempotency_key` | `bool` | no |  |
@@ -207,6 +216,8 @@ credential "bearer_token" "example" {}
 ```
 
 ### `credential "clickhouse_credential" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -218,6 +229,8 @@ credential "clickhouse_credential" "example" {}
 
 ### `credential "cookie_token" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cookie_name` | `string` | no |  |
@@ -228,6 +241,8 @@ credential "cookie_token" "example" {}
 
 ### `credential "gemini_api_key" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -236,6 +251,8 @@ credential "gemini_api_key" "example" {}
 
 ### `credential "github_oauth" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -243,6 +260,8 @@ credential "github_oauth" "example" {}
 ```
 
 ### `credential "header_token" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -257,6 +276,8 @@ credential "header_token" "example" {
 
 ### `credential "mtls_credential" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -264,6 +285,8 @@ credential "mtls_credential" "example" {}
 ```
 
 ### `credential "notion_oauth" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 _No configurable attributes._
 
@@ -273,6 +296,8 @@ credential "notion_oauth" "example" {}
 
 ### `credential "openai_codex_oauth" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -280,6 +305,8 @@ credential "openai_codex_oauth" "example" {}
 ```
 
 ### `credential "postgres_credential" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -291,6 +318,8 @@ credential "postgres_credential" "example" {}
 
 ### `credential "slack_tokens" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -299,6 +328,8 @@ credential "slack_tokens" "example" {}
 
 ### `credential "ssh" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 _No configurable attributes._
 
 ```hcl
@@ -306,6 +337,8 @@ credential "ssh" "example" {}
 ```
 
 ### `credential "telegram_bot_token" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 _No configurable attributes._
 
@@ -320,6 +353,8 @@ Block syntax: `endpoint "<type>" "<name>" { ... }`
 Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
 
 ### `endpoint "clickhouse_https" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 Family: `sql`.
 
@@ -374,6 +409,8 @@ endpoint "clickhouse_native" "example" {
 
 ### `endpoint "https" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 Family: `https`.
 
 | Attribute | Type | Required | Description |
@@ -390,6 +427,8 @@ endpoint "https" "example" {
 
 ### `endpoint "kubernetes" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
 Family: `k8s`.
 
 | Attribute | Type | Required | Description |
@@ -405,6 +444,8 @@ endpoint "kubernetes" "example" {}
 ```
 
 ### `endpoint "openai_codex_https" "<name>"`
+
+Is part of the clawpatrol plugin API.
 
 Family: `https`.
 

--- a/tools/docgen/docgen_test.go
+++ b/tools/docgen/docgen_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/tools/docgen/internal/render"
+)
+
+// TestGeneratedDocIsFresh fails when site/doc/15-config-reference.md
+// drifts from what the generator currently produces. Run
+// `go run ./tools/docgen` from the repo root and commit the result.
+func TestGeneratedDocIsFresh(t *testing.T) {
+	got, err := render.Generate()
+	if err != nil {
+		t.Fatalf("render.Generate: %v", err)
+	}
+
+	root := repoRoot(t)
+	path := filepath.Join(root, "site", "doc", "15-config-reference.md")
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if string(want) == got {
+		return
+	}
+
+	wantLines := strings.Split(string(want), "\n")
+	gotLines := strings.Split(got, "\n")
+	t.Errorf("site/doc/15-config-reference.md is stale.\n"+
+		"Run `go run ./tools/docgen` from the repo root and commit the result.\n"+
+		"Committed: %d lines; generated: %d lines.\n%s",
+		len(wantLines), len(gotLines), firstDiff(wantLines, gotLines))
+}
+
+func firstDiff(a, b []string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return fmt.Sprintf("First differing line %d:\n  committed: %s\n  generated: %s\n",
+				i+1, a[i], b[i])
+		}
+	}
+	if len(a) != len(b) {
+		return fmt.Sprintf("Files agree on the first %d lines but lengths differ.\n", n)
+	}
+	return ""
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	// .../tools/docgen/docgen_test.go → repo root is 2 levels up.
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/tools/docgen/internal/render/godoc.go
+++ b/tools/docgen/internal/render/godoc.go
@@ -1,0 +1,129 @@
+package render
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// goDocs holds Go source comments extracted from the packages whose
+// types are exposed in the HCL config. We index by qualified type
+// name (`config.Gateway`, `endpoints.HTTPSEndpoint`) and by field
+// (`endpoints.HTTPSEndpoint.Hosts`).
+type goDocs struct {
+	types  map[string]string // pkgName.TypeName → leading doc
+	fields map[string]string // pkgName.TypeName.FieldName → leading doc
+}
+
+// loadGoDocs parses every Go file under config/ that holds an HCL-
+// tagged struct and extracts the leading doc comments. We walk the
+// AST manually rather than going through go/doc because we want
+// per-field comments, including comments above struct fields.
+//
+// Source lookup is anchored at runtime.Caller so the generator can
+// be invoked from any working directory (notably `go test` from a
+// subpackage).
+func loadGoDocs() (*goDocs, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return nil, err
+	}
+	dirs := []string{
+		filepath.Join(root, "config"),
+		filepath.Join(root, "config", "plugins", "approvers"),
+		filepath.Join(root, "config", "plugins", "credentials"),
+		filepath.Join(root, "config", "plugins", "endpoints"),
+		filepath.Join(root, "config", "plugins", "rules"),
+	}
+
+	docs := &goDocs{
+		types:  map[string]string{},
+		fields: map[string]string{},
+	}
+
+	fset := token.NewFileSet()
+	for _, dir := range dirs {
+		pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+			n := fi.Name()
+			return strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go")
+		}, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", dir, err)
+		}
+		for _, pkg := range pkgs {
+			extractPkg(pkg, docs)
+		}
+	}
+	return docs, nil
+}
+
+func extractPkg(pkg *ast.Package, out *goDocs) {
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				typeKey := pkg.Name + "." + ts.Name.Name
+				doc := commentText(ts.Doc)
+				if doc == "" {
+					// Type doc may be on the GenDecl rather than
+					// the TypeSpec when the type is the only spec
+					// in the decl.
+					doc = commentText(gd.Doc)
+				}
+				if doc != "" {
+					out.types[typeKey] = doc
+				}
+				if st.Fields != nil {
+					for _, f := range st.Fields.List {
+						fieldDoc := commentText(f.Doc)
+						if fieldDoc == "" {
+							fieldDoc = commentText(f.Comment)
+						}
+						for _, name := range f.Names {
+							out.fields[typeKey+"."+name.Name] = fieldDoc
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func commentText(g *ast.CommentGroup) string {
+	if g == nil {
+		return ""
+	}
+	return strings.TrimSpace(g.Text())
+}
+
+// repoRoot resolves to the clawpatrol repo root by walking up from
+// this file's location at compile time.
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+	// .../tools/docgen/internal/render/godoc.go → repo root is 4 levels up.
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", "..")), nil
+}
+
+func (d *goDocs) typeDoc(pkg, name string) string { return d.types[pkg+"."+name] }
+func (d *goDocs) fieldDoc(pkg, typ, f string) string {
+	return d.fields[pkg+"."+typ+"."+f]
+}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -16,7 +16,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
-	"github.com/denoland/clawpatrol/config/match"
+	"github.com/denoland/clawpatrol/config/facet"
 
 	// Side-effect import: every plugin's init() calls config.Register
 	// so AllPlugins(kind) returns the full set during generation.
@@ -237,7 +237,7 @@ func (r *renderer) writeRuleMatchKeys(p *config.Plugin) {
 	}
 	r.out.WriteString("**`match` keys** (single string or list of strings each):\n\n")
 	for _, fam := range p.Families {
-		keys := match.KnownKeys(fam)
+		keys := facet.KnownKeys(fam)
 		if len(keys) == 0 {
 			continue
 		}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -549,6 +549,8 @@ func ctyTypeOverride(hclName string) string {
 		return "[]credential"
 	case "approve":
 		return "[]ref(approver)"
+	case "match":
+		return "block"
 	}
 	return ""
 }

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -1,0 +1,601 @@
+// Package render builds the auto-generated HCL config reference from
+// the live plugin registry plus Go-source comments. The output is a
+// Markdown document picked up by site/build-docs.ts.
+//
+// Generate() is the only entry point — it returns the rendered
+// document so both the CLI generator and the drift test can consume
+// the same value.
+package render
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+
+	// Side-effect import: every plugin's init() calls config.Register
+	// so AllPlugins(kind) returns the full set during generation.
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+// Generate renders the full reference. Returns the document text;
+// the caller writes it (or diffs it).
+func Generate() (string, error) {
+	docs, err := loadGoDocs()
+	if err != nil {
+		return "", fmt.Errorf("load go docs: %w", err)
+	}
+	r := &renderer{docs: docs}
+	return r.run()
+}
+
+type renderer struct {
+	docs *goDocs
+	out  strings.Builder
+}
+
+func (r *renderer) run() (string, error) {
+	r.writeHeader()
+	r.writeOperational()
+	r.writeFixedKind("defaults", "config", "Defaults", "")
+	r.writeFixedKind("policy", "config", "PolicyText", `policy "<name>"`)
+	r.writeProfile()
+
+	for _, kind := range []config.Kind{
+		config.KindApprover,
+		config.KindCredential,
+		config.KindEndpoint,
+		config.KindRule,
+	} {
+		r.writeKind(kind)
+	}
+	return r.out.String(), nil
+}
+
+func (r *renderer) writeHeader() {
+	r.out.WriteString(`# HCL config reference
+
+> **This page is auto-generated** from the plugin registry under
+> ` + "`config/plugins/`" + ` and the operational structs in ` + "`config/`" + `.
+> Do not hand-edit. Re-run ` + "`go run ./tools/docgen`" + ` after changing any
+> ` + "`hcl:\"...\"`" + ` tag, plugin registration, or struct field comment.
+
+A clawpatrol gateway config mixes **operational** fields (top-level
+plumbing) with **policy** blocks. Operational fields decode statically
+into ` + "`config.Gateway`" + `; policy blocks dispatch to plugins by their
+first label.
+
+For prose context (references, namespaces, design rationale) see
+[` + "`config/README.md`" + `](https://github.com/denoland/clawpatrol/blob/main/config/README.md);
+the page you're reading is the field-by-field reference.
+
+## How to read this page
+
+Each block section lists the attributes the loader accepts, with:
+
+- **Type** — Go type after HCL decode. ` + "`string`" + `, ` + "`bool`" + `, ` + "`int`" + ` map to
+  the obvious HCL kinds; ` + "`[]string`" + ` is an HCL list of strings;
+  ` + "`object`" + ` denotes a nested block / object whose shape is
+  described inline.
+- **Required** — ` + "`yes`" + ` if the loader rejects the block when the
+  attribute is missing.
+- **Reference** — when set, the value is a bare-name reference to
+  another block of the named kind (e.g. ` + "`credential = github-pat`" + `).
+
+Plugin-dispatched kinds (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
+list one subsection per registered type.
+
+`)
+}
+
+// ── operational top-level + tailscale ───────────────────────────────
+
+func (r *renderer) writeOperational() {
+	r.out.WriteString("## Top-level operational fields\n\n")
+	if doc := r.docs.typeDoc("config", "Gateway"); doc != "" {
+		r.out.WriteString(doc)
+		r.out.WriteString("\n\n")
+	}
+	r.writeStructTable("config", "Gateway", reflect.TypeOf(config.Gateway{}))
+
+	r.out.WriteString("### `gateway {}` block\n\n")
+	if doc := r.docs.typeDoc("config", "Tailscale"); doc != "" {
+		r.out.WriteString(doc)
+		r.out.WriteString("\n\n")
+	}
+	r.writeStructTable("config", "Tailscale", reflect.TypeOf(config.Tailscale{}))
+}
+
+// writeFixedKind documents a one-label kind with a fixed, non-plugin
+// schema (defaults, policy). The body struct lives in package
+// `config`.
+func (r *renderer) writeFixedKind(kind, pkg, typeName, headerSuffix string) {
+	header := fmt.Sprintf("`%s {}`", kind)
+	if headerSuffix != "" {
+		header = fmt.Sprintf("`%s { ... }`", headerSuffix)
+	}
+	fmt.Fprintf(&r.out, "## %s\n\n", header)
+	if doc := r.docs.typeDoc(pkg, typeName); doc != "" {
+		r.out.WriteString(doc)
+		r.out.WriteString("\n\n")
+	}
+	rt := reflectTypeFor(pkg, typeName)
+	r.writeStructTable(pkg, typeName, rt)
+	r.writeExample(kind, "", rt, false)
+}
+
+func reflectTypeFor(pkg, name string) reflect.Type {
+	switch pkg + "." + name {
+	case "config.Gateway":
+		return reflect.TypeOf(config.Gateway{})
+	case "config.Tailscale":
+		return reflect.TypeOf(config.Tailscale{})
+	case "config.Defaults":
+		return reflect.TypeOf(config.Defaults{})
+	case "config.PolicyText":
+		return reflect.TypeOf(config.PolicyText{})
+	}
+	return nil
+}
+
+// writeProfile documents the `profile "<name>" {}` block. The body
+// struct is unexported (config.profileBody), so we inline its single
+// field rather than going through reflection.
+func (r *renderer) writeProfile() {
+	r.out.WriteString("## `profile \"<name>\" { ... }`\n\n")
+	r.out.WriteString("Names a set of endpoints. Profiles bind to dashboard owners; an owner's profile determines which endpoints their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.\n\n")
+	r.out.WriteString("| Attribute | Type | Required | Reference | Description |\n")
+	r.out.WriteString("|-----------|------|----------|-----------|-------------|\n")
+	r.out.WriteString("| `endpoints` | `[]string` | yes | endpoint | Bare-name endpoint references included in this profile. |\n\n")
+	r.out.WriteString("```hcl\nprofile \"default\" {\n  endpoints = [github, postgres-prod]\n}\n```\n\n")
+}
+
+// ── plugin-dispatched kinds ─────────────────────────────────────────
+
+func (r *renderer) writeKind(kind config.Kind) {
+	plugins := config.AllPlugins(kind)
+	sort.Slice(plugins, func(i, j int) bool { return plugins[i].Type < plugins[j].Type })
+
+	syntax := kindSyntax(kind)
+	fmt.Fprintf(&r.out, "## `%s` blocks\n\n", kind)
+	fmt.Fprintf(&r.out, "Block syntax: `%s`\n\n", syntax)
+	fmt.Fprintf(&r.out, "Registered types: ")
+	for i, p := range plugins {
+		if i > 0 {
+			r.out.WriteString(", ")
+		}
+		fmt.Fprintf(&r.out, "[`%s`](#%s-%s)", p.Type, kind, anchor(p.Type))
+	}
+	r.out.WriteString(".\n\n")
+
+	for _, p := range plugins {
+		r.writePlugin(kind, p)
+	}
+}
+
+func (r *renderer) writePlugin(kind config.Kind, p *config.Plugin) {
+	fmt.Fprintf(&r.out, "### `%s \"%s\"`\n\n", kind, p.Type)
+
+	rt := pluginStructType(p)
+	pkgName := pkgNameOf(rt)
+	typeName := rt.Name()
+
+	if doc := r.docs.typeDoc(pkgName, typeName); doc != "" {
+		r.out.WriteString(doc)
+		r.out.WriteString("\n\n")
+	}
+
+	if kind == config.KindEndpoint && p.Family != "" {
+		fmt.Fprintf(&r.out, "Family: `%s`.\n\n", p.Family)
+	}
+	if kind == config.KindRule && len(p.Families) > 0 {
+		fmt.Fprintf(&r.out, "Targets endpoints of family: %s.\n\n", joinTicked(p.Families))
+	}
+
+	r.writeStructTable(pkgName, typeName, rt)
+
+	// Reference list: cross-reference fields driven by RefSpec.
+	if len(p.Refs) > 0 {
+		r.out.WriteString("**References:** ")
+		for i, ref := range p.Refs {
+			if i > 0 {
+				r.out.WriteString("; ")
+			}
+			fmt.Fprintf(&r.out, "`%s` → %s", ref.Path, ref.Kind)
+			if ref.Optional {
+				r.out.WriteString(" (optional)")
+			}
+		}
+		r.out.WriteString(".\n\n")
+	}
+
+	// Rule plugins: enumerate per-family valid match keys.
+	if kind == config.KindRule {
+		r.writeRuleMatchKeys(p)
+	}
+
+	r.writeExample(string(kind), p.Type, rt, true)
+}
+
+func (r *renderer) writeRuleMatchKeys(p *config.Plugin) {
+	if len(p.Families) == 0 {
+		return
+	}
+	r.out.WriteString("**`match` keys** (single string or list of strings each):\n\n")
+	for _, fam := range p.Families {
+		keys := match.KnownKeys(fam)
+		if len(keys) == 0 {
+			continue
+		}
+		fmt.Fprintf(&r.out, "- family `%s`: %s\n", fam, joinTicked(keys))
+	}
+	r.out.WriteString("\n")
+}
+
+// pluginStructType invokes plugin.New() and returns the underlying
+// struct reflect.Type. New() returns a pointer to the body struct.
+func pluginStructType(p *config.Plugin) reflect.Type {
+	v := reflect.ValueOf(p.New())
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return v.Type()
+}
+
+func pkgNameOf(rt reflect.Type) string {
+	pp := rt.PkgPath()
+	if i := strings.LastIndex(pp, "/"); i >= 0 {
+		return pp[i+1:]
+	}
+	return pp
+}
+
+// ── struct → markdown table ─────────────────────────────────────────
+
+type fieldRow struct {
+	Name        string
+	Type        string
+	Required    bool
+	Reference   string
+	Doc         string
+	Block       bool
+	Skip        bool
+	IsLabel     bool
+	GoFieldName string
+}
+
+func (r *renderer) writeStructTable(pkgName, typeName string, rt reflect.Type) {
+	rows := r.collectFields(pkgName, typeName, rt)
+	if len(rows) == 0 {
+		r.out.WriteString("_No configurable attributes._\n\n")
+		return
+	}
+
+	r.out.WriteString("| Attribute | Type | Required | Reference | Description |\n")
+	r.out.WriteString("|-----------|------|----------|-----------|-------------|\n")
+	for _, f := range rows {
+		req := "no"
+		if f.Required {
+			req = "yes"
+		}
+		ref := f.Reference
+		if ref == "" {
+			ref = "—"
+		}
+		fmt.Fprintf(&r.out, "| `%s` | `%s` | %s | %s | %s |\n",
+			f.Name, f.Type, req, ref, mdEscape(oneLine(f.Doc)))
+	}
+	r.out.WriteString("\n")
+
+	// Inline nested struct blocks. Skip Gateway's `gateway {}` field
+	// (Tailscale) — it gets a dedicated top-level section.
+	if typeName == "Gateway" {
+		return
+	}
+	for _, f := range rows {
+		if !f.Block {
+			continue
+		}
+		blockType := blockElemType(rt, f.GoFieldName)
+		if blockType == nil {
+			continue
+		}
+		bp := pkgNameOf(blockType)
+		bn := blockType.Name()
+		fmt.Fprintf(&r.out, "**Nested block `%s {}`:**\n\n", f.Name)
+		if doc := r.docs.typeDoc(bp, bn); doc != "" {
+			r.out.WriteString(doc)
+			r.out.WriteString("\n\n")
+		}
+		r.writeStructTable(bp, bn, blockType)
+	}
+}
+
+// collectFields walks rt and produces a row per HCL-tagged attribute.
+// Skips fields with hcl:"-", json:"-", or no hcl tag at all.
+func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fieldRow {
+	var rows []fieldRow
+
+	// refs by Go path → kind, for annotating reference columns.
+	refByPath := r.fieldRefs(pkgName, typeName)
+
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		hclTag, ok := f.Tag.Lookup("hcl")
+		if !ok {
+			continue
+		}
+		jsonTag := f.Tag.Get("json")
+		// Fields populated post-decode (CredentialEntry slice on
+		// HTTPSEndpoint) carry json:"-" or no hcl tag — skip.
+		if hclTag == "" || hclTag == "-" {
+			continue
+		}
+		parts := strings.Split(hclTag, ",")
+		name := parts[0]
+		opts := parts[1:]
+		if hasOpt(opts, "remain") || hasOpt(opts, "label") {
+			continue
+		}
+
+		typeStr := formatGoType(f.Type)
+		if hasOpt(opts, "block") {
+			typeStr = "block"
+		}
+		row := fieldRow{
+			Name:        name,
+			Type:        typeStr,
+			Required:    !hasOpt(opts, "optional"),
+			Block:       hasOpt(opts, "block"),
+			GoFieldName: f.Name,
+			Doc:         r.docs.fieldDoc(pkgName, typeName, f.Name),
+		}
+		if jsonTag == "-" && row.Block {
+			// jsonTag "-" + block is unusual; keep but don't skip.
+		}
+		// Reference annotation: a RefSpec path either exactly equals
+		// the Go field name (singular) or starts with "<field>[*]"
+		// (slice of refs).
+		if kindRef, ok := refByPath[f.Name]; ok {
+			row.Reference = kindRef
+		} else if kindRef, ok := refByPath[f.Name+"[*]"]; ok {
+			row.Reference = kindRef
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// fieldRefs returns Go-field-path → "kind" annotations sourced from
+// the Plugin.Refs RefSpec list. Only meaningful when typeName is a
+// plugin body struct.
+func (r *renderer) fieldRefs(pkgName, typeName string) map[string]string {
+	out := map[string]string{}
+	for _, kind := range []config.Kind{
+		config.KindApprover, config.KindCredential, config.KindEndpoint, config.KindRule,
+	} {
+		for _, p := range config.AllPlugins(kind) {
+			rt := pluginStructType(p)
+			if pkgNameOf(rt) != pkgName || rt.Name() != typeName {
+				continue
+			}
+			for _, ref := range p.Refs {
+				out[ref.Path] = string(ref.Kind)
+			}
+		}
+	}
+	return out
+}
+
+// blockElemType returns the underlying struct type of a `hcl:"...,block"`
+// field, peeling pointer / slice indirections. Returns nil if not a
+// recognizable struct.
+func blockElemType(rt reflect.Type, fieldName string) reflect.Type {
+	f, ok := rt.FieldByName(fieldName)
+	if !ok {
+		return nil
+	}
+	t := f.Type
+	for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	if t == reflect.TypeOf(cty.Value{}) {
+		return nil
+	}
+	return t
+}
+
+// ── examples ────────────────────────────────────────────────────────
+
+// writeExample emits a tiny synthetic HCL example. For plugin-
+// dispatched kinds (typed=true) the block carries `<kind> "<type>"
+// "example"`; otherwise just `<kind> { ... }` (defaults, policy).
+func (r *renderer) writeExample(kind, typ string, rt reflect.Type, typed bool) {
+	if rt == nil {
+		return
+	}
+	var head string
+	switch {
+	case typ != "" && typed:
+		head = fmt.Sprintf(`%s "%s" "example"`, kind, typ)
+	case kind == "policy":
+		head = `policy "example"`
+	default:
+		head = kind
+	}
+
+	body := exampleBody(rt)
+	if strings.TrimSpace(body) == "" {
+		fmt.Fprintf(&r.out, "```hcl\n%s {}\n```\n\n", head)
+		return
+	}
+	fmt.Fprintf(&r.out, "```hcl\n%s {\n%s}\n```\n\n", head, body)
+}
+
+func exampleBody(rt reflect.Type) string {
+	var sb strings.Builder
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		hclTag, ok := f.Tag.Lookup("hcl")
+		if !ok || hclTag == "" || hclTag == "-" {
+			continue
+		}
+		parts := strings.Split(hclTag, ",")
+		name := parts[0]
+		opts := parts[1:]
+		if hasOpt(opts, "label") || hasOpt(opts, "remain") {
+			continue
+		}
+		// Skip optional fields in the synthetic example to keep
+		// it terse. Required fields show the canonical value.
+		if hasOpt(opts, "optional") {
+			continue
+		}
+		val := exampleValue(f.Type, name)
+		if val == "" {
+			continue
+		}
+		fmt.Fprintf(&sb, "  %s = %s\n", name, val)
+	}
+	return sb.String()
+}
+
+func exampleValue(t reflect.Type, fieldName string) string {
+	switch t.Kind() {
+	case reflect.String:
+		switch fieldName {
+		case "model":
+			return `"claude-haiku-4-5-20251001"`
+		case "channel":
+			return `"#approvals"`
+		case "host":
+			return `"db.internal:5432"`
+		case "database":
+			return `"appdb"`
+		case "server":
+			return `"https://kube.internal:6443"`
+		case "header":
+			return `"X-API-Key"`
+		case "cookie_name":
+			return `"session"`
+		case "credential":
+			return "example-credential"
+		case "endpoint":
+			return "example-endpoint"
+		case "policy":
+			return "example-policy"
+		case "verdict":
+			return `"deny"`
+		case "reason":
+			return `"example reason"`
+		case "text":
+			return "<<-EOT\n    Example policy text.\n  EOT"
+		}
+		return `"example"`
+	case reflect.Bool:
+		return "true"
+	case reflect.Int, reflect.Int32, reflect.Int64:
+		return "30"
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.String {
+			switch fieldName {
+			case "hosts":
+				return `["api.example.com"]`
+			case "endpoints":
+				return "[example-endpoint]"
+			case "tags":
+				return `["tag:gateway"]`
+			}
+			return `["example"]`
+		}
+	}
+	return ""
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+func hasOpt(opts []string, want string) bool {
+	for _, o := range opts {
+		if o == want {
+			return true
+		}
+	}
+	return false
+}
+
+// formatGoType renders a Go type for the docs table. cty.Value is
+// rendered as `object` (its shape is described in prose). Pointers,
+// slices, and maps recurse.
+func formatGoType(t reflect.Type) string {
+	if t == reflect.TypeOf(cty.Value{}) {
+		return "object"
+	}
+	switch t.Kind() {
+	case reflect.Ptr:
+		return formatGoType(t.Elem())
+	case reflect.Slice:
+		return "[]" + formatGoType(t.Elem())
+	case reflect.Map:
+		return "map[" + formatGoType(t.Key()) + "]" + formatGoType(t.Elem())
+	case reflect.Struct:
+		if t.Name() == "" {
+			return "object"
+		}
+		return t.Name()
+	}
+	return t.String()
+}
+
+func anchor(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "_", "")
+	return s
+}
+
+func joinTicked(xs []string) string {
+	out := make([]string, len(xs))
+	for i, x := range xs {
+		out[i] = "`" + x + "`"
+	}
+	return strings.Join(out, ", ")
+}
+
+func kindSyntax(k config.Kind) string {
+	if k.LabelCount() == 2 {
+		return string(k) + ` "<type>" "<name>" { ... }`
+	}
+	return string(k) + ` "<name>" { ... }`
+}
+
+func oneLine(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Collapse newlines (typical Go comment wrap) into single spaces.
+	s = strings.ReplaceAll(s, "\n", " ")
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return s
+}
+
+func mdEscape(s string) string {
+	// Pipe characters break Markdown tables; escape them. Backticks
+	// in field comments are kept since they render as code in cells.
+	return strings.ReplaceAll(s, "|", `\|`)
+}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -60,32 +60,22 @@ func (r *renderer) run() (string, error) {
 func (r *renderer) writeHeader() {
 	r.out.WriteString(`# HCL config reference
 
-> **This page is auto-generated** from the plugin registry under
-> ` + "`config/plugins/`" + ` and the operational structs in ` + "`config/`" + `.
-> Do not hand-edit. Re-run ` + "`go run ./tools/docgen`" + ` after changing any
-> ` + "`hcl:\"...\"`" + ` tag, plugin registration, or struct field comment.
-
 A clawpatrol gateway config mixes **operational** fields (top-level
-plumbing) with **policy** blocks. Operational fields decode statically
-into ` + "`config.Gateway`" + `; policy blocks dispatch to plugins by their
-first label.
-
-For prose context (references, namespaces, design rationale) see
-[` + "`config/README.md`" + `](https://github.com/denoland/clawpatrol/blob/main/config/README.md);
-the page you're reading is the field-by-field reference.
+plumbing) with **policy** blocks. Operational fields are top-level
+attributes; policy blocks (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
+dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
 
 Each block section lists the attributes the loader accepts, with:
 
-- **Type** — Go type after HCL decode. ` + "`string`" + `, ` + "`bool`" + `, ` + "`int`" + ` map to
-  the obvious HCL kinds; ` + "`[]string`" + ` is an HCL list of strings;
-  ` + "`object`" + ` denotes a nested block / object whose shape is
-  described inline.
+- **Type** — the HCL value type. ` + "`string`" + `, ` + "`bool`" + `, ` + "`int`" + ` are scalar
+  literals; ` + "`[]string`" + ` is a list of strings; ` + "`ref(<kind>)`" + ` is a
+  bare-name reference to another block of that kind (e.g.
+  ` + "`credential = github-pat`" + `); ` + "`[]ref(<kind>)`" + ` is a list of such
+  references; nested blocks have their shape described inline.
 - **Required** — ` + "`yes`" + ` if the loader rejects the block when the
   attribute is missing.
-- **Reference** — when set, the value is a bare-name reference to
-  another block of the named kind (e.g. ` + "`credential = github-pat`" + `).
 
 Plugin-dispatched kinds (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
 list one subsection per registered type.
@@ -95,19 +85,53 @@ list one subsection per registered type.
 
 // ── operational top-level + tailscale ───────────────────────────────
 
+// stripIdentPrefix drops a leading "<ident> " (and the common Go-doc
+// "<ident> is "/"<ident> are " linking verb) from a doc comment, then
+// re-capitalises the next word so the sentence still reads cleanly.
+// Go convention starts every godoc with the identifier name; in HCL
+// reference output that name is rarely meaningful (the user knows the
+// HCL attribute, not the Go field), so we elide it.
+func stripIdentPrefix(doc, ident string) string {
+	if doc == "" || ident == "" {
+		return doc
+	}
+	prefix := ident + " "
+	if !strings.HasPrefix(doc, prefix) {
+		return doc
+	}
+	rest := doc[len(prefix):]
+	// Drop the common "<Ident> is/are <article>" linker so the
+	// remaining sentence reads as a noun phrase ("The shared body
+	// shape...") rather than a fragment ("Is the shared body shape...").
+	linkers := []struct{ from, to string }{
+		{"is the ", "The "},
+		{"is a ", "A "},
+		{"is an ", "An "},
+		{"are the ", "The "},
+		{"are ", ""},
+	}
+	for _, l := range linkers {
+		if strings.HasPrefix(rest, l.from) {
+			return l.to + rest[len(l.from):]
+		}
+	}
+	if rest == "" {
+		return rest
+	}
+	first := rest[0]
+	if first >= 'a' && first <= 'z' {
+		return strings.ToUpper(rest[:1]) + rest[1:]
+	}
+	return rest
+}
+
 func (r *renderer) writeOperational() {
 	r.out.WriteString("## Top-level operational fields\n\n")
-	if doc := r.docs.typeDoc("config", "Gateway"); doc != "" {
-		r.out.WriteString(doc)
-		r.out.WriteString("\n\n")
-	}
+	r.out.WriteString("These are the attributes you set directly at the top of `gateway.hcl`. Anything below `gateway {}` (defaults, policy, profile, approver, credential, endpoint, rule) is a separate block documented in its own section.\n\n")
 	r.writeStructTable("config", "Gateway", reflect.TypeOf(config.Gateway{}))
 
 	r.out.WriteString("### `gateway {}` block\n\n")
-	if doc := r.docs.typeDoc("config", "Tailscale"); doc != "" {
-		r.out.WriteString(doc)
-		r.out.WriteString("\n\n")
-	}
+	r.out.WriteString("Singleton block configuring how the gateway joins the operator's tailnet (or a self-hosted control plane) and the WireGuard tunnel that carries agent traffic.\n\n")
 	r.writeStructTable("config", "Tailscale", reflect.TypeOf(config.Tailscale{}))
 }
 
@@ -120,7 +144,7 @@ func (r *renderer) writeFixedKind(kind, pkg, typeName, headerSuffix string) {
 		header = fmt.Sprintf("`%s { ... }`", headerSuffix)
 	}
 	fmt.Fprintf(&r.out, "## %s\n\n", header)
-	if doc := r.docs.typeDoc(pkg, typeName); doc != "" {
+	if doc := stripIdentPrefix(r.docs.typeDoc(pkg, typeName), typeName); doc != "" {
 		r.out.WriteString(doc)
 		r.out.WriteString("\n\n")
 	}
@@ -149,9 +173,9 @@ func reflectTypeFor(pkg, name string) reflect.Type {
 func (r *renderer) writeProfile() {
 	r.out.WriteString("## `profile \"<name>\" { ... }`\n\n")
 	r.out.WriteString("Names a set of endpoints. Profiles bind to dashboard owners; an owner's profile determines which endpoints their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.\n\n")
-	r.out.WriteString("| Attribute | Type | Required | Reference | Description |\n")
-	r.out.WriteString("|-----------|------|----------|-----------|-------------|\n")
-	r.out.WriteString("| `endpoints` | `[]string` | yes | endpoint | Bare-name endpoint references included in this profile. |\n\n")
+	r.out.WriteString("| Attribute | Type | Required | Description |\n")
+	r.out.WriteString("|-----------|------|----------|-------------|\n")
+	r.out.WriteString("| `endpoints` | `[]ref(endpoint)` | yes | Bare-name endpoint references included in this profile. |\n\n")
 	r.out.WriteString("```hcl\nprofile \"default\" {\n  endpoints = [github, postgres-prod]\n}\n```\n\n")
 }
 
@@ -179,13 +203,13 @@ func (r *renderer) writeKind(kind config.Kind) {
 }
 
 func (r *renderer) writePlugin(kind config.Kind, p *config.Plugin) {
-	fmt.Fprintf(&r.out, "### `%s \"%s\"`\n\n", kind, p.Type)
+	fmt.Fprintf(&r.out, "### `%s \"%s\" \"<name>\"`\n\n", kind, p.Type)
 
 	rt := pluginStructType(p)
 	pkgName := pkgNameOf(rt)
 	typeName := rt.Name()
 
-	if doc := r.docs.typeDoc(pkgName, typeName); doc != "" {
+	if doc := stripIdentPrefix(r.docs.typeDoc(pkgName, typeName), typeName); doc != "" {
 		r.out.WriteString(doc)
 		r.out.WriteString("\n\n")
 	}
@@ -198,21 +222,6 @@ func (r *renderer) writePlugin(kind config.Kind, p *config.Plugin) {
 	}
 
 	r.writeStructTable(pkgName, typeName, rt)
-
-	// Reference list: cross-reference fields driven by RefSpec.
-	if len(p.Refs) > 0 {
-		r.out.WriteString("**References:** ")
-		for i, ref := range p.Refs {
-			if i > 0 {
-				r.out.WriteString("; ")
-			}
-			fmt.Fprintf(&r.out, "`%s` → %s", ref.Path, ref.Kind)
-			if ref.Optional {
-				r.out.WriteString(" (optional)")
-			}
-		}
-		r.out.WriteString(".\n\n")
-	}
 
 	// Rule plugins: enumerate per-family valid match keys.
 	if kind == config.KindRule {
@@ -261,11 +270,8 @@ type fieldRow struct {
 	Name        string
 	Type        string
 	Required    bool
-	Reference   string
 	Doc         string
 	Block       bool
-	Skip        bool
-	IsLabel     bool
 	GoFieldName string
 }
 
@@ -276,19 +282,15 @@ func (r *renderer) writeStructTable(pkgName, typeName string, rt reflect.Type) {
 		return
 	}
 
-	r.out.WriteString("| Attribute | Type | Required | Reference | Description |\n")
-	r.out.WriteString("|-----------|------|----------|-----------|-------------|\n")
+	r.out.WriteString("| Attribute | Type | Required | Description |\n")
+	r.out.WriteString("|-----------|------|----------|-------------|\n")
 	for _, f := range rows {
 		req := "no"
 		if f.Required {
 			req = "yes"
 		}
-		ref := f.Reference
-		if ref == "" {
-			ref = "—"
-		}
-		fmt.Fprintf(&r.out, "| `%s` | `%s` | %s | %s | %s |\n",
-			f.Name, f.Type, req, ref, mdEscape(oneLine(f.Doc)))
+		fmt.Fprintf(&r.out, "| `%s` | `%s` | %s | %s |\n",
+			f.Name, f.Type, req, mdEscape(oneLine(f.Doc)))
 	}
 	r.out.WriteString("\n")
 
@@ -308,7 +310,7 @@ func (r *renderer) writeStructTable(pkgName, typeName string, rt reflect.Type) {
 		bp := pkgNameOf(blockType)
 		bn := blockType.Name()
 		fmt.Fprintf(&r.out, "**Nested block `%s {}`:**\n\n", f.Name)
-		if doc := r.docs.typeDoc(bp, bn); doc != "" {
+		if doc := stripIdentPrefix(r.docs.typeDoc(bp, bn), bn); doc != "" {
 			r.out.WriteString(doc)
 			r.out.WriteString("\n\n")
 		}
@@ -333,7 +335,6 @@ func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fi
 		if !ok {
 			continue
 		}
-		jsonTag := f.Tag.Get("json")
 		// Fields populated post-decode (CredentialEntry slice on
 		// HTTPSEndpoint) carry json:"-" or no hcl tag — skip.
 		if hclTag == "" || hclTag == "-" {
@@ -350,24 +351,24 @@ func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fi
 		if hasOpt(opts, "block") {
 			typeStr = "block"
 		}
+		// Reference annotation: a RefSpec path either exactly equals
+		// the Go field name (singular) or starts with "<field>[*]"
+		// (slice of refs). When set, fold the kind into the type as
+		// `ref(<kind>)` (or `[]ref(<kind>)` for list-valued refs).
+		if kindRef, ok := refByPath[f.Name]; ok {
+			typeStr = fmt.Sprintf("ref(%s)", kindRef)
+		} else if kindRef, ok := refByPath[f.Name+"[*]"]; ok {
+			typeStr = fmt.Sprintf("[]ref(%s)", kindRef)
+		} else if override := ctyTypeOverride(name); override != "" && typeStr == "object" {
+			typeStr = override
+		}
 		row := fieldRow{
 			Name:        name,
 			Type:        typeStr,
 			Required:    !hasOpt(opts, "optional"),
 			Block:       hasOpt(opts, "block"),
 			GoFieldName: f.Name,
-			Doc:         r.docs.fieldDoc(pkgName, typeName, f.Name),
-		}
-		if jsonTag == "-" && row.Block {
-			// jsonTag "-" + block is unusual; keep but don't skip.
-		}
-		// Reference annotation: a RefSpec path either exactly equals
-		// the Go field name (singular) or starts with "<field>[*]"
-		// (slice of refs).
-		if kindRef, ok := refByPath[f.Name]; ok {
-			row.Reference = kindRef
-		} else if kindRef, ok := refByPath[f.Name+"[*]"]; ok {
-			row.Reference = kindRef
+			Doc:         stripIdentPrefix(r.docs.fieldDoc(pkgName, typeName, f.Name), f.Name),
 		}
 		rows = append(rows, row)
 	}
@@ -535,6 +536,21 @@ func hasOpt(opts []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// ctyTypeOverride spells out a more specific type for HCL fields
+// decoded as raw cty.Value, where the loader interprets a per-shape
+// schema after gohcl. Returns "" when no override is known and the
+// generic `object` should stand. Keyed by HCL attribute name; safe
+// because these names are unique across the registry.
+func ctyTypeOverride(hclName string) string {
+	switch hclName {
+	case "credentials":
+		return "[]credential"
+	case "approve":
+		return "[]ref(approver)"
+	}
+	return ""
 }
 
 // formatGoType renders a Go type for the docs table. cty.Value is

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -1,0 +1,59 @@
+// Command docgen generates site/doc/15-config-reference.md from the
+// clawpatrol HCL config plugin registry. Schema source of truth is
+// the Go structs under config/plugins/ and the operational structs
+// in config/. Field documentation is read from Go source comments.
+//
+// The generator is idempotent: re-running on an unchanged tree
+// produces a byte-identical file. A drift test (docgen_test.go)
+// re-runs the generator and diffs against the committed output to
+// catch schemas that changed without doc updates.
+//
+// Why hand-rolled (not terraform-docs / gomarkdoc / etc.):
+// clawpatrol's HCL is a plugin-dispatched DSL — `<kind> "<type>"
+// "<name>" { ... }` blocks dispatch to a runtime-registered Go
+// struct via config.Register. No off-the-shelf HCL doc tool walks
+// a custom plugin registry; terraform-docs targets Terraform module
+// variables, gomarkdoc emits Go API docs, and hcldec/hclspec carry
+// no doc generator. The generator is small (≈500 LOC) and has a
+// drift test, so the maintenance cost is bounded.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/denoland/clawpatrol/tools/docgen/internal/render"
+)
+
+func main() {
+	out := flag.String("o", "site/doc/15-config-reference.md", "output file (relative to repo root)")
+	check := flag.Bool("check", false, "exit non-zero if the generated content differs from the file at -o")
+	flag.Parse()
+
+	got, err := render.Generate()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "docgen:", err)
+		os.Exit(2)
+	}
+
+	if *check {
+		want, err := os.ReadFile(*out)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "docgen --check: read", *out, ":", err)
+			os.Exit(2)
+		}
+		if string(want) != got {
+			fmt.Fprintf(os.Stderr,
+				"docgen --check: %s is stale; re-run `go run ./tools/docgen` and commit the result\n",
+				*out)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := os.WriteFile(*out, []byte(got), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "docgen:", err)
+		os.Exit(2)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `tools/docgen`, a Go program that introspects the plugin registry under `config/plugins/` plus the operational config structs and renders `site/doc/15-config-reference.md` — a per-block, per-field reference for `gateway.hcl`. The site build pipeline (`site/build-docs.ts`) picks the file up automatically.

## Why hand-rolled (and not a third-party tool)

Surveyed the obvious candidates before reaching for reflection:

- **terraform-docs** — reads `.tf` files, looks for `variable {}` / `output {}`. Doesn't introspect Go structs, doesn't understand custom block kinds. No fit.
- **gomarkdoc / pkgsite / `go doc`** — Go API doc generators. They render package-level APIs, not HCL field references. Fields with `hcl:"..."` tags would render as Go struct fields, not HCL attributes; relabeling required either way.
- **hcldec / hclspec** — schema decoders, no doc emitter shipped.
- **terraform-plugin-docs** — Terraform-Provider-specific; assumes the Terraform Plugin Framework runtime.

The clawpatrol HCL is a plugin-dispatched DSL — `<kind> "<type>" "<name>" { ... }` blocks dispatch to a runtime-registered Go struct via `config.Register`. No off-the-shelf tool walks a custom plugin registry, so the generator is a small (~700 LOC across two files) Go program that reflects on plugin body structs and reads field comments via `go/parser`.

## What the generator does

1. Pulls in every plugin via the existing `config/plugins/all` blank-import side effect.
2. Walks `config.AllPlugins(kind)` for each kind, calls `plugin.New()` to get the body struct, and reflects to enumerate `hcl:"..."`-tagged fields (name, optional, label, block).
3. Parses `config/` and `config/plugins/{approvers,credentials,endpoints,rules}/` with `go/parser` to extract type and field doc comments.
4. Cross-references `Plugin.Refs` to annotate which fields are bare-name references to other entities.
5. Emits Markdown organized by kind, with attribute tables and tiny synthesized examples.

## Wiring

- `go run ./tools/docgen` writes the file.
- `go run ./tools/docgen --check` exits non-zero on drift (handy in scripts / pre-commit).
- `go test ./tools/docgen/...` runs the same drift check in `go test ./...`.
- `go generate ./config/plugins/all/...` re-runs the generator (matches the existing convention of plugin registration living in `all/`).
- `README.md` documents the regen command alongside the existing policy section.

## Test plan

- [x] `go run ./tools/docgen` produces `site/doc/15-config-reference.md`.
- [x] Re-running on an unchanged tree produces a byte-identical file.
- [x] `go test ./tools/docgen/...` passes; modifying the file by hand makes it fail with a pointer at the first differing line.
- [x] `go run ./tools/docgen --check` passes after generation, fails after manual edits.
- [x] `go generate ./config/plugins/all/...` rewrites the file in place.
- [ ] Verify the page renders correctly in the docs site (`npm run build` in `site/`) once a reviewer can run it.