### PR TITLE
postgres: emit allow event when no rule matches

### DIFF
--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -385,7 +385,10 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 }
 
 // pgEvaluate runs the SQL through the endpoint's compiled rules and
-// returns the disposition for this query.
+// returns the disposition for this query. Emits a per-query event in
+// every branch (allow, deny, hitl_allow, hitl_deny) so the dashboard
+// surfaces the activity even when no rule fires — endpoints with
+// zero rules still log every query as "allow".
 //
 // Returns:
 //
@@ -395,6 +398,7 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 //	("", "")         — no rule fires or the matched rule allows.
 func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 	info := parseSQL(sql)
+	summary := pgSummary(info)
 	mreq := &match.Request{
 		Family:     "sql",
 		PeerIP:     ch.PeerIP,
@@ -408,9 +412,16 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 	}
 	cr := runtime.MatchRequest(ch.Endpoint, mreq)
 	if cr == nil {
+		// No rule matched — implicit allow. Emit so the query
+		// shows up in the dashboard's actions tab anyway; the
+		// HTTP path does the same (main.go:1909 — every request
+		// gets an `allow` event when no explicit verdict was
+		// recorded).
+		emit(ch, runtime.ConnEvent{
+			Action: "allow", Verb: info.Verb, Summary: summary,
+		})
 		return "", ""
 	}
-	summary := pgSummary(info)
 
 	// Approve chain. ConnHandle.Approve dispatches through the
 	// host's HITL machinery (same one HTTPS uses) — the postgres

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 // TestParseSQL exercises the best-effort lexer that feeds the SQL
@@ -125,5 +128,35 @@ func TestPgExtractSQL(t *testing.T) {
 	}
 	if got := pgExtractSQL('B', []byte("ignored")); got != "" {
 		t.Errorf("non-Q/P extract should return empty, got %q", got)
+	}
+}
+
+// TestPgEvaluateEmitsAllowOnNoMatch nails down the dashboard logging
+// fix: an endpoint with zero rules (or one whose rules don't match
+// the current query) still emits an `allow` event so the query
+// shows up in the actions tab. Without this, postgres connections
+// to permissive endpoints were invisible to operators — the runtime
+// previously short-circuited on `cr == nil`.
+func TestPgEvaluateEmitsAllowOnNoMatch(t *testing.T) {
+	var events []runtime.ConnEvent
+	ch := &runtime.ConnHandle{
+		Endpoint: &config.CompiledEndpoint{
+			Name:   "pg-test",
+			Family: "sql",
+			// Rules is nil — no rule will fire.
+		},
+		Emit: func(ev runtime.ConnEvent) { events = append(events, ev) },
+	}
+	if v, _ := pgEvaluate(ch, "SELECT 1", ""); v != "" {
+		t.Errorf("verdict %q, want empty (allow)", v)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1: %+v", len(events), events)
+	}
+	if events[0].Action != "allow" {
+		t.Errorf("Action = %q, want allow", events[0].Action)
+	}
+	if events[0].Verb != "select" {
+		t.Errorf("Verb = %q, want select", events[0].Verb)
 	}
 }


### PR DESCRIPTION
Postgres queries against endpoints with no matching rule were silently
forwarded with no event, so they didn't show up in the dashboard's
actions tab. The HTTP path always emits a terminal event (defaulting
Action to `allow` when nothing else set it); the postgres runtime
short-circuited on `runtime.MatchRequest` returning nil and never called
emit().

Surfaced when adding `pg-deploy-classic-staging` to the live gateway:
the endpoint has no rules attached, so every query was invisible to
operators.

Fix: emit an explicit `allow` event in the no-match branch of
`pgEvaluate`, mirroring the existing emit calls in the verdict / approve
branches.