### PR TITLE
doc: dry-run design proposal (discussion)

### DIFF
--- a/doc/dry-run-design.md
+++ b/doc/dry-run-design.md
@@ -6,26 +6,33 @@
 ## Goal
 
 Add a CLI subcommand that runs a candidate HCL policy against a
-**fixture suite of actions with expected verdicts** and reports
-pass/fail, like a test runner:
+**recorded actions file** and reports any verdicts the new policy
+would change:
 
 ```
-clawpatrol test --config ./candidate.hcl --suite ./actions.json
+clawpatrol test --config ./candidate.hcl --actions ./actions.json
 ```
 
-The suite is a list of `{action, expected_verdict}` pairs. The
-command compiles the candidate config in-process and runs each
-action through `runtime.MatchRequest`, comparing the returned
-verdict against the expected one. Exit status is non-zero on any
-mismatch.
+The actions file is a list of recorded gateway actions. Each
+entry carries the request the gateway saw and the verdict it
+produced — `action` (`allow` / `deny` / `approve` /
+`passthrough`), the name of the matched `rule`, and the
+`reason`. Nothing in the format is test-specific: it is the same
+shape the gateway logs for live traffic, just persisted to a
+file.
 
-To keep the suite-authoring burden low, the dashboard grows a
-**"Download as test suite"** button on its recent-actions view.
-The button emits a ready-made suite file populated from the
-actions the gateway has actually seen, each pre-filled with the
-verdict it produced under the live config. Operators run that
-file as-is to lock in current behaviour, or edit individual
-entries to drive a policy change.
+`clawpatrol test` compiles the candidate config in-process, runs
+each request through `runtime.MatchRequest`, and reports any
+entry whose new verdict differs from the recorded one. Exit
+status is non-zero on any diff.
+
+To keep the authoring burden low, the dashboard grows a
+**"Download actions"** button on its recent-actions view. The
+button emits an actions file populated from the actions the
+gateway has actually seen, each carrying the verdict it produced
+under the live config. Operators run that file as-is to lock in
+current behaviour, or edit individual entries to drive a policy
+change.
 
 The point is iteration speed and CI: today an operator changes a
 rule, pushes a full config reload, watches live traffic, and
@@ -48,7 +55,7 @@ That's the entire surface this subcommand needs to drive.
 
 A `match.Request` is plain data: `Family`, `Method`, `URL`,
 `Headers`, `Body`, `PeerIP`, parsed path. It serializes cleanly
-to JSON, which is what the suite format is.
+to JSON, which is what the actions-file format is built on.
 
 ### 1.2 Config compile is reusable from a CLI process
 
@@ -63,12 +70,18 @@ CLI process — no gateway required.
 The event sink (`web.go:1582`, `Sink` / `Event`) buffers the
 last 500 actions in-memory and persists to SQLite. The
 dashboard's `/api/state` and `/api/events` endpoints already
-expose this stream, and `Event` carries everything the suite
-needs: `Method`, `Path`, `ReqHeaders`, `ReqBody`, `Host`,
-`Mode`, plus the produced verdict in `Action` + `Reason`.
+expose this stream, and `Event` carries most of what the
+actions file needs: `Method`, `Path`, `ReqHeaders`, `ReqBody`,
+`Host`, `Mode`, plus the produced verdict in `Action` +
+`Reason`. The matched rule name is **not** currently on
+`Event` — `MatchRequest` returns the `*CompiledRule` (which
+has `.Name`), but the call sites at `main.go:1638` etc. drop
+it before logging. A small extension of `Event` (`Rule string`)
+populated at the existing dispatch sites is enough; no new
+plumbing.
 
-A "download these as a test suite" endpoint is a re-shape of an
-existing dataset, not a new pipeline.
+A "download these as an actions file" endpoint is then a
+re-shape of an existing dataset, not a new pipeline.
 
 ### 1.4 Subcommand wiring
 
@@ -83,20 +96,20 @@ sibling file (`run_linux.go`, `onboard.go`, etc.). Adding
 ┌──────────────────────────────────┐    ┌──────────────────────────────┐
 │  clawpatrol test                 │    │  gateway dashboard           │
 │   --config candidate.hcl         │    │                              │
-│   --suite actions.json           │    │  recent actions view         │
+│   --actions actions.json         │    │  recent actions view         │
 │                                  │    │  ┌────────────────────────┐  │
-│  1. config.Load(candidate.hcl)   │    │  │ [Download test suite]  │  │
+│  1. config.Load(candidate.hcl)   │    │  │ [Download actions]     │  │
 │     + config.Compile()           │    │  └────────────────────────┘  │
 │                                  │    │            │                 │
-│  2. read suite.json              │    │            ▼                 │
-│     → []SuiteEntry{              │    │  GET /api/actions/export     │
-│         req: match.Request,      │    │   → ndjson over last N       │
-│         want: Verdict,           │    │     events, each rendered    │
-│       }                          │    │     as a SuiteEntry          │
-│                                  │    │     (req + observed verdict) │
+│  2. read actions.json            │    │            ▼                 │
+│     → []Action{                  │    │  GET /api/actions/export     │
+│         request: match.Request,  │    │   → ndjson over last N       │
+│         verdict: Verdict,        │    │     events, each rendered    │
+│       }                          │    │     as an Action             │
+│                                  │    │     (request + verdict)      │
 │  3. for each entry:              │◀───┤                              │
 │       got := MatchRequest(...)   │    └──────────────────────────────┘
-│       diff against want          │
+│       diff got vs verdict        │
 │                                  │
 │  4. print summary + exit code    │
 └──────────────────────────────────┘
@@ -104,31 +117,47 @@ sibling file (`run_linux.go`, `onboard.go`, etc.). Adding
 
 Concrete plumbing:
 
-- **Suite format** (new): newline-delimited JSON, one entry per
-  line:
+- **Actions format** (new): newline-delimited JSON, one entry
+  per line. Same shape whether the file came from the dashboard
+  exporter or was hand-written:
   ```
-  {"name":"...", "request":{...match.Request...}, "expect":{"action":"allow","reason_contains":"..."}}
+  {"request":{...match.Request...}, "verdict":{"action":"allow","rule":"public-readonly","reason":"..."}}
   ```
+  - `verdict.action` is one of `allow`, `deny`, `approve`,
+    `passthrough`. `approve` is terminal — the human approver
+    chain is not invoked (§3.C).
+  - `verdict.rule` is the name of the matched `CompiledRule`
+    (`config/compile.go:165`), or empty when nothing matched
+    and the endpoint default fired.
+  - `verdict.reason` is the human-readable string the runtime
+    produced.
+  No `expected_*` / `assert_*` keys — the format is not
+  test-specific. The CLI is the test runner; the file is
+  recorded reality.
   ndjson because it streams cleanly, diffs cleanly, and the
   dashboard can emit it incrementally.
-- **CLI** (`test.go`, new file): parses `--config`, `--suite`,
+- **CLI** (`test.go`, new file): parses `--config`, `--actions`,
   optional `--endpoint` (which compiled endpoint to dispatch
   against — defaults to first matching by host), optional
-  `--update` to rewrite the suite file with observed verdicts.
+  `--update` to rewrite the actions file with the new verdicts.
   No network, no auth, no gateway dependency.
 - **Test runner**: a thin loop that calls `MatchRequest` per
-  entry and compares. Verdict comparison: exact match on
-  `Action`; `reason_contains` substring match on `Reason` if
-  set. Mismatches print a diff and bump the failure counter.
+  entry and compares the new verdict against the recorded one.
+  Comparison: exact match on `verdict.action` and
+  `verdict.rule`. Mismatches print a diff and bump the failure
+  counter. `verdict.reason` is informational and not part of
+  the comparison (it changes too freely under safe edits).
 - **Dashboard endpoint**: `GET /api/actions/export` returns the
   ndjson form of the recent-events ring. The dashboard UI gets
-  a "Download test suite" button on the actions list that hits
+  a "Download actions" button on the actions list that hits
   this endpoint and offers the result as a file download. Auth:
   same `dashboard_secret` as the rest of `/api/*` (§3.E).
-- **Dashboard renderer**: for each `Event` in the export window,
-  map fields → `match.Request` and `expect.action = ev.Action`
-  / `expect.reason_contains = ev.Reason`. Output is "what the
-  gateway actually decided" — a regression baseline.
+- **Dashboard renderer**: for each `Event` in the export
+  window, map fields → `request: match.Request` and
+  `verdict: {action: ev.Action, rule: ev.Rule, reason:
+  ev.Reason}`. This requires the small `Event.Rule` extension
+  noted in §1.3. Output is "what the gateway actually
+  decided" — a regression baseline.
 
 This design removes everything that was hard about the previous
 proposal: no session keying, no ephemeral peers, no response
@@ -137,9 +166,10 @@ endpoint, no TTL sweep, no live-traffic carve-out.
 
 ## 3. Open questions (please answer before code)
 
-### A. Suite scope: per-endpoint or global?
+### A. Actions-file scope: per-endpoint or global?
 
-`MatchRequest` is per-`CompiledEndpoint`. The suite either:
+`MatchRequest` is per-`CompiledEndpoint`. The actions file
+either:
 
 1. Pins each entry to an endpoint by name (or by host →
    endpoint resolution at run time), then dispatches into that
@@ -149,7 +179,7 @@ endpoint, no TTL sweep, no live-traffic carve-out.
    the compiled policy) before dispatching. Closer to "what
    would the gateway do end-to-end with this request?"
 
