### PR TITLE
mitm: strip credential-bearing response headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -1852,6 +1852,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		if resp.ContentLength < 0 && len(resp.TransferEncoding) == 0 && !resp.Close {
 			resp.TransferEncoding = []string{"chunked"}
 		}
+		// Snapshot the upstream's response headers for the audit log
+		// before stripping credential-bearing ones — the dashboard
+		// still wants to show what the upstream actually sent.
+		ev.RespHeaders = flatHeaders(resp.Header)
+		stripAuthResponseHeaders(resp.Header)
 		writeErr := resp.Write(tc)
 		_ = rtDur
 		_ = resp.Body.Close()
@@ -1873,7 +1878,6 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		}
 		ev.Status = resp.StatusCode
 		ev.ReqHeaders = flatHeaders(req.Header)
-		ev.RespHeaders = flatHeaders(resp.Header)
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()

--- a/response_sanitize.go
+++ b/response_sanitize.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+)
+
+// authResponseHeaders lists response header names that, on a
+// credentialled MITM path, would hand the agent a usable
+// authentication artifact even though the original injected
+// credential never touched the agent's request.
+//
+// Set-Cookie / Set-Cookie2 carry session cookies and OAuth
+// refresh-token cookies. WWW-Authenticate / Proxy-Authenticate
+// carry challenges that some schemes piggy-back tokens onto.
+// Authentication-Info / Proxy-Authentication-Info carry
+// response-side auth state. None of them are needed by a
+// non-authenticating agent to consume the response body.
+var authResponseHeaders = []string{
+	"Set-Cookie",
+	"Set-Cookie2",
+	"WWW-Authenticate",
+	"Proxy-Authenticate",
+	"Authentication-Info",
+	"Proxy-Authentication-Info",
+}
+
+func isAuthResponseHeader(name string) bool {
+	for _, n := range authResponseHeaders {
+		if strings.EqualFold(name, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripAuthResponseHeaders removes credential-bearing response
+// headers in-place from a parsed http.Header.
+func stripAuthResponseHeaders(h http.Header) {
+	for _, name := range authResponseHeaders {
+		h.Del(name)
+	}
+}
+
+// stripAuthResponseHeadersRaw removes credential-bearing header
+// lines from a raw HTTP response header block (status line +
+// CRLF-separated headers + terminating CRLFCRLF). Used on the WS
+// upgrade-response path where Go's http.Response.Write mangles
+// Connection / Upgrade and would break the 101 handshake — we
+// filter byte-verbatim here instead of round-tripping through
+// http.Response.
+func stripAuthResponseHeadersRaw(headerBytes []byte) []byte {
+	const term = "\r\n\r\n"
+	if !bytes.HasSuffix(headerBytes, []byte(term)) {
+		return headerBytes
+	}
+	body := headerBytes[:len(headerBytes)-len(term)]
+	lines := bytes.Split(body, []byte("\r\n"))
+	kept := make([][]byte, 0, len(lines))
+	for i, line := range lines {
+		if i == 0 {
+			kept = append(kept, line)
+			continue
+		}
+		if c := bytes.IndexByte(line, ':'); c >= 0 {
+			name := strings.TrimSpace(string(line[:c]))
+			if isAuthResponseHeader(name) {
+				continue
+			}
+		}
+		kept = append(kept, line)
+	}
+	out := bytes.Join(kept, []byte("\r\n"))
+	out = append(out, '\r', '\n', '\r', '\n')
+	return out
+}

--- a/response_sanitize_test.go
+++ b/response_sanitize_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestStripAuthResponseHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Add("Set-Cookie", "session=abc")
+	h.Add("Set-Cookie", "refresh=def")
+	h.Set("Set-Cookie2", "legacy=ghi")
+	h.Set("WWW-Authenticate", `Bearer realm="x"`)
+	h.Set("Proxy-Authenticate", `Basic realm="x"`)
+	h.Set("Authentication-Info", `nextnonce="x"`)
+	h.Set("Proxy-Authentication-Info", `rspauth="x"`)
+	h.Set("X-Custom", "keep")
+
+	stripAuthResponseHeaders(h)
+
+	for _, name := range []string{
+		"Set-Cookie", "Set-Cookie2", "WWW-Authenticate",
+		"Proxy-Authenticate", "Authentication-Info",
+		"Proxy-Authentication-Info",
+	} {
+		if v := h.Values(name); len(v) != 0 {
+			t.Errorf("header %q not stripped, got %v", name, v)
+		}
+	}
+	if h.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type was clobbered: %q", h.Get("Content-Type"))
+	}
+	if h.Get("X-Custom") != "keep" {
+		t.Errorf("X-Custom was clobbered: %q", h.Get("X-Custom"))
+	}
+}
+
+func TestStripAuthResponseHeadersRaw(t *testing.T) {
+	in := []byte("HTTP/1.1 101 Switching Protocols\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Accept: abc\r\n" +
+		"set-cookie: session=abc\r\n" +
+		"Set-Cookie: refresh=def\r\n" +
+		"WWW-Authenticate: Bearer realm=\"x\"\r\n" +
+		"X-Custom: keep\r\n" +
+		"\r\n")
+	out := stripAuthResponseHeadersRaw(in)
+
+	s := string(out)
+	for _, banned := range []string{
+		"set-cookie", "Set-Cookie", "WWW-Authenticate",
+		"session=abc", "refresh=def", "Bearer",
+	} {
+		if strings.Contains(s, banned) {
+			t.Errorf("expected %q to be stripped, output:\n%s", banned, s)
+		}
+	}
+	for _, kept := range []string{
+		"HTTP/1.1 101 Switching Protocols",
+		"Upgrade: websocket",
+		"Connection: Upgrade",
+		"Sec-WebSocket-Accept: abc",
+		"X-Custom: keep",
+	} {
+		if !strings.Contains(s, kept) {
+			t.Errorf("expected %q preserved, output:\n%s", kept, s)
+		}
+	}
+	if !bytes.HasSuffix(out, []byte("\r\n\r\n")) {
+		t.Errorf("output does not end with CRLFCRLF: %q",
+			string(out[max(0, len(out)-8):]))
+	}
+}
+
+func TestStripAuthResponseHeadersRawNoTerminator(t *testing.T) {
+	in := []byte("HTTP/1.1 200 OK\r\nSet-Cookie: x=y\r\n")
+	out := stripAuthResponseHeadersRaw(in)
+	if !bytes.Equal(in, out) {
+		t.Errorf("malformed input should pass through unchanged")
+	}
+}

--- a/ws.go
+++ b/ws.go
@@ -139,6 +139,12 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 		log.Printf("ws read resp: %v", err)
 		return
 	}
