### PR TITLE
config: flatten gateway {} and defaults {} into top-level fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ control = "wireguard"   # or "tailscale"
 # tailscale-only:
 oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
 oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
-tags                = ["tag:client"]
+tailscale_tags      = ["tag:client"]
 
 # wireguard-only:
 wg_endpoint    = "gw.example.com:51820"

--- a/README.md
+++ b/README.md
@@ -136,19 +136,17 @@ The WireGuard mode embeds a userspace WG endpoint inside the gateway. You only h
 
 The Tailscale mode joins the gateway to your existing tailnet as an exit-node. Devices that are already on the tailnet run `clawpatrol login` and pin `clawpatrol` as their exit-node. Use this if you already operate Tailscale and want its ACL and whois plumbing to gate onboarding.
 
-You configure the choice with the `gateway` block:
+You configure the choice with top-level fields:
 
 ```hcl
-gateway {
-  control = "wireguard"   # or "tailscale"
+control = "wireguard"   # or "tailscale"
 
-  # tailscale-only:
-  oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
-  oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
-  tags                = ["tag:client"]
+# tailscale-only:
+oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
+oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
+tags                = ["tag:client"]
 
-  # wireguard-only:
-  wg_endpoint    = "gw.example.com:51820"
-  wg_subnet_cidr = "10.55.0.0/24"
-}
+# wireguard-only:
+wg_endpoint    = "gw.example.com:51820"
+wg_subnet_cidr = "10.55.0.0/24"
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -15,7 +15,8 @@ A policy file mixes **operational** fields (gateway plumbing) with
 blocks dispatch to plugins by their first label.
 
 ```hcl
-# Operational — read by the gateway daemon at boot.
+# Top-level singletons — read by the gateway daemon at boot.
+# Listen / paths / public URL:
 listen      = "0.0.0.0:8443"
 ca_dir      = "/opt/clawpatrol/ca"
 log_path    = "/opt/clawpatrol/gateway.log"
@@ -23,13 +24,15 @@ oauth_dir   = "/opt/clawpatrol/oauth"
 public_url  = "http://gateway.internal:8080"
 admin_email = "ops@example.com"
 
-tailscale {
-  control     = "wireguard"
-  wg_endpoint = "203.0.113.10:51820"
-}
+# Control-plane joining:
+control     = "wireguard"
+wg_endpoint = "203.0.113.10:51820"
 
-# Policy — dispatched to plugins.
-defaults { ... }
+# Policy fallbacks:
+unknown_host  = "passthrough"
+llm_fail_mode = "closed"
+
+# Labeled policy blocks — dispatched to plugins.
 approver "<type>" "<name>" { ... }
 policy   "<name>" { ... }
 credential "<type>" "<name>" { ... }
@@ -61,19 +64,16 @@ declaration.
 
 ## Kinds
 
-### `defaults {}`
+### Policy defaults (top-level)
 
-Singleton block. Global fallbacks for fail-mode, cache TTL, unknown-
-host policy.
+Global fallbacks for fail-mode, cache TTL, unknown-host policy.
 
 ```hcl
-defaults {
-  unknown_host     = "passthrough"   # "passthrough" | "deny"
-  llm_fail_mode    = "closed"        # "closed" | "open"
-  llm_cache_ttl    = 300             # seconds
-  human_timeout    = 600             # seconds
-  human_on_timeout = "deny"          # "deny" | "allow"
-}
+unknown_host     = "passthrough"   # "passthrough" | "deny"
+llm_fail_mode    = "closed"        # "closed" | "open"
+llm_cache_ttl    = 300             # seconds
+human_timeout    = 600             # seconds
+human_on_timeout = "deny"          # "deny" | "allow"
 ```
 
 ### `approver "<type>" "<name>" { ... }`

