### PR TITLE
chore(ci): remove golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
       - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: cd www && npm ci && npm run build
-      - uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.12.2
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Taking 4+ minutes per PR run. `gofmt` + `go vet` (in the test job) catch the real issues fast. golangci-lint is a nice-to-have, not worth the CI latency tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)