### PR TITLE
audit: gunzip response samples so the dashboard renders plaintext

### DIFF
--- a/main.go
+++ b/main.go
@@ -1869,7 +1869,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Reason = err.Error()
 			ev.Ms = time.Since(start).Milliseconds()
 			ev.ReqSha = reqS.sha()
-			ev.ReqBody = reqS.sample()
+			ev.ReqBody = reqS.sample(req.Header.Get("Content-Encoding"))
 			ev.In = reqS.n
 			g.emitEnd(ev)
 			return
@@ -1923,9 +1923,9 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()
-		ev.ReqBody = reqS.sample()
+		ev.ReqBody = reqS.sample(req.Header.Get("Content-Encoding"))
 		ev.RespSha = respS.sha()
-		ev.RespBody = respS.sample()
+		ev.RespBody = respS.sample(resp.Header.Get("Content-Encoding"))
 		ev.Ms = time.Since(start).Milliseconds()
 		g.emitEnd(ev)
 		if g.agents != nil && agentAddr != "" {

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"strings"
+	"testing"
+)
+
+func gzipped(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write([]byte(s)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestSamplerSampleGzip(t *testing.T) {
+	want := `{"hello":"world","arr":[1,2,3]}`
+	s := newSampler(4096)
+	_, _ = s.Write(gzipped(t, want))
+	got := s.sample("gzip")
+	if got != want {
+		t.Fatalf("gzip sample\n  want %q\n   got %q", want, got)
+	}
+}
+
+func TestSamplerSamplePlaintext(t *testing.T) {
+	s := newSampler(4096)
+	_, _ = s.Write([]byte(`{"hello":"world"}`))
+	if got := s.sample(""); got != `{"hello":"world"}` {
+		t.Fatalf("plaintext sample: %q", got)
+	}
+}
+
+func TestSamplerSampleBinaryFallback(t *testing.T) {
+	// Raw binary bytes with no encoding header — should hex-prefix.
+	s := newSampler(4096)
+	_, _ = s.Write([]byte{0x00, 0xff, 0x01, 0xfe})
+	got := s.sample("")
+	if !strings.HasPrefix(got, "binary:") {
+		t.Fatalf("expected binary: prefix, got %q", got)
+	}
+}
+
+func TestSamplerSampleNonGzipEncodingIgnored(t *testing.T) {
+	// br/deflate aren't decoded yet; falling through to printable
+	// check on the raw bytes is the documented behaviour.
+	s := newSampler(4096)
+	_, _ = s.Write([]byte{0x1f, 0x8b, 0x08, 0x00}) // gzip-magic but unknown encoding
+	got := s.sample("br")
+	if !strings.HasPrefix(got, "binary:") {
+		t.Fatalf("expected binary: for unknown encoding, got %q", got)
+	}
+}

--- a/web.go
+++ b/web.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -2024,14 +2025,43 @@ func (s *sampler) sha() string {
 	return hex.EncodeToString(s.hash.Sum(nil))
 }
 
-func (s *sampler) sample() string {
+// sample returns the audit-log preview of the captured body. When
+// encoding names a compression we know how to decode (currently only
+// gzip — the encoding most agents request via Accept-Encoding and
+// most upstreams reply with), the buffered prefix is decompressed
+// first so a JSON response doesn't get rendered as "binary:<hex>"
+// just because it's still on the wire as gzip.
+func (s *sampler) sample(encoding string) string {
 	if s.buf.Len() == 0 {
 		return ""
 	}
-	if isPrintable(s.buf.Bytes()) {
-		return s.buf.String()
+	raw := s.buf.Bytes()
+	body := maybeDecode(raw, encoding)
+	if isPrintable(body) {
+		return string(body)
 	}
-	return "binary:" + hex.EncodeToString(s.buf.Bytes()[:min(64, s.buf.Len())])
+	return "binary:" + hex.EncodeToString(raw[:min(64, len(raw))])
+}
+
+// maybeDecode returns the decompressed prefix of buf when encoding is
+// gzip, or buf unchanged otherwise. The sampler captures at most cap
+// bytes, so the gzip stream is almost always truncated mid-block —
+// io.ReadAll returns whatever the reader managed before hitting
+// io.ErrUnexpectedEOF, which is exactly what we want for a preview.
+func maybeDecode(buf []byte, encoding string) []byte {
+	if !strings.EqualFold(strings.TrimSpace(encoding), "gzip") {
+		return buf
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(buf))
+	if err != nil {
+		return buf
+	}
+	defer func() { _ = zr.Close() }()
+	out, _ := io.ReadAll(zr)
+	if len(out) == 0 {
+		return buf
+	}
+	return out
 }
 
 func isPrintable(b []byte) bool {


### PR DESCRIPTION
## What it looks like before

In the dashboard's per-action detail view, gzipped response bodies show up as a hex blob:

```
binary:1f8b08000000000000003ab56a4926249954b2aa562a4a2dc82fce2c92faa84f10a4a737328252b4b53...
```

Headers next to it confirm the cause — `Content-Encoding: gzip`, `Content-Type: application/json`.

## Why

The MITM samples 4 KiB of every request/response body for the audit log. The captured bytes are whatever was on the wire, and Go's transport leaves the response body compressed when the agent advertised `Accept-Encoding: gzip`. `isPrintable` correctly classifies the gzip magic + deflate bytes as non-printable, and `sample()` falls back to `binary:<hex>`.

## What changes

`sample()` takes a `contentEncoding string`. When that's `gzip`, the buffer is run through `gzip.NewReader` before the printable check. Truncated streams are fine — `io.ReadAll` returns whatever the reader managed before `io.ErrUnexpectedEOF`, which is exactly what a 4 KiB preview wants. Unknown encodings (br, deflate) fall through to the existing `binary:<hex>` path; the function is shaped so adding them later is one switch arm.

Three call sites in `main.go` pass `req.Header.Get("Content-Encoding")` or the response equivalent. Tests cover plaintext, gzipped JSON, raw-binary fallback, and unsupported-encoding fallback.

Historical audit rows keep their old `binary:` text — the fix is going-forward only.

## Test plan

- [x] `go test ./...` — green, including four new `TestSamplerSample*` cases.
- [ ] `clawpatrol gateway` against a fixture that proxies to github.com — confirm the dashboard's RESPONSE BODY section shows the JSON payload instead of `binary:`.
