### PR TITLE
fix(ne): rename sleepWithCompletionHandler for Xcode 16.4

### DIFF
--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -161,7 +161,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     // causing startProxy to be called again. Setting reasserting=true
     // during sleep tells the runtime the tunnel is temporarily down;
     // clearing it on wake avoids a full stop/start cycle.
-    override func sleepWithCompletionHandler(_ completionHandler: @escaping () -> Void) {
+    override func sleep(completionHandler: @escaping () -> Void) {
         reasserting = true
         completionHandler()
     }


### PR DESCRIPTION
Fixes the release CI failure in the `macos-app` job.

Xcode 16.4 (macOS 15.5 SDK) made the `NEProvider` Swift rename a hard error:

```
Provider.swift:164:19: error: 'sleepWithCompletionHandler' has been renamed to 'sleep(completionHandler:)'
** ARCHIVE FAILED **
```

One-line fix: `sleepWithCompletionHandler(_:)` → `sleep(completionHandler:)`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)