### PR TITLE
feat: Discord bot token credential

### DIFF
--- a/config/plugins/credentials/discord.go
+++ b/config/plugins/credentials/discord.go
@@ -1,0 +1,89 @@
+package credentials
+
+// discord_bot_token lets agents run ordinary Discord bot SDKs without
+// exposing the real bot token to the child process. `clawpatrol env`
+// pushes token-shaped placeholders into the common Discord SDK env var
+// names; REST requests get Authorization: Bot <real token>, and Gateway
+// WebSocket IDENTIFY frames have the placeholder swapped inside their JSON
+// text payload before the bytes reach Discord.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// phDiscord is intentionally token-shaped enough for Discord SDKs and
+// example apps that sanity-check env vars before opening REST/Gateway
+// connections. The gateway replaces it before it reaches discord.com.
+const phDiscord = "MTAwMDAwMDAwMDAwMDAwMDAwMA.clawpatrol-placeholder-do-not-use.xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+// DiscordBotToken injects Discord bot tokens for REST and Gateway SDK traffic.
+type DiscordBotToken struct{}
+
+// InjectHTTP is part of the clawpatrol plugin API.
+func (*DiscordBotToken) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
+	tok := discordBotTokenSecret(sec)
+	if tok == "" {
+		return nil
+	}
+	auth := req.Header.Get("Authorization")
+	if strings.Contains(auth, phDiscord) {
+		req.Header.Set("Authorization", strings.ReplaceAll(auth, phDiscord, tok))
+		return nil
+	}
+	// Normal SDKs send `Authorization: Bot <token>` after reading
+	// DISCORD_TOKEN / DISCORD_BOT_TOKEN. If the caller omitted the
+	// header, stamp the configured bot credential directly.
+	if auth == "" {
+		req.Header.Set("Authorization", "Bot "+tok)
+	}
+	return nil
+}
+
+// RewriteWebSocketPayload is part of the clawpatrol plugin API.
+func (*DiscordBotToken) RewriteWebSocketPayload(_ context.Context, payload []byte, sec runtime.Secret) ([]byte, bool, error) {
+	tok := discordBotTokenSecret(sec)
+	if tok == "" || !bytes.Contains(payload, []byte(phDiscord)) {
+		return payload, false, nil
+	}
+	return bytes.ReplaceAll(payload, []byte(phDiscord), []byte(tok)), true, nil
+}
+
+func discordBotTokenSecret(sec runtime.Secret) string {
+	if v := sec.Extras["bot"]; v != "" {
+		return v
+	}
+	return string(sec.Bytes)
+}
+
+// SecretSlots is part of the clawpatrol plugin API.
+func (*DiscordBotToken) SecretSlots() []config.SecretSlot {
+	return []config.SecretSlot{{Label: "Discord bot token", Description: "Bot token from the Discord developer portal"}}
+}
+
+// EnvVars is part of the clawpatrol plugin API.
+func (*DiscordBotToken) EnvVars() []config.EnvVar {
+	return []config.EnvVar{
+		{Name: "DISCORD_TOKEN", Value: phDiscord, Description: "Discord bot token placeholder (common SDK/example env var)"},
+		{Name: "DISCORD_BOT_TOKEN", Value: phDiscord, Description: "Discord bot token placeholder"},
+	}
+}
+
+func init() {
+	var _ runtime.HTTPCredentialRuntime = (*DiscordBotToken)(nil)
+	var _ runtime.WebSocketCredentialRuntime = (*DiscordBotToken)(nil)
+	var _ config.EnvPushdownProvider = (*DiscordBotToken)(nil)
+	config.Register(&config.Plugin{
+		Kind:    config.KindCredential,
+		Type:    "discord_bot_token",
+		New:     newer[DiscordBotToken](),
+		Runtime: (*DiscordBotToken)(nil),
+		Build:   passthrough,
+		Emit:    emptyEmit,
+	})
+}

