### PR TITLE
Route browser TLS through endpoint tunnels

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -119,20 +119,23 @@ func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName st
 	return tc, nil
 }
 
-// dialBrowserTLS opens a TCP connection and performs a uTLS handshake
-// using Chrome's TLS fingerprint (HelloChrome_Auto), with ALPN forced
-// to http/1.1. Used for WS upgrades to chatgpt.com — Cloudflare WAF
+// dialBrowserTLS opens a tunnel-aware TCP connection and performs a uTLS
+// handshake using Chrome's TLS fingerprint (HelloChrome_Auto), with ALPN
+// forced to http/1.1. Used for WS upgrades to chatgpt.com — Cloudflare WAF
 // otherwise rejects the WS handshake with "Attack attempt detected".
 //
 // Plain Go TLS works fine for chatgpt.com HTTP requests but the WS
 // upgrade specifically gets fingerprint-blocked. Mimicking Chrome's
 // ClientHello bypasses it.
-func dialBrowserTLS(ctx context.Context, network, addr, serverName string) (net.Conn, error) {
-	d := &net.Dialer{}
-	raw, err := d.DialContext(ctx, network, addr)
+func (g *Gateway) dialBrowserTLS(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint) (net.Conn, error) {
+	raw, err := g.dialThrough(ctx, ep, network, addr)
 	if err != nil {
 		return nil, err
 	}
+	return browserTLSOver(ctx, raw, serverName)
+}
+
+func browserTLSOver(ctx context.Context, raw net.Conn, serverName string) (net.Conn, error) {
 	// HelloChrome_Auto bakes ALPN ["h2","http/1.1"] into the ClientHello.
 	// We need http/1.1 only (WS upgrade requires HTTP/1.1; raw response
 	// reader breaks on h2 SETTINGS frames). Apply preset spec, mutate

--- a/dial_test.go
+++ b/dial_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+type fakeTLSCredential struct {
+	configured atomic.Int32
+}
+
+func (c *fakeTLSCredential) ConfigureUpstreamTLS(_ *tls.Config, _ runtime.Secret) error {
+	c.configured.Add(1)
+	return nil
+}
+
+type fakeSecretStore struct{}
+
+func (fakeSecretStore) Get(string, string) (runtime.Secret, error) {
+	return runtime.Secret{}, nil
+}
+
+func endpointWithTunnelAndTLSCredential(name string, tunnel *config.CompiledTunnel, credential *fakeTLSCredential) *config.CompiledEndpoint {
+	return &config.CompiledEndpoint{
+		Name:   name,
+		Tunnel: tunnel,
+		Credentials: []*config.CompiledCredential{{
+			Credential: &config.Entity{
+				Symbol: &config.Symbol{Name: "mtls"},
+				Body:   credential,
+			},
+		}},
+	}
+}
+
+func TestTransportBrowserTLSUsesEndpointTunnel(t *testing.T) {
+	oldHosts := browserTLSHosts
+	browserTLSHosts = []string{"browser.invalid"}
+	t.Cleanup(func() { browserTLSHosts = oldHosts })
+
+	sentinel := errors.New("fake tunnel dial used")
+	ct, fake := makeCompiledTunnel("egress", runtime.TunnelShareSingleton, 0, false, nil)
+	fake.dialErr = sentinel
+	ep := &config.CompiledEndpoint{Name: "browser", Tunnel: ct}
+	g := &Gateway{
+		dialer:  &net.Dialer{},
+		tunnels: NewTunnelManager(runtime.EnvSecretStore{}, ""),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := g.transportFor(ep).DialTLSContext(ctx, "tcp", "browser.invalid:443")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("DialTLSContext error = %v, want fake tunnel sentinel", err)
+	}
+	if got := fake.dialCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
+	}
+	if fake.dialAddr != "browser.invalid:443" {
+		t.Fatalf("fake tunnel Dial addr = %q, want browser.invalid:443", fake.dialAddr)
+	}
+}
+
+func TestDialWSUpstreamBrowserTLSUsesEndpointTunnel(t *testing.T) {
+	sentinel := errors.New("fake tunnel dial used")
+	ct, fake := makeCompiledTunnel("egress", runtime.TunnelShareSingleton, 0, false, nil)
+	fake.dialErr = sentinel
+	ep := &config.CompiledEndpoint{Name: "browser-ws", Tunnel: ct}
+	g := &Gateway{
+		dialer:  &net.Dialer{},
+		tunnels: NewTunnelManager(runtime.EnvSecretStore{}, ""),
+	}
+
+	_, err := g.dialWSUpstream(context.Background(), "browser.invalid", ep, "")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("dialWSUpstream error = %v, want fake tunnel sentinel", err)
+	}
+	if got := fake.dialCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
+	}
+	if fake.dialAddr != "browser.invalid:443" {
+		t.Fatalf("fake tunnel Dial addr = %q, want browser.invalid:443", fake.dialAddr)
+	}
+}
+
+func TestBrowserTLSHandshakeFailureReleasesTunnel(t *testing.T) {
+	ct, fake := makeCompiledTunnel("egress", runtime.TunnelShareSingleton, 0, false, nil)
+	fake.closePeerOnDial = true
+	ep := &config.CompiledEndpoint{Name: "browser", Tunnel: ct}
+	g := &Gateway{
+		dialer:  &net.Dialer{},
+		tunnels: NewTunnelManager(runtime.EnvSecretStore{}, ""),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := g.dialBrowserTLS(ctx, "tcp", "browser.invalid:443", "browser.invalid", ep)
+	if err == nil {
+		t.Fatal("dialBrowserTLS succeeded, want handshake error")
+	}
+	if got := fake.dialCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
+	}
+	if got := fake.closeCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Close count = %d, want 1", got)
+	}
+}
+
+func TestBrowserTLSDialErrorReleasesTunnel(t *testing.T) {
+	sentinel := errors.New("fake tunnel dial failed")
+	ct, fake := makeCompiledTunnel("egress", runtime.TunnelShareSingleton, 0, false, nil)
+	fake.dialErr = sentinel
+	ep := &config.CompiledEndpoint{Name: "browser", Tunnel: ct}
+	g := &Gateway{
+		dialer:  &net.Dialer{},
+		tunnels: NewTunnelManager(runtime.EnvSecretStore{}, ""),
+	}
+
+	_, err := g.dialBrowserTLS(context.Background(), "tcp", "browser.invalid:443", "browser.invalid", ep)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("dialBrowserTLS error = %v, want fake tunnel sentinel", err)
+	}
+	if got := fake.dialCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
+	}
+	if got := fake.closeCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Close count = %d, want 1", got)
+	}
+}
+
+func TestTransportBrowserTLSWithClientCertUsesDialUpstream(t *testing.T) {
+	oldHosts := browserTLSHosts
+	browserTLSHosts = []string{"browser.invalid"}
+	t.Cleanup(func() { browserTLSHosts = oldHosts })
+
+	sentinel := errors.New("fake tunnel dial used")
+	ct, fake := makeCompiledTunnel("egress", runtime.TunnelShareSingleton, 0, false, nil)
+	fake.dialErr = sentinel
+	credential := &fakeTLSCredential{}
+	ep := endpointWithTunnelAndTLSCredential("browser-mtls", ct, credential)
+	g := &Gateway{
+		dialer:  &net.Dialer{},
+		tunnels: NewTunnelManager(runtime.EnvSecretStore{}, ""),
+		secrets: fakeSecretStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := g.transportFor(ep).DialTLSContext(ctx, "tcp", "browser.invalid:443")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("DialTLSContext error = %v, want fake tunnel sentinel", err)
+	}
+	if got := credential.configured.Load(); got != 1 {
+		t.Fatalf("TLS credential configured count = %d, want 1", got)
+	}
+	if got := fake.dialCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
+	}
+}
+
+func TestDialWSUpstreamWithClientCertUsesDialUpstream(t *testing.T) {
+	sentinel := errors.New("fake tunnel dial used")
+	ct, fake := makeCompiledTunnel("egress", runtime.TunnelShareSingleton, 0, false, nil)
+	fake.dialErr = sentinel
+	credential := &fakeTLSCredential{}
+	ep := endpointWithTunnelAndTLSCredential("browser-ws-mtls", ct, credential)
+	g := &Gateway{
+		dialer:  &net.Dialer{},
+		tunnels: NewTunnelManager(runtime.EnvSecretStore{}, ""),
+		secrets: fakeSecretStore{},
+	}
+
+	_, err := g.dialWSUpstream(context.Background(), "browser.invalid", ep, "")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("dialWSUpstream error = %v, want fake tunnel sentinel", err)
+	}
+	if got := credential.configured.Load(); got != 1 {
+		t.Fatalf("TLS credential configured count = %d, want 1", got)
+	}
+	if got := fake.dialCount.Load(); got != 1 {
+		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -292,7 +292,7 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 				h = addr
 			}
 			if needsBrowserTLS(h) && !endpointWantsClientCert(ep) {
-				return dialBrowserTLS(ctx, network, addr, h)
+				return g.dialBrowserTLS(ctx, network, addr, h, ep)
 			}
 			profile, _ := ctx.Value(profileCtxKey{}).(string)
 			return g.dialUpstream(ctx, network, addr, h, ep, profile)

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -16,10 +16,14 @@ import (
 // fakeTunnel implements runtime.TunnelRuntime for tests. Open returns
 // a fakeOpenedTunnel; the test inspects open / close counts.
 type fakeTunnel struct {
-	openCount  atomic.Int32
-	closeCount atomic.Int32
-	openErr    error
-	openDelay  time.Duration
+	openCount       atomic.Int32
+	closeCount      atomic.Int32
+	dialCount       atomic.Int32
+	openErr         error
+	dialErr         error
+	dialAddr        string
+	closePeerOnDial bool
+	openDelay       time.Duration
 }
 
 func (f *fakeTunnel) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
@@ -41,11 +45,20 @@ type fakeOpenedTunnel struct {
 }
 
 func (t *fakeOpenedTunnel) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	t.parent.dialCount.Add(1)
+	t.parent.dialAddr = addr
+	if t.parent.dialErr != nil {
+		return nil, t.parent.dialErr
+	}
 	if t.via != nil {
 		return t.via.Dial(ctx, network, addr)
 	}
 	a, b := net.Pipe()
-	_ = a
+	if t.parent.closePeerOnDial {
+		_ = a.Close()
+	} else {
+		_ = a
+	}
 	return b, nil
 }
 

