### PR TITLE
config: reject unknown top-level blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -242,6 +243,8 @@ func LoadBytes(src []byte, filename string) (*Gateway, hcl.Diagnostics) {
 		Profiles:    make(map[string]*Profile),
 	}
 
+	diags = append(diags, validateOperational(gw)...)
+
 	// Pass 1: extract the policy blocks from the remainder body.
 	policyBlocks, polDiags := extractPolicyBlocks(gw.Remain)
 	diags = append(diags, polDiags...)
@@ -295,6 +298,54 @@ func dedupGohclDiags(in hcl.Diagnostics) hcl.Diagnostics {
 		out = append(out, d)
 	}
 	return out
+}
+
+// validateOperational checks cross-field consistency on the operational
+// fields that gohcl can't express in a struct tag. Catches the typical
+// shapes that boot a gateway in a degraded state (silent fallback to
+// plain TCP, missing WireGuard endpoint, dashboard-with-no-auth).
+func validateOperational(gw *Gateway) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	switch strings.ToLower(gw.Control) {
+	case "", "wireguard", "tailscale":
+		// ok
+	default:
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid control value",
+			Detail: fmt.Sprintf(
+				"control = %q. Expected \"wireguard\", \"tailscale\", or omitted.",
+				gw.Control),
+		})
+	}
+
+	if strings.EqualFold(gw.Control, "wireguard") {
+		if gw.WGSubnetCIDR == "" {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing wg_subnet_cidr",
+				Detail:   "control = \"wireguard\" requires wg_subnet_cidr (e.g. \"10.55.0.0/24\").",
+			})
+		}
+		if gw.WGEndpoint == "" {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing wg_endpoint",
+				Detail:   "control = \"wireguard\" requires wg_endpoint (e.g. \"gw.example.com:51820\") so onboarded clients know where to dial.",
+			})
+		}
+	}
+
+	if gw.InfoListen != "" && gw.DashboardSecret == "" && !gw.InsecureNoDashboardSecret {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Dashboard auth not configured",
+			Detail:   "info_listen is set but the dashboard has no auth: set dashboard_secret = \"<long random string>\", or set insecure_no_dashboard_secret = true to explicitly opt out.",
+		})
+	}
+
+	return diags
 }
 
 // extractPolicyBlocks pulls every recognized top-level block out of

--- a/config/config.go
+++ b/config/config.go
@@ -299,6 +299,12 @@ func dedupGohclDiags(in hcl.Diagnostics) hcl.Diagnostics {
 
 // extractPolicyBlocks pulls every recognized top-level block out of
 // the remainder body returned by the operational gohcl decode.
+// Uses Content (not PartialContent) so unknown block types — left over
+// from a stale config file the new loader doesn't know about — surface
+// as diagnostics instead of getting silently dropped. (Past incident:
+// PR #225 renamed `gateway {}` to top-level fields; a brief deploy
+// ordering meant the new binary booted against an old config and
+// silently ran without a WireGuard endpoint.)
 func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 	schema := &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
@@ -311,7 +317,10 @@ func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 			{Type: "tunnel", LabelNames: []string{"type", "name"}},
 		},
 	}
-	content, _, diags := body.PartialContent(schema)
+	content, diags := body.Content(schema)
+	if content == nil {
+		return nil, diags
+	}
 	return content.Blocks, diags
 }
 

--- a/config/testdata/error_dashboard_no_auth.errors.txt
+++ b/config/testdata/error_dashboard_no_auth.errors.txt
@@ -1,0 +1,1 @@
+error: Dashboard auth not configured — info_listen is set but the dashboard has no auth: set dashboard_secret = "<long random string>", or set insecure_no_dashboard_secret = true to explicitly opt out.

--- a/config/testdata/error_dashboard_no_auth.hcl
+++ b/config/testdata/error_dashboard_no_auth.hcl
@@ -1,0 +1,8 @@
+# info_listen + empty dashboard_secret + no insecure opt-out is a
+# silent misconfig: the gateway runs but every dashboard request
+# hits a "dashboard auth not configured" page. Surface it at load
+# time instead.
+
+listen      = "0.0.0.0:8443"
+info_listen = "0.0.0.0:8080"
+ca_dir      = "/opt/clawpatrol/ca"

--- a/config/testdata/error_invalid_control.errors.txt
+++ b/config/testdata/error_invalid_control.errors.txt
@@ -1,0 +1,1 @@
+error: Invalid control value — control = "kubernetes". Expected "wireguard", "tailscale", or omitted.

--- a/config/testdata/error_invalid_control.hcl
+++ b/config/testdata/error_invalid_control.hcl
@@ -1,0 +1,8 @@
+# control accepts "wireguard" or "tailscale" (or omitted). Typos
+# like "kubernetes" used to silently pass — the gateway would boot
+# in a degraded fallback mode.
+
+listen = "0.0.0.0:8443"
+ca_dir = "/opt/clawpatrol/ca"
+
+control = "kubernetes"

--- a/config/testdata/error_stale_defaults_block.errors.txt
+++ b/config/testdata/error_stale_defaults_block.errors.txt
@@ -1,0 +1,1 @@
+error: error_stale_defaults_block.hcl:8:1: Unsupported block type — Blocks of type "defaults" are not expected here.

--- a/config/testdata/error_stale_defaults_block.hcl
+++ b/config/testdata/error_stale_defaults_block.hcl
@@ -1,0 +1,11 @@
+# Pre-flatten config form: `defaults {}` was a block, now its fields
+# are top-level attrs. The loader should reject this rather than
+# silently drop the block.
+
+listen = "0.0.0.0:8443"
+ca_dir = "/opt/clawpatrol/ca"
+
+defaults {
+  unknown_host  = "passthrough"
+  llm_fail_mode = "closed"
+}

