### PR TITLE
join: take gateway URL as positional arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Detected public IP: gw.example.com
 └ Wrote /etc/systemd/system/clawpatrol-gateway.service
 
 Dashboard: http://gw.example.com:9080
-Join command: clawpatrol join --url http://gw.example.com:9080
+Join command: clawpatrol join http://gw.example.com:9080
 ```
 
 ```
@@ -34,7 +34,7 @@ systemctl enable --now clawpatrol-gateway
 On every machine you want to route through the gateway, run `clawpatrol join`. You'll get a one-time code; verify it matches in the browser tab that opens, approve, and you're done.
 
 ```
-clawpatrol join --url http://gw.example.com:9080
+clawpatrol join http://gw.example.com:9080
 
 Verify code in browser:
 
@@ -122,7 +122,7 @@ rule "sql_rule" "pg-secret-defense" {
 
 Clawpatrol ships two control planes for the gateway-to-device tunnel. Pick one when you run `gateway init`; the default is WireGuard.
 
-The WireGuard mode embeds a userspace WG endpoint inside the gateway. You only have to open one UDP port — there's no daemon, no `wg-quick`, and no kernel module on the gateway host. Devices run `clawpatrol join --url <gw>` and walk away with a per-machine WG conf.
+The WireGuard mode embeds a userspace WG endpoint inside the gateway. You only have to open one UDP port — there's no daemon, no `wg-quick`, and no kernel module on the gateway host. Devices run `clawpatrol join <gw>` and walk away with a per-machine WG conf.
 
 The Tailscale mode joins the gateway to your existing tailnet as an exit-node. Devices that are already on the tailnet run `clawpatrol login` and pin `clawpatrol` as their exit-node. Use this if you already operate Tailscale and want its ACL and whois plumbing to gate onboarding.
 

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -37,7 +37,7 @@ in promiscuous mode — same shape as unclaw's `boringtun` + `smoltcp`
   derived via curve25519 at boot. Peer (pubkey → IP) map persisted
   at `<oauth_dir>/wg-peers.json`, replayed on every restart so
   existing clients survive gateway redeploys.
-- `clawpatrol join --url <gw>` runs once: prints user-code, opens
+- `clawpatrol join <gw>` runs once: prints user-code, opens
   dashboard URL, server mints a fresh keypair, allocates a /32 from
   the configured subnet, registers the peer with wireguard-go,
   hands back a `wg-quick` conf. Server **auto-claims** the peer
@@ -105,7 +105,7 @@ in `/opt/clawpatrol/oauth/`.
 
 ```bash
 curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
-clawpatrol join --url http://your-gw.example.com:8080
+clawpatrol join http://your-gw.example.com:8080
 # approve at the displayed URL, done — claude/gh/codex just work
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -133,4 +133,4 @@ if [ "$OS" = "darwin" ]; then
   rm -rf "$APP_TMP"
 fi
 
-echo "next: clawpatrol join --url <gateway-url>"
+echo "next: clawpatrol join <gateway-url>"

