### PR TITLE
fix: gateway init defaults to ~/.clawpatrol when not root

### DIFF
--- a/login.go
+++ b/login.go
@@ -979,9 +979,20 @@ func installTailscale() error {
 // writes a sane wireguard-mode gateway.hcl, opens firewall ports,
 // and prints the run command. Replaces the bash-script deploy hacks.
 
+func defaultGatewayDataDir() string {
+	if os.Getuid() == 0 {
+		return "/etc/clawpatrol"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "/etc/clawpatrol"
+	}
+	return filepath.Join(home, ".clawpatrol")
+}
+
 func runGatewayInit(args []string) {
 	fs := flag.NewFlagSet("gateway init", flag.ExitOnError)
-	dataDir := fs.String("data-dir", "/etc/clawpatrol", "where to put gateway.hcl + CA + state")
+	dataDir := fs.String("data-dir", defaultGatewayDataDir(), "where to put gateway.hcl + CA + state")
 	publicURL := fs.String("public-url", "", "public dashboard URL (auto-detected from public IP if empty)")
 	publicIP := fs.String("public-ip", "", "public IP for the WG endpoint (auto-detected if empty)")
 	wgPort := fs.Int("wg-port", 51820, "wireguard UDP port")


### PR DESCRIPTION
## Summary

- `clawpatrol gateway init` was hardcoded to `/etc/clawpatrol`, requiring root/sudo
- Now defaults to `$HOME/.clawpatrol` for non-root, `/etc/clawpatrol` for root
- `--data-dir` flag still overrides both
- Firewall (iptables via `runAsRoot`) and systemd unit already handle non-root gracefully

## Test plan

- [ ] `clawpatrol gateway init` as non-root → creates `~/.clawpatrol/{ca,oauth,gateway.hcl}`
- [ ] `clawpatrol gateway init` as root → creates `/etc/clawpatrol/...` (unchanged behavior)
- [ ] `clawpatrol gateway init --data-dir /tmp/test` → uses `/tmp/test` regardless of uid

🤖 Generated with [Claude Code](https://claude.com/claude-code)