### PR TITLE
fix(darwin): resolve golangci-lint warnings in run_darwin.go

### DIFF
--- a/run_darwin.go
+++ b/run_darwin.go
@@ -17,6 +17,7 @@ package main
 // `Clawpatrol run` just forks the user command.
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -60,8 +61,8 @@ func sessionIPC(msg string) error {
 	if err != nil {
 		return err
 	}
-	defer c.Close()
-	c.SetDeadline(time.Now().Add(2 * time.Second))
+	defer func() { _ = c.Close() }()
+	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
 	if _, err := c.Write([]byte(msg)); err != nil {
 		return err
 	}
@@ -102,7 +103,8 @@ func runRun(args []string) {
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
 	c.Env = os.Environ()
 	if err := c.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())
 		}
 		fail(fmt.Sprintf("run: %v", err))
@@ -129,7 +131,8 @@ func ensureMacProxyUp() error {
 	cmd = exec.Command(macHelperPath, "start", confPath)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			// helper exits non-zero if profile missing — map to friendlier msg.
 			ws := ee.Sys().(syscall.WaitStatus)
 			if ws.ExitStatus() != 0 {
@@ -153,7 +156,7 @@ func ensureMacProxyUp() error {
 // when conf or mode changed).
 func macHelperInstall(wholeMachine bool) error {
 	if _, err := os.Stat(macHelperPath); err != nil {
-		return fmt.Errorf("Clawpatrol.app not at /Applications — reinstall: curl -fsSL https://clawpatrol.dev/install.sh | sh")
+		return fmt.Errorf("missing Clawpatrol.app at /Applications — reinstall: curl -fsSL https://clawpatrol.dev/install.sh | sh")
 	}
 	args := []string{"install"}
 	if wholeMachine {
@@ -165,10 +168,10 @@ func macHelperInstall(wholeMachine bool) error {
 		return err
 	}
 	confPath := filepath.Join(os.Getenv("HOME"), ".config", "clawpatrol", "wg.conf")
-	if _, err := os.Stat(confPath); err != nil {
-		return nil
+	if _, err := os.Stat(confPath); err == nil {
+		c = exec.Command(macHelperPath, "start", confPath)
+		c.Stdout, c.Stderr = os.Stdout, os.Stderr
+		return c.Run()
 	}
-	c = exec.Command(macHelperPath, "start", confPath)
-	c.Stdout, c.Stderr = os.Stdout, os.Stderr
-	return c.Run()
+	return nil
 }


### PR DESCRIPTION
## Summary
- errcheck: handle `c.Close()` / `SetDeadline` return values
- errorlint: replace `err.(*exec.ExitError)` assertions with `errors.As`
- nilerr: invert `wg.conf` stat check so we only run `start` on success
- staticcheck: lowercase leading word of an error string

## Test plan
- [x] `golangci-lint run` reports 0 issues
- [ ] `go build ./...` on darwin