### PR TITLE
test: cover HTTP body forwarding after match buffering

### DIFF
--- a/http_body_test.go
+++ b/http_body_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBufferHTTPBodyForMatchPreservesUpstreamForwardingBody(t *testing.T) {
+	const body = `{"prompt":"please forward me"}`
+	var upstreamBody string
+	var upstreamContentLength int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamContentLength = r.ContentLength
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("upstream read body: %v", err)
+		}
+		upstreamBody = string(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL+"/v1/messages", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	matchBody := bufferHTTPBodyForMatch(req)
+	if string(matchBody) != body {
+		t.Fatalf("match body = %q, want %q", matchBody, body)
+	}
+	if req.ContentLength != int64(len(body)) {
+		t.Fatalf("ContentLength = %d, want %d", req.ContentLength, len(body))
+	}
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if upstreamBody != body {
+		t.Fatalf("upstream body = %q, want %q", upstreamBody, body)
+	}
+	if upstreamContentLength != int64(len(body)) {
+		t.Fatalf("upstream ContentLength = %d, want %d", upstreamContentLength, len(body))
+	}
+}
+
+func TestBufferHTTPBodyForMatchKeepsFullLargeForwardingBody(t *testing.T) {
+	body := strings.Repeat("a", maxHTTPMatchBody) + "tail"
+	var upstreamBodyLen int
+	var upstreamContentLength int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamContentLength = r.ContentLength
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("upstream read body: %v", err)
+		}
+		upstreamBodyLen = len(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL+"/large", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	matchBody := bufferHTTPBodyForMatch(req)
+	if len(matchBody) != maxHTTPMatchBody {
+		t.Fatalf("match body len = %d, want %d", len(matchBody), maxHTTPMatchBody)
+	}
+	if req.ContentLength != int64(len(body)) {
+		t.Fatalf("ContentLength = %d, want %d", req.ContentLength, len(body))
+	}
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if upstreamBodyLen != len(body) {
+		t.Fatalf("upstream body len = %d, want %d", upstreamBodyLen, len(body))
+	}
+	if upstreamContentLength != int64(len(body)) {
+		t.Fatalf("upstream ContentLength = %d, want %d", upstreamContentLength, len(body))
+	}
+}
+
+func TestBufferHTTPBodyForMatchStreamsUnknownLengthRemainder(t *testing.T) {
+	body := strings.Repeat("b", maxHTTPMatchBody) + "tail"
+	var upstreamBodyLen int
+	var upstreamContentLength int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamContentLength = r.ContentLength
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("upstream read body: %v", err)
+		}
+		upstreamBodyLen = len(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL+"/chunked", io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.ContentLength = -1
+
+	matchBody := bufferHTTPBodyForMatch(req)
+	if len(matchBody) != maxHTTPMatchBody {
+		t.Fatalf("match body len = %d, want %d", len(matchBody), maxHTTPMatchBody)
+	}
+	if req.ContentLength != -1 {
+		t.Fatalf("ContentLength = %d, want -1", req.ContentLength)
+	}
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if upstreamBodyLen != len(body) {
+		t.Fatalf("upstream body len = %d, want %d", upstreamBodyLen, len(body))
+	}
+	if upstreamContentLength != -1 {
+		t.Fatalf("upstream ContentLength = %d, want -1", upstreamContentLength)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1534,6 +1534,22 @@ func (w *countWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+const maxHTTPMatchBody = 1 << 20
+
+func bufferHTTPBodyForMatch(req *http.Request) []byte {
+	if req.Body == nil {
+		return nil
+	}
+	b, err := io.ReadAll(io.LimitReader(req.Body, maxHTTPMatchBody))
+	if err != nil {
+		return nil
+	}
+	// Re-attach the buffered prefix in front of the original stream,
+	// which may still contain bytes beyond maxHTTPMatchBody.
+	req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(b), req.Body))
+	return b
+}
+
 // mitmHTTPS handles an SNI-matched TLS connection for an HTTPS-family
 // endpoint (https, kubernetes). It mints a leaf cert, terminates TLS,
 // then loops reading HTTP requests and dispatching each through the
@@ -1588,14 +1604,8 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// body we read up to 1 MiB and re-attach. Reads beyond 1 MiB
 		// stream through unbuffered (rare for agent traffic).
 		var matchBody []byte
-		if req.Body != nil && (req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH") {
-			b, rdErr := io.ReadAll(io.LimitReader(req.Body, 1<<20))
-			if rdErr == nil {
-				matchBody = b
-				// Re-attach: buffered prefix + rest of original stream.
-				// Do not close req.Body — it still holds bytes beyond 1 MiB.
-				req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(b), req.Body))
-			}
+		if req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH" {
+			matchBody = bufferHTTPBodyForMatch(req)
 		}
 
 		mreq := &match.Request{
@@ -1785,12 +1795,8 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 
 		trackKind := trackKindFor(host)
 		var trackedReqBody []byte
-		if trackKind != "" && req.Body != nil {
-			b, _ := io.ReadAll(io.LimitReader(req.Body, 1<<20))
-			trackedReqBody = b
-			// Re-attach: buffered prefix + rest of original stream.
-			// Do not close req.Body — it still holds bytes beyond 1 MiB.
-			req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(b), req.Body))
+		if trackKind != "" {
+			trackedReqBody = bufferHTTPBodyForMatch(req)
 		}
 		// Pre-create session from the request body so streaming SSE
 		// responses (codex /backend-api/codex/responses, anthropic


### PR DESCRIPTION
## Summary

- Add regression coverage for the request body buffering behavior fixed in #138.
- Cover the `body_json` / `body_contains` match path where the gateway reads up to 1 MiB for matching, then forwards the original request upstream.
- Verify large known-length and unknown-length bodies still forward the bytes after the 1 MiB match prefix instead of truncating at the buffered prefix.
- Extract the shared HTTP match-body buffering helper so the matcher and LLM tracking paths use the same replay behavior under test.

## Test plan

- [x] `go test . -run TestBufferHTTPBodyForMatch -count=1 -v`
- [x] `go test ./...`
