### PR TITLE
www: format timestamps as yyyy-MM-dd HH:mm:ss.SSS

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,23 @@
+# Project conventions
+
+This file is the single source of truth for repo-level agent
+instructions. `AGENTS.md` at the repo root is a symlink to this file
+so Codex and Claude Code both pick it up.
+
+## Dates and times
+
+Render every timestamp in the UI as `yyyy-MM-dd HH:mm:ss.SSS` (24-hour,
+locale-independent, millisecond precision). When only the time-of-day
+is shown, use `HH:mm:ss.SSS`.
+
+Helpers live in `www/src/lib/format.ts`:
+
+- `fmtDateTime(t)` — full timestamp.
+- `fmtTime(t)` — time-of-day only.
+
+Do not call `toLocaleDateString`, `toLocaleTimeString`, or
+`toLocaleString` for date/time rendering. They produce different
+output per locale (`5/11/2026` in en-US, `11/05/2026` in en-GB,
+`11.5.2026` in de-DE), which makes log entries unreadable across a
+team. Number formatting (`Intl.NumberFormat`, `Number.toLocaleString`)
+is fine — the rule is about dates and times.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
-.claude/
+.claude/*
+!.claude/CLAUDE.md
 ca/
 ts-state/
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { type EventRecord, type FacetSchema } from "../lib/api";
 import { formatFacetValue, useFacets } from "../lib/facets";
+import { fmtTime } from "../lib/format";
 
 type RowState = EventRecord & { frames?: { direction: string; frame: string; ts: string }[] };
 
@@ -183,11 +184,7 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
         window.location.hash = `#/request/${ev.id}`;
       }
     : undefined;
-  const t = new Date(ev.ts);
-  const time =
-    t.toLocaleTimeString([], { hour12: false }) +
-    "." +
-    String(t.getMilliseconds()).padStart(3, "0");
+  const time = fmtTime(ev.ts);
   const inFlight = ev.phase === "start";
   const status = ev.status || 0;
   const statusColor = inFlight

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { getAction, type Agent, type EventRecord, type FacetSchema } from "../lib/api";
 import { formatFacetValue, useFacets } from "../lib/facets";
+import { fmtDateTime } from "../lib/format";
 
 export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] }) {
   const [ev, setEv] = useState<EventRecord | null>(null);
@@ -28,13 +29,7 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
     );
   }
 
-  const t = new Date(ev.ts);
-  const time =
-    t.toLocaleDateString() +
-    " " +
-    t.toLocaleTimeString([], { hour12: false }) +
-    "." +
-    String(t.getMilliseconds()).padStart(3, "0");
+  const time = fmtDateTime(ev.ts);
   const status = ev.status || 0;
   const statusColor =
     status >= 500

--- a/www/src/lib/format.ts
+++ b/www/src/lib/format.ts
@@ -38,6 +38,46 @@ export function shortModel(m?: string): string {
   return s;
 }
 
+function pad(n: number, width = 2): string {
+  return String(n).padStart(width, "0");
+}
+
+// fmtDateTime renders local time as `yyyy-MM-dd HH:mm:ss.SSS`. Used
+// everywhere a timestamp shows up in the UI — keeps the format
+// locale-independent. See AGENTS.md.
+export function fmtDateTime(t: string | number | Date): string {
+  const d = t instanceof Date ? t : new Date(t);
+  return (
+    d.getFullYear() +
+    "-" +
+    pad(d.getMonth() + 1) +
+    "-" +
+    pad(d.getDate()) +
+    " " +
+    pad(d.getHours()) +
+    ":" +
+    pad(d.getMinutes()) +
+    ":" +
+    pad(d.getSeconds()) +
+    "." +
+    pad(d.getMilliseconds(), 3)
+  );
+}
+
+// fmtTime renders local time as `HH:mm:ss.SSS` (date omitted).
+export function fmtTime(t: string | number | Date): string {
+  const d = t instanceof Date ? t : new Date(t);
+  return (
+    pad(d.getHours()) +
+    ":" +
+    pad(d.getMinutes()) +
+    ":" +
+    pad(d.getSeconds()) +
+    "." +
+    pad(d.getMilliseconds(), 3)
+  );
+}
+
 export function fmtExpiry(unix?: number): string {
   if (!unix) return "—";
   const sec = unix - Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## What changes

- The action detail page (`/#/request/<id>`) and the live-requests row both rendered timestamps via `toLocaleDateString` / `toLocaleTimeString`. Output shape depends on browser locale: en-US shows `5/11/2026 16:57:23.157`, en-GB shows `11/05/2026 …`, de-DE shows `11.5.2026 …`. Unreadable across a team.
- Two new helpers in `www/src/lib/format.ts`:
  - `fmtDateTime(t)` → `yyyy-MM-dd HH:mm:ss.SSS`
  - `fmtTime(t)` → `HH:mm:ss.SSS`
- Both call sites now use the helpers.

## AGENTS.md + .claude/CLAUDE.md

To stop this drifting back: a repo-level instruction file pins the rule. The source lives at `.claude/CLAUDE.md` (Claude Code's convention) and `AGENTS.md` at the repo root is a symlink to it ([agents.md](https://agents.md/) convention, picked up by Codex and other agents). One source of truth, both ecosystems happy.

`.claude/CLAUDE.md` was being swallowed by the existing `.claude/` gitignore entry; switched it to `.claude/*` + an `!.claude/CLAUDE.md` allow-pattern so only this one file is tracked.

## Test plan
- [x] `cd www && npm run build` — clean.
- [ ] Open `/#/request/<id>` — confirm the timestamp at the top reads `yyyy-MM-dd HH:mm:ss.SSS`.
- [ ] Open the live-requests panel — confirm row times read `HH:mm:ss.SSS`.
