### PR TITLE
tunnel: refresh always-on pins on config change

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net"
 	"sort"
@@ -127,6 +130,13 @@ type CompiledTunnel struct {
 	// Plugins fetch the secret bytes via SecretStore.Get keyed on
 	// Credential.Symbol.Name.
 	Credential *Entity
+
+	// Fingerprint is a stable hash of the compiled tunnel definition,
+	// including its credential definition and via chain. Runtime
+	// managers use it to distinguish same-name tunnels across policy
+	// reloads without retaining or logging raw config/secret-bearing
+	// fields.
+	Fingerprint string `json:"-"`
 }
 
 // KeepaliveAlwaysSentinel is the duration value that means "pin
@@ -495,7 +505,107 @@ func compileTunnels(cp *CompiledPolicy, p *Policy) error {
 			cur = cur.Via
 		}
 	}
+	if err := fingerprintTunnels(cp.Tunnels); err != nil {
+		return err
+	}
 	return nil
+}
+
+type compiledTunnelFingerprint struct {
+	Name            string                         `json:"name"`
+	PluginKind      Kind                           `json:"plugin_kind"`
+	PluginType      string                         `json:"plugin_type"`
+	Body            any                            `json:"body"`
+	Sharing         string                         `json:"sharing"`
+	Keepalive       time.Duration                  `json:"keepalive"`
+	KeepaliveAlways bool                           `json:"keepalive_always"`
+	ViaName         string                         `json:"via_name,omitempty"`
+	ViaFingerprint  string                         `json:"via_fingerprint,omitempty"`
+	Credential      *compiledCredentialFingerprint `json:"credential,omitempty"`
+}
+
+type compiledCredentialFingerprint struct {
+	Name       string `json:"name"`
+	PluginKind Kind   `json:"plugin_kind"`
+	PluginType string `json:"plugin_type"`
+	Body       any    `json:"body"`
+}
+
+func fingerprintTunnels(tunnels map[string]*CompiledTunnel) error {
+	memo := map[*CompiledTunnel]string{}
+	for name, ct := range tunnels {
+		fp, err := tunnelFingerprint(ct, memo)
+		if err != nil {
+			return fmt.Errorf("tunnel %q: fingerprint: %w", name, err)
+		}
+		ct.Fingerprint = fp
+	}
+	return nil
+}
+
+func tunnelFingerprint(ct *CompiledTunnel, memo map[*CompiledTunnel]string) (string, error) {
+	if ct == nil {
+		return "", nil
+	}
+	if fp, ok := memo[ct]; ok {
+		return fp, nil
+	}
+	viaFP, err := tunnelFingerprint(ct.Via, memo)
+	if err != nil {
+		return "", err
+	}
+	rec := compiledTunnelFingerprint{
+		Name:            ct.Name,
+		PluginKind:      pluginKind(ct.Plugin),
+		PluginType:      pluginType(ct.Plugin),
+		Body:            ct.Body,
+		Sharing:         ct.Sharing,
+		Keepalive:       ct.Keepalive,
+		KeepaliveAlways: ct.KeepaliveAlways,
+		Credential:      credentialFingerprint(ct.Credential),
+	}
+	if ct.Via != nil {
+		rec.ViaName = ct.Via.Name
+		rec.ViaFingerprint = viaFP
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	fp := hex.EncodeToString(sum[:])
+	memo[ct] = fp
+	return fp, nil
+}
+
+func credentialFingerprint(ent *Entity) *compiledCredentialFingerprint {
+	if ent == nil {
+		return nil
+	}
+	name := ""
+	if ent.Symbol != nil {
+		name = ent.Symbol.Name
+	}
+	return &compiledCredentialFingerprint{
+		Name:       name,
+		PluginKind: pluginKind(ent.Plugin),
+		PluginType: pluginType(ent.Plugin),
+		Body:       ent.Body,
+	}
+}
+
+func pluginKind(p *Plugin) Kind {
+	if p == nil {
+		return ""
+	}
+	return p.Kind
+}
+
+func pluginType(p *Plugin) string {
+	if p == nil {
+		return ""
+	}
+	return p.Type
 }
 
 // parseKeepalive turns the HCL keepalive string into (duration,

--- a/config/compile_test.go
+++ b/config/compile_test.go
@@ -202,6 +202,109 @@ func TestCompileTunnel(t *testing.T) {
 	}
 }
 