-**Recommendation: (2)**, with the suite carrying the original
+**Recommendation: (2)**, with each entry carrying the original
 `Host` field. It matches what operators read on the dashboard
 and what the export button can populate without extra metadata.
 (1) is a fallback if some endpoint family doesn't fit clean
@@ -175,23 +205,25 @@ fields are sufficient for replay.
 **Decision needed:** OK to ship HTTPS-first with SQL family
 support landing in a follow-up bead if any field is missing?
 
-### C. Approver-chain (HITL) verdicts in the suite
+### C. Approver-chain (HITL) verdicts in the actions file
 
-A live `approve` verdict in production triggers the human
-approver chain. Under `clawpatrol test`, running approvers is
-wrong (pages humans, slow, non-deterministic).
+A live `approve` verdict in production hands off to the human
+approver chain, which ultimately produces an `allow` / `deny`.
+Under `clawpatrol test`, invoking that chain is wrong (pages
+humans, slow, non-deterministic).
 
-**Recommendation:** the test runner treats `approve` as a
-terminal verdict — it matches the literal string `approve`
-without invoking any chain. This is consistent with the suite
-being a *policy match* test, not an end-to-end test.
+**Resolved (per review):** both the recorded verdict and the
+runner treat `approve` as terminal. The exporter writes
+`verdict.action = "approve"` whenever the matched rule routes
+to a human approver, and the runner compares that literal
+string without invoking any chain. The actions file is a
+*policy match* file, not an end-to-end recording — what the
+human ultimately decided is out of scope.
 
-**Decision needed:** confirm.
-
-### D. Suite emission: redaction
+### D. Actions-file emission: redaction
 
 `Event.ReqBody` and `RespBody` may contain secrets the operator
-doesn't want in a checked-in suite file. The export endpoint
+doesn't want in a checked-in actions file. The export endpoint
 should respect the same redaction rules the dashboard already
 applies for display (`web_redaction_test.go` exists — confirm
 during implementation that those rules are reusable here).
@@ -217,11 +249,11 @@ How many recent events should the button download?
 
 - Whole ring (last 500): matches what the dashboard already
   shows; simplest mental model.
-- Time-windowed (`?since=...`): supports "test suite for the
-  last hour of activity"; small UI addition.
+- Time-windowed (`?since=...`): supports "actions from the last
+  hour of activity"; small UI addition.
 - Filter by `agent` / `mode` / `host`: lets operators export a
-  per-agent or per-host suite. Likely useful given the dashboard
-  already filters this way.
+  per-agent or per-host actions file. Likely useful given the
+  dashboard already filters this way.
 
 **Recommendation:** start with whole ring + `?since=` query
 parameter. Per-agent/per-host filtering can land as the UI
@@ -235,23 +267,28 @@ After the above questions are answered, the implementation PR should:
 
 - Add `clawpatrol test` subcommand (`test.go`) — pure CLI,
   no gateway dependency.
-- Define the ndjson suite format (`test_suite.go` or similar)
-  shared between the CLI runner and the dashboard exporter.
+- Define the ndjson actions format (`actions_file.go` or
+  similar) shared between the CLI runner and the dashboard
+  exporter.
+- Extend `Event` with `Rule string` and populate it at the
+  existing dispatch sites (`main.go:1638`, postgres,
+  clickhouse_native) so the exporter can carry the matched
+  rule name.
 - Add `GET /api/actions/export` returning the recent-events
-  ring as suite ndjson, with redaction reusing the dashboard's
-  existing rules.
-- Add the "Download test suite" button to the dashboard's
+  ring as actions ndjson, with redaction reusing the
+  dashboard's existing rules.
+- Add the "Download actions" button to the dashboard's
   recent-actions view.
 - HTTPS endpoint family in v1; SQL families covered if their
   recorded event fields are sufficient.
-- Tests: unit tests for the runner (verdict match / mismatch /
-  reason substring), a golden-file test for export ndjson
+- Tests: unit tests for the runner (verdict match / mismatch
+  on action and rule), a golden-file test for export ndjson
   shape, and an integration test that exports → runs → asserts
-  100% pass on the current config.
+  zero diffs against the current config.
 
 Out of scope for v1: live-session candidate dispatch (the
 previous proposal — superseded), mock upstream, time-travel
-replay against a historical config, suite-vs-suite diffing.
+replay against a historical config, file-vs-file diffing.
 
 ## 5. References
 

--- a/doc/dry-run-design.md
+++ b/doc/dry-run-design.md
@@ -5,34 +5,40 @@
 
 ## Goal
 
-Add a CLI subcommand that runs a candidate HCL policy against a
-**recorded actions file** and reports any verdicts the new policy
-would change:
+Add a CLI subcommand that runs a candidate HCL policy against
+**recorded gateway actions** — one JSON file per action, checked
+into a `testdata/` (or `fixtures/`) directory — and reports any
+verdicts the new policy would change. Operators can run against a
+single file or against a whole directory:
 
 ```
-clawpatrol test --config ./candidate.hcl --actions ./actions.json
+clawpatrol test candidate.hcl testdata/action1.json
+clawpatrol test candidate.hcl testdata/
 ```
 
