### PR TITLE
docs: refresh approval-rules for recent landed changes

### DIFF
--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -80,7 +80,8 @@ condition = "sql.statement.matches('(?i)\\bpassword\\b')"
 ```
 
 `verb`, `tables`, and `function` are extracted by a best-effort
-lexer — see "Gotchas" below.
+lexer over a lower-cased copy of the statement — see
+[Case sensitivity](#case-sensitivity-by-variable) below.
 
 `tables` and `function` are **multi-valued** facets: a single
 statement can name several tables (`SELECT ... FROM a JOIN b`) and
@@ -114,6 +115,11 @@ condition = "!k8s.resource.endsWith('/exec') && !k8s.resource.endsWith('/attach'
 A rule bound to `https` endpoints sees `http.*` only; a rule bound
 to `kubernetes` endpoints sees `k8s.*` only. Mixing families across
 a rule's `endpoints = [...]` is a load error.
+
+`ssh` endpoints exist but have no rule family yet — the gateway
+terminates auth and splices channels as opaque byte streams, emitting
+a single `allow` event at session start. Rules cannot gate anything
+inside an SSH session today.
 
 
 ## How to create a rule
@@ -219,14 +225,17 @@ accessed with dot notation. Common idioms:
 | `http.method`                 | upper-case (normalized) |
 | `http.path`, `http.query`, `http.headers`, `http.body` | as on the wire |
 | `sql.verb`                    | lower-case (normalized) |
-| `sql.tables`, `sql.function`, `sql.statement` | lower-case (statement is lower-cased before extraction) |
+| `sql.tables`, `sql.function`  | lower-case (extracted from a lower-cased copy of the statement) |
+| `sql.statement`               | as on the wire (raw text, no case folding) |
 | `k8s.verb`                    | lower-case (normalized) |
 | `k8s.resource`, `k8s.namespace`, `k8s.name`, `k8s.params` | as on the wire |
 
-For SQL, the parser lower-cases the statement before extracting
-verbs, tables, and functions — so `'Users' in sql.tables` will never
-fire. Write literals in the same case the parser will produce
-(lower).
+For SQL, the parser lower-cases an internal copy of the statement
+before extracting verbs, tables, and functions — so
+`'Users' in sql.tables` will never fire. Write literals in the same
+case the parser will produce (lower). `sql.statement` itself is the
+raw on-the-wire text; match it case-blindly with a `(?i)` regex
+flag (`sql.statement.matches('(?i)\\bpassword\\b')`).
 
 ### `credential = X`
 


### PR DESCRIPTION
## Summary

Edit `site/doc/approval-rules.md` to match `origin/main` reality. No
restructuring — only targeted fixes where the prose has drifted.

## Per-change tracking

- **Fix dangling "Gotchas" reference (pre-existing since #144)** —
  the SQL family section pointed to a "Gotchas" section that does not
  exist on `main`. Relink to the existing Case sensitivity table
  instead.
- **Note that SSH endpoints are policy pass-through (#90)** — the SSH
  endpoint plugin added `endpoint "ssh"` but no `ssh_rule` family
  (explicitly out of scope in the PR body: "Protocol decode / rule
  enforcement … nothing inside an SSH session is currently inspected
  or gateable"). Add a one-paragraph note in the Rule families
  section so operators don't expect `ssh.*` variables to exist.
- **Split `sql.statement` out of the lower-case row in the Case
  sensitivity table** — verified against
  `config/plugins/facets/sql/sql.go:144` (only `Verb` is lowered when
  building the CEL activation), `config/plugins/endpoints/postgres.go:676,680`
  (Postgres extracts from a lowered copy but keeps `info.Statement = sql`
  raw), and `config/plugins/endpoints/clickhouse_native_sql.go:42`
  (ClickHouse keeps `Statement` raw too). The doc previously claimed
  `sql.statement` was lower-cased, which contradicts the existing
  `(?i)`-regex example in the same file.

## Out of scope (verified in flight, not merged)

- cl-1ov (matcher case-folding for always-lowercased facets)
- cl-89r (fail-closed on inspection-buffer overflow, branch
  `origin/polecat/dust-mp1j6ab4`)
- Gotchas-section extraction (cl-to5, branch
  `origin/polecat/thunder-mowj69e3`)

Per the bead's "don't document things that haven't landed" rule, the
existing doc is left untouched in these areas.

## Test plan

- [x] `cd site && npm run build` renders the doc without warnings
      (15 doc pages built)
- [ ] Manual review of the rendered page