+func TestCompileTunnelFingerprintTracksConfig(t *testing.T) {
+	base := `
+credential "bearer_token" "tok" {}
+tunnel "local_command" "t" {
+  command    = ["ssh", "old-bastion"]
+  listen     = "127.0.0.1:1001"
+  keepalive  = "always"
+  credential = tok
+}
+`
+	same := `
+credential "bearer_token" "tok" {}
+tunnel "local_command" "t" {
+  command    = ["ssh", "old-bastion"]
+  listen     = "127.0.0.1:1001"
+  keepalive  = "always"
+  credential = tok
+}
+`
+	commandChanged := `
+credential "bearer_token" "tok" {}
+tunnel "local_command" "t" {
+  command    = ["ssh", "new-bastion"]
+  listen     = "127.0.0.1:1001"
+  keepalive  = "always"
+  credential = tok
+}
+`
+	credentialChanged := `
+credential "bearer_token" "tok" { idempotency_key = true }
+tunnel "local_command" "t" {
+  command    = ["ssh", "old-bastion"]
+  listen     = "127.0.0.1:1001"
+  keepalive  = "always"
+  credential = tok
+}
+`
+
+	baseFP := compileTunnelFingerprint(t, base, "t")
+	if baseFP == "" {
+		t.Fatal("Fingerprint is empty")
+	}
+	if sameFP := compileTunnelFingerprint(t, same, "t"); sameFP != baseFP {
+		t.Fatalf("same config fingerprint = %q, want %q", sameFP, baseFP)
+	}
+	if changedFP := compileTunnelFingerprint(t, commandChanged, "t"); changedFP == baseFP {
+		t.Fatal("command change did not change tunnel fingerprint")
+	}
+	if changedFP := compileTunnelFingerprint(t, credentialChanged, "t"); changedFP == baseFP {
+		t.Fatal("credential change did not change tunnel fingerprint")
+	}
+}
+
+func TestCompileTunnelFingerprintTracksViaChain(t *testing.T) {
+	base := `
+tunnel "local_command" "base" {
+  command = ["ssh", "old-jump"]
+  listen  = "127.0.0.1:1001"
+}
+tunnel "local_command" "child" {
+  command = ["ssh", "child"]
+  listen  = "127.0.0.1:1002"
+  via     = base
+}
+`
+	viaChanged := `
+tunnel "local_command" "base" {
+  command = ["ssh", "new-jump"]
+  listen  = "127.0.0.1:1001"
+}
+tunnel "local_command" "child" {
+  command = ["ssh", "child"]
+  listen  = "127.0.0.1:1002"
+  via     = base
+}
+`
+
+	baseChildFP := compileTunnelFingerprint(t, base, "child")
+	if baseChildFP == "" {
+		t.Fatal("child Fingerprint is empty")
+	}
+	if changedChildFP := compileTunnelFingerprint(t, viaChanged, "child"); changedChildFP == baseChildFP {
+		t.Fatal("via tunnel config change did not change child tunnel fingerprint")
+	}
+}
+
+func compileTunnelFingerprint(t *testing.T, src string, name string) string {
+	t.Helper()
+	gw, diags := config.LoadBytes([]byte(src), "fingerprint.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ct := cp.Tunnels[name]
+	if ct == nil {
+		t.Fatalf("missing tunnel %q", name)
+	}
+	return ct.Fingerprint
+}
+
 // TestCompileTunnelViaCycle: a → b → a fails to compile with a
 // diagnostic that names the cycle.
 func TestCompileTunnelViaCycle(t *testing.T) {

--- a/tunnel.go
+++ b/tunnel.go
@@ -47,9 +47,9 @@ type TunnelManager struct {
 	mu      sync.Mutex
 	entries map[mgrKey]*tunnelEntry
 	// pinned holds the manager's own release closure per pinned
-	// (name, sharingKey) tuple. SetPolicy stores one Acquire result
-	// per `keepalive = "always"` tunnel and drops it again when the
-	// pin disappears from a subsequent policy.
+	// (name, sharingKey, fingerprint) tuple. SetPolicy stores one
+	// Acquire result per `keepalive = "always"` tunnel and drops it
+	// again when the pin disappears from a subsequent policy.
 	pinned map[mgrKey]func()
 
 	// connSeq feeds per_conn sharing keys.
@@ -57,8 +57,9 @@ type TunnelManager struct {
 }
 
 type mgrKey struct {
-	Name string
-	Key  string
+	Name        string
+	Key         string
+	Fingerprint string
 }
 
 type tunnelEntry struct {
@@ -105,7 +106,7 @@ func (m *TunnelManager) Acquire(ctx context.Context, ct *config.CompiledTunnel, 
 		return nil, func() {}, fmt.Errorf("tunnel manager: nil CompiledTunnel")
 	}
 	key := m.shareKey(ct, endpoint)
-	mk := mgrKey{Name: ct.Name, Key: key}
+	mk := mgrKey{Name: ct.Name, Key: key, Fingerprint: ct.Fingerprint}
 
 	m.mu.Lock()
 	e, exists := m.entries[mk]
@@ -285,7 +286,7 @@ func (m *TunnelManager) SetPolicy(ctx context.Context, policy *config.CompiledPo
 			// are rare but legal — treat the empty key as the pin
 			// target because there's no per-endpoint identity at
 			// pin time.
-			wantPin[mgrKey{Name: ct.Name, Key: ""}] = ct
+			wantPin[mgrKey{Name: ct.Name, Key: "", Fingerprint: ct.Fingerprint}] = ct
 		}
 	}
 

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -82,6 +82,12 @@ func makeCompiledTunnel(name string, sharing string, keepalive time.Duration, al
 	}, body
 }
 
+func makeCompiledTunnelWithFingerprint(name string, sharing string, keepalive time.Duration, always bool, via *config.CompiledTunnel, fingerprint string) (*config.CompiledTunnel, *fakeTunnel) {
+	ct, fake := makeCompiledTunnel(name, sharing, keepalive, always, via)
+	ct.Fingerprint = fingerprint
+	return ct, fake
+}
+
 // TestManagerSingletonRefcount: two acquires share one Open; release
 // of both with keepalive=0 tears it down.
 func TestManagerSingletonRefcount(t *testing.T) {
@@ -231,6 +237,51 @@ func TestManagerKeepaliveAlways(t *testing.T) {
 	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{}})
 	if got := fake.closeCount.Load(); got != 1 {
 		t.Errorf("closeCount = %d after pin drop, want 1", got)
+	}
+}
+
+func TestManagerKeepaliveAlwaysReopensWhenFingerprintChanges(t *testing.T) {
+	m := NewTunnelManager(runtime.EnvSecretStore{}, "")
+	oldCT, oldFake := makeCompiledTunnelWithFingerprint("t1", runtime.TunnelShareSingleton, 0, true, nil, "old-config")
+	newCT, newFake := makeCompiledTunnelWithFingerprint("t1", runtime.TunnelShareSingleton, 0, true, nil, "new-config")
+
+	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{"t1": oldCT}})
+	if got := oldFake.openCount.Load(); got != 1 {
+		t.Fatalf("old openCount after initial pin = %d, want 1", got)
+	}
+
+	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{"t1": newCT}})
+
+	if got := oldFake.closeCount.Load(); got != 1 {
+		t.Errorf("old closeCount after same-name config change = %d, want 1", got)
+	}
+	if got := newFake.openCount.Load(); got != 1 {
+		t.Errorf("new openCount after same-name config change = %d, want 1", got)
+	}
+}
+
+func TestManagerKeepaliveAlwaysFingerprintChangeDoesNotStealInFlightOldTunnel(t *testing.T) {
+	m := NewTunnelManager(runtime.EnvSecretStore{}, "")
+	oldCT, oldFake := makeCompiledTunnelWithFingerprint("t1", runtime.TunnelShareSingleton, 0, true, nil, "old-config")
+	newCT, newFake := makeCompiledTunnelWithFingerprint("t1", runtime.TunnelShareSingleton, 0, true, nil, "new-config")
+
+	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{"t1": oldCT}})
+	_, oldDispatcherRel, err := m.Acquire(context.Background(), oldCT, "ep")
+	if err != nil {
+		t.Fatalf("old dispatcher acquire: %v", err)
+	}
+
+	m.SetPolicy(context.Background(), &config.CompiledPolicy{Tunnels: map[string]*config.CompiledTunnel{"t1": newCT}})
+
+	if got := oldFake.closeCount.Load(); got != 0 {
+		t.Errorf("old closeCount while dispatcher still holds old tunnel = %d, want 0", got)
+	}
+	if got := newFake.openCount.Load(); got != 1 {
+		t.Fatalf("new openCount after same-name config change = %d, want 1", got)
+	}
+	oldDispatcherRel()
+	if got := oldFake.closeCount.Load(); got != 1 {
+		t.Errorf("old closeCount after old dispatcher release = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add compiled tunnel fingerprints that track tunnel body/config, credential config, keepalive/sharing settings, and via-chain changes
- include the fingerprint in tunnel manager keys so same-name `keepalive = "always"` tunnels are treated as stale and reopened when their compiled definition changes
- preserve old fingerprint entries for in-flight callers by only dropping the manager-held always-on pin; replacement-open resource-conflict retry is intentionally left as follow-up scope

## Testing
- `go test ./config -run 'TestCompileTunnel(FingerprintTracks(Config|ViaChain)|$)' -count=1`
- `go test . -run 'TestManagerKeepaliveAlways(ReopensWhenFingerprintChanges|FingerprintChangeDoesNotStealInFlightOldTunnel|$)' -count=1`
- `go test ./...`
- `go vet ./...`
- `go test -race ./config .`
- `git diff --check`

## Notes
- The fingerprint is not serialized in compiled policy JSON and is used only as manager bookkeeping for reload/lifecycle decisions.
- If a replacement always-on tunnel cannot open because an old in-flight tunnel still owns an underlying resource, this PR logs the failed pin attempt and relies on a later request/reload/restart rather than adding pending/retry lifecycle state in this change.
