### PR TITLE
Separate HITL operator identity from credential profile selection

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -613,7 +613,7 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	caller, _ := w.ownerForCaller(r)
+	selectedProfile, _ := w.credentialProfileKeyForRequest(r)
 	for _, name := range names {
 		ent := policy.Credentials[name]
 		row := IntegrationRow{ID: name, Name: name, Type: ent.Plugin.Type}
@@ -637,10 +637,10 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 		}
 		if sp, ok := ent.Body.(config.SecretSlotsProvider); ok {
 			row.Slots = sp.SecretSlots()
-			if caller != "" {
-				present, _ := credentialSlotPresence(w.g.db, name, caller)
+			if selectedProfile != "" {
+				present, _ := credentialSlotPresence(w.g.db, name, selectedProfile)
 				if len(present) > 0 {
-					row.Owners = append(row.Owners, Owner{Owner: caller, Connected: true})
+					row.Owners = append(row.Owners, Owner{Owner: selectedProfile, Connected: true})
 				}
 			}
 		}

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -61,7 +61,7 @@ in promiscuous mode — same shape as unclaw's `boringtun` + `smoltcp`
   approval. Multi-user setups need an auth proxy
   (Cloudflare Access, basic auth, etc.) that fills
   `X-Forwarded-User` / `X-Forwarded-Email` (~10 LoC to teach
-  `ownerForCaller` to read those).
+  profile resolution to read those).
 - Both endpoints behind the same NAT egress IP can't establish a
   WG handshake (UDP hairpin drop). Same constraint as plain unclaw
   remote mode. Use a real public-IP VPS for the gateway.

--- a/oauth.go
+++ b/oauth.go
@@ -549,9 +549,9 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "no oauth integration: "+id, 400)
 		return
 	}
-	owner, ownerLabel := w.ownerForCaller(r)
+	owner, ownerLabel := w.credentialProfileKeyForRequest(r)
 	if owner == "" {
-		http.Error(rw, "could not determine owner identity (tailscale whois failed)", 400)
+		http.Error(rw, "could not determine profile", 400)
 		return
 	}
 	// User may opt into additional scopes (e.g. SSH/GPG key management

--- a/onboard.go
+++ b/onboard.go
@@ -529,9 +529,9 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "approval requires an authenticated operator", http.StatusForbidden)
 		return
 	}
-	owner, _ := w.targetOwnerForRequest(r)
+	owner, _ := w.credentialProfileKeyForRequest(r)
 	if owner == "" {
-		http.Error(rw, "approval requires a target owner or profile", http.StatusForbidden)
+		http.Error(rw, "approval requires a profile", http.StatusForbidden)
 		return
 	}
 	code := r.URL.Query().Get("code")

--- a/web.go
+++ b/web.go
@@ -579,10 +579,13 @@ func (w *webMux) callerIdentity(r *http.Request) (user, device, displayHost stri
 	return who.UserProfile.LoginName, who.Node.StableID, who.Node.HostName
 }
 
