### PR TITLE
site: glossary entries for Action and Facet

### DIFF
--- a/site/doc/03a-glossary.md
+++ b/site/doc/03a-glossary.md
@@ -98,8 +98,7 @@ A single named matchable property inside a [rule](#rule)'s
 `credential`; `k8s_rule` carries `resource` / `verb` / `namespace` /
 `name` / `params` / `credential`. Per-facet semantics vary — list
 values are any-of, a `!`-prefix on a string negates it, and individual
-facets are glob, PCRE, or exact match (see
-[`config/README.md`](../../config/README.md) for the full table).
+facets are glob, PCRE, or exact match.
 
 ### Approver
 

--- a/site/doc/03a-glossary.md
+++ b/site/doc/03a-glossary.md
@@ -69,13 +69,37 @@ are fetched at injection time. Built-in shapes include `bearer_token`,
 `postgres_credential`, `anthropic_manual_key`, and the OAuth variants.
 See [Configuration vocabulary](#configuration-vocabulary).
 
+### Action
+
+One unit of agent work the gateway sees and applies policy to — one
+HTTP call, one SQL query, one `kubectl` invocation, one SSH command.
+Each action targets an [endpoint](#endpoint), is gated by the matching
+[rule](#rule)'s [outcome](#outcome), and surfaces in the dashboard's
+live request feed (record kinds: `http`, `sql`, `k8s`, `ssh`) with its
+own detail page. "Action" is the operator-visible concept of "the
+thing the agent did."
+
 ### Rule
 
 One policy decision targeting one or more [endpoints](#endpoint). Three
 rule types — `http_rule`, `sql_rule`, `k8s_rule` — each constrained to
-a matching endpoint family. A rule has a `match = { ... }` map (facets
-depend on the rule type) and an [outcome](#outcome) — either a literal
-`verdict` or an `approve = [...]` chain.
+a matching endpoint family. A rule has a `match = { ... }` map of
+[facets](#facet) (the set depends on the rule type) and an
+[outcome](#outcome) — either a literal `verdict` or an `approve = [...]`
+chain.
+
+### Facet
+
+A single named matchable property inside a [rule](#rule)'s
+`match { ... }` block. Each rule family exposes its own facet set:
+`http_rule` carries `method` / `path` / `query` / `headers` /
+`body_json` / `body_contains` / `credential`; `sql_rule` carries
+`verb` / `tables` / `function` / `statement` / `statement_regex` /
+`credential`; `k8s_rule` carries `resource` / `verb` / `namespace` /
+`name` / `params` / `credential`. Per-facet semantics vary — list
+values are any-of, a `!`-prefix on a string negates it, and individual
+facets are glob, PCRE, or exact match (see
+[`config/README.md`](../../config/README.md) for the full table).
 
 ### Approver
 


### PR DESCRIPTION
## Summary

- Adds **Action** to the Concepts section between Endpoint and Rule — the operator-visible unit of agent work (one HTTP call / SQL query / kubectl invocation / SSH command), with cross-links to endpoint, rule, outcome, and the live request feed record kinds (`http`, `sql`, `k8s`, `ssh`).
- Adds **Facet** right after Rule — defines a single named match property, enumerates the per-family facet sets (`http_rule` / `sql_rule` / `k8s_rule`), and notes the any-of / `!`-negation / glob-vs-regex semantics with a pointer to `config/README.md` for the full table.
- Updates the existing Rule entry to cross-reference the new Facet entry.

## Test plan

- [x] `npm run build` in `site/` — no warnings; both new entries render with working anchor links.