### PR TITLE
analytics: stable scatter sample, exact bar counts, gated polling

### DIFF
--- a/web.go
+++ b/web.go
@@ -1013,13 +1013,17 @@ func (w *webMux) apiAnalytics(
 		whereArgs = append(whereArgs, agent)
 	}
 
+	// Sort by the random suffix of action_id (UUIDv7, so the last
+	// chars are uniform random) instead of RANDOM(). Same range +
+	// agent → same sample, so a polling dashboard doesn't reshuffle
+	// the scatter every 10 s.
 	query := `
 		SELECT action_id, ts_ns, mode, agent_ip, host,
 		       method, path, status, bytes_in, bytes_out,
 		       ms, action, reason
 		FROM actions
 		WHERE ` + where + `
-		ORDER BY RANDOM()
+		ORDER BY COALESCE(substr(action_id, -8), CAST(ts_ns AS TEXT))
 		LIMIT ?`
 	args := append(append([]any{}, whereArgs...), limit)
 	rows, err := w.g.db.Query(query, args...)
@@ -1078,12 +1082,48 @@ func (w *webMux) apiAnalytics(
 		 FROM actions WHERE `+where, whereArgs...,
 	).Scan(&totalCount, &errorCount)
 
+	// Real per-device / per-host counts so the bar lists aren't
+	// capped at the sample size either. Same filter; bar charts only
+	// render the top ~10 so 50 is a generous cap.
+	byDevice := groupCount(w.g.db,
+		`SELECT agent_ip, COUNT(*) FROM actions
+		 WHERE `+where+` AND agent_ip IS NOT NULL AND agent_ip != ''
+		 GROUP BY agent_ip ORDER BY 2 DESC LIMIT 50`,
+		whereArgs)
+	byHost := groupCount(w.g.db,
+		`SELECT host, COUNT(*) FROM actions
+		 WHERE `+where+` AND host IS NOT NULL AND host != ''
+		 GROUP BY host ORDER BY 2 DESC LIMIT 50`,
+		whereArgs)
+
 	writeJSON(rw, map[string]any{
 		"events":      out,
 		"total":       len(out),
 		"total_count": totalCount,
 		"error_count": errorCount.Int64,
+		"by_device":   byDevice,
+		"by_host":     byHost,
 	})
+}
+
+func groupCount(db *sql.DB, q string, args []any) []map[string]any {
+	out := []map[string]any{}
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var k sql.NullString
+		var c int64
+		if err := rows.Scan(&k, &c); err != nil || !k.Valid {
+			continue
+		}
+		out = append(out, map[string]any{
+			"key": k.String, "count": c,
+		})
+	}
+	return out
 }
 
 func writeJSON(rw http.ResponseWriter, v any) {

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -58,6 +58,9 @@ export function AnalyticsPage({ ip, agents }: {
   const [events, setEvents] = useState<EventRecord[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [errorCount, setErrorCount] = useState(0);
+  type Counts = Array<{ key: string; count: number }>;
+  const [byDevice, setByDevice] = useState<Counts>([]);
+  const [byHost, setByHost] = useState<Counts>([]);
   const [range, setRange] =
     useQS("range", "1h" as Range, RANGES);
   const [filterDevice, setFilterDevice] = useState<
@@ -71,19 +74,36 @@ export function AnalyticsPage({ ip, agents }: {
     agents.map(a => [a.ip, a.hostname || a.ip]),
   );
 
+  // Skip setState (and thus the chart redraw) when the polled
+  // response is identical to the last one — common on long ranges
+  // where 24h of data barely shifts every 10 s.
+  const lastSig = useRef("");
   useEffect(() => {
+    lastSig.current = "";
     let cancelled = false;
     const load = () => {
       getAnalytics({ range, agent: ip, limit: 5000 })
         .then((r) => {
           if (cancelled) return;
+          const first = r.events[0]?.id ?? "";
+          const last = r.events[r.events.length - 1]?.id ?? "";
+          const sig = `${r.total_count}|${r.error_count}|${r.events.length}|${first}|${last}`;
+          if (sig === lastSig.current) return;
+          lastSig.current = sig;
           setEvents(r.events);
           setTotalCount(r.total_count);
           setErrorCount(r.error_count);
+          setByDevice(r.by_device ?? []);
+          setByHost(r.by_host ?? []);
         })
         .catch(() => {});
     };
     load();
+    // Auto-refresh only for short ranges. On 1h+ the data barely
+    // shifts per poll and the redraw is mostly noise.
+    if (RANGE_MS[range] >= 3600e3) {
+      return () => { cancelled = true; };
+    }
     const t = setInterval(load, 10000);
     return () => { cancelled = true; clearInterval(t); };
   }, [ip, range]);
@@ -190,9 +210,8 @@ export function AnalyticsPage({ ip, agents }: {
       <div className={"grid gap-4 " + (isGlobal ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1")}>
         {isGlobal && (
           <BarList
-            title="By device"
-            events={events}
-            field="agent_ip"
+            title="Count by device"
+            items={byDevice}
             active={filterDevice}
             labelFn={(v) => agentNames.get(v) ?? v}
             colorFn={(_, label) => deviceColor(label)}
@@ -203,9 +222,8 @@ export function AnalyticsPage({ ip, agents }: {
           />
         )}
         <BarList
-          title="By host"
-          events={events}
-          field="host"
+          title="Count by host"
+          items={byHost}
           active={filterHost}
           colorFn={(key) => hostColor(key)}
           onClickFn={(v) => {
@@ -656,26 +674,20 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
 // --- horizontal bar list ---
 
 function BarList({
-  title, events, field, active, labelFn, onClickFn, colorFn,
+  title, items: rawItems, active, labelFn, onClickFn, colorFn,
 }: {
   title: string;
-  events: EventRecord[];
-  field: "host" | "agent_ip";
+  items: Array<{ key: string; count: number }>;
   active?: string | null;
   labelFn?: (v: string) => string;
   onClickFn?: (v: string) => void;
   colorFn?: (key: string, label: string) => string;
 }) {
-  const counts = new Map<string, number>();
-  for (const e of events) {
-    const v = (field === "host" ? e.host : e.agent_ip) ?? "";
-    if (!v) continue;
-    counts.set(v, (counts.get(v) ?? 0) + 1);
-  }
-  const items = [...counts.entries()]
-    .map(([k, v]) => ({ key: k, label: labelFn ? labelFn(k) : k, value: v }))
-    .sort((a, b) => b.value - a.value);
-
+  const items = rawItems.map((it) => ({
+    key: it.key,
+    label: labelFn ? labelFn(it.key) : it.key,
+    value: it.count,
+  }));
   const max = items.length ? items[0].value : 0;
 
   return (

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -347,6 +347,8 @@ export async function getAnalytics(params: {
   total: number;
   total_count: number;
   error_count: number;
+  by_device: Array<{ key: string; count: number }>;
+  by_host: Array<{ key: string; count: number }>;
 }> {
   const p = new URLSearchParams({ range: params.range });
   if (params.agent) p.set("agent", params.agent);


### PR DESCRIPTION
## Summary

- Replace `ORDER BY RANDOM()` in `/api/analytics` with `ORDER BY substr(action_id, -8)`. UUIDv7 has a uniform random suffix, so this gives a stable pseudo-random sample — same range + agent yields the same 5000 rows. 24h dashboards no longer reshuffle every 10 s.
- Add real `GROUP BY agent_ip` / `GROUP BY host` aggregates so the "By device" / "By host" bar lists show exact counts for the time range, not whatever happened to land in the scatter sample.
- Skip the React `setState` when the polled response signature (`total_count | error_count | length | first id | last id`) matches the previous one — no chart redraw when nothing changed.
- Gate the 10 s poll behind `RANGE_MS[range] < 1h`. `1h` / `6h` / `24h` load once and stay put; the short ranges still refresh.
- Rename "By device" / "By host" → "Count by device" / "Count by host" so the heading describes what the number is.

## Test plan

- [ ] Open `#/analytics?range=24h` on a busy gateway — chart should paint once and stay still; bar list totals should match the headline `Requests`.
- [ ] Switch to `#/analytics?range=5m` — chart updates every 10 s as new events come in.
- [ ] Confirm scatter dots in `5m` represent only the latest 5 min; nothing older drifts in.
- [ ] Bar list headers read "Count by device" / "Count by host".
