### PR TITLE
mitm: redact injected credentials in samples

### DIFF
--- a/main.go
+++ b/main.go
@@ -1772,6 +1772,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// to stamp onto the request. Schema-only credential types
 		// (slack / telegram / gemini / etc.) leave Runtime nil; we
 		// pass through verbatim and rely on policy alone.
+		sampleRedactor := newBodySampleRedactor()
 		if cc := runtime.ResolveCredential(ep, mreq); cc != nil {
 			// Plugin.Runtime is a typed-nil sentinel used only for
 			// interface-compliance assertions; the actual decoded HCL
@@ -1784,11 +1785,15 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					log.Printf("secret %s/%s: %v — forwarding without injection", cc.Credential.Symbol.Name, profile, err)
 				} else if len(sec.Bytes) == 0 && len(sec.Extras) == 0 {
 					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
-				} else if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
-					log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+				} else {
+					sampleRedactor.AddSecret(sec)
+					if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
+						log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+					}
 				}
 			}
 		}
+		redactedReqPath := sampleRedactor.Redact(req.URL.Path)
 
 		// WebSocket upgrade. http.Transport.RoundTrip mangles the
 		// 101 response and Cloudflare's WAF rejects modified frames,
@@ -1797,7 +1802,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// runs until either side closes — when it returns, the
 		// caller's request loop ends naturally.
 		if isWSUpgrade(req) {
-			log.Printf("ws-upgrade %s %s", host, req.URL.Path)
+			log.Printf("ws-upgrade %s %s", host, redactedReqPath)
 			ev.Action = "ws"
 			// Frame-level observability: handleWSUpgrade emits one
 			// frame event per WS message in either direction so the
@@ -1805,7 +1810,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			// surfacing a single "ws" row at session close. Carries
 			// the same request ID as the upgrade so the dashboard
 			// nests them under the parent row.
-			frameEmit := func(direction string, sample string) {
+			frameEmit := func(direction string, sample string, truncated bool) {
 				g.sink.Emit(Event{
 					Ts:        time.Now().UTC(),
 					ID:        ev.ID,
@@ -1813,9 +1818,9 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					Mode:      "mitm",
 					Host:      host,
 					Method:    "WS",
-					Path:      req.URL.Path,
+					Path:      redactedReqPath,
 					AgentIP:   ev.AgentIP,
-					Frame:     sample,
+					Frame:     sampleRedactor.RedactStringSample(sample, truncated),
 					Direction: direction,
 				})
 			}
@@ -1842,7 +1847,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			sessionHint = req.Header.Get("Session-Id")
 		}
 		if trackKind != "" && len(trackedReqBody) > 0 && g.agents != nil {
-			g.preCreateLLMSession(c, trackKind, req.URL.Path, trackedReqBody, sessionHint)
+			g.preCreateLLMSession(c, trackKind, redactedReqPath, trackedReqBody, sessionHint)
 		}
 		reqS := newSampler(4096)
 		if req.Body != nil {
@@ -1853,14 +1858,15 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		resp, err := transport.RoundTrip(req.WithContext(context.WithValue(req.Context(), profileCtxKey{}, profile)))
 		rtDur := time.Since(rtStart)
 		if err != nil {
-			log.Printf("mitm upstream %s %s: %v", host, req.URL.Path, err)
+			redactedErr := sampleRedactor.Redact(err.Error())
+			log.Printf("mitm upstream %s %s: %s", host, redactedReqPath, redactedErr)
 			_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 			ev.Status = 502
 			ev.Action = "error"
-			ev.Reason = err.Error()
+			ev.Reason = redactedErr
 			ev.Ms = time.Since(start).Milliseconds()
 			ev.ReqSha = reqS.sha()
-			ev.ReqBody = reqS.sample()
+			ev.ReqBody = sampleRedactor.RedactSample(reqS)
 			ev.In = reqS.n
 			g.emitEnd(ev)
 			return
@@ -1888,7 +1894,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// Snapshot the upstream's response headers for the audit log
 		// before stripping credential-bearing ones — the dashboard
 		// still wants to show what the upstream actually sent.
-		ev.RespHeaders = flatHeaders(resp.Header)
+		ev.RespHeaders = sampleRedactor.RedactHeaderMap(flatHeaders(resp.Header))
 		stripAuthResponseHeaders(resp.Header)
 		writeErr := resp.Write(tc)
 		_ = rtDur
@@ -1903,20 +1909,20 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					_ = zr.Close()
 				}
 			}
-			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint)
+			g.trackLLMUsage(c, trackKind, redactedReqPath, trackedReqBody, body, sessionHint)
 		}
 
 		if ev.Action == "" {
 			ev.Action = "allow"
 		}
 		ev.Status = resp.StatusCode
