### PR TITLE
fix(macos): bypassUDP silently drops all IPv4 UDP — AF_UNSPEC/AF_INET6 sockaddr mismatch

### DIFF
--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -742,8 +742,12 @@ extension BypassUDP: Hashable {
 
 private func fillSockaddr(_ ss: inout sockaddr_storage, host: String, port: String) -> Bool {
     guard let p = UInt16(port) else { return false }
-    var hints = addrinfo(ai_flags: AI_NUMERICHOST | AI_NUMERICSERV,
-                         ai_family: AF_UNSPEC, ai_socktype: SOCK_DGRAM,
+    // AF_INET6 + AI_V4MAPPED: IPv4 addresses are returned as IPv4-mapped
+    // sockaddr_in6 (::ffff:x.x.x.x), which sendto accepts on the dual-stack
+    // AF_INET6 socket. AF_UNSPEC returns sockaddr_in for IPv4, which sendto
+    // rejects with EAFNOSUPPORT — silently dropped → all UDP bypasses fail.
+    var hints = addrinfo(ai_flags: AI_NUMERICHOST | AI_NUMERICSERV | AI_V4MAPPED,
+                         ai_family: AF_INET6, ai_socktype: SOCK_DGRAM,
                          ai_protocol: IPPROTO_UDP, ai_addrlen: 0,
                          ai_canonname: nil, ai_addr: nil, ai_next: nil)
     var res: UnsafeMutablePointer<addrinfo>?


### PR DESCRIPTION
## Root cause

`fillSockaddr` used `AF_UNSPEC` in `getaddrinfo` hints, returning `sockaddr_in` (AF_INET) for IPv4 addresses. The bypass socket is `AF_INET6` dual-stack. `sendto` with AF_INET6 socket + AF_INET `sockaddr_in` returns `EAFNOSUPPORT` — discarded silently because `sendOne` ignores the return value.

**Every bypassed UDP flow sent nothing, got no reply, timed out. DNS to Tailscale MagicDNS (`100.100.100.100:53`), `8.8.8.8:53`, NTP, QUIC — all silently dropped → internet broken while NE active.**

Confirmed in logs: UDP flows accepted, DNS query bytes written, retried every ~1s, then system logged `Closing reads, not closed by plugin` — closed because plugin never wrote a response back.

## Fix

`AF_INET6 + AI_V4MAPPED` in `getaddrinfo` hints: IPv4 addresses returned as IPv4-mapped `sockaddr_in6` (`::ffff:x.x.x.x`), which `sendto` accepts on the dual-stack socket. On Darwin, `getnameinfo(NI_NUMERICHOST)` converts IPv4-mapped `sockaddr_in6` back to dotted-decimal on recv — source endpoints returned to flows stay as plain IPv4 strings.

## Test plan

- [ ] Enable NE, verify DNS resolves (`dig google.com @100.100.100.100`)
- [ ] Normal browsing works while NE active (non-clawpatrol browser, per-process mode)
- [ ] No `Closing reads, not closed by plugin` for DNS flows in system log
- [ ] clawpatrol children still tunnel correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)