### PR TITLE
Add --read-only-config flag to gateway

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,12 +246,7 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 type Gateway struct {
 	cfg     *config.Gateway
 	cfgPath string // path the HCL config was loaded from
-	// readOnlyConfig, when set via --read-only-config, rejects every
-	// dashboard write that mutates cfgPath. The dashboard reads the
-	// flag from /api/state and hides its editor affordances; the
-	// server enforces it regardless of UI state.
-	readOnlyConfig bool
-	db             *sql.DB
+	db      *sql.DB
 	policy  atomic.Pointer[config.CompiledPolicy]
 	certs   *CertCache
 	dialer  *net.Dialer
@@ -260,6 +255,11 @@ type Gateway struct {
 	agents  *AgentRegistry
 	hitl    *HITLRegistry
 	onboard *onboardRegistry
+	// readOnlyConfig, when set via --read-only-config, rejects every
+	// dashboard write that mutates cfgPath. The dashboard reads the
+	// flag from /api/state and hides its editor affordances; the
+	// server enforces it regardless of UI state.
+	readOnlyConfig bool
 	// secrets hands credential plugins the secret bytes they inject
 	// at request time. Default env-var-backed; OAuth-flow credentials
 	// land via a follow-up bridge that delegates to OAuthRegistry.

--- a/main.go
+++ b/main.go
@@ -246,7 +246,12 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 type Gateway struct {
 	cfg     *config.Gateway
 	cfgPath string // path the HCL config was loaded from
-	db      *sql.DB
+	// readOnlyConfig, when set via --read-only-config, rejects every
+	// dashboard write that mutates cfgPath. The dashboard reads the
+	// flag from /api/state and hides its editor affordances; the
+	// server enforces it regardless of UI state.
+	readOnlyConfig bool
+	db             *sql.DB
 	policy  atomic.Pointer[config.CompiledPolicy]
 	certs   *CertCache
 	dialer  *net.Dialer
@@ -2140,6 +2145,8 @@ func runGateway(args []string) {
 	}
 	fs := flag.NewFlagSet("gateway", flag.ExitOnError)
 	cfgPath := fs.String("config", "config.yaml", "config file")
+	readOnly := fs.Bool("read-only-config", false,
+		"reject dashboard writes to the HCL config file")
 	_ = fs.Parse(args)
 
 	startModelRefresh()
@@ -2183,16 +2190,20 @@ func runGateway(args []string) {
 		log.Fatalf("oauth: %v", err)
 	}
 	g := &Gateway{
-		cfg:     cfg,
-		cfgPath: *cfgPath,
-		db:      db,
-		certs:   certs,
-		dialer:  newUpstreamDialer(cfg.Resolver),
-		sink:    sink,
-		oauth:   oauthReg,
-		agents:  NewAgentRegistry(),
-		hitl:    newHITLRegistry(sink),
-		onboard: newOnboardRegistry(),
+		cfg:            cfg,
+		cfgPath:        *cfgPath,
+		readOnlyConfig: *readOnly,
+		db:             db,
+		certs:          certs,
+		dialer:         newUpstreamDialer(cfg.Resolver),
+		sink:           sink,
+		oauth:          oauthReg,
+		agents:         NewAgentRegistry(),
+		hitl:           newHITLRegistry(sink),
+		onboard:        newOnboardRegistry(),
+	}
+	if *readOnly {
+		log.Printf("config: read-only mode (dashboard writes rejected)")
 	}
 	g.secrets = newGatewaySecretStore(db, oauthReg)
 	g.tunnels = NewTunnelManager(g.secrets, cfg.CADir)

--- a/web.go
+++ b/web.go
@@ -655,10 +655,11 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 	w.stateCacheMu.RUnlock()
 
 	state := map[string]any{
-		"whoami":       w.whoamiData(r),
-		"integrations": w.statusList(r),
-		"agents":       w.agentsList(),
-		"update":       currentUpdateBanner.Load(),
+		"whoami":           w.whoamiData(r),
+		"integrations":     w.statusList(r),
+		"agents":           w.agentsList(),
+		"update":           currentUpdateBanner.Load(),
+		"read_only_config": w.g.readOnlyConfig,
 	}
 	body, err := json.Marshal(state)
 	if err != nil {
@@ -846,6 +847,10 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
+	if w.g.readOnlyConfig {
+		http.Error(rw, "read-only config", http.StatusForbidden)
+		return
+	}
 	if r.Method != "POST" {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
@@ -897,6 +902,10 @@ func (w *webMux) apiConfigPreview(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (w *webMux) apiConfigSave(rw http.ResponseWriter, r *http.Request) {
+	if w.g.readOnlyConfig {
+		http.Error(rw, "read-only config", http.StatusForbidden)
+		return
+	}
 	if r.Method != "POST" {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return

--- a/web_config_test.go
+++ b/web_config_test.go
@@ -243,6 +243,40 @@ func TestAPIConfigSaveRejectsUnpreviewedContent(t *testing.T) {
 	}
 }
 
+func TestAPIConfigReadOnlyModeRejectsWrites(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	original := []byte("insecure_no_dashboard_secret = true\n")
+	if err := os.WriteFile(cfgPath, original, 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	w := &webMux{g: &Gateway{cfgPath: cfgPath, readOnlyConfig: true}}
+
+	preview := httptest.NewRequest(http.MethodPost, "/api/config/preview",
+		strings.NewReader("insecure_no_dashboard_secret=false\n"))
+	pr := httptest.NewRecorder()
+	w.apiConfigPreview(pr, preview)
+	if pr.Code != http.StatusForbidden {
+		t.Fatalf("preview status = %d, want 403, body = %s", pr.Code, pr.Body.String())
+	}
+
+	save := httptest.NewRequest(http.MethodPost, "/api/config/save",
+		strings.NewReader(`{"content":"x","expected_revision":"r","preview_token":"t"}`))
+	sr := httptest.NewRecorder()
+	w.apiConfigSave(sr, save)
+	if sr.Code != http.StatusForbidden {
+		t.Fatalf("save status = %d, want 403, body = %s", sr.Code, sr.Body.String())
+	}
+
+	contents, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read cfg: %v", err)
+	}
+	if !bytes.Equal(contents, original) {
+		t.Fatalf("read-only mode wrote file: %q", contents)
+	}
+}
+
 func TestAPIConfigPutIsReadOnly(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "gateway.hcl")

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -43,6 +43,7 @@ export default function App() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [whoami, setWhoami] = useState<Whoami | null>(null);
   const [update, setUpdate] = useState<UpdateBanner | null>(null);
+  const [readOnlyConfig, setReadOnlyConfig] = useState(false);
   const [connectId, setConnectId] = useState<string | null>(null);
   const [connectProfile, setConnectProfile] = useState<string | undefined>(undefined);
   const [showAddDevice, setShowAddDevice] = useState(false);
@@ -65,6 +66,7 @@ export default function App() {
       setAgents(s.agents || []);
       setWhoami(s.whoami);
       setUpdate(s.update ?? null);
+      setReadOnlyConfig(!!s.read_only_config);
     } catch {
       /* swallow */
     }
@@ -160,6 +162,7 @@ export default function App() {
           agents={agents}
           integrations={integrations}
           whoami={whoami}
+          readOnlyConfig={readOnlyConfig}
           onBack={() => navigate("")}
           onConnect={(id, profile) => {
             setConnectId(id);
@@ -171,7 +174,13 @@ export default function App() {
       {showAddDevice && (
         <AddDeviceModal publicURL={whoami?.public_url} onClose={() => setShowAddDevice(false)} />
       )}
-      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} onSaved={refresh} />}
+      {showSettings && (
+        <SettingsModal
+          readOnly={readOnlyConfig}
+          onClose={() => setShowSettings(false)}
+          onSaved={refresh}
+        />
+      )}
       {connectId && (
         <ConnectModal
           id={connectId}

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -21,6 +21,7 @@ export function DevicePage({
   agents,
   integrations,
   whoami,
+  readOnlyConfig,
   onBack,
   onConnect,
   onRefresh,
@@ -29,6 +30,7 @@ export function DevicePage({
   agents: Agent[];
   integrations: Integration[];
   whoami: Whoami | null;
+  readOnlyConfig?: boolean;
   onBack: () => void;
   onConnect: (id: string, profile?: string) => void;
   onRefresh: () => void;
@@ -228,7 +230,7 @@ export function DevicePage({
       />
 
       {/* rules — per-device scope (with global rules layered in) */}
-      <RulesPanel deviceIP={a.ip} profile={a.profile} />
+      <RulesPanel deviceIP={a.ip} profile={a.profile} readOnly={readOnlyConfig} />
     </main>
   );
 }

--- a/www/src/components/HCLEditor.tsx
+++ b/www/src/components/HCLEditor.tsx
@@ -19,15 +19,17 @@ export function HCLEditor({
   value,
   onChange,
   minHeight = 320,
+  readOnly,
 }: {
   value: string;
   onChange: (v: string) => void;
   minHeight?: number;
+  readOnly?: boolean;
 }) {
   return (
     <Editor
       value={value}
-      onValueChange={onChange}
+      onValueChange={readOnly ? () => {} : onChange}
       highlight={(code) => Prism.highlight(code, Prism.languages.hcl, "hcl")}
       padding={16}
       style={{

--- a/www/src/components/RulesPanel.tsx
+++ b/www/src/components/RulesPanel.tsx
@@ -6,7 +6,14 @@ import { RulesEditor } from "./RulesEditor";
 // Rules panel. Profile-level rules only — device-specific overrides
 // are gone. The pencil opens gateway.hcl. Device pages pass `profile`
 // so the listing filters to the device's profile.
-export function RulesPanel({ profile }: { deviceIP?: string; profile?: string }) {
+export function RulesPanel({
+  profile,
+  readOnly,
+}: {
+  deviceIP?: string;
+  profile?: string;
+  readOnly?: boolean;
+}) {
   const [rows, setRows] = useState<RuleSummary[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
@@ -31,7 +38,7 @@ export function RulesPanel({ profile }: { deviceIP?: string; profile?: string })
       <Section
         title="Rules"
         rows={visible}
-        onEdit={() => setEditing(true)}
+        onEdit={readOnly ? undefined : () => setEditing(true)}
         editTitle="edit gateway.hcl"
       />
       {editing && (

--- a/www/src/components/SettingsModal.tsx
+++ b/www/src/components/SettingsModal.tsx
@@ -7,7 +7,15 @@ import { getConfigHCL, previewConfigHCL, saveConfigHCL, type ConfigSavePreview }
 import { ConfigSaveReview } from "./ConfigSaveReview";
 import { HCLEditor } from "./HCLEditor";
 
-export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
+export function SettingsModal({
+  onClose,
+  onSaved,
+  readOnly,
+}: {
+  onClose: () => void;
+  onSaved: () => void;
+  readOnly?: boolean;
+}) {
   const [text, setText] = useState("");
   const [original, setOriginal] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -73,6 +81,11 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
           <div className="flex items-center px-4 py-3 border-b border-[#e5e5e5]">
             <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3]">
               GATEWAY SETTINGS · gateway.hcl
+              {readOnly && (
+                <span className="ml-2 normal-case tracking-normal text-[#737373]">
+                  · read-only (--read-only-config)
+                </span>
+              )}
             </div>
             <button
               onClick={onClose}
@@ -83,19 +96,21 @@ export function SettingsModal({ onClose, onSaved }: { onClose: () => void; onSav
           </div>
 
           <div className="flex-1 overflow-auto">
-            <HCLEditor value={text} onChange={setText} minHeight={420} />
+            <HCLEditor value={text} onChange={setText} minHeight={420} readOnly={readOnly} />
           </div>
 
           <div className="flex items-center gap-2 px-4 py-3 border-t border-[#e5e5e5]">
             {err && <div className="text-[11px] text-red-600 truncate">{err}</div>}
             {okMsg && <div className="text-[11px] text-green-700 truncate">{okMsg}</div>}
-            <button
-              onClick={save}
-              disabled={!dirty || busy}
-              className="ml-auto text-[11px] px-3 py-1 bg-black text-white rounded disabled:opacity-40 hover:bg-[#171717]"
-            >
-              {busy ? "saving…" : "save"}
-            </button>
+            {!readOnly && (
+              <button
+                onClick={save}
+                disabled={!dirty || busy}
+                className="ml-auto text-[11px] px-3 py-1 bg-black text-white rounded disabled:opacity-40 hover:bg-[#171717]"
+              >
+                {busy ? "saving…" : "save"}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -317,6 +317,10 @@ type StateResp = {
   integrations: Integration[];
   agents: Agent[];
   update?: UpdateBanner | null;
+  // When true, the gateway was launched with --read-only-config and
+  // will reject /api/config/preview + /api/config/save with 403. The
+  // dashboard hides its editor affordances to match.
+  read_only_config?: boolean;
 };
 let lastStateTag = "";
 let lastState: StateResp | null = null;


### PR DESCRIPTION
## Summary
- Adds a `--read-only-config` boolean to `clawpatrol gateway`. When set, `/api/config/preview` and `/api/config/save` return 403 — the only on-disk HCL write paths the dashboard owns.
- Surfaces the flag via `/api/state` as `read_only_config` so the dashboard hides the RulesPanel pencil and the SettingsModal save button (header gains a `· read-only (--read-only-config)` tag, HCL editor becomes view-only).
- Scope is intentionally narrow to the HCL file. Credential, OAuth, device/profile, HITL, and onboarding endpoints continue to work because they do not touch `gateway.hcl`.

## Test plan
- [x] `go test ./...` — includes new `TestAPIConfigReadOnlyModeRejectsWrites` covering 403 on both endpoints and that the file is untouched.
- [x] `go vet ./...`
- [x] `npm run build` in `www/`
- [x] `./clawpatrol gateway --help` lists the new flag
- [ ] Smoke: start gateway with `--read-only-config`, confirm dashboard shows no save/edit affordances and `curl -X POST /api/config/save` returns 403; restart without the flag, confirm editor returns
