### PR TITLE
join: warn on plain-http public gateway URL

### DIFF
--- a/login.go
+++ b/login.go
@@ -61,6 +61,9 @@ func runJoin(args []string) {
 		fail("usage: clawpatrol join <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine]")
 	}
 	gatewayURL := rest[0]
+	if err := requireSecureGatewayURL(gatewayURL); err != nil {
+		fail("%v", err)
+	}
 	// Fetch CA + write shell rc BEFORE the VPN goes up. Once
 	// `wg-quick up` flips the default route through the gateway,
 	// reaching the gateway's public URL goes via the tunnel — which
@@ -129,6 +132,46 @@ func postJoinSetup(gateway, caDir string, skipTrust bool) (joinSetup, error) {
 		s.shellRC = true
 	}
 	return s, nil
+}
+
+// requireSecureGatewayURL gates the gateway URL the agent host is
+// about to trust the CA root from. The CA root is the anchor for
+// every subsequent intercepted TLS connection, so an on-path
+// attacker who can substitute it during onboarding owns all later
+// credentialled traffic. Require https for non-loopback hosts;
+// permit http only when the gateway is on the same machine.
+func requireSecureGatewayURL(gateway string) error {
+	u, err := neturl.Parse(gateway)
+	if err != nil {
+		return fmt.Errorf("parse gateway URL %q: %w", gateway, err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("refusing to fetch gateway CA from %s over "+
+			"plain http: use https for non-loopback gateways (a network "+
+			"attacker can otherwise substitute their own CA and intercept "+
+			"every subsequent intercepted TLS connection)", gateway)
+	default:
+		return fmt.Errorf("gateway URL must use http or https, got %q", gateway)
+	}
+}
+
+func isLoopbackHost(h string) bool {
+	if h == "" {
+		return false
+	}
+	if h == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(h); ip != nil && ip.IsLoopback() {
+		return true
+	}
+	return false
 }
 
 func fetchCAHTTP(gateway, dst string) error {

--- a/login.go
+++ b/login.go
@@ -61,7 +61,7 @@ func runJoin(args []string) {
 		fail("usage: clawpatrol join <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine]")
 	}
 	gatewayURL := rest[0]
-	if err := requireSecureGatewayURL(gatewayURL); err != nil {
+	if err := checkGatewayURL(gatewayURL); err != nil {
 		fail("%v", err)
 	}
 	// Fetch CA + write shell rc BEFORE the VPN goes up. Once
@@ -134,13 +134,15 @@ func postJoinSetup(gateway, caDir string, skipTrust bool) (joinSetup, error) {
 	return s, nil
 }
 
-// requireSecureGatewayURL gates the gateway URL the agent host is
-// about to trust the CA root from. The CA root is the anchor for
-// every subsequent intercepted TLS connection, so an on-path
-// attacker who can substitute it during onboarding owns all later
-// credentialled traffic. Require https for non-loopback hosts;
-// permit http only when the gateway is on the same machine.
-func requireSecureGatewayURL(gateway string) error {
+// checkGatewayURL validates the gateway URL the agent host is about
+// to trust the CA root from. The CA root is the anchor for every
+// subsequent intercepted TLS connection, so an on-path attacker who
+// substitutes it during onboarding owns all later credentialled
+// traffic. https is the supported configuration; http to loopback
+// is fine for local development; http to a public host warns but
+// proceeds, since requiring https outright would block operators
+// whose gateway is not yet behind TLS.
+func checkGatewayURL(gateway string) error {
 	u, err := neturl.Parse(gateway)
 	if err != nil {
 		return fmt.Errorf("parse gateway URL %q: %w", gateway, err)
@@ -152,10 +154,13 @@ func requireSecureGatewayURL(gateway string) error {
 		if isLoopbackHost(u.Hostname()) {
 			return nil
 		}
-		return fmt.Errorf("refusing to fetch gateway CA from %s over "+
-			"plain http: use https for non-loopback gateways (a network "+
-			"attacker can otherwise substitute their own CA and intercept "+
-			"every subsequent intercepted TLS connection)", gateway)
+		fmt.Fprintf(os.Stderr,
+			"⚠ fetching gateway CA from %s over plain http — "+
+				"a network attacker on path can substitute the CA "+
+				"and intercept every subsequent intercepted TLS "+
+				"connection; use https for non-loopback gateways\n",
+			gateway)
+		return nil
 	default:
 		return fmt.Errorf("gateway URL must use http or https, got %q", gateway)
 	}

--- a/login_test.go
+++ b/login_test.go
@@ -1,31 +1,47 @@
 package main
 
-import "testing"
+import (
+	"io"
+	"os"
+	"testing"
+)
 
-func TestRequireSecureGatewayURL(t *testing.T) {
+func TestCheckGatewayURL(t *testing.T) {
 	cases := []struct {
-		in string
-		ok bool
+		in       string
+		ok       bool
+		wantWarn bool
 	}{
-		{"https://gw.example.com:9080", true},
-		{"https://gw.example.com", true},
-		{"http://localhost:9080", true},
-		{"http://localhost", true},
-		{"http://127.0.0.1:9080", true},
-		{"http://127.0.0.1", true},
-		{"http://[::1]:9080", true},
-		{"http://gw.example.com:9080", false},
-		{"http://example.com", false},
-		{"http://1.2.3.4", false},
-		{"ftp://example.com", false},
-		{"gw.example.com:9080", false},
-		{"", false},
+		{"https://gw.example.com:9080", true, false},
+		{"https://gw.example.com", true, false},
+		{"http://localhost:9080", true, false},
+		{"http://localhost", true, false},
+		{"http://127.0.0.1:9080", true, false},
+		{"http://127.0.0.1", true, false},
+		{"http://[::1]:9080", true, false},
+		{"http://gw.example.com:9080", true, true},
+		{"http://example.com", true, true},
+		{"http://1.2.3.4", true, true},
+		{"ftp://example.com", false, false},
+		{"gw.example.com:9080", false, false},
+		{"", false, false},
 	}
 	for _, c := range cases {
-		err := requireSecureGatewayURL(c.in)
+		old := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+		err := checkGatewayURL(c.in)
+		_ = w.Close()
+		os.Stderr = old
+		buf, _ := io.ReadAll(r)
+		warned := len(buf) > 0
 		if (err == nil) != c.ok {
-			t.Errorf("requireSecureGatewayURL(%q) = %v, want ok=%v",
+			t.Errorf("checkGatewayURL(%q) err=%v, want ok=%v",
 				c.in, err, c.ok)
+		}
+		if warned != c.wantWarn {
+			t.Errorf("checkGatewayURL(%q) warned=%v, want warn=%v",
+				c.in, warned, c.wantWarn)
 		}
 	}
 }

--- a/login_test.go
+++ b/login_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestRequireSecureGatewayURL(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"https://gw.example.com:9080", true},
+		{"https://gw.example.com", true},
+		{"http://localhost:9080", true},
+		{"http://localhost", true},
+		{"http://127.0.0.1:9080", true},
+		{"http://127.0.0.1", true},
+		{"http://[::1]:9080", true},
+		{"http://gw.example.com:9080", false},
+		{"http://example.com", false},
+		{"http://1.2.3.4", false},
+		{"ftp://example.com", false},
+		{"gw.example.com:9080", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		err := requireSecureGatewayURL(c.in)
+		if (err == nil) != c.ok {
+			t.Errorf("requireSecureGatewayURL(%q) = %v, want ok=%v",
+				c.in, err, c.ok)
+		}
+	}
+}


### PR DESCRIPTION
Addresses item 1 of #193.

The agent host trusts the CA root fetched from `<gateway>/ca.crt`
as the anchor for every subsequent intercepted TLS connection. If
that fetch happens over plain http, a network attacker on path
during onboarding can substitute their own CA and intercept every
later credentialled connection. The CA root is at least as trust-
critical as the join credential the doc highlights, so this risk
should not go unflagged.

This change validates the gateway URL at the `clawpatrol join`
entry point:

* `https://...` — accepted silently.
* `http://localhost`, `http://127.0.0.1`, `http://[::1]` — accepted
  silently; loopback is fine for local development.
* `http://<public host>` — accepted with a stderr warning
  explaining the on-path-attacker risk. Hard-rejecting would block
  operators whose gateway is not yet behind TLS.
* Missing or non-http(s) scheme — error, since the fetch could not
  proceed anyway.

The Tailscale-mode CA fetch in `fetchCA` is intentionally left as
plain http: it talks to a tailnet IP over Tailscale's authenticated
WireGuard overlay, so the on-path-attacker threat is already
handled at the network layer there.

A table-driven test covers each branch and asserts whether a
warning is emitted by capturing stderr.