### PR TITLE
site: fix landing page mobile layout

### DIFF
--- a/site/src/Layout.tsx
+++ b/site/src/Layout.tsx
@@ -5,7 +5,7 @@ import { Stripe } from "./components/Stripe";
 
 export function Layout({ children }: { children: ComponentChildren }) {
   return (
-    <div class="min-h-screen bg-canvas text-text font-sans">
+    <div class="min-h-screen bg-canvas text-text font-sans overflow-x-hidden">
       <a
         href="#main"
         class="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-50 focus:px-4 focus:py-2 focus:bg-console-dark focus:text-canvas focus:rounded focus:outline-2 focus:outline-rust focus:font-display"

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 export function Footer() {
   return (
     <footer
-      class="px-8 py-16 text-xs
+      class="px-6 sm:px-8 py-12 sm:py-16 text-xs
         font-mono text-canvas bg-console-dark"
     >
       <div

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -1,13 +1,17 @@
 export function Header() {
   return (
-    <nav class="w-full px-8 py-8 bg-navy-100">
+    <nav class="w-full px-6 py-5 sm:px-8 sm:py-8 bg-navy-100">
       <div className="max-w-6xl mx-auto flex flex-wrap justify-between gap-y-2 items-center">
         <a
           href="/"
           class="text-2xl
         font-black font-display hover:text-rust"
         >
-          <img src="cp-logo-test.svg" alt="" class="h-12 w-auto" />
+          <img
+            src="cp-logo-test.svg"
+            alt=""
+            class="h-9 sm:h-12 w-auto"
+          />
         </a>
         <div class="flex items-center gap-4 sm:gap-8 text-sm">
           <a

--- a/site/src/sections/AnalyticsSection.tsx
+++ b/site/src/sections/AnalyticsSection.tsx
@@ -3,10 +3,10 @@ import { SectionLabel } from "../components/SectionLabel";
 
 export function AnalyticsSection() {
   return (
-    <section class="pt-32 pb-28">
-      <div class="max-w-5xl mx-auto px-8">
+    <section class="pt-20 pb-16 sm:pt-32 sm:pb-28">
+      <div class="max-w-5xl mx-auto px-6 sm:px-8">
         <SectionLabel>What you've been missing</SectionLabel>
-        <h3 class="text-4xl lg:text-5xl font-display font-bold text-center">
+        <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-center text-balance">
           See everything your agents do in the Claw Patrol dashboard
         </h3>
         <p

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -137,7 +137,7 @@ function ApproverCard({
   diagram: ComponentChildren;
 }) {
   return (
-    <article class="isolate bg-transparent relative lg:squircle-xl lg:p-8 xl:p-12">
+    <article class="isolate min-w-0 bg-transparent relative lg:squircle-xl lg:p-8 xl:p-12">
       <div className="hidden w-full h-full border-2 lg:block border-navy squircle-xl z-10 absolute inset-0"></div>
       <div className="hidden lg:block absolute w-full h-full top-2 left-2 bg-navy-100 squircle-xl z-0" />
       <div className="relative z-10 flex flex-col gap-4">
@@ -177,7 +177,7 @@ export function ApproversSection() {
         <SectionLabel>Approvers</SectionLabel>
 
         <div class="max-w-3xl mb-14">
-          <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold  mb-5 text-text">
+          <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5 text-text">
             Humans, models, <span class="text-rust">your call</span>
           </h3>
           <p class="text-base  text-text-muted">
@@ -186,7 +186,7 @@ export function ApproversSection() {
           </p>
         </div>
 
-        <div class="grid gap-8 lg:grid-cols-[1fr_auto_1fr] lg:gap-4">
+        <div class="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_auto_1fr] lg:gap-4">
           <ApproverCard
             title="LLM judge"
             verdict="require_llm"

--- a/site/src/sections/ComparisonSection.tsx
+++ b/site/src/sections/ComparisonSection.tsx
@@ -100,15 +100,15 @@ const ROWS: {
 
 export function ComparisonSection() {
   return (
-    <section class="max-w-5xl mx-auto px-8 pt-8 pb-28 border-t border-navy-200/50">
-      <div class="pt-28" />
+    <section class="max-w-5xl mx-auto px-6 sm:px-8 pt-8 pb-20 sm:pb-28 border-t border-navy-200/50">
+      <div class="pt-16 sm:pt-28" />
       <div class="max-w-max">
         <SectionLabel>How it compares</SectionLabel>
       </div>
-      <h3 class="text-4xl lg:text-5xl font-display font-bold ">
+      <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-balance">
         More than a gateway, more than a sandbox
       </h3>
-      <p class=" max-w-2xl mb-16 text-base  text-text-muted mt-8">
+      <p class=" max-w-2xl mb-12 sm:mb-16 text-base  text-text-muted mt-6 sm:mt-8">
         Many teams have attacked this problem — credential vaults, LLM gateways,
         sandboxes — but most stop at the surface. Hiding a key isn't enough if
         the agent can still DROP TABLE or exfiltrate data through an allowed
@@ -116,15 +116,15 @@ export function ComparisonSection() {
         run, which endpoints get called, what payloads look like. Claw Patrol
         goes that deep.
       </p>
-      <div class="overflow-x-auto">
+      <div class="overflow-x-auto -mx-6 px-6 sm:mx-0 sm:px-0">
         <table class="w-full text-sm font-sans">
           <thead>
             <tr class="border-b-2 border-navy-200">
-              <th class="text-left py-3 pr-4 font-medium font-display text-text-muted" />
+              <th class="text-left py-3 pr-2 sm:pr-4 font-medium font-display text-text-muted" />
               {FEATURES.map((f) => (
                 <th
                   key={f}
-                  class="py-3 px-3 font-medium
+                  class="py-3 px-1.5 sm:px-3 font-medium
                      text-text-muted align-bottom
                     text-2xs uppercase tracking-widest"
                 >
@@ -142,7 +142,7 @@ export function ComparisonSection() {
                 }`}
               >
                 <td
-                  class={`py-3 px-4 font-bold font-sans font
+                  class={`py-3 px-2 sm:px-4 font-bold font-sans font
                     whitespace-nowrap ${
                       row.highlight ? "text-navy" : "text-navy-400"
                     }`}
@@ -164,7 +164,7 @@ export function ComparisonSection() {
                 {row.checks.map((ok, i) => {
                   const anchor = slug(`${row.name} ${FEATURES[i]} ${ok}`);
                   return (
-                    <td key={i} class="py-3 px-3 text-center text-lg">
+                    <td key={i} class="py-3 px-1.5 sm:px-3 text-center text-lg">
                       <a href={`/docs/competitors/#${anchor}`}>
                         {ok ? CHECK : CROSS}
                       </a>

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -11,7 +11,7 @@ export function HeroSection() {
         class="grid md:grid-cols-2 gap-10
         md:gap-16 items-center"
       >
-        <div>
+        <div class="min-w-0">
           <h1
             class="text-4xl sm:text-5xl md:text-6xl md:text-[4rem]
               font-bold
@@ -39,7 +39,7 @@ export function HeroSection() {
           </div>
         </div>
 
-        <div class="flex justify-center">
+        <div class="flex justify-center min-w-0">
           <img
             src="/clawpatrol.png"
             alt="Claw Patrol mascot"

--- a/site/src/sections/HowItWorksSection.tsx
+++ b/site/src/sections/HowItWorksSection.tsx
@@ -257,12 +257,12 @@ function AnalyticsDiagram() {
 
 export function HowItWorksSection() {
   return (
-    <section class="py-24 sm:py-32 bg-linear-to-br from-navy-50 to-navy-200">
-      <div class="max-w-5xl mx-auto px-8">
+    <section class="py-20 sm:py-32 bg-linear-to-br from-navy-50 to-navy-200">
+      <div class="max-w-5xl mx-auto px-6 sm:px-8">
         <SectionLabel>The foundation</SectionLabel>
 
         <div class="max-w-2xl mb-14">
-          <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold  mb-5 text-text">
+          <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5 text-text">
             Rules need a substrate.
           </h3>
           <p class="text-base  text-text-muted">
@@ -273,7 +273,7 @@ export function HowItWorksSection() {
         </div>
 
         <div class="grid md:grid-cols-2 gap-6">
-          <div class="p-8 rounded-sm bg-canvas-dark border border-navy-200">
+          <div class="p-6 sm:p-8 rounded-sm bg-canvas-dark border border-navy-200">
             <h3 class="text-base uppercase mb-4 text-console-dark font-display font-bold">
               Full audit log
             </h3>
@@ -287,7 +287,7 @@ export function HowItWorksSection() {
               <li>Drill into full headers, body, and formatted prompts</li>
             </ul>
           </div>
-          <div class="p-8 rounded-sm bg-canvas-dark border border-navy-200">
+          <div class="p-6 sm:p-8 rounded-sm bg-canvas-dark border border-navy-200">
             <h3 class="text-base uppercase mb-4 text-console-dark font-display font-bold">
               Secret injection
             </h3>

--- a/site/src/sections/IntegrationsSection.tsx
+++ b/site/src/sections/IntegrationsSection.tsx
@@ -14,8 +14,8 @@ const INTEGRATIONS = [
 
 export function IntegrationsSection() {
   return (
-    <section class="py-28 text-center bg-linear-to-b from-navy-100 to-navy-50">
-      <div class="max-w-5xl mx-auto px-8">
+    <section class="py-20 sm:py-28 text-center bg-linear-to-b from-navy-100 to-navy-50">
+      <div class="max-w-5xl mx-auto px-6 sm:px-8">
         <SectionLabel>Built-in plugins</SectionLabel>
         <p class="text-center max-w-2xl mx-auto mb-16   text-text-muted">
           Plugins are pre-configured integrations with external services.
@@ -51,8 +51,8 @@ export function IntegrationsSection() {
             </a>
           ))}
         </div>
-        <p class="text-center mt-16 tracking-wider text-navy-500">— OR —</p>
-        <div class="text-center mt-16 mb-8">
+        <p class="text-center mt-12 sm:mt-16 tracking-wider text-navy-500">— OR —</p>
+        <div class="text-center mt-12 sm:mt-16 mb-8">
           <Button href="/docs/08-plugins/" variant="normal" size="lg">
             Write your own plugin in one TypeScript file{" "}
             <span class="ml-1" aria-hidden="true">

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -29,18 +29,18 @@ const PROBLEMS = [
 
 export function ProblemSection() {
   return (
-    <section class="max-w-5xl mx-auto px-8 pt-32 pb-28 border-t border-navy-200/50">
+    <section class="max-w-5xl mx-auto px-6 sm:px-8 pt-20 pb-16 sm:pt-32 sm:pb-28 border-t border-navy-200/50">
       <SectionLabel>The problem</SectionLabel>
-      <div class="max-w-2xl mx-auto space-y-20">
+      <div class="max-w-2xl mx-auto space-y-12 sm:space-y-20">
         {PROBLEMS.map(({ title, body }, i) => (
-          <div key={title} class="grid grid-cols-[auto_1fr] gap-6">
-            <div class="flex items-center justify-center min-w-16">
-              <span class="text-4xl sm:text-7xl font-bold font-display  select-none text-rust">
+          <div key={title} class="grid grid-cols-[auto_1fr] gap-3 sm:gap-6">
+            <div class="flex items-center justify-center min-w-10 sm:min-w-16">
+              <span class="text-5xl sm:text-7xl font-bold font-display  select-none text-rust">
                 {i + 1}
               </span>
             </div>
             <div class="py-1">
-              <h3 class="text-3xl font-display font-bold text-console-dark mb-3">
+              <h3 class="text-2xl sm:text-3xl font-display font-bold text-console-dark mb-3">
                 {title}
               </h3>
               <p class="text-base  text-text-muted">{body}</p>

--- a/site/src/sections/ProtocolDepthSection.tsx
+++ b/site/src/sections/ProtocolDepthSection.tsx
@@ -58,7 +58,7 @@ export function ProtocolDepthSection() {
         <SectionLabel>Not just HTTP</SectionLabel>
 
         <div class="max-w-3xl mx-auto text-center mb-16">
-          <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold  mb-5">
+          <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5">
             Rules dive into <span class="text-rust">every action.</span>
           </h3>
           <p class="text-base  text-canvas/70">
@@ -72,11 +72,11 @@ export function ProtocolDepthSection() {
         <p class="text-xs uppercase tracking-[0.25em] font-display font-bold text-rust-300 mb-5 text-center">
           Match anything in the action
         </p>
-        <ul class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {PROTOCOLS.map((p) => (
             <li
               key={p.name}
-              class="bg-navy squircle-lg p-6
+              class="min-w-0 bg-navy squircle-lg p-6
                 flex flex-col gap-4"
             >
               <h4 class="text-3xl font-display font-bold text-canvas">

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -42,7 +42,7 @@ function RuleCodeBlock() {
      full highlighter for one snippet. */
   return (
     <pre
-      class="text-[13px] sm:text-sm  font-mono
+      class="min-w-0 text-[13px] sm:text-sm  font-mono
         bg-console-dark text-canvas/85 squircle-md p-6 overflow-x-auto
         border border-navy-700"
     >
@@ -129,9 +129,9 @@ export function RulesSection() {
       <div class="max-w-6xl mx-auto px-6 sm:px-8">
         <SectionLabel>Approval rules</SectionLabel>
 
-        <div class="grid lg:grid-cols-[2fr_3fr] gap-8 lg:gap-16 xl:gap-32 items-start mb-20">
-          <div>
-            <h3 class="text-4xl sm:text-5xl md:text-6xl lg:text-[3.25rem] font-display font-bold  mb-6 text-text">
+        <div class="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-8 lg:gap-16 xl:gap-32 items-start mb-20">
+          <div class="min-w-0">
+            <h3 class="text-4xl sm:text-5xl md:text-6xl lg:text-[3.25rem] font-display font-bold text-balance mb-6 text-text">
               You write the rules.{" "}
               <span class="text-rust">Claw Patrol enforces them.</span>
             </h3>


### PR DESCRIPTION
## Summary
- Grid items defaulted to `min-width: auto` (= min-content), so HCL `<pre>` blocks with long unbreakable lines blew the grid tracks past the viewport in the Hero, Rules, Approvers, and Protocol-depth sections. Added `grid-cols-1` + `min-w-0` so the pre clips internally via its existing `overflow-x-auto` instead of widening the card.
- Tightened horizontal padding (`px-8` → `px-6 sm:px-8`) and mobile vertical spacing across Header, Footer, Problem, HowItWorks, Analytics, Comparison, and Integrations.
- Defensive `overflow-x-hidden` on the layout root as a belt-and-suspenders against future stray overflowers.

## Test plan
- [ ] Hard refresh the dev server on a real phone (or Safari responsive ≤ 414px) — hero text, HCL code blocks, Approver cards, and Protocol cards stay inside the viewport
- [ ] At ≥ md (768px) the desktop two-column layouts still render the same (no regression from added `grid-cols-1`)
- [ ] Comparison table still scrolls internally on mobile