### PR TITLE
Fix Postgres pump context cancellation

### DIFF
--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -351,10 +351,26 @@ func pgStartupParam(body []byte, key string) string {
 
 // pgClientToServer pumps the agent's outbound message stream to the
 // upstream, inspecting Query / Parse for policy.
-func pgClientToServer(_ context.Context, ch *runtime.ConnHandle, upstream net.Conn, credName string) {
+func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.Conn, credName string) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = ch.Conn.Close()
+		case <-done:
+		}
+	}()
+
 	buf := make([]byte, 0, 64*1024)
 	tmp := make([]byte, 32*1024)
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		n, err := ch.Conn.Read(tmp)
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -1,7 +1,10 @@
 package endpoints
 
 import (
+	"context"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -189,6 +192,28 @@ func TestPgExtractSQL(t *testing.T) {
 // shows up in the actions tab. Without this, postgres connections
 // to permissive endpoints were invisible to operators — the runtime
 // previously short-circuited on `cr == nil`.
+func TestPgClientToServerReturnsOnContextCancel(t *testing.T) {
+	agent, gateway := net.Pipe()
+	defer agent.Close()
+	upstream, upstreamPeer := net.Pipe()
+	defer upstream.Close()
+	defer upstreamPeer.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "")
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("pgClientToServer did not return after context cancellation")
+	}
+}
+
 func TestPgEvaluateEmitsAllowOnNoMatch(t *testing.T) {
 	var events []runtime.ConnEvent
 	ch := &runtime.ConnHandle{

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -186,12 +186,6 @@ func TestPgExtractSQL(t *testing.T) {
 	}
 }
 
-// TestPgEvaluateEmitsAllowOnNoMatch nails down the dashboard logging
-// fix: an endpoint with zero rules (or one whose rules don't match
-// the current query) still emits an `allow` event so the query
-// shows up in the actions tab. Without this, postgres connections
-// to permissive endpoints were invisible to operators — the runtime
-// previously short-circuited on `cr == nil`.
 func TestPgClientToServerReturnsOnContextCancel(t *testing.T) {
 	agent, gateway := net.Pipe()
 	defer agent.Close()
@@ -214,6 +208,12 @@ func TestPgClientToServerReturnsOnContextCancel(t *testing.T) {
 	}
 }
 
+// TestPgEvaluateEmitsAllowOnNoMatch nails down the dashboard logging
+// fix: an endpoint with zero rules (or one whose rules don't match
+// the current query) still emits an `allow` event so the query
+// shows up in the actions tab. Without this, postgres connections
+// to permissive endpoints were invisible to operators — the runtime
+// previously short-circuited on `cr == nil`.
 func TestPgEvaluateEmitsAllowOnNoMatch(t *testing.T) {
 	var events []runtime.ConnEvent
 	ch := &runtime.ConnHandle{

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -188,10 +188,10 @@ func TestPgExtractSQL(t *testing.T) {
 
 func TestPgClientToServerReturnsOnContextCancel(t *testing.T) {
 	agent, gateway := net.Pipe()
-	defer agent.Close()
+	defer func() { _ = agent.Close() }()
 	upstream, upstreamPeer := net.Pipe()
-	defer upstream.Close()
-	defer upstreamPeer.Close()
+	defer func() { _ = upstream.Close() }()
+	defer func() { _ = upstreamPeer.Close() }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})


### PR DESCRIPTION
## Summary
- make pgClientToServer return when its context is cancelled
- close the client side of the pipe to unblock pending reads on cancellation
- add a regression test for cancellation behavior

## Tests
- go test ./config/plugins/endpoints
- go vet ./...
- go test ./...