-The actions file is a list of recorded gateway actions. Each
-entry carries the request the gateway saw and the verdict it
-produced — `action` (`allow` / `deny` / `approve` /
+Each file under the actions directory is one recorded gateway
+action. It carries the request the gateway saw and the verdict
+it produced — `action` (`allow` / `deny` / `approve` /
 `passthrough`), the name of the matched `rule`, and the
 `reason`. Nothing in the format is test-specific: it is the same
 shape the gateway logs for live traffic, just persisted to a
-file.
+file. One file per action keeps each fixture independently
+diffable, easy to add or remove, and trivial to skip by renaming.
 
 `clawpatrol test` compiles the candidate config in-process, runs
 each request through `runtime.MatchRequest`, and reports any
 entry whose new verdict differs from the recorded one. Exit
-status is non-zero on any diff.
+status is non-zero if any verdict (e.g. `approve`, `deny`) the
+candidate produces does not match the decision stored in the
+file — for a directory run, any single mismatch fails the run.
 
 To keep the authoring burden low, the dashboard grows a
 **"Download actions"** button on its recent-actions view. The
-button emits an actions file populated from the actions the
-gateway has actually seen, each carrying the verdict it produced
-under the live config. Operators run that file as-is to lock in
-current behaviour, or edit individual entries to drive a policy
-change.
+button emits a zip of one file per recorded action, populated
+from what the gateway has actually seen and each carrying the
+verdict it produced under the live config. Operators unpack into
+`testdata/` and run as-is to lock in current behaviour, or edit
+individual files to drive a policy change.
 
 The point is iteration speed and CI: today an operator changes a
 rule, pushes a full config reload, watches live traffic, and
@@ -55,7 +61,7 @@ That's the entire surface this subcommand needs to drive.
 
 A `match.Request` is plain data: `Family`, `Method`, `URL`,
 `Headers`, `Body`, `PeerIP`, parsed path. It serializes cleanly
-to JSON, which is what the actions-file format is built on.
+to JSON, which is what each per-action file holds.
 
 ### 1.2 Config compile is reusable from a CLI process
 
@@ -80,8 +86,8 @@ it before logging. A small extension of `Event` (`Rule string`)
 populated at the existing dispatch sites is enough; no new
 plumbing.
 
-A "download these as an actions file" endpoint is then a
-re-shape of an existing dataset, not a new pipeline.
+A "download these as a zipped actions directory" endpoint is
+then a re-shape of an existing dataset, not a new pipeline.
 
 ### 1.4 Subcommand wiring
 
@@ -95,33 +101,46 @@ sibling file (`run_linux.go`, `onboard.go`, etc.). Adding
 ```
 ┌──────────────────────────────────┐    ┌──────────────────────────────┐
 │  clawpatrol test                 │    │  gateway dashboard           │
-│   --config candidate.hcl         │    │                              │
-│   --actions actions.json         │    │  recent actions view         │
+│   candidate.hcl                  │    │                              │
+│   testdata/                      │    │  recent actions view         │
 │                                  │    │  ┌────────────────────────┐  │
 │  1. config.Load(candidate.hcl)   │    │  │ [Download actions]     │  │
 │     + config.Compile()           │    │  └────────────────────────┘  │
 │                                  │    │            │                 │
-│  2. read actions.json            │    │            ▼                 │
-│     → []Action{                  │    │  GET /api/actions/export     │
-│         request: match.Request,  │    │   → ndjson over last N       │
-│         verdict: Verdict,        │    │     events, each rendered    │
-│       }                          │    │     as an Action             │
-│                                  │    │     (request + verdict)      │
-│  3. for each entry:              │◀───┤                              │
-│       got := MatchRequest(...)   │    └──────────────────────────────┘
+│  2. resolve path arg:            │    │            ▼                 │
+│     • file → one Action          │    │  GET /api/actions/export     │
+│     • dir  → glob *.json         │    │   → zip of one .json per     │
+│                                  │    │     event in the export      │
+│     each loads as:               │    │     window (request +        │
+│       Action{                    │    │     verdict per file)        │
+│         request: match.Request,  │    │                              │
+│         verdict: Verdict,        │    └──────────────────────────────┘
+│       }                          │
+│                                  │
+│  3. for each Action:             │
+│       got := MatchRequest(...)   │
 │       diff got vs verdict        │
 │                                  │
 │  4. print summary + exit code    │
+│     (non-zero on any mismatch)   │
 └──────────────────────────────────┘
 ```
 
 Concrete plumbing:
 
-- **Actions format** (new): newline-delimited JSON, one entry
-  per line. Same shape whether the file came from the dashboard
-  exporter or was hand-written:
-  ```
-  {"request":{...match.Request...}, "verdict":{"action":"allow","rule":"public-readonly","reason":"..."}}
+- **Actions format** (new): one JSON file per action, checked
+  into a `testdata/` (or `fixtures/`) directory. Same shape
+  whether the file came from the dashboard exporter or was
+  hand-written:
+  ```json
+  {
+    "request": { "...match.Request..." },
+    "verdict": {
+      "action": "allow",
+      "rule":   "public-readonly",
+      "reason": "..."
+    }
+  }
   ```
   - `verdict.action` is one of `allow`, `deny`, `approve`,
     `passthrough`. `approve` is terminal — the human approver
@@ -132,32 +151,43 @@ Concrete plumbing:
   - `verdict.reason` is the human-readable string the runtime
     produced.
   No `expected_*` / `assert_*` keys — the format is not
-  test-specific. The CLI is the test runner; the file is
-  recorded reality.
-  ndjson because it streams cleanly, diffs cleanly, and the
-  dashboard can emit it incrementally.
-- **CLI** (`test.go`, new file): parses `--config`, `--actions`,
-  optional `--endpoint` (which compiled endpoint to dispatch
-  against — defaults to first matching by host), optional
-  `--update` to rewrite the actions file with the new verdicts.
-  No network, no auth, no gateway dependency.
+  test-specific. The CLI is the test runner; each file is
+  recorded reality. One file per action keeps each fixture
+  independently diffable in `git`, makes it easy to add or
+  remove a single case, and lets operators skip a case by
+  renaming or deleting one file rather than editing a
+  multi-record blob.
+- **CLI** (`test.go`, new file): two positional args —
+  `clawpatrol test <config> <path>` — where `<path>` is either
+  a single `*.json` file or a directory. Directory mode globs
+  `*.json` at the top level (no recursion in v1; revisit if
+  operators ask for it). Flags: optional `--endpoint` (which
+  compiled endpoint to dispatch against — defaults to first
+  matching by host) and optional `--update` to rewrite the
+  matching files in place with the new verdicts. No network,
+  no auth, no gateway dependency.
 - **Test runner**: a thin loop that calls `MatchRequest` per
-  entry and compares the new verdict against the recorded one.
+  file and compares the new verdict against the recorded one.
   Comparison: exact match on `verdict.action` and
-  `verdict.rule`. Mismatches print a diff and bump the failure
-  counter. `verdict.reason` is informational and not part of
-  the comparison (it changes too freely under safe edits).
-- **Dashboard endpoint**: `GET /api/actions/export` returns the
-  ndjson form of the recent-events ring. The dashboard UI gets
-  a "Download actions" button on the actions list that hits
-  this endpoint and offers the result as a file download. Auth:
-  same `dashboard_secret` as the rest of `/api/*` (§3.E).
+  `verdict.rule`. Mismatches print a diff keyed by file path
+  and bump the failure counter. Exit status is non-zero if any
+  file mismatches. `verdict.reason` is informational and not
+  part of the comparison (it changes too freely under safe
+  edits).
+- **Dashboard endpoint**: `GET /api/actions/export` returns a
+  `application/zip` of one `<action-id>.json` file per event
+  in the export window. The dashboard UI gets a "Download
+  actions" button on the actions list that hits this endpoint
+  and offers the result as a `.zip` download. Auth: same
+  `dashboard_secret` as the rest of `/api/*` (§3.E).
 - **Dashboard renderer**: for each `Event` in the export
   window, map fields → `request: match.Request` and
   `verdict: {action: ev.Action, rule: ev.Rule, reason:
-  ev.Reason}`. This requires the small `Event.Rule` extension
-  noted in §1.3. Output is "what the gateway actually
-  decided" — a regression baseline.
+  ev.Reason}`, emit as a single JSON file under a stable name
+  (e.g. `<timestamp>-<short-sha>.json`), zip the lot. This
+  requires the small `Event.Rule` extension noted in §1.3.
+  Output is "what the gateway actually decided" — a
+  regression baseline.
 
 This design removes everything that was hard about the previous
 proposal: no session keying, no ephemeral peers, no response
@@ -216,14 +246,14 @@ humans, slow, non-deterministic).
 runner treat `approve` as terminal. The exporter writes
 `verdict.action = "approve"` whenever the matched rule routes
 to a human approver, and the runner compares that literal
-string without invoking any chain. The actions file is a
-*policy match* file, not an end-to-end recording — what the
+string without invoking any chain. Each action file is a
+*policy match* record, not an end-to-end recording — what the
 human ultimately decided is out of scope.
 
-### D. Actions-file emission: redaction
+### D. Actions emission: redaction
 
 `Event.ReqBody` and `RespBody` may contain secrets the operator
-doesn't want in a checked-in actions file. The export endpoint
+doesn't want in checked-in fixture files. The export endpoint
 should respect the same redaction rules the dashboard already
 applies for display (`web_redaction_test.go` exists — confirm
 during implementation that those rules are reusable here).
@@ -252,7 +282,7 @@ How many recent events should the button download?
 - Time-windowed (`?since=...`): supports "actions from the last
   hour of activity"; small UI addition.
 - Filter by `agent` / `mode` / `host`: lets operators export a
-  per-agent or per-host actions file. Likely useful given the
+  per-agent or per-host fixture set. Likely useful given the
   dashboard already filters this way.
 
 **Recommendation:** start with whole ring + `?since=` query
@@ -266,25 +296,27 @@ needs it.
 After the above questions are answered, the implementation PR should:
 
 - Add `clawpatrol test` subcommand (`test.go`) — pure CLI,
-  no gateway dependency.
-- Define the ndjson actions format (`actions_file.go` or
+  no gateway dependency. Two positional args:
+  `clawpatrol test <config> <file-or-dir>`.
+- Define the per-action JSON format (`action_file.go` or
   similar) shared between the CLI runner and the dashboard
   exporter.
 - Extend `Event` with `Rule string` and populate it at the
   existing dispatch sites (`main.go:1638`, postgres,
   clickhouse_native) so the exporter can carry the matched
   rule name.
-- Add `GET /api/actions/export` returning the recent-events
-  ring as actions ndjson, with redaction reusing the
-  dashboard's existing rules.
+- Add `GET /api/actions/export` returning a zip of one
+  `<id>.json` per event in the recent-events ring, with
+  redaction reusing the dashboard's existing rules.
 - Add the "Download actions" button to the dashboard's
   recent-actions view.
 - HTTPS endpoint family in v1; SQL families covered if their
   recorded event fields are sufficient.
 - Tests: unit tests for the runner (verdict match / mismatch
-  on action and rule), a golden-file test for export ndjson
-  shape, and an integration test that exports → runs → asserts
-  zero diffs against the current config.
+  on action and rule, single-file and directory modes), a
+  golden-file test for export zip shape, and an integration
+  test that exports → unpacks → runs → asserts zero diffs
+  against the current config.
 
 Out of scope for v1: live-session candidate dispatch (the
 previous proposal — superseded), mock upstream, time-travel

--- a/doc/dry-run-design.md
+++ b/doc/dry-run-design.md
@@ -1,0 +1,337 @@
+# clawpatrol — `dry-run` design proposal
+
+> **Status:** design / discussion. No implementation yet. Open
+> questions in §3 must be resolved before code lands.
+
+## Goal
+
+Add a CLI subcommand that lets an operator try a candidate HCL
+policy against the **live production gateway**, scoped to a single
+session, with no upstream traffic actually forwarded:
+
+```
+clawpatrol dry-run --config ./candidate.hcl <cmd> [args...]
+```
+
+Same shape as `clawpatrol run`, but every action the wrapped agent
+generates is matched against the candidate config rather than the
+gateway's global config, and the gateway returns synthesised
+responses instead of proxying. When the session ends, the candidate
+config is dropped.
+
+The point is iteration speed: operators currently have to push a
+full config reload to test a rule change, which affects every
+device. Dry-run lets one operator probe a candidate config from
+their own machine without touching anybody else's traffic.
+
+## 1. What I read
+
+Citations are file:line in `denoland/clawpatrol@main`.
+
+### 1.1 Single policy-dispatch point exists (HTTPS path)
+
+`runtime.MatchRequest(ep, req)` at `config/runtime/dispatch.go:45`
+walks an endpoint's priority-sorted rule list and returns the first
+match. The HTTPS / K8s path calls this exactly once per request at
+`main.go:1632` after building a `match.Request` containing
+`Family`, `Method`, `URL`, `Headers`, `Body`, `PeerIP` and (for
+k8s) the parsed path.
+
+The compiled policy is held atomically on the `Gateway` struct and
+read via `g.Policy()` (atomic load of `*config.CompiledPolicy`).
+SIGHUP / mtime-based reload swaps it in via `g.policy.Store(cp)`,
+so request handlers always see a consistent snapshot for the
+lifetime of one request.
+
+### 1.2 SQL plugins do their own matching
+
+postgres / clickhouse_native do **not** route through
+`MatchRequest`. They walk rules themselves inside their per-conn
+handlers (`main.go:1169` for postgres). This is relevant for
+acceptance criteria — the first iteration probably can't cover
+every endpoint family with one shim; HTTPS is the cheapest
+beachhead.
+
+### 1.3 Session identity at the gateway is `PeerIP`
+
+`peerIP(c net.Conn)` at `main.go:2026` extracts the canonical IPv4
+form of the WG remote address and is the universal session key.
+`g.profileFor(pip)` (`main.go:319`) and the onboard registry
+(`onboard.go:121`) are both keyed by it. Every per-request lookup
+flows through this.
+
+### 1.4 But "session" and "PeerIP" are not 1:1 — see §3.A
+
+This is the central design problem. It deserves its own section
+below. The short version: **one Linux host, one PeerIP, even when
+the operator runs N concurrent `clawpatrol run`s.**
+
+### 1.5 Config compile is reusable from a request handler
+
+`loadConfig(path)` at `main.go:92` is `config.Load() +
+config.Compile()`. `Compile()` (`config/compile.go:194`) returns a
+fresh `*CompiledPolicy` with no global mutation. It's safe and
+cheap enough to call on demand for a candidate-config upload (mtime
+poller currently runs it every 3s anyway).
+
+A `*CompiledPolicy` is on the order of 10–100 KB for a real
+config. Holding one extra per active dry-run session is fine.
+
+### 1.6 Existing CLI ↔ gateway control channel
+
+The dashboard's API listener (routes registered at `web.go:208+`)
+already speaks JSON over the same listener as the proxy and gates
+mutating routes on `dashboard_secret` (cookie or
+`X-Clawpatrol-Secret` header — see `checkDashboardSecret`).
+Existing precedent for "client uploads HCL, gateway compiles":
+`POST /api/config/preview` and `POST /api/config/save` already do
+this for the global config (with revision tokens to prevent
+clobbering).
+
+There is no per-device API token usable from the CLI today —
+`api-token` files exist on devices but are scoped to env-pushdown
+flows, not generic API auth.
+
+### 1.7 Subcommand wiring
+
+CLI subcommands live as a flat `switch os.Args[1]` in `main.go`
+(around line 2000), each delegating to a `runFoo(args)` in a
+sibling file (`run_linux.go`, `onboard.go`, etc.). Adding
+`dry-run` is a one-line switch case + a new `dry_run.go`.
+
+## 2. Proposed architecture
+
+```
+┌──────────────────────────────┐         ┌─────────────────────────────────┐
+│  operator's host             │         │  gateway                        │
+│                              │         │                                 │
+│  clawpatrol dry-run          │         │  POST /api/dry-run/sessions     │
+│   --config candidate.hcl     │ ──HCL──▶│   { hcl, ttl }                  │
+│   <cmd> [args...]            │         │   → compile via                 │
+│                              │ ◀─token─│     config.Load()+Compile()     │
+│  ┌────────────────────────┐  │         │   → mint session key            │
+│  │ tunnel established     │  │         │   → store {key→CompiledPolicy}  │
+│  │ with session key       │──tunnel──▶│   → return session token        │
+│  │ (see §3.A)             │  │         │                                 │
+│  └────────────────────────┘  │         │  per-request dispatch:          │
+│                              │         │   if session has dry-run        │
+│  exec <cmd>                  │         │     policy attached:            │
+│   └─ generates requests      │         │     match against candidate,    │
+│                              │         │     synthesise response,        │
+│                              │         │     tag event { dryRun: true }  │
+└──────────────────────────────┘         │   else: normal path             │
+                                         │                                 │
+                                         │  session-end:                   │
+                                         │   drop {key→CompiledPolicy}     │
+                                         └─────────────────────────────────┘
+```
+
+Concrete plumbing:
+
+- **CLI** (`dry_run.go`, new file): `flag.FlagSet` parses
+  `--config`; reads HCL bytes; POSTs them to the gateway's API;
+  receives a session token; establishes the tunnel (delegating to
+  the same code path as `clawpatrol run`) wired with the session
+  token; execs the wrapped command. Whole-machine devices are
+  rejected up front (see §3.B).
+- **Gateway API**: `POST /api/dry-run/sessions` handler in
+  `web.go` accepting `{hcl, ttl}` and returning
+  `{sessionToken, expiresAt}`. Auth: §3.E.
+- **Gateway state**: a new field on `Gateway`, e.g.
+  `dryRun *dryRunRegistry`, mapping session-key →
+  `*config.CompiledPolicy` plus expiry. Single mutex, copy-out
+  semantics (caller gets a pointer to an immutable
+  `CompiledPolicy`).
+- **Dispatch hook**: at `main.go:1632`, before
+  `runtime.MatchRequest(ep, mreq)`, do
+  `if dr := g.dryRun.Lookup(sessionKey); dr != nil { ep =
+  dr.EndpointFor(host, profile); mreq.DryRun = true }`. The
+  request continues through `MatchRequest` against the candidate
+  endpoint definition.
+- **Response synthesis**: when `mreq.DryRun` is true, replace the
+  upstream dial with a synthesiser per verdict (§3.C).
+- **Event tagging**: stamp `Event.DryRun = true` so the dashboard
+  and event sink can filter / badge dry-run actions.
+- **Cleanup**: TTL sweep (e.g. 5 min idle) plus an explicit
+  `DELETE /api/dry-run/sessions/{token}` the CLI calls on clean
+  exit.
+
+## 3. Open questions (please answer before code)
+
+### A. How does the gateway distinguish concurrent sessions on one host?
+
+This is the biggest one and the bead's framing ("session keys off
+WG peer ID") is incomplete. On Linux, `clawpatrol run`
+(`run_linux.go:68`) reads `~/.config/clawpatrol/wg.conf` written
+by `join` — the same WG private key for every invocation. Two
+concurrent `run`s from the same host therefore share one PeerIP at
+the gateway. macOS is even more collapsed: all wrapped processes
+funnel through the macOS extension's single shared WG tunnel and
+appear under one peer.
+
+PeerIP alone cannot tell us whether a request came from a dry-run
+session or from a regular one running in parallel.
+
+Three plausible directions:
+
+1. **Mint an ephemeral WG peer per dry-run session.** The new
+   `POST /api/dry-run/sessions` issues a fresh WG keypair + IP;
+   the CLI brings up its own short-lived tunnel scoped to just
+   the wrapped command's namespace (Linux) or hands the helper a
+   one-off conf (macOS). Each dry-run gets a unique PeerIP, the
+   gateway's existing PeerIP-keyed dispatch needs no schema
+   change, and dropping the peer at session end is a clean teardown
+   signal.
+   Cost: a new gateway code path that mints+revokes ephemeral peers
+   without going through the `join` approval flow.
+2. **In-band session token in request metadata.** CLI injects e.g.
+   an `X-Clawpatrol-DryRun: <token>` header. Works for HTTPS,
+   doesn't work for postgres / clickhouse / non-HTTP without a
+   per-protocol shim. We'd ship HTTPS dry-run first.
+3. **Per-session src-port marking.** CLI's namespace SO_MARKs its
+   sockets / picks a known src-port range; gateway derives session
+   from `(PeerIP, src_port_range)`. Brittle — kernels reuse ports
+   freely.
+
+**Recommendation: (1).** It is the only option that keeps PeerIP
+the universal session key, doesn't require per-plugin protocol
+knowledge, and gives us a clean disconnect signal. Worth the new
+ephemeral-peer endpoint.
+
+**Decision needed:** is (1) acceptable, or do you want (2) and
+explicit "HTTPS-only first" scoping?
+
+### B. Whole-machine mode
+
+`--whole-machine` joins (`login.go:573+`) install a persistent
+`wg-quick` interface routing all host traffic through one peer.
+There is no per-process boundary. Dry-run on whole-machine would
+mean "every packet on this host gets matched against the candidate
+config," which is more like a global config swap than a session
+test.
+
+**Recommendation:** reject `clawpatrol dry-run` on a whole-machine
+device at CLI-time with a clear message ("this host joined in
+whole-machine mode; dry-run is per-process only — re-join without
+`--whole-machine` to use it"). Out of scope for this iteration.
+
+**Decision needed:** confirm reject, or do we want a degraded
+"applies to all host traffic" mode for whole-machine?
+
+### C. Response synthesis per verdict
+
+For the four verdict types:
+
+- **deny** — gateway returns the same shape it would in prod
+  (HTTP 4xx, postgres `ErrorResponse`, etc.). No question.
+- **allow** — must return *something* so the wrapped agent can
+  keep running. Options:
+  - HTTP 200 + empty body + a `X-Clawpatrol-DryRun: allowed`
+    marker header. Cheapest, but the agent may break on missing
+    expected fields.
+  - Per-protocol minimal "OK" (HTTP: 200/empty; postgres: a
+    `ReadyForQuery` after no-op; clickhouse_native: empty `EndOfStream`).
+    Slightly more work, much friendlier to real agents.
+  - Forward to an operator-configured mock upstream.
+    Powerful, much bigger scope.
+- **approve** (HITL) — running approver chains under dry-run is
+  wrong (would page humans). Three options: auto-deny, auto-allow
+  + tag `would-have-required-approval`, or run only the LLM
+  pre-stage and skip the human stage.
+- **passthrough** (`unknown_host`) — same shape as allow.
+
+**Recommendation:** per-protocol minimal OK for `allow` /
+`passthrough`, and **auto-allow + `wouldRequireApproval: true` tag
+on the event** for `approve`. That gives operators "would this
+config let the agent get further than the prod config does" as
+useful signal without paging anyone. Mock upstream is a follow-up
+feature.
+
+**Decision needed:** confirm `approve → auto-allow + tag`.
+
+### D. Server-side state divergence
+
+A would-have-run `INSERT` doesn't actually run, so a follow-up
+`SELECT` won't see the row. The agent's behaviour during dry-run
+diverges from real prod. This is fundamental to the contract — I'll
+document it explicitly in the help text and the design comment so
+operators don't misread dry-run as a faithful end-to-end replay.
+
+**Decision needed:** none, just confirming we accept the
+divergence.
+
+### E. Auth on the upload endpoint
+
+Two reasonable choices:
+
+- **`dashboard_secret`** — reuses existing auth, identical to
+  `/api/config/preview`. But that secret is admin-scoped; an
+  operator who doesn't have the dashboard secret today can't run
+  dry-run, which feels backwards (any device user should be able
+  to test policies for their own session).
+- **Same auth as the device's normal traffic.** The CLI is
+  already running under a joined identity (the WG peer
+  authenticates by key); we'd let any onboarded peer upload a
+  candidate config for its own session.
+
+**Recommendation:** the second. Dry-run is a "test policy for
+*me*" operation; gating it behind the admin secret is too strict.
+
+**Decision needed:** confirm device-scoped auth, or do we want
+admin-only?
+
+### F. Config-discard timing
+
+- Linux ephemeral peer: drop on WG handshake timeout (~3 min idle)
+  or explicit CLI cleanup call.
+- macOS: NE process termination → CLI cleanup call.
+- TTL sweep as a fallback in case both signals are missed.
+
+**Decision needed:** is a 5-minute idle TTL the right fallback?
+Could be longer (15 min) for slow agents.
+
+### G. Logging / metrics contamination
+
+Dry-run actions should land in the same event sink/store so the
+dashboard can render them, but tagged `dryRun: true` so they don't
+contaminate real-traffic metrics (allow rate, deny rate, latency
+SLOs). The dashboard rendering is a follow-up; the tag itself
+lands here.
+
+**Decision needed:** confirm tag-but-store.
+
+## 4. Proposed scope for the first PR
+
+After the above questions are answered, the implementation PR should:
+
+- Add `clawpatrol dry-run` subcommand (Linux per-process + macOS
+  per-process; reject whole-machine).
+- Add the chosen session-keying mechanism from §3.A.
+- Add `POST /api/dry-run/sessions` (and `DELETE /sessions/{id}`)
+  with the chosen auth from §3.E.
+- Hook dispatch at `main.go:1632` to consult the dry-run registry
+  before falling through to the global `MatchRequest` path.
+- HTTPS path only for verdict synthesis in v1.
+- Event tagging (`Event.DryRun bool`).
+- Tests: per-session config attachment & TTL drop; HTTPS dry-run
+  end-to-end with a fixture candidate config asserting (a) no
+  upstream dial happened, (b) verdict came from candidate config,
+  (c) registry empty after teardown.
+
+Out of scope for v1: postgres / clickhouse_native dispatch
+(separate beads), dashboard UI for dry-run sessions, mock upstream,
+config-vs-config diffing, time-travel replay.
+
+## 5. References
+
+- Bead: `cl-d9d`
+- Central dispatch: `config/runtime/dispatch.go:45`,
+  `main.go:1632`
+- Session keying: `main.go:319`, `main.go:2026`,
+  `onboard.go:121`
+- Config load/compile: `main.go:92`, `config/compile.go:194`
+- Existing config-upload precedent: `web.go:222`
+  (`/api/config/preview`, `/api/config/save`)
+- Linux per-process: `run_linux.go:52`
+- macOS per-process: `run_darwin.go:43`
+- Whole-machine join: `login.go:573`

--- a/doc/dry-run-design.md
+++ b/doc/dry-run-design.md
@@ -33,12 +33,13 @@ candidate produces does not match the decision stored in the
 file — for a directory run, any single mismatch fails the run.
 
 To keep the authoring burden low, the dashboard grows a
-**"Download actions"** button on its recent-actions view. The
-button emits a zip of one file per recorded action, populated
-from what the gateway has actually seen and each carrying the
-verdict it produced under the live config. Operators unpack into
-`testdata/` and run as-is to lock in current behaviour, or edit
-individual files to drive a policy change.
+**"Download action"** button on the individual action detail
+page (`RequestDetailPage`). The button emits a single JSON file
+for that action, carrying the request and the verdict the
+gateway produced under the live config. Operators drop the file
+into `testdata/` and run as-is to lock in current behaviour, or
+edit it to drive a policy change. Building a multi-action
+fixture set is a matter of downloading each action of interest.
 
 The point is iteration speed and CI: today an operator changes a
 rule, pushes a full config reload, watches live traffic, and
@@ -86,8 +87,8 @@ it before logging. A small extension of `Event` (`Rule string`)
 populated at the existing dispatch sites is enough; no new
 plumbing.
 
-A "download these as a zipped actions directory" endpoint is
-then a re-shape of an existing dataset, not a new pipeline.
+A "download this action as a JSON file" endpoint is then a
+re-shape of an existing dataset, not a new pipeline.
 
 ### 1.4 Subcommand wiring
 
@@ -102,17 +103,17 @@ sibling file (`run_linux.go`, `onboard.go`, etc.). Adding
 ┌──────────────────────────────────┐    ┌──────────────────────────────┐
 │  clawpatrol test                 │    │  gateway dashboard           │
 │   candidate.hcl                  │    │                              │
-│   testdata/                      │    │  recent actions view         │
+│   testdata/                      │    │  action detail page          │
 │                                  │    │  ┌────────────────────────┐  │
-│  1. config.Load(candidate.hcl)   │    │  │ [Download actions]     │  │
+│  1. config.Load(candidate.hcl)   │    │  │ [Download action]      │  │
 │     + config.Compile()           │    │  └────────────────────────┘  │
 │                                  │    │            │                 │
 │  2. resolve path arg:            │    │            ▼                 │
 │     • file → one Action          │    │  GET /api/actions/export     │
-│     • dir  → glob *.json         │    │   → zip of one .json per     │
-│                                  │    │     event in the export      │
-│     each loads as:               │    │     window (request +        │
-│       Action{                    │    │     verdict per file)        │
+│     • dir  → glob *.json         │    │     ?id=<event-id>           │
+│                                  │    │   → one .json for that       │
+│     each loads as:               │    │     event (request +         │
+│       Action{                    │    │     verdict)                 │
 │         request: match.Request,  │    │                              │
 │         verdict: Verdict,        │    └──────────────────────────────┘
 │       }                          │
@@ -174,20 +175,21 @@ Concrete plumbing:
   file mismatches. `verdict.reason` is informational and not
   part of the comparison (it changes too freely under safe
   edits).
-- **Dashboard endpoint**: `GET /api/actions/export` returns a
-  `application/zip` of one `<action-id>.json` file per event
-  in the export window. The dashboard UI gets a "Download
-  actions" button on the actions list that hits this endpoint
-  and offers the result as a `.zip` download. Auth: same
-  `dashboard_secret` as the rest of `/api/*` (§3.E).
-- **Dashboard renderer**: for each `Event` in the export
-  window, map fields → `request: match.Request` and
-  `verdict: {action: ev.Action, rule: ev.Rule, reason:
-  ev.Reason}`, emit as a single JSON file under a stable name
-  (e.g. `<timestamp>-<short-sha>.json`), zip the lot. This
-  requires the small `Event.Rule` extension noted in §1.3.
-  Output is "what the gateway actually decided" — a
-  regression baseline.
+- **Dashboard endpoint**: `GET /api/actions/export?id=<event-id>`
+  returns one `application/json` action file for the named
+  event. The dashboard UI gets a "Download action" button on
+  the individual action detail page (`RequestDetailPage`) that
+  hits this endpoint with the current event id and offers the
+  result as a `.json` download. Operators build a fixture set
+  by downloading each action of interest into `testdata/`.
+  Auth: same `dashboard_secret` as the rest of `/api/*` (§3.E).
+- **Dashboard renderer**: for the requested `Event`, map fields
+  → `request: match.Request` and `verdict: {action: ev.Action,
+  rule: ev.Rule, reason: ev.Reason}`, emit as a single JSON file
+  under a stable name (e.g. `<timestamp>-<short-sha>.json`).
+  This requires the small `Event.Rule` extension noted in §1.3.
+  Output is "what the gateway actually decided" — a regression
+  baseline.
 
 This design removes everything that was hard about the previous
 proposal: no session keying, no ephemeral peers, no response
@@ -275,21 +277,17 @@ endpoint is just a more convenient shape.
 
 ### F. Export window
 
-How many recent events should the button download?
+With the button on the individual action detail page, v1 ships
+single-action download by event id. Operators build a fixture
+set by downloading each action of interest into `testdata/`.
 
-- Whole ring (last 500): matches what the dashboard already
-  shows; simplest mental model.
-- Time-windowed (`?since=...`): supports "actions from the last
-  hour of activity"; small UI addition.
-- Filter by `agent` / `mode` / `host`: lets operators export a
-  per-agent or per-host fixture set. Likely useful given the
-  dashboard already filters this way.
+A list-level "Download all" (zip of the whole ring, `?since=...`,
+or filtered by `agent` / `mode` / `host`) is a natural follow-up
+if operators want bulk export without clicking through every
+action.
 
-**Recommendation:** start with whole ring + `?since=` query
-parameter. Per-agent/per-host filtering can land as the UI
-needs it.
-
-**Decision needed:** confirm scope.
+**Decision needed:** confirm v1 is single-action only, with bulk
+export deferred.
 
 ## 4. Proposed scope for the first PR
 
@@ -305,18 +303,18 @@ After the above questions are answered, the implementation PR should:
   existing dispatch sites (`main.go:1638`, postgres,
   clickhouse_native) so the exporter can carry the matched
   rule name.
-- Add `GET /api/actions/export` returning a zip of one
-  `<id>.json` per event in the recent-events ring, with
-  redaction reusing the dashboard's existing rules.
-- Add the "Download actions" button to the dashboard's
-  recent-actions view.
+- Add `GET /api/actions/export?id=<event-id>` returning one
+  `<id>.json` for the named event as an Action, with redaction
+  reusing the dashboard's existing rules.
+- Add the "Download action" button to the dashboard's
+  individual action detail page (`RequestDetailPage`).
 - HTTPS endpoint family in v1; SQL families covered if their
   recorded event fields are sufficient.
 - Tests: unit tests for the runner (verdict match / mismatch
   on action and rule, single-file and directory modes), a
-  golden-file test for export zip shape, and an integration
-  test that exports → unpacks → runs → asserts zero diffs
-  against the current config.
+  golden-file test for the exported per-action JSON shape, and
+  an integration test that exports → drops into `testdata/` →
+  runs → asserts zero diffs against the current config.
 
 Out of scope for v1: live-session candidate dispatch (the
 previous proposal — superseded), mock upstream, time-travel

--- a/doc/dry-run-design.md
+++ b/doc/dry-run-design.md
@@ -1,337 +1,265 @@
-# clawpatrol — `dry-run` design proposal
+# clawpatrol — `clawpatrol test` design proposal
 
 > **Status:** design / discussion. No implementation yet. Open
 > questions in §3 must be resolved before code lands.
 
 ## Goal
 
-Add a CLI subcommand that lets an operator try a candidate HCL
-policy against the **live production gateway**, scoped to a single
-session, with no upstream traffic actually forwarded:
+Add a CLI subcommand that runs a candidate HCL policy against a
+**fixture suite of actions with expected verdicts** and reports
+pass/fail, like a test runner:
 
 ```
-clawpatrol dry-run --config ./candidate.hcl <cmd> [args...]
+clawpatrol test --config ./candidate.hcl --suite ./actions.json
 ```
 
-Same shape as `clawpatrol run`, but every action the wrapped agent
-generates is matched against the candidate config rather than the
-gateway's global config, and the gateway returns synthesised
-responses instead of proxying. When the session ends, the candidate
-config is dropped.
+The suite is a list of `{action, expected_verdict}` pairs. The
+command compiles the candidate config in-process and runs each
+action through `runtime.MatchRequest`, comparing the returned
+verdict against the expected one. Exit status is non-zero on any
+mismatch.
 
-The point is iteration speed: operators currently have to push a
-full config reload to test a rule change, which affects every
-device. Dry-run lets one operator probe a candidate config from
-their own machine without touching anybody else's traffic.
+To keep the suite-authoring burden low, the dashboard grows a
+**"Download as test suite"** button on its recent-actions view.
+The button emits a ready-made suite file populated from the
+actions the gateway has actually seen, each pre-filled with the
+verdict it produced under the live config. Operators run that
+file as-is to lock in current behaviour, or edit individual
+entries to drive a policy change.
+
+The point is iteration speed and CI: today an operator changes a
+rule, pushes a full config reload, watches live traffic, and
+hopes. `clawpatrol test` makes the loop a `git diff` + one
+command, with no gateway involvement and no auth.
 
 ## 1. What I read
 
 Citations are file:line in `denoland/clawpatrol@main`.
 
-### 1.1 Single policy-dispatch point exists (HTTPS path)
+### 1.1 Single policy-dispatch point exists
 
 `runtime.MatchRequest(ep, req)` at `config/runtime/dispatch.go:45`
-walks an endpoint's priority-sorted rule list and returns the first
-match. The HTTPS / K8s path calls this exactly once per request at
-`main.go:1632` after building a `match.Request` containing
-`Family`, `Method`, `URL`, `Headers`, `Body`, `PeerIP` and (for
-k8s) the parsed path.
+walks an endpoint's priority-sorted rule list and returns the
+first match. The HTTPS / K8s path calls it at `main.go:1638`,
+postgres at `config/plugins/endpoints/postgres.go:432`, and
+clickhouse_native at
+`config/plugins/endpoints/clickhouse_native_runtime.go:692`.
+That's the entire surface this subcommand needs to drive.
 
-The compiled policy is held atomically on the `Gateway` struct and
-read via `g.Policy()` (atomic load of `*config.CompiledPolicy`).
-SIGHUP / mtime-based reload swaps it in via `g.policy.Store(cp)`,
-so request handlers always see a consistent snapshot for the
-lifetime of one request.
+A `match.Request` is plain data: `Family`, `Method`, `URL`,
+`Headers`, `Body`, `PeerIP`, parsed path. It serializes cleanly
+to JSON, which is what the suite format is.
 
-### 1.2 SQL plugins do their own matching
-
-postgres / clickhouse_native do **not** route through
-`MatchRequest`. They walk rules themselves inside their per-conn
-handlers (`main.go:1169` for postgres). This is relevant for
-acceptance criteria — the first iteration probably can't cover
-every endpoint family with one shim; HTTPS is the cheapest
-beachhead.
-
-### 1.3 Session identity at the gateway is `PeerIP`
-
-`peerIP(c net.Conn)` at `main.go:2026` extracts the canonical IPv4
-form of the WG remote address and is the universal session key.
-`g.profileFor(pip)` (`main.go:319`) and the onboard registry
-(`onboard.go:121`) are both keyed by it. Every per-request lookup
-flows through this.
-
-### 1.4 But "session" and "PeerIP" are not 1:1 — see §3.A
-
-This is the central design problem. It deserves its own section
-below. The short version: **one Linux host, one PeerIP, even when
-the operator runs N concurrent `clawpatrol run`s.**
-
-### 1.5 Config compile is reusable from a request handler
+### 1.2 Config compile is reusable from a CLI process
 
 `loadConfig(path)` at `main.go:92` is `config.Load() +
-config.Compile()`. `Compile()` (`config/compile.go:194`) returns a
-fresh `*CompiledPolicy` with no global mutation. It's safe and
-cheap enough to call on demand for a candidate-config upload (mtime
-poller currently runs it every 3s anyway).
+config.Compile()`. `Compile()` (`config/compile.go:194`) returns
+a fresh `*CompiledPolicy` with no global mutation, no DB, no
+network. It is safe and cheap to call directly from a one-shot
+CLI process — no gateway required.
 
-A `*CompiledPolicy` is on the order of 10–100 KB for a real
-config. Holding one extra per active dry-run session is fine.
+### 1.3 The dashboard already renders an actions feed
 
-### 1.6 Existing CLI ↔ gateway control channel
+The event sink (`web.go:1582`, `Sink` / `Event`) buffers the
+last 500 actions in-memory and persists to SQLite. The
+dashboard's `/api/state` and `/api/events` endpoints already
+expose this stream, and `Event` carries everything the suite
+needs: `Method`, `Path`, `ReqHeaders`, `ReqBody`, `Host`,
+`Mode`, plus the produced verdict in `Action` + `Reason`.
 
-The dashboard's API listener (routes registered at `web.go:208+`)
-already speaks JSON over the same listener as the proxy and gates
-mutating routes on `dashboard_secret` (cookie or
-`X-Clawpatrol-Secret` header — see `checkDashboardSecret`).
-Existing precedent for "client uploads HCL, gateway compiles":
-`POST /api/config/preview` and `POST /api/config/save` already do
-this for the global config (with revision tokens to prevent
-clobbering).
+A "download these as a test suite" endpoint is a re-shape of an
+existing dataset, not a new pipeline.
 
-There is no per-device API token usable from the CLI today —
-`api-token` files exist on devices but are scoped to env-pushdown
-flows, not generic API auth.
-
-### 1.7 Subcommand wiring
+### 1.4 Subcommand wiring
 
 CLI subcommands live as a flat `switch os.Args[1]` in `main.go`
 (around line 2000), each delegating to a `runFoo(args)` in a
 sibling file (`run_linux.go`, `onboard.go`, etc.). Adding
-`dry-run` is a one-line switch case + a new `dry_run.go`.
+`test` is a one-line switch case + a new `test.go`.
 
 ## 2. Proposed architecture
 
 ```
-┌──────────────────────────────┐         ┌─────────────────────────────────┐
-│  operator's host             │         │  gateway                        │
-│                              │         │                                 │
-│  clawpatrol dry-run          │         │  POST /api/dry-run/sessions     │
-│   --config candidate.hcl     │ ──HCL──▶│   { hcl, ttl }                  │
-│   <cmd> [args...]            │         │   → compile via                 │
-│                              │ ◀─token─│     config.Load()+Compile()     │
-│  ┌────────────────────────┐  │         │   → mint session key            │
-│  │ tunnel established     │  │         │   → store {key→CompiledPolicy}  │
-│  │ with session key       │──tunnel──▶│   → return session token        │
-│  │ (see §3.A)             │  │         │                                 │
-│  └────────────────────────┘  │         │  per-request dispatch:          │
-│                              │         │   if session has dry-run        │
-│  exec <cmd>                  │         │     policy attached:            │
-│   └─ generates requests      │         │     match against candidate,    │
-│                              │         │     synthesise response,        │
-│                              │         │     tag event { dryRun: true }  │
-└──────────────────────────────┘         │   else: normal path             │
-                                         │                                 │
-                                         │  session-end:                   │
-                                         │   drop {key→CompiledPolicy}     │
-                                         └─────────────────────────────────┘
+┌──────────────────────────────────┐    ┌──────────────────────────────┐
+│  clawpatrol test                 │    │  gateway dashboard           │
+│   --config candidate.hcl         │    │                              │
+│   --suite actions.json           │    │  recent actions view         │
+│                                  │    │  ┌────────────────────────┐  │
+│  1. config.Load(candidate.hcl)   │    │  │ [Download test suite]  │  │
+│     + config.Compile()           │    │  └────────────────────────┘  │
+│                                  │    │            │                 │
+│  2. read suite.json              │    │            ▼                 │
+│     → []SuiteEntry{              │    │  GET /api/actions/export     │
+│         req: match.Request,      │    │   → ndjson over last N       │
+│         want: Verdict,           │    │     events, each rendered    │
+│       }                          │    │     as a SuiteEntry          │
+│                                  │    │     (req + observed verdict) │
+│  3. for each entry:              │◀───┤                              │
+│       got := MatchRequest(...)   │    └──────────────────────────────┘
+│       diff against want          │
+│                                  │
+│  4. print summary + exit code    │
+└──────────────────────────────────┘
 ```
 
 Concrete plumbing:
 
-- **CLI** (`dry_run.go`, new file): `flag.FlagSet` parses
-  `--config`; reads HCL bytes; POSTs them to the gateway's API;
-  receives a session token; establishes the tunnel (delegating to
-  the same code path as `clawpatrol run`) wired with the session
-  token; execs the wrapped command. Whole-machine devices are
-  rejected up front (see §3.B).
-- **Gateway API**: `POST /api/dry-run/sessions` handler in
-  `web.go` accepting `{hcl, ttl}` and returning
-  `{sessionToken, expiresAt}`. Auth: §3.E.
-- **Gateway state**: a new field on `Gateway`, e.g.
-  `dryRun *dryRunRegistry`, mapping session-key →
-  `*config.CompiledPolicy` plus expiry. Single mutex, copy-out
-  semantics (caller gets a pointer to an immutable
-  `CompiledPolicy`).
-- **Dispatch hook**: at `main.go:1632`, before
-  `runtime.MatchRequest(ep, mreq)`, do
-  `if dr := g.dryRun.Lookup(sessionKey); dr != nil { ep =
-  dr.EndpointFor(host, profile); mreq.DryRun = true }`. The
-  request continues through `MatchRequest` against the candidate
-  endpoint definition.
-- **Response synthesis**: when `mreq.DryRun` is true, replace the
-  upstream dial with a synthesiser per verdict (§3.C).
-- **Event tagging**: stamp `Event.DryRun = true` so the dashboard
-  and event sink can filter / badge dry-run actions.
-- **Cleanup**: TTL sweep (e.g. 5 min idle) plus an explicit
-  `DELETE /api/dry-run/sessions/{token}` the CLI calls on clean
-  exit.
+- **Suite format** (new): newline-delimited JSON, one entry per
+  line:
+  ```
+  {"name":"...", "request":{...match.Request...}, "expect":{"action":"allow","reason_contains":"..."}}
+  ```
+  ndjson because it streams cleanly, diffs cleanly, and the
+  dashboard can emit it incrementally.
+- **CLI** (`test.go`, new file): parses `--config`, `--suite`,
+  optional `--endpoint` (which compiled endpoint to dispatch
+  against — defaults to first matching by host), optional
+  `--update` to rewrite the suite file with observed verdicts.
+  No network, no auth, no gateway dependency.
+- **Test runner**: a thin loop that calls `MatchRequest` per
+  entry and compares. Verdict comparison: exact match on
+  `Action`; `reason_contains` substring match on `Reason` if
+  set. Mismatches print a diff and bump the failure counter.
+- **Dashboard endpoint**: `GET /api/actions/export` returns the
+  ndjson form of the recent-events ring. The dashboard UI gets
+  a "Download test suite" button on the actions list that hits
+  this endpoint and offers the result as a file download. Auth:
+  same `dashboard_secret` as the rest of `/api/*` (§3.E).
+- **Dashboard renderer**: for each `Event` in the export window,
+  map fields → `match.Request` and `expect.action = ev.Action`
+  / `expect.reason_contains = ev.Reason`. Output is "what the
+  gateway actually decided" — a regression baseline.
+
+This design removes everything that was hard about the previous
+proposal: no session keying, no ephemeral peers, no response
+synthesis, no whole-machine carve-out, no auth on a new gateway
+endpoint, no TTL sweep, no live-traffic carve-out.
 
 ## 3. Open questions (please answer before code)
 
-### A. How does the gateway distinguish concurrent sessions on one host?
+### A. Suite scope: per-endpoint or global?
 
-This is the biggest one and the bead's framing ("session keys off
-WG peer ID") is incomplete. On Linux, `clawpatrol run`
-(`run_linux.go:68`) reads `~/.config/clawpatrol/wg.conf` written
-by `join` — the same WG private key for every invocation. Two
-concurrent `run`s from the same host therefore share one PeerIP at
-the gateway. macOS is even more collapsed: all wrapped processes
-funnel through the macOS extension's single shared WG tunnel and
-appear under one peer.
+`MatchRequest` is per-`CompiledEndpoint`. The suite either:
 
-PeerIP alone cannot tell us whether a request came from a dry-run
-session or from a regular one running in parallel.
+1. Pins each entry to an endpoint by name (or by host →
+   endpoint resolution at run time), then dispatches into that
+   endpoint's rule list. Mirrors how `MatchRequest` is actually
+   called in production.
+2. Walks endpoint resolution itself (host-based lookup against
+   the compiled policy) before dispatching. Closer to "what
+   would the gateway do end-to-end with this request?"
 
-Three plausible directions:
+**Recommendation: (2)**, with the suite carrying the original
+`Host` field. It matches what operators read on the dashboard
+and what the export button can populate without extra metadata.
+(1) is a fallback if some endpoint family doesn't fit clean
+host-based lookup.
 
-1. **Mint an ephemeral WG peer per dry-run session.** The new
-   `POST /api/dry-run/sessions` issues a fresh WG keypair + IP;
-   the CLI brings up its own short-lived tunnel scoped to just
-   the wrapped command's namespace (Linux) or hands the helper a
-   one-off conf (macOS). Each dry-run gets a unique PeerIP, the
-   gateway's existing PeerIP-keyed dispatch needs no schema
-   change, and dropping the peer at session end is a clean teardown
-   signal.
-   Cost: a new gateway code path that mints+revokes ephemeral peers
-   without going through the `join` approval flow.
-2. **In-band session token in request metadata.** CLI injects e.g.
-   an `X-Clawpatrol-DryRun: <token>` header. Works for HTTPS,
-   doesn't work for postgres / clickhouse / non-HTTP without a
-   per-protocol shim. We'd ship HTTPS dry-run first.
-3. **Per-session src-port marking.** CLI's namespace SO_MARKs its
-   sockets / picks a known src-port range; gateway derives session
-   from `(PeerIP, src_port_range)`. Brittle — kernels reuse ports
-   freely.
+**Decision needed:** confirm (2), or do you want (1) for
+explicit endpoint targeting?
 
-**Recommendation: (1).** It is the only option that keeps PeerIP
-the universal session key, doesn't require per-plugin protocol
-knowledge, and gives us a clean disconnect signal. Worth the new
-ephemeral-peer endpoint.
+### B. Which protocols / endpoint families?
 
-**Decision needed:** is (1) acceptable, or do you want (2) and
-explicit "HTTPS-only first" scoping?
+HTTPS path is one `MatchRequest` call. Postgres and
+clickhouse_native build their own `match.Request` from
+protocol-level state before calling `MatchRequest` — same
+dispatch primitive, different request synthesis.
 
-### B. Whole-machine mode
+**Recommendation:** v1 covers any endpoint family whose
+`match.Request` is fully reconstructible from the data the
+event sink already records. HTTPS qualifies trivially. SQL
+plugins likely qualify (we already record `req_body` /
+`req_sha`); confirm during implementation that the recorded
+fields are sufficient for replay.
 
-`--whole-machine` joins (`login.go:573+`) install a persistent
-`wg-quick` interface routing all host traffic through one peer.
-There is no per-process boundary. Dry-run on whole-machine would
-mean "every packet on this host gets matched against the candidate
-config," which is more like a global config swap than a session
-test.
+**Decision needed:** OK to ship HTTPS-first with SQL family
+support landing in a follow-up bead if any field is missing?
 
-**Recommendation:** reject `clawpatrol dry-run` on a whole-machine
-device at CLI-time with a clear message ("this host joined in
-whole-machine mode; dry-run is per-process only — re-join without
-`--whole-machine` to use it"). Out of scope for this iteration.
+### C. Approver-chain (HITL) verdicts in the suite
 
-**Decision needed:** confirm reject, or do we want a degraded
-"applies to all host traffic" mode for whole-machine?
+A live `approve` verdict in production triggers the human
+approver chain. Under `clawpatrol test`, running approvers is
+wrong (pages humans, slow, non-deterministic).
 
-### C. Response synthesis per verdict
+**Recommendation:** the test runner treats `approve` as a
+terminal verdict — it matches the literal string `approve`
+without invoking any chain. This is consistent with the suite
+being a *policy match* test, not an end-to-end test.
 
-For the four verdict types:
+**Decision needed:** confirm.
 
-- **deny** — gateway returns the same shape it would in prod
-  (HTTP 4xx, postgres `ErrorResponse`, etc.). No question.
-- **allow** — must return *something* so the wrapped agent can
-  keep running. Options:
-  - HTTP 200 + empty body + a `X-Clawpatrol-DryRun: allowed`
-    marker header. Cheapest, but the agent may break on missing
-    expected fields.
-  - Per-protocol minimal "OK" (HTTP: 200/empty; postgres: a
-    `ReadyForQuery` after no-op; clickhouse_native: empty `EndOfStream`).
-    Slightly more work, much friendlier to real agents.
-  - Forward to an operator-configured mock upstream.
-    Powerful, much bigger scope.
-- **approve** (HITL) — running approver chains under dry-run is
-  wrong (would page humans). Three options: auto-deny, auto-allow
-  + tag `would-have-required-approval`, or run only the LLM
-  pre-stage and skip the human stage.
-- **passthrough** (`unknown_host`) — same shape as allow.
+### D. Suite emission: redaction
 
-**Recommendation:** per-protocol minimal OK for `allow` /
-`passthrough`, and **auto-allow + `wouldRequireApproval: true` tag
-on the event** for `approve`. That gives operators "would this
-config let the agent get further than the prod config does" as
-useful signal without paging anyone. Mock upstream is a follow-up
-feature.
+`Event.ReqBody` and `RespBody` may contain secrets the operator
+doesn't want in a checked-in suite file. The export endpoint
+should respect the same redaction rules the dashboard already
+applies for display (`web_redaction_test.go` exists — confirm
+during implementation that those rules are reusable here).
 
-**Decision needed:** confirm `approve → auto-allow + tag`.
+The CLI also wants a `--scrub` flag to drop bodies entirely if
+the operator just wants method/path/headers coverage.
 
-### D. Server-side state divergence
+**Decision needed:** redact-by-default on export, or raw-by-
+default with an explicit redact flag?
 
-A would-have-run `INSERT` doesn't actually run, so a follow-up
-`SELECT` won't see the row. The agent's behaviour during dry-run
-diverges from real prod. This is fundamental to the contract — I'll
-document it explicitly in the help text and the design comment so
-operators don't misread dry-run as a faithful end-to-end replay.
+### E. Auth on the export endpoint
 
-**Decision needed:** none, just confirming we accept the
-divergence.
+Reuse `dashboard_secret` (same auth as
+`/api/state`, `/api/events`). The data being exported is data
+the caller can already pull from `/api/events`; the export
+endpoint is just a more convenient shape.
 
-### E. Auth on the upload endpoint
+**Decision needed:** confirm `dashboard_secret`.
 
-Two reasonable choices:
+### F. Export window
 
-- **`dashboard_secret`** — reuses existing auth, identical to
-  `/api/config/preview`. But that secret is admin-scoped; an
-  operator who doesn't have the dashboard secret today can't run
-  dry-run, which feels backwards (any device user should be able
-  to test policies for their own session).
-- **Same auth as the device's normal traffic.** The CLI is
-  already running under a joined identity (the WG peer
-  authenticates by key); we'd let any onboarded peer upload a
-  candidate config for its own session.
+How many recent events should the button download?
 
-**Recommendation:** the second. Dry-run is a "test policy for
-*me*" operation; gating it behind the admin secret is too strict.
+- Whole ring (last 500): matches what the dashboard already
+  shows; simplest mental model.
+- Time-windowed (`?since=...`): supports "test suite for the
+  last hour of activity"; small UI addition.
+- Filter by `agent` / `mode` / `host`: lets operators export a
+  per-agent or per-host suite. Likely useful given the dashboard
+  already filters this way.
 
-**Decision needed:** confirm device-scoped auth, or do we want
-admin-only?
+**Recommendation:** start with whole ring + `?since=` query
+parameter. Per-agent/per-host filtering can land as the UI
+needs it.
 
-### F. Config-discard timing
-
-- Linux ephemeral peer: drop on WG handshake timeout (~3 min idle)
-  or explicit CLI cleanup call.
-- macOS: NE process termination → CLI cleanup call.
-- TTL sweep as a fallback in case both signals are missed.
-
-**Decision needed:** is a 5-minute idle TTL the right fallback?
-Could be longer (15 min) for slow agents.
-
-### G. Logging / metrics contamination
-
-Dry-run actions should land in the same event sink/store so the
-dashboard can render them, but tagged `dryRun: true` so they don't
-contaminate real-traffic metrics (allow rate, deny rate, latency
-SLOs). The dashboard rendering is a follow-up; the tag itself
-lands here.
-
-**Decision needed:** confirm tag-but-store.
+**Decision needed:** confirm scope.
 
 ## 4. Proposed scope for the first PR
 
 After the above questions are answered, the implementation PR should:
 
-- Add `clawpatrol dry-run` subcommand (Linux per-process + macOS
-  per-process; reject whole-machine).
-- Add the chosen session-keying mechanism from §3.A.
-- Add `POST /api/dry-run/sessions` (and `DELETE /sessions/{id}`)
-  with the chosen auth from §3.E.
-- Hook dispatch at `main.go:1632` to consult the dry-run registry
-  before falling through to the global `MatchRequest` path.
-- HTTPS path only for verdict synthesis in v1.
-- Event tagging (`Event.DryRun bool`).
-- Tests: per-session config attachment & TTL drop; HTTPS dry-run
-  end-to-end with a fixture candidate config asserting (a) no
-  upstream dial happened, (b) verdict came from candidate config,
-  (c) registry empty after teardown.
+- Add `clawpatrol test` subcommand (`test.go`) — pure CLI,
+  no gateway dependency.
+- Define the ndjson suite format (`test_suite.go` or similar)
+  shared between the CLI runner and the dashboard exporter.
+- Add `GET /api/actions/export` returning the recent-events
+  ring as suite ndjson, with redaction reusing the dashboard's
+  existing rules.
+- Add the "Download test suite" button to the dashboard's
+  recent-actions view.
+- HTTPS endpoint family in v1; SQL families covered if their
+  recorded event fields are sufficient.
+- Tests: unit tests for the runner (verdict match / mismatch /
+  reason substring), a golden-file test for export ndjson
+  shape, and an integration test that exports → runs → asserts
+  100% pass on the current config.
 
-Out of scope for v1: postgres / clickhouse_native dispatch
-(separate beads), dashboard UI for dry-run sessions, mock upstream,
-config-vs-config diffing, time-travel replay.
+Out of scope for v1: live-session candidate dispatch (the
+previous proposal — superseded), mock upstream, time-travel
+replay against a historical config, suite-vs-suite diffing.
 
 ## 5. References
 
 - Bead: `cl-d9d`
 - Central dispatch: `config/runtime/dispatch.go:45`,
-  `main.go:1632`
-- Session keying: `main.go:319`, `main.go:2026`,
-  `onboard.go:121`
+  `main.go:1638`
 - Config load/compile: `main.go:92`, `config/compile.go:194`
-- Existing config-upload precedent: `web.go:222`
-  (`/api/config/preview`, `/api/config/save`)
-- Linux per-process: `run_linux.go:52`
-- macOS per-process: `run_darwin.go:43`
-- Whole-machine join: `login.go:573`
+- Event sink and recent ring: `web.go:1582`, `web.go:1620`
+- Dashboard API surface: `web.go:208`+ (`/api/state`,
+  `/api/events`, `/api/actions/`)
+- Redaction rules: `web_redaction_test.go`


### PR DESCRIPTION
**Status: design discussion, no implementation yet.**

Design doc for a new `clawpatrol dry-run --config <hcl>` subcommand
that tests a candidate HCL policy against the live gateway for a
single session, with no upstream forwarding. Full proposal in
`doc/dry-run-design.md`.

I'm opening this draft so we can lock the open questions in §3
before any code lands — the central one (§3.A) is a real design
fork.

## TL;DR

- **Single dispatch point** exists for HTTPS (`runtime.MatchRequest` at `config/runtime/dispatch.go:45`, called at `main.go:1632`). v1 should be HTTPS-only; postgres / clickhouse_native walk rules themselves.
- **Session keying is the problem.** PeerIP is the universal session key today (`main.go:2026`), but it's **not 1:1 with a `clawpatrol run` invocation**: Linux `run` reuses the host's `wg.conf`, macOS funnels every wrapped process through one shared tunnel. Two concurrent `run`s on one host share one PeerIP.
- **Recommended fix:** mint an **ephemeral WG peer per dry-run invocation**, so each session gets a unique PeerIP and the existing dispatch path needs no schema change. Details in §3.A.
- **Config compile is reusable.** `loadConfig` / `config.Compile` are pure, safe to call from a request handler, ~10–100 KB per policy.
- **Upload path:** mirror existing `/api/config/preview` shape. Device-scoped auth (any onboarded peer can test their own session), not the admin `dashboard_secret`.
- **Verdict synthesis:** per-protocol minimal OK for `allow`/`passthrough`; auto-allow + `wouldRequireApproval: true` tag for `approve` so HITL chains don't actually page humans.
- **Whole-machine:** reject at CLI-time; no per-process boundary to scope to.

## Open questions

Listed in `doc/dry-run-design.md` §3. The ones I'd most like an
answer on before writing code:

1. **§3.A — session keying.** Ephemeral WG peer per dry-run (my
   recommendation) vs. in-band `X-Clawpatrol-DryRun` header
   (HTTPS-only) vs. src-port marking?
2. **§3.C — `approve` verdict** under dry-run: auto-allow + tag
   (my recommendation), auto-deny, or run LLM stage only?
3. **§3.E — auth on the upload endpoint:** device-scoped (my
   recommendation) or admin `dashboard_secret`?
4. **§3.B — confirm whole-machine reject** with a clear error
   message.

Once these settle I'll open a follow-up implementation PR scoped
to: ephemeral-peer endpoint, the dispatch hook, HTTPS verdict
synthesis, event tagging, and tests.

## Acceptance criteria for the eventual implementation PR

(Lifted from the bead `cl-d9d` and slightly tightened in §4 of the
doc.)

- `clawpatrol dry-run --config <hcl> <cmd>` runs `<cmd>` with every
  HTTPS action matched against the candidate config; no upstream
  traffic sent; synthesised responses sufficient for the wrapped
  agent to keep running; per-session config dropped at session end.
- PR description names the verdict-synthesis decisions made here
  and links back to this thread.
- Tests cover per-session config attach/drop and the HTTPS dry-run
  request path end-to-end.

cc whoever owns the gateway runtime — would love a sanity check on
§3.A in particular.