### PR TITLE
matcher: lowercase want values at compile time for always-lowercase facets

### DIFF
--- a/config/match/cel.go
+++ b/config/match/cel.go
@@ -280,12 +280,16 @@ func referencesPath(root celast.Expr, paths []celPath) bool {
 //
 // Recognised shapes — for each, the literal is normalized:
 //
-//	<path> == "X"           // and the symmetric "X" == <path>
-//	<path> != "X"           // and the symmetric "X" != <path>
-//	<path> in ["X", "Y"]    // every string literal in the list
-//	<path>.startsWith("X")  // member-call args
+//	<path> == "X"                            // and the symmetric "X" == <path>
+//	<path> != "X"                            // and the symmetric "X" != <path>
+//	<path> in ["X", "Y"]                     // every string literal in the list
+//	"X" in <path>                            // path is a list-typed facet
+//	<path>.startsWith("X")                   // member-call args
 //	<path>.endsWith("X")
 //	<path>.contains("X")
+//	sets.intersects(<path>, ["X", "Y"])      // and the symmetric form
+//	sets.contains(<path>, ["X", "Y"])
+//	sets.equivalent(<path>, ["X", "Y"])
 //
 // matches() is deliberately not normalized — its argument is a regex,
 // where case classes like `[A-Z]` are meaningful and the operator can
@@ -313,15 +317,39 @@ func normalizeWantLiterals(root celast.Expr, paths []celPath) {
 				}
 			case operators.In:
 				args := c.Args()
-				if len(args) == 2 && matchesPath(args[0], paths) && args[1].Kind() == celast.ListKind {
-					for _, el := range args[1].AsList().Elements() {
-						lowercaseStringLiteral(el)
+				if len(args) == 2 {
+					switch {
+					case matchesPath(args[0], paths) && args[1].Kind() == celast.ListKind:
+						for _, el := range args[1].AsList().Elements() {
+							lowercaseStringLiteral(el)
+						}
+					case matchesPath(args[1], paths):
+						// `"X" in <path>` — path is a list-typed facet.
+						lowercaseStringLiteral(args[0])
 					}
 				}
 			case "startsWith", "endsWith", "contains":
 				if c.IsMemberFunction() && matchesPath(c.Target(), paths) {
 					for _, a := range c.Args() {
 						lowercaseStringLiteral(a)
+					}
+				}
+			case "sets.intersects", "sets.contains", "sets.equivalent":
+				// Two-list set predicates from cel-go ext.Sets(). When
+				// one argument is a declared-lowercase path and the
+				// other is a list literal, lowercase the literal's
+				// string elements so an upper-case want still matches
+				// the lower-cased got.
+				args := c.Args()
+				if len(args) == 2 {
+					if matchesPath(args[0], paths) && args[1].Kind() == celast.ListKind {
+						for _, el := range args[1].AsList().Elements() {
+							lowercaseStringLiteral(el)
+						}
+					} else if matchesPath(args[1], paths) && args[0].Kind() == celast.ListKind {
+						for _, el := range args[0].AsList().Elements() {
+							lowercaseStringLiteral(el)
+						}
 					}
 				}
 			}

--- a/config/plugins/facets/https/https_test.go
+++ b/config/plugins/facets/https/https_test.go
@@ -139,6 +139,24 @@ func TestHTTPMatcherMethodCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestHTTPMatcherPathCaseSensitive locks in that the compile-time
+// case-normalisation applied to always-lowercase facets (method,
+// k8s.resource, sql.tables, ...) does NOT bleed into http.path.
+// HTTP paths are case-sensitive per RFC 3986 and the gateway does
+// not fold the got side, so `/Foo` must NOT match got `/foo`.
+func TestHTTPMatcherPathCaseSensitive(t *testing.T) {
+	m, err := facet.NewMatcher("http", "http.path == '/Foo'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Match(httpReq("GET", "/foo")) {
+		t.Errorf("expected case-sensitive path mismatch")
+	}
+	if !m.Match(httpReq("GET", "/Foo")) {
+		t.Errorf("expected case-sensitive path match for identical case")
+	}
+}
+
 func TestHTTPMatcherBodyJSON(t *testing.T) {
 	m, err := facet.NewMatcher("http", "http.method == 'PATCH' && http.body_json.archived == true")
 	if err != nil {

--- a/config/plugins/facets/k8s/k8s.go
+++ b/config/plugins/facets/k8s/k8s.go
@@ -136,7 +136,13 @@ func init() {
 // matching string literals in the rule source at compile time, so
 // `k8s.verb == "GET"` matches a get request even though the
 // activation reports `verb = "get"`.
-var lowercasedPaths = []string{"k8s.verb"}
+//
+// `resource` is always lowercase too: kubernetes API server routes
+// only resolve lowercase resource segments (`/api/v1/pods`, never
+// `/Pods`), so the Meta derived from the URL path is always lower.
+// `namespace` and `name` are case-sensitive (kubernetes allows mixed
+// case there) and intentionally stay unnormalised.
+var lowercasedPaths = []string{"k8s.verb", "k8s.resource"}
 
 // Kubernetes Meta is derived entirely from the request URL + method,
 // not from buffered request bytes, so no k8s.* field is affected by

--- a/config/plugins/facets/k8s/k8s_match_test.go
+++ b/config/plugins/facets/k8s/k8s_match_test.go
@@ -40,6 +40,70 @@ func TestK8sMatcherVerbCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestK8sMatcherResourceCaseInsensitive locks in that a rule written
+// as `k8s.resource == "Pods"` matches got `pods`. The kubernetes API
+// server only routes lowercase resource segments, so the Meta the
+// matcher reads is always lower; CompileCondition normalizes the
+// want literals so an operator typing `Pods` still resolves.
+func TestK8sMatcherResourceCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		resource  string
+		want      bool
+	}{
+		{"uppercase want", "k8s.resource == 'PODS'", "pods", true},
+		{"mixed-case want", "k8s.resource == 'Pods'", "pods", true},
+		{"uppercase list", "k8s.resource in ['PODS', 'SECRETS']", "secrets", true},
+		{"uppercase list miss", "k8s.resource in ['PODS', 'SECRETS']", "configmaps", false},
+		{"endsWith uppercase suffix", "k8s.resource.endsWith('/EXEC')", "pods/exec", true},
+		{"startsWith uppercase prefix", "k8s.resource.startsWith('Pods/')", "pods/exec", true},
+		{"reversed equality", "'Pods' == k8s.resource", "pods", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("k8s", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{Family: "k8s", Meta: &k8sfacet.Meta{Verb: "get", Resource: tc.resource}}
+			if got := m.Match(req); got != tc.want {
+				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			}
+		})
+	}
+}
+
+// TestK8sMatcherNameNamespaceCaseSensitive pins the surrounding
+// facets' case-sensitivity: kubernetes object names and namespaces
+// are case-significant identifiers, so a mixed-case want must NOT
+// silently match a lower-cased got.
+func TestK8sMatcherNameNamespaceCaseSensitive(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		meta      *k8sfacet.Meta
+		want      bool
+	}{
+		{"name mismatch on case", "k8s.name == 'MyApp'", &k8sfacet.Meta{Name: "myapp"}, false},
+		{"name exact case matches", "k8s.name == 'MyApp'", &k8sfacet.Meta{Name: "MyApp"}, true},
+		{"namespace mismatch on case", "k8s.namespace == 'Prod'", &k8sfacet.Meta{Namespace: "prod"}, false},
+		{"namespace exact case matches", "k8s.namespace == 'Prod'", &k8sfacet.Meta{Namespace: "Prod"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("k8s", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{Family: "k8s", Meta: tc.meta}
+			if got := m.Match(req); got != tc.want {
+				t.Errorf("Match=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestK8sMatcherNegationAndGlobs(t *testing.T) {
 	m, err := facet.NewMatcher("k8s",
 		"k8s.verb in ['create', 'update', 'patch', 'delete'] && !k8s.name.startsWith('debug-') "+

--- a/config/plugins/facets/sql/sql.go
+++ b/config/plugins/facets/sql/sql.go
@@ -155,7 +155,16 @@ func init() {
 // matching string literals in the rule source at compile time, so
 // `sql.verb == "SELECT"` matches a select statement even though the
 // activation reports `verb = "select"`.
-var lowercasedPaths = []string{"sql.verb"}
+//
+// `tables` and `functions` are always-lower too: the postgres and
+// clickhouse parsers fold identifiers via strings.ToLower
+// (config/plugins/endpoints/postgres_sql.go,
+// clickhouse_native_sql.go), so a rule written
+// `"Users" in sql.tables` or
+// `sets.intersects(sql.tables, ["Users"])` still matches got `users`.
+// `statement` stays case-preserving — operators opt into
+// case-insensitivity via `statement.matches('(?i)...')`.
+var lowercasedPaths = []string{"sql.verb", "sql.tables", "sql.functions"}
 
 // truncatablePaths declares every SQL field, because the wire
 // frontends (postgres pgClientToServer, clickhouse_native

--- a/config/plugins/facets/sql/sql_match_test.go
+++ b/config/plugins/facets/sql/sql_match_test.go
@@ -57,6 +57,89 @@ func TestSQLMatcherVerbCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestSQLMatcherTablesAndFunctionsCaseInsensitive locks in that a
+// rule written as `"Users" in sql.tables` or
+// `sets.intersects(sql.tables, ["Users"])` matches an upper-case want
+// against the always-lower got side. Postgres and clickhouse parsers
+// fold identifiers to lower-case before populating Meta, so any rule
+// that types tables/functions in any case must still resolve.
+func TestSQLMatcherTablesAndFunctionsCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		meta      *sqlfacet.Meta
+		want      bool
+	}{
+		{
+			"in-list literal upper, got lower",
+			"'Users' in sql.tables",
+			&sqlfacet.Meta{Verb: "select", Tables: []string{"users"}},
+			true,
+		},
+		{
+			"in-list literal upper, miss",
+			"'Orders' in sql.tables",
+			&sqlfacet.Meta{Verb: "select", Tables: []string{"users"}},
+			false,
+		},
+		{
+			"sets.intersects mixed-case want list",
+			"sets.intersects(sql.tables, ['Users', 'USER_SECRETS'])",
+			&sqlfacet.Meta{Verb: "select", Tables: []string{"user_secrets"}},
+			true,
+		},
+		{
+			"sets.intersects no overlap",
+			"sets.intersects(sql.tables, ['Users'])",
+			&sqlfacet.Meta{Verb: "select", Tables: []string{"orders"}},
+			false,
+		},
+		{
+			"functions upper-case literal",
+			"'Now' in sql.functions",
+			&sqlfacet.Meta{Verb: "select", Functions: []string{"now"}},
+			true,
+		},
+		{
+			"sets.intersects on functions",
+			"sets.intersects(sql.functions, ['Pg_Sleep', 'NOW'])",
+			&sqlfacet.Meta{Verb: "select", Functions: []string{"now"}},
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("sql", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{Family: "sql", Meta: tc.meta}
+			if got := m.Match(req); got != tc.want {
+				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			}
+		})
+	}
+}
+
+// TestSQLMatcherStatementCaseSensitive locks in that `sql.statement`
+// stays case-preserving even though sibling fields (verb / tables /
+// functions) are case-folded. Operators opt into case-insensitive
+// statement matches via `statement.matches('(?i)...')`.
+func TestSQLMatcherStatementCaseSensitive(t *testing.T) {
+	m, err := facet.NewMatcher("sql", "sql.statement == 'SELECT 1'")
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	req := &match.Request{Family: "sql", Meta: &sqlfacet.Meta{Verb: "select", Statement: "select 1"}}
+	if m.Match(req) {
+		t.Errorf("case-sensitive statement should NOT match lower-cased SQL")
+	}
+	req.Meta = &sqlfacet.Meta{Verb: "select", Statement: "SELECT 1"}
+	if !m.Match(req) {
+		t.Errorf("case-sensitive statement should match identical SQL")
+	}
+}
+
 // TestSQLMatcherDatabaseCaseSensitive pins the database facet's
 // case-sensitivity: postgres treats database names as identifiers, so
 // `sql.database == "Prod"` MUST distinguish "Prod" from "prod". The


### PR DESCRIPTION
## Summary

Several rule facets compare an operator-supplied want value against a runtime got value that the gateway has already lower-cased. An operator writing `verb = "SELECT"` for SQL or `resource = "Pods"` for k8s could silently miss because the matcher compared verbatim against the always-lower-cased got side.

This PR extends the existing compile-time case-folding mechanism (`lowercasedPaths` + `normalizeWantLiterals` in `config/match/cel.go`) to cover `sql.tables`, `sql.functions`, and `k8s.resource` — facets whose got side is always lower-cased — so the want literals in the rule source are lowered at compile time.

> **Note:** this PR was reworked on top of current `main` (`0b5a6d2`). The original glob-based `LowerGlobs` approach is obsolete — `main` now folds case via CEL AST rewriting (`normalizeWantLiterals`) at compile time, not via globs. The description below reflects the actual implementation on the branch.

## Per-facet classification

| Family | Facet | Got side normalised? | Want side fix |
|---|---|---|---|
| http_rule | `method` | not always-lower (raw `net/http`); compared case-insensitively at runtime | leave alone |
| http_rule | `path` / `query` / `body_*` | case-sensitive (RFC) | leave alone |
| http_rule | `headers` | name canonical-cased (case-insensitive lookup); values verbatim | leave alone |
| sql_rule | `verb` | always-lower (postgres/clickhouse parsers) | already in `lowercasedPaths` |
| sql_rule | `tables` | always-lower (parsers fold identifiers via `strings.ToLower`) | **add to `lowercasedPaths` (new)** |
| sql_rule | `functions` | always-lower (same parser paths) | **add to `lowercasedPaths` (new)** |
| sql_rule | `statement` | case-sensitive raw SQL | leave alone (`matches('(?i)...')` opt-in) |
| k8s_rule | `verb` | always-lower (derived from HTTP method into a fixed vocabulary) | already in `lowercasedPaths` |
| k8s_rule | `resource` | always-lower (k8s API server only routes lower-case resource segments) | **add to `lowercasedPaths` (new)** |
| k8s_rule | `namespace` / `name` | case-sensitive (k8s allows mixed case) | leave alone |
| k8s_rule | `params` | per-param case-sensitive | leave alone |

## Changes

- `config/plugins/facets/sql/sql.go`: add `sql.tables` and `sql.functions` to `lowercasedPaths`, with a comment documenting why they are always-lower.
- `config/plugins/facets/k8s/k8s.go`: add `k8s.resource` to `lowercasedPaths`, with the same rationale.
- `config/match/cel.go`: extend `normalizeWantLiterals` to recognise the additional AST shapes these list-typed facets are used with — `"X" in <path>` (literal-LHS membership) and the `sets.intersects` / `sets.contains` / `sets.equivalent` two-list predicates — in addition to the previously handled `<path> == "X"`, `<path> in [list]`, and member `startsWith`/`endsWith`/`contains`.

## Test plan

- [x] `go test ./config/...` — all tests pass.
- [x] SQL (`sql_match_test.go`): `verb` case-insensitive incl. mixed-case list; `tables`/`functions` case-insensitive via literal-LHS `in` and `sets.intersects` with mixed/upper-case wants; `statement` stays case-sensitive.
- [x] k8s (`k8s_match_test.go`): `verb` and `resource` case-insensitive (`==`, `in`, `startsWith`/`endsWith`, reversed equality, globs, negation); `name`/`namespace` stay case-sensitive.
- [x] HTTP (`https_test.go`): `path` stays case-sensitive — locks in that case-folding does not bleed into `http.path`.