--- a/config/plugins/credentials/discord_test.go
+++ b/config/plugins/credentials/discord_test.go
@@ -1,0 +1,64 @@
+package credentials
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestDiscordInjectHTTPStampsBotAuthorization(t *testing.T) {
+	plugin := &DiscordBotToken{}
+	req, err := http.NewRequest("GET", "https://discord.com/api/v10/users/@me", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bot "+phDiscord)
+
+	if err := plugin.InjectHTTP(req.Context(), req, runtime.Secret{Bytes: []byte("real.discord.token")}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bot real.discord.token" {
+		t.Fatalf("Authorization = %q, want Bot real.discord.token", got)
+	}
+}
+
+func TestDiscordEnvVarsPushBotTokenPlaceholders(t *testing.T) {
+	got := (&DiscordBotToken{}).EnvVars()
+	want := map[string]bool{
+		"DISCORD_BOT_TOKEN": false,
+		"DISCORD_TOKEN":     false,
+	}
+	for _, ev := range got {
+		if _, ok := want[ev.Name]; ok {
+			want[ev.Name] = true
+			if ev.Value != phDiscord {
+				t.Fatalf("%s value = %q, want %q", ev.Name, ev.Value, phDiscord)
+			}
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Fatalf("EnvVars missing %s: %#v", name, got)
+		}
+	}
+}
+
+func TestDiscordRewriteWebSocketPayloadReplacesPlaceholder(t *testing.T) {
+	plugin := &DiscordBotToken{}
+	payload := []byte(`{"op":2,"d":{"token":"` + phDiscord + `","intents":513}}`)
+	rewritten, changed, err := plugin.RewriteWebSocketPayload(t.Context(), bytes.Clone(payload), runtime.Secret{Bytes: []byte("real.discord.token")})
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !changed {
+		t.Fatal("RewriteWebSocketPayload changed=false, want true")
+	}
+	if bytes.Contains(rewritten, []byte(phDiscord)) {
+		t.Fatalf("rewritten payload still contains placeholder: %s", rewritten)
+	}
+	if !bytes.Contains(rewritten, []byte(`"token":"real.discord.token"`)) {
+		t.Fatalf("rewritten payload does not contain real token: %s", rewritten)
+	}
+}

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -30,6 +30,17 @@ type HTTPCredentialRuntime interface {
 	InjectHTTP(ctx context.Context, req *http.Request, sec Secret) error
 }
 
+// WebSocketCredentialRuntime is the credential-plugin contract for
+// server-bound WebSocket text payloads that carry token placeholders.
+// The gateway calls this after decoding/unmasking a complete text frame
+// but before forwarding it upstream; implementations must return a new
+// plaintext payload and indicate whether the frame must be rebuilt.
+// Inspectors still receive the original placeholder-bearing payload so
+// real secrets are not emitted to logs or the dashboard.
+type WebSocketCredentialRuntime interface {
+	RewriteWebSocketPayload(ctx context.Context, payload []byte, sec Secret) ([]byte, bool, error)
+}
+
 // HTTPSyntheticResponder is the optional contract an endpoint
 // plugin's runtime implements when it needs to short-circuit certain
 // matched requests and return a synthetic response without forwarding

--- a/main.go
+++ b/main.go
@@ -1777,34 +1777,48 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// multi-credential dispatch asks the endpoint plugin's
 		// PlaceholderDetector which placeholder the agent sent),
 		// fetch the secret bytes from the configured store, and
-		// hand both to the credential plugin's HTTPCredentialRuntime
-		// to stamp onto the request. Schema-only credential types
-		// (slack / telegram / gemini / etc.) leave Runtime nil; we
-		// pass through verbatim and rely on policy alone.
+		// hand both to the credential plugin's request-time runtime hooks
+		// to stamp HTTP auth or rewrite server-bound WS token placeholders.
+		// Schema-only credential types leave Runtime nil; we pass through
+		// verbatim and rely on policy alone.
+		var rewriteWSPayload wsPayloadRewriter
 		if cc := runtime.ResolveCredential(ep, mreq); cc != nil {
 			// Plugin.Runtime is a typed-nil sentinel used only for
 			// interface-compliance assertions; the actual decoded HCL
 			// values (BearerToken.IdempotencyKey, PostgresCredential.User,
 			// etc.) live on Body. Invoke methods through Body so the
 			// receiver is the real instance.
-			if injector, ok := cc.Credential.Body.(runtime.HTTPCredentialRuntime); ok {
+			injector, wantsHTTP := cc.Credential.Body.(runtime.HTTPCredentialRuntime)
+			wsRewriter, wantsWS := cc.Credential.Body.(runtime.WebSocketCredentialRuntime)
+			if wantsHTTP || (wantsWS && isWSUpgrade(req)) {
 				sec, err := g.secrets.Get(cc.Credential.Symbol.Name, profile)
 				if err != nil {
 					log.Printf("secret %s/%s: %v — forwarding without injection", cc.Credential.Symbol.Name, profile, err)
 				} else if len(sec.Bytes) == 0 && len(sec.Extras) == 0 {
 					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
-				} else if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
-					log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+				} else {
+					if wantsHTTP {
+						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
+							log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+						}
+					}
+					if wantsWS && isWSUpgrade(req) {
+						wsSec := sec
+						rewriteWSPayload = func(payload []byte) ([]byte, bool, error) {
+							return wsRewriter.RewriteWebSocketPayload(req.Context(), payload, wsSec)
+						}
+					}
 				}
 			}
 		}
 
 		// WebSocket upgrade. http.Transport.RoundTrip mangles the
