### PR TITLE
fix: bring down clawpatrol tunnel before poll in whole-machine rejoin

### DIFF
--- a/login.go
+++ b/login.go
@@ -626,6 +626,16 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		interval = 3 * time.Second
 	}
 	deadline := time.Now().Add(time.Duration(start.ExpiresIn) * time.Second)
+
+	// In whole-machine mode the clawpatrol WireGuard tunnel already routes
+	// all traffic — including these poll requests. When the admin approves,
+	// MintKey evicts our old peer from the gateway device, killing the
+	// tunnel mid-poll and hanging the spinner indefinitely. Bring it down
+	// before polling so requests go over the regular internet.
+	if wholeMachine {
+		_ = runAsRoot("wg-quick", "down", "clawpatrol").Run()
+	}
+
 	stopSpin := startSpinner("Waiting for approval")
 	authKey, loginServer, apiToken := "", "", ""
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
## Summary

- `clawpatrol join --whole-machine` run a second time (while tunnel already up) hangs at "Waiting for approval" indefinitely
- Root cause: in whole-machine mode, all traffic routes through the existing WireGuard session — including `/api/onboard/poll` requests. When the admin approves, `MintKey` calls `AddPeer` which evicts the old peer from the gateway device, killing the active tunnel mid-poll. The poll loop can no longer reach the gateway and spins until timeout.
- Fix: drop the tunnel (`wg-quick down clawpatrol`) before starting the poll loop so poll requests go over the regular internet. The tunnel is re-established at the end of the flow as normal.

The user's existing workaround (`wg-quick down clawpatrol` then re-run join) is now automatic.

## Test plan

- [ ] Run `clawpatrol join --url <gw> --whole-machine` once (succeeds, tunnel up)
- [ ] Run the same command again without `wg-quick down` — should no longer hang at "Waiting for approval"
- [ ] Verify approval flow completes and new tunnel comes up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)