### PR TITLE
Match default-port TLS hosts by bare SNI

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -39,9 +39,11 @@ type CompiledPolicy struct {
 }
 
 // CompiledProfile binds an identity to the endpoint set its requests
-// dispatch against. Endpoints map by name; HostIndex maps every host
-// (with port) to the endpoint that owns it for fast SNI / authority
-// lookup.
+// dispatch against. Endpoints map by name; HostIndex maps exact
+// declared hosts plus bare-host aliases for HTTPS-family default-port
+// declarations to the endpoint that owns them for fast SNI / authority
+// lookup. CompiledEndpoint.Hosts keeps the operator-declared strings
+// unchanged.
 type CompiledProfile struct {
 	Name      string
 	Endpoints map[string]*CompiledEndpoint
@@ -274,6 +276,24 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				profile.HostIndex[h] = ce
 			}
 		}
+		// Add default-port TLS aliases only after every exact host is
+		// indexed. That lets an explicit bare host beat any alias, while
+		// keeping the alias attached to the HTTPS-family endpoint that
+		// declared it even if another endpoint collides on the exact
+		// host:port string.
+		for _, epName := range pr.Endpoints {
+			ce, ok := cp.Endpoints[epName]
+			if !ok {
+				continue
+			}
+			for _, h := range ce.Hosts {
+				if bare, ok := bareHostAlias(ce, h); ok {
+					if _, exists := profile.HostIndex[bare]; !exists {
+						profile.HostIndex[bare] = ce
+					}
+				}
+			}
+		}
 		cp.Profiles[name] = profile
 	}
 
@@ -340,6 +360,17 @@ func hasResolvableHostname(hosts []string) bool {
 		}
 	}
 	return false
+}
+
+func bareHostAlias(ep *CompiledEndpoint, host string) (string, bool) {
+	if ep == nil || (ep.Family != "https" && ep.Family != "k8s") {
+		return "", false
+	}
+	bare, port, err := net.SplitHostPort(host)
+	if err != nil || bare == "" || port != "443" {
+		return "", false
+	}
+	return bare, true
 }
 
 // hostExtractor / credentialExtractor are the small cross-cut readers

--- a/config/runtime/dispatch.go
+++ b/config/runtime/dispatch.go
@@ -5,15 +5,13 @@ import (
 	"github.com/denoland/clawpatrol/config/match"
 )
 
