### PR TITLE
Require dashboard auth for onboarding approvals in non-tailscale modes

### DIFF
--- a/onboard.go
+++ b/onboard.go
@@ -516,9 +516,10 @@ func (w *webMux) apiOnboardLookup(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// apiOnboardApprove is hit by the dashboard "approve" button. The
-// caller must be an existing tailnet member (whois succeeds) — this
-// gates onboarding behind an existing trusted user.
+// apiOnboardApprove is hit by the dashboard "approve" button.
+// Approval is an operator action: in production with dashboard_secret
+// configured, dashboardSecretGate must authenticate the request before
+// this handler can approve a pending device.
 func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)

--- a/web.go
+++ b/web.go
@@ -131,7 +131,8 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 		"/api/onboard/poll":    true,
 		"/api/onboard/claim":   true,
 		"/api/onboard/lookup":  true,
-		"/api/onboard/approve": true,
+		"/api/onboard/approve": true, // tailnetGate authenticates this in Tailscale mode.
+		// In skipped tailnet modes, tailnetGate requires dashboard auth for approve.
 		// /api/env-pushdown is NOT public — it's gated by the
 		// per-peer bearer minted at onboard time. The handler
 		// validates `Authorization: Bearer <token>` against
@@ -281,7 +282,20 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 		w.g.cfg.Tailscale.Control != ""
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if publicPaths[r.URL.Path] || skipGate {
+		if publicPaths[r.URL.Path] {
+			next.ServeHTTP(rw, r)
+			return
+		}
+		if skipGate {
+			// In non-Tailscale control modes there is no tailnet identity to
+			// authenticate approval, so keep the historical Tailscale-mode
+			// behavior while requiring dashboard auth for this operator action.
+			if r.URL.Path == "/api/onboard/approve" && w.g.cfg.DashboardSecret != "" {
+				if !checkDashboardSecret(r, w.g.cfg.DashboardSecret) {
+					http.Error(rw, "dashboard secret required", http.StatusUnauthorized)
+					return
+				}
+			}
 			next.ServeHTTP(rw, r)
 			return
 		}

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+const authTestDashboardCredential = "test-dashboard-credential"
+
+func newOnboardAuthTestHandler() http.Handler {
+	return newOnboardAuthTestHandlerForControl("wireguard")
+}
+
+func newOnboardAuthTestHandlerForControl(control string) http.Handler {
+	cfg := &config.Gateway{
+		DashboardSecret: authTestDashboardCredential,
+		Tailscale:       &config.Tailscale{Control: control},
+		Policy:          &config.Policy{},
+	}
+	g := &Gateway{
+		cfg:     cfg,
+		onboard: newOnboardRegistry(),
+	}
+	return newWebMux(g, "", *cfg.Tailscale, "https://gateway.example.test")
+}
+
+func TestOnboardApproveRequiresDashboardSecretInWireGuardMode(t *testing.T) {
+	h := newOnboardAuthTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusUnauthorized, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "dashboard secret required") {
+		t.Fatalf("body = %q, want dashboard secret error", rr.Body.String())
+	}
+}
+
+func TestOnboardApproveWithDashboardSecretReachesHandlerInWireGuardMode(t *testing.T) {
+	h := newOnboardAuthTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
+	req.Header.Set("X-Clawpatrol-Secret", authTestDashboardCredential)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusNotFound, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "unknown or expired code") {
+		t.Fatalf("body = %q, want onboard handler error", rr.Body.String())
+	}
+}
+
+func TestOnboardApproveWithDashboardSecretMarksPendingSessionApprovedInWireGuardMode(t *testing.T) {
+	h := newOnboardAuthTestHandler()
+	startReq := httptest.NewRequest(http.MethodPost, "/api/onboard/start?hostname=test-device&profile=default", nil)
+	startRR := httptest.NewRecorder()
+	h.ServeHTTP(startRR, startReq)
+	if startRR.Code != http.StatusOK {
+		t.Fatalf("start status = %d, want %d; body = %q", startRR.Code, http.StatusOK, startRR.Body.String())
+	}
+	var start struct {
+		UserCode string `json:"user_code"`
+	}
+	if err := json.NewDecoder(startRR.Body).Decode(&start); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	if start.UserCode == "" {
+		t.Fatalf("start response missing user_code")
+	}
+
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code="+url.QueryEscape(start.UserCode)+"&profile=default", nil)
+	approveReq.Header.Set("X-Clawpatrol-Secret", authTestDashboardCredential)
+	approveRR := httptest.NewRecorder()
+	h.ServeHTTP(approveRR, approveReq)
+	if approveRR.Code != http.StatusOK {
+		t.Fatalf("approve status = %d, want %d; body = %q", approveRR.Code, http.StatusOK, approveRR.Body.String())
+	}
+
+	lookupReq := httptest.NewRequest(http.MethodGet, "/api/onboard/lookup?code="+url.QueryEscape(start.UserCode), nil)
+	lookupReq.RemoteAddr = "127.0.0.1:12345"
+	lookupReq.Header.Set("Tailscale-User-Login", "operator@example.test")
+	lookupRR := httptest.NewRecorder()
+	h.ServeHTTP(lookupRR, lookupReq)
+	if lookupRR.Code != http.StatusOK {
+		t.Fatalf("lookup status = %d, want %d; body = %q", lookupRR.Code, http.StatusOK, lookupRR.Body.String())
+	}
+	var lookup struct {
+		Approved bool `json:"approved"`
+	}
+	if err := json.NewDecoder(lookupRR.Body).Decode(&lookup); err != nil {
+		t.Fatalf("decode lookup response: %v", err)
+	}
+	if !lookup.Approved {
+		t.Fatalf("lookup approved = false, want true")
+	}
+}
+
+func TestOnboardStartRemainsPublicWithDashboardSecretInWireGuardMode(t *testing.T) {
+	h := newOnboardAuthTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/start?hostname=test-device&profile=default", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "device_code") {
+		t.Fatalf("body = %q, want onboarding start response", rr.Body.String())
+	}
+}
+
+func TestOnboardApproveAllowsTailscaleServeCallerWithoutDashboardSecretInTailscaleMode(t *testing.T) {
+	h := newOnboardAuthTestHandlerForControl("tailscale")
+	startReq := httptest.NewRequest(http.MethodPost, "/api/onboard/start?hostname=test-device&profile=default", nil)
+	startRR := httptest.NewRecorder()
+	h.ServeHTTP(startRR, startReq)
+	if startRR.Code != http.StatusOK {
+		t.Fatalf("start status = %d, want %d; body = %q", startRR.Code, http.StatusOK, startRR.Body.String())
+	}
+	var start struct {
+		UserCode string `json:"user_code"`
+	}
+	if err := json.NewDecoder(startRR.Body).Decode(&start); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	if start.UserCode == "" {
+		t.Fatalf("start response missing user_code")
+	}
+
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code="+url.QueryEscape(start.UserCode)+"&profile=default", nil)
+	approveReq.RemoteAddr = "127.0.0.1:12345"
+	approveReq.Header.Set("Tailscale-User-Login", "operator@example.test")
+	approveRR := httptest.NewRecorder()
+	h.ServeHTTP(approveRR, approveReq)
+	if approveRR.Code != http.StatusOK {
+		t.Fatalf("approve status = %d, want %d; body = %q", approveRR.Code, http.StatusOK, approveRR.Body.String())
+	}
+
+	lookupReq := httptest.NewRequest(http.MethodGet, "/api/onboard/lookup?code="+url.QueryEscape(start.UserCode), nil)
+	lookupReq.RemoteAddr = "127.0.0.1:12345"
+	lookupReq.Header.Set("Tailscale-User-Login", "operator@example.test")
+	lookupRR := httptest.NewRecorder()
+	h.ServeHTTP(lookupRR, lookupReq)
+	if lookupRR.Code != http.StatusOK {
+		t.Fatalf("lookup status = %d, want %d; body = %q", lookupRR.Code, http.StatusOK, lookupRR.Body.String())
+	}
+	var lookup struct {
+		Approved bool `json:"approved"`
+	}
+	if err := json.NewDecoder(lookupRR.Body).Decode(&lookup); err != nil {
+		t.Fatalf("decode lookup response: %v", err)
+	}
+	if !lookup.Approved {
+		t.Fatalf("lookup approved = false, want true")
+	}
+}
+
+func TestOnboardApproveRequiresTailnetCallerEvenWithDashboardSecretInTailscaleMode(t *testing.T) {
+	h := newOnboardAuthTestHandlerForControl("tailscale")
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
+	req.RemoteAddr = "203.0.113.10:12345"
+	req.Header.Set("X-Clawpatrol-Secret", authTestDashboardCredential)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "tailnet access required") {
+		t.Fatalf("body = %q, want tailnet access error", rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- require dashboard authentication for `/api/onboard/approve` when the tailnet gate is skipped in WireGuard/proxy-style control modes
- preserve existing Tailscale-mode behavior where a verified tailnet caller can approve without a dashboard secret, and dashboard secret alone does not bypass tailnet membership
- keep public onboarding start/poll/claim/lookup paths available for unauthenticated onboarding clients
- add regression coverage for WireGuard-mode auth, Tailscale-mode tailnet membership behavior, and public onboarding start

## Tests
- go test ./ -run 'TestOnboard(ApproveRequiresDashboardSecretInWireGuardMode|ApproveWithDashboardSecretReachesHandlerInWireGuardMode|ApproveWithDashboardSecretMarksPendingSessionApprovedInWireGuardMode|StartRemainsPublicWithDashboardSecretInWireGuardMode|ApproveAllowsTailscaleServeCallerWithoutDashboardSecretInTailscaleMode|ApproveRequiresTailnetCallerEvenWithDashboardSecretInTailscaleMode)' -count=1
- go test ./...
- go vet ./...
