### PR TITLE
Linux per-run ephemeral WG identity

### DIFF
--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -1,0 +1,139 @@
+package main
+
+// Ephemeral peer support: each `clawpatrol run` on Linux gets its own
+// WireGuard keypair and IP rather than sharing the device's permanent
+// identity. Without this, concurrent runs on the same machine fight
+// over a single WireGuard session — keepalives from one process
+// invalidate the other's session causing intermittent packet loss.
+//
+// The client POSTs an ephemeral pubkey; the gateway allocates a fresh
+// IP, wires it up, and inherits the parent device's profile. On clean
+// exit the client DELETEs the peer. The permanent device record
+// (from `clawpatrol join`) is untouched.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"sync"
+)
+
+var ephemeralAllocMu sync.Mutex
+
+// allocateEphemeralIP picks the next unused IP in subnetCIDR.
+// The DB UNIQUE constraint on wg_peers.ip is the authoritative
+// safety net against concurrent allocation races.
+func allocateEphemeralIP(subnetCIDR string) (string, error) {
+	ephemeralAllocMu.Lock()
+	defer ephemeralAllocMu.Unlock()
+	used := map[string]bool{}
+	if globalDB != nil {
+		rows, err := globalDB.Query("SELECT ip FROM wg_peers")
+		if err == nil {
+			for rows.Next() {
+				var ip string
+				if rows.Scan(&ip) == nil {
+					used[ip] = true
+				}
+			}
+			_ = rows.Close()
+		}
+	}
+	_, cidr, err := net.ParseCIDR(subnetCIDR)
+	if err != nil {
+		return "", err
+	}
+	first := cidr.IP.To4()
+	for i := 2; i < 255; i++ {
+		ip := net.IPv4(first[0], first[1], first[2], byte(i)).String()
+		if !used[ip] {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("wireguard subnet %s exhausted", subnetCIDR)
+}
+
+// apiEphemeralPeer dispatches POST (add) and DELETE (remove) on
+// /api/peer/ephemeral. Both require a valid per-peer bearer token.
+func (w *webMux) apiEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		w.apiAddEphemeralPeer(rw, r)
+	case http.MethodDelete:
+		w.apiRemoveEphemeralPeer(rw, r)
+	default:
+		http.Error(rw, "POST or DELETE", http.StatusMethodNotAllowed)
+	}
+}
+
+func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	parentIP := peerIPForAPIToken(w.g.db, token)
+	if parentIP == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if globalWG == nil || w.ts.WGSubnetCIDR == "" {
+		http.Error(rw, "wireguard not active", http.StatusServiceUnavailable)
+		return
+	}
+	pubkeyHex := r.URL.Query().Get("pubkey")
+	if pubkeyHex == "" {
+		http.Error(rw, "missing pubkey", http.StatusBadRequest)
+		return
+	}
+	ip, err := allocateEphemeralIP(w.ts.WGSubnetCIDR)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := globalWG.AddPeer(pubkeyHex, ip); err != nil {
+		http.Error(rw, "add peer: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.g.db.Exec(
+		"UPDATE wg_peers SET ephemeral=1, parent_ip=? WHERE pubkey=?",
+		parentIP, pubkeyHex,
+	)
+	if profile := w.g.profileFor(parentIP); profile != "" {
+		w.g.onboard.AssignProfile(ip, profile)
+	}
+	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
+	writeJSON(rw, map[string]string{"ip": ip, "ip6": ip6})
+}
+
+// apiRemoveEphemeralPeer handles DELETE /api/peer/ephemeral?pubkey=<hex>.
+// Only the parent device (identified by bearer token) may remove its
+// own ephemeral peers.
+func (w *webMux) apiRemoveEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	parentIP := peerIPForAPIToken(w.g.db, token)
+	if parentIP == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	pubkeyHex := r.URL.Query().Get("pubkey")
+	if pubkeyHex == "" {
+		http.Error(rw, "missing pubkey", http.StatusBadRequest)
+		return
+	}
+	var peerIP, storedParent string
+	if err := w.g.db.QueryRow(
+		"SELECT ip, parent_ip FROM wg_peers WHERE pubkey=? AND ephemeral=1",
+		pubkeyHex,
+	).Scan(&peerIP, &storedParent); err != nil || storedParent != parentIP {
+		http.Error(rw, "not found", http.StatusNotFound)
+		return
+	}
+	if globalWG != nil {
+		globalWG.RevokePeerByIP(peerIP)
+	}
+	if w.g.onboard != nil {
+		w.g.onboard.ForgetIP(peerIP)
+	}
+	if w.g.agents != nil {
+		w.g.agents.Delete(peerIP)
+	}
+	rw.WriteHeader(http.StatusNoContent)
+}

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -31,13 +31,16 @@ func allocateEphemeralIP(subnetCIDR string) (string, error) {
 	if globalDB != nil {
 		rows, err := globalDB.Query("SELECT ip FROM wg_peers")
 		if err == nil {
+			defer func() { _ = rows.Close() }()
 			for rows.Next() {
 				var ip string
 				if rows.Scan(&ip) == nil {
 					used[ip] = true
 				}
 			}
-			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				used = map[string]bool{}
+			}
 		}
 	}
 	_, cidr, err := net.ParseCIDR(subnetCIDR)

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -489,7 +489,12 @@ private var sessionListenFD: Int32 = -1
 private func startSessionListener() {
     unlink(sessionSockPath)
     let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-    if fd < 0 { return }
+    if fd < 0 {
+        os_log("session socket: socket() failed errno=%d", log: log, type: .error, errno)
+        return
+    }
+    var one: Int32 = 1
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, socklen_t(MemoryLayout<Int32>.size))
     var addr = sockaddr_un()
     addr.sun_family = sa_family_t(AF_UNIX)
     let pathBytes = sessionSockPath.utf8CString
