### PR TITLE
slack: add missing space between host and path in HITL title

### DIFF
--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -118,7 +118,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 	}
 	link := strings.TrimRight(target.DashboardURL, "/") + "/#hitl/" + target.PendingID
 
-	title := fmt.Sprintf("Approve: %s %s%s", req.Method, req.Host, slackTrunc(req.Path, 60))
+	title := fmt.Sprintf("Approve: %s %s %s", req.Method, req.Host, slackTrunc(req.Path, 60))
 	blocks := []map[string]any{
 		{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
 		{"type": "section", "fields": []map[string]any{
@@ -176,7 +176,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 
 	body := map[string]any{
 		"channel": target.Channel,
-		"text":    fmt.Sprintf("clawpatrol HITL: %s %s%s", req.Method, req.Host, req.Path),
+		"text":    fmt.Sprintf("clawpatrol HITL: %s %s %s", req.Method, req.Host, req.Path),
 		"blocks":  blocks,
 	}
 	if target.ThreadTS != "" {


### PR DESCRIPTION
The HITL Slack notification's title was missing a space between
`req.Host` and `req.Path`:

```go
title := fmt.Sprintf("Approve: %s %s%s", req.Method, req.Host,
                     slackTrunc(req.Path, 60))
```

For HTTP it rendered acceptably because `Path` starts with `/`.
For postgres approvals `Path` is a SQL summary built by
`pgSummary` that doesn't, so the title smushed:

```
Approve: update 10.78.0.4UPDATE tables=[users] update users…
```

Same one-character fix in the fallback `text` field older
Slack clients render in lieu of blocks.