### PR TITLE
gateway: prune stale HTTP transports on reload

### DIFF
--- a/dial_test.go
+++ b/dial_test.go
@@ -57,7 +57,9 @@ func TestTransportBrowserTLSUsesEndpointTunnel(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	_, err := g.transportFor(ep).DialTLSContext(ctx, "tcp", "browser.invalid:443")
+	transport, releaseTransport := g.transportFor(ep)
+	defer releaseTransport()
+	_, err := transport.DialTLSContext(ctx, "tcp", "browser.invalid:443")
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("DialTLSContext error = %v, want fake tunnel sentinel", err)
 	}
@@ -154,7 +156,9 @@ func TestTransportBrowserTLSWithClientCertUsesDialUpstream(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	_, err := g.transportFor(ep).DialTLSContext(ctx, "tcp", "browser.invalid:443")
+	transport, releaseTransport := g.transportFor(ep)
+	defer releaseTransport()
+	_, err := transport.DialTLSContext(ctx, "tcp", "browser.invalid:443")
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("DialTLSContext error = %v, want fake tunnel sentinel", err)
 	}

--- a/main.go
+++ b/main.go
@@ -283,14 +283,46 @@ type Gateway struct {
 	transports sync.Map // *config.CompiledEndpoint -> *http.Transport
 }
 
