### PR TITLE
Avoid storing raw dashboard secret in cookie

### DIFF
--- a/web.go
+++ b/web.go
@@ -204,7 +204,7 @@ func renderDashboardMisconfigured(rw http.ResponseWriter, r *http.Request) {
 }
 
 func checkDashboardSecret(r *http.Request, want string) bool {
-	if c, err := r.Cookie("cp_dash"); err == nil && subtle.ConstantTimeCompare([]byte(c.Value), []byte(want)) == 1 {
+	if c, err := r.Cookie("cp_dash"); err == nil && subtle.ConstantTimeCompare([]byte(c.Value), []byte(dashboardCookieValue(want))) == 1 {
 		return true
 	}
 	if h := r.Header.Get("X-Clawpatrol-Secret"); h != "" && subtle.ConstantTimeCompare([]byte(h), []byte(want)) == 1 {
@@ -239,32 +239,34 @@ func (w *webMux) apiDashboardLogin(rw http.ResponseWriter, r *http.Request) {
 			renderLogin(rw, next, "wrong secret", 401)
 			return
 		}
-		http.SetCookie(rw, &http.Cookie{
-			Name:     "cp_dash",
-			Value:    want,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   30 * 24 * 3600, // 30d
-		})
+		setDashboardCookie(rw, want)
 		http.Redirect(rw, r, next, http.StatusFound)
 		return
 	}
 	// GET — accept ?secret= one-shot to set the cookie automatically
 	// (so an operator can paste a single URL with the secret).
 	if q := r.URL.Query().Get("secret"); q != "" && subtle.ConstantTimeCompare([]byte(q), []byte(want)) == 1 {
-		http.SetCookie(rw, &http.Cookie{
-			Name:     "cp_dash",
-			Value:    want,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   30 * 24 * 3600,
-		})
+		setDashboardCookie(rw, want)
 		http.Redirect(rw, r, next, http.StatusFound)
 		return
 	}
 	renderLogin(rw, next, "", 200)
+}
+
+func dashboardCookieValue(secret string) string {
+	sum := sha256.Sum256([]byte("clawpatrol-dashboard-cookie\x00" + secret))
+	return "v1." + hex.EncodeToString(sum[:])
+}
+
+func setDashboardCookie(rw http.ResponseWriter, secret string) {
+	http.SetCookie(rw, &http.Cookie{
+		Name:     "cp_dash",
+		Value:    dashboardCookieValue(secret),
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   30 * 24 * 3600,
+	})
 }
 
 func renderLogin(rw http.ResponseWriter, next, errMsg string, status int) {

--- a/web_dashboard_cookie_test.go
+++ b/web_dashboard_cookie_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestDashboardLoginCookieDoesNotStoreRawSecret(t *testing.T) {
+	const secret = "s3cr3t"
+	w := &webMux{g: &Gateway{cfg: &config.Gateway{DashboardSecret: secret}}}
+	form := url.Values{"secret": {secret}}
+	r := httptest.NewRequest(http.MethodPost, "/__login", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rw := httptest.NewRecorder()
+
+	w.apiDashboardLogin(rw, r)
+
+	var dashCookie *http.Cookie
+	for _, c := range rw.Result().Cookies() {
+		if c.Name == "cp_dash" {
+			dashCookie = c
+		}
+	}
+	if dashCookie == nil {
+		t.Fatal("login did not set cp_dash cookie")
+	}
+	if dashCookie.Value == secret {
+		t.Fatal("cp_dash cookie stored the raw dashboard secret")
+	}
+
+	authReq := httptest.NewRequest(http.MethodGet, "/api/state", nil)
+	authReq.AddCookie(dashCookie)
+	if !checkDashboardSecret(authReq, secret) {
+		t.Fatal("derived dashboard cookie was rejected")
+	}
+}
+
+func TestRawDashboardSecretCookieIsRejected(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/state", nil)
+	r.AddCookie(&http.Cookie{Name: "cp_dash", Value: "s3cr3t"})
+	if checkDashboardSecret(r, "s3cr3t") {
+		t.Fatal("raw dashboard secret cookie was accepted")
+	}
+}


### PR DESCRIPTION
## Summary
- store a derived dashboard cookie token instead of the raw dashboard_secret
- validate cp_dash against the derived token
- reject cookies containing the raw dashboard_secret
- add regression tests for cookie contents and validation

## Tests
- go test ./...
- go vet ./...