### PR TITLE
Log HTTP server startup failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -2234,12 +2234,10 @@ func runGateway(args []string) {
 
 	if cfg.InfoListen != "" {
 		mux := newWebMux(g, cfg.CADir, *cfg.Tailscale, cfg.PublicURL)
-		go func() {
-			_ = http.ListenAndServe(cfg.InfoListen, mux)
-		}()
+		go serveHTTPLogged("dashboard", cfg.InfoListen, mux)
 		printDashboardURL(cfg.InfoListen)
 	}
-	go func() { _ = http.ListenAndServe("127.0.0.1:6060", nil) }()
+	go serveHTTPLogged("pprof", "127.0.0.1:6060", nil)
 	go g.servePorts()
 
 	// Embedded userspace WireGuard server. When operator sets
@@ -2317,6 +2315,19 @@ func runGateway(args []string) {
 		}
 		go g.handle(c, "")
 	}
+}
+
+func serveHTTPLogged(name, addr string, handler http.Handler) {
+	if err := http.ListenAndServe(addr, handler); err != nil {
+		logHTTPServerExit(name, addr, err)
+	}
+}
+
+func logHTTPServerExit(name, addr string, err error) {
+	if err == nil || errors.Is(err, http.ErrServerClosed) {
+		return
+	}
+	log.Printf("%s http server on %s stopped: %v", name, addr, err)
 }
 
 // portOf extracts the numeric port from a "host:port" or ":port" listen

--- a/main_http_server_test.go
+++ b/main_http_server_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestLogHTTPServerExitLogsUnexpectedErrors(t *testing.T) {
+	var buf bytes.Buffer
+	oldOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOut)
+
+	logHTTPServerExit("dashboard", "127.0.0.1:1", errors.New("bind failed"))
+
+	got := buf.String()
+	if !strings.Contains(got, "dashboard http server on 127.0.0.1:1 stopped: bind failed") {
+		t.Fatalf("log output = %q", got)
+	}
+}
+
+func TestLogHTTPServerExitIgnoresServerClosed(t *testing.T) {
+	var buf bytes.Buffer
+	oldOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOut)
+
+	logHTTPServerExit("dashboard", "127.0.0.1:1", http.ErrServerClosed)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("log output = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- log dashboard and pprof HTTP server errors instead of discarding them
- ignore expected http.ErrServerClosed exits
- add tests for HTTP server exit logging

## Tests
- go test ./...
- go vet ./...