-// HostEndpoint resolves a profile + SNI host (with port stripped to
-// match how endpoint plugins record hosts) to the endpoint that owns
-// it. Returns nil when the profile doesn't bind any matching endpoint
-// — the caller then applies the defaults.unknown_host policy.
-//
-// Hosts include port when an endpoint declared one ("localhost:8443"),
-// per the v14 design notes. We try the host-with-port first, then a
-// bare host fallback so agents that connect on the default port don't
-// have to know whether the endpoint hardcoded ":443".
+// HostEndpoint resolves a profile + SNI/authority host to the endpoint
+// that owns it. Compile populates HostIndex with exact declared hosts
+// plus bare-host aliases for HTTPS-family default-port declarations,
+// so a TLS SNI value like "api.example.com" can match an endpoint
+// declared as "api.example.com:443" without a runtime scan. Returns nil
+// when the profile doesn't bind any matching endpoint — the caller then
+// applies the defaults.unknown_host policy.
 func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.CompiledEndpoint {
 	if policy == nil {
 		return nil

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -41,7 +41,12 @@ rule "http_rule" "github-default" {
 
 func compile(t *testing.T) *config.CompiledPolicy {
 	t.Helper()
-	gw, diags := config.LoadBytes([]byte(fixture), "in.hcl")
+	return compileFixture(t, fixture)
+}
+
+func compileFixture(t *testing.T, src string) *config.CompiledPolicy {
+	t.Helper()
+	gw, diags := config.LoadBytes([]byte(src), "in.hcl")
 	if diags.HasErrors() {
 		t.Fatalf("load: %v", diags)
 	}
@@ -66,6 +71,110 @@ func TestHostEndpoint(t *testing.T) {
 	// Unknown profile + known host → fallback scan finds it.
 	if got := runtime.HostEndpoint(cp, "no-such-profile", "github.com"); got == nil {
 		t.Errorf("fallback scan should find github.com")
+	}
+}
+
+func TestHostEndpointMatchesBareSNIForPortQualifiedHost(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "api" {
+  hosts = ["api.example.com:443"]
+}
+profile "default" { endpoints = [api] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com"); got == nil || got.Name != "api" {
+		t.Fatalf("bare SNI host resolved to %+v, want api", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com:443"); got == nil || got.Name != "api" {
+		t.Fatalf("exact port-qualified host resolved to %+v, want api", got)
+	}
+	if got := runtime.HostEndpoint(cp, "missing-profile", "api.example.com"); got == nil || got.Name != "api" {
+		t.Fatalf("fallback scan resolved to %+v, want api", got)
+	}
+}
+
+func TestHostEndpointMatchesBareSNIForPortQualifiedKubernetesServer(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "kubernetes" "cluster" {
+  server = "cluster.example.com:443"
+}
+profile "default" { endpoints = [cluster] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "cluster.example.com"); got == nil || got.Name != "cluster" {
+		t.Fatalf("bare Kubernetes SNI host resolved to %+v, want cluster", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "cluster.example.com:443"); got == nil || got.Name != "cluster" {
+		t.Fatalf("exact Kubernetes server host resolved to %+v, want cluster", got)
+	}
+}
+
+func TestHostEndpointBareHostExactBindingBeatsPortAlias(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "port_qualified" {
+  hosts = ["api.example.com:443"]
+}
+endpoint "https" "bare" {
+  hosts = ["api.example.com"]
+}
+profile "default" { endpoints = [port_qualified, bare] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com"); got == nil || got.Name != "bare" {
+		t.Fatalf("bare host resolved to %+v, want explicit bare endpoint", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com:443"); got == nil || got.Name != "port_qualified" {
+		t.Fatalf("port-qualified host resolved to %+v, want port-qualified endpoint", got)
+	}
+}
+
+func TestHostEndpointDoesNotAliasNonDefaultHTTPSPort(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "api" {
+  hosts = ["api.example.com:8443"]
+}
+profile "default" { endpoints = [api] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com"); got != nil {
+		t.Fatalf("bare host resolved to %+v, want nil for non-default port alias", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com:8443"); got == nil || got.Name != "api" {
+		t.Fatalf("exact non-default port host resolved to %+v, want api", got)
+	}
+}
+
+func TestHostEndpointDoesNotAliasNonHTTPFamilies(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "postgres" "db" {
+  host     = "db.example.com:5432"
+  database = "app"
+}
+profile "default" { endpoints = [db] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "db.example.com"); got != nil {
+		t.Fatalf("bare SQL host resolved to %+v, want nil", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "db.example.com:5432"); got == nil || got.Name != "db" {
+		t.Fatalf("exact SQL host resolved to %+v, want db", got)
+	}
+}
+
+func TestHostEndpointPortAliasCannotBeCapturedByNonHTTPExactCollision(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "api" {
+  hosts = ["api.example.com:443"]
+}
+endpoint "postgres" "db" {
+  host     = "api.example.com:443"
+  database = "app"
+}
+profile "default" { endpoints = [api, db] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com"); got == nil || got.Name != "api" {
+		t.Fatalf("bare SNI host resolved to %+v, want HTTPS endpoint", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add compile-time bare-host aliases for `https` and `k8s` endpoints that declare the default TLS port `:443`, so TLS SNI like `api.example.com` matches an endpoint configured as `api.example.com:443` instead of falling through unknown-host passthrough.
- Keep `HostEndpoint` as a map lookup and leave operator-declared `CompiledEndpoint.Hosts` unchanged.
- Add regression coverage for exact bare-host precedence, non-default HTTPS ports, non-HTTP endpoint families, and `host:443` collision ownership.

## Test plan
- `go test ./config/... -count=1`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- `test -z "$(gofmt -l config/compile.go config/runtime/dispatch.go config/runtime/dispatch_test.go)"`

## Review
- Static security scan: no findings.
- Independent spec/security/code-quality review: passed after fixing overbroad aliases and alias-owner collision.
- `golangci-lint run ./...` was not run locally because `golangci-lint` is not installed in this environment.