-		ev.ReqHeaders = flatHeaders(req.Header)
+		ev.ReqHeaders = sampleRedactor.RedactHeaderMap(flatHeaders(req.Header))
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()
-		ev.ReqBody = reqS.sample()
+		ev.ReqBody = sampleRedactor.RedactSample(reqS)
 		ev.RespSha = respS.sha()
-		ev.RespBody = respS.sample()
+		ev.RespBody = sampleRedactor.RedactSample(respS)
 		ev.Ms = time.Since(start).Milliseconds()
 		g.emitEnd(ev)
 		if g.agents != nil && agentAddr != "" {

--- a/sample_redaction.go
+++ b/sample_redaction.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/hex"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+const (
+	bodySampleRedactionMarker = "***"
+	binarySamplePreviewBytes  = 64
+)
+
+var (
+	telegramBotTokenInPath = regexp.MustCompile(`bot\d{6,}:[A-Za-z0-9_-]{20,}`)
+	telegramBotTokenBare   = regexp.MustCompile(`\b\d{6,}:[A-Za-z0-9_-]{20,}\b`)
+)
+
+type bodySampleRedactor struct {
+	needles []string
+}
+
+func newBodySampleRedactor() *bodySampleRedactor {
+	return &bodySampleRedactor{}
+}
+
+func (r *bodySampleRedactor) AddSecret(sec runtime.Secret) {
+	r.addSecretBytes(sec.Bytes)
+	for _, v := range sec.Extras {
+		r.addSecretBytes([]byte(v))
+	}
+}
+
+func (r *bodySampleRedactor) addSecretBytes(b []byte) {
+	if len(b) < 4 {
+		return
+	}
+	raw := string(b)
+	r.addNeedle(raw)
+	r.addNeedle(hex.EncodeToString(b))
+	if escaped := url.QueryEscape(raw); escaped != raw {
+		r.addNeedle(escaped)
+	}
+	if escaped := url.PathEscape(raw); escaped != raw {
+		r.addNeedle(escaped)
+	}
+}
+
+func (r *bodySampleRedactor) addNeedle(needle string) {
+	if len(needle) < 4 {
+		return
+	}
+	for _, existing := range r.needles {
+		if existing == needle {
+			return
+		}
+	}
+	r.needles = append(r.needles, needle)
+}
+
+func (r *bodySampleRedactor) Redact(sample string) string {
+	if sample == "" {
+		return ""
+	}
+	needles := append([]string(nil), r.needles...)
+	sort.SliceStable(needles, func(i, j int) bool {
+		return len(needles[i]) > len(needles[j])
+	})
+	for _, needle := range needles {
+		sample = strings.ReplaceAll(sample, needle, bodySampleRedactionMarker)
+	}
+	sample = telegramBotTokenInPath.ReplaceAllString(sample, "bot"+bodySampleRedactionMarker)
+	sample = telegramBotTokenBare.ReplaceAllString(sample, bodySampleRedactionMarker)
+	return sample
+}
+
+func (r *bodySampleRedactor) RedactStringSample(sample string, truncated bool) string {
+	if truncated && len(r.needles) > 0 && sample != "" {
+		return bodySampleRedactionMarker
+	}
+	return r.Redact(sample)
+}
+
+func (r *bodySampleRedactor) RedactSample(s *sampler) string {
+	if s == nil {
+		return ""
+	}
+	truncated := s.n > int64(s.buf.Len())
+	if !truncated && s.buf.Len() > binarySamplePreviewBytes && !isPrintable(s.buf.Bytes()) {
+		truncated = true
+	}
+	return r.RedactStringSample(s.sample(), truncated)
+}
+
+func (r *bodySampleRedactor) RedactHeaderMap(headers map[string]string) map[string]string {
+	for k, v := range headers {
+		if v != bodySampleRedactionMarker {
+			headers[k] = r.Redact(v)
+		}
+	}
+	return headers
+}

