### PR TITLE
ci: restore Go build cache explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}-
+            go-${{ runner.os }}-
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- disables `actions/setup-go`'s implicit Go cache in the test job
- restores/saves `~/.cache/go-build` and `~/go/pkg/mod` explicitly with `actions/cache@v5`
- uses SHA-specific primary keys plus Go module restore-key prefixes so PRs can reuse recent `main` build caches

## Test plan
- [x] `git diff --check`
- [x] workflow text check for `actions/cache@v5`, `cache: false`, and `hashFiles('go.mod', 'go.sum')`

This is meant to test whether a warmer compiled Go object cache reduces the ~3 minute `go test ./...` compile/link phase observed in CI.
