### PR TITLE
telemetry: reject oversized payloads with 413

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -237,7 +237,9 @@ Schema versioned in the URL so we can add fields later without
 breaking older clients (they get the v1 response shape forever; v2
 clients can ask for richer responses).
 
-The Worker validates: payload < 4 KB, required fields present.
-Anything else is dropped with a 400 and no detail body — bad clients
-get silence. No other public routes; the data is read via D1 SQL.
+The Worker validates: payload ≤ 4 KB, measured in UTF-8 bytes,
+required fields present. If `Content-Length` is over the limit, the
+Worker rejects the request before reading the body. Oversized
+payloads return 413; malformed JSON or schema errors return 400.
+No other public routes; the data is read via D1 SQL.
 

--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "vite build && tsx build-docs.ts",
     "deploy": "npm run build && wrangler deploy",
+    "test": "tsx --test worker/**/*.test.ts",
     "telemetry": "tsx scripts/telemetry.ts"
   },
   "dependencies": {

--- a/site/worker/index.test.ts
+++ b/site/worker/index.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import worker from "./index";
+
+type PreparedStatement = {
+  bind: (...args: unknown[]) => PreparedStatement;
+  run: () => Promise<void>;
+};
+
+function env() {
+  const calls = { prepare: 0, bind: [] as unknown[][], releaseFetch: 0 };
+  const stmt: PreparedStatement = {
+    bind: (...args: unknown[]) => {
+      calls.bind.push(args);
+      return stmt;
+    },
+    run: async () => {},
+  };
+  return {
+    calls,
+    env: {
+      ASSETS: { fetch: async () => new Response("asset") },
+      TELEMETRY_DB: {
+        prepare: () => {
+          calls.prepare++;
+          return stmt;
+        },
+      },
+    },
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("rejects oversized telemetry payloads from Content-Length before reading the body", async () => {
+  const { env: testEnv, calls } = env();
+  const body = new ReadableStream({
+    pull(controller) {
+      controller.error(new Error("body should not be read"));
+    },
+  });
+  const req = new Request("https://clawpatrol.dev/api/telemetry/v1/check", {
+    method: "POST",
+    headers: { "Content-Length": "4097" },
+    body,
+    duplex: "half",
+  } as RequestInit & { duplex: "half" });
+
+  const res = await worker.fetch(req, testEnv);
+
+  assert.equal(res.status, 413);
+  assert.equal(calls.prepare, 0);
+});
+
+test("rejects payloads over the byte limit, not just the JavaScript string length", async () => {
+  const { env: testEnv, calls } = env();
+  globalThis.fetch = async () => {
+    calls.releaseFetch++;
+    return Response.json({ tag_name: "v1.0.0", html_url: "https://example.com" });
+  };
+  const text = JSON.stringify({
+    instance_id: "01HZTEST",
+    version: "0.4.2",
+    os: "linux",
+    arch: "amd64",
+    git_sha: "€".repeat(1400),
+  });
+  assert.ok(text.length <= 4096);
+  assert.ok(new TextEncoder().encode(text).byteLength > 4096);
+
+  const res = await worker.fetch(
+    new Request("https://clawpatrol.dev/api/telemetry/v1/check", {
+      method: "POST",
+      body: text,
+    }),
+    testEnv,
+  );
+
+  assert.equal(res.status, 413);
+  assert.equal(calls.prepare, 0);
+  assert.equal(calls.releaseFetch, 0);
+});

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -14,7 +14,7 @@ interface Env {
   TELEMETRY_DB: D1Database;
 }
 
-const MAX_BODY = 4096;
+const MAX_BODY_BYTES = 4096;
 const RELEASES_URL =
   "https://api.github.com/repos/denoland/clawpatrol/releases/latest";
 
@@ -35,8 +35,18 @@ async function handleCheck(
   if (req.method !== "POST") {
     return new Response(null, { status: 405 });
   }
+  const contentLength = req.headers.get("Content-Length");
+  if (contentLength !== null) {
+    const n = Number(contentLength);
+    if (Number.isFinite(n) && n > MAX_BODY_BYTES) {
+      return new Response(null, { status: 413 });
+    }
+  }
+
   const text = await req.text();
-  if (text.length > MAX_BODY) return new Response(null, { status: 400 });
+  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
 
   let body: Record<string, unknown>;
   try {


### PR DESCRIPTION
## Summary

- Reject telemetry checks with `Content-Length` over 4 KiB before reading the body.
- Measure the fallback payload limit in UTF-8 bytes instead of JavaScript string length.
- Return `413 Payload Too Large` for oversized telemetry payloads, while keeping malformed JSON / schema errors on `400`.
- Add worker tests for the early-reject path and multi-byte byte-length enforcement.

## Test plan

- [x] `cd site && npm test`
- [x] `cd site && npm run build`
- [x] `git diff --check`
