### PR TITLE
Add clawpatrol validate <config.hcl>

### DIFF
--- a/main.go
+++ b/main.go
@@ -2042,6 +2042,8 @@ func main() {
 		runEnv(os.Args[2:])
 	case "init-ca":
 		runInitCA(os.Args[2:])
+	case "validate":
+		runValidate(os.Args[2:])
 	case "uninstall":
 		runUninstall(os.Args[2:])
 	case "status":
@@ -2126,6 +2128,7 @@ usage:
   clawpatrol uninstall                   tear down everything this machine installed
   clawpatrol env                         print shell exports for sourcing
   clawpatrol init-ca DIR                 generate a new CA in DIR
+  clawpatrol validate <config.hcl>       parse + compile a config and exit
   clawpatrol version`)
 	os.Exit(2)
 }

--- a/validate.go
+++ b/validate.go
@@ -5,20 +5,30 @@ import (
 	"os"
 )
 
-// runValidate parses + compiles an HCL config and reports diagnostics.
-// Exit 0 on success, 1 on validation failure, 2 on usage error. Same
-// pipeline the gateway uses at startup — anything that would crash the
-// daemon shows up here first.
+// runValidate is the CLI entry: print msg, exit with code.
 func runValidate(args []string) {
+	msg, code := validateCmd(args)
+	if code == 0 {
+		fmt.Println(msg)
+		return
+	}
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(code)
+}
+
+// validateCmd is the pure side: same arg parsing, but returns
+// (output, exitCode) instead of touching stdio. Same pipeline the
+// gateway uses at startup — anything that would crash the daemon
+// shows up here first. Exit codes: 0 ok, 1 validation failure,
+// 2 usage error.
+func validateCmd(args []string) (string, int) {
 	if len(args) != 1 || args[0] == "-h" || args[0] == "--help" {
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol validate <config.hcl>")
-		os.Exit(2)
+		return "usage: clawpatrol validate <config.hcl>", 2
 	}
 	_, cp, err := loadConfig(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: %v\n", args[0], err)
-		os.Exit(1)
+		return fmt.Sprintf("%s: %v", args[0], err), 1
 	}
-	fmt.Printf("ok: %s — %d endpoints across %d profile(s)\n",
-		args[0], len(cp.Endpoints), len(cp.Profiles))
+	return fmt.Sprintf("ok: %s — %d endpoints across %d profile(s)",
+		args[0], len(cp.Endpoints), len(cp.Profiles)), 0
 }

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// runValidate parses + compiles an HCL config and reports diagnostics.
+// Exit 0 on success, 1 on validation failure, 2 on usage error. Same
+// pipeline the gateway uses at startup — anything that would crash the
+// daemon shows up here first.
+func runValidate(args []string) {
+	if len(args) != 1 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol validate <config.hcl>")
+		os.Exit(2)
+	}
+	_, cp, err := loadConfig(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", args[0], err)
+		os.Exit(1)
+	}
+	fmt.Printf("ok: %s — %d endpoints across %d profile(s)\n",
+		args[0], len(cp.Endpoints), len(cp.Profiles))
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Re-uses config/testdata fixtures so we don't drift from the suite
+// that owns the load/compile contract.
+func TestValidateCmd(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		want    int
+		prefix  string // wanted output prefix
+		mustHas string // substring that must appear in output
+	}{
+		{"ok-minimal", []string{"config/testdata/feature_minimal.hcl"}, 0, "ok: ", "1 profile(s)"},
+		{"err-unknown-endpoint", []string{"config/testdata/error_unknown_endpoint.hcl"}, 1, "", "mystery"},
+		{"err-name-collision", []string{"config/testdata/error_name_collision.hcl"}, 1, "", "shared"},
+		{"usage-no-args", nil, 2, "usage:", "validate"},
+		{"usage-too-many", []string{"a.hcl", "b.hcl"}, 2, "usage:", "validate"},
+		{"usage-help", []string{"--help"}, 2, "usage:", "validate"},
+		{"err-missing-file", []string{filepath.Join(t.TempDir(), "nope.hcl")}, 1, "", "nope.hcl"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, code := validateCmd(tc.args)
+			if code != tc.want {
+				t.Fatalf("exit = %d, want %d (msg=%q)", code, tc.want, msg)
+			}
+			if tc.prefix != "" && !strings.HasPrefix(msg, tc.prefix) {
+				t.Errorf("msg = %q, want prefix %q", msg, tc.prefix)
+			}
+			if tc.mustHas != "" && !strings.Contains(msg, tc.mustHas) {
+				t.Errorf("msg = %q, want substring %q", msg, tc.mustHas)
+			}
+		})
+	}
+}
+
+// TestValidateCmdBadHCL covers syntactically broken HCL (parse error
+// before compile even gets a chance). Inline so the fixture set in
+// config/testdata stays focused on semantic checks.
+func TestValidateCmdBadHCL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.hcl")
+	if err := os.WriteFile(path, []byte("endpoint \"https\" \"x\" { hosts = [\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	msg, code := validateCmd([]string{path})
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (msg=%q)", code, msg)
+	}
+	if !strings.Contains(msg, "Missing expression") && !strings.Contains(msg, "expression") {
+		t.Errorf("msg = %q, want HCL parse diagnostic", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `clawpatrol validate <config.hcl>` — runs the same `config.Load() + config.Compile()` pipeline the gateway uses at startup, prints a one-line summary on success, surfaces diagnostics (file:line) on failure.

```
$ clawpatrol validate gateway.hcl
ok: gateway.hcl — 19 endpoints across 11 profile(s)

$ clawpatrol validate /tmp/bad.hcl
/tmp/bad.hcl: /tmp/bad.hcl:2,1-1: Missing expression; Expected the start of an expression, but found the end of the file.
$ echo $?
1
```

Motivated by `example/policy-config`: now that the prod.example.com gateway runs `--read-only-config` and reads its HCL from that repo, we want PR-time validation so a typo can't land on prod via a merge. Follow-up will add a workflow in `policy-config` that runs this against `gateway.hcl` on every PR.

Exit codes: `0` ok, `1` validation failure, `2` usage error.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — green.
- [x] `clawpatrol validate <prod-config>` → `ok: …` exit 0.
- [x] `clawpatrol validate <truncated-hcl>` → diagnostic, exit 1.
- [x] `clawpatrol validate` (no args) → usage, exit 2.
