### PR TITLE
k8s: parse non-resource URIs as verb=meta

### DIFF
--- a/config/plugins/facets/k8s/k8s.go
+++ b/config/plugins/facets/k8s/k8s.go
@@ -176,6 +176,13 @@ func buildActivation(req *match.Request) map[string]any {
 //	/api/v1/namespaces/<ns>/<resource>/<name>/<sub> → subresource (exec / portforward / etc.)
 //	/apis/<group>/<v>/...                           → same shapes under named groups
 //
+// Non-resource URIs that kubectl / client-go probe reflexively
+// before any resource call (`/api`, `/apis`, `/api/<v>`, `/apis/<g>`,
+// `/apis/<g>/<v>`, `/healthz`, `/livez`, `/readyz`, `/version`,
+// `/openapi/...`, `/metrics`) parse as `verb = "meta"` with empty
+// resource. Configs allow them with `k8s.verb == "meta"` rather than
+// folding them into `list` / `get`.
+//
 // Verb derives from the HTTP method (GET → list/get/watch, POST →
 // create, PUT → update, PATCH → patch, DELETE → delete). GET
 // requests with watch=true are normalized to watch. kubectl uses
@@ -185,6 +192,9 @@ func parsePath(method, rawURL string) *Meta {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil
+	}
+	if isMetaPath(strings.Trim(u.Path, "/")) {
+		return &Meta{Verb: "meta"}
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) < 2 {
@@ -249,4 +259,28 @@ func parsePath(method, rawURL string) *Meta {
 		m.Verb = "watch"
 	}
 	return m
+}
+
+// isMetaPath reports whether p (URL path, leading/trailing slashes
+// trimmed) targets a non-resource k8s URI — API discovery, health
+// probes, version, OpenAPI schema, prometheus scrape. These are
+// hit reflexively by kubectl / client-go before any resource call.
+func isMetaPath(p string) bool {
+	switch p {
+	case "api", "apis", "healthz", "livez", "readyz", "version",
+		"metrics", "openapi":
+		return true
+	}
+	if strings.HasPrefix(p, "openapi/") {
+		return true
+	}
+	// /api/<v> with nothing after.
+	if rest, ok := strings.CutPrefix(p, "api/"); ok {
+		return !strings.Contains(rest, "/")
+	}
+	// /apis/<g> or /apis/<g>/<v>, nothing after.
+	if rest, ok := strings.CutPrefix(p, "apis/"); ok {
+		return strings.Count(rest, "/") <= 1
+	}
+	return false
 }

--- a/config/plugins/facets/k8s/k8s_meta_test.go
+++ b/config/plugins/facets/k8s/k8s_meta_test.go
@@ -1,0 +1,51 @@
+package k8s
+
+import "testing"
+
+// TestParsePathMeta covers the non-resource URIs kubectl/client-go
+// probes reflexively. They must all parse to verb=meta with empty
+// resource so a single `k8s.verb == "meta"` rule covers the set.
+func TestParsePathMeta(t *testing.T) {
+	meta := []string{
+		"/api", "/apis",
+		"/api/v1",
+		"/apis/apps", "/apis/apps/v1",
+		"/healthz", "/livez", "/readyz",
+		"/version", "/metrics",
+		"/openapi/v2", "/openapi/v3", "/openapi/v3/apis/apps/v1",
+	}
+	for _, u := range meta {
+		m := parsePath("GET", u)
+		if m == nil {
+			t.Errorf("%s: got nil, want verb=meta", u)
+			continue
+		}
+		if m.Verb != "meta" {
+			t.Errorf("%s: verb=%q, want meta", u, m.Verb)
+		}
+		if m.Resource != "" || m.Namespace != "" || m.Name != "" {
+			t.Errorf("%s: meta path leaked resource/ns/name: %+v", u, m)
+		}
+	}
+
+	// Resource calls must NOT collapse into meta — they need to
+	// keep flowing through the regular list/get path so deny rules
+	// keyed on a specific resource still fire.
+	resource := []struct{ url, verb, res string }{
+		{"/api/v1/pods", "list", "pods"},
+		{"/api/v1/namespaces", "list", "namespaces"},
+		{"/api/v1/namespaces/foo/pods", "list", "pods"},
+		{"/apis/apps/v1/deployments", "list", "deployments"},
+	}
+	for _, c := range resource {
+		m := parsePath("GET", c.url)
+		if m == nil {
+			t.Errorf("%s: nil meta on resource URL", c.url)
+			continue
+		}
+		if m.Verb != c.verb || m.Resource != c.res {
+			t.Errorf("%s: got verb=%q resource=%q, want %q/%q",
+				c.url, m.Verb, m.Resource, c.verb, c.res)
+		}
+	}
+}

--- a/config/plugins/facets/k8s/k8s_test.go
+++ b/config/plugins/facets/k8s/k8s_test.go
@@ -75,10 +75,16 @@ func TestParsePath(t *testing.T) {
 			},
 		},
 		{
-			name:   "non k8s path returns nil",
+			name:   "non-k8s-shaped path returns nil",
+			method: "GET",
+			rawURL: "/some/random/path",
+			want:   nil,
+		},
+		{
+			name:   "health probe parses as verb=meta",
 			method: "GET",
 			rawURL: "/healthz",
-			want:   nil,
+			want:   &Meta{Verb: "meta"},
 		},
 	}
 