+	// Drop credential-bearing response headers (Set-Cookie, WWW-
+	// Authenticate, …) before they cross to the agent. Filters
+	// bytes verbatim — must not parse + re-serialise, since that
+	// mangles the Connection / Upgrade hop-by-hop headers the
+	// 101 handshake depends on.
+	headerBytes = stripAuthResponseHeadersRaw(headerBytes)
 	statusLine := ""
 	if i := bytes.Index(headerBytes, []byte("\r\n")); i >= 0 {
 		statusLine = string(headerBytes[:i])


### PR DESCRIPTION
Addresses item 3 of #193.

The proxy injects credentials into outbound requests but does not
filter them out of inbound responses. Upstream `Set-Cookie` /
`Set-Cookie2`, `WWW-Authenticate`, `Proxy-Authenticate`, and
`Authentication-Info` / `Proxy-Authentication-Info` forward
verbatim to the agent today. For OAuth-style flows that hands the
agent a usable session credential: the original API key never
reaches it, but the session cookie the upstream sets in response
does — `site/doc/11-security-model.md`'s "no injected credential
ever reaches the agent" property fails by example.

This change drops the credential-bearing response headers before
writing back to the agent on both transports.

* `main.go` (HTTPS MITM, `mitmHTTPS` → `resp.Write(tc)`):
  capture the upstream's headers into the audit log first, then
  call `stripAuthResponseHeaders(resp.Header)` and write. The
  dashboard still sees what the upstream actually sent; the agent
  sees a sanitised response.
* `ws.go` (WS 101 upgrade response): filter the raw header bytes
  before forwarding. Cannot route through `http.Response.Write`
  here — Go mangles `Connection: upgrade` / `Upgrade: websocket`
  on 101 responses, breaking the handshake (this is why the
  existing code forwards byte-verbatim in the first place).

The deny list lives in `response_sanitize.go` so future additions
(custom challenge headers, plugin-declared auth cookies, …) have
an obvious home. Both helpers are unit-tested, including the WS
case where `Set-Cookie` lives alongside the upgrade headers that
must survive.

No equivalent mitigation in `example/ref-impl` to inspire from:
its `streamResponse` only strips hop-by-hop encoding headers
(`transfer-encoding`, `connection`, `keep-alive`,
`content-encoding`, `content-length`), and `redactCredentials` is
for log / approval-record hygiene, not the response-to-agent path.

Out of scope here:
* per-plugin opt-out for benign cookies — fine for a follow-up;
  default-deny is the right starting point.
* response header sanitisation on the non-MITM splice path —
  splice traffic never gets a credential injected, so the same
  threat doesn't apply.