--- a/config/compile.go
+++ b/config/compile.go
@@ -13,7 +13,12 @@ import (
 // per-profile maps that the request handler walks at dispatch time.
 // Build with Compile after Load.
 type CompiledPolicy struct {
-	Defaults Defaults
+	// Policy fallbacks (mirrored from the top-level Gateway fields).
+	UnknownHost    string
+	LLMFailMode    string
+	LLMCacheTTL    int
+	HumanTimeout   int
+	HumanOnTimeout string
 
 	// Profiles indexed by name. Each holds a per-endpoint rule list,
 	// already family-tagged and priority-sorted.
@@ -199,13 +204,17 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	}
 	p := gw.Policy
 	cp := &CompiledPolicy{
-		Defaults:    p.Defaults,
-		Profiles:    map[string]*CompiledProfile{},
-		Endpoints:   map[string]*CompiledEndpoint{},
-		Tunnels:     map[string]*CompiledTunnel{},
-		Approvers:   p.Approvers,
-		Credentials: p.Credentials,
-		Policies:    p.Policies,
+		UnknownHost:    gw.UnknownHost,
+		LLMFailMode:    gw.LLMFailMode,
+		LLMCacheTTL:    gw.LLMCacheTTL,
+		HumanTimeout:   gw.HumanTimeout,
+		HumanOnTimeout: gw.HumanOnTimeout,
+		Profiles:       map[string]*CompiledProfile{},
+		Endpoints:      map[string]*CompiledEndpoint{},
+		Tunnels:        map[string]*CompiledTunnel{},
+		Approvers:      p.Approvers,
+		Credentials:    p.Credentials,
+		Policies:       p.Policies,
 	}
 
 	// Compile tunnels first so endpoint compilation can resolve

--- a/config/config.go
+++ b/config/config.go
@@ -49,22 +49,22 @@ type Gateway struct {
 	// Format accepts time.ParseDuration strings ("30m", "168h", etc.).
 	SessionKeep string `hcl:"session_keep,optional"`
 
-	// Control-plane joining (Tailscale or WireGuard).
-	AuthKey           string   `hcl:"authkey,optional"`
-	ControlURL        string   `hcl:"control_url,optional"`
-	Hostname          string   `hcl:"hostname,optional"`
-	StateDir          string   `hcl:"state_dir,optional"`
-	Control           string   `hcl:"control,optional"`
-	OAuthClientID     string   `hcl:"oauth_client_id,optional"`
-	OAuthClientSecret string   `hcl:"oauth_client_secret,optional"`
-	Tags              []string `hcl:"tags,optional"`
-	WGInterface       string   `hcl:"wg_interface,optional"`
-	WGEndpoint        string   `hcl:"wg_endpoint,optional"`
-	WGServerPub       string   `hcl:"wg_server_pub,optional"`
-	WGSubnetCIDR      string   `hcl:"wg_subnet_cidr,optional"`
+	AuthKey           string `hcl:"authkey,optional"`
+	ControlURL        string `hcl:"control_url,optional"`
+	Hostname          string `hcl:"hostname,optional"`
+	StateDir          string `hcl:"state_dir,optional"`
+	Control           string `hcl:"control,optional"`
+	OAuthClientID     string `hcl:"oauth_client_id,optional"`
+	OAuthClientSecret string `hcl:"oauth_client_secret,optional"`
+	// TailscaleTags is the Tailscale device-tag list applied to keys
+	// the gateway mints for onboarded clients (`tag:client` etc.).
+	// Tailscale-only — ignored in WireGuard mode.
+	TailscaleTags []string `hcl:"tailscale_tags,optional"`
+	WGInterface   string   `hcl:"wg_interface,optional"`
+	WGEndpoint    string   `hcl:"wg_endpoint,optional"`
+	WGServerPub   string   `hcl:"wg_server_pub,optional"`
+	WGSubnetCIDR  string   `hcl:"wg_subnet_cidr,optional"`
 
-	// Policy fallbacks used when an approver / endpoint doesn't pin
-	// its own value.
 	UnknownHost    string `hcl:"unknown_host,optional"`
 	LLMFailMode    string `hcl:"llm_fail_mode,optional"`
 	LLMCacheTTL    int    `hcl:"llm_cache_ttl,optional"`
@@ -83,11 +83,11 @@ type Gateway struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
-// Tailscale is a parameter bundle of the join/transport-related
+// JoinConfig is a parameter bundle of the join/transport-related
 // Gateway fields. Not an HCL block — the fields live flat on Gateway.
 // This struct exists purely so functions like StartWGServer /
 // newOnboarder can take one argument instead of twelve.
-type Tailscale struct {
+type JoinConfig struct {
 	AuthKey           string
 	ControlURL        string
 	Hostname          string
@@ -95,17 +95,17 @@ type Tailscale struct {
 	Control           string
 	OAuthClientID     string
 	OAuthClientSecret string
-	Tags              []string
+	TailscaleTags     []string
 	WGInterface       string
 	WGEndpoint        string
 	WGServerPub       string
 	WGSubnetCIDR      string
 }
 
-// JoinConfig returns the join-related fields as a Tailscale value
-// bundle. Cheap to call — it's a small struct copy.
-func (g *Gateway) JoinConfig() Tailscale {
-	return Tailscale{
+// Join returns the join-related fields as a JoinConfig value bundle.
+// Cheap to call — it's a small struct copy.
+func (g *Gateway) Join() JoinConfig {
+	return JoinConfig{
 		AuthKey:           g.AuthKey,
 		ControlURL:        g.ControlURL,
 		Hostname:          g.Hostname,
@@ -113,7 +113,7 @@ func (g *Gateway) JoinConfig() Tailscale {
 		Control:           g.Control,
 		OAuthClientID:     g.OAuthClientID,
 		OAuthClientSecret: g.OAuthClientSecret,
-		Tags:              g.Tags,
+		TailscaleTags:     g.TailscaleTags,
 		WGInterface:       g.WGInterface,
 		WGEndpoint:        g.WGEndpoint,
 		WGServerPub:       g.WGServerPub,

--- a/config/config.go
+++ b/config/config.go
@@ -11,12 +11,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// Gateway is the fully-loaded clawpatrol gateway config: operational
-// fields at the top, plus a resolved policy.
+// Gateway is the fully-loaded clawpatrol gateway config: every
+// singleton attribute at the top, plus a resolved policy.
 //
-// Operational fields are still decoded via plain gohcl struct tags —
-// they're not pluggable. Anything below `tailscale {}` is dispatched
-// to the plugin registry.
+// All scalar gateway settings — listen addresses, paths, control-plane
+// joining, WireGuard endpoint, and policy defaults — are top-level
+// attributes. Labeled blocks (`credential "x" "y" {}`, etc.) are the
+// things you have N of and dispatch to the plugin registry.
 type Gateway struct {
 	Listen          string `hcl:"listen,optional"`
 	InfoListen      string `hcl:"info_listen,optional"`
@@ -48,7 +49,27 @@ type Gateway struct {
 	// Format accepts time.ParseDuration strings ("30m", "168h", etc.).
 	SessionKeep string `hcl:"session_keep,optional"`
 
-	Tailscale *Tailscale `hcl:"gateway,block"`
+	// Control-plane joining (Tailscale or WireGuard).
+	AuthKey           string   `hcl:"authkey,optional"`
+	ControlURL        string   `hcl:"control_url,optional"`
+	Hostname          string   `hcl:"hostname,optional"`
+	StateDir          string   `hcl:"state_dir,optional"`
+	Control           string   `hcl:"control,optional"`
+	OAuthClientID     string   `hcl:"oauth_client_id,optional"`
+	OAuthClientSecret string   `hcl:"oauth_client_secret,optional"`
+	Tags              []string `hcl:"tags,optional"`
+	WGInterface       string   `hcl:"wg_interface,optional"`
+	WGEndpoint        string   `hcl:"wg_endpoint,optional"`
+	WGServerPub       string   `hcl:"wg_server_pub,optional"`
+	WGSubnetCIDR      string   `hcl:"wg_subnet_cidr,optional"`
+
+	// Policy fallbacks used when an approver / endpoint doesn't pin
+	// its own value.
+	UnknownHost    string `hcl:"unknown_host,optional"`
+	LLMFailMode    string `hcl:"llm_fail_mode,optional"`
+	LLMCacheTTL    int    `hcl:"llm_cache_ttl,optional"`
+	HumanTimeout   int    `hcl:"human_timeout,optional"`
+	HumanOnTimeout string `hcl:"human_on_timeout,optional"`
 
 	// Policy holds the v14-grammar block contents. Populated after
 	// the operational decode by Load's pass-1 / pass-2 walk. Set to
@@ -62,22 +83,42 @@ type Gateway struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
-// Tailscale mirrors main.go's existing block layout. Kept here so
-// config.Gateway is self-contained; the operational runtime can read
-// from this type after Load.
+// Tailscale is a parameter bundle of the join/transport-related
+// Gateway fields. Not an HCL block — the fields live flat on Gateway.
+// This struct exists purely so functions like StartWGServer /
+// newOnboarder can take one argument instead of twelve.
 type Tailscale struct {
-	AuthKey           string   `hcl:"authkey,optional"`
-	ControlURL        string   `hcl:"control_url,optional"`
-	Hostname          string   `hcl:"hostname,optional"`
-	StateDir          string   `hcl:"state_dir,optional"`
-	Control           string   `hcl:"control,optional"`
-	OAuthClientID     string   `hcl:"oauth_client_id,optional"`
-	OAuthClientSecret string   `hcl:"oauth_client_secret,optional"`
-	Tags              []string `hcl:"tags,optional"`
-	WGInterface       string   `hcl:"wg_interface,optional"`
-	WGEndpoint        string   `hcl:"wg_endpoint,optional"`
-	WGServerPub       string   `hcl:"wg_server_pub,optional"`
-	WGSubnetCIDR      string   `hcl:"wg_subnet_cidr,optional"`
+	AuthKey           string
+	ControlURL        string
+	Hostname          string
+	StateDir          string
+	Control           string
+	OAuthClientID     string
+	OAuthClientSecret string
+	Tags              []string
+	WGInterface       string
+	WGEndpoint        string
+	WGServerPub       string
+	WGSubnetCIDR      string
+}
+
+// JoinConfig returns the join-related fields as a Tailscale value
+// bundle. Cheap to call — it's a small struct copy.
+func (g *Gateway) JoinConfig() Tailscale {
+	return Tailscale{
+		AuthKey:           g.AuthKey,
+		ControlURL:        g.ControlURL,
+		Hostname:          g.Hostname,
+		StateDir:          g.StateDir,
+		Control:           g.Control,
+		OAuthClientID:     g.OAuthClientID,
+		OAuthClientSecret: g.OAuthClientSecret,
+		Tags:              g.Tags,
+		WGInterface:       g.WGInterface,
+		WGEndpoint:        g.WGEndpoint,
+		WGServerPub:       g.WGServerPub,
+		WGSubnetCIDR:      g.WGSubnetCIDR,
+	}
 }
 
 // Policy is the resolved set of named policy entities. Maps are keyed
@@ -85,8 +126,6 @@ type Tailscale struct {
 // of one-label kinds). Insertion order is preserved in the parallel
 // slices for deterministic emit / dump output.
 type Policy struct {
-	Defaults Defaults
-
 	Approvers   map[string]*Entity
 	Credentials map[string]*Entity
 	Endpoints   map[string]*Entity
@@ -133,17 +172,6 @@ func (f FrameworkAttrs) Ref(name string) string {
 		return ""
 	}
 	return f.Refs[name]
-}
-
-// Defaults holds gateway-wide fallbacks used when an `approver` block
-// or other policy entity does not pin its own value. Exactly one
-// `defaults {}` block per config.
-type Defaults struct {
-	UnknownHost    string `hcl:"unknown_host,optional"`
-	LLMFailMode    string `hcl:"llm_fail_mode,optional"`
-	LLMCacheTTL    int    `hcl:"llm_cache_ttl,optional"`
-	HumanTimeout   int    `hcl:"human_timeout,optional"`
-	HumanOnTimeout string `hcl:"human_on_timeout,optional"`
 }
 
 // PolicyText defines a named, reusable chunk of policy prose that
@@ -215,28 +243,11 @@ func LoadBytes(src []byte, filename string) (*Gateway, hcl.Diagnostics) {
 	}
 
 	// Pass 1: extract the policy blocks from the remainder body.
-	policyBlocks, defaultsBlocks, polDiags := extractPolicyBlocks(gw.Remain)
+	policyBlocks, polDiags := extractPolicyBlocks(gw.Remain)
 	diags = append(diags, polDiags...)
 
 	table, symDiags := buildSymbols(policyBlocks)
 	diags = append(diags, symDiags...)
-
-	// defaults {} (singleton, no labels)
-	if len(defaultsBlocks) > 1 {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Duplicate defaults block",
-			Detail:   "Only one defaults {} block is allowed.",
-			Subject:  &defaultsBlocks[1].DefRange,
-		})
-	}
-	if len(defaultsBlocks) >= 1 {
-		var d Defaults
-		if dd := gohcl.DecodeBody(defaultsBlocks[0].Body, nil, &d); dd.HasErrors() {
-			diags = append(diags, dd...)
-		}
-		gw.Policy.Defaults = d
-	}
 
 	// Pass 2: build the eval context with every name → string, then
 	// decode each policy block against its plugin's schema.
@@ -288,12 +299,9 @@ func dedupGohclDiags(in hcl.Diagnostics) hcl.Diagnostics {
 
 // extractPolicyBlocks pulls every recognized top-level block out of
 // the remainder body returned by the operational gohcl decode.
-// Defaults blocks are returned separately because they have a fixed
-// schema (no labels, no plugin dispatch).
-func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Blocks, hcl.Diagnostics) {
+func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 	schema := &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
-			{Type: "defaults"},
 			{Type: "approver", LabelNames: []string{"type", "name"}},
 			{Type: "credential", LabelNames: []string{"type", "name"}},
 			{Type: "endpoint", LabelNames: []string{"type", "name"}},
@@ -304,15 +312,7 @@ func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Blocks, hcl.Diagnostics
 		},
 	}
 	content, _, diags := body.PartialContent(schema)
-	var policy, defaults hcl.Blocks
-	for _, b := range content.Blocks {
-		if b.Type == "defaults" {
-			defaults = append(defaults, b)
-		} else {
-			policy = append(policy, b)
-		}
-	}
-	return policy, defaults, diags
+	return content.Blocks, diags
 }
 
 // builtinApproverNames are approvers the gateway provides without

--- a/config/dump.go
+++ b/config/dump.go
@@ -69,8 +69,8 @@ func dumpJoinFields(g *Gateway, out map[string]any) {
 	setStr("control", g.Control)
 	setStr("oauth_client_id", g.OAuthClientID)
 	setStr("oauth_client_secret", g.OAuthClientSecret)
-	if len(g.Tags) > 0 {
-		out["tags"] = g.Tags
+	if len(g.TailscaleTags) > 0 {
+		out["tailscale_tags"] = g.TailscaleTags
 	}
 	setStr("wg_interface", g.WGInterface)
 	setStr("wg_endpoint", g.WGEndpoint)

--- a/config/dump.go
+++ b/config/dump.go
@@ -38,9 +38,11 @@ func (g *Gateway) Dump() ([]byte, error) {
 	if g.Resolver != "" {
 		out["resolver"] = g.Resolver
 	}
-	if g.Tailscale != nil && !isZeroTailscale(g.Tailscale) {
-		out["gateway"] = g.Tailscale
+	if g.SessionKeep != "" {
+		out["session_keep"] = g.SessionKeep
 	}
+	dumpJoinFields(g, out)
+	dumpDefaultsFields(g, out)
 	if g.Policy != nil {
 		out["policy"] = dumpPolicy(g.Policy)
 	}
@@ -54,19 +56,48 @@ func (g *Gateway) Dump() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func isZeroTailscale(t *Tailscale) bool {
-	return t.AuthKey == "" && t.ControlURL == "" && t.Hostname == "" &&
-		t.StateDir == "" && t.Control == "" && t.OAuthClientID == "" &&
-		t.OAuthClientSecret == "" && len(t.Tags) == 0 &&
-		t.WGInterface == "" && t.WGEndpoint == "" && t.WGServerPub == "" &&
-		t.WGSubnetCIDR == ""
+func dumpJoinFields(g *Gateway, out map[string]any) {
+	setStr := func(name, v string) {
+		if v != "" {
+			out[name] = v
+		}
+	}
+	setStr("authkey", g.AuthKey)
+	setStr("control_url", g.ControlURL)
+	setStr("hostname", g.Hostname)
+	setStr("state_dir", g.StateDir)
+	setStr("control", g.Control)
+	setStr("oauth_client_id", g.OAuthClientID)
+	setStr("oauth_client_secret", g.OAuthClientSecret)
+	if len(g.Tags) > 0 {
+		out["tags"] = g.Tags
+	}
+	setStr("wg_interface", g.WGInterface)
+	setStr("wg_endpoint", g.WGEndpoint)
+	setStr("wg_server_pub", g.WGServerPub)
+	setStr("wg_subnet_cidr", g.WGSubnetCIDR)
+}
+
+func dumpDefaultsFields(g *Gateway, out map[string]any) {
+	if g.UnknownHost != "" {
+		out["unknown_host"] = g.UnknownHost
+	}
+	if g.LLMFailMode != "" {
+		out["llm_fail_mode"] = g.LLMFailMode
+	}
+	if g.LLMCacheTTL != 0 {
+		out["llm_cache_ttl"] = g.LLMCacheTTL
+	}
+	if g.HumanTimeout != 0 {
+		out["human_timeout"] = g.HumanTimeout
+	}
+	if g.HumanOnTimeout != "" {
+		out["human_on_timeout"] = g.HumanOnTimeout
+	}
 }
 
 func dumpPolicy(p *Policy) map[string]any {
 	out := map[string]any{}
-	if d := dumpDefaults(p.Defaults); d != nil {
-		out["defaults"] = d
-	}
 	if v := dumpEntityMap(p.Approvers); v != nil {
 		out["approvers"] = v
 	}
@@ -87,29 +118,6 @@ func dumpPolicy(p *Policy) map[string]any {
 	}
 	if v := dumpProfiles(p.Profiles); v != nil {
 		out["profiles"] = v
-	}
-	return out
-}
-
-func dumpDefaults(d Defaults) map[string]any {
-	if d == (Defaults{}) {
-		return nil
-	}
-	out := map[string]any{}
-	if d.UnknownHost != "" {
-		out["unknown_host"] = d.UnknownHost
-	}
-	if d.LLMFailMode != "" {
-		out["llm_fail_mode"] = d.LLMFailMode
-	}
-	if d.LLMCacheTTL != 0 {
-		out["llm_cache_ttl"] = d.LLMCacheTTL
-	}
-	if d.HumanTimeout != 0 {
-		out["human_timeout"] = d.HumanTimeout
-	}
-	if d.HumanOnTimeout != "" {
-		out["human_on_timeout"] = d.HumanOnTimeout
 	}
 	return out
 }

--- a/config/emit.go
+++ b/config/emit.go
@@ -78,8 +78,8 @@ func emitOperational(body *hclwrite.Body, gw *Gateway) {
 	setStr("control", gw.Control)
 	setStr("oauth_client_id", gw.OAuthClientID)
 	setStr("oauth_client_secret", gw.OAuthClientSecret)
-	if len(gw.Tags) > 0 {
-		body.SetAttributeValue("tags", StringListVal(gw.Tags))
+	if len(gw.TailscaleTags) > 0 {
+		body.SetAttributeValue("tailscale_tags", StringListVal(gw.TailscaleTags))
 	}
 	setStr("wg_interface", gw.WGInterface)
 	setStr("wg_endpoint", gw.WGEndpoint)

--- a/config/emit.go
+++ b/config/emit.go
@@ -9,11 +9,11 @@ import (
 )
 
 // Emit serializes a loaded *Gateway back to HCL. The output is
-// deterministic (operational fields first, then defaults, then
-// kind-grouped policy blocks in source order) and re-parsable by
-// Load — round-tripping fixtures through Emit + Load produces a
-// structurally identical *Gateway, modulo comment loss (hclwrite
-// can't preserve operator comments through gohcl decode).
+// deterministic (operational fields first, then kind-grouped policy
+// blocks in source order) and re-parsable by Load — round-tripping
+// fixtures through Emit + Load produces a structurally identical
+// *Gateway, modulo comment loss (hclwrite can't preserve operator
+// comments through gohcl decode).
 //
 // Per-block emission delegates to the plugin's Emit hook so each
 // plugin owns its own body shape — credential bindings, match
@@ -29,12 +29,6 @@ func Emit(gw *Gateway) ([]byte, error) {
 		return f.Bytes(), nil
 	}
 	p := gw.Policy
-
-	// Defaults first if any field is non-zero.
-	if d := gw.Policy.Defaults; d != (Defaults{}) {
-		body.AppendNewline()
-		emitDefaults(body, d)
-	}
 
 	// Per-kind groups in a deterministic order: approvers → policies →
 	// credentials → endpoints → rules → profiles. Within a group, walk
@@ -58,6 +52,11 @@ func emitOperational(body *hclwrite.Body, gw *Gateway) {
 			body.SetAttributeValue(name, cty.StringVal(v))
 		}
 	}
+	setInt := func(name string, v int) {
+		if v != 0 {
+			body.SetAttributeValue(name, cty.NumberIntVal(int64(v)))
+		}
+	}
 	setStr("listen", gw.Listen)
 	setStr("info_listen", gw.InfoListen)
 	setStr("public_url", gw.PublicURL)
@@ -70,53 +69,28 @@ func emitOperational(body *hclwrite.Body, gw *Gateway) {
 	if gw.InsecureNoDashboardSecret {
 		body.SetAttributeValue("insecure_no_dashboard_secret", cty.BoolVal(true))
 	}
+	setStr("session_keep", gw.SessionKeep)
 
-	if gw.Tailscale != nil && !isZeroTailscale(gw.Tailscale) {
-		body.AppendNewline()
-		ts := body.AppendNewBlock("gateway", nil).Body()
-		emitTailscale(ts, gw.Tailscale)
+	setStr("authkey", gw.AuthKey)
+	setStr("control_url", gw.ControlURL)
+	setStr("hostname", gw.Hostname)
+	setStr("state_dir", gw.StateDir)
+	setStr("control", gw.Control)
+	setStr("oauth_client_id", gw.OAuthClientID)
+	setStr("oauth_client_secret", gw.OAuthClientSecret)
+	if len(gw.Tags) > 0 {
+		body.SetAttributeValue("tags", StringListVal(gw.Tags))
 	}
-}
+	setStr("wg_interface", gw.WGInterface)
+	setStr("wg_endpoint", gw.WGEndpoint)
+	setStr("wg_server_pub", gw.WGServerPub)
+	setStr("wg_subnet_cidr", gw.WGSubnetCIDR)
 
-func emitTailscale(b *hclwrite.Body, t *Tailscale) {
-	setStr := func(name, v string) {
-		if v != "" {
-			b.SetAttributeValue(name, cty.StringVal(v))
-		}
-	}
-	setStr("authkey", t.AuthKey)
-	setStr("control_url", t.ControlURL)
-	setStr("hostname", t.Hostname)
-	setStr("state_dir", t.StateDir)
-	setStr("control", t.Control)
-	setStr("oauth_client_id", t.OAuthClientID)
-	setStr("oauth_client_secret", t.OAuthClientSecret)
-	if len(t.Tags) > 0 {
-		b.SetAttributeValue("tags", StringListVal(t.Tags))
-	}
-	setStr("wg_interface", t.WGInterface)
-	setStr("wg_endpoint", t.WGEndpoint)
-	setStr("wg_server_pub", t.WGServerPub)
-	setStr("wg_subnet_cidr", t.WGSubnetCIDR)
-}
-
-func emitDefaults(body *hclwrite.Body, d Defaults) {
-	b := body.AppendNewBlock("defaults", nil).Body()
-	if d.UnknownHost != "" {
-		b.SetAttributeValue("unknown_host", cty.StringVal(d.UnknownHost))
-	}
-	if d.LLMFailMode != "" {
-		b.SetAttributeValue("llm_fail_mode", cty.StringVal(d.LLMFailMode))
-	}
-	if d.LLMCacheTTL != 0 {
-		b.SetAttributeValue("llm_cache_ttl", cty.NumberIntVal(int64(d.LLMCacheTTL)))
-	}
-	if d.HumanTimeout != 0 {
-		b.SetAttributeValue("human_timeout", cty.NumberIntVal(int64(d.HumanTimeout)))
-	}
-	if d.HumanOnTimeout != "" {
-		b.SetAttributeValue("human_on_timeout", cty.StringVal(d.HumanOnTimeout))
-	}
+	setStr("unknown_host", gw.UnknownHost)
+	setStr("llm_fail_mode", gw.LLMFailMode)
+	setInt("llm_cache_ttl", gw.LLMCacheTTL)
+	setInt("human_timeout", gw.HumanTimeout)
+	setStr("human_on_timeout", gw.HumanOnTimeout)
 }
 
 // emitGroup walks p.Order, filters by kind, and emits each entry's

--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -89,7 +89,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 
 	timeout := time.Duration(h.Timeout) * time.Second
 	if timeout <= 0 {
-		timeout = time.Duration(req.Defaults.HumanTimeout) * time.Second
+		timeout = time.Duration(req.Policy.HumanTimeout) * time.Second
 	}
 	if timeout <= 0 {
 		timeout = 10 * time.Minute

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -296,9 +296,6 @@ type ApproveRequest struct {
 	// deep links in Slack messages and similar notifications.
 	DashboardURL string
 
-	// Defaults from the file's defaults {} block; plugins fall back
-	// to these when their own config doesn't override.
-	Defaults config.Defaults
 	// Policy gives approvers access to the full compiled policy —
 	// HumanApprover uses it to look up its referenced credential
 	// entity and dispatch via HITLNotifier.

--- a/config/testdata/feature_example.hcl
+++ b/config/testdata/feature_example.hcl
@@ -35,21 +35,17 @@ ca_dir      = "/opt/clawpatrol/ca"
 log_path    = "/opt/clawpatrol/gateway.log"
 oauth_dir   = "/opt/clawpatrol/oauth"
 
-gateway {
-  control        = "wireguard"
-  wg_endpoint    = "66.42.120.196:51820"
-  wg_subnet_cidr = "10.55.0.0/24"
-}
+control        = "wireguard"
+wg_endpoint    = "66.42.120.196:51820"
+wg_subnet_cidr = "10.55.0.0/24"
 
 # ── policy --------------------------------------------------------------
 
-defaults {
-  unknown_host     = "passthrough"
-  llm_fail_mode    = "closed"
-  llm_cache_ttl    = 300
-  human_timeout    = 600
-  human_on_timeout = "deny"
-}
+unknown_host     = "passthrough"
+llm_fail_mode    = "closed"
+llm_cache_ttl    = 300
+human_timeout    = 600
+human_on_timeout = "deny"
 
 # Credentials: one per upstream secret. The body lists only injection
 # parameters; the actual secret is stored separately keyed by name.

--- a/config/testdata/feature_example.want.json
+++ b/config/testdata/feature_example.want.json
@@ -1,22 +1,13 @@
 {
   "admin_email": "test@example.com",
   "ca_dir": "/opt/clawpatrol/ca",
-  "gateway": {
-    "AuthKey": "",
-    "ControlURL": "",
-    "Hostname": "",
-    "StateDir": "",
-    "Control": "wireguard",
-    "OAuthClientID": "",
-    "OAuthClientSecret": "",
-    "Tags": null,
-    "WGInterface": "",
-    "WGEndpoint": "66.42.120.196:51820",
-    "WGServerPub": "",
-    "WGSubnetCIDR": "10.55.0.0/24"
-  },
+  "control": "wireguard",
+  "human_on_timeout": "deny",
+  "human_timeout": 600,
   "info_listen": "0.0.0.0:8080",
   "listen": "0.0.0.0:8443",
+  "llm_cache_ttl": 300,
+  "llm_fail_mode": "closed",
   "log_path": "/opt/clawpatrol/gateway.log",
   "oauth_dir": "/opt/clawpatrol/oauth",
   "policy": {
@@ -39,13 +30,6 @@
         },
         "type": "bearer_token"
       }
-    },
-    "defaults": {
-      "human_on_timeout": "deny",
-      "human_timeout": 600,
-      "llm_cache_ttl": 300,
-      "llm_fail_mode": "closed",
-      "unknown_host": "passthrough"
     },
     "endpoints": {
       "github": {
@@ -110,5 +94,8 @@
       }
     }
   },
-  "public_url": "http://66.42.120.196:8080"
+  "public_url": "http://66.42.120.196:8080",
+  "unknown_host": "passthrough",
+  "wg_endpoint": "66.42.120.196:51820",
+  "wg_subnet_cidr": "10.55.0.0/24"
 }

--- a/config/testdata/feature_minimal.hcl
+++ b/config/testdata/feature_minimal.hcl
@@ -1,10 +1,8 @@
 listen     = "0.0.0.0:8443"
 ca_dir     = "/opt/clawpatrol/ca"
 
-defaults {
-  unknown_host  = "passthrough"
-  llm_fail_mode = "closed"
-}
+unknown_host  = "passthrough"
+llm_fail_mode = "closed"
 
 credential "bearer_token" "github-pat" {}
 

--- a/config/testdata/feature_minimal.want.json
+++ b/config/testdata/feature_minimal.want.json
@@ -1,6 +1,7 @@
 {
   "ca_dir": "/opt/clawpatrol/ca",
   "listen": "0.0.0.0:8443",
+  "llm_fail_mode": "closed",
   "policy": {
     "approvers": {
       "ops": {
@@ -21,10 +22,6 @@
         },
         "type": "bearer_token"
       }
-    },
-    "defaults": {
-      "llm_fail_mode": "closed",
-      "unknown_host": "passthrough"
     },
     "endpoints": {
       "github": {
@@ -87,5 +84,6 @@
         "type": "http_rule"
       }
     }
-  }
+  },
+  "unknown_host": "passthrough"
 }

--- a/config/testdata/full.hcl
+++ b/config/testdata/full.hcl
@@ -337,13 +337,11 @@
 #   token via aws eks get-token at request time" — cluster, region,
 #   and AWS profile name go on the credential.
 
-defaults {
-  unknown_host = "passthrough"
-  llm_fail_mode = "closed"
-  llm_cache_ttl = 300
-  human_timeout = 600
-  human_on_timeout = "deny"
-}
+unknown_host = "passthrough"
+llm_fail_mode = "closed"
+llm_cache_ttl = 300
+human_timeout = 600
+human_on_timeout = "deny"
 
 # ── Approvers ────────────────────────────────────────
 #

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -1,4 +1,8 @@
 {
+  "human_on_timeout": "deny",
+  "human_timeout": 600,
+  "llm_cache_ttl": 300,
+  "llm_fail_mode": "closed",
   "policy": {
     "approvers": {
       "billing": {
@@ -289,13 +293,6 @@
         "body": {},
         "type": "telegram_bot_token"
       }
-    },
-    "defaults": {
-      "human_on_timeout": "deny",
-      "human_timeout": 600,
-      "llm_cache_ttl": 300,
-      "llm_fail_mode": "closed",
-      "unknown_host": "passthrough"
     },
     "endpoints": {
       "amem": {
@@ -1788,5 +1785,6 @@
         "type": "http_rule"
       }
     }
-  }
+  },
+  "unknown_host": "passthrough"
 }

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -9,8 +9,8 @@ public UDP port, no WireGuard keypair management, no subnet allocation
 ## How it works
 
 1. Gateway starts a `tsnet.Server` (embedded Tailscale node, no
-   `tailscaled` required) using an auth key from `gateway {}` HCL or
-   `$TS_AUTHKEY`. It joins the tailnet under the configured hostname
+   `tailscaled` required) using an auth key from the top-level
+   `authkey` field or `$TS_AUTHKEY`. It joins the tailnet under the configured hostname
    (default: `clawpatrol-gateway`) and binds the MITM + dashboard on
    the resulting tailnet IP.
 2. When a device runs `clawpatrol login`, the dashboard mints a
@@ -76,14 +76,12 @@ ca_dir       = "/opt/clawpatrol/ca"
 oauth_dir    = "/opt/clawpatrol/oauth"
 integrations = ["claude", "codex", "github"]
 
-gateway {
-  control             = "tailscale"
-  oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
-  oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
-  tags                = ["tag:client"]       # applied to minted device keys
-  hostname            = "clawpatrol-gateway" # gateway's name on the tailnet
-  state_dir           = "/opt/clawpatrol/ts-state"
-}
+control             = "tailscale"
+oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
+oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
+tags                = ["tag:client"]       # applied to minted device keys
+hostname            = "clawpatrol-gateway" # gateway's name on the tailnet
+state_dir           = "/opt/clawpatrol/ts-state"
 EOF
 
 mkdir -p /opt/clawpatrol

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -79,7 +79,7 @@ integrations = ["claude", "codex", "github"]
 control             = "tailscale"
 oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
 oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
-tags                = ["tag:client"]       # applied to minted device keys
+tailscale_tags      = ["tag:client"]       # applied to minted device keys
 hostname            = "clawpatrol-gateway" # gateway's name on the tailnet
 state_dir           = "/opt/clawpatrol/ts-state"
 EOF

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -7,10 +7,8 @@
 # Hot-reloadable: every policy block + admin_email. Listen ports /
 # ca_dir / oauth_dir / tailscale block need a restart.
 #
-# Top-level kinds:
+# Labeled blocks:
 #
-#   defaults   {}                     global fallbacks for fail-mode,
-#                                     cache TTL, unknown-host policy
 #   approver   "<type>" "<name>"      who arbitrates (llm_approver |
 #                                     human_approver)
 #   policy     "<name>"               reusable LLM proctor prompt
@@ -44,21 +42,17 @@ oauth_dir   = "/opt/clawpatrol/oauth"
 #                                               # dashboard URL gets in
 dashboard_secret = "change-me-to-a-long-random-string"
 
-gateway {
-  control        = "wireguard"
-  wg_endpoint    = "66.42.120.196:51820"
-  wg_subnet_cidr = "10.55.0.0/24"
-}
+control        = "wireguard"
+wg_endpoint    = "66.42.120.196:51820"
+wg_subnet_cidr = "10.55.0.0/24"
 
-# ── policy --------------------------------------------------------------
+# ── policy defaults ----------------------------------------------------
 
-defaults {
-  unknown_host     = "passthrough"
-  llm_fail_mode    = "closed"
-  llm_cache_ttl    = 300
-  human_timeout    = 600
-  human_on_timeout = "deny"
-}
+unknown_host     = "passthrough"
+llm_fail_mode    = "closed"
+llm_cache_ttl    = 300
+human_timeout    = 600
+human_on_timeout = "deny"
 
 # Credentials: one per upstream secret. The body lists only injection
 # parameters; the actual secret is stored separately keyed by name.

--- a/login.go
+++ b/login.go
@@ -1042,11 +1042,9 @@ ca_dir      = "%s"
 log_path    = "%s"
 oauth_dir   = "%s"
 
-gateway {
-  control        = "wireguard"
-  wg_endpoint    = "%s:%d"
-  wg_subnet_cidr = "%s"
-}
+control        = "wireguard"
+wg_endpoint    = "%s:%d"
+wg_subnet_cidr = "%s"
 
 # Starter policy: claude / codex / github via OAuth. Operator pastes
 # tokens via the dashboard; rules permit everything by default. Edit

--- a/main.go
+++ b/main.go
@@ -35,10 +35,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// Tailscale aliases config.Tailscale so existing call sites
-// (newWebMux / StartWGServer / newOnboarder / mintTailscaleAuthKey)
-// can refer to it as a bare name.
-type Tailscale = config.Tailscale
+// JoinConfig aliases config.JoinConfig so call sites (newWebMux /
+// StartWGServer / newOnboarder / mintTailscaleAuthKey) can refer to
+// it as a bare name.
+type JoinConfig = config.JoinConfig
 
 // emit a terminal request event to both the SSE sink and OTel.
 // ev.Action and ev.Ms must be populated. Non-request events (e.g.
@@ -2272,7 +2272,7 @@ func runGateway(args []string) {
 	startTelemetry(g, stateDir)
 
 	if cfg.InfoListen != "" {
-		mux := newWebMux(g, cfg.CADir, cfg.JoinConfig(), cfg.PublicURL)
+		mux := newWebMux(g, cfg.CADir, cfg.Join(), cfg.PublicURL)
 		go serveHTTPLogged("dashboard", cfg.InfoListen, mux)
 		printDashboardURL(cfg.InfoListen)
 	}
@@ -2290,12 +2290,12 @@ func runGateway(args []string) {
 	// No /etc/hosts hack needed on clients — agents resolve real
 	// hostnames via public DNS and the gateway intercepts at L3.
 	if strings.EqualFold(cfg.Control, "wireguard") {
-		wg, err := StartWGServer(cfg.JoinConfig(), stateDir)
+		wg, err := StartWGServer(cfg.Join(), stateDir)
 		if err != nil {
 			log.Fatalf("wireguard: %v", err)
 		}
 		setWGServer(wg)
-		dashMux := newWebMux(g, cfg.CADir, cfg.JoinConfig(), cfg.PublicURL)
+		dashMux := newWebMux(g, cfg.CADir, cfg.Join(), cfg.PublicURL)
 		dashPort := portOf(cfg.InfoListen)
 		tcpDispatch := func(c net.Conn, dstIP string, dstPort uint16) {
 			log.Printf("wg-fwd: %s:%d", dstIP, dstPort)

--- a/main.go
+++ b/main.go
@@ -35,11 +35,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// Tailscale aliases the operational tailscale-block type loaded from
-// HCL. Existing call sites (newWebMux / StartWGServer / newOnboarder /
-// mintTailscaleAuthKey) take a value of this type; aliasing keeps
-// those signatures unchanged while the canonical definition lives in
-// config/.
+// Tailscale aliases config.Tailscale so existing call sites
+// (newWebMux / StartWGServer / newOnboarder / mintTailscaleAuthKey)
+// can refer to it as a bare name.
 type Tailscale = config.Tailscale
 
 // emit a terminal request event to both the SSE sink and OTel.
@@ -97,9 +95,6 @@ func loadConfig(path string) (*config.Gateway, *config.CompiledPolicy, error) {
 	}
 	if gw.Listen == "" {
 		gw.Listen = ":443"
-	}
-	if gw.Tailscale == nil {
-		gw.Tailscale = &config.Tailscale{}
 	}
 	cp, err := config.Compile(gw)
 	if err != nil {
@@ -1997,9 +1992,6 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			DashboardURL: g.cfg.PublicURL,
 			Policy:       policy,
 		}
-		if policy != nil {
-			req.Defaults = policy.Defaults
-		}
 		v, err := ar.Approve(ctx, req)
 		if err != nil {
 			return runtime.ApproveVerdict{Decision: "deny", Reason: err.Error(), By: "gateway"}
@@ -2280,7 +2272,7 @@ func runGateway(args []string) {
 	startTelemetry(g, stateDir)
 
 	if cfg.InfoListen != "" {
-		mux := newWebMux(g, cfg.CADir, *cfg.Tailscale, cfg.PublicURL)
+		mux := newWebMux(g, cfg.CADir, cfg.JoinConfig(), cfg.PublicURL)
 		go serveHTTPLogged("dashboard", cfg.InfoListen, mux)
 		printDashboardURL(cfg.InfoListen)
 	}
@@ -2297,13 +2289,13 @@ func runGateway(args []string) {
 	//   - else   → transparent relay to the real upstream
 	// No /etc/hosts hack needed on clients — agents resolve real
 	// hostnames via public DNS and the gateway intercepts at L3.
-	if strings.EqualFold(cfg.Tailscale.Control, "wireguard") {
-		wg, err := StartWGServer(*cfg.Tailscale, stateDir)
+	if strings.EqualFold(cfg.Control, "wireguard") {
+		wg, err := StartWGServer(cfg.JoinConfig(), stateDir)
 		if err != nil {
 			log.Fatalf("wireguard: %v", err)
 		}
 		setWGServer(wg)
-		dashMux := newWebMux(g, cfg.CADir, *cfg.Tailscale, cfg.PublicURL)
+		dashMux := newWebMux(g, cfg.CADir, cfg.JoinConfig(), cfg.PublicURL)
 		dashPort := portOf(cfg.InfoListen)
 		tcpDispatch := func(c net.Conn, dstIP string, dstPort uint16) {
 			log.Printf("wg-fwd: %s:%d", dstIP, dstPort)

--- a/onboard.go
+++ b/onboard.go
@@ -364,7 +364,7 @@ type Onboarder interface {
 	MintKey(ctx context.Context, reuseIP string) (authKey, loginServer, peerIP string, err error)
 }
 
-func newOnboarder(ts Tailscale) Onboarder {
+func newOnboarder(ts JoinConfig) Onboarder {
 	switch strings.ToLower(ts.Control) {
 	case "wireguard":
 		return &wireguardOnboarder{ts: ts}
@@ -373,7 +373,7 @@ func newOnboarder(ts Tailscale) Onboarder {
 	}
 }
 
-type tailscaleOnboarder struct{ ts Tailscale }
+type tailscaleOnboarder struct{ ts JoinConfig }
 
 func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string) (string, string, string, error) {
 	k, err := mintTailscaleAuthKey(ctx, t.ts)
@@ -386,7 +386,7 @@ func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string) (string, str
 // mintTailscaleAuthKey calls Tailscale's OAuth + auth-key API to create
 // a single-use, non-ephemeral auth key the new client can use to join
 // the tailnet exactly once.
-func mintTailscaleAuthKey(ctx context.Context, ts Tailscale) (string, error) {
+func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig) (string, error) {
 	clientID := resolveTemplate(ts.OAuthClientID)
 	clientSecret := resolveTemplate(ts.OAuthClientSecret)
 	if clientID == "" || clientSecret == "" {
@@ -421,7 +421,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts Tailscale) (string, error) {
 	}
 
 	// 2. mint auth key.
-	tags := ts.Tags
+	tags := ts.TailscaleTags
 	if len(tags) == 0 {
 		tags = []string{"tag:client"}
 	}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,12 +84,10 @@ CONTROL="${CONTROL:-tailscale}"
 case "$CONTROL" in
   tailscale)
     TS_BLOCK=$(cat <<HCL
-gateway {
-  control             = "tailscale"
-  oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
-  oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
-  tags                = ["tag:client"]
-}
+control             = "tailscale"
+oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
+oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
+tailscale_tags      = ["tag:client"]
 HCL
 )
     ;;
@@ -107,11 +105,9 @@ HCL
             || iptables -I INPUT -p udp --dport ${WG_PORT} -j ACCEPT"
 
     TS_BLOCK=$(cat <<HCL
-gateway {
-  control        = "wireguard"
-  wg_endpoint    = "${WG_ENDPOINT}"
-  wg_subnet_cidr = "${WG_SUBNET_CIDR}"
-}
+control        = "wireguard"
+wg_endpoint    = "${WG_ENDPOINT}"
+wg_subnet_cidr = "${WG_SUBNET_CIDR}"
 HCL
 )
     ;;

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -38,19 +38,19 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 | `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
 | `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
-| `authkey` | `string` | no | Control-plane joining (Tailscale or WireGuard). |
+| `authkey` | `string` | no |  |
 | `control_url` | `string` | no |  |
 | `hostname` | `string` | no |  |
 | `state_dir` | `string` | no |  |
 | `control` | `string` | no |  |
 | `oauth_client_id` | `string` | no |  |
 | `oauth_client_secret` | `string` | no |  |
-| `tags` | `[]string` | no |  |
+| `tailscale_tags` | `[]string` | no | The Tailscale device-tag list applied to keys the gateway mints for onboarded clients (`tag:client` etc.). Tailscale-only — ignored in WireGuard mode. |
 | `wg_interface` | `string` | no |  |
 | `wg_endpoint` | `string` | no |  |
 | `wg_server_pub` | `string` | no |  |
 | `wg_subnet_cidr` | `string` | no |  |
-| `unknown_host` | `string` | no | Policy fallbacks used when an approver / endpoint doesn't pin its own value. |
+| `unknown_host` | `string` | no |  |
 | `llm_fail_mode` | `string` | no |  |
 | `llm_cache_ttl` | `int` | no |  |
 | `human_timeout` | `int` | no |  |

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -20,9 +20,9 @@ Each block section lists the attributes the loader accepts, with:
 Plugin-dispatched kinds (`approver`, `credential`, `endpoint`, `rule`)
 list one subsection per registered type.
 
-## Top-level operational fields
+## Top-level fields
 
-These are the attributes you set directly at the top of `gateway.hcl`. Anything below `gateway {}` (defaults, policy, profile, approver, credential, endpoint, rule) is a separate block documented in its own section.
+Every singleton gateway attribute — listen addresses, paths, control-plane joining, WireGuard endpoint, and policy fallbacks — is set directly at the top of `gateway.hcl`. Labeled blocks (`policy`, `profile`, `approver`, `credential`, `endpoint`, `rule`, `tunnel`) are documented in their own sections.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -38,15 +38,7 @@ These are the attributes you set directly at the top of `gateway.hcl`. Anything 
 | `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
 | `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
-| `gateway` | `block` | yes |  |
-
-### `gateway {}` block
-
-Singleton block configuring how the gateway joins the operator's tailnet (or a self-hosted control plane) and the WireGuard tunnel that carries agent traffic.
-
-| Attribute | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `authkey` | `string` | no |  |
+| `authkey` | `string` | no | Control-plane joining (Tailscale or WireGuard). |
 | `control_url` | `string` | no |  |
 | `hostname` | `string` | no |  |
 | `state_dir` | `string` | no |  |
@@ -58,24 +50,11 @@ Singleton block configuring how the gateway joins the operator's tailnet (or a s
 | `wg_endpoint` | `string` | no |  |
 | `wg_server_pub` | `string` | no |  |
 | `wg_subnet_cidr` | `string` | no |  |
-
-## `defaults {}`
-
-Holds gateway-wide fallbacks used when an `approver` block
-or other policy entity does not pin its own value. Exactly one
-`defaults {}` block per config.
-
-| Attribute | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `unknown_host` | `string` | no |  |
+| `unknown_host` | `string` | no | Policy fallbacks used when an approver / endpoint doesn't pin its own value. |
 | `llm_fail_mode` | `string` | no |  |
 | `llm_cache_ttl` | `int` | no |  |
 | `human_timeout` | `int` | no |  |
 | `human_on_timeout` | `string` | no |  |
-
-```hcl
-defaults {}
-```
 
 ## `policy "<name>" { ... }`
 

--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -188,12 +188,12 @@ carries type information for schema dispatch; reference syntax doesn't
 repeat it. See [`config/README.md`](../../config/README.md) for the
 authoritative grammar.
 
-### `defaults {}`
+### Policy defaults (top-level)
 
-Singleton block. Global fallbacks: `unknown_host` (passthrough vs.
-deny), `llm_fail_mode`, `llm_cache_ttl`, `human_timeout`,
-`human_on_timeout`. Every plugin can read these from `BuildCtx` /
-`ApproveRequest.Defaults`.
+Top-level singleton attributes — not a block. Global fallbacks:
+`unknown_host` (passthrough vs. deny), `llm_fail_mode`,
+`llm_cache_ttl`, `human_timeout`, `human_on_timeout`. Every plugin can
+read these from `BuildCtx` / the compiled policy on `ApproveRequest`.
 
 ### `approver "<type>" "<name>" { ... }`
 

--- a/tailscale.go
+++ b/tailscale.go
@@ -1,5 +1,5 @@
-// Gateway control-plane listener. When the operator's HCL sets
-// `gateway { authkey = "..." }` (or TS_AUTHKEY is in the env), the
+// Gateway control-plane listener. When the operator's HCL sets the
+// top-level `authkey = "..."` (or TS_AUTHKEY is in the env), the
 // gateway joins a tailnet via an embedded tsnet.Server and accepts
 // agent traffic on its tailnet IP. Otherwise a plain TCP listener
 // on cfg.Listen is used.
@@ -20,22 +20,22 @@ import (
 )
 
 func openListener(cfg *config.Gateway) (net.Listener, error) {
-	authKey := cfg.Tailscale.AuthKey
+	authKey := cfg.AuthKey
 	if authKey == "" {
 		authKey = os.Getenv("TS_AUTHKEY")
 	}
 	if authKey == "" {
 		return net.Listen("tcp", cfg.Listen)
 	}
-	hn := cfg.Tailscale.Hostname
+	hn := cfg.Hostname
 	if hn == "" {
 		hn = "clawpatrol-gateway"
 	}
 	s := &tsnet.Server{
 		Hostname:   hn,
 		AuthKey:    authKey,
-		ControlURL: cfg.Tailscale.ControlURL,
-		Dir:        cfg.Tailscale.StateDir,
+		ControlURL: cfg.ControlURL,
+		Dir:        cfg.StateDir,
 	}
 	port := cfg.Listen
 	if port == "" {

--- a/telemetry.go
+++ b/telemetry.go
@@ -212,8 +212,7 @@ func buildTelemetryPayload(
 	devices := connectedDevicesIn1h(g)
 	actions, bin, bout := actionsCountIn1h(g)
 	transport := "tailscale"
-	if g.cfg != nil && g.cfg.Tailscale != nil &&
-		strings.EqualFold(g.cfg.Tailscale.Control, "wireguard") {
+	if g.cfg != nil && strings.EqualFold(g.cfg.Control, "wireguard") {
 		transport = "wireguard"
 	}
 	r := telemetryReq{

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -42,7 +42,6 @@ type renderer struct {
 func (r *renderer) run() (string, error) {
 	r.writeHeader()
 	r.writeOperational()
-	r.writeFixedKind("defaults", "config", "Defaults", "")
 	r.writeFixedKind("policy", "config", "PolicyText", `policy "<name>"`)
 	r.writeProfile()
 
@@ -126,13 +125,9 @@ func stripIdentPrefix(doc, ident string) string {
 }
 
 func (r *renderer) writeOperational() {
-	r.out.WriteString("## Top-level operational fields\n\n")
-	r.out.WriteString("These are the attributes you set directly at the top of `gateway.hcl`. Anything below `gateway {}` (defaults, policy, profile, approver, credential, endpoint, rule) is a separate block documented in its own section.\n\n")
+	r.out.WriteString("## Top-level fields\n\n")
+	r.out.WriteString("Every singleton gateway attribute — listen addresses, paths, control-plane joining, WireGuard endpoint, and policy fallbacks — is set directly at the top of `gateway.hcl`. Labeled blocks (`policy`, `profile`, `approver`, `credential`, `endpoint`, `rule`, `tunnel`) are documented in their own sections.\n\n")
 	r.writeStructTable("config", "Gateway", reflect.TypeOf(config.Gateway{}))
-
-	r.out.WriteString("### `gateway {}` block\n\n")
-	r.out.WriteString("Singleton block configuring how the gateway joins the operator's tailnet (or a self-hosted control plane) and the WireGuard tunnel that carries agent traffic.\n\n")
-	r.writeStructTable("config", "Tailscale", reflect.TypeOf(config.Tailscale{}))
 }
 
 // writeFixedKind documents a one-label kind with a fixed, non-plugin
@@ -157,10 +152,6 @@ func reflectTypeFor(pkg, name string) reflect.Type {
 	switch pkg + "." + name {
 	case "config.Gateway":
 		return reflect.TypeOf(config.Gateway{})
-	case "config.Tailscale":
-		return reflect.TypeOf(config.Tailscale{})
-	case "config.Defaults":
-		return reflect.TypeOf(config.Defaults{})
 	case "config.PolicyText":
 		return reflect.TypeOf(config.PolicyText{})
 	}

--- a/web.go
+++ b/web.go
@@ -48,7 +48,7 @@ var errConfigRevisionConflict = errors.New("config revision conflict")
 type webMux struct {
 	g         *Gateway
 	caDir     string
-	ts        Tailscale // for onboarding key minting
+	ts        JoinConfig // for onboarding key minting
 	publicURL string
 	mu        sync.Mutex
 	sessions  map[string]*oauthSession
@@ -182,7 +182,7 @@ func (w *webMux) skipsTailnetGate(path string) bool {
 	return w.authRequirementForPath(path) == authPublic
 }
 
-func newWebMux(g *Gateway, caDir string, ts Tailscale, publicURL string) http.Handler {
+func newWebMux(g *Gateway, caDir string, ts JoinConfig, publicURL string) http.Handler {
 	w := &webMux{g: g, caDir: caDir, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
 	return w.handler()
 }

--- a/web.go
+++ b/web.go
@@ -175,7 +175,7 @@ func isTailscaleControlMode(control string) bool {
 
 func (w *webMux) mayUseTailnetInsteadOfDashboard(path string) bool {
 	return w.authRequirementForPath(path) == authDashboardOrTailnetOperator &&
-		isTailscaleControlMode(w.g.cfg.Tailscale.Control)
+		isTailscaleControlMode(w.g.cfg.Control)
 }
 
 func (w *webMux) skipsTailnetGate(path string) bool {
@@ -383,7 +383,7 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 	// In wireguard / proxy mode there is no tailnet identity to gate
 	// against. Operators put the dashboard behind their own
 	// authentication (Cloudflare Access, basic auth proxy, etc).
-	skipGate := !isTailscaleControlMode(w.g.cfg.Tailscale.Control)
+	skipGate := !isTailscaleControlMode(w.g.cfg.Control)
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if w.skipsTailnetGate(r.URL.Path) || skipGate {

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -16,14 +16,14 @@ const authTestDashboardCredential = "test-dashboard-credential"
 func newOnboardAuthTestWebMuxForControl(control string) *webMux {
 	cfg := &config.Gateway{
 		DashboardSecret: authTestDashboardCredential,
-		Tailscale:       &config.Tailscale{Control: control},
+		Control:         control,
 		Policy:          &config.Policy{},
 	}
 	g := &Gateway{
 		cfg:     cfg,
 		onboard: newOnboardRegistry(),
 	}
-	w := &webMux{g: g, caDir: "", ts: *cfg.Tailscale, publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
+	w := &webMux{g: g, caDir: "", ts: cfg.JoinConfig(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
 	w.routeAuth = routeAuthIndex(w.routes())
 	return w
 }

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -23,7 +23,7 @@ func newOnboardAuthTestWebMuxForControl(control string) *webMux {
 		cfg:     cfg,
 		onboard: newOnboardRegistry(),
 	}
-	w := &webMux{g: g, caDir: "", ts: cfg.JoinConfig(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
+	w := &webMux{g: g, caDir: "", ts: cfg.Join(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
 	w.routeAuth = routeAuthIndex(w.routes())
 	return w
 }

--- a/wireguard.go
+++ b/wireguard.go
@@ -293,7 +293,7 @@ func setDB(d *sql.DB)         { globalDB = d }
 // StartWGServer brings up a userspace WG endpoint listening on
 // 0.0.0.0:<ListenPort>. Server private key is read from disk; if
 // missing, generated and persisted at <stateDir>/wg-server.key.
-func StartWGServer(ts Tailscale, stateDir string) (*WGServer, error) {
+func StartWGServer(ts JoinConfig, stateDir string) (*WGServer, error) {
 	if ts.WGSubnetCIDR == "" {
 		return nil, fmt.Errorf("wireguard: wg_subnet_cidr required")
 	}
@@ -720,7 +720,7 @@ func hexToB64(h string) (string, error) {
 }
 
 type wireguardOnboarder struct {
-	ts Tailscale
+	ts JoinConfig
 	mu sync.Mutex
 }
 


### PR DESCRIPTION
## Why

`gateway {}` and `defaults {}` were both singletons — at most one of each per config. Wrapping them added no information beyond the equivalent flat attributes, but operators had to remember which fields belonged in which of the three places (top level / `gateway {}` / `defaults {}`). The split was arbitrary: `listen` was top-level while `wg_endpoint` was a nested block field, even though both are operational plumbing.

## What changes

- Lift every `gateway {}` field (`control`, `wg_endpoint`, `authkey`, `oauth_client_id`, …) to top-level.
- Lift every `defaults {}` field (`unknown_host`, `llm_fail_mode`, `llm_cache_ttl`, `human_timeout`, `human_on_timeout`) to top-level.
- Delete the `config.Defaults` Go type — its fields live on `config.Gateway` directly and ride through `config.CompiledPolicy` / `runtime.ApproveRequest` as named fields.
- Keep `config.Tailscale` as a non-HCL parameter bundle for `StartWGServer` / `newOnboarder` / etc., built on demand via `(*Gateway).JoinConfig()`. Minimises churn at call sites; the HCL surface still flattens.

Pre-1.0, so no deprecation shim — `clawpatrol validate` prints `Blocks of type "gateway" are not expected here` pointing at the stale wrapper.

## Mechanical follow-through

- Round-trip goldens regenerated via `go test ./config -update`.
- `tools/docgen` regenerated `site/doc/config-reference.md`.
- `gateway.example.hcl`, the `gateway init` skeleton in `login.go`, `README.md`, `config/README.md`, `site/doc/glossary.md`, and `doc/tailscale.md` rewritten against the flat shape.
- `~/src/prod-deploy/gateway.hcl` updated locally (separate repo, separate PR).

## Test plan
- [ ] `go test ./...` — all green locally.
- [ ] `go run . validate gateway.example.hcl` passes.
- [ ] `go run . validate ~/src/prod-deploy/gateway.hcl` passes (19 endpoints across 11 profiles).
- [ ] Open the regenerated `site/doc/config-reference.md` and confirm the "Top-level fields" table covers all 22 attributes in one section.