--- a/config/testdata/full.hcl
+++ b/config/testdata/full.hcl
@@ -1151,6 +1151,11 @@ rule "k8s-exec-content-check" {
   condition = "k8s.resource == 'pods/exec'"
   approve   = [k8s-exec-content-judge]
 }
+rule "k8s-allow-meta" {
+  endpoints = [k8s-dev-ams, k8s-dev-ord, k8s-eks-deployng-prod]
+  condition = "k8s.verb == 'meta'"
+  verdict   = "allow"
+}
 rule "k8s-reads" {
   endpoints = [k8s-dev-ams, k8s-dev-ord, k8s-eks-deployng-prod]
   condition = "k8s.verb in ['get', 'list', 'watch']"

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -858,6 +858,19 @@
           "verdict": "allow"
         }
       },
+      "k8s-allow-meta": {
+        "body": {
+          "name": "k8s-allow-meta",
+          "family": "k8s",
+          "endpoints": [
+            "k8s-dev-ams",
+            "k8s-dev-ord",
+            "k8s-eks-deployng-prod"
+          ],
+          "condition": "k8s.verb == 'meta'",
+          "verdict": "allow"
+        }
+      },
       "k8s-debug-pods": {
         "body": {
           "name": "k8s-debug-pods",


### PR DESCRIPTION
kubectl and client-go probe a set of non-resource k8s URIs
reflexively before any resource call: API discovery roots
(`/api`, `/apis`, `/api/<v>`, `/apis/<g>`, `/apis/<g>/<v>`),
health probes (`/healthz`, `/livez`, `/readyz`), the version
endpoint, the OpenAPI schema (`/openapi/...`), and the
prometheus scrape endpoint (`/metrics`). The path parser returns
nil for these today, so no k8s rule matches and the per-cluster
default-deny fires — observed on the dev cluster earlier:
dev's `kubectl get pods` got denied on `GET /api` and gave up
before reaching `/api/v1/pods`.

Parse them as `verb = "meta"` with empty resource. Configs allow
them with `k8s.verb == 'meta'` rather than overloading `list` /
`get`; reads stay focused on actual resources, and a hardened
config can deny meta without affecting resource access.

This should have ridden along with #219; it was committed an
hour after that PR was squash-merged so it never made it onto
main. Pulled out as its own commit cherry-picked off current
main.

`full.hcl` picks up a `k8s-allow-meta` rule. The k8s parsePath
test gains cases for the meta shapes. End-user side
(`prod.example.com`) follows in
example/prod-deploy#4.