-// transportFor returns the cached http.Transport for ep, building it
-// on first use. dialBrowserTLS for Cloudflare-fronted hosts; mTLS
-// endpoints stay on dialUpstream so credential plugins run.
-func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
-	if v, ok := g.transports.Load(ep); ok {
-		return v.(*http.Transport)
+// transportFor returns the cached http.Transport for a current endpoint,
+// building it on first use. If an in-flight connection still references an
+// endpoint pointer from a previous policy generation, return an uncached
+// transport and a release function instead of re-inserting the stale pointer.
+// dialBrowserTLS for Cloudflare-fronted hosts; mTLS endpoints stay on
+// dialUpstream so credential plugins run.
+func (g *Gateway) transportFor(ep *config.CompiledEndpoint) (*http.Transport, func()) {
+	if !g.endpointInCurrentPolicy(ep) {
+		tr := g.newTransport(ep)
+		return tr, tr.CloseIdleConnections
 	}
-	tr := &http.Transport{
+	tr := g.newTransport(ep)
+	actual, _ := g.transports.LoadOrStore(ep, tr)
+	actualTransport := actual.(*http.Transport)
+	if actualTransport != tr {
+		tr.CloseIdleConnections()
+	}
+	if !g.endpointInCurrentPolicy(ep) {
+		g.transports.Delete(ep)
+		actualTransport.CloseIdleConnections()
+		return actualTransport, actualTransport.CloseIdleConnections
+	}
+	return actualTransport, func() {}
+}
+
+func (g *Gateway) endpointInCurrentPolicy(ep *config.CompiledEndpoint) bool {
+	policy := g.Policy()
+	if policy == nil {
+		return true
+	}
+	for _, current := range policy.Endpoints {
+		if current == ep {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *Gateway) newTransport(ep *config.CompiledEndpoint) *http.Transport {
+	return &http.Transport{
 		DialContext: g.dialer.DialContext,
 		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			h, _, err := net.SplitHostPort(addr)
@@ -308,8 +340,29 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 		MaxIdleConns:        128,
 		MaxIdleConnsPerHost: 8,
 	}
-	actual, _ := g.transports.LoadOrStore(ep, tr)
-	return actual.(*http.Transport)
+}
+
+func (g *Gateway) pruneTransports(policy *config.CompiledPolicy) {
+	live := map[*config.CompiledEndpoint]struct{}{}
+	if policy != nil {
+		for _, ep := range policy.Endpoints {
+			live[ep] = struct{}{}
+		}
+	}
+	g.transports.Range(func(key, value any) bool {
+		ep, ok := key.(*config.CompiledEndpoint)
+		if !ok {
+			return true
+		}
+		if _, keep := live[ep]; keep {
+			return true
+		}
+		g.transports.Delete(key)
+		if tr, ok := value.(*http.Transport); ok {
+			tr.CloseIdleConnections()
+		}
+		return true
+	})
 }
 
 // Policy returns the current snapshot of the lowered runtime policy.
@@ -371,6 +424,7 @@ func (g *Gateway) watchConfig(path string) {
 			continue
 		}
 		g.policy.Store(policy)
+		g.pruneTransports(policy)
 		registerOAuthCredentials(g.oauth, policy)
 		g.connIdx.Store(runtime.BuildConnIndex(policy))
 		if g.tunnels != nil {
@@ -1608,7 +1662,8 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 	// which threw away the idle-conn pool and racked up ~10KB of
 	// internal map allocations per request. Per-endpoint cache lets
 	// repeat requests to the same upstream reuse keep-alives.
-	transport := g.transportFor(ep)
+	transport, releaseTransport := g.transportFor(ep)
+	defer releaseTransport()
 
 	br := bufio.NewReader(tc)
 	for {

--- a/transport_cache_test.go
+++ b/transport_cache_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestPruneTransportsRemovesEndpointsMissingAfterReload(t *testing.T) {
+	oldEndpoint := &config.CompiledEndpoint{Name: "api", Family: "https"}
+	reloadedEndpoint := &config.CompiledEndpoint{Name: "api", Family: "https"}
+	removedEndpoint := &config.CompiledEndpoint{Name: "old", Family: "https"}
+
+	g := &Gateway{dialer: &net.Dialer{}}
+	g.policy.Store(&config.CompiledPolicy{Endpoints: map[string]*config.CompiledEndpoint{
+		"api": oldEndpoint,
+		"old": removedEndpoint,
+	}})
+	oldTransport, releaseOld := g.transportFor(oldEndpoint)
+	defer releaseOld()
+	removedTransport, releaseRemoved := g.transportFor(removedEndpoint)
+	defer releaseRemoved()
+
+	reloadedPolicy := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{
+			"api": reloadedEndpoint,
+		},
+	}
+	g.policy.Store(reloadedPolicy)
+	g.pruneTransports(reloadedPolicy)
+
+	if _, ok := g.transports.Load(oldEndpoint); ok {
+		t.Fatalf("transport for stale pointer to still-present endpoint remained cached")
+	}
+	if _, ok := g.transports.Load(removedEndpoint); ok {
+		t.Fatalf("transport for removed endpoint remained cached")
+	}
+	if _, ok := g.transports.Load(reloadedEndpoint); ok {
+		t.Fatalf("reload pruning should not eagerly create transports for new endpoints")
+	}
+	got, releaseReloaded := g.transportFor(reloadedEndpoint)
+	defer releaseReloaded()
+	if got == oldTransport || got == removedTransport {
+		t.Fatalf("transportFor reused a stale transport after reload prune")
+	}
+}
+
+func TestTransportForStaleEndpointAfterReloadDoesNotRecache(t *testing.T) {
+	oldEndpoint := &config.CompiledEndpoint{Name: "api", Family: "https"}
+	reloadedEndpoint := &config.CompiledEndpoint{Name: "api", Family: "https"}
+
+	g := &Gateway{dialer: &net.Dialer{}}
+	g.policy.Store(&config.CompiledPolicy{Endpoints: map[string]*config.CompiledEndpoint{
+		"api": oldEndpoint,
+	}})
+	oldTransport, releaseOld := g.transportFor(oldEndpoint)
+	defer releaseOld()
+
+	reloadedPolicy := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{
+			"api": reloadedEndpoint,
+		},
+	}
+	g.policy.Store(reloadedPolicy)
+	g.pruneTransports(reloadedPolicy)
+
+	staleTransport, releaseStale := g.transportFor(oldEndpoint)
+	defer releaseStale()
+	if staleTransport == nil {
+		t.Fatalf("transportFor returned nil transport for stale endpoint")
+	}
+	if staleTransport == oldTransport {
+		t.Fatalf("transportFor reused pruned cached transport for stale endpoint")
+	}
+	if _, ok := g.transports.Load(oldEndpoint); ok {
+		t.Fatalf("transportFor re-cached stale endpoint after reload prune")
+	}
+
+	currentTransport, releaseCurrent := g.transportFor(reloadedEndpoint)
+	defer releaseCurrent()
+	if currentTransport == nil {
+		t.Fatalf("transportFor returned nil transport for current endpoint")
+	}
+	if _, ok := g.transports.Load(reloadedEndpoint); !ok {
+		t.Fatalf("transportFor did not cache current reloaded endpoint")
+	}
+}


### PR DESCRIPTION
## Summary
- Prunes per-endpoint HTTP transports after a successful config reload so old `*CompiledEndpoint` pointer keys do not remain cached indefinitely.
- Treats in-flight handlers that still hold stale endpoint pointers as uncached transports and closes their idle connections on release, avoiding stale re-insertion after pruning.
- Adds regression coverage for old/removed endpoint pruning and stale post-reload `transportFor` calls.

## Test plan
- [x] `go test ./...`
- [x] `go test -race .`
- [x] `go vet ./...`
- [x] `git diff --check`
