### PR TITLE
Fix settings editor render after dependency update

### DIFF
--- a/www/src/components/HCLEditor.tsx
+++ b/www/src/components/HCLEditor.tsx
@@ -3,10 +3,17 @@
 // both the global gateway.hcl editor and the per-device fragment
 // editor.
 
-import Editor from "react-simple-code-editor";
+import RawEditor from "react-simple-code-editor";
 import Prism from "prismjs";
 import "prismjs/components/prism-hcl";
 import "prismjs/themes/prism.css";
+
+// react-simple-code-editor publishes a CommonJS bundle with a default export.
+// Newer Vite/Rolldown builds can preserve that as `{ default: Component }`,
+// so unwrap it before handing the value to React. Otherwise the settings modal
+// crashes with React error #130 when the editor first renders.
+const Editor = ((RawEditor as unknown as { default?: typeof RawEditor }).default ??
+  RawEditor) as typeof RawEditor;
 
 export function HCLEditor({
   value,


### PR DESCRIPTION
## Summary
- unwrap `react-simple-code-editor`'s nested CommonJS default export before rendering it
- fixes the settings gear flow blanking/crashing when the `gateway.hcl` editor mounts after the Vite 8 dependency update

## Test plan
- `cd www && npm run format:check`
- `cd www && npm run lint:github`
- `cd www && npm run build`
- `git diff --check`
- browser verification: clicked the settings gear and confirmed the `gateway.hcl` editor renders

![image](https://github.com/user-attachments/assets/24cf1bb7-8845-4dfc-b94c-83613c651884)

## Notes
- Regression appears to have been introduced by #164 (`vite` 5 → 8 / `@vitejs/plugin-react` 4 → 6), which changed how the CommonJS editor package is bundled.
