### PR TITLE
gateway: keep all persistent state in sqlite

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -7,13 +7,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"database/sql"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"math/big"
 	"net"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -25,17 +24,31 @@ type CertCache struct {
 	cache  map[string]*tls.Certificate
 }
 
-func loadCA(dir string) (*CertCache, error) {
-	cb, err := os.ReadFile(filepath.Join(dir, "ca.crt"))
-	if err != nil {
-		return nil, fmt.Errorf("ca.crt: %w", err)
+// loadOrMintCA returns the gateway's MITM CA, materializing it on
+// first call. If the ca_material row is absent, mints a fresh
+// ECDSA-P256 key + self-signed cert (10y validity) and inserts.
+// Subsequent boots see the row and return the existing material —
+// the cert is stable across restarts so peers don't have to
+// reinstall the trust anchor.
+func loadOrMintCA(db *sql.DB) (*CertCache, error) {
+	if db == nil {
+		return nil, fmt.Errorf("ca: no db")
 	}
-	kb, err := os.ReadFile(filepath.Join(dir, "ca.key"))
-	if err != nil {
-		return nil, fmt.Errorf("ca.key: %w", err)
+	var certPEM, keyPEM []byte
+	err := db.QueryRow(`SELECT cert_pem, key_pem FROM ca_material WHERE id = 1`).
+		Scan(&certPEM, &keyPEM)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return mintAndStoreCA(db)
+	case err != nil:
+		return nil, fmt.Errorf("ca read: %w", err)
 	}
-	cblock, _ := pem.Decode(cb)
-	kblock, _ := pem.Decode(kb)
+	return parseCertCache(certPEM, keyPEM)
+}
+
+func parseCertCache(certPEM, keyPEM []byte) (*CertCache, error) {
+	cblock, _ := pem.Decode(certPEM)
+	kblock, _ := pem.Decode(keyPEM)
 	if cblock == nil || kblock == nil {
 		return nil, errors.New("bad pem")
 	}
@@ -90,13 +103,14 @@ func (c *CertCache) mint(host string) (*tls.Certificate, error) {
 	return t, nil
 }
 
-func writeCA(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
+// mintAndStoreCA generates fresh root material and persists it to the
+// ca_material row. Called automatically by loadOrMintCA when the row
+// is absent. Returns the parsed CertCache so the caller can use it
+// without a second DB round-trip.
+func mintAndStoreCA(db *sql.DB) (*CertCache, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	serial, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
 	tmpl := &x509.Certificate{
@@ -110,19 +124,34 @@ func writeCA(dir string) error {
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	kb, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if err := os.WriteFile(filepath.Join(dir, "ca.crt"),
-		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644); err != nil {
-		return err
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: kb})
+	if _, err := db.Exec(
+		`INSERT INTO ca_material (id, cert_pem, key_pem, created_ns) VALUES (1, ?, ?, ?)`,
+		certPEM, keyPEM, time.Now().UnixNano(),
+	); err != nil {
+		return nil, fmt.Errorf("ca insert: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "ca.key"),
-		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: kb}), 0o600); err != nil {
-		return err
+	return parseCertCache(certPEM, keyPEM)
+}
+
+// importCAFromPEM inserts pre-existing PEM material into ca_material.
+// Used by the legacy-state importer to move on-disk ca.crt + ca.key
+// into sqlite on first boot of a migrated gateway. Caller should
+// guard against double-insert by checking the row first.
+func importCAFromPEM(db *sql.DB, certPEM, keyPEM []byte) error {
+	if _, err := parseCertCache(certPEM, keyPEM); err != nil {
+		return fmt.Errorf("validate legacy ca: %w", err)
 	}
-	return nil
+	_, err := db.Exec(
+		`INSERT INTO ca_material (id, cert_pem, key_pem, created_ns) VALUES (1, ?, ?, ?)`,
+		certPEM, keyPEM, time.Now().UnixNano(),
+	)
+	return err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -20,13 +20,25 @@ import (
 // attributes. Labeled blocks (`credential "x" "y" {}`, etc.) are the
 // things you have N of and dispatch to the plugin registry.
 type Gateway struct {
-	Listen          string `hcl:"listen,optional"`
-	InfoListen      string `hcl:"info_listen,optional"`
-	PublicURL       string `hcl:"public_url,optional"`
-	AdminEmail      string `hcl:"admin_email,optional"`
-	CADir           string `hcl:"ca_dir,optional"`
-	Resolver        string `hcl:"resolver,optional"`
-	LogPath         string `hcl:"log_path,optional"`
+	Listen     string `hcl:"listen,optional"`
+	InfoListen string `hcl:"info_listen,optional"`
+	PublicURL  string `hcl:"public_url,optional"`
+	AdminEmail string `hcl:"admin_email,optional"`
+	// CADir is the legacy path the gateway used to keep the CA cert
+	// + ssh host keys on disk. Kept for backwards compat: existing
+	// configs still parse, and state_import.go consults this path to
+	// move any leftover on-disk artifacts into sqlite on first boot
+	// of a migrated gateway. New deployments should set state_dir
+	// instead — the gateway now keeps everything in sqlite.
+	CADir string `hcl:"ca_dir,optional"`
+	// StateDir is the directory holding clawpatrol.db. Falls back to
+	// OAuthDir (historical name) or ${CADir}/../oauth or
+	// ${HOME}/.clawpatrol/state, in that order.
+	StateDir string `hcl:"state_dir,optional"`
+	Resolver string `hcl:"resolver,optional"`
+	LogPath  string `hcl:"log_path,optional"`
+	// OAuthDir is the historical state directory name. Equivalent to
+	// state_dir and kept for backwards compat.
 	OAuthDir        string `hcl:"oauth_dir,optional"`
 	DashboardSecret string `hcl:"dashboard_secret,optional"`
 	// InsecureNoDashboardSecret opts out of dashboard auth. Required
@@ -53,7 +65,6 @@ type Gateway struct {
 	AuthKey           string `hcl:"authkey,optional"`
 	ControlURL        string `hcl:"control_url,optional"`
 	Hostname          string `hcl:"hostname,optional"`
-	StateDir          string `hcl:"state_dir,optional"`
 	Control           string `hcl:"control,optional"`
 	OAuthClientID     string `hcl:"oauth_client_id,optional"`
 	OAuthClientSecret string `hcl:"oauth_client_secret,optional"`

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -34,8 +34,6 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -181,13 +179,27 @@ func init() {
 
 // ── Synthetic Agent Identity JWT + JWKS ──────────────────────────────
 //
-// Keys live as a JSON file in the user's clawpatrol dir (same dir
-// `clawpatrol login` writes ca.crt to). Both the gateway process
-// (which serves the JWKS) and the `clawpatrol env` CLI (which mints
-// the JWT) read from the same path so the JWT's kid resolves against
-// what the gateway exposes.
+// Keys live in the host's BlobStore under
+// (kind=CodexJWTKeysKind, name=""). The gateway process serves both
+// the JWKS and the JWT mint path (clients fetch the minted JWT over
+// /api/env-pushdown), so the keypair is gateway-internal.
+//
+// SetBlobStore plumbs the host's BlobStore into this package. The
+// gateway wires it up once after OpenDB; tests substitute an
+// in-memory fake. Mirrors the wireguard.go setDB/globalDB precedent
+// for plugin code that needs gateway-side persistence without a
+// circular import.
 
-const codexJWTKeysFile = "codex_jwt_keys.json"
+// CodexJWTKeysKind is the BlobStore namespace for the gateway's
+// minted RSA + ed25519 Agent Identity JWT signing material.
+// Exported so the gateway's legacy-state importer can address the
+// row when migrating on-disk codex_jwt_keys.json into sqlite.
+const CodexJWTKeysKind = "codex_jwt_keys"
+
+var blobs runtime.BlobStore
+
+// SetBlobStore is part of the clawpatrol plugin API.
+func SetBlobStore(b runtime.BlobStore) { blobs = b }
 
 // codexJWTKeys is the persisted keypair set. RSA signs the JWT
 // envelope (codex enforces RS256). Ed25519 lives inside the JWT as
@@ -210,27 +222,21 @@ var (
 
 func loadCodexJWTKeys() (*codexJWTKeys, error) {
 	codexKeysOnce.Do(func() {
-		codexKeys, codexKeysErr = loadOrGenerateCodexJWTKeys(codexJWTKeysPath())
+		codexKeys, codexKeysErr = loadOrGenerateCodexJWTKeys(blobs)
 	})
 	return codexKeys, codexKeysErr
 }
 
-// codexJWTKeysPath mirrors the main package's defaultClawpatrolDir
-// (see login.go). Replicated here to avoid an inversion — endpoint
-// plugins live below the main package.
-func codexJWTKeysPath() string {
-	if d := os.Getenv("CLAWPATROL_DIR"); d != "" {
-		return filepath.Join(d, codexJWTKeysFile)
+func loadOrGenerateCodexJWTKeys(b runtime.BlobStore) (*codexJWTKeys, error) {
+	if b == nil {
+		return nil, fmt.Errorf("codex jwt keys: no blob store")
 	}
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".clawpatrol", codexJWTKeysFile)
-}
-
-func loadOrGenerateCodexJWTKeys(path string) (*codexJWTKeys, error) {
-	if b, err := os.ReadFile(path); err == nil {
+	if data, found, err := b.Get(CodexJWTKeysKind, ""); err != nil {
+		return nil, fmt.Errorf("codex jwt keys read: %w", err)
+	} else if found {
 		var k codexJWTKeys
-		if err := json.Unmarshal(b, &k); err != nil {
-			return nil, fmt.Errorf("read %s: %w", path, err)
+		if err := json.Unmarshal(data, &k); err != nil {
+			return nil, fmt.Errorf("parse codex jwt keys: %w", err)
 		}
 		if k.KID != "" && k.RSAPrivatePKCS8B64 != "" && k.Ed25519PKCS8B64 != "" {
 			return &k, nil
@@ -268,15 +274,12 @@ func loadOrGenerateCodexJWTKeys(path string) (*codexJWTKeys, error) {
 		RSAPrivatePKCS8B64: base64.StdEncoding.EncodeToString(rsaDER),
 		Ed25519PKCS8B64:    base64.StdEncoding.EncodeToString(edDER),
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
-	}
 	out, err := json.MarshalIndent(k, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal keys: %w", err)
 	}
-	if err := os.WriteFile(path, out, 0o600); err != nil {
-		return nil, fmt.Errorf("write %s: %w", path, err)
+	if err := b.Put(CodexJWTKeysKind, "", out); err != nil {
+		return nil, fmt.Errorf("write codex jwt keys: %w", err)
 	}
 	return k, nil
 }

--- a/config/plugins/endpoints/openai_codex_https_test.go
+++ b/config/plugins/endpoints/openai_codex_https_test.go
@@ -12,12 +12,49 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 )
+
+// fakeBlobs is an in-memory runtime.BlobStore for tests. Plugins read
+// / write blobs through this in place of the production sqlite-backed
+// store. Keyed by (kind, name) like the real one.
+type fakeBlobs struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newFakeBlobs() *fakeBlobs { return &fakeBlobs{m: map[string][]byte{}} }
+
+func (f *fakeBlobs) key(kind, name string) string { return kind + "\x00" + name }
+
+func (f *fakeBlobs) Get(kind, name string) ([]byte, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.m[f.key(kind, name)]
+	return v, ok, nil
+}
+
+func (f *fakeBlobs) Put(kind, name string, data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	f.m[f.key(kind, name)] = cp
+	return nil
+}
+
+// resetCodexKeys clears the sync.Once-cached keypair so a test gets a
+// fresh BlobStore-backed mint without inheriting state from earlier
+// tests in the same process.
+func resetCodexKeys(t *testing.T, b *fakeBlobs) {
+	t.Helper()
+	codexKeysOnce = sync.Once{}
+	codexKeys = nil
+	codexKeysErr = nil
+	SetBlobStore(b)
+}
 
 // TestCodexJWTRoundTrip mints a JWT and verifies its RS256 signature
 // using the public key extracted from the JWKS the gateway would
@@ -26,25 +63,15 @@ import (
 // codex-rs/agent-identity/src/lib.rs:147-171). If this passes, codex
 // will accept the JWT.
 func TestCodexJWTRoundTrip(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("CLAWPATROL_DIR", dir)
-
-	// Reset the package-level once so the test gets fresh keys in a
-	// clean tempdir. The init runs once per process; the production
-	// API caches via sync.Once so we have to break out of it here.
-	codexKeysOnce = sync.Once{}
-	codexKeys = nil
-	codexKeysErr = nil
+	b := newFakeBlobs()
+	resetCodexKeys(t, b)
 
 	jwt, err := mintCodexAccessToken()
 	if err != nil {
 		t.Fatalf("mint: %v", err)
 	}
-	if !strings.HasSuffix(filepath.Dir(codexJWTKeysPath()), filepath.Base(dir)) {
-		t.Fatalf("CLAWPATROL_DIR not honored: %s", codexJWTKeysPath())
-	}
-	if _, err := os.Stat(codexJWTKeysPath()); err != nil {
-		t.Fatalf("keys file missing: %v", err)
+	if _, found, _ := b.Get(CodexJWTKeysKind, ""); !found {
+		t.Fatalf("keys blob not persisted")
 	}
 
 	jwksJSON, err := codexJWKSResponse()
@@ -144,10 +171,7 @@ func TestCodexJWTRoundTrip(t *testing.T) {
 // CODEX_ACCESS_TOKEN / CODEX_AGENT_IDENTITY env vars (both for cross-
 // version codex compat) plus the auth-API base URL override.
 func TestCodexEndpointEnvVars(t *testing.T) {
-	t.Setenv("CLAWPATROL_DIR", t.TempDir())
-	codexKeysOnce = sync.Once{}
-	codexKeys = nil
-	codexKeysErr = nil
+	resetCodexKeys(t, newFakeBlobs())
 
 	got := (&OpenAICodexHTTPSEndpoint{}).EnvVars()
 	want := map[string]bool{
@@ -177,10 +201,7 @@ func TestCodexEndpointEnvVars(t *testing.T) {
 // Both must return 200 with parseable JSON; non-matching paths must
 // fall through.
 func TestCodexRespondHTTP(t *testing.T) {
-	t.Setenv("CLAWPATROL_DIR", t.TempDir())
-	codexKeysOnce = sync.Once{}
-	codexKeys = nil
-	codexKeysErr = nil
+	resetCodexKeys(t, newFakeBlobs())
 
 	rt := OpenAICodexHTTPSEndpointRuntime{}
 	cases := []struct {
@@ -233,10 +254,7 @@ func TestCodexRespondHTTP(t *testing.T) {
 // confirm the bytes the agent sees are what we serve. Closest thing
 // to an integration test without standing up the full MITM gateway.
 func TestCodexSynthRoundTripOverHTTP(t *testing.T) {
-	t.Setenv("CLAWPATROL_DIR", t.TempDir())
-	codexKeysOnce = sync.Once{}
-	codexKeys = nil
-	codexKeysErr = nil
+	resetCodexKeys(t, newFakeBlobs())
 
 	rt := OpenAICodexHTTPSEndpointRuntime{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -22,10 +22,11 @@ package endpoints
 // that IP; when the conn lands on the VIP, dispatch consults the
 // VIP table to recover the hostname (and thus the endpoint).
 //
-// The gateway-side host key is per-endpoint, persisted under
-// <ca_dir>/ssh/<endpoint>.key (lazy-generated ed25519 on first use).
-// Operators add the printed fingerprint to their known_hosts so
-// `ssh user@hostname` doesn't prompt.
+// The gateway-side host key is per-endpoint, persisted in the host's
+// BlobStore under kind="ssh_host_key", name=<endpoint name>
+// (lazy-generated ed25519 on first use). Operators add the printed
+// fingerprint to their known_hosts so `ssh user@hostname` doesn't
+// prompt.
 
 import (
 	"bytes"
@@ -39,8 +40,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -149,8 +148,8 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	if ch.Endpoint == nil || ch.Endpoint.Family != "ssh" {
 		return fmt.Errorf("ssh runtime invoked on non-ssh endpoint %v", ch.Endpoint)
 	}
-	if ch.CADir == "" {
-		return fmt.Errorf("ssh runtime needs CADir to persist host keys; gateway hasn't set ca_dir")
+	if ch.Blobs == nil {
+		return fmt.Errorf("ssh runtime needs a BlobStore to persist host keys")
 	}
 	ep, ok := ch.Endpoint.Body.(*SSHEndpoint)
 	if !ok {
@@ -158,7 +157,7 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	}
 
 	// Step 1: load or mint the per-endpoint host key.
-	hostKey, err := rt.hostKeyFor(ch.Endpoint.Name, ch.CADir)
+	hostKey, err := rt.hostKeyFor(ch.Endpoint.Name, ch.Blobs)
 	if err != nil {
 		return fmt.Errorf("host key for endpoint %q: %w", ch.Endpoint.Name, err)
 	}
@@ -541,27 +540,30 @@ func isProxyDroppedGlobalReq(name string) bool {
 
 // ── Host key persistence ──────────────────────────────────────────────
 
-func (rt *SSHEndpointRuntime) hostKeyFor(endpointName, caDir string) (ssh.Signer, error) {
+// SSHHostKeyKind is the BlobStore namespace for SSH endpoint host
+// keys. Exported so the gateway's legacy-state importer can address
+// the same rows when migrating on-disk <ca_dir>/ssh/<name>.key files
+// into sqlite on first boot.
+const SSHHostKeyKind = "ssh_host_key"
+
+func (rt *SSHEndpointRuntime) hostKeyFor(endpointName string, blobs runtime.BlobStore) (ssh.Signer, error) {
 	if v, ok := rt.keyCache.Load(endpointName); ok {
 		return v.(ssh.Signer), nil
 	}
-	dir := filepath.Join(caDir, "ssh")
-	path := filepath.Join(dir, safeFileName(endpointName)+".key")
 
-	if data, err := os.ReadFile(path); err == nil {
+	data, found, err := blobs.Get(SSHHostKeyKind, endpointName)
+	if err != nil {
+		return nil, fmt.Errorf("ssh host key get: %w", err)
+	}
+	if found {
 		signer, err := ssh.ParsePrivateKey(data)
 		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", path, err)
+			return nil, fmt.Errorf("parse host key for %q: %w", endpointName, err)
 		}
 		rt.keyCache.Store(endpointName, signer)
 		return signer, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, err
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, err
-	}
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -571,57 +573,17 @@ func (rt *SSHEndpointRuntime) hostKeyFor(endpointName, caDir string) (ssh.Signer
 		return nil, err
 	}
 	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-	if err := writeFileAtomic(path, pemData, 0o600); err != nil {
-		return nil, err
+	if err := blobs.Put(SSHHostKeyKind, endpointName, pemData); err != nil {
+		return nil, fmt.Errorf("ssh host key put: %w", err)
 	}
 	signer, err := ssh.NewSignerFromKey(priv)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("ssh: minted host key for endpoint %q at %s — fingerprint %s",
-		endpointName, path, ssh.FingerprintSHA256(signer.PublicKey()))
+	log.Printf("ssh: minted host key for endpoint %q — fingerprint %s",
+		endpointName, ssh.FingerprintSHA256(signer.PublicKey()))
 	rt.keyCache.Store(endpointName, signer)
 	return signer, nil
-}
-
-func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".sshkey-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return os.Rename(tmpName, path)
-}
-
-// safeFileName maps an endpoint name to a filesystem-safe form.
-// Endpoint names already follow HCL identifier rules so this is
-// belt-and-suspenders against future relaxations.
-func safeFileName(s string) string {
-	return strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r >= '0' && r <= '9',
-			r == '-', r == '_', r == '.':
-			return r
-		}
-		return '_'
-	}, s)
 }
 
 // pickUpstream picks the host:port from hosts that matches dstPort.

--- a/config/runtime/blobs.go
+++ b/config/runtime/blobs.go
@@ -1,0 +1,24 @@
+package runtime
+
+// BlobStore is the plugin-facing persistent byte store. Endpoint /
+// credential plugins that need to remember opaque bytes across boots
+// — SSH endpoint host keys, OAuth signing material — call into this
+// instead of touching the filesystem directly.
+//
+// The host (clawpatrol gateway) backs it with a sqlite table; tests
+// can substitute an in-memory map. Plugins address rows by
+// (kind, name): kind is the plugin's stable namespace
+// ("ssh_host_key", "codex_jwt_keys"), name is whatever sub-key the
+// plugin needs (the endpoint name, or empty string for plugin-
+// singleton blobs).
+//
+// Why a small typed interface rather than the SecretStore: secrets
+// are credential-bound, owned-by-profile, and resolved through a
+// lookup chain (dashboard / OAuth / env). Blobs are plugin-internal
+// state with no owner concept — separating the contracts keeps each
+// one simple and lets plugin authors pick the right one without
+// stretching SecretStore semantics.
+type BlobStore interface {
+	Get(kind, name string) ([]byte, bool, error)
+	Put(kind, name string, data []byte) error
+}

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -148,13 +148,16 @@ type ConnHandle struct {
 	// support HITL for this conn family — plugins must default to
 	// deny in that case.
 	Approve func(req ApproveCallRequest) ApproveVerdict
-	// CADir is the gateway's CA / persistent state root (matches
-	// cfg.CADir). Endpoint runtimes that need to persist material
-	// per endpoint — e.g. SSH host keys at <CADir>/ssh/<name>.key —
-	// derive paths from this. Empty when the gateway hasn't been
-	// configured with a CA dir; plugins that need persistence error
-	// out clearly in that case.
+	// CADir is the gateway's persistent state root (matches
+	// cfg.CADir). Kept on the handle for tunnel plugins (Tailscale's
+	// tsnet state dir is derived from it). Endpoint plugins should
+	// persist material through Blobs instead — see ConnHandle.Blobs.
 	CADir string
+	// Blobs is the gateway's plugin-blob store. Endpoint plugins
+	// that need persistent bytes (SSH host keys, JWT signing keys)
+	// read / write through it instead of touching the filesystem.
+	// The host backs it with a sqlite table; tests pass a fake.
+	Blobs BlobStore
 	// DstPort is the destination port the agent connection arrived
 	// on (post-VIP / direct dial). Endpoints whose host strings
 	// carry a non-default port (`hosts = ["x.com:22222"]`) consult

--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -11,9 +11,9 @@
 // VIP is keyed to exactly one hostname.
 //
 // VIPs are stable across both restarts and policy reloads (persisted
-// to <state_dir>/dnsvip.json). When a hostname leaves policy its slot
-// is freed and reused by the next allocation, so the table doesn't
-// grow without bound across long-lived gateways.
+// to the dnsvip_allocations sqlite table). When a hostname leaves
+// policy its slot is freed and reused by the next allocation, so the
+// table doesn't grow without bound across long-lived gateways.
 //
 // The package depends on miekg/dns only for wire-format parsing and
 // serialisation; the server loops are hand-rolled because the
@@ -23,16 +23,13 @@ package dnsvip
 
 import (
 	"context"
+	"database/sql"
 	"encoding/binary"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/netip"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -88,25 +85,20 @@ var (
 const MaxID uint32 = 0xFFFE
 
 type entry struct {
-	ID       uint32     `json:"id"`
-	Hostname string     `json:"hostname"`
-	V4       netip.Addr `json:"v4"`
-	V6       netip.Addr `json:"v6"`
-}
-
-type persistFile struct {
-	Version int     `json:"version"`
-	Entries []entry `json:"entries"`
+	ID       uint32
+	Hostname string
+	V4       netip.Addr
+	V6       netip.Addr
 }
 
 // Allocator owns the hostname↔VIP table and serves DNS over the
-// netstack-supplied conns. Construction loads from disk; the gateway
+// netstack-supplied conns. Construction loads from sqlite; the gateway
 // calls RebuildFromPolicy on every policy load to reconcile
 // allocations against the current endpoint set.
 type Allocator struct {
-	statePath string
-	cidr4     netip.Prefix
-	cidr6     netip.Prefix
+	db    *sql.DB
+	cidr4 netip.Prefix
+	cidr6 netip.Prefix
 
 	mu        sync.RWMutex
 	byName    map[string]*entry        // hostname → entry
@@ -117,11 +109,14 @@ type Allocator struct {
 	used      map[uint32]struct{}      // ID set, for fast in-use check
 }
 
-// New constructs an allocator and loads any existing state from
-// stateDir/dnsvip.json. cidr4/cidr6 may be passed as zero-valued
-// netip.Prefix to use the package defaults. A non-existent state
-// file is fine — the allocator starts empty.
-func New(stateDir string, cidr4, cidr6 netip.Prefix) (*Allocator, error) {
+// New constructs an allocator and loads any existing state from the
+// dnsvip_allocations table. cidr4/cidr6 may be passed as zero-valued
+// netip.Prefix to use the package defaults. An empty table is fine —
+// the allocator starts empty.
+func New(db *sql.DB, cidr4, cidr6 netip.Prefix) (*Allocator, error) {
+	if db == nil {
+		return nil, fmt.Errorf("dnsvip: nil db")
+	}
 	if !cidr4.IsValid() {
 		cidr4 = DefaultCIDR4
 	}
@@ -135,7 +130,7 @@ func New(stateDir string, cidr4, cidr6 netip.Prefix) (*Allocator, error) {
 		return nil, fmt.Errorf("cidr6 must be IPv6: %s", cidr6)
 	}
 	a := &Allocator{
-		statePath: filepath.Join(stateDir, "dnsvip.json"),
+		db:        db,
 		cidr4:     cidr4,
 		cidr6:     cidr6,
 		byName:    map[string]*entry{},
@@ -151,66 +146,76 @@ func New(stateDir string, cidr4, cidr6 netip.Prefix) (*Allocator, error) {
 }
 
 func (a *Allocator) load() error {
-	data, err := os.ReadFile(a.statePath)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
+	rows, err := a.db.Query(`SELECT id, hostname, v4, v6 FROM dnsvip_allocations`)
 	if err != nil {
-		return fmt.Errorf("dnsvip: read %s: %w", a.statePath, err)
+		return fmt.Errorf("dnsvip: read: %w", err)
 	}
-	var f persistFile
-	if err := json.Unmarshal(data, &f); err != nil {
-		return fmt.Errorf("dnsvip: parse %s: %w", a.statePath, err)
-	}
-	for i := range f.Entries {
-		e := &f.Entries[i]
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			id           int64
+			host, v4, v6 string
+		)
+		if err := rows.Scan(&id, &host, &v4, &v6); err != nil {
+			return fmt.Errorf("dnsvip: scan: %w", err)
+		}
+		v4a, err := netip.ParseAddr(v4)
+		if err != nil {
+			log.Printf("dnsvip: dropping persisted entry %s — bad v4 %q: %v", host, v4, err)
+			continue
+		}
+		v6a, err := netip.ParseAddr(v6)
+		if err != nil {
+			log.Printf("dnsvip: dropping persisted entry %s — bad v6 %q: %v", host, v6, err)
+			continue
+		}
 		// Defensive: skip entries whose VIPs fall outside the
 		// configured CIDRs (operator changed the prefix between
 		// boots). They'll be reallocated fresh on next rebuild.
-		if !a.cidr4.Contains(e.V4) || !a.cidr6.Contains(e.V6) {
-			log.Printf("dnsvip: dropping persisted entry %s — VIP outside configured CIDRs", e.Hostname)
+		if !a.cidr4.Contains(v4a) || !a.cidr6.Contains(v6a) {
+			log.Printf("dnsvip: dropping persisted entry %s — VIP outside configured CIDRs", host)
 			continue
 		}
-		a.byName[e.Hostname] = e
-		a.byV4[e.V4] = e
-		a.byV6[e.V6] = e
+		e := &entry{ID: uint32(id), Hostname: host, V4: v4a, V6: v6a}
+		a.byName[host] = e
+		a.byV4[v4a] = e
+		a.byV6[v6a] = e
 		a.used[e.ID] = struct{}{}
 	}
-	return nil
+	return rows.Err()
 }
 
+// persistLocked rewrites the dnsvip_allocations table to match the
+// in-memory byName state. Wrapped in a tx so a crash mid-rebuild
+// leaves the previous table intact — same atomicity the old
+// rename-an-atomic-file path had.
 func (a *Allocator) persistLocked() error {
-	if a.statePath == "" {
+	if a.db == nil {
 		return nil
 	}
-	out := persistFile{Version: 1}
+	tx, err := a.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`DELETE FROM dnsvip_allocations`); err != nil {
+		return err
+	}
+	// Sort for determinism; aids replica diffing + log scanning.
+	entries := make([]*entry, 0, len(a.byName))
 	for _, e := range a.byName {
-		out.Entries = append(out.Entries, *e)
+		entries = append(entries, e)
 	}
-	sort.Slice(out.Entries, func(i, j int) bool { return out.Entries[i].ID < out.Entries[j].ID })
-	buf, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return err
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+	for _, e := range entries {
+		if _, err := tx.Exec(
+			`INSERT INTO dnsvip_allocations (id, hostname, v4, v6) VALUES (?, ?, ?, ?)`,
+			e.ID, e.Hostname, e.V4.String(), e.V6.String(),
+		); err != nil {
+			return err
+		}
 	}
-	dir := filepath.Dir(a.statePath)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(dir, "dnsvip-*.json.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(buf); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return os.Rename(tmpName, a.statePath)
+	return tx.Commit()
 }
 
 // vipForID derives the (v4, v6) pair for an ID. v4 occupies the last

--- a/dnsvip/dnsvip_test.go
+++ b/dnsvip/dnsvip_test.go
@@ -1,17 +1,42 @@
 package dnsvip
 
 import (
+	"database/sql"
+	"fmt"
 	"net"
 	"net/netip"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/miekg/dns"
+	_ "modernc.org/sqlite"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/plugins/endpoints"
 )
+
+// testDB opens a fresh sqlite db with the dnsvip_allocations schema
+// applied. Uses the same modernc/sqlite driver + PRAGMAs the gateway
+// uses in production. Returns a closed-on-cleanup *sql.DB.
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	dsn := fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)", path)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE dnsvip_allocations (
+		id        INTEGER PRIMARY KEY,
+		hostname  TEXT NOT NULL UNIQUE,
+		v4        TEXT NOT NULL UNIQUE,
+		v6        TEXT NOT NULL UNIQUE
+	)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
 
 // fakePolicy builds a CompiledPolicy whose endpoints opt into VIPs.
 // The plugin Type drives defaultPortFor lookups, so we set it to
@@ -45,8 +70,8 @@ type testBody struct {
 func (testBody) RequiresVIP() bool { return true }
 
 func TestRebuildAllocatesAndIsStable(t *testing.T) {
-	dir := t.TempDir()
-	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -72,8 +97,10 @@ func TestRebuildAllocatesAndIsStable(t *testing.T) {
 		t.Fatalf("VIPs drifted after no-op rebuild: was (%v,%v) now (%v,%v)", v4a, v6a, v4a2, v6a2)
 	}
 
-	// Persistence: load a fresh allocator from the same dir.
-	b, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	// Persistence: load a fresh allocator from the same db. Same
+	// DB handle is fine — the in-memory state is in *Allocator, not
+	// in the connection.
+	b, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New 2: %v", err)
 	}
@@ -84,8 +111,8 @@ func TestRebuildAllocatesAndIsStable(t *testing.T) {
 }
 
 func TestRebuildFreesAndRecycles(t *testing.T) {
-	dir := t.TempDir()
-	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -134,9 +161,9 @@ func TestRebuildFreesAndRecycles(t *testing.T) {
 func TestExhaustion(t *testing.T) {
 	// Use a tiny v4 CIDR so we run out fast. /29 leaves us with 7
 	// usable IDs (1..7 — id 0 reserved). The v6 CIDR can stay big.
-	dir := t.TempDir()
+	db := testDB(t)
 	cidr4 := netip.MustParsePrefix("10.99.0.0/29")
-	a, err := New(dir, cidr4, DefaultCIDR6)
+	a, err := New(db, cidr4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -164,8 +191,8 @@ func TestExhaustion(t *testing.T) {
 }
 
 func TestDNSARecordRoundTrip(t *testing.T) {
-	dir := t.TempDir()
-	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -205,8 +232,8 @@ func TestDNSARecordRoundTrip(t *testing.T) {
 }
 
 func TestLookupVIP(t *testing.T) {
-	dir := t.TempDir()
-	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -240,8 +267,8 @@ func TestLookupVIP(t *testing.T) {
 // literal don't issue a DNS query, so a VIP for "172.17.0.1" is
 // stranded state. The direct-IP dispatch path covers those entries.
 func TestRebuildSkipsIPLiteralHosts(t *testing.T) {
-	dir := t.TempDir()
-	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -274,8 +301,8 @@ func TestRebuildSkipsIPLiteralHosts(t *testing.T) {
 // unmatched-traffic path. The same shape applies to any future plugin
 // whose EndpointHosts() does TLS-conditional default-port resolution.
 func TestRebuildResolvesDefaultPortForTLSEndpoint(t *testing.T) {
-	dir := t.TempDir()
-	a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -310,10 +337,10 @@ func TestRebuildResolvesDefaultPortForTLSEndpoint(t *testing.T) {
 }
 
 func TestPersistenceDropsOutOfRangeEntries(t *testing.T) {
-	dir := t.TempDir()
+	db := testDB(t)
 	// Allocate with the default CIDRs.
 	{
-		a, err := New(dir, DefaultCIDR4, DefaultCIDR6)
+		a, err := New(db, DefaultCIDR4, DefaultCIDR6)
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
@@ -326,18 +353,12 @@ func TestPersistenceDropsOutOfRangeEntries(t *testing.T) {
 	// dropped (its VIPs fall outside the new prefixes).
 	cidr4 := netip.MustParsePrefix("10.42.0.0/16")
 	cidr6 := netip.MustParsePrefix("fd42::/64")
-	a, err := New(dir, cidr4, cidr6)
+	a, err := New(db, cidr4, cidr6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	if v4, _ := a.VIPsFor("x.example.com"); v4.IsValid() {
 		t.Fatalf("expected entry to be dropped after CIDR change, still have %v", v4)
-	}
-
-	// Persisted file should still be readable next time.
-	want := filepath.Join(dir, "dnsvip.json")
-	if _, err := os.ReadFile(want); err != nil && !os.IsNotExist(err) {
-		t.Fatalf("dnsvip.json unreadable: %v", err)
 	}
 }
 
@@ -349,7 +370,7 @@ func TestPersistenceDropsOutOfRangeEntries(t *testing.T) {
 // `clickhouse-o11y` even when their resolver inside the WG
 // namespace points at 1.1.1.1.
 func TestForwardUpstreamSynthesisesA(t *testing.T) {
-	a, err := New(t.TempDir(), DefaultCIDR4, DefaultCIDR6)
+	a, err := New(testDB(t), DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -385,7 +406,7 @@ func TestForwardUpstreamSynthesisesA(t *testing.T) {
 // NXDOMAIN. Confirms we don't accidentally fall through to the
 // relay path on resolution errors.
 func TestForwardUpstreamNXDomainOnUnresolvable(t *testing.T) {
-	a, err := New(t.TempDir(), DefaultCIDR4, DefaultCIDR6)
+	a, err := New(testDB(t), DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -407,7 +428,7 @@ func TestForwardUpstreamNXDomainOnUnresolvable(t *testing.T) {
 // SERVFAIL (its empty-dstIP guard) — the route taken is the
 // observable behavior.
 func TestForwardUpstreamRelaysOtherTypes(t *testing.T) {
-	a, err := New(t.TempDir(), DefaultCIDR4, DefaultCIDR6)
+	a, err := New(testDB(t), DefaultCIDR4, DefaultCIDR6)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/denoland/clawpatrol/config/match"
 	_ "github.com/denoland/clawpatrol/config/plugins/all"
 	"github.com/denoland/clawpatrol/config/plugins/approvers"
+	"github.com/denoland/clawpatrol/config/plugins/endpoints"
 	"github.com/denoland/clawpatrol/config/runtime"
 	"github.com/denoland/clawpatrol/dnsvip"
 	"github.com/google/uuid"
@@ -39,6 +40,28 @@ import (
 // StartWGServer / newOnboarder / mintTailscaleAuthKey) can refer to
 // it as a bare name.
 type JoinConfig = config.JoinConfig
+
+// resolveStateDir picks the directory where the gateway keeps its
+// sqlite DB. Priority: cfg.StateDir (new canonical name) →
+// cfg.OAuthDir (the historical name, kept for backwards compat) →
+// ${cfg.CADir}/../oauth (the original layout that put state next to
+// the CA materials).
+func resolveStateDir(cfg *config.Gateway) string {
+	if cfg.StateDir != "" {
+		return cfg.StateDir
+	}
+	if cfg.OAuthDir != "" {
+		return cfg.OAuthDir
+	}
+	if cfg.CADir != "" {
+		return filepath.Join(cfg.CADir, "..", "oauth")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		log.Fatalf("state_dir / oauth_dir / ca_dir all unset and $HOME unavailable")
+	}
+	return filepath.Join(home, ".clawpatrol", "state")
+}
 
 // emit a terminal request event to both the SSE sink and OTel.
 // ev.Action and ev.Ms must be populated. Non-request events (e.g.
@@ -2082,8 +2105,6 @@ func main() {
 		runRun(os.Args[2:])
 	case "env":
 		runEnv(os.Args[2:])
-	case "init-ca":
-		runInitCA(os.Args[2:])
 	case "validate":
 		runValidate(os.Args[2:])
 	case "test":
@@ -2175,24 +2196,12 @@ usage:
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing
-  clawpatrol init-ca DIR                 generate a new CA in DIR
   clawpatrol validate <config.hcl>       parse + compile a config and exit
   clawpatrol test <config> <path>        replay action fixtures against a candidate policy
   clawpatrol version | -v | --version    print version and exit
 
 Documentation: https://clawpatrol.dev/docs/`)
 	os.Exit(2)
-}
-
-func runInitCA(args []string) {
-	if len(args) != 1 || args[0] == "-h" || args[0] == "--help" {
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol init-ca DIR")
-		os.Exit(2)
-	}
-	if err := writeCA(args[0]); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("wrote ca.crt + ca.key to %s\n", args[0])
 }
 
 // gatewayHelp is shown for `clawpatrol gateway -h` and any wrong
@@ -2235,14 +2244,7 @@ func runGateway(args []string) {
 		log.Fatalf("config: %v", err)
 	}
 	logDashboardSecretState(cfg)
-	certs, err := loadCA(cfg.CADir)
-	if err != nil {
-		log.Fatalf("ca: %v", err)
-	}
-	stateDir := cfg.OAuthDir
-	if stateDir == "" {
-		stateDir = filepath.Join(cfg.CADir, "..", "oauth")
-	}
+	stateDir := resolveStateDir(cfg)
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		log.Fatalf("state dir: %v", err)
 	}
@@ -2251,6 +2253,17 @@ func runGateway(args []string) {
 		log.Fatalf("db: %v", err)
 	}
 	setDB(db)
+	blobs := newGatewayBlobStore(db)
+	endpoints.SetBlobStore(blobs)
+	// Move any pre-sqlite on-disk state into the DB so existing
+	// deployments don't lose their CA / WG key / SSH host keys when
+	// they upgrade. No-op on fresh installs and on every subsequent
+	// boot. See state_import.go for per-artifact behavior.
+	importLegacyState(db, blobs, cfg.CADir, stateDir)
+	certs, err := loadOrMintCA(db)
+	if err != nil {
+		log.Fatalf("ca: %v", err)
+	}
 	sink, err := NewSink(db, 4096)
 	if err != nil {
 		log.Fatalf("log: %v", err)
@@ -2297,7 +2310,7 @@ func runGateway(args []string) {
 	// unconditionally so reloads that *add* an SSH endpoint don't
 	// have to re-init. Persists to <stateDir>/dnsvip.json so VIPs
 	// survive restarts.
-	dvip, err := dnsvip.New(stateDir, dnsvip.DefaultCIDR4, dnsvip.DefaultCIDR6)
+	dvip, err := dnsvip.New(db, dnsvip.DefaultCIDR4, dnsvip.DefaultCIDR6)
 	if err != nil {
 		log.Fatalf("dnsvip init: %v", err)
 	}
@@ -2349,7 +2362,7 @@ func runGateway(args []string) {
 		log.Printf("otel: %v", err)
 	}
 
-	startTelemetry(g, stateDir)
+	startTelemetry(g)
 
 	if cfg.InfoListen != "" {
 		mux := newWebMux(g, cfg.CADir, cfg.Join(), cfg.PublicURL)
@@ -2370,7 +2383,7 @@ func runGateway(args []string) {
 	// No /etc/hosts hack needed on clients — agents resolve real
 	// hostnames via public DNS and the gateway intercepts at L3.
 	if strings.EqualFold(cfg.Control, "wireguard") {
-		wg, err := StartWGServer(cfg.Join(), stateDir)
+		wg, err := StartWGServer(cfg.Join())
 		if err != nil {
 			log.Fatalf("wireguard: %v", err)
 		}

--- a/migrations/sqlite/0008_gateway_state.sql
+++ b/migrations/sqlite/0008_gateway_state.sql
@@ -1,0 +1,69 @@
+-- 0008_gateway_state — collapse on-disk gateway state into sqlite.
+--
+-- Before this migration the gateway scattered state across the
+-- filesystem alongside its sqlite db:
+--
+--   ${ca_dir}/ca.crt + ca.key              → ca_material
+--   ${state_dir}/wg-server.key             → wg_server_key
+--   ${ca_dir}/ssh/<endpoint>.key           → gateway_blobs (kind='ssh_host_key')
+--   ${CLAWPATROL_DIR}/codex_jwt_keys.json  → gateway_blobs (kind='codex_jwt_keys')
+--   ${state_dir}/instance_id               → telemetry_state
+--   ${state_dir}/dnsvip.json               → dnsvip_allocations
+--
+-- After this migration the gateway writes exactly one persistent
+-- artifact to disk (the sqlite db). Legacy on-disk files are
+-- auto-imported on first boot, then deleted (see state_import.go).
+--
+-- Tables come in two shapes. Host-owned singletons (CA, WG server
+-- key, telemetry id) get typed columns: their shape is fixed and the
+-- gateway code is the only consumer, so a typed table is honest
+-- about the data and `sqlite3` introspection stays readable.
+-- Plugin-owned state goes through gateway_blobs because plugins
+-- address it by (kind, name) through runtime.BlobStore and a new
+-- plugin shouldn't need a schema migration to land.
+
+CREATE TABLE ca_material (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  cert_pem    BLOB NOT NULL,
+  key_pem     BLOB NOT NULL,
+  created_ns  INTEGER NOT NULL
+);
+
+CREATE TABLE wg_server_key (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  priv_hex    TEXT NOT NULL,
+  created_ns  INTEGER NOT NULL
+);
+
+CREATE TABLE telemetry_state (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  instance_id TEXT NOT NULL,
+  created_ns  INTEGER NOT NULL
+);
+
+-- Generic plugin-owned blob store. Plugins address rows by
+-- (kind, name); kind is the plugin's stable namespace, name is the
+-- sub-key (the SSH endpoint name for ssh_host_key, or empty for
+-- plugin-singleton blobs like codex_jwt_keys). New plugins that
+-- need persistent bytes use this table — DO NOT dump host-owned
+-- typed state here.
+CREATE TABLE gateway_blobs (
+  kind        TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  value       BLOB NOT NULL,
+  updated_ns  INTEGER NOT NULL,
+  PRIMARY KEY (kind, name)
+);
+
+-- DNS-VIP allocations. One row per (hostname, v4, v6) triple.
+-- RebuildFromPolicy rewrites the whole table inside a single tx so
+-- crash-recovery matches the rename-an-atomic-file semantics the
+-- old dnsvip.json had.
+CREATE TABLE dnsvip_allocations (
+  id        INTEGER PRIMARY KEY,
+  hostname  TEXT NOT NULL UNIQUE,
+  v4        TEXT NOT NULL UNIQUE,
+  v6        TEXT NOT NULL UNIQUE
+);
+
+INSERT INTO _schema (version) VALUES (8);

--- a/secrets.go
+++ b/secrets.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -152,6 +153,52 @@ func credentialSlotPresence(db *sql.DB, credential, profile string) (map[string]
 		out[slot] = true
 	}
 	return out, rows.Err()
+}
+
+// gatewayBlobStore is the host-side BlobStore: plugins persist opaque
+// bytes here keyed by (kind, name), backed by the gateway_blobs sqlite
+// table. Companion to gatewaySecretStore — that one handles
+// credential-scoped material, this one handles plugin-internal state.
+type gatewayBlobStore struct {
+	db *sql.DB
+}
+
+func newGatewayBlobStore(db *sql.DB) *gatewayBlobStore {
+	return &gatewayBlobStore{db: db}
+}
+
+// Get is part of the clawpatrol plugin API.
+func (s *gatewayBlobStore) Get(kind, name string) ([]byte, bool, error) {
+	if s == nil || s.db == nil {
+		return nil, false, fmt.Errorf("blob store: no db")
+	}
+	var value []byte
+	err := s.db.QueryRow(
+		`SELECT value FROM gateway_blobs WHERE kind = ? AND name = ?`,
+		kind, name,
+	).Scan(&value)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return value, true, nil
+}
+
+// Put is part of the clawpatrol plugin API.
+func (s *gatewayBlobStore) Put(kind, name string, data []byte) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("blob store: no db")
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO gateway_blobs (kind, name, value, updated_ns)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(kind, name) DO UPDATE SET
+		   value = excluded.value, updated_ns = excluded.updated_ns`,
+		kind, name, data, time.Now().UnixNano(),
+	)
+	return err
 }
 
 // registerOAuthCredentials walks the loaded policy and registers each

--- a/setup.go
+++ b/setup.go
@@ -1042,20 +1042,17 @@ func runGatewayInit(args []string) {
 	skipFirewall := fs.Bool("no-firewall", false, "skip iptables ACCEPT rules")
 	_ = fs.Parse(args)
 
-	// 1. data dir + CA -----------------------------------------------------
+	// 1. data dir ----------------------------------------------------------
+	// The gateway lazy-mints its CA into sqlite on first boot, so
+	// there's nothing to pre-create here besides the state directory
+	// itself. ${dataDir}/ca is kept (empty for now) so the generated
+	// gateway.hcl's ca_dir path resolves to a real directory — the
+	// CA materials themselves live in the DB.
 	if err := os.MkdirAll(filepath.Join(*dataDir, "ca"), 0o700); err != nil {
 		fail("mkdir ca: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(*dataDir, "oauth"), 0o700); err != nil {
 		fail("mkdir oauth: %v", err)
-	}
-	caPath := filepath.Join(*dataDir, "ca", "ca.crt")
-	caGenerated := false
-	if _, err := os.Stat(caPath); err != nil {
-		if err := writeCA(filepath.Join(*dataDir, "ca")); err != nil {
-			fail("init-ca: %v", err)
-		}
-		caGenerated = true
 	}
 
 	// 2. detect public IP if not given -------------------------------------
@@ -1144,9 +1141,6 @@ profile "default" {
 	fmt.Println()
 	fmt.Printf("Detected public IP: %s\n", ip)
 	items := []string{}
-	if caGenerated {
-		items = append(items, "Generated CA at "+caPath)
-	}
 	items = append(items, "Wrote "+cfgPath)
 	if len(fwOpened) > 0 {
 		items = append(items, "Opened "+strings.Join(fwOpened, " + "))

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -30,10 +30,11 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 | `info_listen` | `string` | no |  |
 | `public_url` | `string` | no |  |
 | `admin_email` | `string` | no |  |
-| `ca_dir` | `string` | no |  |
+| `ca_dir` | `string` | no | The legacy path the gateway used to keep the CA cert + ssh host keys on disk. Kept for backwards compat: existing configs still parse, and state_import.go consults this path to move any leftover on-disk artifacts into sqlite on first boot of a migrated gateway. New deployments should set state_dir instead — the gateway now keeps everything in sqlite. |
+| `state_dir` | `string` | no | The directory holding clawpatrol.db. Falls back to OAuthDir (historical name) or ${CADir}/../oauth or ${HOME}/.clawpatrol/state, in that order. |
 | `resolver` | `string` | no |  |
 | `log_path` | `string` | no |  |
-| `oauth_dir` | `string` | no |  |
+| `oauth_dir` | `string` | no | The historical state directory name. Equivalent to state_dir and kept for backwards compat. |
 | `dashboard_secret` | `string` | no |  |
 | `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
@@ -41,7 +42,6 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 | `authkey` | `string` | no |  |
 | `control_url` | `string` | no |  |
 | `hostname` | `string` | no |  |
-| `state_dir` | `string` | no |  |
 | `control` | `string` | no |  |
 | `oauth_client_id` | `string` | no |  |
 | `oauth_client_secret` | `string` | no |  |

--- a/state_import.go
+++ b/state_import.go
@@ -1,0 +1,299 @@
+package main
+
+// Legacy-state import. Before 0008_gateway_state, the gateway
+// scattered six small pieces of state across the filesystem next to
+// its sqlite db (CA cert+key, WG server key, per-endpoint SSH host
+// keys, codex JWT keys, telemetry instance id, dnsvip allocations).
+// On first boot of a migrated gateway this importer reads any of
+// those files that still exist, writes their contents into sqlite,
+// and deletes the originals.
+//
+// Each artifact is independent: a failure on one (missing file,
+// permission error, parse failure) doesn't block the others, and the
+// import is idempotent — it only runs against an empty destination
+// row, so a partial import on boot N resumes cleanly on boot N+1.
+// Once every artifact has migrated, the importer is a no-op.
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"log"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/denoland/clawpatrol/config/plugins/endpoints"
+)
+
+// importLegacyState moves any pre-sqlite on-disk state into the DB
+// and removes the source files. Errors are logged but never fatal —
+// the gateway can always fall back to minting fresh material.
+func importLegacyState(db *sql.DB, blobs *gatewayBlobStore, caDir, stateDir string) {
+	importLegacyCA(db, caDir)
+	importLegacyWGKey(db, stateDir)
+	importLegacyInstanceID(db, stateDir)
+	importLegacyDNSVIP(db, stateDir)
+	importLegacySSHHostKeys(blobs, caDir)
+	importLegacyCodexJWTKeys(blobs)
+}
+
+func importLegacyCA(db *sql.DB, caDir string) {
+	if caDir == "" {
+		return
+	}
+	if hasRow(db, `SELECT 1 FROM ca_material WHERE id = 1`) {
+		return
+	}
+	certPath := filepath.Join(caDir, "ca.crt")
+	keyPath := filepath.Join(caDir, "ca.key")
+	certPEM, certErr := os.ReadFile(certPath)
+	keyPEM, keyErr := os.ReadFile(keyPath)
+	if errors.Is(certErr, fs.ErrNotExist) && errors.Is(keyErr, fs.ErrNotExist) {
+		return
+	}
+	if certErr != nil {
+		log.Printf("import: ca.crt: %v", certErr)
+		return
+	}
+	if keyErr != nil {
+		log.Printf("import: ca.key: %v", keyErr)
+		return
+	}
+	if err := importCAFromPEM(db, certPEM, keyPEM); err != nil {
+		log.Printf("import: ca insert: %v", err)
+		return
+	}
+	log.Printf("import: ca.crt + ca.key → ca_material; removing %s", caDir)
+	_ = os.Remove(certPath)
+	_ = os.Remove(keyPath)
+}
+
+func importLegacyWGKey(db *sql.DB, stateDir string) {
+	if stateDir == "" {
+		return
+	}
+	if hasRow(db, `SELECT 1 FROM wg_server_key WHERE id = 1`) {
+		return
+	}
+	path := filepath.Join(stateDir, "wg-server.key")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Printf("import: wg-server.key: %v", err)
+		return
+	}
+	if err := importWGServerKey(db, string(data)); err != nil {
+		log.Printf("import: wg key insert: %v", err)
+		return
+	}
+	log.Printf("import: wg-server.key → wg_server_key")
+	_ = os.Remove(path)
+}
+
+func importLegacyInstanceID(db *sql.DB, stateDir string) {
+	if stateDir == "" {
+		return
+	}
+	if hasRow(db, `SELECT 1 FROM telemetry_state WHERE id = 1`) {
+		return
+	}
+	path := filepath.Join(stateDir, "instance_id")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Printf("import: instance_id: %v", err)
+		return
+	}
+	if err := importTelemetryInstanceID(db, string(data)); err != nil {
+		log.Printf("import: instance_id insert: %v", err)
+		return
+	}
+	log.Printf("import: instance_id → telemetry_state")
+	_ = os.Remove(path)
+}
+
+// legacyDNSVIPFile mirrors the old persistFile shape in dnsvip.go
+// (kept here because dnsvip no longer needs JSON serialization).
+type legacyDNSVIPFile struct {
+	Version int                 `json:"version"`
+	Entries []legacyDNSVIPEntry `json:"entries"`
+}
+
+type legacyDNSVIPEntry struct {
+	ID       uint32     `json:"id"`
+	Hostname string     `json:"hostname"`
+	V4       netip.Addr `json:"v4"`
+	V6       netip.Addr `json:"v6"`
+}
+
+func importLegacyDNSVIP(db *sql.DB, stateDir string) {
+	if stateDir == "" {
+		return
+	}
+	if hasRow(db, `SELECT 1 FROM dnsvip_allocations LIMIT 1`) {
+		return
+	}
+	path := filepath.Join(stateDir, "dnsvip.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Printf("import: dnsvip.json: %v", err)
+		return
+	}
+	var f legacyDNSVIPFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		log.Printf("import: dnsvip.json parse: %v", err)
+		return
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		log.Printf("import: dnsvip tx: %v", err)
+		return
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, e := range f.Entries {
+		if !e.V4.IsValid() || !e.V6.IsValid() || e.Hostname == "" {
+			continue
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO dnsvip_allocations (id, hostname, v4, v6) VALUES (?, ?, ?, ?)`,
+			e.ID, e.Hostname, e.V4.String(), e.V6.String(),
+		); err != nil {
+			log.Printf("import: dnsvip insert %q: %v", e.Hostname, err)
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("import: dnsvip commit: %v", err)
+		return
+	}
+	log.Printf("import: dnsvip.json (%d entries) → dnsvip_allocations", len(f.Entries))
+	_ = os.Remove(path)
+}
+
+func importLegacySSHHostKeys(blobs *gatewayBlobStore, caDir string) {
+	if caDir == "" || blobs == nil {
+		return
+	}
+	sshDir := filepath.Join(caDir, "ssh")
+	entries, err := os.ReadDir(sshDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Printf("import: read %s: %v", sshDir, err)
+		return
+	}
+	var imported, kept int
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".key") {
+			continue
+		}
+		endpointName := strings.TrimSuffix(e.Name(), ".key")
+		// Skip if the blob already exists — this is the idempotency
+		// guard for partial re-runs.
+		if _, found, err := blobs.Get(endpoints.SSHHostKeyKind, endpointName); err == nil && found {
+			kept++
+			continue
+		}
+		path := filepath.Join(sshDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("import: read %s: %v", path, err)
+			continue
+		}
+		if err := blobs.Put(endpoints.SSHHostKeyKind, endpointName, data); err != nil {
+			log.Printf("import: ssh host key %q: %v", endpointName, err)
+			continue
+		}
+		_ = os.Remove(path)
+		imported++
+	}
+	if imported > 0 {
+		log.Printf("import: %d ssh host key(s) → gateway_blobs", imported)
+	}
+	if imported > 0 || kept == 0 {
+		// Drop the now-empty ssh/ directory. os.Remove fails harmless-
+		// ly if it's non-empty (e.g. a stray .DS_Store), which is the
+		// behavior we want.
+		_ = os.Remove(sshDir)
+	}
+}
+
+func importLegacyCodexJWTKeys(blobs *gatewayBlobStore) {
+	if blobs == nil {
+		return
+	}
+	if _, found, err := blobs.Get(endpoints.CodexJWTKeysKind, ""); err == nil && found {
+		return
+	}
+	// codex_jwt_keys.json lived under $CLAWPATROL_DIR or
+	// ~/.clawpatrol — same path resolution the old plugin used.
+	path := codexLegacyJWTKeysPath()
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Printf("import: codex_jwt_keys.json: %v", err)
+		return
+	}
+	// Sanity check: it's JSON and has the three expected fields.
+	var probe struct {
+		KID                string `json:"kid"`
+		RSAPrivatePKCS8B64 string `json:"rsa_private_pkcs8_b64"`
+		Ed25519PKCS8B64    string `json:"ed25519_private_pkcs8_b64"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil || probe.KID == "" {
+		log.Printf("import: codex_jwt_keys.json malformed; skipping")
+		return
+	}
+	if err := blobs.Put(endpoints.CodexJWTKeysKind, "", data); err != nil {
+		log.Printf("import: codex jwt keys put: %v", err)
+		return
+	}
+	log.Printf("import: codex_jwt_keys.json → gateway_blobs")
+	_ = os.Remove(path)
+}
+
+// codexLegacyJWTKeysPath mirrors the path resolution the old codex
+// endpoint plugin used: $CLAWPATROL_DIR if set, else ~/.clawpatrol.
+func codexLegacyJWTKeysPath() string {
+	if d := os.Getenv("CLAWPATROL_DIR"); d != "" {
+		return filepath.Join(d, "codex_jwt_keys.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".clawpatrol", "codex_jwt_keys.json")
+}
+
+// hasRow returns true when the given SELECT yields at least one row.
+// Used by import helpers as the "destination already populated" guard
+// so a re-run on a partially-migrated gateway is a no-op.
+func hasRow(db *sql.DB, query string, args ...any) bool {
+	row := db.QueryRow(query, args...)
+	var one int
+	err := row.Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+		log.Printf("import: %q: %v", query, err)
+		return false
+	}
+	return true
+}

--- a/state_import_test.go
+++ b/state_import_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/plugins/endpoints"
+)
+
+// TestStateImportRoundTrip drops every legacy on-disk artifact into a
+// scratch directory, runs the importer, and verifies the data lands
+// in sqlite and the source files are removed.
+func TestStateImportRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	caDir := filepath.Join(dir, "ca")
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(filepath.Join(caDir, "ssh"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Mint a real CA so importLegacyCA's parse step is exercised
+	// end-to-end. Reuses ca.go: we read the rows after writing the
+	// disk files, check they round-trip.
+	caScratch := filepath.Join(dir, "scratch.db")
+	scratch, err := OpenDB(caScratch)
+	if err != nil {
+		t.Fatalf("scratch open: %v", err)
+	}
+	cc, err := loadOrMintCA(scratch)
+	if err != nil {
+		t.Fatalf("mint scratch CA: %v", err)
+	}
+	_ = scratch.Close()
+	_ = cc
+	var caCert, caKey []byte
+	{
+		db2, err := OpenDB(caScratch)
+		if err != nil {
+			t.Fatalf("reopen scratch: %v", err)
+		}
+		if err := db2.QueryRow(`SELECT cert_pem, key_pem FROM ca_material WHERE id = 1`).
+			Scan(&caCert, &caKey); err != nil {
+			t.Fatalf("read scratch: %v", err)
+		}
+		_ = db2.Close()
+	}
+	if err := os.WriteFile(filepath.Join(caDir, "ca.crt"), caCert, 0o644); err != nil {
+		t.Fatalf("write ca.crt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(caDir, "ca.key"), caKey, 0o600); err != nil {
+		t.Fatalf("write ca.key: %v", err)
+	}
+
+	// WG server key.
+	wgHex, err := wgGenPrivateHex()
+	if err != nil {
+		t.Fatalf("wg gen: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "wg-server.key"), []byte(wgHex), 0o600); err != nil {
+		t.Fatalf("write wg key: %v", err)
+	}
+
+	// Instance ID.
+	instanceID := newReqID()
+	if err := os.WriteFile(filepath.Join(stateDir, "instance_id"), []byte(instanceID+"\n"), 0o600); err != nil {
+		t.Fatalf("write instance_id: %v", err)
+	}
+
+	// dnsvip.json.
+	dnsvipJSON := []byte(`{
+		"version": 1,
+		"entries": [{
+			"id": 7,
+			"hostname": "h.example.com",
+			"v4": "10.78.0.7",
+			"v6": "fd78::7"
+		}]
+	}`)
+	if err := os.WriteFile(filepath.Join(stateDir, "dnsvip.json"), dnsvipJSON, 0o600); err != nil {
+		t.Fatalf("write dnsvip: %v", err)
+	}
+
+	// SSH host key: a PEM body is enough; importLegacySSHHostKeys
+	// just round-trips the bytes through the blob store.
+	sshKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("fake ed25519 key bytes")})
+	if err := os.WriteFile(filepath.Join(caDir, "ssh", "edge.key"), sshKeyPEM, 0o600); err != nil {
+		t.Fatalf("write ssh key: %v", err)
+	}
+
+	// Codex JWT keys. Need a JSON blob with the three expected fields
+	// so the import sanity check passes.
+	codexJSON, _ := json.Marshal(map[string]string{
+		"kid":                       "sha256--legacy",
+		"rsa_private_pkcs8_b64":     "aGVsbG8=",
+		"ed25519_private_pkcs8_b64": "d29ybGQ=",
+	})
+	codexDir := filepath.Join(dir, "clawpatrol")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatalf("mkdir codex: %v", err)
+	}
+	codexPath := filepath.Join(codexDir, "codex_jwt_keys.json")
+	if err := os.WriteFile(codexPath, codexJSON, 0o600); err != nil {
+		t.Fatalf("write codex: %v", err)
+	}
+	t.Setenv("CLAWPATROL_DIR", codexDir)
+
+	// Run the importer.
+	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	blobs := newGatewayBlobStore(db)
+	importLegacyState(db, blobs, caDir, stateDir)
+
+	// Assert rows present.
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM ca_material`).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("ca_material rows = %d (err %v)", n, err)
+	}
+	if err := db.QueryRow(`SELECT count(*) FROM wg_server_key`).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("wg_server_key rows = %d (err %v)", n, err)
+	}
+	var gotInstance string
+	if err := db.QueryRow(`SELECT instance_id FROM telemetry_state WHERE id = 1`).Scan(&gotInstance); err != nil {
+		t.Fatalf("telemetry: %v", err)
+	}
+	if gotInstance != instanceID {
+		t.Fatalf("instance_id = %q want %q", gotInstance, instanceID)
+	}
+	if err := db.QueryRow(`SELECT count(*) FROM dnsvip_allocations`).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("dnsvip rows = %d (err %v)", n, err)
+	}
+	if data, found, err := blobs.Get(endpoints.SSHHostKeyKind, "edge"); err != nil || !found || len(data) == 0 {
+		t.Fatalf("ssh host key: found=%v err=%v len=%d", found, err, len(data))
+	}
+	if data, found, err := blobs.Get(endpoints.CodexJWTKeysKind, ""); err != nil || !found || len(data) == 0 {
+		t.Fatalf("codex keys: found=%v err=%v len=%d", found, err, len(data))
+	}
+
+	// Assert source files removed.
+	for _, p := range []string{
+		filepath.Join(caDir, "ca.crt"),
+		filepath.Join(caDir, "ca.key"),
+		filepath.Join(stateDir, "wg-server.key"),
+		filepath.Join(stateDir, "instance_id"),
+		filepath.Join(stateDir, "dnsvip.json"),
+		filepath.Join(caDir, "ssh", "edge.key"),
+		codexPath,
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected %s removed, stat err = %v", p, err)
+		}
+	}
+}
+
+// TestStateImportIdempotent confirms a second run doesn't error and
+// doesn't overwrite the rows it already inserted. We do this by
+// pre-populating the destination, dropping the source files, and
+// running the importer — the rows should stay exactly as we set them.
+func TestStateImportIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Plant an existing row.
+	want := newReqID()
+	if err := importTelemetryInstanceID(db, want); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Drop a stale file claiming a different id.
+	if err := os.WriteFile(filepath.Join(stateDir, "instance_id"), []byte("stale-id\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	blobs := newGatewayBlobStore(db)
+	importLegacyState(db, blobs, "", stateDir)
+
+	var got string
+	if err := db.QueryRow(`SELECT instance_id FROM telemetry_state WHERE id = 1`).Scan(&got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got != want {
+		t.Fatalf("import overwrote existing row: got %q want %q", got, want)
+	}
+	// And since the destination row was non-empty, the stale file
+	// should NOT have been deleted — the import is a no-op when the
+	// row already exists.
+	if _, err := os.Stat(filepath.Join(stateDir, "instance_id")); err != nil {
+		t.Errorf("expected stale file to remain (importer skipped); stat err = %v", err)
+	}
+}
+
+// TestLoadOrMintCAStable confirms a second call returns the same
+// material — the row persists across reopens.
+func TestLoadOrMintCAStable(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(filepath.Join(dir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	a, err := loadOrMintCA(db)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	b, err := loadOrMintCA(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if a.caCert.SerialNumber.Cmp(b.caCert.SerialNumber) != 0 {
+		t.Fatalf("CA drifted: %v -> %v", a.caCert.SerialNumber, b.caCert.SerialNumber)
+	}
+}
+
+// TestLoadOrGenWGServerKeyStable mirrors the CA test for the WG key.
+func TestLoadOrGenWGServerKeyStable(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(filepath.Join(dir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	a, err := loadOrGenWGServerKey(db)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	b, err := loadOrGenWGServerKey(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if a != b {
+		t.Fatalf("WG priv drifted: %q -> %q", a, b)
+	}
+}
+
+// TestLoadOrCreateInstanceIDStable mirrors the CA test for telemetry.
+func TestLoadOrCreateInstanceIDStable(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(filepath.Join(dir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	a, err := loadOrCreateInstanceID(db)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	b, err := loadOrCreateInstanceID(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if a != b {
+		t.Fatalf("instance id drifted: %q -> %q", a, b)
+	}
+}
+
+// TestGatewayBlobStoreRoundTrip exercises the sqlite-backed
+// BlobStore in isolation — Put then Get returns the same bytes,
+// and a non-existent key returns (nil, false, nil).
+func TestGatewayBlobStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(filepath.Join(dir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	s := newGatewayBlobStore(db)
+
+	if data, found, err := s.Get("kind1", "name1"); err != nil || found || data != nil {
+		t.Fatalf("empty get: found=%v err=%v data=%v", found, err, data)
+	}
+	if err := s.Put("kind1", "name1", []byte("hello")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	data, found, err := s.Get("kind1", "name1")
+	if err != nil || !found || string(data) != "hello" {
+		t.Fatalf("get back: data=%q found=%v err=%v", data, found, err)
+	}
+	// Overwrite.
+	if err := s.Put("kind1", "name1", []byte("world")); err != nil {
+		t.Fatalf("put 2: %v", err)
+	}
+	data, found, err = s.Get("kind1", "name1")
+	if err != nil || !found || string(data) != "world" {
+		t.Fatalf("overwrite: data=%q found=%v err=%v", data, found, err)
+	}
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -78,12 +77,12 @@ func telemetryEnabled(cfg *config.Gateway) bool {
 	return true
 }
 
-func startTelemetry(g *Gateway, stateDir string) {
+func startTelemetry(g *Gateway) {
 	if !telemetryEnabled(g.cfg) {
 		log.Printf("telemetry: disabled")
 		return
 	}
-	id, err := loadOrCreateInstanceID(stateDir)
+	id, err := loadOrCreateInstanceID(g.db)
 	if err != nil {
 		log.Printf("telemetry: %v; disabled", err)
 		return
@@ -270,18 +269,25 @@ func actionsCountIn1h(g *Gateway) (int64, int64, int64) {
 	return count.Int64, bytesIn.Int64, bytesOut.Int64
 }
 
-func loadOrCreateInstanceID(stateDir string) (string, error) {
-	path := filepath.Join(stateDir, "instance_id")
-	if b, err := os.ReadFile(path); err == nil {
-		s := strings.TrimSpace(string(b))
-		if s != "" {
-			return s, nil
+func loadOrCreateInstanceID(db *sql.DB) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("instance_id: no db")
+	}
+	var id string
+	err := db.QueryRow(`SELECT instance_id FROM telemetry_state WHERE id = 1`).Scan(&id)
+	if err == nil {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			return id, nil
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
+	} else if !errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("read instance_id: %w", err)
 	}
-	id := newReqID() // UUIDv7
-	if err := os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+	id = newReqID() // UUIDv7
+	if _, err := db.Exec(
+		`INSERT INTO telemetry_state (id, instance_id, created_ns) VALUES (1, ?, ?)`,
+		id, time.Now().UnixNano(),
+	); err != nil {
 		// Non-fatal: emit the ID this run, accept that the next
 		// restart will mint a new one and over-count by one.
 		log.Printf(
@@ -290,6 +296,20 @@ func loadOrCreateInstanceID(stateDir string) (string, error) {
 		)
 	}
 	return id, nil
+}
+
+// importTelemetryInstanceID writes a pre-existing UUIDv7 into
+// telemetry_state. Used by the legacy-state importer.
+func importTelemetryInstanceID(db *sql.DB, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("instance_id empty")
+	}
+	_, err := db.Exec(
+		`INSERT INTO telemetry_state (id, instance_id, created_ns) VALUES (1, ?, ?)`,
+		id, time.Now().UnixNano(),
+	)
+	return err
 }
 
 func shortID(s string) string {

--- a/wireguard.go
+++ b/wireguard.go
@@ -22,6 +22,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"expvar"
 	"fmt"
 	"net"
@@ -291,9 +292,10 @@ func setWGServer(s *WGServer) { globalWG = s }
 func setDB(d *sql.DB)         { globalDB = d }
 
 // StartWGServer brings up a userspace WG endpoint listening on
-// 0.0.0.0:<ListenPort>. Server private key is read from disk; if
-// missing, generated and persisted at <stateDir>/wg-server.key.
-func StartWGServer(ts JoinConfig, stateDir string) (*WGServer, error) {
+// 0.0.0.0:<ListenPort>. Server private key is read from the
+// wg_server_key sqlite row; if missing, generated and persisted on
+// first boot. Stable across restarts so onboarded peers keep working.
+func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	if ts.WGSubnetCIDR == "" {
 		return nil, fmt.Errorf("wireguard: wg_subnet_cidr required")
 	}
@@ -304,7 +306,7 @@ func StartWGServer(ts JoinConfig, stateDir string) (*WGServer, error) {
 		}
 	}
 
-	priv, err := loadOrGenWGKey(stateDir + "/wg-server.key")
+	priv, err := loadOrGenWGServerKey(globalDB)
 	if err != nil {
 		return nil, err
 	}
@@ -653,21 +655,47 @@ func (s *WGServer) RevokePeerByIP(ip string) {
 	_, _ = s.db.Exec("DELETE FROM wg_peers WHERE ip = ?", ip)
 }
 
-func loadOrGenWGKey(path string) (string, error) {
-	if b, err := os.ReadFile(path); err == nil {
-		return strings.TrimSpace(string(b)), nil
+// loadOrGenWGServerKey returns the gateway's WG server private key in
+// hex (the format wireguard-go's IpcSet expects). Reads from the
+// wg_server_key sqlite row; mints + persists on first call.
+func loadOrGenWGServerKey(db *sql.DB) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("wg server key: no db")
 	}
-	priv, err := wgGenPrivateHex()
+	var priv string
+	err := db.QueryRow(`SELECT priv_hex FROM wg_server_key WHERE id = 1`).Scan(&priv)
+	if err == nil {
+		return strings.TrimSpace(priv), nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("wg server key read: %w", err)
+	}
+	priv, err = wgGenPrivateHex()
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(strings.TrimSuffix(path, "/wg-server.key"), 0o700); err != nil {
-		return "", err
-	}
-	if err := os.WriteFile(path, []byte(priv), 0o600); err != nil {
-		return "", err
+	if _, err := db.Exec(
+		`INSERT INTO wg_server_key (id, priv_hex, created_ns) VALUES (1, ?, ?)`,
+		priv, time.Now().UnixNano(),
+	); err != nil {
+		return "", fmt.Errorf("wg server key insert: %w", err)
 	}
 	return priv, nil
+}
+
+// importWGServerKey writes a pre-existing hex key into wg_server_key.
+// Used by the legacy-state importer to move the on-disk
+// wg-server.key into sqlite. Caller guards against double-insert.
+func importWGServerKey(db *sql.DB, privHex string) error {
+	privHex = strings.TrimSpace(privHex)
+	if _, err := wgPubFromPrivHex(privHex); err != nil {
+		return fmt.Errorf("validate legacy wg key: %w", err)
+	}
+	_, err := db.Exec(
+		`INSERT INTO wg_server_key (id, priv_hex, created_ns) VALUES (1, ?, ?)`,
+		privHex, time.Now().UnixNano(),
+	)
+	return err
 }
 
 func wgPubFromPrivHex(privHex string) (string, error) {


### PR DESCRIPTION
Before this change the gateway scattered six small pieces of state
across the filesystem next to its sqlite db:

* \`\${ca_dir}/ca.crt\` + \`ca.key\`            — MITM root CA material
* \`\${state_dir}/wg-server.key\`             — WG server private key
* \`\${ca_dir}/ssh/<endpoint>.key\`           — per-endpoint SSH host keys
* \`~/.clawpatrol/codex_jwt_keys.json\`      — Codex JWT signing keys
* \`\${state_dir}/instance_id\`               — telemetry UUID
* \`\${state_dir}/dnsvip.json\`               — DNS-VIP allocations

All six now live in sqlite via a new migration
(\`0008_gateway_state.sql\`). The gateway writes exactly one
persistent artifact to disk: the sqlite db itself.

* Host-owned singletons (CA, WG server key, telemetry id) get typed
  tables.
* Plugin-owned state (SSH host keys, Codex JWT keys) goes through
  a new \`runtime.BlobStore\` interface so a new plugin can add
  persistent state without a schema migration.
* \`dnsvip_allocations\` is a relational table; \`RebuildFromPolicy\`
  rewrites it inside a single tx so crash atomicity matches the
  rename-an-atomic-file semantics the previous JSON file had.
* Existing deployments auto-import their on-disk state on first
  boot (\`state_import.go\`). Each artifact is independent, the
  import is idempotent against partial re-runs, and sources are
  removed after a successful copy.
* The HCL schema gains an optional \`state_dir\` field; \`ca_dir\`
  and \`oauth_dir\` are kept for backwards compat.
* \`clawpatrol init-ca\` is gone — the CA is now lazy-minted on
  first gateway boot.