-// targetOwnerForRequest returns the credential-bucket key selected by a
-// dashboard request. It is target/profile selection only; it must not be
-// used as evidence that the caller is authenticated.
-func (w *webMux) targetOwnerForRequest(r *http.Request) (key, label string) {
+// credentialProfileKeyForRequest returns the credentials.profile key used when
+// dashboard requests read or write OAuth/secret rows. Prefer an explicit
+// profile selector, then the configured default policy profile. The remaining
+// fallbacks preserve legacy single-user/per-caller credential keys; they are
+// not necessarily declared policy profiles and must not be used as evidence
+// that the caller is authenticated.
+func (w *webMux) credentialProfileKeyForRequest(r *http.Request) (key, label string) {
 	if p := r.URL.Query().Get("profile"); p != "" {
 		return p, p
 	}
@@ -600,13 +603,6 @@ func (w *webMux) targetOwnerForRequest(r *http.Request) (key, label string) {
 		return user, user
 	}
 	return host, host
-}
-
-// ownerForCaller is the legacy name for targetOwnerForRequest. Existing
-// handlers still use it to choose credential buckets; new authenticated
-// operator checks should consume principal from context instead.
-func (w *webMux) ownerForCaller(r *http.Request) (key, label string) {
-	return w.targetOwnerForRequest(r)
 }
 
 // whoamiData backs the whoami slice of /api/state. No HTTP handler —
@@ -727,7 +723,7 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Owner == "" {
-		body.Owner, _ = w.ownerForCaller(r)
+		body.Owner, _ = w.credentialProfileKeyForRequest(r)
 	}
 	if body.Owner == "" {
 		http.Error(rw, "missing owner", 400)
@@ -792,7 +788,7 @@ func (w *webMux) apiCredentialsClear(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Owner == "" {
-		body.Owner, _ = w.ownerForCaller(r)
+		body.Owner, _ = w.credentialProfileKeyForRequest(r)
 	}
 	if err := clearCredentialSecrets(w.g.db, body.ID, body.Owner); err != nil {
 		http.Error(rw, err.Error(), 500)
@@ -1209,9 +1205,9 @@ func (w *webMux) apiRulesAI(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "prompt required", 400)
 		return
 	}
-	owner, _ := w.ownerForCaller(r)
+	owner, _ := w.credentialProfileKeyForRequest(r)
 	if owner == "" {
-		http.Error(rw, "tailnet identity required", http.StatusForbidden)
+		http.Error(rw, "profile required", http.StatusForbidden)
 		return
 	}
 	out, refused, err := generateRuleHCL(r.Context(), w.g, body.Agent, owner, body.Prompt, body.CurrentYAML, body.Scope)
@@ -1243,8 +1239,12 @@ func (w *webMux) apiHITLDecide(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, err.Error(), 400)
 		return
 	}
-	owner, _ := w.ownerForCaller(r)
-	ok := w.g.hitl.Decide(body.ID, runtime.HITLDecision{Allow: body.Allow, By: owner})
+	principal, ok := principalFromContext(r.Context())
+	if !ok {
+		http.Error(rw, "decision requires an authenticated operator", http.StatusForbidden)
+		return
+	}
+	ok = w.g.hitl.Decide(body.ID, runtime.HITLDecision{Allow: body.Allow, By: principal.Owner})
 	writeJSON(rw, map[string]bool{"ok": ok})
 }
 

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 const authTestDashboardCredential = "test-dashboard-credential"
@@ -259,5 +261,50 @@ func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeDoesNotRequireD
 	}
 	if !strings.Contains(rr.Body.String(), "unknown or expired code") {
 		t.Fatalf("body = %q, want onboard handler error", rr.Body.String())
+	}
+}
+
+func TestHITLDecideRejectsProfileFallbackWithoutAuthenticatedPrincipal(t *testing.T) {
+	w := newOnboardAuthTestWebMux()
+	w.g.hitl = newHITLRegistry(nil)
+	id, ch := w.g.hitl.Add(runtime.HITLPending{Host: "api.example.test", Method: http.MethodPost, Path: "/v1/write"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/hitl/decide?profile=default", bytes.NewBufferString(`{"id":"`+id+`","allow":true}`))
+	rr := httptest.NewRecorder()
+	w.apiHITLDecide(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	select {
+	case d := <-ch:
+		t.Fatalf("decision was recorded using profile fallback: %+v", d)
+	default:
+	}
+}
+
+func TestHITLDecideRecordsAuthenticatedPrincipalNotTargetProfile(t *testing.T) {
+	w := newOnboardAuthTestWebMux()
+	w.g.hitl = newHITLRegistry(nil)
+	id, ch := w.g.hitl.Add(runtime.HITLPending{Host: "api.example.test", Method: http.MethodPost, Path: "/v1/write"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/hitl/decide?profile=default", bytes.NewBufferString(`{"id":"`+id+`","allow":true}`))
+	req = req.WithContext(contextWithPrincipal(req.Context(), principal{Kind: principalDashboardSecret, Owner: "operator@example.com"}))
+	rr := httptest.NewRecorder()
+	w.apiHITLDecide(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	select {
+	case d := <-ch:
+		if !d.Allow {
+			t.Fatalf("decision allow = false, want true")
+		}
+		if d.By != "operator@example.com" {
+			t.Fatalf("decision by = %q, want authenticated principal", d.By)
+		}
+	default:
+		t.Fatalf("no decision recorded")
 	}
 }


### PR DESCRIPTION
## Summary
- remove the legacy `ownerForCaller` helper so caller identity and credential profile selection are no longer named as the same concept
- rename the request-selection helper to `credentialProfileKeyForRequest`, making it explicit that it returns the `credentials.profile` storage key rather than an authenticated identity
- require an authenticated dashboard operator principal for dashboard HITL decisions and record that principal in `runtime.HITLDecision.By` instead of any `?profile=` fallback
- add regression coverage for profile fallback not being accepted as dashboard HITL identity

Closes #177.

## Tests
- `test -z "$(gofmt -l agents.go oauth.go web.go onboard.go web_auth_test.go)"`
- `! git grep -n 'target owner\|targetOwner\|credential bucket\|credentialBucket\|owner/profile\|profile/owner\|owner selection\|target profile' -- .`
- `git diff --check`
- `go test ./ -run 'TestHITLDecide|TestOnboardApprove|TestRouteAuthRequirementsDocumentOnboardingBoundary|TestCredentialWebhookPrefixAuthPolicyIsSelfAuthenticating' -count=1`
- `go vet ./...`
- `go test ./...`
- static scan over auth/secret/principal-related additions: no findings
- independent read-only reviewer: `APPROVED_NO_FINDINGS`

## Notes
- `golangci-lint` is not installed locally, so local lint was covered by `go vet ./...`; GitHub CI `lint` passed on the previous revision and will be rechecked for this amended head.
