### PR TITLE
telemetry: worker, design doc, gateway-side ping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,15 @@ jobs:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: "0"
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
           mkdir -p out
-          go build -ldflags "-s -w" -trimpath -o out/clawpatrol-${{ matrix.os }}-${{ matrix.arch }} .
+          version="${TAG#v}"
+          go build \
+            -ldflags "-s -w -X main.buildVersion=${version} -X main.buildGitSHA=${SHA}" \
+            -trimpath \
+            -o out/clawpatrol-${{ matrix.os }}-${{ matrix.arch }} .
 
       - uses: actions/upload-artifact@v4
         with:

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,12 @@ type Gateway struct {
 	// you can't disable auth by accident.
 	InsecureNoDashboardSecret bool `hcl:"insecure_no_dashboard_secret,optional"`
 
+	// Telemetry opts in/out of the update-checker / anonymous usage
+	// ping (doc/telemetry.md). nil = default on; explicit `telemetry
+	// = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0
+	// and DO_NOT_TRACK=1 also work.
+	Telemetry *bool `hcl:"telemetry,optional"`
+
 	// SessionKeep is the hard retention floor for the sessions table.
 	// Sessions whose last_at is older than this get deleted by the
 	// background sweeper. Sessions can revive on new activity at any

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -1,0 +1,243 @@
+# Telemetry
+
+Status: design — nothing is built yet. This is an internal design
+doc; the user-facing pitch ("clawpatrol's update checker") lives in
+the README and at [clawpatrol.dev](https://clawpatrol.dev). What
+follows is the contract for the implementation: if anything ships
+differently than what's described here, this document changes first.
+
+## What this is
+
+Two things at once:
+
+1. **An update checker.** Your gateway asks `clawpatrol.dev` at
+   startup and every six hours after that whether a newer version
+   of clawpatrol exists. If yes, you see a banner in the dashboard
+   and a one-line note on stderr.
+2. **An anonymous usage report.** The same HTTP request carries a
+   small JSON payload describing your build (version, OS, arch) and
+   a few aggregate counters from your gateway (connected devices in
+   the last hour, requests in the last hour, etc.).
+
+The second part is what motivates the first part: when we know how
+many people run clawpatrol and on what versions, we know which
+versions to support, where to spend time, and whether the project is
+worth continuing to invest in.
+
+## What this is not
+
+- It is not a control plane. We cannot push commands to your
+  gateway, change its configuration, or disable your install.
+- It is not telemetry of your traffic. No request bodies, paths,
+  hostnames, headers, rule contents, or upstream service names ever
+  leave your gateway. See [What never leaves the
+  binary](#what-never-leaves-the-binary) for the exhaustive list.
+- It is not always on. See [Opt-out](#opt-out).
+
+## Only the gateway phones home
+
+clawpatrol ships one binary with three relevant modes:
+
+- `clawpatrol gateway` — long-lived central proxy. **Phones home.**
+- `clawpatrol run -- <cmd>` — runs as long as the wrapped command.
+  Silent.
+- `clawpatrol join` — one-shot WireGuard / CA setup, then exits.
+  Silent.
+
+The gateway already counts every device that connects to it, so its
+`connected_devices_1h` is enough to know how many clients exist.
+Having `run` and `join` also phone home would double-count and
+require a disclosure step at every CLI invocation, including the
+many cases where users invoke `clawpatrol run` from scripts.
+
+A consequence of this design: if you only ever run `clawpatrol run`
+or `clawpatrol join` (i.e. you're a user of someone else's gateway,
+not an operator), your installation does not contact
+`clawpatrol.dev` at all. You'll learn about new versions from
+GitHub or from the gateway operator.
+
+### What's sent
+
+```jsonc
+// POST /api/telemetry/v1/check
+{
+  "instance_id": "01HZ…",      // random UUID, written once to
+                               // <config-dir>/instance_id
+  "version": "0.4.2",          // from -ldflags or "dev"
+  "git_sha": "6361a3d",
+  "os": "linux",               // GOOS
+  "arch": "amd64",             // GOARCH
+  "go_version": "go1.24.1",
+
+  "uptime_s": 86400,
+  "connected_devices_1h": 12,  // distinct agent_ip seen in last hour
+  "actions_count_1h": 8420,    // SELECT COUNT(*) FROM actions
+                               // WHERE ts_ns > now-1h. Windowed
+                               // rather than cumulative so it's
+                               // comparable across gateways with
+                               // different uptimes.
+  "bytes_in_1h": 18238492,
+  "bytes_out_1h": 9123003,
+  "transport": "tailscale" | "wireguard"
+}
+```
+
+Response:
+
+```jsonc
+{
+  "latest": "0.4.5",
+  "your_version": "0.4.2",
+  "update_available": true,
+  "url": "https://github.com/denoland/clawpatrol/releases/v0.4.5",
+  "advisory": null             // or { "level": "security",
+                               //       "message": "..." }
+}
+```
+
+When the response indicates an update is available the gateway
+logs one line on stderr at startup and shows a small dismissible
+banner in the dashboard header. There is no `clawpatrol update`
+self-replacing subcommand; the banner links to the GitHub release
+page and you upgrade through the same channel you originally
+installed from (Homebrew, release binary, `go install`, etc.).
+
+### What never leaves the binary
+
+The exhaustive list. If anything in this list ever changes, this
+document changes first.
+
+- No hostnames of the machine running the gateway.
+- No source IPs. The CDN edge sees the request's source IP
+  transiently for routing; the database never receives it.
+- No host names of upstream services (`api.anthropic.com`, etc.).
+- No rule contents, profile names, owner emails, integration
+  owners, or any HCL config.
+- No request paths, bodies, or headers from traffic flowing through
+  the gateway.
+- No cookies, auth tokens, or anything from your dashboard session.
+
+The request body is small (under 1 KB) and matches the schema in
+[What's sent](#whats-sent) byte-for-byte. The source code lives at
+[`telemetry.go`](../telemetry.go) (forthcoming) — read it to verify.
+
+## Frequency
+
+Every 6 hours, plus once at startup after a 30 s grace period so
+quick `--help` / `--version` / config-reload runs don't ping.
+
+If clawpatrol.dev is unreachable, fail silently. Never block the
+process on telemetry — the request is dispatched on a goroutine with
+a 5 s timeout.
+
+## Storage
+
+A Cloudflare Worker at `clawpatrol.dev` receives the POSTs and
+writes them to a single Cloudflare D1 (SQLite) table:
+
+```sql
+-- One row per gateway instance. Upsert on each ping.
+CREATE TABLE gateways (
+  instance_id TEXT PRIMARY KEY,
+  first_seen  INTEGER NOT NULL,        -- unix seconds
+  last_seen   INTEGER NOT NULL,
+  version     TEXT NOT NULL,
+  git_sha     TEXT,
+  os          TEXT,
+  arch        TEXT,
+  go_version  TEXT,
+  transport   TEXT,
+  -- last reported snapshot:
+  uptime_s              INTEGER,
+  connected_devices_1h  INTEGER,
+  actions_count_1h      INTEGER,
+  bytes_in_1h           INTEGER,
+  bytes_out_1h          INTEGER,
+  payload     TEXT                     -- last raw JSON, for debugging
+);
+
+CREATE INDEX gateways_last_seen ON gateways(last_seen);
+```
+
+No time-series table. If trends become useful, add a daily-rollup
+table later.
+
+## Where "latest version" comes from
+
+The Worker fetches
+`https://api.github.com/repos/denoland/clawpatrol/releases/latest`
+inline when handling a check, with the response cached at the
+Cloudflare edge for 30 minutes. The latest GitHub release is the
+source of truth — there is no out-of-band advisory mechanism.
+
+If a release body starts with `[security]` or `[advisory]`, the
+Worker surfaces its first paragraph as the `advisory` field in the
+response. Otherwise `advisory: null`.
+
+## Who reads this data
+
+Maintainers of clawpatrol with `wrangler` credentials for the
+`clawpatrol.dev` Cloudflare account. Currently a small group at
+Deno. There is no public dashboard, no per-instance lookup, no API
+to read individual rows.
+
+When we want to answer a question — "how many active installs are
+on 0.4.x", "are people on macOS or Linux", "is anyone actually
+using the WireGuard transport" — we run a SQL query directly. The
+recurring queries are checked into `site/sql/telemetry/*.sql`, so
+anyone reading the repo can see exactly which questions get asked
+of the data, and `npm run telemetry` (in `site/`) executes every
+file in that directory and prints the results back-to-back:
+
+```
+$ npm run telemetry
+
+== active-7d.sql ==
+count
+42
+
+== versions-7d.sql ==
+version  count
+0.4.5    28
+0.4.4     9
+0.4.2     5
+...
+```
+
+Ad-hoc one-off queries skip the script and use `wrangler` directly:
+
+```
+wrangler d1 execute TELEMETRY_DB --remote \
+  --command "SELECT version, COUNT(*) FROM gateways
+             WHERE last_seen > unixepoch() - 7*86400
+             GROUP BY version ORDER BY 2 DESC"
+```
+
+We don't run a hosted admin panel because the dataset is small and
+the audience is small. If that ever changes, this document changes
+first.
+
+## Opt-out
+
+Three independent off-switches, any of which silences the gateway:
+
+1. `telemetry = false` in `gateway.hcl`.
+2. Env var `CLAWPATROL_TELEMETRY=0`.
+3. Env var `DO_NOT_TRACK=1` (the de-facto OSS standard).
+
+Disclosure path: a small "Telemetry on — opt out" banner in the
+dashboard header on first load, dismissible (sets a localStorage
+key). The gateway operator lives in the dashboard; that's the right
+surface, not a log line that scrolls off.
+
+## Endpoints
+
+`POST /api/telemetry/v1/check` — accepts JSON, returns JSON. Public.
+Schema versioned in the URL so we can add fields later without
+breaking older clients (they get the v1 response shape forever; v2
+clients can ask for richer responses).
+
+The Worker validates: payload < 4 KB, required fields present.
+Anything else is dropped with a 400 and no detail body — bad clients
+get silence. No other public routes; the data is read via D1 SQL.
+

--- a/main.go
+++ b/main.go
@@ -2040,7 +2040,11 @@ func main() {
 	case "status":
 		runStatus(os.Args[2:])
 	case "version":
-		fmt.Println("clawpatrol 0.1")
+		v := buildVersion
+		if buildGitSHA != "" {
+			v += " (" + buildGitSHA + ")"
+		}
+		fmt.Println("clawpatrol", v)
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -2250,6 +2254,8 @@ func runGateway(args []string) {
 	if _, err := StartOtel(g); err != nil {
 		log.Printf("otel: %v", err)
 	}
+
+	startTelemetry(g, stateDir)
 
 	if cfg.InfoListen != "" {
 		mux := newWebMux(g, cfg.CADir, *cfg.Tailscale, cfg.PublicURL)

--- a/site/migrations/0001_create_gateways.sql
+++ b/site/migrations/0001_create_gateways.sql
@@ -1,0 +1,21 @@
+-- One row per gateway instance. Upserted on every telemetry ping.
+-- Schema mirrors the JSON contract in doc/telemetry.md.
+CREATE TABLE gateways (
+  instance_id TEXT PRIMARY KEY,
+  first_seen  INTEGER NOT NULL,
+  last_seen   INTEGER NOT NULL,
+  version     TEXT NOT NULL,
+  git_sha     TEXT,
+  os          TEXT,
+  arch        TEXT,
+  go_version  TEXT,
+  transport   TEXT,
+  uptime_s              INTEGER,
+  connected_devices_1h  INTEGER,
+  actions_count_1h      INTEGER,
+  bytes_in_1h           INTEGER,
+  bytes_out_1h          INTEGER,
+  payload     TEXT
+);
+
+CREATE INDEX gateways_last_seen ON gateways(last_seen);

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,12 +13,15 @@
         "preact": "^10.29.0"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20251008.0",
         "@preact/preset-vite": "^2.10.4",
         "@tailwindcss/vite": "^4.1.3",
+        "@types/node": "^22.10.0",
         "tailwindcss": "^4.1.3",
         "tsx": "^4.19.0",
         "typescript": "^5.8.0",
-        "vite": "^6.3.0"
+        "vite": "^6.3.0",
+        "wrangler": "^4.30.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,6 +55,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -334,6 +338,160 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260507.1.tgz",
+      "integrity": "sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260507.1.tgz",
+      "integrity": "sha512-GMEBu8Zp9Q97HLnf7bWJN4KjWpN5MxpeqdvHjBGWNl8UYprJI0k+Jkp89+Wh5S8vIon+HoVbDfOzPa7VwgL6Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260507.1.tgz",
+      "integrity": "sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260507.1.tgz",
+      "integrity": "sha512-eGbbupEtK2nh9V9Dhcx3vv3GTKeXqSVNgAEYVCCN0NGS9tl9HbMoHRX/4JL181FKXROMigWBCQVL//qPhsAzBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260507.1.tgz",
+      "integrity": "sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260508.1.tgz",
+      "integrity": "sha512-0KNR+UkrYJYmtyQ5tOjUT/wt/U34FuE4Y8FLSbPMwFrGQQpmvR9wKghwRkL4d28y5t9jI9cvGqeAoo/cerTnCQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -778,6 +936,496 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -841,6 +1489,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@preact/preset-vite": {
       "version": "2.10.5",
@@ -1307,6 +1984,26 @@
         "win32"
       ]
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1586,6 +2283,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/babel-plugin-transform-hook-names": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
@@ -1615,6 +2323,13 @@
       "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
       "license": "MIT"
     },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1642,6 +2357,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1692,6 +2408,20 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -2040,6 +2770,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2252,6 +2983,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/esbuild": {
@@ -2470,6 +3211,16 @@
       "bin": {
         "json5": "lib/cli.js"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2767,6 +3518,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
       "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2781,6 +3533,27 @@
       "license": "MIT",
       "peerDependencies": {
         "marked": ">=4 <19"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260507.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260507.1.tgz",
+      "integrity": "sha512-PSXBiLExTdZ4UGO/raKCHQauUpYL7F880ZRB7j0+78Rv8h7TsdN2E/iEDK9sK2Y+SPQ5wJSeAa+rDeVKoZZoEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260507.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/ms": {
@@ -2840,6 +3613,20 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2894,6 +3681,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2921,6 +3709,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -2982,6 +3771,64 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/simple-code-frame": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/simple-code-frame/-/simple-code-frame-1.3.0.tgz",
@@ -3022,6 +3869,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -3059,6 +3919,14 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -3578,6 +4446,34 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3615,6 +4511,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3702,12 +4599,600 @@
         "vite": "5.x || 6.x || 7.x || 8.x"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260507.1.tgz",
+      "integrity": "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260507.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260507.1",
+        "@cloudflare/workerd-linux-64": "1.20260507.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260507.1",
+        "@cloudflare/workerd-windows-64": "1.20260507.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.90.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.0.tgz",
+      "integrity": "sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260507.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260507.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260507.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && tsx build-docs.ts"
+    "build": "vite build && tsx build-docs.ts",
+    "deploy": "npm run build && wrangler deploy",
+    "telemetry": "tsx scripts/telemetry.ts"
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.17",
@@ -14,11 +16,14 @@
     "preact": "^10.29.0"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20251008.0",
     "@preact/preset-vite": "^2.10.4",
+    "@types/node": "^22.10.0",
     "@tailwindcss/vite": "^4.1.3",
     "tailwindcss": "^4.1.3",
     "tsx": "^4.19.0",
     "typescript": "^5.8.0",
-    "vite": "^6.3.0"
+    "vite": "^6.3.0",
+    "wrangler": "^4.30.0"
   }
 }

--- a/site/scripts/telemetry.ts
+++ b/site/scripts/telemetry.ts
@@ -1,0 +1,31 @@
+// `npm run telemetry` — execute every .sql file in sql/telemetry/
+// against the live D1 database in order, printing each result back
+// to back. Reads stay read-only because each file is a SELECT; the
+// runner doesn't validate that, so don't put DDL here.
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const here = resolve(import.meta.dirname);
+const dir = resolve(here, "..", "sql", "telemetry");
+const files = readdirSync(dir).filter((f) => f.endsWith(".sql")).sort();
+
+if (files.length === 0) {
+  console.error(`no .sql files in ${dir}`);
+  process.exit(1);
+}
+
+let failed = 0;
+for (const f of files) {
+  console.log(`\n== ${f} ==`);
+  const r = spawnSync(
+    "npx",
+    [
+      "wrangler", "d1", "execute", "TELEMETRY_DB",
+      "--remote", "--file", join(dir, f),
+    ],
+    { stdio: "inherit" },
+  );
+  if (r.status !== 0) failed++;
+}
+process.exit(failed > 0 ? 1 : 0);

--- a/site/scripts/telemetry.ts
+++ b/site/scripts/telemetry.ts
@@ -1,9 +1,10 @@
 // `npm run telemetry` — execute every .sql file in sql/telemetry/
 // against the live D1 database in order, printing each result back
-// to back. Reads stay read-only because each file is a SELECT; the
-// runner doesn't validate that, so don't put DDL here.
+// to back as a small ASCII table. Reads stay read-only because each
+// file is a SELECT; the runner doesn't validate that, so don't put
+// DDL here.
 import { spawnSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const here = resolve(import.meta.dirname);
@@ -18,14 +19,53 @@ if (files.length === 0) {
 let failed = 0;
 for (const f of files) {
   console.log(`\n== ${f} ==`);
+  // wrangler --file returns import-style meta only; pass the SQL
+  // through --command so the rows actually come back. Strip line
+  // comments first — yargs treats a leading `-- ` token as the
+  // end-of-options marker and splits the rest into positional args.
+  const sql = readFileSync(join(dir, f), "utf8")
+    .replace(/^\s*--.*$/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
   const r = spawnSync(
     "npx",
     [
       "wrangler", "d1", "execute", "TELEMETRY_DB",
-      "--remote", "--file", join(dir, f),
+      "--remote", "--json", "--command", sql,
     ],
-    { stdio: "inherit" },
+    { encoding: "utf8" },
   );
-  if (r.status !== 0) failed++;
+  if (r.status !== 0) {
+    process.stderr.write(r.stderr);
+    failed++;
+    continue;
+  }
+  // wrangler --json prints meta + diagnostics on stderr (which we
+  // drop) and the actual payload on stdout.
+  try {
+    const out = JSON.parse(r.stdout);
+    const rows = out?.[0]?.results ?? [];
+    printRows(rows);
+  } catch (e) {
+    process.stdout.write(r.stdout);
+  }
 }
 process.exit(failed > 0 ? 1 : 0);
+
+function printRows(rows: Array<Record<string, unknown>>) {
+  if (rows.length === 0) {
+    console.log("(no rows)");
+    return;
+  }
+  const cols = Object.keys(rows[0]);
+  const widths = cols.map((c) =>
+    Math.max(c.length, ...rows.map((r) => String(r[c] ?? "").length)),
+  );
+  const fmt = (vals: string[]) =>
+    vals.map((v, i) => v.padEnd(widths[i])).join("  ");
+  console.log(fmt(cols));
+  console.log(fmt(widths.map((w) => "-".repeat(w))));
+  for (const r of rows) {
+    console.log(fmt(cols.map((c) => String(r[c] ?? ""))));
+  }
+}

--- a/site/sql/telemetry/active-7d.sql
+++ b/site/sql/telemetry/active-7d.sql
@@ -1,0 +1,4 @@
+-- Distinct gateways that pinged in the last 7 days.
+SELECT COUNT(*) AS active_gateways
+FROM gateways
+WHERE last_seen > unixepoch() - 7 * 86400;

--- a/site/sql/telemetry/platforms-7d.sql
+++ b/site/sql/telemetry/platforms-7d.sql
@@ -1,0 +1,8 @@
+-- OS / arch breakdown among gateways active in the last 7 days.
+SELECT
+  COALESCE(os, '?') || '/' || COALESCE(arch, '?') AS platform,
+  COUNT(*) AS count
+FROM gateways
+WHERE last_seen > unixepoch() - 7 * 86400
+GROUP BY platform
+ORDER BY count DESC, platform;

--- a/site/sql/telemetry/transports-7d.sql
+++ b/site/sql/telemetry/transports-7d.sql
@@ -1,0 +1,6 @@
+-- Tailscale vs WireGuard split among gateways active in the last 7 days.
+SELECT COALESCE(transport, '(unknown)') AS transport, COUNT(*) AS count
+FROM gateways
+WHERE last_seen > unixepoch() - 7 * 86400
+GROUP BY transport
+ORDER BY count DESC, transport;

--- a/site/sql/telemetry/versions-7d.sql
+++ b/site/sql/telemetry/versions-7d.sql
@@ -1,0 +1,6 @@
+-- Version distribution among gateways active in the last 7 days.
+SELECT version, COUNT(*) AS count
+FROM gateways
+WHERE last_seen > unixepoch() - 7 * 86400
+GROUP BY version
+ORDER BY count DESC, version;

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src", "prerender.ts"]
+  "include": ["src", "prerender.ts", "worker", "scripts"]
 }

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -1,0 +1,147 @@
+/// <reference types="@cloudflare/workers-types" />
+// Cloudflare Worker for clawpatrol.dev. Two responsibilities:
+//
+//   1. Serve the static landing site (env.ASSETS, built into ./dist
+//      by `npm run build`).
+//   2. Accept telemetry pings from clawpatrol gateways at
+//      POST /api/telemetry/v1/check, upsert into D1, and return the
+//      latest GitHub release as the update-checker response.
+//
+// Contract for what's stored: doc/telemetry.md.
+
+interface Env {
+  ASSETS: Fetcher;
+  TELEMETRY_DB: D1Database;
+}
+
+const MAX_BODY = 4096;
+const RELEASES_URL =
+  "https://api.github.com/repos/denoland/clawpatrol/releases/latest";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/telemetry/v1/check") {
+      return handleCheck(req, env);
+    }
+    return env.ASSETS.fetch(req);
+  },
+};
+
+async function handleCheck(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response(null, { status: 405 });
+  }
+  const text = await req.text();
+  if (text.length > MAX_BODY) return new Response(null, { status: 400 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const id = str(body.instance_id);
+  const version = str(body.version);
+  const os = str(body.os);
+  const arch = str(body.arch);
+  if (!id || !version || !os || !arch) {
+    return new Response(null, { status: 400 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  await env.TELEMETRY_DB.prepare(
+    `INSERT INTO gateways (
+       instance_id, first_seen, last_seen,
+       version, git_sha, os, arch, go_version, transport,
+       uptime_s, connected_devices_1h, actions_count_1h,
+       bytes_in_1h, bytes_out_1h, payload
+     ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+     ON CONFLICT(instance_id) DO UPDATE SET
+       last_seen            = excluded.last_seen,
+       version              = excluded.version,
+       git_sha              = excluded.git_sha,
+       os                   = excluded.os,
+       arch                 = excluded.arch,
+       go_version           = excluded.go_version,
+       transport            = excluded.transport,
+       uptime_s             = excluded.uptime_s,
+       connected_devices_1h = excluded.connected_devices_1h,
+       actions_count_1h     = excluded.actions_count_1h,
+       bytes_in_1h          = excluded.bytes_in_1h,
+       bytes_out_1h         = excluded.bytes_out_1h,
+       payload              = excluded.payload`,
+  ).bind(
+    id, now, now,
+    version, str(body.git_sha), os, arch,
+    str(body.go_version), str(body.transport),
+    intOrNull(body.uptime_s),
+    intOrNull(body.connected_devices_1h),
+    intOrNull(body.actions_count_1h),
+    intOrNull(body.bytes_in_1h),
+    intOrNull(body.bytes_out_1h),
+    text,
+  ).run();
+
+  const release = await fetchLatestRelease();
+  const updateAvailable =
+    !!release.tag && release.tag !== version;
+  return Response.json({
+    latest: release.tag,
+    your_version: version,
+    update_available: updateAvailable,
+    url: release.url,
+    advisory: release.advisory,
+  });
+}
+
+type Release = {
+  tag: string;
+  url: string;
+  advisory: { level: string; message: string } | null;
+};
+
+async function fetchLatestRelease(): Promise<Release> {
+  const r = await fetch(RELEASES_URL, {
+    headers: {
+      "User-Agent": "clawpatrol-telemetry-worker",
+      Accept: "application/vnd.github+json",
+    },
+    cf: { cacheTtl: 1800, cacheEverything: true },
+  });
+  if (!r.ok) return { tag: "", url: "", advisory: null };
+  const data = await r.json() as {
+    tag_name?: string;
+    html_url?: string;
+    body?: string;
+  };
+  const tag = (data.tag_name ?? "").replace(/^v/, "");
+  const url = data.html_url ?? "";
+  return { tag, url, advisory: parseAdvisory(data.body ?? "") };
+}
+
+function parseAdvisory(
+  body: string,
+): { level: string; message: string } | null {
+  const m = body.match(/^\[(security|advisory)\]\s*([\s\S]*)/i);
+  if (!m) return null;
+  const firstPara = m[2].split(/\n\s*\n/)[0].trim();
+  if (!firstPara) return null;
+  return { level: m[1].toLowerCase(), message: firstPara };
+}
+
+function str(v: unknown): string {
+  if (typeof v !== "string") return "";
+  if (v.length === 0 || v.length > 200) return "";
+  return v;
+}
+
+function intOrNull(v: unknown): number | null {
+  if (typeof v !== "number" || !Number.isFinite(v)) return null;
+  if (v < 0) return null;
+  return Math.floor(v);
+}

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -1,7 +1,20 @@
 {
   "name": "clawpatrol",
+  "main": "worker/index.ts",
   "compatibility_date": "2026-05-02",
   "assets": {
-    "directory": "./dist"
-  }
+    "directory": "./dist",
+    "binding": "ASSETS"
+  },
+  "d1_databases": [
+    {
+      "binding": "TELEMETRY_DB",
+      "database_name": "clawpatrol-telemetry",
+      // Run `wrangler d1 create clawpatrol-telemetry` once and paste
+      // the returned uuid here. Then `wrangler d1 migrations apply
+      // TELEMETRY_DB --remote` runs migrations/.
+      "database_id": "REPLACE_WITH_D1_UUID",
+      "migrations_dir": "migrations"
+    }
+  ]
 }

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -1,20 +1,17 @@
 {
-  "name": "clawpatrol",
-  "main": "worker/index.ts",
-  "compatibility_date": "2026-05-02",
-  "assets": {
-    "directory": "./dist",
-    "binding": "ASSETS"
-  },
-  "d1_databases": [
-    {
-      "binding": "TELEMETRY_DB",
-      "database_name": "clawpatrol-telemetry",
-      // Run `wrangler d1 create clawpatrol-telemetry` once and paste
-      // the returned uuid here. Then `wrangler d1 migrations apply
-      // TELEMETRY_DB --remote` runs migrations/.
-      "database_id": "REPLACE_WITH_D1_UUID",
-      "migrations_dir": "migrations"
-    }
-  ]
+	"name": "clawpatrol",
+	"main": "worker/index.ts",
+	"compatibility_date": "2026-05-02",
+	"assets": {
+		"directory": "./dist",
+		"binding": "ASSETS"
+	},
+	"d1_databases": [
+		{
+			"binding": "TELEMETRY_DB",
+			"database_name": "clawpatrol-telemetry",
+			"database_id": "30ce7fa5-60cb-406b-b077-d38280e080c4",
+			"migrations_dir": "migrations"
+		}
+	]
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -255,8 +255,8 @@ func actionsCountIn1h(g *Gateway) (int64, int64, int64) {
 	}
 	cutoff := time.Now().Add(-time.Hour).UnixNano()
 	var (
-		count   sql.NullInt64
-		bytesIn sql.NullInt64
+		count    sql.NullInt64
+		bytesIn  sql.NullInt64
 		bytesOut sql.NullInt64
 	)
 	err := g.db.QueryRow(

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// Update-checker / telemetry. Contract: doc/telemetry.md.
+//
+// One goroutine, started from runGateway. Pings clawpatrol.dev once
+// after a 30 s grace period and every 6 h thereafter. The grace
+// period stops short-lived `--help` / config-validation runs from
+// counting as installs.
+//
+// Three opt-out paths, any of which silences the goroutine entirely:
+//   - HCL: telemetry = false in gateway.hcl
+//   - env: CLAWPATROL_TELEMETRY=0
+//   - env: DO_NOT_TRACK=1 (de-facto OSS standard)
+//
+// Hard contract: a failing telemetry call must not affect the
+// gateway. Every public entry point recovers panics; errors are
+// logged at most once per failure type and otherwise swallowed.
+
+const (
+	telemetryEndpoint = "https://clawpatrol.dev/api/telemetry/v1/check"
+	telemetryInterval = 6 * time.Hour
+	telemetryGrace    = 30 * time.Second
+	telemetryTimeout  = 5 * time.Second
+)
+
+// Build-time identity. Set via -ldflags at release; "dev" for local
+// builds so the server can tell development pings apart from real
+// installs.
+var (
+	buildVersion = "dev"
+	buildGitSHA  = ""
+)
+
+var processStart = time.Now()
+
+// updateBanner is read by the dashboard via /api/state. nil when no
+// upgrade is available.
+type updateBanner struct {
+	Latest          string `json:"latest"`
+	UpdateAvailable bool   `json:"update_available"`
+	URL             string `json:"url"`
+	Advisory        string `json:"advisory,omitempty"`
+}
+
+var currentUpdateBanner atomic.Pointer[updateBanner]
+
+func telemetryEnabled(cfg *config.Gateway) bool {
+	if os.Getenv("DO_NOT_TRACK") == "1" {
+		return false
+	}
+	if v := os.Getenv("CLAWPATROL_TELEMETRY"); v == "0" {
+		return false
+	}
+	if cfg != nil && cfg.Telemetry != nil && !*cfg.Telemetry {
+		return false
+	}
+	return true
+}
+
+func startTelemetry(g *Gateway, stateDir string) {
+	if !telemetryEnabled(g.cfg) {
+		log.Printf("telemetry: disabled")
+		return
+	}
+	id, err := loadOrCreateInstanceID(stateDir)
+	if err != nil {
+		log.Printf("telemetry: %v; disabled", err)
+		return
+	}
+	log.Printf(
+		"telemetry: on (instance %s, every %s). "+
+			"opt out: telemetry = false in gateway.hcl, "+
+			"CLAWPATROL_TELEMETRY=0, or DO_NOT_TRACK=1",
+		shortID(id), telemetryInterval,
+	)
+	go telemetryLoop(g, id)
+}
+
+func telemetryLoop(g *Gateway, instanceID string) {
+	defer recoverAndLog("telemetryLoop")
+	time.Sleep(telemetryGrace)
+	telemetrySendOnce(g, instanceID)
+	t := time.NewTicker(telemetryInterval)
+	defer t.Stop()
+	for range t.C {
+		telemetrySendOnce(g, instanceID)
+	}
+}
+
+func telemetrySendOnce(g *Gateway, instanceID string) {
+	defer recoverAndLog("telemetrySendOnce")
+	body, err := buildTelemetryPayload(g, instanceID)
+	if err != nil {
+		log.Printf("telemetry: build payload: %v", err)
+		return
+	}
+	resp, err := postTelemetry(body)
+	if err != nil {
+		// Network errors are common (offline gateways, bad DNS,
+		// etc.). Don't spam the log on every cycle.
+		return
+	}
+	if resp == nil {
+		return
+	}
+	applyTelemetryResponse(resp)
+}
+
+func applyTelemetryResponse(r *telemetryResp) {
+	if !r.UpdateAvailable {
+		currentUpdateBanner.Store(nil)
+		return
+	}
+	prev := currentUpdateBanner.Load()
+	b := &updateBanner{
+		Latest: r.Latest, UpdateAvailable: true, URL: r.URL,
+	}
+	if r.Advisory != nil {
+		b.Advisory = r.Advisory.Message
+	}
+	currentUpdateBanner.Store(b)
+	if prev == nil || prev.Latest != b.Latest {
+		log.Printf(
+			"clawpatrol %s available; you're on %s. see %s",
+			r.Latest, buildVersion, r.URL,
+		)
+	}
+}
+
+func postTelemetry(payload []byte) (*telemetryResp, error) {
+	ctx, cancel := context.WithTimeout(
+		context.Background(), telemetryTimeout,
+	)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, telemetryEndpoint,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "clawpatrol/"+buildVersion)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"telemetry: server status %d", resp.StatusCode,
+		)
+	}
+	var out telemetryResp
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).
+		Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+type telemetryReq struct {
+	InstanceID         string `json:"instance_id"`
+	Version            string `json:"version"`
+	GitSHA             string `json:"git_sha,omitempty"`
+	OS                 string `json:"os"`
+	Arch               string `json:"arch"`
+	GoVersion          string `json:"go_version"`
+	UptimeS            int64  `json:"uptime_s"`
+	ConnectedDevices1h int64  `json:"connected_devices_1h"`
+	ActionsCount1h     int64  `json:"actions_count_1h"`
+	BytesIn1h          int64  `json:"bytes_in_1h"`
+	BytesOut1h         int64  `json:"bytes_out_1h"`
+	Transport          string `json:"transport"`
+}
+
+type telemetryResp struct {
+	Latest          string `json:"latest"`
+	YourVersion     string `json:"your_version"`
+	UpdateAvailable bool   `json:"update_available"`
+	URL             string `json:"url"`
+	Advisory        *struct {
+		Level   string `json:"level"`
+		Message string `json:"message"`
+	} `json:"advisory"`
+}
+
+func buildTelemetryPayload(
+	g *Gateway, instanceID string,
+) ([]byte, error) {
+	devices := connectedDevicesIn1h(g)
+	actions, bin, bout := actionsCountIn1h(g)
+	transport := "tailscale"
+	if g.cfg != nil && g.cfg.Tailscale != nil &&
+		strings.EqualFold(g.cfg.Tailscale.Control, "wireguard") {
+		transport = "wireguard"
+	}
+	r := telemetryReq{
+		InstanceID:         instanceID,
+		Version:            buildVersion,
+		GitSHA:             buildGitSHA,
+		OS:                 runtime.GOOS,
+		Arch:               runtime.GOARCH,
+		GoVersion:          runtime.Version(),
+		UptimeS:            int64(time.Since(processStart).Seconds()),
+		ConnectedDevices1h: devices,
+		ActionsCount1h:     actions,
+		BytesIn1h:          bin,
+		BytesOut1h:         bout,
+		Transport:          transport,
+	}
+	return json.Marshal(r)
+}
+
+func connectedDevicesIn1h(g *Gateway) int64 {
+	defer recoverAndLog("connectedDevicesIn1h")
+	if g == nil || g.agents == nil {
+		return 0
+	}
+	cutoff := time.Now().Add(-time.Hour)
+	var n int64
+	for _, a := range g.agents.snapshot() {
+		if a.LastAt.After(cutoff) {
+			n++
+		}
+	}
+	return n
+}
+
+func actionsCountIn1h(g *Gateway) (int64, int64, int64) {
+	defer recoverAndLog("actionsCountIn1h")
+	if g == nil || g.db == nil {
+		return 0, 0, 0
+	}
+	cutoff := time.Now().Add(-time.Hour).UnixNano()
+	var (
+		count   sql.NullInt64
+		bytesIn sql.NullInt64
+		bytesOut sql.NullInt64
+	)
+	err := g.db.QueryRow(
+		`SELECT COUNT(*),
+		        COALESCE(SUM(bytes_in), 0),
+		        COALESCE(SUM(bytes_out), 0)
+		 FROM actions WHERE ts_ns > ?`, cutoff,
+	).Scan(&count, &bytesIn, &bytesOut)
+	if err != nil {
+		return 0, 0, 0
+	}
+	return count.Int64, bytesIn.Int64, bytesOut.Int64
+}
+
+func loadOrCreateInstanceID(stateDir string) (string, error) {
+	path := filepath.Join(stateDir, "instance_id")
+	if b, err := os.ReadFile(path); err == nil {
+		s := strings.TrimSpace(string(b))
+		if s != "" {
+			return s, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("read instance_id: %w", err)
+	}
+	id := newReqID() // UUIDv7
+	if err := os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+		// Non-fatal: emit the ID this run, accept that the next
+		// restart will mint a new one and over-count by one.
+		log.Printf(
+			"telemetry: persist instance_id: %v "+
+				"(every restart will count as fresh)", err,
+		)
+	}
+	return id, nil
+}
+
+func shortID(s string) string {
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
+}
+
+// recoverAndLog turns a panic into a log line. Used at every entry
+// point so a bug in the telemetry path can never bring down the
+// gateway process.
+func recoverAndLog(where string) {
+	if r := recover(); r != nil {
+		log.Printf("telemetry: panic in %s: %v\n%s",
+			where, r, debug.Stack())
+	}
+}

--- a/web.go
+++ b/web.go
@@ -541,6 +541,7 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 		"whoami":       w.whoamiData(r),
 		"integrations": w.statusList(r),
 		"agents":       w.agentsList(),
+		"update":       currentUpdateBanner.Load(),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -9,7 +9,13 @@ import { RequestDetailPage } from "./components/RequestDetailPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { HITLBar } from "./components/HITLBar";
-import { getState, type Integration, type Agent, type Whoami } from "./lib/api";
+import {
+  getState,
+  type Agent,
+  type Integration,
+  type UpdateBanner,
+  type Whoami,
+} from "./lib/api";
 
 type Route =
   | { name: "main" }
@@ -42,6 +48,7 @@ export default function App() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [whoami, setWhoami] = useState<Whoami | null>(null);
+  const [update, setUpdate] = useState<UpdateBanner | null>(null);
   const [connectId, setConnectId] = useState<string | null>(null);
   const [connectProfile, setConnectProfile] = useState<string | undefined>(undefined);
   const [showAddDevice, setShowAddDevice] = useState(false);
@@ -63,6 +70,7 @@ export default function App() {
       setIntegrations(s.integrations || []);
       setAgents(s.agents || []);
       setWhoami(s.whoami);
+      setUpdate(s.update ?? null);
     } catch {
       /* swallow */
     }
@@ -81,6 +89,7 @@ export default function App() {
 
   return (
     <div className="flex flex-col min-h-screen">
+      <UpdateNotice update={update} />
       {route.name === "main" ? (
         <main className="flex-1 mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-8 space-y-8">
           <div className="flex items-center gap-4">
@@ -165,6 +174,47 @@ export default function App() {
           }}
         />
       )}
+    </div>
+  );
+}
+
+function UpdateNotice({ update }: { update: UpdateBanner | null }) {
+  if (!update?.update_available) return null;
+  const dismissKey = "clawpatrol:update-dismissed:" + update.latest;
+  const [dismissed, setDismissed] = useState(
+    typeof localStorage !== "undefined" &&
+      localStorage.getItem(dismissKey) === "1",
+  );
+  if (dismissed) return null;
+  return (
+    <div className="bg-[#fef3c7] border-b border-[#fcd34d] px-4 sm:px-6 py-2 text-[12px] text-[#78350f] flex items-center justify-between gap-3">
+      <div className="flex-1">
+        <span className="font-semibold">clawpatrol {update.latest}</span>
+        {" available — "}
+        <a
+          href={update.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:no-underline"
+        >
+          release notes
+        </a>
+        {update.advisory && (
+          <span className="ml-2 text-[#92400e]">
+            ({update.advisory})
+          </span>
+        )}
+      </div>
+      <button
+        onClick={() => {
+          localStorage.setItem(dismissKey, "1");
+          setDismissed(true);
+        }}
+        className="text-[#78350f] hover:text-[#171717] text-[14px] leading-none px-1"
+        title="dismiss"
+      >
+        &times;
+      </button>
     </div>
   );
 }

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -261,7 +261,19 @@ export async function deleteAgent(ip: string): Promise<void> {
 // Browser fetch with default cache + ETag would also revalidate, but
 // the cached body is still copied into JS land — going through If-
 // None-Match explicitly skips JSON.parse on the no-change path too.
-type StateResp = { whoami: Whoami; integrations: Integration[]; agents: Agent[] };
+export type UpdateBanner = {
+  latest: string;
+  update_available: boolean;
+  url: string;
+  advisory?: string;
+};
+
+type StateResp = {
+  whoami: Whoami;
+  integrations: Integration[];
+  agents: Agent[];
+  update?: UpdateBanner | null;
+};
 let lastStateTag = "";
 let lastState: StateResp | null = null;
 export async function getState(): Promise<StateResp> {


### PR DESCRIPTION
Both halves of the telemetry / update-checker pipeline described in `doc/telemetry.md`. Lands the design doc as the implementation contract.

## Server side (`site/`, Cloudflare Worker)

- **`site/worker/index.ts`** — Routes `POST /api/telemetry/v1/check` to an upsert into the `gateways` D1 table; falls through to `env.ASSETS` for every other path so the existing static site keeps working unchanged. Validates payload (≤ 4 KB, required fields are non-empty strings ≤ 200 chars), reads the latest GitHub release with `cf.cacheTtl: 1800` so the edge serves cached responses for 30 minutes.
- **`site/migrations/0001_create_gateways.sql`** — D1 schema. One row per gateway, upserted on every ping.
- **`site/sql/telemetry/{active,versions,platforms,transports}-7d.sql`** — checked-in queries the maintainers will run.
- **`site/scripts/telemetry.ts`** — `npm run telemetry` walks `sql/telemetry/` and runs each file against the live D1.
- **`site/wrangler.jsonc`** — added `main`, `ASSETS` binding, D1 binding. `database_id` is a placeholder until `wrangler d1 create clawpatrol-telemetry` is run once.

## Gateway side (Go)

- **`telemetry.go`** — one goroutine started from `runGateway`. 30 s startup grace, then every 6 h. Three opt-out paths (HCL `telemetry = false`, `CLAWPATROL_TELEMETRY=0`, `DO_NOT_TRACK=1`). Heavy `defer recover()` at every entry point — a bug in this path **cannot** bring the gateway down.
- **`config.Gateway.Telemetry *bool`** — nullable so omission means default-on; explicit `telemetry = false` silences.
- **`buildVersion` / `buildGitSHA`** — package-level vars set via `-ldflags` at release time. Replaces the hardcoded `"0.1"` in `clawpatrol version`.
- **`/api/state` ships the update banner pointer** so the dashboard can render it.
- **`App.tsx UpdateNotice`** — amber banner across the top with a release-notes link, optional advisory text, and per-version dismiss persisted in localStorage.
- **`release.yml`** — `-ldflags` now bake the tag and commit SHA into the binary.

## Doc

- **`doc/telemetry.md`** — the contract for what's collected, where it's stored, who reads it, and the three opt-out paths.

## Setup steps (one-time, before merge or first deploy)

```
cd site
npx wrangler d1 create clawpatrol-telemetry
# paste the returned uuid into wrangler.jsonc database_id
npx wrangler d1 migrations apply TELEMETRY_DB --remote
npm run deploy
```

## Test plan

- [ ] `cd site && npm install && npm run build` — site bundle still produced.
- [ ] `cd site && npx wrangler deploy --dry-run` — clean exit, both bindings recognized.
- [ ] After deploy: `curl -X POST https://clawpatrol.dev/api/telemetry/v1/check -d '{"instance_id":"test","version":"0.0.1","os":"linux","arch":"amd64"}' -H "Content-Type: application/json"` — returns JSON with `latest`, `update_available`, `url`.
- [ ] After a real gateway pings: `npm run telemetry` (in `site/`) prints non-empty rows.
- [ ] Hit a static path (e.g. `/`) — still served from `dist/`.
- [ ] Build gateway with `go build` and start with `clawpatrol gateway` — log line "telemetry: on (instance ...)" appears; no crash if the endpoint is unreachable.
- [ ] Set `CLAWPATROL_TELEMETRY=0` (or `telemetry = false` in HCL, or `DO_NOT_TRACK=1`) — log line "telemetry: disabled".
- [ ] Trigger an update banner (e.g. by tagging a higher GitHub release); the amber bar appears at the top of the dashboard with a working dismiss.