-		// 101 response and Cloudflare's WAF rejects modified frames,
-		// so we hand off to a raw byte bridge that forwards the
-		// upgrade verbatim and pumps frames untouched. The handler
-		// runs until either side closes — when it returns, the
-		// caller's request loop ends naturally.
+		// 101 response and Cloudflare's WAF rejects unexpectedly modified
+		// frames, so we hand off to a raw byte bridge. Frames remain
+		// byte-faithful unless the selected credential provides an explicit
+		// WS token-placeholder rewriter (for example Discord Gateway
+		// IDENTIFY). The handler runs until either side closes — when it
+		// returns, the caller's request loop ends naturally.
 		if isWSUpgrade(req) {
 			log.Printf("ws-upgrade %s %s", host, req.URL.Path)
 			ev.Action = "ws"
@@ -1828,7 +1842,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					Direction: direction,
 				})
 			}
-			g.handleWSUpgrade(tc, br, req, host, frameEmit, ep, profile)
+			g.handleWSUpgrade(tc, br, req, host, frameEmit, ep, profile, rewriteWSPayload)
 			ev.Status = 101
 			ev.Ms = time.Since(start).Milliseconds()
 			g.emitEnd(ev)

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -143,7 +143,7 @@ approver "llm_approver" "example" {
 
 Block syntax: `credential "<type>" "<name>" { ... }`
 
-Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_eks_credential`](#credential-awsekscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`telegram_bot_token`](#credential-telegrambottoken).
+Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_eks_credential`](#credential-awsekscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`telegram_bot_token`](#credential-telegrambottoken).
 
 ### `credential "anthropic_manual_key" "<name>"`
 
@@ -216,6 +216,16 @@ Is part of the clawpatrol plugin API.
 
 ```hcl
 credential "cookie_token" "example" {}
+```
+
+### `credential "discord_bot_token" "<name>"`
+
+Injects Discord bot tokens for REST and Gateway SDK traffic.
+
+_No configurable attributes._
+
+```hcl
+credential "discord_bot_token" "example" {}
 ```
 
 ### `credential "gemini_api_key" "<name>"`

--- a/ws.go
+++ b/ws.go
@@ -1,11 +1,12 @@
 package main
 
-// WebSocket bridging for the new policy. RFC 6455 frames pass
-// through verbatim — placeholder substitution is gone with the
-// legacy Swap field, so the bridge is just byte-faithful in both
-// directions. Text frames going server-bound get observed (decoded
-// + permessage-deflate inflated) for codex-WS token-usage tracking
-// when the host matches; nothing is mutated on the wire.
+// WebSocket bridging for the new policy. RFC 6455 frames normally pass
+// through verbatim; server-bound text frames can be rebuilt only when a
+// credential plugin explicitly owns an in-frame placeholder (currently used
+// for Discord Gateway token hiding). Text frames also get observed (decoded
+// + permessage-deflate inflated) for codex-WS token-usage tracking when the
+// host matches; observers receive the original placeholder payload rather
+// than any rewritten secret-bearing bytes.
 //
 // Why a separate bridge instead of letting http.Transport.RoundTrip
 // handle the 101 Switching Protocols: Cloudflare's WAF on
@@ -50,6 +51,8 @@ type wsParams struct {
 	clientNoTakeover bool // client_no_context_takeover
 	serverNoTakeover bool // server_no_context_takeover
 }
+
+type wsPayloadRewriter func([]byte) ([]byte, bool, error)
 
 func parseWSExtensions(headerVal string) wsParams {
 	var p wsParams
@@ -96,7 +99,7 @@ func (g *Gateway) dialWSUpstream(ctx context.Context, upstream string, ep *confi
 // raw byte bridge once the agent's request looks like a WS upgrade.
 // The connection stays alive until either side closes; pumpWS
 // observes text frames for codex usage tracking when applicable.
-func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string) {
+func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string, rewriteClientPayload wsPayloadRewriter) {
 	agentAddr := peerIP(client) // capture before netstack races to nil
 
 	// dialWSUpstream preserves the existing split: endpoints that require a
@@ -232,12 +235,12 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 	done := make(chan struct{}, 2)
 	// client → server (frames are masked on this side)
 	go func() {
-		_ = pumpWS(br, up, params, true, clientToServer, func(n int) { track(int64(n), 0) })
+		_ = pumpWS(br, up, params, true, clientToServer, rewriteClientPayload, func(n int) { track(int64(n), 0) })
 		done <- struct{}{}
 	}()
 	// server → client (frames are NOT masked)
 	go func() {
-		_ = pumpWS(upBR, client, params, false, serverToClient, func(n int) { track(0, int64(n)) })
+		_ = pumpWS(upBR, client, params, false, serverToClient, nil, func(n int) { track(0, int64(n)) })
 		done <- struct{}{}
 	}()
 	<-done
@@ -280,25 +283,50 @@ func parseRespHeaders(raw []byte) http.Header {
 	return h
 }
 
-// pumpWS reads frames from src and forwards bytes verbatim to dst.
-// For text frames, a COPY of the payload is unmasked + decompressed
-// (if RSV1 set and deflate negotiated) and passed to onPayload for
-// inspection. We do NOT modify or re-mask frames — Cloudflare's WAF
-// on chatgpt.com closes the connection with 1007 ("invalid frame
-// payload data") if forwarded frames don't byte-match what the
-// client sent.
+// pumpWS reads frames from src and forwards bytes to dst. Most
+// connections stay byte-verbatim; rewritePayload is only for credential
+// plugins whose SDKs put token placeholders inside server-bound text
+// frames (Discord Gateway IDENTIFY). For text frames, a COPY of the
+// payload is unmasked + decompressed (if RSV1 set and deflate negotiated)
+// and passed to onPayload for inspection. Inspectors see the original
+// placeholder payload, never the rewritten secret-bearing bytes.
 //
 // fromClient controls which deflate context-takeover state to use.
-func pumpWS(src *bufio.Reader, dst io.Writer, params wsParams, fromClient bool, onPayload func([]byte), onFrameBytes func(int)) error {
+func pumpWS(src *bufio.Reader, dst io.Writer, params wsParams, fromClient bool, onPayload func([]byte), rewritePayload wsPayloadRewriter, onFrameBytes func(int)) error {
 	noTakeover := params.serverNoTakeover
 	if fromClient {
 		noTakeover = params.clientNoTakeover
 	}
 	infl := &wsInflater{}
 	for {
-		raw, _, op, compressed, masked, maskKey, payload, err := readFrameRaw(src)
+		raw, b0, op, compressed, masked, maskKey, payload, err := readFrameRaw(src)
 		if err != nil {
 			return err
+		}
+		plain := payload
+		if op == wsOpText && (onPayload != nil || rewritePayload != nil) {
+			plain = unmaskWSPayload(payload, masked, maskKey)
+			if compressed && params.deflate {
+				if dec := infl.decompress(plain, noTakeover); dec != nil {
+					plain = dec
+				}
+			}
+		}
+		if op == wsOpText && onPayload != nil {
+			onPayload(plain)
+		}
+		// Only rebuild uncompressed text frames. Rewriting compressed frames
+		// would require re-compressing with the negotiated permessage-deflate
+		// context; Discord SDKs send IDENTIFY as plain text, so leave any
+		// compressed traffic byte-faithful instead of corrupting it.
+		if op == wsOpText && rewritePayload != nil && !compressed {
+			rewritten, changed, err := rewritePayload(plain)
+			if err != nil {
+				return err
+			}
+			if changed {
+				raw = buildFrameRaw(b0, masked, maskKey, rewritten)
+			}
 		}
 		if onFrameBytes != nil {
 			onFrameBytes(len(raw))
@@ -306,25 +334,53 @@ func pumpWS(src *bufio.Reader, dst io.Writer, params wsParams, fromClient bool, 
 		if _, werr := dst.Write(raw); werr != nil {
 			return werr
 		}
-		if op == wsOpText && onPayload != nil {
-			plain := payload
-			if masked {
-				plain = make([]byte, len(payload))
-				for i := range payload {
-					plain[i] = payload[i] ^ maskKey[i%4]
-				}
-			}
-			if compressed && params.deflate {
-				if dec := infl.decompress(plain, noTakeover); dec != nil {
-					plain = dec
-				}
-			}
-			onPayload(plain)
-		}
 		if op == wsOpClose {
 			return nil
 		}
 	}
+}
+
+func unmaskWSPayload(payload []byte, masked bool, maskKey [4]byte) []byte {
+	if !masked {
+		return payload
+	}
+	plain := make([]byte, len(payload))
+	for i := range payload {
+		plain[i] = payload[i] ^ maskKey[i%4]
+	}
+	return plain
+}
+
+func buildFrameRaw(b0 byte, masked bool, maskKey [4]byte, payload []byte) []byte {
+	var raw bytes.Buffer
+	raw.WriteByte(b0)
+	maskBit := byte(0)
+	if masked {
+		maskBit = wsMaskBit
+	}
+	switch n := len(payload); {
+	case n < 126:
+		raw.WriteByte(maskBit | byte(n))
+	case n <= 0xffff:
+		raw.WriteByte(maskBit | 126)
+		var ext [2]byte
+		binary.BigEndian.PutUint16(ext[:], uint16(n))
+		raw.Write(ext[:])
+	default:
+		raw.WriteByte(maskBit | 127)
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(n))
+		raw.Write(ext[:])
+	}
+	if masked {
+		raw.Write(maskKey[:])
+		for i, b := range payload {
+			raw.WriteByte(b ^ maskKey[i%4])
+		}
+		return raw.Bytes()
+	}
+	raw.Write(payload)
+	return raw.Bytes()
 }
 
 // wsInflater handles permessage-deflate decompression with optional

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestPumpWSRewritesMaskedClientTextPayload(t *testing.T) {
+	placeholder := []byte("DISCORD_PLACEHOLDER")
+	actual := []byte("real.discord.token")
+	originalPayload := []byte(`{"op":2,"d":{"token":"DISCORD_PLACEHOLDER"}}`)
+
+	var src bytes.Buffer
+	src.Write(testWSFrame(0x80|wsOpText, true, [4]byte{1, 2, 3, 4}, originalPayload))
+	src.Write(testWSFrame(0x80|wsOpClose, true, [4]byte{5, 6, 7, 8}, nil))
+
+	var dst bytes.Buffer
+	var observed []byte
+	rewrite := func(payload []byte) ([]byte, bool, error) {
+		if !bytes.Contains(payload, placeholder) {
+			return payload, false, nil
+		}
+		return bytes.ReplaceAll(payload, placeholder, actual), true, nil
+	}
+	if err := pumpWS(bufio.NewReader(&src), &dst, wsParams{}, true, func(payload []byte) {
+		observed = append([]byte(nil), payload...)
+	}, rewrite, nil); err != nil {
+		t.Fatalf("pumpWS: %v", err)
+	}
+
+	raw, _, op, compressed, masked, maskKey, payload, err := readFrameRaw(bufio.NewReader(bytes.NewReader(dst.Bytes())))
+	if err != nil {
+		t.Fatalf("read forwarded frame: %v", err)
+	}
+	if op != wsOpText || compressed || !masked {
+		t.Fatalf("forwarded frame metadata op=%d compressed=%v masked=%v raw=%x", op, compressed, masked, raw)
+	}
+	plain := make([]byte, len(payload))
+	for i := range payload {
+		plain[i] = payload[i] ^ maskKey[i%4]
+	}
+	if bytes.Contains(plain, placeholder) {
+		t.Fatalf("forwarded payload still contains placeholder: %s", plain)
+	}
+	if !bytes.Contains(plain, actual) {
+		t.Fatalf("forwarded payload missing actual token: %s", plain)
+	}
+	if !bytes.Contains(observed, placeholder) || bytes.Contains(observed, actual) {
+		t.Fatalf("observed payload should keep safe placeholder, got: %s", observed)
+	}
+}
+
+func testWSFrame(b0 byte, masked bool, key [4]byte, payload []byte) []byte {
+	var out bytes.Buffer
+	out.WriteByte(b0)
+	maskBit := byte(0)
+	if masked {
+		maskBit = wsMaskBit
+	}
+	switch n := len(payload); {
+	case n < 126:
+		out.WriteByte(maskBit | byte(n))
+	case n <= 0xffff:
+		out.WriteByte(maskBit | 126)
+		var ext [2]byte
+		binary.BigEndian.PutUint16(ext[:], uint16(n))
+		out.Write(ext[:])
+	default:
+		out.WriteByte(maskBit | 127)
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(n))
+		out.Write(ext[:])
+	}
+	if masked {
+		out.Write(key[:])
+		for i, b := range payload {
+			out.WriteByte(b ^ key[i%4])
+		}
+		return out.Bytes()
+	}
+	out.Write(payload)
+	return out.Bytes()
+}


### PR DESCRIPTION
## Summary
- add a native `discord_bot_token` credential that pushes Discord SDK token-shaped placeholders via `DISCORD_TOKEN` and `DISCORD_BOT_TOKEN`
- inject `Authorization: Bot ...` for Discord REST calls and rewrite Discord Gateway WebSocket IDENTIFY text payloads before forwarding upstream
- keep WebSocket frame observers/dashboard samples on the placeholder-bearing payload so real bot tokens are not exposed
- document the new credential type in the config reference

## Test plan
- `go test ./config/plugins/credentials ./ -run 'TestDiscord|TestPumpWS' -count=1 -v`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
