### PR TITLE
Allow env pushdown through tailnet gate

### DIFF
--- a/web.go
+++ b/web.go
@@ -287,6 +287,7 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 		"/api/onboard/start":     true,
 		"/api/onboard/poll":      true,
 		"/api/onboard/claim":     true, // device_code-gated; safe to be public
+		"/api/env-pushdown":      true, // bearer-token gated by the handler
 		"/api/slack/interactive": true, // signed payload; verified via slack signing secret
 		"/info":                  true,
 		"/ca.crt":                true, // gateway's public CA cert, intentionally exposed

--- a/web_tailnet_gate_test.go
+++ b/web_tailnet_gate_test.go
@@ -11,7 +11,7 @@ import (
 func TestTailnetGateAllowsEnvPushdownToReachBearerAuth(t *testing.T) {
 	w := &webMux{g: &Gateway{cfg: &config.Gateway{Tailscale: &config.Tailscale{Control: "tailscale"}}}}
 	reached := false
-	h := w.tailnetGate(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	h := w.tailnetGate(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		reached = true
 		http.Error(rw, "unknown or missing peer api token", http.StatusUnauthorized)
 	}))

--- a/web_tailnet_gate_test.go
+++ b/web_tailnet_gate_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestTailnetGateAllowsEnvPushdownToReachBearerAuth(t *testing.T) {
+	w := &webMux{g: &Gateway{cfg: &config.Gateway{Tailscale: &config.Tailscale{Control: "tailscale"}}}}
+	reached := false
+	h := w.tailnetGate(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		reached = true
+		http.Error(rw, "unknown or missing peer api token", http.StatusUnauthorized)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/env-pushdown", nil)
+	r.RemoteAddr = "203.0.113.10:12345"
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, r)
+
+	if !reached {
+		t.Fatal("/api/env-pushdown was blocked by tailnetGate before bearer auth")
+	}
+	if rw.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d from bearer auth handler", rw.Code, http.StatusUnauthorized)
+	}
+}


### PR DESCRIPTION
## Summary
- allow /api/env-pushdown through tailnetGate so its bearer-token auth can run
- add a regression test that non-tailnet callers reach the bearer auth handler instead of being rejected by tailnetGate

## Tests
- go test ./...
- go vet ./...