--- a/web.go
+++ b/web.go
@@ -2062,7 +2062,7 @@ func (s *sampler) sample() string {
 	if isPrintable(s.buf.Bytes()) {
 		return s.buf.String()
 	}
-	return "binary:" + hex.EncodeToString(s.buf.Bytes()[:min(64, s.buf.Len())])
+	return "binary:" + hex.EncodeToString(s.buf.Bytes()[:min(binarySamplePreviewBytes, s.buf.Len())])
 }
 
 func isPrintable(b []byte) bool {

--- a/web_redaction_test.go
+++ b/web_redaction_test.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"bytes"
+	"encoding/hex"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/denoland/clawpatrol/config/plugins/credentials"
+	"github.com/denoland/clawpatrol/config/runtime"
 )
 
 func TestFlatHeadersRedactsSensitiveHeaders(t *testing.T) {
@@ -43,5 +50,204 @@ func TestFlatHeadersRedactionIsCaseInsensitive(t *testing.T) {
 	}
 	if got["X-PASSWORD"] != "***" {
 		t.Fatalf("X-PASSWORD = %q, want redacted", got["X-PASSWORD"])
+	}
+}
+
+func TestBodySampleRedactorRedactsCredentialBytes(t *testing.T) {
+	const credentialValue = "123456789:REAL_SECRET_TOKEN"
+	sample := `{"url":"https://example.com/bot` + credentialValue + `/hook"}`
+
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: []byte(credentialValue)})
+	got := redactor.Redact(sample)
+
+	if strings.Contains(got, credentialValue) || strings.Contains(got, "REAL_SECRET_TOKEN") {
+		t.Fatalf("redacted sample still contains credential: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("redacted sample = %q, want redaction marker", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsTelegramPostInjectionBodySample(t *testing.T) {
+	const placeholder = "0000000000:clawpatrol-placeholder-do-not-use"
+	const credentialValue = "123456789:REAL_SECRET_TOKEN"
+	body := `{"url":"https://example.com/bot` + placeholder + `/hook"}`
+	req, err := http.NewRequest("POST", "https://api.telegram.org/bot"+placeholder+"/setWebhook", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	redactor := newBodySampleRedactor()
+	sec := runtime.Secret{Bytes: []byte(credentialValue)}
+	redactor.AddSecret(sec)
+	if err := (&credentials.TelegramBotToken{}).InjectHTTP(req.Context(), req, sec); err != nil {
+		t.Fatalf("inject telegram credential: %v", err)
+	}
+	reqS := newSampler(4096)
+	req.Body = wrapBodySampler(req.Body, reqS)
+	if _, err := io.ReadAll(req.Body); err != nil {
+		t.Fatalf("read sampled request body: %v", err)
+	}
+
+	got := redactor.RedactSample(reqS)
+	if strings.Contains(got, credentialValue) || strings.Contains(got, "REAL_SECRET_TOKEN") {
+		t.Fatalf("redacted post-injection sample still contains credential: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("redacted post-injection sample = %q, want redaction marker", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsConfiguredSecretFromHeaderValues(t *testing.T) {
+	const credentialValue = "header-value-that-must-not-leak"
+	req, err := http.NewRequest("GET", "https://example.com/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	redactor := newBodySampleRedactor()
+	sec := runtime.Secret{Bytes: []byte(credentialValue)}
+	redactor.AddSecret(sec)
+	if err := (&credentials.HeaderToken{Header: "X-Trace-Context", Prefix: "trace="}).InjectHTTP(req.Context(), req, sec); err != nil {
+		t.Fatalf("inject header credential: %v", err)
+	}
+
+	got := redactor.RedactHeaderMap(flatHeaders(req.Header))
+	if strings.Contains(got["X-Trace-Context"], credentialValue) || strings.Contains(got["X-Trace-Context"], "must-not-leak") {
+		t.Fatal("redacted header still contains configured credential")
+	}
+	if !strings.Contains(got["X-Trace-Context"], "***") {
+		t.Fatalf("redacted header = %q, want redaction marker", got["X-Trace-Context"])
+	}
+	if got["Accept"] != "application/json" {
+		t.Fatalf("Accept = %q, want original value", got["Accept"])
+	}
+}
+
+func TestBodySampleRedactorRedactsTruncatedSamplesWithConfiguredSecrets(t *testing.T) {
+	const credentialValue = "boundary-secret-value-that-crosses-sample-cap"
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: []byte(credentialValue)})
+
+	s := newSampler(16)
+	if _, err := s.Write([]byte(strings.Repeat("a", 14) + credentialValue + "tail")); err != nil {
+		t.Fatalf("write sample: %v", err)
+	}
+
+	got := redactor.RedactSample(s)
+	if got != "***" {
+		t.Fatalf("redacted truncated sample = %q, want conservative marker", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsTruncatedStringSamplesWithConfiguredSecrets(t *testing.T) {
+	const credentialValue = "websocket-secret-value-that-crosses-sample-cap"
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: []byte(credentialValue)})
+
+	got := redactor.RedactStringSample(strings.Repeat("a", 10)+credentialValue[:4], true)
+	if got != "***" {
+		t.Fatalf("redacted truncated string sample = %q, want conservative marker", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsBinarySamplesTruncatedByHexPreview(t *testing.T) {
+	secretBytes := []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe}
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: secretBytes})
+
+	s := newSampler(128)
+	payload := append([]byte{0x00}, bytes.Repeat([]byte{'a'}, binarySamplePreviewBytes-2)...)
+	payload = append(payload, secretBytes...)
+	if _, err := s.Write(payload); err != nil {
+		t.Fatalf("write sample: %v", err)
+	}
+
+	got := redactor.RedactSample(s)
+	if got != "***" {
+		t.Fatalf("redacted binary preview sample = %q, want conservative marker", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsOverlappingSecretsLongestFirst(t *testing.T) {
+	const shortCredential = "overlap-secret"
+	const longCredential = "overlap-secret-with-suffix"
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: []byte(shortCredential)})
+	redactor.AddSecret(runtime.Secret{Bytes: []byte(longCredential)})
+
+	got := redactor.Redact("value=" + longCredential)
+	if strings.Contains(got, "with-suffix") || strings.Contains(got, longCredential) || strings.Contains(got, shortCredential) {
+		t.Fatalf("redacted overlapping sample still contains credential material: %q", got)
+	}
+	if got != "value=***" {
+		t.Fatalf("redacted overlapping sample = %q, want full credential replaced once", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsSecretExtras(t *testing.T) {
+	const slackBotCredential = "xoxb-secret-bot-token"
+	const slackSigningCredential = "slack-signing-secret"
+	sample := "bot=" + slackBotCredential + " signing=" + slackSigningCredential + " public=ok"
+
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Extras: map[string]string{
+		"bot":            slackBotCredential,
+		"signing_secret": slackSigningCredential,
+	}})
+	got := redactor.Redact(sample)
+
+	for _, credentialValue := range []string{slackBotCredential, slackSigningCredential} {
+		if strings.Contains(got, credentialValue) {
+			t.Fatalf("redacted sample still contains %q: %q", credentialValue, got)
+		}
+	}
+	if !strings.Contains(got, "public=ok") {
+		t.Fatalf("redacted sample lost non-secret text: %q", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsURLEscapedCredentialBytes(t *testing.T) {
+	const credentialValue = "123456789:REAL_SECRET_TOKEN"
+	sample := "url=https%3A%2F%2Fexample.com%2Fbot123456789%3AREAL_SECRET_TOKEN%2Fhook"
+
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: []byte(credentialValue)})
+	got := redactor.Redact(sample)
+
+	if strings.Contains(got, "123456789%3AREAL_SECRET_TOKEN") || strings.Contains(got, "REAL_SECRET_TOKEN") {
+		t.Fatalf("redacted escaped sample still contains credential: %q", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsBinaryHexSecret(t *testing.T) {
+	secretBytes := []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe}
+	sample := "binary:00" + hex.EncodeToString(secretBytes) + "ff"
+
+	redactor := newBodySampleRedactor()
+	redactor.AddSecret(runtime.Secret{Bytes: secretBytes})
+	got := redactor.Redact(sample)
+
+	if strings.Contains(got, hex.EncodeToString(secretBytes)) {
+		t.Fatalf("redacted binary sample still contains hex credential: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("redacted binary sample = %q, want redaction marker", got)
+	}
+}
+
+func TestBodySampleRedactorRedactsTelegramTokenPattern(t *testing.T) {
+	const credentialValue = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghi"
+	sample := `{"url":"https://example.com/bot` + credentialValue + `/hook"}`
+
+	got := newBodySampleRedactor().Redact(sample)
+
+	if strings.Contains(got, credentialValue) {
+		t.Fatalf("redacted sample still contains Telegram token: %q", got)
+	}
+	if !strings.Contains(got, "bot***") {
+		t.Fatalf("redacted sample = %q, want Telegram token redacted after bot prefix", got)
 	}
 }

--- a/ws.go
+++ b/ws.go
@@ -96,7 +96,7 @@ func (g *Gateway) dialWSUpstream(ctx context.Context, upstream string, ep *confi
 // raw byte bridge once the agent's request looks like a WS upgrade.
 // The connection stays alive until either side closes; pumpWS
 // observes text frames for codex usage tracking when applicable.
-func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string) {
+func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string, truncated bool), ep *config.CompiledEndpoint, profile string) {
 	agentAddr := peerIP(client) // capture before netstack races to nil
 
 	// dialWSUpstream preserves the existing split: endpoints that require a
@@ -205,10 +205,12 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 			}
 			if frameEmit != nil {
 				s := text
+				truncated := false
 				if len(s) > wsFrameSampleCap {
 					s = s[:wsFrameSampleCap]
+					truncated = true
 				}
-				frameEmit(direction, string(s))
+				frameEmit(direction, string(s), truncated)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add request-scoped redaction for configured credential values before MITM traffic samples, headers, paths, errors, and WebSocket frame previews are emitted.
- Cover raw secret bytes, derived `runtime.Secret.Extras`, URL-escaped/path-escaped/hex forms, Telegram-style token patterns, and overlapping secret values.
- Conservatively redact truncated request/response/body/WebSocket/binary previews when configured secrets are in scope.

## Test plan
- `go test . -run 'TestBodySampleRedactor|TestFlatHeaders' -count=1`
- `(cd www && npm run build) && go test ./...`
- `$(go env GOPATH)/bin/golangci-lint run ./...`
- `git diff --check`
- static scan over `git diff`: `No static security scan findings`

## Review
- Independent review completed after implementation and follow-up hardening: `APPROVED_NO_FINDINGS`.