--- a/login.go
+++ b/login.go
@@ -49,7 +49,6 @@ type tsPeer struct {
 // system trust) — single command, full setup.
 func runJoin(args []string) {
 	fs := flag.NewFlagSet("join", flag.ExitOnError)
-	gatewayURL := fs.String("url", "", "gateway URL (e.g. http://gw.example.com:8080) — required")
 	gwName := fs.String("name", "clawpatrol", "exit-node hostname on the tailnet")
 	caOut := fs.String("ca-dir", defaultClawpatrolDir(), "where to store the fetched CA")
 	skipTrust := fs.Bool("no-trust", false, "fetch CA but skip system trust install (do it manually)")
@@ -57,20 +56,22 @@ func runJoin(args []string) {
 	profile := fs.String("profile", "", "profile to assign at approval time (defaults to the gateway's default profile if the approver doesn't pick one)")
 	hostname := fs.String("hostname", "", "device name to register with the gateway (defaults to os.Hostname)")
 	_ = fs.Parse(args)
-	if *gatewayURL == "" {
-		fail("usage: clawpatrol join --url <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine]")
+	rest := fs.Args()
+	if len(rest) != 1 || rest[0] == "" {
+		fail("usage: clawpatrol join <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine]")
 	}
+	gatewayURL := rest[0]
 	// Fetch CA + write shell rc BEFORE the VPN goes up. Once
 	// `wg-quick up` flips the default route through the gateway,
 	// reaching the gateway's public URL goes via the tunnel — which
 	// can't carry traffic until the gateway has internet egress
 	// configured (MASQUERADE etc). The CA is small + cheap and the
 	// onboard endpoints are reachable on the public path.
-	setup, err := postJoinSetup(*gatewayURL, *caOut, *skipTrust)
+	setup, err := postJoinSetup(gatewayURL, *caOut, *skipTrust)
 	if err != nil {
 		fail("ca fetch: %v", err)
 	}
-	wgMode, err := onboardViaDeviceFlow(*gatewayURL, *wholeMachine, *profile, *hostname, setup)
+	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, setup)
 	if err != nil {
 		fail("join: %v", err)
 	}
@@ -1108,7 +1109,7 @@ profile "default" {
 	printTreeItems(items)
 	fmt.Println()
 	fmt.Printf("Dashboard: %s\n", url)
-	fmt.Printf("Join command: clawpatrol join --url %s\n", url)
+	fmt.Printf("Join command: clawpatrol join %s\n", url)
 }
 
 // detectPublicIP queries plain-text IP echo services. We validate

--- a/main.go
+++ b/main.go
@@ -2123,7 +2123,7 @@ func usage() {
 
 usage:
   clawpatrol gateway [-config FILE]      run the gateway server
-  clawpatrol join --url <gateway-url>    onboard this machine via wg device flow
+  clawpatrol join <gateway-url>          onboard this machine via wg device flow
                   [--hostname NAME]      device name to register (default: os.Hostname)
                   [--profile NAME]       suggest a profile for the approver
                   [--whole-machine]      bring up wg-quick (route all traffic)

--- a/run_darwin.go
+++ b/run_darwin.go
@@ -80,7 +80,7 @@ func runRun(args []string) {
 	if _, err := os.Stat(macHelperPath); err != nil {
 		fail("Clawpatrol.app not installed. Build + install from macos/:\n" +
 			"  cd macos && ./install.sh\n" +
-			"then: clawpatrol join --url <gateway>")
+			"then: clawpatrol join <gateway>")
 	}
 	if err := ensureMacProxyUp(); err != nil {
 		fail(fmt.Sprintf("ensure proxy up: %v", err))
@@ -119,7 +119,7 @@ func runRun(args []string) {
 func ensureMacProxyUp() error {
 	confPath := filepath.Join(os.Getenv("HOME"), ".config", "clawpatrol", "wg.conf")
 	if _, err := os.Stat(confPath); err != nil {
-		return fmt.Errorf("no wg.conf at %s — run `clawpatrol join --url <gateway>` first", confPath)
+		return fmt.Errorf("no wg.conf at %s — run `clawpatrol join <gateway>` first", confPath)
 	}
 	// `install` may surface the system-extension approval prompt the
 	// first time; once activated it's a fast no-op.
@@ -143,7 +143,7 @@ func ensureMacProxyUp() error {
 
 // macHelperInstall is invoked from runJoin (on darwin) right after
 // the wg.conf is written so the user gets a single-prompt onboarding:
-// `clawpatrol join --url ...` → wg conf saved → sysext approved →
+// `clawpatrol join …` → wg conf saved → sysext approved →
 // proxy up. wholeMachine maps to the helper's --whole-machine flag.
 //
 // After saving the profile, push the freshly written wg.conf into the

--- a/run_linux.go
+++ b/run_linux.go
@@ -66,7 +66,7 @@ func runRun(args []string) {
 
 	cfg, err := parseRunConf(*confPath)
 	if err != nil {
-		fail("conf %s: %v\n  hint: run `clawpatrol join --url <gw>` first", *confPath, err)
+		fail("conf %s: %v\n  hint: run `clawpatrol join <gw>` first", *confPath, err)
 	}
 
 	checkUserNS()

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -198,7 +198,7 @@ table ip clawpatrol {
 }
 NFT
 # Open dashboard/onboard port (8080) on the public iface — needed for
-# brand-new clients running \`clawpatrol join --url ...\` since they
+# brand-new clients running \`clawpatrol join …\` since they
 # aren't on the tailnet yet. The tailnetGate middleware in web.go
 # restricts non-tailnet callers to /api/onboard/* + /info anyway.
 if ! iptables -C INPUT -p tcp --dport 8080 -j ACCEPT 2>/dev/null; then
@@ -259,7 +259,7 @@ echo "  -- tailnet IP: $(tailscale ip -4 | head -1)"
 
 # Tailscale Funnel: expose port 8080 publicly via the tailnet's
 # magic DNS hostname (https://<host>.<tailnet>.ts.net). Avoids
-# distributing raw IPs in `clawpatrol join --url` commands. Requires
+# distributing raw IPs in `clawpatrol join` commands. Requires
 # `nodeAttrs: [funnel]` on this node in the tailnet ACL.
 echo "  -- enabling tailscale funnel for :8080"
 tailscale funnel reset 2>/dev/null || true

--- a/site/doc/04-architecture.md
+++ b/site/doc/04-architecture.md
@@ -131,7 +131,7 @@ The gateway pulls in three plugin families:
 ## Connection modes
 
 There are three ways to connect a device to the gateway. Onboarding
-runs through `clawpatrol join --url <gateway>`: the dashboard mints
+runs through `clawpatrol join <gateway>`: the dashboard mints
 a WireGuard keypair, allocates a `/32` from the configured subnet,
 registers the peer with the running wireguard-go device, and the
 device persists the resulting `wg-quick`-style config at

--- a/site/doc/05-cli.md
+++ b/site/doc/05-cli.md
@@ -95,11 +95,12 @@ Options:
 
 ### `clawpatrol join`
 
-Register this device with an existing gateway (low-level,
-used internally by `onboard`).
+Register this device with an existing gateway. The URL is the only
+positional argument; `--hostname`, `--profile`, `--whole-machine`,
+and `--no-trust` are optional flags.
 
 ```bash
-clawpatrol join --server URL
+clawpatrol join <gateway-url>
 ```
 
 ### `clawpatrol --version`

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -133,4 +133,4 @@ if [ "$OS" = "darwin" ]; then
   rm -rf "$APP_TMP"
 fi
 
-echo "next: clawpatrol join --url <gateway-url>"
+echo "next: clawpatrol join <gateway-url>"

--- a/web.go
+++ b/web.go
@@ -308,7 +308,7 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 			login = r.Header.Get("Tailscale-User-Login")
 		}
 		if login == "" {
-			http.Error(rw, "tailnet access required — onboard via `clawpatrol join --url <gateway>`", 403)
+			http.Error(rw, "tailnet access required — onboard via `clawpatrol join <gateway>`", 403)
 			return
 		}
 		next.ServeHTTP(rw, r)

--- a/www/src/components/AddDeviceModal.tsx
+++ b/www/src/components/AddDeviceModal.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 export function AddDeviceModal({ publicURL, onClose }: { publicURL?: string; onClose: () => void }) {
   const url = publicURL || window.location.origin;
   const installCmd = "curl -fsSL https://clawpatrol.dev/install.sh | sh";
-  const joinCmd = `clawpatrol join --url ${url}`;
+  const joinCmd = `clawpatrol join ${url}`;
 
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50" onClick={onClose}>


### PR DESCRIPTION
## Summary

`clawpatrol join` required `-url` on every invocation — the flag added ceremony for an arg that was effectively positional. Drop it:

```
clawpatrol join http://gw.example.com:8080      # new
clawpatrol join --url http://gw.example.com:8080 # old
```

Other `join` flags (`--hostname`, `--profile`, `--whole-machine`, `--no-trust`, `--ca-dir`, `--name`) keep their flag form.

Updates every place that printed the old form:

- `clawpatrol gateway init` summary (the "Join command:" line)
- `usage:` help text
- Dashboard "Add device" modal copy-paste snippet
- `README.md`
- `doc/wireguard.md`
- `install.sh` (root + `site/public/install.sh`)
- `scripts/deploy.sh` comments
- `site/doc/04-architecture.md`, `site/doc/05-cli.md` (the latter also had a stale `--server` example, corrected)
- gateway-side error messages in `web.go`, `run_darwin.go`, `run_linux.go`

## Test plan

- [ ] `clawpatrol join` (no args) prints the new usage line.
- [ ] `clawpatrol join http://gw.example.com:8080` proceeds to CA fetch (replaces old flag form).
- [ ] `clawpatrol join --hostname foo http://gw.example.com:8080` works (flags + positional coexist).
- [ ] Dashboard "Add device" modal shows the new snippet.
- [ ] `clawpatrol gateway init` prints the new "Join command:" line.