@@ -506,9 +511,16 @@ private func startSessionListener() {
             Darwin.bind(fd, sa, len)
         }
     }
-    if rc != 0 { Darwin.close(fd); return }
+    if rc != 0 {
+        os_log("session socket: bind() failed errno=%d", log: log, type: .error, errno)
+        Darwin.close(fd); return
+    }
     chmod(sessionSockPath, 0o666)
-    if listen(fd, 16) != 0 { Darwin.close(fd); return }
+    if listen(fd, 16) != 0 {
+        os_log("session socket: listen() failed errno=%d", log: log, type: .error, errno)
+        Darwin.close(fd); return
+    }
+    os_log("session socket: listening at %{public}@", log: log, type: .info, sessionSockPath)
     sessionListenFD = fd
     DispatchQueue.global(qos: .userInitiated).async {
         while true {

--- a/migrations/sqlite/0007_ephemeral_peers.sql
+++ b/migrations/sqlite/0007_ephemeral_peers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE wg_peers ADD COLUMN ephemeral INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE wg_peers ADD COLUMN parent_ip TEXT;

--- a/run_linux.go
+++ b/run_linux.go
@@ -21,13 +21,17 @@ package main
 
 import (
 	"bufio"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -74,6 +78,12 @@ func runRun(args []string) {
 
 	// Stamp CA + per-credential env vars; child and user's cmd inherit them.
 	applyEnvPushdown(defaultClawpatrolDir())
+
+	// Allocate a per-run ephemeral WireGuard identity so concurrent
+	// `clawpatrol run` invocations on the same machine don't share a
+	// keypair and fight over the gateway's WG session.
+	cleanupEphemeral, _ := ephemeralPeer(cfg)
+	defer cleanupEphemeral()
 
 	// socketpair: TUN fd handoff (child→parent) via SCM_RIGHTS.
 	// pipe: parent signals child "WG is up, finish setup".
@@ -190,12 +200,18 @@ func runRunChild() {
 	_ = wgUpR.Close()
 
 	cfg := mustParseRunConf(os.Getenv("CLAWPATROL_RUN_CONF"))
+	// CLAWPATROL_EPHEMERAL_ADDR overrides cfg.Address when the parent
+	// successfully registered an ephemeral WG identity for this run.
+	addrSource := cfg.Address
+	if ea := os.Getenv("CLAWPATROL_EPHEMERAL_ADDR"); ea != "" {
+		addrSource = ea
+	}
 	// Address may carry both v4 and v6 separated by ", " — gateway-emitted
 	// wg-quick conf looks like `Address = 10.55.0.5/32, fd77::5/128`. The
 	// `ip addr add` command rejects the comma-joined form ("any valid
 	// prefix is expected rather than ..."), so split + assign each addr.
 	var addrs []string
-	for _, part := range strings.Split(cfg.Address, ",") {
+	for _, part := range strings.Split(addrSource, ",") {
 		s := strings.TrimSpace(part)
 		if s == "" {
 			continue
@@ -487,6 +503,102 @@ func (t *rawFDTun) Write(bufs [][]byte, offset int) (int, error) {
 func (t *rawFDTun) Close() error {
 	close(t.events)
 	return t.f.Close()
+}
+
+// --- ephemeral peer --------------------------------------------------
+
+// ephemeralPeer registers a fresh per-run WireGuard keypair with the
+// gateway, mutates cfg to use the ephemeral private key and address,
+// and sets CLAWPATROL_EPHEMERAL_ADDR so the re-exec'd child uses the
+// ephemeral IP for `ip addr add`. Returns a cleanup func that removes
+// the ephemeral peer from the gateway on exit.
+//
+// Best-effort: any failure logs a warning and returns a no-op cleanup
+// so the caller falls back to the shared permanent identity.
+func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
+	noop := func() {}
+	dir := defaultClawpatrolDir()
+
+	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway")))
+	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
+	if gwURL == "" || token == "" {
+		return noop, fmt.Errorf("ephemeral peer: no gateway url or api-token")
+	}
+
+	client, err := gatewayHTTPClient(filepath.Join(dir, "ca.crt"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: build http client: %v (using shared identity)\n", err)
+		return noop, err
+	}
+
+	privB64, pubHex, _, err := wgGenKeypair()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: keygen: %v (using shared identity)\n", err)
+		return noop, err
+	}
+
+	req, _ := http.NewRequest(http.MethodPost,
+		gwURL+"/api/peer/ephemeral?pubkey="+pubHex, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: register: %v (using shared identity)\n", err)
+		return noop, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: gateway returned %d (using shared identity)\n", resp.StatusCode)
+		return noop, fmt.Errorf("gateway %d", resp.StatusCode)
+	}
+
+	var result struct {
+		IP  string `json:"ip"`
+		IP6 string `json:"ip6"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: decode response: %v (using shared identity)\n", err)
+		return noop, err
+	}
+
+	cfg.PrivateKey = privB64
+	cfg.Address = result.IP + "/32, " + result.IP6 + "/128"
+	_ = os.Setenv("CLAWPATROL_EPHEMERAL_ADDR", cfg.Address)
+
+	return func() {
+		dreq, _ := http.NewRequest(http.MethodDelete,
+			gwURL+"/api/peer/ephemeral?pubkey="+pubHex, nil)
+		dreq.Header.Set("Authorization", "Bearer "+token)
+		if dr, derr := client.Do(dreq); derr == nil {
+			_ = dr.Body.Close()
+		}
+	}, nil
+}
+
+// gatewayHTTPClient builds an http.Client that trusts caPath in addition
+// to system roots.
+func gatewayHTTPClient(caPath string) (*http.Client, error) {
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		roots = x509.NewCertPool()
+	}
+	if pem, err := os.ReadFile(caPath); err == nil {
+		roots.AppendCertsFromPEM(pem)
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: roots},
+		},
+	}, nil
+}
+
+// readFileSilent reads a file and returns its contents as a string,
+// or empty on any error.
+func readFileSilent(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // --- helpers ---------------------------------------------------------

--- a/run_linux.go
+++ b/run_linux.go
@@ -549,7 +549,7 @@ func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
 		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: register: %v (using shared identity)\n", err)
 		return noop, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: gateway returned %d (using shared identity)\n", resp.StatusCode)
 		return noop, fmt.Errorf("gateway %d", resp.StatusCode)

--- a/run_linux.go
+++ b/run_linux.go
@@ -537,8 +537,12 @@ func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
 		return noop, err
 	}
 
-	req, _ := http.NewRequest(http.MethodPost,
+	req, err := http.NewRequest(http.MethodPost,
 		gwURL+"/api/peer/ephemeral?pubkey="+pubHex, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: build request: %v (using shared identity)\n", err)
+		return noop, err
+	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -565,8 +569,11 @@ func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
 	_ = os.Setenv("CLAWPATROL_EPHEMERAL_ADDR", cfg.Address)
 
 	return func() {
-		dreq, _ := http.NewRequest(http.MethodDelete,
+		dreq, err := http.NewRequest(http.MethodDelete,
 			gwURL+"/api/peer/ephemeral?pubkey="+pubHex, nil)
+		if err != nil {
+			return
+		}
 		dreq.Header.Set("Authorization", "Bearer "+token)
 		if dr, derr := client.Do(dreq); derr == nil {
 			_ = dr.Body.Close()

--- a/web.go
+++ b/web.go
@@ -238,6 +238,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodGet, Path: "/api/onboard/lookup", Auth: authTailnetOperator, Handler: w.apiOnboardLookup},
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
+		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
 		{Method: http.MethodGet, Path: "/__login", Auth: authTailnetOperator, Handler: w.apiDashboardLogin},
 	}
 }


### PR DESCRIPTION
## Summary

- Multiple `clawpatrol run` on the same Linux machine shared a WireGuard keypair, causing keepalives from one process to stomp the other's session — intermittent packet loss in the losing process
- Each run now registers an ephemeral keypair with the gateway and gets its own WG IP (inheriting the parent device's profile), then deregisters on clean exit
- Falls back silently to the shared permanent identity if the gateway is unreachable or WG is not active

## Changes

- `ephemeral_peer.go` — gateway handlers for `POST /api/peer/ephemeral` and `DELETE /api/peer/ephemeral`, authenticated by existing per-peer bearer token
- `migrations/sqlite/0007_ephemeral_peers.sql` — adds `ephemeral` + `parent_ip` columns to `wg_peers` for ownership verification on delete
- `web.go` — registers the new route (`authSelfAuthenticating`)
- `run_linux.go` — generates ephemeral keypair pre-fork, registers with gateway, mutates `cfg` to use ephemeral key + allocated IP, sets `CLAWPATROL_EPHEMERAL_ADDR` for child namespace, defers DELETE on exit

## Test plan

- [ ] Two concurrent `clawpatrol run` on same Linux machine no longer drop packets
- [ ] `wg_peers` shows two distinct IPs after two runs start; both removed after exit
- [ ] Fallback: gateway unreachable → warning printed, runs proceed with shared identity
- [ ] `DELETE /api/peer/ephemeral` rejects wrong parent (different bearer token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)