### PR TITLE
hitl: compact Slack message + matching dashboard labels

### DIFF
--- a/config/plugins/approvers/util.go
+++ b/config/plugins/approvers/util.go
@@ -15,11 +15,17 @@ import (
 // pool (dashboard, human).
 func buildPending(req runtime.ApproveRequest) runtime.HITLPending {
 	now := time.Now()
+	family := ""
+	if req.Endpoint != nil {
+		family = req.Endpoint.Family
+	}
 	return runtime.HITLPending{
 		AgentIP:    req.Profile,
 		Host:       req.Host,
 		Method:     req.Method,
 		Path:       req.Path,
+		Endpoint:   runtime.HITLEndpointLabel(req),
+		Family:     family,
 		UA:         req.UA,
 		BodySample: req.BodySample,
 		Reason:     req.Reason,

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -232,7 +232,6 @@ func slackTrunc(s string, n int) string {
 	return s
 }
 
-
 // WebhookRoutes returns Slack's interactive callback handler. main
 // mounts it at /api/cred/<credName>/interactive — operator pastes
 // that URL into the Slack app's "Interactivity & Shortcuts" config.

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -118,20 +118,34 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 	}
 	link := strings.TrimRight(target.DashboardURL, "/") + "/#hitl/" + target.PendingID
 
-	title := fmt.Sprintf("Approve: %s %s %s", req.Method, req.Host, slackTrunc(req.Path, 60))
+	endpoint := runtime.HITLEndpointLabel(req)
+	queryLabel := runtime.HITLQueryLabel(req.Endpoint)
+
+	title := slackTrunc(runtime.HITLTitle(req.Method, endpoint), 140)
 	blocks := []map[string]any{
 		{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
-		{"type": "section", "fields": []map[string]any{
-			{"type": "mrkdwn", "text": "*Method*\n`" + req.Method + "`"},
-			{"type": "mrkdwn", "text": "*Host*\n`" + req.Host + "`"},
-			{"type": "mrkdwn", "text": "*Path*\n`" + slackTrunc(req.Path, 80) + "`"},
-			{"type": "mrkdwn", "text": "*Agent*\n`" + req.Profile + "`"},
+		{"type": "section", "text": map[string]any{
+			"type": "mrkdwn",
+			"text": "*" + queryLabel + "*\n```" + slackTrunc(req.Path, 800) + "```",
 		}},
 	}
+	ctx := []map[string]any{}
+	if req.Profile != "" {
+		ctx = append(ctx, map[string]any{
+			"type": "mrkdwn",
+			"text": "agent `" + req.Profile + "`",
+		})
+	}
 	if r := strings.TrimSpace(req.Reason); r != "" {
+		ctx = append(ctx, map[string]any{
+			"type": "mrkdwn",
+			"text": "reason: " + slackTrunc(r, 200),
+		})
+	}
+	if len(ctx) > 0 {
 		blocks = append(blocks, map[string]any{
-			"type": "section",
-			"text": map[string]any{"type": "mrkdwn", "text": "*Reason*\n" + r},
+			"type":     "context",
+			"elements": ctx,
 		})
 	}
 	if bs := strings.TrimSpace(req.BodySample); bs != "" {
@@ -176,7 +190,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 
 	body := map[string]any{
 		"channel": target.Channel,
-		"text":    fmt.Sprintf("clawpatrol HITL: %s %s %s", req.Method, req.Host, req.Path),
+		"text":    "clawpatrol: " + title,
 		"blocks":  blocks,
 	}
 	if target.ThreadTS != "" {
@@ -217,6 +231,7 @@ func slackTrunc(s string, n int) string {
 	}
 	return s
 }
+
 
 // WebhookRoutes returns Slack's interactive callback handler. main
 // mounts it at /api/cred/<credName>/interactive — operator pastes

--- a/config/runtime/hitl.go
+++ b/config/runtime/hitl.go
@@ -1,0 +1,62 @@
+package runtime
+
+import (
+	"strings"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// Shared HITL prompt formatting helpers. Used by both the Slack
+// notifier (config/plugins/credentials/slack.go) and the dashboard
+// pending-approvals widget (via buildPending → /api/hitl/pending)
+// so the labelling is consistent across surfaces.
+
+// HITLEndpointLabel returns the most concrete endpoint identifier
+// for a HITL prompt. For HTTPS the request's Host is a real
+// hostname (api.anthropic.com), so we use it. For SQL / k8s the
+// Host is typically a virtual IP, so we prefer the operator-defined
+// endpoint resource name (e.g. "users-db") and only fall back to
+// Host when no endpoint metadata is available.
+func HITLEndpointLabel(req ApproveRequest) string {
+	ep := req.Endpoint
+	if ep != nil && ep.Family == "https" && req.Host != "" {
+		return req.Host
+	}
+	if ep != nil && ep.Name != "" {
+		return ep.Name
+	}
+	return req.Host
+}
+
+// HITLQueryLabel picks a family-appropriate label for the body of a
+// HITL prompt: "Query" for SQL, "Resource" for k8s, "Path" for
+// HTTPS or unknown families.
+func HITLQueryLabel(ep *config.CompiledEndpoint) string {
+	if ep == nil {
+		return "Path"
+	}
+	switch ep.Family {
+	case "sql":
+		return "Query"
+	case "k8s":
+		return "Resource"
+	}
+	return "Path"
+}
+
+// HITLTitle builds the Slack header / dashboard title:
+// "Approve <verb> · <endpoint>". Either half may be empty; an empty
+// input is dropped so we never emit "Approve  ·  ".
+func HITLTitle(method, endpoint string) string {
+	method = strings.TrimSpace(method)
+	endpoint = strings.TrimSpace(endpoint)
+	switch {
+	case method != "" && endpoint != "":
+		return "Approve " + method + " · " + endpoint
+	case endpoint != "":
+		return "Approve " + endpoint
+	case method != "":
+		return "Approve " + method
+	}
+	return "Approve"
+}

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -336,11 +336,19 @@ type HITLPool interface {
 // tags match the dashboard's existing field names — that endpoint is
 // public API to the in-tree React UI.
 type HITLPending struct {
-	ID         string    `json:"id"`
-	AgentIP    string    `json:"agent_ip"`
-	Host       string    `json:"host"`
-	Method     string    `json:"method"`
-	Path       string    `json:"path"`
+	ID      string `json:"id"`
+	AgentIP string `json:"agent_ip"`
+	Host    string `json:"host"`
+	Method  string `json:"method"`
+	Path    string `json:"path"`
+	// Endpoint is the operator-readable identifier for what's being
+	// called. HITLEndpointLabel-derived: hostname for HTTPS, resource
+	// name for SQL / k8s where Host is a virtual IP.
+	Endpoint string `json:"endpoint,omitempty"`
+	// Family is the endpoint family ("https" | "sql" | "k8s") so the
+	// dashboard can pick a matching label for Path ("Query" /
+	// "Resource" / "Path"). Empty when no endpoint metadata is set.
+	Family     string    `json:"family,omitempty"`
 	UA         string    `json:"ua,omitempty"`
 	BodySample string    `json:"body_sample,omitempty"`
 	Reason     string    `json:"reason,omitempty"`

--- a/www/src/components/HITLBar.tsx
+++ b/www/src/components/HITLBar.tsx
@@ -49,13 +49,20 @@ export function HITLBar() {
           <col style={{ width: 160 }} />
         </colgroup>
         <tbody>
-          {pending.map((p) => (
+          {pending.map((p) => {
+            const ep = p.endpoint || p.host;
+            // HTTPS paths start with `/` and concatenate cleanly into
+            // a URL ("api.anthropic.com/v1/messages"). SQL / k8s
+            // paths don't start with `/`; insert a space so we get
+            // "users-db UPDATE ..." rather than "users-dbUPDATE ...".
+            const sep = p.path && !p.path.startsWith("/") ? " " : "";
+            return (
             <tr key={p.id} className="border-b border-[#f5f5f5] last:border-b-0 hover:bg-[#f9f9f9]">
               <Td className="text-[11px] text-[#525252] tabular-nums truncate">{p.agent_ip}</Td>
               <Td className="text-[11px] uppercase font-semibold text-[#9a3412]">{p.method}</Td>
               <Td>
-                <span className="text-[12px] text-[#171717] truncate block" title={p.host + p.path}>
-                  <span className="text-[#737373]">{p.host}</span>
+                <span className="text-[12px] text-[#171717] truncate block" title={ep + sep + p.path}>
+                  <span className="text-[#737373]">{ep}{sep}</span>
                   <span>{p.path}</span>
                 </span>
                 {p.reason && <div className="text-[10px] text-[#737373] truncate">{p.reason}</div>}
@@ -77,7 +84,8 @@ export function HITLBar() {
                 </div>
               </Td>
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -197,6 +197,13 @@ export type HITLPending = {
   host: string;
   method: string;
   path: string;
+  // Operator-readable endpoint identifier (hostname for HTTPS,
+  // resource name for SQL/k8s where host is a virtual IP).
+  // Computed server-side; falls back to host when unset.
+  endpoint?: string;
+  // Endpoint family — "https" | "sql" | "k8s". Used to label the
+  // path column ("Path" vs "Query" vs "Resource") in the UI.
+  family?: string;
   ua?: string;
   body_sample?: string;
   reason?: string;


### PR DESCRIPTION
The Slack HITL approval prompt was a 4-cell field grid that read poorly for long SQL queries. The title pasted `method + virtual-IP + truncated-SQL` into one line, "Host" was a virtual IP (operationally useless for SQL/k8s), and "Path" is a misnomer for a query. Same labels showed up in the dashboard's `HITLBar`.

## Slack message — before / after

**Before:** header `Approve: update 10.78.0.4UPDATE tables=[users] update users set name = name where fal…`, then a 4-field grid (`Method`, `Host`, `Path`, `Agent`).

**After:**

- **Header**: `Approve <verb> · <endpoint>` — e.g. `Approve update · users-db` or `Approve POST · api.anthropic.com`.
- **Section**: the request body in a fenced code block, labelled `*Query*` for SQL, `*Resource*` for k8s, `*Path*` for HTTPS / unknown.
- **Context**: a small grey footer line — `agent dev2 · reason: …` — only when there's something to say.
- **Body sample / Approve+Deny buttons**: unchanged.

The "endpoint" label algorithm matches the design discussion: prefer URL-y values, fall back to resource name, fall back to host. Concretely — `req.Host` for HTTPS (already a real hostname like `api.anthropic.com`), `Endpoint.Name` for SQL/k8s (e.g. `users-db`) since `req.Host` is a virtual IP there.

## Dashboard dedupe

`HITLEndpointLabel` / `HITLQueryLabel` / `HITLTitle` moved into `config/runtime/hitl.go` so both surfaces share one implementation. `HITLPending` now ships `endpoint` + `family` fields populated server-side in `buildPending`. `HITLBar` reads `endpoint` instead of raw host, so a SQL row in the dashboard reads `users-db UPDATE …` instead of `10.78.0.4UPDATE …`. HTTPS rows are unchanged because for HTTPS the endpoint label *is* the host.

## Files

- `config/runtime/hitl.go` — new, the three shared helpers.
- `config/runtime/runtime.go` — `HITLPending` gains `Endpoint` and `Family`.
- `config/plugins/approvers/util.go` — `buildPending` populates them.
- `config/plugins/credentials/slack.go` — new layout; uses `runtime.HITL*` helpers.
- `www/src/lib/api.ts` — type extension.
- `www/src/components/HITLBar.tsx` — render `endpoint` (with a space separator when path doesn't start with `/`).

## Test plan

- [ ] Trigger a SQL HITL — Slack header reads `Approve <verb> · <endpoint name>`, body uses `*Query*` label, no `Host` field, no virtual IP visible.
- [ ] Trigger an HTTPS HITL — Slack header reads `Approve <method> · <hostname>`, body uses `*Path*` label.
- [ ] Trigger a k8s HITL — body uses `*Resource*` label.
- [ ] Dashboard `PENDING APPROVALS` row for a SQL request reads `users-db UPDATE …` (or whichever resource name), not the virtual IP.
- [ ] Dashboard row for HTTPS reads identically to before (`api.anthropic.com/v1/messages`).
- [ ] Approve + Deny buttons still work end-to-end on Slack and the dashboard.