--- a/ws.go
+++ b/ws.go
@@ -80,6 +80,18 @@ func isWSUpgrade(req *http.Request) bool {
 	return strings.Contains(conn, "upgrade") && upg == "websocket"
 }
 
+// dialWSUpstream opens the upstream TLS connection used by the raw WS bridge.
+// mTLS endpoints keep using dialUpstream so credential plugins can populate the
+// stdlib TLS config; all other WS upstreams use browser TLS while still honoring
+// endpoint tunnel configuration via dialBrowserTLS.
+func (g *Gateway) dialWSUpstream(ctx context.Context, upstream string, ep *config.CompiledEndpoint, profile string) (net.Conn, error) {
+	addr := net.JoinHostPort(upstream, "443")
+	if endpointWantsClientCert(ep) {
+		return g.dialUpstream(ctx, "tcp", addr, upstream, ep, profile)
+	}
+	return g.dialBrowserTLS(ctx, "tcp", addr, upstream, ep)
+}
+
 // handleWSUpgrade swaps the http.Transport-driven request loop for a
 // raw byte bridge once the agent's request looks like a WS upgrade.
 // The connection stays alive until either side closes; pumpWS
@@ -87,17 +99,11 @@ func isWSUpgrade(req *http.Request) bool {
 func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string) {
 	agentAddr := peerIP(client) // capture before netstack races to nil
 
-	// Endpoints that require a client cert (e.g. kubernetes mTLS) must
-	// use dialUpstream so the credential plugin can inject the cert.
-	// All other upstreams use dialBrowserTLS — Cloudflare WAF rejects
-	// plain Go TLS fingerprints on WS handshakes to chatgpt.com.
-	var up net.Conn
-	var err error
-	if endpointWantsClientCert(ep) {
-		up, err = g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream, ep, profile)
-	} else {
-		up, err = dialBrowserTLS(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream)
-	}
+	// dialWSUpstream preserves the existing split: endpoints that require a
+	// client cert (e.g. kubernetes mTLS) use dialUpstream so credential plugins
+	// can inject the cert; all other WS upstreams use browser TLS because
+	// Cloudflare WAF rejects plain Go TLS fingerprints on chatgpt.com.
+	up, err := g.dialWSUpstream(context.Background(), upstream, ep, profile)
 	if err != nil {
 		_, _ = fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 		log.Printf("ws dial %s: %v", upstream, err)


### PR DESCRIPTION
## Summary
- Route browser/uTLS raw TCP creation through `Gateway.dialThrough` so endpoint tunnel settings are honored before the Chrome-like TLS handshake is applied.
- Use the same tunnel-aware browser TLS path for raw WebSocket upstream dials.
- Keep client-cert/mTLS endpoints on `dialUpstream`, and add regression coverage for tunnel release on dial and handshake failures.

## Test plan
- `go test . -run 'TestTransportBrowserTLSUsesEndpointTunnel|TestDialWSUpstreamBrowserTLSUsesEndpointTunnel|TestBrowserTLSHandshakeFailureReleasesTunnel|TestBrowserTLSDialErrorReleasesTunnel|TestTransportBrowserTLSWithClientCertUsesDialUpstream|TestDialWSUpstreamWithClientCertUsesDialUpstream' -count=1`
- `go test . -count=1`
- `go test ./... -count=1`
- `git diff --check`
- `golangci-lint run ./...`

## Review
- Static security scan: no findings.
- Independent code review: passed with no security concerns, logic errors, or suggestions.
