### PR TITLE
Stop accepting dashboard secret in query string

### DIFF
--- a/web.go
+++ b/web.go
@@ -111,7 +111,7 @@ func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Ha
 }
 
 // dashboardSecretGate requires every non-public request to carry the
-// configured dashboard_secret (cookie / header / query). Onboarding
+// configured dashboard_secret (cookie / header). Onboarding
 // + health endpoints stay open so brand-new clients can still join.
 //
 // When dashboard_secret is empty, the gate's behavior depends on
@@ -210,9 +210,6 @@ func checkDashboardSecret(r *http.Request, want string) bool {
 	if h := r.Header.Get("X-Clawpatrol-Secret"); h != "" && subtle.ConstantTimeCompare([]byte(h), []byte(want)) == 1 {
 		return true
 	}
-	if q := r.URL.Query().Get("secret"); q != "" && subtle.ConstantTimeCompare([]byte(q), []byte(want)) == 1 {
-		return true
-	}
 	return false
 }
 
@@ -246,20 +243,6 @@ func (w *webMux) apiDashboardLogin(rw http.ResponseWriter, r *http.Request) {
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 			MaxAge:   30 * 24 * 3600, // 30d
-		})
-		http.Redirect(rw, r, next, http.StatusFound)
-		return
-	}
-	// GET — accept ?secret= one-shot to set the cookie automatically
-	// (so an operator can paste a single URL with the secret).
-	if q := r.URL.Query().Get("secret"); q != "" && subtle.ConstantTimeCompare([]byte(q), []byte(want)) == 1 {
-		http.SetCookie(rw, &http.Cookie{
-			Name:     "cp_dash",
-			Value:    want,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   30 * 24 * 3600,
 		})
 		http.Redirect(rw, r, next, http.StatusFound)
 		return

--- a/web_dashboard_auth_test.go
+++ b/web_dashboard_auth_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestDashboardSecretQueryParamIsNotAccepted(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/state?secret=s3cr3t", nil)
+	if checkDashboardSecret(r, "s3cr3t") {
+		t.Fatal("dashboard secret in query string was accepted")
+	}
+
+	r = httptest.NewRequest(http.MethodGet, "/api/state", nil)
+	r.Header.Set("X-Clawpatrol-Secret", "s3cr3t")
+	if !checkDashboardSecret(r, "s3cr3t") {
+		t.Fatal("dashboard secret header was rejected")
+	}
+}
+
+func TestDashboardLoginGetDoesNotAcceptSecretQueryParam(t *testing.T) {
+	w := &webMux{g: &Gateway{cfg: &config.Gateway{DashboardSecret: "s3cr3t"}}}
+	r := httptest.NewRequest(http.MethodGet, "/__login?secret=s3cr3t&next=/api/state", nil)
+	rw := httptest.NewRecorder()
+
+	w.apiDashboardLogin(rw, r)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rw.Code, http.StatusOK)
+	}
+	if cookies := rw.Result().Cookies(); len(cookies) != 0 {
+		t.Fatalf("GET /__login?secret=... set cookies: %+v", cookies)
+	}
+}


### PR DESCRIPTION
## Summary
- stop accepting dashboard_secret via ?secret= query parameters
- remove GET /__login?secret=... auto-login behavior
- keep cookie and X-Clawpatrol-Secret header auth working
- add regression tests for query-string secret rejection

## Tests
- go test ./...
- go vet ./...