### PR TITLE
Harden audit-sensitive runtime paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 22
       - run: cd www && npm ci && npm run build
+      - run: cd site && npm ci && npm run typecheck && npm test && npm run build
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
@@ -32,5 +33,6 @@ jobs:
         with:
           node-version: 22
       - run: cd www && npm ci && npm run format:check && npm run lint:github && npm run build
+      - run: cd site && npm ci && npm run typecheck && npm test && npm run build
       - run: gofmt -l . && test -z "$(gofmt -l .)"
       - run: go test ./...

--- a/config/match/match.go
+++ b/config/match/match.go
@@ -57,7 +57,8 @@ type K8sMeta struct {
 // SQLMeta describes one parsed SQL statement. The pg / clickhouse
 // front-ends populate it before walking the rule list.
 type SQLMeta struct {
-	Verb      string   // select | insert | update | delete | merge | ...
+	Verb      string   // first verb: select | insert | update | delete | merge | ...
+	Verbs     []string // all verbs in a multi-statement simple query
 	Tables    []string // unqualified table names referenced
 	Functions []string // unqualified function names called
 	Statement string   // the raw text — exposed for `statement` /
@@ -380,10 +381,19 @@ func (m *sqlMatcher) Match(req *Request) bool {
 		return false
 	}
 	if len(m.verb) > 0 {
+		candidates := req.SQL.Verbs
+		if len(candidates) == 0 && req.SQL.Verb != "" {
+			candidates = []string{req.SQL.Verb}
+		}
 		ok := false
 		for _, v := range m.verb {
-			if equalsIgnoreCase(req.SQL.Verb, v) {
-				ok = true
+			for _, got := range candidates {
+				if equalsIgnoreCase(got, v) {
+					ok = true
+					break
+				}
+			}
+			if ok {
 				break
 			}
 		}
@@ -410,15 +420,35 @@ func (m *sqlMatcher) Match(req *Request) bool {
 	return true
 }
 
-// anyOfStrings: at least one candidate satisfies the glob list. Used
-// for tables / functions where a SELECT can name several.
+// anyOfStrings applies list-of-globs semantics across multi-candidate
+// facets (SQL tables / functions). A negative glob rejects the entire
+// facet if any candidate matches it; positives are still any-match.
+// Negative-only lists pass when all candidates avoid the forbidden
+// patterns.
 func anyOfStrings(candidates []string, globs []glob) bool {
-	for _, c := range candidates {
-		if matchAny(globs, c) {
-			return true
+	if len(globs) == 0 {
+		return true
+	}
+	hasPositive := false
+	positiveOK := false
+	for _, g := range globs {
+		if !g.neg {
+			hasPositive = true
+		}
+		for _, c := range candidates {
+			ok := matchGlob(g.pattern, c)
+			if g.neg && ok {
+				return false
+			}
+			if !g.neg && ok {
+				positiveOK = true
+			}
 		}
 	}
-	return false
+	if hasPositive {
+		return positiveOK
+	}
+	return true
 }
 
 func lowerAll(xs []string) []string {

--- a/config/match/match_test.go
+++ b/config/match/match_test.go
@@ -211,6 +211,58 @@ func TestSQLMatcherVerbAndTables(t *testing.T) {
 	}
 }
 
+func TestSQLMatcherNegativeGlobsRejectAnyCandidate(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]any
+		meta *match.SQLMeta
+		want bool
+	}{
+		{
+			name: "positive table match rejected by separate forbidden table",
+			raw:  map[string]any{"tables": []any{"users", "!secret_*"}},
+			meta: &match.SQLMeta{Tables: []string{"users", "secret_tokens"}},
+			want: false,
+		},
+		{
+			name: "positive table match accepted when no forbidden table present",
+			raw:  map[string]any{"tables": []any{"users", "!secret_*"}},
+			meta: &match.SQLMeta{Tables: []string{"users", "accounts"}},
+			want: true,
+		},
+		{
+			name: "negative-only tables require all candidates avoid forbidden glob",
+			raw:  map[string]any{"tables": []any{"!secret_*"}},
+			meta: &match.SQLMeta{Tables: []string{"users", "secret_tokens"}},
+			want: false,
+		},
+		{
+			name: "negative-only tables accept all safe candidates",
+			raw:  map[string]any{"tables": []any{"!secret_*"}},
+			meta: &match.SQLMeta{Tables: []string{"users", "accounts"}},
+			want: true,
+		},
+		{
+			name: "function negatives reject any forbidden function",
+			raw:  map[string]any{"function": []any{"count", "!pg_*"}},
+			meta: &match.SQLMeta{Functions: []string{"count", "pg_sleep"}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := match.New("sql", tc.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req := &match.Request{Family: "sql", SQL: tc.meta}
+			if got := m.Match(req); got != tc.want {
+				t.Fatalf("Match=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSQLMatcherStatementRegex(t *testing.T) {
 	m, err := match.New("sql", map[string]any{
 		"verb":            "select",

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -42,7 +42,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -424,6 +423,7 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 		Credential: credName,
 		SQL: &match.SQLMeta{
 			Verb:      info.Verb,
+			Verbs:     info.Verbs,
 			Tables:    info.Tables,
 			Functions: info.Functions,
 			Statement: info.Statement,
@@ -642,41 +642,367 @@ func indexByte(b []byte, c byte) int {
 
 type pgInfo struct {
 	Verb      string
+	Verbs     []string
 	Tables    []string
 	Functions []string
 	Statement string
 }
 
-var (
-	pgTableRE = regexp.MustCompile(`(?i)\b(?:from|update|into|join)\s+([a-z_][a-z0-9_.]*)`)
-	pgFuncRE  = regexp.MustCompile(`(?i)\b([a-z_][a-z0-9_]*)\s*\(`)
-)
+type pgToken struct {
+	text          string
+	quoted        bool
+	stringLiteral bool
+	unicodeRaw    string
+}
 
-// parseSQL extracts verb / tables / functions / statement for the
-// SQL matcher. Best-effort — a SQL parser would be more correct but
-// the matcher's predicates are coarse enough that regex extraction
-// produces actionable results for the v14 use cases (banned verbs,
-// banned functions, secret-table reads).
+// parseSQL extracts verb / tables / functions / statement for the SQL matcher.
+// It is still best-effort, but the lexer deliberately skips comments and string
+// literals and understands quoted identifiers so policy checks cannot be fooled
+// by leading comments or common Postgres identifier syntax.
 func parseSQL(sql string) pgInfo {
 	sql = strings.TrimSpace(sql)
 	info := pgInfo{Statement: sql}
 	if sql == "" {
 		return info
 	}
-	lower := strings.ToLower(sql)
-	if i := strings.IndexAny(lower, " \t\n\r("); i > 0 {
-		info.Verb = lower[:i]
-	} else {
-		info.Verb = lower
+	tokens := pgLex(sql)
+	if len(tokens) == 0 {
+		return info
 	}
-	for _, m := range pgTableRE.FindAllStringSubmatch(lower, -1) {
-		info.Tables = append(info.Tables, m[1])
+	for i, tok := range tokens {
+		if (i == 0 || tokens[i-1].text == ";") && pgIdentifierToken(tok) {
+			info.Verbs = append(info.Verbs, tok.text)
+		}
 	}
-	for _, m := range pgFuncRE.FindAllStringSubmatch(lower, -1) {
-		info.Functions = append(info.Functions, m[1])
+	// Also surface actionable DML/DDL verbs nested inside WITH CTEs or other
+	// expressions. This is intentionally conservative: verb deny rules should not
+	// be bypassed by wrapping DELETE/UPDATE/etc. in a data-modifying CTE.
+	seenVerb := map[string]bool{}
+	for _, v := range info.Verbs {
+		seenVerb[v] = true
+	}
+	for _, tok := range tokens {
+		if !tok.stringLiteral && pgActionVerb(tok.text) && !seenVerb[tok.text] {
+			info.Verbs = append(info.Verbs, tok.text)
+			seenVerb[tok.text] = true
+		}
+	}
+	if len(info.Verbs) > 0 {
+		info.Verb = info.Verbs[0]
+	}
+	if len(info.Verbs) <= 1 {
+		info.Verbs = nil
+	}
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i].text
+		switch tok {
+		case "from", "table":
+			if fn, next, ok := pgReadQualifiedName(tokens, i+1); ok && next < len(tokens) && tokens[next].text == "(" {
+				info.Functions = append(info.Functions, fn)
+			}
+			if names, next, ok := pgReadTableList(tokens, i+1); ok {
+				info.Tables = append(info.Tables, names...)
+				i = next - 1
+			}
+		case "update", "into", "join":
+			if name, next, ok := pgReadQualifiedName(tokens, i+1); ok {
+				info.Tables = append(info.Tables, name)
+				i = next - 1
+			}
+		default:
+			if i+1 < len(tokens) && tokens[i+1].text == "(" && !pgKeywordBeforeParen(tok) {
+				info.Functions = append(info.Functions, tok)
+			}
+		}
 	}
 	return info
 }
+
+func pgLex(sql string) []pgToken {
+	var out []pgToken
+	for i := 0; i < len(sql); {
+		c := sql[i]
+		if isSQLSpace(c) {
+			i++
+			continue
+		}
+		if c == '-' && i+1 < len(sql) && sql[i+1] == '-' {
+			i += 2
+			for i < len(sql) && sql[i] != '\n' && sql[i] != '\r' {
+				i++
+			}
+			continue
+		}
+		if c == '/' && i+1 < len(sql) && sql[i+1] == '*' {
+			i += 2
+			for i+1 < len(sql) && !(sql[i] == '*' && sql[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(sql) {
+				i += 2
+			}
+			continue
+		}
+		if (c == 'E' || c == 'e') && i+1 < len(sql) && sql[i+1] == '\'' {
+			str, next := pgLexStringLiteral(sql, i+1, true)
+			out = append(out, pgToken{text: str, stringLiteral: true})
+			i = next
+			continue
+		}
+		if c == '\'' {
+			str, next := pgLexStringLiteral(sql, i, false)
+			out = append(out, pgToken{text: str, stringLiteral: true})
+			i = next
+			continue
+		}
+		unicodeQuoted := false
+		if (c == 'U' || c == 'u') && i+2 < len(sql) && sql[i+1] == '&' && sql[i+2] == '"' {
+			unicodeQuoted = true
+			i += 2
+			c = sql[i]
+		}
+		if c == '"' {
+			start := i
+			i++
+			var b strings.Builder
+			closed := false
+			for i < len(sql) {
+				if sql[i] == '"' {
+					if i+1 < len(sql) && sql[i+1] == '"' {
+						b.WriteByte('"')
+						i += 2
+						continue
+					}
+					i++
+					closed = true
+					break
+				}
+				b.WriteByte(sql[i])
+				i++
+			}
+			ident := b.String()
+			if !closed {
+				ident = sql[start+1:]
+			}
+			rawIdent := ident
+			if unicodeQuoted {
+				ident = pgDecodeUnicodeIdent(ident, '\\')
+			}
+			tok := pgToken{text: strings.ToLower(ident), quoted: true}
+			if unicodeQuoted {
+				tok.unicodeRaw = rawIdent
+			}
+			out = append(out, tok)
+			continue
+		}
+		if isSQLIdentStart(c) {
+			start := i
+			i++
+			for i < len(sql) && isSQLIdentPart(sql[i]) {
+				i++
+			}
+			out = append(out, pgToken{text: strings.ToLower(sql[start:i])})
+			continue
+		}
+		if strings.ContainsRune("().,;", rune(c)) {
+			out = append(out, pgToken{text: string(c)})
+		}
+		i++
+	}
+	return out
+}
+
+func pgReadTableList(tokens []pgToken, i int) ([]string, int, bool) {
+	var names []string
+	name, next, ok := pgReadQualifiedName(tokens, i)
+	if !ok {
+		return nil, i, false
+	}
+	names = append(names, name)
+	next = pgSkipTableAlias(tokens, next)
+	for next < len(tokens) && tokens[next].text == "," {
+		next++
+		name, after, ok := pgReadQualifiedName(tokens, next)
+		if !ok {
+			break
+		}
+		names = append(names, name)
+		next = pgSkipTableAlias(tokens, after)
+	}
+	return names, next, true
+}
+
+func pgSkipTableAlias(tokens []pgToken, i int) int {
+	if i < len(tokens) && tokens[i].text == "as" && i+1 < len(tokens) && pgIdentifierToken(tokens[i+1]) {
+		return i + 2
+	}
+	if i < len(tokens) && pgIdentifierToken(tokens[i]) && !pgTableAliasBoundary(tokens[i].text) {
+		return i + 1
+	}
+	return i
+}
+
+func pgTableAliasBoundary(tok string) bool {
+	switch tok {
+	case "where", "join", "left", "right", "inner", "outer", "full", "cross", "on", "using", "group", "order", "limit", "offset", "union", "intersect", "except", "returning", "set", "values", "select", "delete", "update", "insert", "merge", "drop", "alter", "create", "truncate", "copy":
+		return true
+	default:
+		return false
+	}
+}
+
+func pgLexStringLiteral(sql string, i int, escape bool) (string, int) {
+	i++
+	var b strings.Builder
+	for i < len(sql) {
+		if sql[i] == '\'' {
+			if i+1 < len(sql) && sql[i+1] == '\'' {
+				b.WriteByte('\'')
+				i += 2
+				continue
+			}
+			i++
+			break
+		}
+		if escape && sql[i] == '\\' && i+1 < len(sql) {
+			if i+3 < len(sql) && (sql[i+1] == 'x' || sql[i+1] == 'X') {
+				if r, ok := pgParseHexRune(sql[i+2 : i+4]); ok {
+					b.WriteRune(r)
+					i += 4
+					continue
+				}
+			}
+			b.WriteByte(sql[i+1])
+			i += 2
+			continue
+		}
+		b.WriteByte(sql[i])
+		i++
+	}
+	return b.String(), i
+}
+
+func pgReadQualifiedName(tokens []pgToken, i int) (string, int, bool) {
+	if i+1 < len(tokens) && tokens[i].text == "if" && tokens[i+1].text == "exists" {
+		i += 2
+	}
+	if i < len(tokens) && tokens[i].text == "only" {
+		i++
+		paren := i < len(tokens) && tokens[i].text == "("
+		if paren {
+			i++
+		}
+		name, next, ok := pgReadQualifiedName(tokens, i)
+		if !ok {
+			return "", i, false
+		}
+		if paren && next < len(tokens) && tokens[next].text == ")" {
+			next++
+		}
+		return name, next, true
+	}
+	if i >= len(tokens) || !pgIdentifierToken(tokens[i]) {
+		return "", i, false
+	}
+	parts := []string{pgIdentifierText(tokens, i)}
+	i++
+	for i+1 < len(tokens) && tokens[i].text == "." && pgIdentifierToken(tokens[i+1]) {
+		parts = append(parts, pgIdentifierText(tokens, i+1))
+		i += 2
+	}
+	return strings.Join(parts, "."), i, true
+}
+
+func pgIdentifierText(tokens []pgToken, i int) string {
+	tok := tokens[i]
+	if tok.unicodeRaw != "" && i+2 < len(tokens) && tokens[i+1].text == "uescape" && tokens[i+2].stringLiteral && len(tokens[i+2].text) == 1 {
+		return strings.ToLower(pgDecodeUnicodeIdent(tok.unicodeRaw, tokens[i+2].text[0]))
+	}
+	return tok.text
+}
+
+func pgIdentifierToken(tok pgToken) bool {
+	if tok.stringLiteral {
+		return false
+	}
+	if tok.quoted {
+		return tok.text != ""
+	}
+	return tok.text != "" && isSQLIdentStart(tok.text[0])
+}
+
+func pgKeywordBeforeParen(tok string) bool {
+	switch tok {
+	case "select", "where", "join", "from", "into", "update", "values", "as", "on", "and", "or", "not", "in", "exists", "case", "when":
+		return true
+	default:
+		return false
+	}
+}
+
+func pgActionVerb(tok string) bool {
+	switch tok {
+	case "select", "insert", "update", "delete", "merge", "drop", "alter", "create", "truncate", "copy":
+		return true
+	default:
+		return false
+	}
+}
+
+func pgDecodeUnicodeIdent(s string, esc byte) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] != esc {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == esc {
+			b.WriteByte(esc)
+			i += 2
+			continue
+		}
+		digits := 4
+		start := i + 1
+		if start < len(s) && s[start] == '+' {
+			digits = 6
+			start++
+		}
+		if start+digits <= len(s) {
+			if r, ok := pgParseHexRune(s[start : start+digits]); ok {
+				b.WriteRune(r)
+				i = start + digits
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+func pgParseHexRune(s string) (rune, bool) {
+	var v rune
+	for _, c := range s {
+		switch {
+		case '0' <= c && c <= '9':
+			v = v*16 + c - '0'
+		case 'a' <= c && c <= 'f':
+			v = v*16 + c - 'a' + 10
+		case 'A' <= c && c <= 'F':
+			v = v*16 + c - 'A' + 10
+		default:
+			return 0, false
+		}
+	}
+	return v, true
+}
+
+func isSQLSpace(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' }
+func isSQLIdentStart(c byte) bool {
+	return c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+}
+func isSQLIdentPart(c byte) bool { return isSQLIdentStart(c) || ('0' <= c && c <= '9') || c == '$' }
 
 // Compile-time interface check — keeps PostgresEndpointRuntime in
 // sync with the contract.

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -42,19 +42,14 @@ func TestParseSQL(t *testing.T) {
 			},
 		},
 		{
-			// Regex-based extraction is overgreedy by design: it
-			// flags every `<ident>(` callsite, which includes the
-			// table-name + parens (audit (...)) and SQL keywords
-			// like values(. The matcher consumes a list — banned-
-			// function rules check whether their target is anywhere
-			// in the list, so noise is harmless. Caveat: a SQL
-			// parser would be more precise; accepted trade-off.
+			// The lexer avoids treating INSERT target lists and VALUES
+			// clauses as function calls while still surfacing real calls.
 			"insert with function",
 			"INSERT INTO audit (ts, what) VALUES (now(), 'x')",
 			pgInfo{
 				Verb:      "insert",
 				Tables:    []string{"audit"},
-				Functions: []string{"audit", "values", "now"},
+				Functions: []string{"now"},
 				Statement: "INSERT INTO audit (ts, what) VALUES (now(), 'x')",
 			},
 		},
@@ -88,10 +83,11 @@ func TestParseSQL(t *testing.T) {
 			pgInfo{},
 		},
 		{
-			"multi-statement keeps raw statement and first verb",
+			"multi-statement keeps raw statement and all verbs",
 			"SELECT * FROM users; DELETE FROM sessions",
 			pgInfo{
 				Verb:      "select",
+				Verbs:     []string{"select", "delete"},
 				Tables:    []string{"users", "sessions"},
 				Functions: nil,
 				Statement: "SELECT * FROM users; DELETE FROM sessions",
@@ -108,13 +104,165 @@ func TestParseSQL(t *testing.T) {
 			},
 		},
 		{
-			"quoted identifier is best-effort only",
+			"comma-separated from tables are all matched",
+			"SELECT * FROM users u, github_identities AS gi",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"users", "github_identities"},
+				Functions: nil,
+				Statement: "SELECT * FROM users u, github_identities AS gi",
+			},
+		},
+		{
+			"table-valued function is still recorded as function",
+			"SELECT * FROM pg_terminate_backend(123)",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"pg_terminate_backend"},
+				Functions: []string{"pg_terminate_backend"},
+				Statement: "SELECT * FROM pg_terminate_backend(123)",
+			},
+		},
+		{
+			"quoted identifier is matched",
 			"SELECT * FROM \"Sensitive Table\"",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"sensitive table"},
+				Functions: nil,
+				Statement: "SELECT * FROM \"Sensitive Table\"",
+			},
+		},
+		{
+			"ONLY table modifier is skipped",
+			"SELECT * FROM ONLY secret_table",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "SELECT * FROM ONLY secret_table",
+			},
+		},
+		{
+			"unicode quoted identifier is matched",
+			"SELECT * FROM U&\"secret_table\"",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "SELECT * FROM U&\"secret_table\"",
+			},
+		},
+		{
+			"drop table extracts table name",
+			"DROP TABLE secret_table",
+			pgInfo{
+				Verb:      "drop",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "DROP TABLE secret_table",
+			},
+		},
+		{
+			"drop table if exists skips optional clause",
+			"DROP TABLE IF EXISTS secret_table",
+			pgInfo{
+				Verb:      "drop",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "DROP TABLE IF EXISTS secret_table",
+			},
+		},
+		{
+			"leading empty statement uses first real verb",
+			"; DELETE FROM sessions",
+			pgInfo{
+				Verb:      "delete",
+				Tables:    []string{"sessions"},
+				Functions: nil,
+				Statement: "; DELETE FROM sessions",
+			},
+		},
+		{
+			"leading empty multi-statement exposes all real verbs",
+			"; SELECT 1; DELETE FROM sessions",
+			pgInfo{
+				Verb:      "select",
+				Verbs:     []string{"select", "delete"},
+				Tables:    []string{"sessions"},
+				Functions: nil,
+				Statement: "; SELECT 1; DELETE FROM sessions",
+			},
+		},
+		{
+			"with data-modifying cte exposes nested verb",
+			"WITH gone AS (DELETE FROM sessions RETURNING id) SELECT 1",
+			pgInfo{
+				Verb:      "with",
+				Verbs:     []string{"with", "delete", "select"},
+				Tables:    []string{"sessions"},
+				Functions: nil,
+				Statement: "WITH gone AS (DELETE FROM sessions RETURNING id) SELECT 1",
+			},
+		},
+		{
+			"unicode escaped quoted identifier is decoded",
+			"SELECT * FROM U&\"secret\\005Ftable\"",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "SELECT * FROM U&\"secret\\005Ftable\"",
+			},
+		},
+		{
+			"unicode escaped quoted identifier honors custom escape",
+			"SELECT * FROM U&\"secret!005Ftable\" UESCAPE '!'",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "SELECT * FROM U&\"secret!005Ftable\" UESCAPE '!'",
+			},
+		},
+		{
+			"unicode escaped quoted identifier honors escaped custom escape literal",
+			"SELECT * FROM U&\"secret!005Ftable\" UESCAPE E'!'",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "SELECT * FROM U&\"secret!005Ftable\" UESCAPE E'!'",
+			},
+		},
+		{
+			"unicode escaped quoted identifier honors hex escaped custom escape literal",
+			"SELECT * FROM U&\"secret!005Ftable\" UESCAPE E'\\x21'",
+			pgInfo{
+				Verb:      "select",
+				Tables:    []string{"secret_table"},
+				Functions: nil,
+				Statement: "SELECT * FROM U&\"secret!005Ftable\" UESCAPE E'\\x21'",
+			},
+		},
+		{
+			"escaped string literal contents are not verbs",
+			"SELECT E'not a \\' DELETE FROM sessions'",
 			pgInfo{
 				Verb:      "select",
 				Tables:    nil,
 				Functions: nil,
-				Statement: "SELECT * FROM \"Sensitive Table\"",
+				Statement: "SELECT E'not a \\' DELETE FROM sessions'",
+			},
+		},
+		{
+			"string literal contents are not verbs",
+			"SELECT 'DELETE FROM sessions'",
+			pgInfo{
+				Verb:      "select",
+				Tables:    nil,
+				Functions: nil,
+				Statement: "SELECT 'DELETE FROM sessions'",
 			},
 		},
 	}

--- a/config/runtime/dispatch.go
+++ b/config/runtime/dispatch.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"net"
+
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/match"
 )
@@ -18,23 +20,46 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 	if policy == nil {
 		return nil
 	}
-	prof, ok := policy.Profiles[profile]
-	if !ok {
-		// Single-tenant fallback: if no peer-to-profile mapping is
-		// established, walk every profile and return the first match.
-		// Matches main.go's existing profileFor behavior when only
-		// one profile exists.
-		for _, p := range policy.Profiles {
-			if ep := p.HostIndex[host]; ep != nil {
+	lookup := func(p *config.CompiledProfile) *config.CompiledEndpoint {
+		if p == nil {
+			return nil
+		}
+		for _, h := range hostLookupCandidates(host) {
+			if ep := p.HostIndex[h]; ep != nil {
 				return ep
 			}
 		}
 		return nil
 	}
-	if ep := prof.HostIndex[host]; ep != nil {
-		return ep
+	if profile != "" {
+		// A named profile is an authorization boundary. If a peer maps to a
+		// profile that disappeared after reload, fail closed instead of falling
+		// through to another profile's endpoint.
+		return lookup(policy.Profiles[profile])
+	}
+	// Single-tenant fallback: if no peer-to-profile mapping is established,
+	// walk every profile and return the first matching endpoint.
+	for _, p := range policy.Profiles {
+		if ep := lookup(p); ep != nil {
+			return ep
+		}
 	}
 	return nil
+}
+
+func hostLookupCandidates(host string) []string {
+	if host == "" {
+		return nil
+	}
+	out := []string{host}
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		if p == "443" {
+			out = append(out, h)
+		}
+	} else {
+		out = append(out, net.JoinHostPort(host, "443"))
+	}
+	return out
 }
 
 // MatchRequest walks an endpoint's priority-sorted rule list and

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -63,9 +63,49 @@ func TestHostEndpoint(t *testing.T) {
 	if got := runtime.HostEndpoint(cp, "default", "unknown.example"); got != nil {
 		t.Errorf("unknown host should resolve to nil, got %+v", got)
 	}
-	// Unknown profile + known host → fallback scan finds it.
-	if got := runtime.HostEndpoint(cp, "no-such-profile", "github.com"); got == nil {
+	// Empty profile + known host → fallback scan finds it.
+	if got := runtime.HostEndpoint(cp, "", "github.com"); got == nil {
 		t.Errorf("fallback scan should find github.com")
+	}
+	if got := runtime.HostEndpoint(cp, "no-such-profile", "github.com"); got != nil {
+		t.Errorf("unknown named profile should fail closed, got %+v", got)
+	}
+}
+
+func TestHostEndpointDefaultPortFallbackPreservesExactPrecedence(t *testing.T) {
+	src := `
+credential "bearer_token" "pat" {}
+endpoint "https" "bare" {
+  hosts = ["api.example.com"]
+  credential = pat
+}
+endpoint "https" "default_port" {
+  hosts = ["port.example.com:443"]
+  credential = pat
+}
+endpoint "https" "exact_port" {
+  hosts = ["api.example.com:443"]
+  credential = pat
+}
+profile "default" { endpoints = [bare, default_port, exact_port] }
+`
+	gw, diags := config.LoadBytes([]byte(src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if got := runtime.HostEndpoint(cp, "default", "port.example.com"); got == nil || got.Name != "default_port" {
+		t.Fatalf("bare runtime host should fall back to declared :443 endpoint, got %+v", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com:443"); got == nil || got.Name != "exact_port" {
+		t.Fatalf("exact host:port should win before bare fallback, got %+v", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "api.example.com"); got == nil || got.Name != "bare" {
+		t.Fatalf("exact bare host should win before :443 fallback, got %+v", got)
 	}
 }
 

--- a/dial.go
+++ b/dial.go
@@ -119,20 +119,24 @@ func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName st
 	return tc, nil
 }
 
-// dialBrowserTLS opens a TCP connection and performs a uTLS handshake
-// using Chrome's TLS fingerprint (HelloChrome_Auto), with ALPN forced
-// to http/1.1. Used for WS upgrades to chatgpt.com — Cloudflare WAF
-// otherwise rejects the WS handshake with "Attack attempt detected".
-//
-// Plain Go TLS works fine for chatgpt.com HTTP requests but the WS
-// upgrade specifically gets fingerprint-blocked. Mimicking Chrome's
-// ClientHello bypasses it.
-func dialBrowserTLS(ctx context.Context, network, addr, serverName string) (net.Conn, error) {
-	d := &net.Dialer{}
-	raw, err := d.DialContext(ctx, network, addr)
+// dialBrowserTLS opens an upstream connection through the gateway's normal
+// endpoint path (including any configured tunnel) and performs a uTLS handshake
+// using Chrome's TLS fingerprint (HelloChrome_Auto), with ALPN forced to
+// http/1.1. Used for WS upgrades to chatgpt.com — Cloudflare WAF otherwise
+// rejects the WS handshake with "Attack attempt detected".
+func (g *Gateway) dialBrowserTLS(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint) (net.Conn, error) {
+	raw, err := g.dialThrough(ctx, ep, network, addr)
 	if err != nil {
 		return nil, err
 	}
+	return dialBrowserTLSConn(ctx, raw, serverName)
+}
+
+// dialBrowserTLSConn performs a uTLS handshake over an already-open raw
+// connection. Keeping this split makes the security invariant explicit: callers
+// that know about endpoints must use Gateway.dialBrowserTLS so tunnels are not
+// bypassed.
+func dialBrowserTLSConn(ctx context.Context, raw net.Conn, serverName string) (net.Conn, error) {
 	// HelloChrome_Auto bakes ALPN ["h2","http/1.1"] into the ClientHello.
 	// We need http/1.1 only (WS upgrade requires HTTP/1.1; raw response
 	// reader breaks on h2 SETTINGS frames). Apply preset spec, mutate
@@ -157,4 +161,25 @@ func dialBrowserTLS(ctx context.Context, network, addr, serverName string) (net.
 		return nil, err
 	}
 	return c, nil
+}
+
+// dialBrowserTLSDirect opens a direct TCP connection and performs a uTLS
+// handshake. It is intentionally kept out of endpoint-aware paths; use only for
+// tests or code that has already proven no endpoint tunnel applies.
+//
+// dialBrowserTLS opens a TCP connection and performs a uTLS handshake
+// using Chrome's TLS fingerprint (HelloChrome_Auto), with ALPN forced
+// to http/1.1. Used for WS upgrades to chatgpt.com — Cloudflare WAF
+// otherwise rejects the WS handshake with "Attack attempt detected".
+//
+// Plain Go TLS works fine for chatgpt.com HTTP requests but the WS
+// upgrade specifically gets fingerprint-blocked. Mimicking Chrome's
+// ClientHello bypasses it.
+func dialBrowserTLSDirect(ctx context.Context, network, addr, serverName string) (net.Conn, error) {
+	d := &net.Dialer{}
+	raw, err := d.DialContext(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+	return dialBrowserTLSConn(ctx, raw, serverName)
 }

--- a/main.go
+++ b/main.go
@@ -292,7 +292,7 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 				h = addr
 			}
 			if needsBrowserTLS(h) && !endpointWantsClientCert(ep) {
-				return dialBrowserTLS(ctx, network, addr, h)
+				return g.dialBrowserTLS(ctx, network, addr, h, ep)
 			}
 			profile, _ := ctx.Value(profileCtxKey{}).(string)
 			return g.dialUpstream(ctx, network, addr, h, ep, profile)
@@ -304,6 +304,19 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 	}
 	actual, _ := g.transports.LoadOrStore(ep, tr)
 	return actual.(*http.Transport)
+}
+
+// closeTransports closes and removes every cached endpoint transport. Called
+// after a successful policy reload so old endpoints cannot keep using stale
+// idle connections, credentials, or tunnel paths through their transport cache.
+func (g *Gateway) closeTransports() {
+	g.transports.Range(func(k, v any) bool {
+		if tr, ok := v.(*http.Transport); ok {
+			tr.CloseIdleConnections()
+		}
+		g.transports.Delete(k)
+		return true
+	})
 }
 
 // Policy returns the current snapshot of the lowered runtime policy.
@@ -365,6 +378,7 @@ func (g *Gateway) watchConfig(path string) {
 			continue
 		}
 		g.policy.Store(policy)
+		g.closeTransports()
 		registerOAuthCredentials(g.oauth, policy)
 		g.connIdx.Store(runtime.BuildConnIndex(policy))
 		if g.tunnels != nil {
@@ -1716,13 +1730,13 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			if r, handled, err := responder.RespondHTTP(req.Context(), req); err != nil {
 				log.Printf("respond %s: %v", ep.Name, err)
 			} else if handled {
-				if r.Body != nil {
-					defer func() { _ = r.Body.Close() }()
-				}
 				ev.Status = r.StatusCode
 				ev.Action = "synth"
 				if err := r.Write(tc); err != nil {
 					log.Printf("synth write %s %s: %v", host, req.URL.Path, err)
+				}
+				if r.Body != nil {
+					_ = r.Body.Close()
 				}
 				ev.Ms = time.Since(start).Milliseconds()
 				g.emitEnd(ev)
@@ -1739,6 +1753,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// to stamp onto the request. Schema-only credential types
 		// (slack / telegram / gemini / etc.) leave Runtime nil; we
 		// pass through verbatim and rely on policy alone.
+		var injectedSecrets []runtime.Secret
 		if cc := runtime.ResolveCredential(ep, mreq); cc != nil {
 			// Plugin.Runtime is a typed-nil sentinel used only for
 			// interface-compliance assertions; the actual decoded HCL
@@ -1753,6 +1768,8 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
 				} else if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
 					log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+				} else {
+					injectedSecrets = append(injectedSecrets, sec)
 				}
 			}
 		}
@@ -1827,7 +1844,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Reason = err.Error()
 			ev.Ms = time.Since(start).Milliseconds()
 			ev.ReqSha = reqS.sha()
-			ev.ReqBody = reqS.sample()
+			ev.ReqBody = reqS.sampleRedacted(injectedSecrets)
 			ev.In = reqS.n
 			g.emitEnd(ev)
 			return
@@ -1877,7 +1894,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()
-		ev.ReqBody = reqS.sample()
+		ev.ReqBody = reqS.sampleRedacted(injectedSecrets)
 		ev.RespSha = respS.sha()
 		ev.RespBody = respS.sample()
 		ev.Ms = time.Since(start).Milliseconds()

--- a/site/package.json
+++ b/site/package.json
@@ -7,6 +7,7 @@
     "build": "vite build && tsx build-docs.ts",
     "deploy": "npm run build && wrangler deploy",
     "test": "tsx --test worker/**/*.test.ts",
+    "typecheck": "tsc --noEmit",
     "telemetry": "tsx scripts/telemetry.ts"
   },
   "dependencies": {

--- a/site/worker/index.test.ts
+++ b/site/worker/index.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import worker from "./index";
+import worker, { isUpdateAvailable } from "./index";
 
 type PreparedStatement = {
   bind: (...args: unknown[]) => PreparedStatement;
@@ -17,18 +17,16 @@ function env() {
     },
     run: async () => {},
   };
-  return {
-    calls,
-    env: {
-      ASSETS: { fetch: async () => new Response("asset") },
-      TELEMETRY_DB: {
-        prepare: () => {
-          calls.prepare++;
-          return stmt;
-        },
+  const testEnv = {
+    ASSETS: { fetch: async (_req: Request) => new Response("asset") } as Fetcher,
+    TELEMETRY_DB: {
+      prepare: () => {
+        calls.prepare++;
+        return stmt;
       },
-    },
+    } as unknown as D1Database,
   };
+  return { calls, env: testEnv };
 }
 
 const originalFetch = globalThis.fetch;
@@ -84,4 +82,58 @@ test("rejects payloads over the byte limit, not just the JavaScript string lengt
   assert.equal(res.status, 413);
   assert.equal(calls.prepare, 0);
   assert.equal(calls.releaseFetch, 0);
+});
+
+test("rejects oversized telemetry without Content-Length before reading all chunks", async () => {
+  const { env: testEnv, calls } = env();
+  let pulls = 0;
+  const chunk = new Uint8Array(2048);
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls++;
+      controller.enqueue(chunk);
+      if (pulls >= 4) controller.close();
+    },
+  });
+
+  const res = await worker.fetch(
+    new Request("https://clawpatrol.dev/api/telemetry/v1/check", {
+      method: "POST",
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" }),
+    testEnv,
+  );
+
+  assert.equal(res.status, 413);
+  assert.equal(calls.prepare, 0);
+  assert.ok(pulls < 4, `expected early cancellation, read ${pulls} chunks`);
+});
+
+test("compares update versions by major/minor/patch and ignores build metadata", () => {
+  const cases = [
+    { current: "1.2.3", latest: "v1.2.4", want: true },
+    { current: "1.2.3", latest: "v1.3.0", want: true },
+    { current: "1.2.3", latest: "v2.0.0", want: true },
+    { current: "1.2.3-rc.1", latest: "v1.2.3", want: true },
+    { current: "1.2.3-beta.1", latest: "v1.2.3-rc.1", want: true },
+    { current: "1.2.3-rc.2", latest: "v1.2.3-rc.10", want: true },
+    { current: "1.2.3-alpha.10", latest: "v1.2.3-alpha.2", want: false },
+    { current: "1.2.3", latest: "v1.2.3", want: false },
+    { current: "1.2.3+local", latest: "v1.2.3+build.5", want: false },
+    { current: "1.2.3", latest: "v1.2.3-rc.1", want: false },
+    { current: "1.2.4", latest: "v1.2.3", want: false },
+    { current: "", latest: "v1.2.4", want: false },
+    { current: "dev", latest: "v1.2.4", want: false },
+    { current: "1.2", latest: "v1.2.4", want: false },
+    { current: "1.2.3", latest: "", want: false },
+  ];
+
+  for (const tc of cases) {
+    assert.equal(
+      isUpdateAvailable(tc.current, tc.latest),
+      tc.want,
+      `${tc.current} vs ${tc.latest}`,
+    );
+  }
 });

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -43,14 +43,14 @@ async function handleCheck(
     }
   }
 
-  const text = await req.text();
-  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+  const bodyText = await readRequestBody(req, MAX_BODY_BYTES);
+  if (bodyText === null) {
     return new Response(null, { status: 413 });
   }
 
   let body: Record<string, unknown>;
   try {
-    body = JSON.parse(text);
+    body = JSON.parse(bodyText);
   } catch {
     return new Response(null, { status: 400 });
   }
@@ -94,12 +94,11 @@ async function handleCheck(
     intOrNull(body.actions_count_1h),
     intOrNull(body.bytes_in_1h),
     intOrNull(body.bytes_out_1h),
-    text,
+    bodyText,
   ).run();
 
   const release = await fetchLatestRelease();
-  const updateAvailable =
-    !!release.tag && release.tag !== version;
+  const updateAvailable = isUpdateAvailable(version, release.tag);
   return Response.json({
     latest: release.tag,
     your_version: version,
@@ -114,6 +113,48 @@ type Release = {
   url: string;
   advisory: { level: string; message: string } | null;
 };
+
+async function readRequestBody(
+  req: Request,
+  limitBytes: number,
+): Promise<string | null> {
+  if (!req.body) return "";
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = limitBytes + 1 - total;
+      if (value.byteLength > remaining) {
+        chunks.push(value.slice(0, remaining));
+        await reader.cancel();
+        return null;
+      }
+
+      total += value.byteLength;
+      chunks.push(value);
+      if (total > limitBytes) {
+        await reader.cancel();
+        return null;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
 
 async function fetchLatestRelease(): Promise<Release> {
   const r = await fetch(RELEASES_URL, {
@@ -142,6 +183,57 @@ function parseAdvisory(
   const firstPara = m[2].split(/\n\s*\n/)[0].trim();
   if (!firstPara) return null;
   return { level: m[1].toLowerCase(), message: firstPara };
+}
+
+
+export function isUpdateAvailable(current: string, latest: string): boolean {
+  const currentVersion = parseVersion(current);
+  const latestVersion = parseVersion(latest);
+  if (!currentVersion || !latestVersion) return false;
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (latestVersion[key] > currentVersion[key]) return true;
+    if (latestVersion[key] < currentVersion[key]) return false;
+  }
+  if (currentVersion.prerelease && !latestVersion.prerelease) return true;
+  if (!currentVersion.prerelease && latestVersion.prerelease) return false;
+  if (currentVersion.prerelease && latestVersion.prerelease) {
+    return comparePrerelease(latestVersion.prerelease, currentVersion.prerelease) > 0;
+  }
+  return false;
+}
+
+function comparePrerelease(a: string, b: string): number {
+  const aa = a.split(".");
+  const bb = b.split(".");
+  const n = Math.max(aa.length, bb.length);
+  for (let i = 0; i < n; i++) {
+    const av = aa[i];
+    const bv = bb[i];
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    if (av === bv) continue;
+    const an = /^[0-9]+$/.test(av) ? Number(av) : null;
+    const bn = /^[0-9]+$/.test(bv) ? Number(bv) : null;
+    if (an !== null && bn !== null) return an > bn ? 1 : -1;
+    if (an !== null) return -1;
+    if (bn !== null) return 1;
+    return av > bv ? 1 : -1;
+  }
+  return 0;
+}
+
+function parseVersion(
+  version: string,
+): { major: number; minor: number; patch: number; prerelease: string | null } | null {
+  const m = version
+    .trim()
+    .match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+  if (!m) return null;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+  if (![major, minor, patch].every(Number.isSafeInteger)) return null;
+  return { major, minor, patch, prerelease: m[4] ?? null };
 }
 
 function str(v: unknown): string {

--- a/tunnel.go
+++ b/tunnel.go
@@ -49,8 +49,8 @@ type TunnelManager struct {
 	// pinned holds the manager's own release closure per pinned
 	// (name, sharingKey) tuple. SetPolicy stores one Acquire result
 	// per `keepalive = "always"` tunnel and drops it again when the
-	// pin disappears from a subsequent policy.
-	pinned map[mgrKey]func()
+	// pin disappears or its compiled tunnel config changes in a subsequent policy.
+	pinned map[mgrKey]pinnedTunnel
 
 	// connSeq feeds per_conn sharing keys.
 	connSeq atomic.Uint64
@@ -59,6 +59,11 @@ type TunnelManager struct {
 type mgrKey struct {
 	Name string
 	Key  string
+}
+
+type pinnedTunnel struct {
+	ct  *config.CompiledTunnel
+	rel func()
 }
 
 type tunnelEntry struct {
@@ -73,6 +78,10 @@ type tunnelEntry struct {
 	// read tunnel / openErr.
 	openOnce sync.Once
 	openErr  error
+
+	// ct is the compiled tunnel configuration that opened this runtime. It lets
+	// reloads detach stale entries while in-flight users drain.
+	ct *config.CompiledTunnel
 
 	// tunnel is the live runtime.Tunnel returned by body.Open.
 	tunnel runtime.Tunnel
@@ -92,7 +101,7 @@ func NewTunnelManager(secrets runtime.SecretStore, cadir string) *TunnelManager 
 		secrets: secrets,
 		cadir:   cadir,
 		entries: map[mgrKey]*tunnelEntry{},
-		pinned:  map[mgrKey]func(){},
+		pinned:  map[mgrKey]pinnedTunnel{},
 	}
 }
 
@@ -107,14 +116,33 @@ func (m *TunnelManager) Acquire(ctx context.Context, ct *config.CompiledTunnel, 
 	key := m.shareKey(ct, endpoint)
 	mk := mgrKey{Name: ct.Name, Key: key}
 
+	var staleTunnel runtime.Tunnel
+	var staleViaRelease func()
 	m.mu.Lock()
 	e, exists := m.entries[mk]
+	if exists && e.ct != ct {
+		// A policy reload can produce a new CompiledTunnel for the same logical
+		// manager key while old callers still hold references. Detach the stale
+		// entry so new acquires open the new config; old release closures keep the
+		// old runtime alive only until their refcount drains. If it is already idle,
+		// close it now rather than leaving an unreachable idle timer behind.
+		if e.timer != nil {
+			e.timer.Stop()
+			e.timer = nil
+		}
+		if e.refcount == 0 {
+			staleTunnel, staleViaRelease = e.tunnel, e.viaRelease
+		}
+		delete(m.entries, mk)
+		exists = false
+	}
 	if !exists {
 		e = &tunnelEntry{
 			name:      ct.Name,
 			sharing:   ct.Sharing,
 			keepalive: ct.Keepalive,
 			always:    ct.KeepaliveAlways,
+			ct:        ct,
 		}
 		m.entries[mk] = e
 	}
@@ -124,6 +152,12 @@ func (m *TunnelManager) Acquire(ctx context.Context, ct *config.CompiledTunnel, 
 	}
 	e.refcount++
 	m.mu.Unlock()
+	if staleTunnel != nil {
+		_ = staleTunnel.Close()
+	}
+	if staleViaRelease != nil {
+		staleViaRelease()
+	}
 
 	// Exactly one Acquire per entry runs body.Open; the others
 	// wait on openOnce and read the result.
@@ -188,7 +222,7 @@ func (m *TunnelManager) Acquire(ctx context.Context, ct *config.CompiledTunnel, 
 		return nil, func() {}, e.openErr
 	}
 
-	return wrapTunnel(e.tunnel), m.releaseFunc(mk), nil
+	return wrapTunnel(e.tunnel), m.releaseFunc(mk, e), nil
 }
 
 // shareKey produces the sharing-bucket key for a tunnel + endpoint.
@@ -205,9 +239,9 @@ func (m *TunnelManager) shareKey(ct *config.CompiledTunnel, endpoint string) str
 
 // releaseFunc returns a closure that decrements refcount on the
 // keyed entry exactly once.
-func (m *TunnelManager) releaseFunc(mk mgrKey) func() {
+func (m *TunnelManager) releaseFunc(mk mgrKey, e *tunnelEntry) func() {
 	var once sync.Once
-	return func() { once.Do(func() { m.releaseEntry(mk) }) }
+	return func() { once.Do(func() { m.releaseEntry(mk, e) }) }
 }
 
 // releaseEntry decrements the entry's refcount and either tears it
@@ -215,23 +249,25 @@ func (m *TunnelManager) releaseFunc(mk mgrKey) func() {
 // not a special case here — SetPolicy is the sole owner of the
 // synthetic +1 that keeps pinned tunnels up; once that pin is
 // released, this method tears down like any other.
-func (m *TunnelManager) releaseEntry(mk mgrKey) {
+func (m *TunnelManager) releaseEntry(mk mgrKey, e *tunnelEntry) {
 	m.mu.Lock()
-	e, ok := m.entries[mk]
-	if !ok {
+	if e == nil {
 		m.mu.Unlock()
 		return
 	}
 	if e.refcount > 0 {
 		e.refcount--
 	}
+	current := m.entries[mk] == e
 	if e.refcount > 0 {
 		m.mu.Unlock()
 		return
 	}
-	if e.keepalive == 0 {
+	if e.keepalive == 0 || !current {
 		t, vr := e.tunnel, e.viaRelease
-		delete(m.entries, mk)
+		if current {
+			delete(m.entries, mk)
+		}
 		m.mu.Unlock()
 		if t != nil {
 			_ = t.Close()
@@ -289,21 +325,20 @@ func (m *TunnelManager) SetPolicy(ctx context.Context, policy *config.CompiledPo
 		}
 	}
 
-	// Snapshot pinned releases that need to be dropped.
+	// Snapshot pinned releases that need to be dropped. If an always-on
+	// tunnel keeps the same manager key but its compiled config changed,
+	// drop the old pin so the next block acquires a fresh runtime instance.
 	m.mu.Lock()
 	staleRels := make([]func(), 0)
-	for mk, rel := range m.pinned {
-		if _, keep := wantPin[mk]; !keep {
-			staleRels = append(staleRels, rel)
+	for mk, pin := range m.pinned {
+		want, keep := wantPin[mk]
+		if !keep || pin.ct != want {
+			staleRels = append(staleRels, pin.rel)
 			delete(m.pinned, mk)
+			continue
 		}
-	}
-	// Tunnels that are still pinned in the new policy don't need
-	// re-Acquire — their existing rel keeps the entry alive.
-	for mk := range wantPin {
-		if _, already := m.pinned[mk]; already {
-			delete(wantPin, mk)
-		}
+		// Same config remains pinned; no re-Acquire needed.
+		delete(wantPin, mk)
 	}
 	m.mu.Unlock()
 
@@ -320,7 +355,7 @@ func (m *TunnelManager) SetPolicy(ctx context.Context, policy *config.CompiledPo
 			continue
 		}
 		m.mu.Lock()
-		m.pinned[mk] = rel
+		m.pinned[mk] = pinnedTunnel{ct: ct, rel: rel}
 		m.mu.Unlock()
 	}
 }
@@ -330,7 +365,7 @@ func (m *TunnelManager) Close() {
 	m.mu.Lock()
 	entries := m.entries
 	m.entries = map[mgrKey]*tunnelEntry{}
-	m.pinned = map[mgrKey]func(){}
+	m.pinned = map[mgrKey]pinnedTunnel{}
 	m.mu.Unlock()
 	for _, e := range entries {
 		if e.timer != nil {

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -144,6 +144,33 @@ func TestManagerKeepaliveIdleTimer(t *testing.T) {
 	}
 }
 
+func TestManagerReloadClosesDetachedIdleEntry(t *testing.T) {
+	m := NewTunnelManager(runtime.EnvSecretStore{}, "")
+	ct, fake := makeCompiledTunnel("t1", runtime.TunnelShareSingleton, time.Minute, false, nil)
+
+	_, rel, err := m.Acquire(context.Background(), ct, "ep")
+	if err != nil {
+		t.Fatalf("acquire old config: %v", err)
+	}
+	rel()
+	if got := fake.closeCount.Load(); got != 0 {
+		t.Fatalf("old closeCount before reload = %d, want 0", got)
+	}
+
+	ct2, fake2 := makeCompiledTunnel("t1", runtime.TunnelShareSingleton, time.Minute, false, nil)
+	_, rel2, err := m.Acquire(context.Background(), ct2, "ep")
+	if err != nil {
+		t.Fatalf("acquire new config: %v", err)
+	}
+	defer rel2()
+	if got := fake.closeCount.Load(); got != 1 {
+		t.Fatalf("old closeCount after detached idle reload = %d, want 1", got)
+	}
+	if got := fake2.openCount.Load(); got != 1 {
+		t.Fatalf("new openCount after reload = %d, want 1", got)
+	}
+}
+
 // TestManagerOpenError: Open failure cleans up the entry so a retry
 // behaves like a first-acquire.
 func TestManagerOpenError(t *testing.T) {
@@ -214,10 +241,51 @@ func TestManagerKeepaliveAlways(t *testing.T) {
 	if got := fake.closeCount.Load(); got != 0 {
 		t.Errorf("closeCount = %d while pinned, want 0", got)
 	}
+	// Setting the exact same compiled tunnel again should keep the pin.
+	m.SetPolicy(context.Background(), policy)
+	if got := fake.openCount.Load(); got != 1 {
+		t.Errorf("openCount = %d after unchanged policy, want 1", got)
+	}
+	// A successful reload builds new CompiledTunnel objects; refresh the
+	// always-on pin so same-name/key tunnels pick up changed config.
+	ct2, fake2 := makeCompiledTunnel("t1", runtime.TunnelShareSingleton, 0, true, nil)
+	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{"t1": ct2}})
+	if got := fake.closeCount.Load(); got != 1 {
+		t.Errorf("old closeCount = %d after refresh, want 1", got)
+	}
+	if got := fake2.openCount.Load(); got != 1 {
+		t.Errorf("new openCount = %d after refresh, want 1", got)
+	}
+	// If a caller still holds the old runtime during reload, new acquires must
+	// still use the new config and the old runtime must close when that caller
+	// drains.
+	ct3, fake3 := makeCompiledTunnel("t1", runtime.TunnelShareSingleton, 0, true, nil)
+	oldHandle, oldRel, err := m.Acquire(context.Background(), ct2, "ep")
+	if err != nil {
+		t.Fatalf("active acquire before second refresh: %v", err)
+	}
+	_ = oldHandle
+	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{"t1": ct3}})
+	if got := fake2.closeCount.Load(); got != 0 {
+		t.Errorf("old active closeCount = %d before caller release, want 0", got)
+	}
+	newHandle, newRel, err := m.Acquire(context.Background(), ct3, "ep")
+	if err != nil {
+		t.Fatalf("acquire new config after refresh: %v", err)
+	}
+	_ = newHandle
+	newRel()
+	if got := fake3.openCount.Load(); got != 1 {
+		t.Errorf("new active-refresh openCount = %d, want 1", got)
+	}
+	oldRel()
+	if got := fake2.closeCount.Load(); got != 1 {
+		t.Errorf("old active closeCount after caller release = %d, want 1", got)
+	}
 	// Drop the pin via SetPolicy with no tunnels.
 	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{}})
-	if got := fake.closeCount.Load(); got != 1 {
-		t.Errorf("closeCount = %d after pin drop, want 1", got)
+	if got := fake3.closeCount.Load(); got != 1 {
+		t.Errorf("new closeCount = %d after pin drop, want 1", got)
 	}
 }
 

--- a/web.go
+++ b/web.go
@@ -66,7 +66,13 @@ type webMux struct {
 type configPreviewToken struct {
 	revision    string
 	contentHash string
+	createdAt   time.Time
 }
+
+const (
+	configPreviewTokenTTL = 10 * time.Minute
+	configPreviewTokenCap = 128
+)
 
 type authRequirement int
 
@@ -859,6 +865,7 @@ func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.mu.Lock()
+	w.pruneConfigPreviewTokensLocked(time.Now())
 	var current []byte
 	var rev string
 	var token string
@@ -875,6 +882,7 @@ func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
 		w.configPreviewTokens()[token] = configPreviewToken{
 			revision:    rev,
 			contentHash: revisionForBytes(formatted),
+			createdAt:   time.Now(),
 		}
 		return nil
 	}); err != nil {
@@ -923,11 +931,14 @@ func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	preview, ok := w.configPreviewTokens()[body.PreviewToken]
+	w.pruneConfigPreviewTokensLocked(time.Now())
+	tokens := w.configPreviewTokens()
+	preview, ok := tokens[body.PreviewToken]
 	if !ok {
 		http.Error(rw, "preview token not found; review changes before saving", http.StatusPreconditionRequired)
 		return
 	}
+	delete(tokens, body.PreviewToken)
 	if preview.revision != body.ExpectedRevision || preview.contentHash != revisionForBytes(formatted) {
 		http.Error(rw, "preview token does not match reviewed content", http.StatusPreconditionFailed)
 		return
@@ -943,7 +954,6 @@ func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
 		if err := writeConfigAtomically(w.g.cfgPath, formatted); err != nil {
 			return err
 		}
-		delete(w.previews, body.PreviewToken)
 		return nil
 	}); err != nil {
 		if errors.Is(err, errConfigRevisionConflict) {
@@ -1036,6 +1046,29 @@ func (w *webMux) configPreviewTokens() map[string]configPreviewToken {
 		w.previews = map[string]configPreviewToken{}
 	}
 	return w.previews
+}
+
+func (w *webMux) pruneConfigPreviewTokensLocked(now time.Time) {
+	tokens := w.configPreviewTokens()
+	for token, preview := range tokens {
+		if preview.createdAt.IsZero() || now.Sub(preview.createdAt) > configPreviewTokenTTL {
+			delete(tokens, token)
+		}
+	}
+	for len(tokens) >= configPreviewTokenCap {
+		var oldestToken string
+		var oldestTime time.Time
+		for token, preview := range tokens {
+			if oldestToken == "" || preview.createdAt.Before(oldestTime) {
+				oldestToken = token
+				oldestTime = preview.createdAt
+			}
+		}
+		if oldestToken == "" {
+			break
+		}
+		delete(tokens, oldestToken)
+	}
 }
 
 func newConfigPreviewToken() (string, error) {
@@ -1925,6 +1958,36 @@ func (s *sampler) sample() string {
 		return s.buf.String()
 	}
 	return "binary:" + hex.EncodeToString(s.buf.Bytes()[:min(64, s.buf.Len())])
+}
+
+func (s *sampler) sampleRedacted(secrets []runtime.Secret) string {
+	return redactSecretSample(s.sample(), secrets)
+}
+
+func redactSecretSample(sample string, secrets []runtime.Secret) string {
+	if sample == "" || len(secrets) == 0 {
+		return sample
+	}
+	out := sample
+	for _, sec := range secrets {
+		out = redactSecretValue(out, string(sec.Bytes))
+		for _, v := range sec.Extras {
+			out = redactSecretValue(out, v)
+		}
+	}
+	return out
+}
+
+func redactSecretValue(sample, secret string) string {
+	// Very short values produce too many false positives in ordinary JSON/body
+	// samples; redact only values that are credibly secret material.
+	if len(secret) < 4 {
+		return sample
+	}
+	sample = strings.ReplaceAll(sample, secret, "***")
+	// Binary samples are rendered as hex. Redact the byte-for-byte hex form too
+	// so non-printable request bodies cannot expose injected credentials.
+	return strings.ReplaceAll(sample, hex.EncodeToString([]byte(secret)), "***")
 }
 
 func isPrintable(b []byte) bool {

--- a/web_config_test.go
+++ b/web_config_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAPIConfigPreviewFormatsAndDiffsWithoutWriting(t *testing.T) {
@@ -211,6 +212,55 @@ func TestAPIConfigSaveRejectsUnpreviewedContent(t *testing.T) {
 	}
 	if !bytes.Equal(contents, original) {
 		t.Fatalf("unpreviewed save wrote file: %q", contents)
+	}
+}
+
+func TestAPIConfigSaveConsumesPreviewTokenOnFailedSave(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	original := []byte("insecure_no_dashboard_secret = true\n")
+	if err := os.WriteFile(cfgPath, original, 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	w := &webMux{g: &Gateway{cfgPath: cfgPath}}
+	preview := previewConfigForTest(t, w, "insecure_no_dashboard_secret=false\n")
+
+	payload := `{"content":"insecure_no_dashboard_secret = true\n","expected_revision":"` + preview.Revision + `","preview_token":"` + preview.PreviewToken + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
+	rr := httptest.NewRecorder()
+	w.apiConfigSave(rr, req)
+	if rr.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status = %d, want 412, body = %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/config/save", strings.NewReader(payload))
+	rr = httptest.NewRecorder()
+	w.apiConfigSave(rr, req)
+	if rr.Code != http.StatusPreconditionRequired {
+		t.Fatalf("reuse status = %d, want 428, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestConfigPreviewTokensPrunedByTTLAndCap(t *testing.T) {
+	w := &webMux{previews: map[string]configPreviewToken{}}
+	now := time.Now()
+	w.previews["expired"] = configPreviewToken{createdAt: now.Add(-configPreviewTokenTTL - time.Second)}
+	w.previews["fresh"] = configPreviewToken{createdAt: now}
+	w.pruneConfigPreviewTokensLocked(now)
+	if _, ok := w.previews["expired"]; ok {
+		t.Fatal("expired token was not pruned")
+	}
+	if _, ok := w.previews["fresh"]; !ok {
+		t.Fatal("fresh token was pruned")
+	}
+
+	w.previews = map[string]configPreviewToken{}
+	for i := 0; i < configPreviewTokenCap; i++ {
+		w.previews[string(rune(i))] = configPreviewToken{createdAt: now.Add(time.Duration(i) * time.Second)}
+	}
+	w.pruneConfigPreviewTokensLocked(now.Add(configPreviewTokenTTL / 2))
+	if len(w.previews) != configPreviewTokenCap-1 {
+		t.Fatalf("token count = %d, want %d", len(w.previews), configPreviewTokenCap-1)
 	}
 }
 

--- a/web_redaction_test.go
+++ b/web_redaction_test.go
@@ -1,9 +1,41 @@
 package main
 
 import (
+	"encoding/hex"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/denoland/clawpatrol/config/runtime"
 )
+
+func TestRedactSecretSampleRedactsBytesAndExtras(t *testing.T) {
+	sec := runtime.Secret{
+		Bytes:  []byte("123456789:REAL_TELEGRAM_TOKEN"),
+		Extras: map[string]string{"bot_token": "extra-secret-value"},
+	}
+
+	got := redactSecretSample(`{"url":"https://example.com/bot123456789:REAL_TELEGRAM_TOKEN/hook","other":"extra-secret-value"}`, []runtime.Secret{sec})
+	if strings.Contains(got, "REAL_TELEGRAM_TOKEN") || strings.Contains(got, "extra-secret-value") {
+		t.Fatalf("sample still contains secret material: %s", got)
+	}
+	if got == "" || got == "***" {
+		t.Fatalf("sample = %q, want redacted sample preserving context", got)
+	}
+}
+
+func TestRedactSecretSampleRedactsHexEncodedBinarySecrets(t *testing.T) {
+	sec := runtime.Secret{Bytes: []byte("binary-secret-value")}
+	hexSecret := hex.EncodeToString(sec.Bytes)
+
+	got := redactSecretSample("binary:0000"+hexSecret+"ffff", []runtime.Secret{sec})
+	if strings.Contains(got, hexSecret) || strings.Contains(got, "binary-secret-value") {
+		t.Fatalf("sample still contains secret material: %s", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("sample = %q, want redaction marker", got)
+	}
+}
 
 func TestFlatHeadersRedactsSensitiveHeaders(t *testing.T) {
 	headers := http.Header{

--- a/ws.go
+++ b/ws.go
@@ -96,7 +96,7 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 	if endpointWantsClientCert(ep) {
 		up, err = g.dialUpstream(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream, ep, profile)
 	} else {
-		up, err = dialBrowserTLS(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream)
+		up, err = g.dialBrowserTLS(context.Background(), "tcp", net.JoinHostPort(upstream, "443"), upstream, ep)
 	}
 	if err != nil {
 		_, _ = fmt.Fprintf(client, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")

--- a/www/src/components/ConfigSaveReview.tsx
+++ b/www/src/components/ConfigSaveReview.tsx
@@ -40,9 +40,9 @@ export function ConfigSaveReview({
         </div>
 
         <div className="px-4 py-3 border-b border-[#e5e5e5] bg-[#fafafa] text-[12px] text-[#404040]">
-          Confirming writes the <span className="font-mono">formatted</span> draft below to disk. If{" "}
-          <span className="font-mono">gateway.hcl</span> changed since this preview, the save is
-          rejected.
+          Confirming writes the <span className="font-mono">formatted</span> config represented by
+          the diff below to disk. If <span className="font-mono">gateway.hcl</span> changed since
+          this preview, the save is rejected.
         </div>
 
         <pre className="config-diff-view flex-1 overflow-auto m-0 p-4 text-[12px] leading-5 font-mono whitespace-pre-wrap language-diff diff-highlight">

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -144,16 +144,6 @@ export async function getRulesJSON(): Promise<string> {
   return JSON.stringify(data ?? [], null, 2);
 }
 
-export async function putRulesJSON(json: string): Promise<{ ok: boolean; count: number }> {
-  const r = await api("/api/rules", {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: json,
-  });
-  if (!r.ok) throw new Error(await r.text());
-  return r.json();
-}
-
 // HCL editor. /api/config returns the full gateway.hcl as raw text.
 
 export async function getConfigHCL(): Promise<string> {
@@ -204,12 +194,6 @@ export async function saveConfigHCL(
   });
   if (!r.ok) throw new Error(await r.text());
   return r.json();
-}
-
-export async function getDeviceRulesHCL(ip: string): Promise<string> {
-  const r = await api(`/api/rules/device?ip=${encodeURIComponent(ip)}&format=hcl`);
-  if (!r.ok) throw new Error(await r.text());
-  return r.text();
 }
 
 export async function listProfiles(): Promise<string[]> {


### PR DESCRIPTION
## Summary
- harden audit-sensitive runtime paths for transport/tunnel lifecycle, profile dispatch, request redaction, and config preview handling
- strengthen Postgres SQL policy metadata extraction for multi-statement verbs, CTE DML, quoted/Unicode identifiers, comma-separated tables, table-valued functions, and destructive table operations
- improve telemetry/version handling and remove unsafe dashboard/client assumptions, with regression coverage across Go, site worker, and dashboard code

## Test plan
- `go test ./...`
- `cd site && npm run typecheck && npm test && npm run build`
- `cd www && npm run format:check && npm run lint && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Review
- Multiple independent adversarial review loops were run.
- Review-discovered blockers were fixed with regression tests, including Postgres `DROP TABLE IF EXISTS`, leading semicolon verbs, data-modifying CTE verbs, `U&`/`UESCAPE` identifiers, comma-separated table lists, table-valued functions, stale tunnel reload handling, binary hex secret redaction, and SemVer prerelease ordering.
- Final independent review result: `APPROVED_NO_FINDINGS`.