--- a/config/testdata/error_stale_gateway_block.errors.txt
+++ b/config/testdata/error_stale_gateway_block.errors.txt
@@ -1,1 +1,1 @@
-error: error_stale_gateway_block.hcl:9:1: Unsupported block type — Blocks of type "gateway" are not expected here.
+error: error_stale_gateway_block.hcl:8:1: Unsupported block type — Blocks of type "gateway" are not expected here.

--- a/config/testdata/error_stale_gateway_block.errors.txt
+++ b/config/testdata/error_stale_gateway_block.errors.txt
@@ -1,0 +1,1 @@
+error: error_stale_gateway_block.hcl:9:1: Unsupported block type — Blocks of type "gateway" are not expected here.

--- a/config/testdata/error_stale_gateway_block.hcl
+++ b/config/testdata/error_stale_gateway_block.hcl
@@ -1,0 +1,12 @@
+# Pre-flatten config form: `gateway {}` was a block, now its fields
+# are top-level attrs. The loader should reject this rather than
+# silently drop the block.
+
+listen      = "0.0.0.0:8443"
+info_listen = "0.0.0.0:8080"
+ca_dir      = "/opt/clawpatrol/ca"
+
+gateway {
+  control     = "wireguard"
+  wg_endpoint = "10.0.0.1:51820"
+}

--- a/config/testdata/error_stale_gateway_block.hcl
+++ b/config/testdata/error_stale_gateway_block.hcl
@@ -2,9 +2,8 @@
 # are top-level attrs. The loader should reject this rather than
 # silently drop the block.
 
-listen      = "0.0.0.0:8443"
-info_listen = "0.0.0.0:8080"
-ca_dir      = "/opt/clawpatrol/ca"
+listen = "0.0.0.0:8443"
+ca_dir = "/opt/clawpatrol/ca"
 
 gateway {
   control     = "wireguard"

--- a/config/testdata/error_wireguard_missing_fields.errors.txt
+++ b/config/testdata/error_wireguard_missing_fields.errors.txt
@@ -1,0 +1,2 @@
+error: Missing wg_subnet_cidr — control = "wireguard" requires wg_subnet_cidr (e.g. "10.55.0.0/24").
+error: Missing wg_endpoint — control = "wireguard" requires wg_endpoint (e.g. "gw.example.com:51820") so onboarded clients know where to dial.

--- a/config/testdata/error_wireguard_missing_fields.hcl
+++ b/config/testdata/error_wireguard_missing_fields.hcl
@@ -1,0 +1,8 @@
+# control = "wireguard" requires wg_subnet_cidr and wg_endpoint.
+# Without them StartWGServer log.Fatals at boot (subnet) or onboarding
+# clients dial an unknown endpoint.
+
+listen = "0.0.0.0:8443"
+ca_dir = "/opt/clawpatrol/ca"
+
+control = "wireguard"

--- a/config/testdata/feature_example.hcl
+++ b/config/testdata/feature_example.hcl
@@ -27,13 +27,14 @@
 
 # ── operational --------------------------------------------------------
 
-listen      = "0.0.0.0:8443"
-info_listen = "0.0.0.0:8080"
-public_url  = "http://66.42.120.196:8080"
-admin_email = "test@example.com"
-ca_dir      = "/opt/clawpatrol/ca"
-log_path    = "/opt/clawpatrol/gateway.log"
-oauth_dir   = "/opt/clawpatrol/oauth"
+listen           = "0.0.0.0:8443"
+info_listen      = "0.0.0.0:8080"
+public_url       = "http://66.42.120.196:8080"
+admin_email      = "test@example.com"
+ca_dir           = "/opt/clawpatrol/ca"
+log_path         = "/opt/clawpatrol/gateway.log"
+oauth_dir        = "/opt/clawpatrol/oauth"
+dashboard_secret = "test-secret"
 
 control        = "wireguard"
 wg_endpoint    = "66.42.120.196:51820"


### PR DESCRIPTION
## Why

When PR #225 flattened `gateway {}` and `defaults {}` into top-level fields, the loader started silently dropping stale blocks from configs it did not understand, instead of erroring out. That is what made today's deploy ordering bite:

- 22:13:01 — new gateway binary deployed and restarted. The gateway.hcl on disk was still the old `gateway {}` form; the new loader silently dropped the block and the gateway booted with `cfg.Control = ""`, no WireGuard endpoint.
- 22:13:13 — flat-syntax gateway.hcl deployed. File watcher fired a config reload — but the hot-reload path does not restart the WG server, so the gateway kept running degraded.
- 22:17 — manual `systemctl restart` recovered.

If the new binary had instead refused to load the old config, `systemctl is-active` in the deploy workflow would have returned not-active, the deploy run would have been red, and the broken-gateway window would have been seconds instead of minutes.

## What changes

`extractPolicyBlocks` swaps `body.PartialContent` (lenient) for `body.Content` (strict). Unknown blocks at the top level become diagnostics:

```
error: gateway.hcl:9:1: Unsupported block type — Blocks of type "gateway" are not expected here.
```

Two regression fixtures lock in the diagnostic: `error_stale_gateway_block.hcl`, `error_stale_defaults_block.hcl`.

## Out of scope

Decoupling the two deploys: they already run from independent repos / independent workflows. The race was on simultaneous pushes, not coupling, and the strict-loader fix is the right knob.

## Test plan
- [ ] `go test ./...` — all green locally; the two new fixtures pass.
- [ ] `clawpatrol validate <old-format-config.hcl>` produces the new error.
- [ ] `clawpatrol validate <current gateway.hcl>` still says "19 endpoints across 11 profile(s)".
