### PR TITLE
Use context diffs for realistic gateway configs

### DIFF
--- a/web.go
+++ b/web.go
@@ -1053,6 +1053,8 @@ type diffOp struct {
 	newLine int
 }
 
+const maxUnifiedDiffCells = 4_000_000 // ~32 MiB DP table on 64-bit Go; covers ~2k x ~2k line configs.
+
 func unifiedDiff(oldName, newName, oldText, newText string) string {
 	if oldText == newText {
 		return ""
@@ -1062,7 +1064,7 @@ func unifiedDiff(oldName, newName, oldText, newText string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "--- %s\n+++ %s\n", oldName, newName)
 
-	if len(oldLines) > 0 && len(newLines) > 0 && len(oldLines) > 250000/len(newLines) {
+	if len(oldLines) > 0 && len(newLines) > 0 && len(oldLines) > maxUnifiedDiffCells/len(newLines) {
 		fmt.Fprintf(&b, "@@ -1,%d +1,%d @@\n", len(oldLines), len(newLines))
 		for _, line := range oldLines {
 			b.WriteByte('-')

--- a/web_config_test.go
+++ b/web_config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -125,6 +126,34 @@ func TestUnifiedDiffSplitsDistantChangesIntoSeparateHunks(t *testing.T) {
 	}
 	if strings.Contains(diff, " line 07\n") {
 		t.Fatalf("diff included distant unchanged middle context:\n%s", diff)
+	}
+}
+
+func TestUnifiedDiffUsesContextDiffForRealisticGatewayConfigSize(t *testing.T) {
+	const lineCount = 600
+	oldLines := make([]string, lineCount)
+	newLines := make([]string, lineCount)
+	for i := range oldLines {
+		oldLines[i] = fmt.Sprintf("line %03d", i+1)
+		newLines[i] = oldLines[i]
+	}
+	newLines[520] = "line 521 changed"
+
+	diff := unifiedDiff("gateway.hcl", "formatted draft",
+		strings.Join(oldLines, "\n")+"\n",
+		strings.Join(newLines, "\n")+"\n",
+	)
+
+	if strings.Contains(diff, "@@ -1,600 +1,600 @@") {
+		t.Fatalf("diff fell back to full-file hunk:\n%s", diff)
+	}
+	for _, want := range []string{"-line 521", "+line 521 changed"} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("diff missing %q:\n%s", want, diff)
+		}
+	}
+	if strings.Contains(diff, " line 300\n") {
+		t.Fatalf("diff included distant unchanged context:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- raise the unified diff fallback threshold from 250k to 4M cells so realistic `gateway.hcl` files keep context hunks instead of falling back to a full-file diff
- add regression coverage for a 600-line config with a one-line edit, ensuring the diff includes the changed line without distant unchanged context

## Test plan
- `cd www && npm ci && npm run build`
- `go test . -run 'TestUnifiedDiff(UsesContextDiffForRealisticGatewayConfigSize|SplitsDistantChangesIntoSeparateHunks)' -count=1`
- `go test ./...`
- `gofmt -l web.go web_config_test.go`
- `git diff --check`
