### PR TITLE
config: add OIDC enrollment grammar

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -132,6 +132,7 @@ type Policy struct {
 	Endpoints   map[string]*Entity
 	Rules       map[string]*Entity
 	Tunnels     map[string]*Entity
+	Enrollments map[string]*Entity
 
 	Policies map[string]*PolicyText
 	Profiles map[string]*Profile
@@ -188,14 +189,16 @@ type PolicyText struct {
 // only body attribute; rules ride along automatically because they're
 // attached to endpoints.
 type Profile struct {
-	Name      string   `json:"name"`
-	Endpoints []string `json:"endpoints"`
+	Name               string   `json:"name"`
+	Endpoints          []string `json:"endpoints"`
+	AllowEphemeralOIDC bool     `json:"allow_ephemeral_oidc,omitempty"`
 }
 
 // profileBody is the gohcl decode target for the profile body — the
 // label is read separately from the block.
 type profileBody struct {
-	Endpoints []string `hcl:"endpoints"`
+	Endpoints          []string `hcl:"endpoints"`
+	AllowEphemeralOIDC bool     `hcl:"allow_ephemeral_oidc,optional"`
 }
 
 // Load parses, validates, and resolves the gateway config at path.
@@ -239,6 +242,7 @@ func LoadBytes(src []byte, filename string) (*Gateway, hcl.Diagnostics) {
 		Endpoints:   make(map[string]*Entity),
 		Rules:       make(map[string]*Entity),
 		Tunnels:     make(map[string]*Entity),
+		Enrollments: make(map[string]*Entity),
 		Policies:    make(map[string]*PolicyText),
 		Profiles:    make(map[string]*Profile),
 	}
@@ -258,6 +262,10 @@ func LoadBytes(src []byte, filename string) (*Gateway, hcl.Diagnostics) {
 	configDir := filepath.Dir(filename)
 	resolveDiags := decodePolicyBlocks(gw.Policy, table, evalCtx, configDir)
 	diags = append(diags, resolveDiags...)
+
+	// Post-decode pass: OIDC enrollment uses normalized public_url as
+	// its deployment-specific audience and requires HTTPS.
+	diags = append(diags, validateOIDCEnrollmentsForGateway(gw)...)
 
 	// Post-decode pass: substitute `<<file:NAME>>` markers in plugin
 	// body fields that opted in via FileIncludable. Runs after Build
@@ -362,6 +370,7 @@ func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 			{Type: "approver", LabelNames: []string{"type", "name"}},
 			{Type: "credential", LabelNames: []string{"type", "name"}},
 			{Type: "endpoint", LabelNames: []string{"type", "name"}},
+			{Type: "enrollment", LabelNames: []string{"type", "name"}},
 			{Type: "rule", LabelNames: []string{"name"}},
 			{Type: "policy", LabelNames: []string{"name"}},
 			{Type: "profile", LabelNames: []string{"name"}},
@@ -418,7 +427,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 		if d := gohcl.DecodeBody(sym.Block.Body, evalCtx, &body); d.HasErrors() {
 			diags = append(diags, d...)
 		}
-		pr := &Profile{Name: sym.Name, Endpoints: body.Endpoints}
+		pr := &Profile{Name: sym.Name, Endpoints: body.Endpoints, AllowEphemeralOIDC: body.AllowEphemeralOIDC}
 		// Cross-check: each endpoint name resolves to an endpoint.
 		for _, ep := range pr.Endpoints {
 			if table.Get(KindEndpoint, ep) != nil {
@@ -452,7 +461,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 	// ordering — symbols are populated in pass 1 — but matching decode
 	// order to compile order keeps Order[] stable across the file's
 	// declaration sequence and avoids surprising readers.
-	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule} {
+	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule, KindEnrollment} {
 		for _, sym := range table.byKind[kind] {
 			plugin := Lookup(sym.Kind, sym.Type)
 			if plugin == nil {
@@ -479,7 +488,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 			}
 			refs, refDiags := resolveRefs(target, sym.Name, plugin, table, sym.Block.DefRange)
 			diags = append(diags, refDiags...)
-			ctx := &BuildCtx{Refs: refs, Symbols: table, Block: sym.Block}
+			ctx := &BuildCtx{Refs: refs, Symbols: table, Policy: p, Block: sym.Block}
 			if plugin.Validate != nil {
 				diags = append(diags, plugin.Validate(target, sym.Name, ctx)...)
 			}
@@ -503,6 +512,8 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 				p.Endpoints[sym.Name] = ent
 			case KindRule:
 				p.Rules[sym.Name] = ent
+			case KindEnrollment:
+				p.Enrollments[sym.Name] = ent
 			}
 			p.Order = append(p.Order, sym.Name)
 		}

--- a/config/dump.go
+++ b/config/dump.go
@@ -113,6 +113,9 @@ func dumpPolicy(p *Policy) map[string]any {
 	if v := dumpEntityMap(p.Rules); v != nil {
 		out["rules"] = v
 	}
+	if v := dumpEntityMap(p.Enrollments); v != nil {
+		out["enrollments"] = v
+	}
 	if v := dumpEntityMap(p.Tunnels); v != nil {
 		out["tunnels"] = v
 	}
@@ -170,7 +173,11 @@ func dumpProfiles(m map[string]*Profile) map[string]any {
 	}
 	out := map[string]any{}
 	for name, p := range m {
-		out[name] = map[string]any{"endpoints": p.Endpoints}
+		row := map[string]any{"endpoints": p.Endpoints}
+		if p.AllowEphemeralOIDC {
+			row["allow_ephemeral_oidc"] = true
+		}
+		out[name] = row
 	}
 	return out
 }

--- a/config/emit.go
+++ b/config/emit.go
@@ -41,6 +41,7 @@ func Emit(gw *Gateway) ([]byte, error) {
 	emitGroup(body, p, KindTunnel)
 	emitGroup(body, p, KindEndpoint)
 	emitGroup(body, p, KindRule)
+	emitGroup(body, p, KindEnrollment)
 	emitGroup(body, p, KindProfile)
 
 	return f.Bytes(), nil
@@ -145,6 +146,12 @@ func leftoverNames(p *Policy, kind Kind, emitted map[string]bool) []string {
 				out = append(out, n)
 			}
 		}
+	case KindEnrollment:
+		for n := range p.Enrollments {
+			if !emitted[n] {
+				out = append(out, n)
+			}
+		}
 	case KindTunnel:
 		for n := range p.Tunnels {
 			if !emitted[n] {
@@ -201,6 +208,12 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 			return false
 		}
 		emitEntityBlock(body, "rule", ent, name)
+	case KindEnrollment:
+		ent, ok := p.Enrollments[name]
+		if !ok {
+			return false
+		}
+		emitEntityBlock(body, "enrollment", ent, name)
 	case KindTunnel:
 		ent, ok := p.Tunnels[name]
 		if !ok {
@@ -216,6 +229,9 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 		b := body.AppendNewBlock("profile", []string{name}).Body()
 		if len(pr.Endpoints) > 0 {
 			SetIdentList(b, "endpoints", pr.Endpoints)
+		}
+		if pr.AllowEphemeralOIDC {
+			b.SetAttributeValue("allow_ephemeral_oidc", cty.BoolVal(true))
 		}
 	default:
 		return false

--- a/config/oidc_enrollment.go
+++ b/config/oidc_enrollment.go
@@ -1,0 +1,232 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type OIDCEnrollment struct {
+	Issuer   string         `json:"issuer"`
+	Profile  string         `json:"profile"`
+	TTL      string         `json:"ttl"`
+	MaxTTL   string         `json:"max_ttl"`
+	Match    map[string]any `json:"match"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type oidcEnrollmentBody struct {
+	Issuer   string    `hcl:"issuer"`
+	Profile  string    `hcl:"profile"`
+	TTL      string    `hcl:"ttl"`
+	MaxTTL   string    `hcl:"max_ttl"`
+	Match    cty.Value `hcl:"match"`
+	Metadata cty.Value `hcl:"metadata,optional"`
+}
+
+func init() {
+	Register(&Plugin{
+		Kind:     KindEnrollment,
+		Type:     "oidc",
+		New:      func() any { return new(oidcEnrollmentBody) },
+		Validate: validateOIDCEnrollment,
+		Build:    buildOIDCEnrollment,
+		Emit:     emitOIDCEnrollment,
+	})
+}
+
+func NormalizePublicURLForOIDC(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("public_url is required")
+	}
+	normalized := strings.TrimRight(trimmed, "/")
+	if normalized == "" {
+		return "", fmt.Errorf("public_url is required")
+	}
+	u, err := url.Parse(normalized)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("public_url must be an absolute HTTPS URL")
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("public_url must use https when OIDC enrollment is configured")
+	}
+	return normalized, nil
+}
+
+func validateOIDCEnrollmentsForGateway(gw *Gateway) hcl.Diagnostics {
+	if gw == nil || gw.Policy == nil || len(gw.Policy.Enrollments) == 0 {
+		return nil
+	}
+	normalized, err := NormalizePublicURLForOIDC(gw.PublicURL)
+	if err != nil {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid OIDC enrollment public_url",
+			Detail:   fmt.Sprintf("OIDC enrollment uses public_url as its expected audience: %v.", err),
+		}}
+	}
+	gw.PublicURL = normalized
+	return nil
+}
+
+func validateOIDCEnrollment(decoded any, name string, ctx *BuildCtx) hcl.Diagnostics {
+	body := decoded.(*oidcEnrollmentBody)
+	var diags hcl.Diagnostics
+
+	if body.Issuer == "" {
+		diags = append(diags, oidcDiag(ctx, "Missing OIDC issuer", fmt.Sprintf("enrollment %q requires issuer.", name)))
+	}
+	if strings.TrimSpace(body.Profile) == "" {
+		diags = append(diags, oidcDiag(ctx, "Missing OIDC enrollment profile", fmt.Sprintf("enrollment %q requires profile.", name)))
+	} else {
+		profSym := ctx.Symbols.Get(KindProfile, body.Profile)
+		if profSym == nil {
+			diags = append(diags, oidcDiag(ctx, "Unknown OIDC enrollment profile", fmt.Sprintf("enrollment %q targets profile %q which is not declared.", name, body.Profile)))
+		} else if prof, ok := ctx.Policy.Profiles[body.Profile]; ok && !prof.AllowEphemeralOIDC {
+			diags = append(diags, oidcDiag(ctx, "Profile does not allow OIDC enrollment", fmt.Sprintf("profile %q must set allow_ephemeral_oidc = true before OIDC enrollment can target it.", body.Profile)))
+		}
+	}
+
+	ttl, ttlErr := time.ParseDuration(body.TTL)
+	if body.TTL == "" || ttlErr != nil || ttl <= 0 {
+		diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment ttl", "ttl must be a positive Go duration string such as \"1h\"."))
+	}
+	maxTTL, maxTTLErr := time.ParseDuration(body.MaxTTL)
+	if body.MaxTTL == "" || maxTTLErr != nil || maxTTL <= 0 {
+		diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment max_ttl", "max_ttl must be a positive Go duration string such as \"2h\"."))
+	}
+	if ttlErr == nil && maxTTLErr == nil && ttl > 0 && maxTTL > 0 && ttl > maxTTL {
+		diags = append(diags, oidcDiag(ctx, "OIDC enrollment ttl exceeds max_ttl", "ttl must be less than or equal to max_ttl."))
+	}
+
+	match, err := ctyObjectToScalarMap(body.Match)
+	if err != nil || len(match) == 0 {
+		diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment match", "match must contain at least one scalar or list-of-scalar claim constraint."))
+	}
+	if body.Metadata.IsKnown() && !body.Metadata.IsNull() {
+		if _, err := ctyObjectToScalarMap(body.Metadata); err != nil {
+			diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment metadata", "metadata must be a map of scalar or list-of-scalar values."))
+		}
+	}
+	return diags
+}
+
+func buildOIDCEnrollment(decoded any, _ string, _ *BuildCtx) (any, hcl.Diagnostics) {
+	body := decoded.(*oidcEnrollmentBody)
+	match, err := ctyObjectToScalarMap(body.Match)
+	if err != nil {
+		return nil, hcl.Diagnostics{&hcl.Diagnostic{Severity: hcl.DiagError, Summary: "Invalid OIDC enrollment match", Detail: err.Error()}}
+	}
+	metadata := map[string]any(nil)
+	if body.Metadata.IsKnown() && !body.Metadata.IsNull() {
+		metadata, err = ctyObjectToScalarMap(body.Metadata)
+		if err != nil {
+			return nil, hcl.Diagnostics{&hcl.Diagnostic{Severity: hcl.DiagError, Summary: "Invalid OIDC enrollment metadata", Detail: err.Error()}}
+		}
+	}
+	return &OIDCEnrollment{
+		Issuer:   body.Issuer,
+		Profile:  body.Profile,
+		TTL:      body.TTL,
+		MaxTTL:   body.MaxTTL,
+		Match:    match,
+		Metadata: metadata,
+	}, nil
+}
+
+func emitOIDCEnrollment(body any, _ string, b *hclwrite.Body) {
+	oe := body.(*OIDCEnrollment)
+	b.SetAttributeValue("issuer", cty.StringVal(oe.Issuer))
+	b.SetAttributeValue("profile", cty.StringVal(oe.Profile))
+	b.SetAttributeValue("ttl", cty.StringVal(oe.TTL))
+	b.SetAttributeValue("max_ttl", cty.StringVal(oe.MaxTTL))
+	b.SetAttributeValue("match", mapToCtyObject(oe.Match))
+	if len(oe.Metadata) > 0 {
+		b.SetAttributeValue("metadata", mapToCtyObject(oe.Metadata))
+	}
+}
+
+func oidcDiag(ctx *BuildCtx, summary, detail string) *hcl.Diagnostic {
+	d := &hcl.Diagnostic{Severity: hcl.DiagError, Summary: summary, Detail: detail}
+	if ctx != nil && ctx.Block != nil {
+		d.Subject = &ctx.Block.DefRange
+	}
+	return d
+}
+
+func ctyObjectToScalarMap(v cty.Value) (map[string]any, error) {
+	if !v.IsKnown() || v.IsNull() || !(v.Type().IsObjectType() || v.Type().IsMapType()) {
+		return nil, fmt.Errorf("value must be an object")
+	}
+	out := map[string]any{}
+	it := v.ElementIterator()
+	for it.Next() {
+		k, val := it.Element()
+		converted, err := ctyScalarOrListToAny(val)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", k.AsString(), err)
+		}
+		out[k.AsString()] = converted
+	}
+	return out, nil
+}
+
+func ctyScalarOrListToAny(v cty.Value) (any, error) {
+	if !v.IsKnown() || v.IsNull() {
+		return nil, fmt.Errorf("value must be known and non-null")
+	}
+	if v.Type() == cty.String {
+		return v.AsString(), nil
+	}
+	if v.Type() == cty.Bool {
+		return v.True(), nil
+	}
+	if v.Type().IsListType() || v.Type().IsTupleType() || v.Type().IsSetType() {
+		var out []string
+		it := v.ElementIterator()
+		for it.Next() {
+			_, elem := it.Element()
+			if elem.Type() != cty.String {
+				return nil, fmt.Errorf("list values must be strings")
+			}
+			out = append(out, elem.AsString())
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("value must be a string, bool, or list of strings")
+}
+
+func mapToCtyObject(m map[string]any) cty.Value {
+	vals := make(map[string]cty.Value, len(m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case string:
+			vals[k] = cty.StringVal(v)
+		case bool:
+			vals[k] = cty.BoolVal(v)
+		case []string:
+			vals[k] = StringListVal(v)
+		case []any:
+			strings := make([]string, 0, len(v))
+			for _, elem := range v {
+				strings = append(strings, fmt.Sprint(elem))
+			}
+			vals[k] = StringListVal(strings)
+		default:
+			vals[k] = cty.StringVal(fmt.Sprint(v))
+		}
+	}
+	return cty.ObjectVal(vals)
+}

--- a/config/oidc_enrollment_test.go
+++ b/config/oidc_enrollment_test.go
@@ -1,0 +1,40 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestNormalizePublicURLForOIDC(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "trims trailing slashes", in: "https://clawpatrol.example.com///", want: "https://clawpatrol.example.com"},
+		{name: "keeps path", in: "https://example.com/clawpatrol/", want: "https://example.com/clawpatrol"},
+		{name: "rejects empty", in: "", wantErr: true},
+		{name: "rejects http", in: "http://clawpatrol.example.com", wantErr: true},
+		{name: "rejects missing scheme", in: "clawpatrol.example.com", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := config.NormalizePublicURLForOIDC(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizePublicURLForOIDC(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -34,13 +34,14 @@ const (
 	KindPolicy     Kind = "policy"
 	KindProfile    Kind = "profile"
 	KindTunnel     Kind = "tunnel"
+	KindEnrollment Kind = "enrollment"
 )
 
 // LabelCount returns how many labels a block of this kind carries
 // (excluding the kind keyword itself).
 func (k Kind) LabelCount() int {
 	switch k {
-	case KindEndpoint, KindCredential, KindApprover, KindTunnel:
+	case KindEndpoint, KindCredential, KindApprover, KindTunnel, KindEnrollment:
 		return 2 // first = type, second = name
 	case KindRule, KindPolicy, KindProfile:
 		return 1 // name
@@ -118,6 +119,7 @@ type Plugin struct {
 type BuildCtx struct {
 	Refs    *Refs
 	Symbols *SymbolTable
+	Policy  *Policy
 	Block   *hcl.Block // for diagnostic ranges when nothing more precise is available
 }
 

--- a/config/symbols.go
+++ b/config/symbols.go
@@ -101,6 +101,7 @@ var blockKinds = map[string]Kind{
 	"policy":     KindPolicy,
 	"profile":    KindProfile,
 	"tunnel":     KindTunnel,
+	"enrollment": KindEnrollment,
 }
 
 // buildSymbols is pass 1. It walks the parsed file's policy blocks,

--- a/config/testdata/error_oidc_empty_match.errors.txt
+++ b/config/testdata/error_oidc_empty_match.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_empty_match.hcl:8:1: Invalid OIDC enrollment match — match must contain at least one scalar or list-of-scalar claim constraint.

--- a/config/testdata/error_oidc_empty_match.hcl
+++ b/config/testdata/error_oidc_empty_match.hcl
@@ -1,0 +1,14 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = {}
+}

--- a/config/testdata/error_oidc_invalid_ttl.errors.txt
+++ b/config/testdata/error_oidc_invalid_ttl.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_invalid_ttl.hcl:8:1: Invalid OIDC enrollment ttl — ttl must be a positive Go duration string such as "1h".

--- a/config/testdata/error_oidc_invalid_ttl.hcl
+++ b/config/testdata/error_oidc_invalid_ttl.hcl
@@ -1,0 +1,14 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "0"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/config/testdata/error_oidc_missing_public_url.errors.txt
+++ b/config/testdata/error_oidc_missing_public_url.errors.txt
@@ -1,0 +1,1 @@
+error: Invalid OIDC enrollment public_url — OIDC enrollment uses public_url as its expected audience: public_url is required.

--- a/config/testdata/error_oidc_missing_public_url.hcl
+++ b/config/testdata/error_oidc_missing_public_url.hcl
@@ -1,0 +1,12 @@
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/config/testdata/error_oidc_non_https_public_url.errors.txt
+++ b/config/testdata/error_oidc_non_https_public_url.errors.txt
@@ -1,0 +1,1 @@
+error: Invalid OIDC enrollment public_url — OIDC enrollment uses public_url as its expected audience: public_url must use https when OIDC enrollment is configured.

--- a/config/testdata/error_oidc_non_https_public_url.hcl
+++ b/config/testdata/error_oidc_non_https_public_url.hcl
@@ -1,0 +1,14 @@
+public_url = "http://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/config/testdata/error_oidc_profile_not_opted_in.errors.txt
+++ b/config/testdata/error_oidc_profile_not_opted_in.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_profile_not_opted_in.hcl:7:1: Profile does not allow OIDC enrollment — profile "ci" must set allow_ephemeral_oidc = true before OIDC enrollment can target it.

--- a/config/testdata/error_oidc_profile_not_opted_in.hcl
+++ b/config/testdata/error_oidc_profile_not_opted_in.hcl
@@ -1,0 +1,13 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/config/testdata/error_oidc_ttl_exceeds_max_ttl.errors.txt
+++ b/config/testdata/error_oidc_ttl_exceeds_max_ttl.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_ttl_exceeds_max_ttl.hcl:8:1: OIDC enrollment ttl exceeds max_ttl — ttl must be less than or equal to max_ttl.

--- a/config/testdata/error_oidc_ttl_exceeds_max_ttl.hcl
+++ b/config/testdata/error_oidc_ttl_exceeds_max_ttl.hcl
@@ -1,0 +1,14 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "3h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/config/testdata/error_oidc_unknown_profile.errors.txt
+++ b/config/testdata/error_oidc_unknown_profile.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_unknown_profile.hcl:3:1: Unknown OIDC enrollment profile — enrollment "ci" targets profile "missing" which is not declared.

--- a/config/testdata/error_oidc_unknown_profile.hcl
+++ b/config/testdata/error_oidc_unknown_profile.hcl
@@ -1,0 +1,9 @@
+public_url = "https://clawpatrol.example.com"
+
+enrollment "oidc" "ci" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "missing"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/config/testdata/error_oidc_unsupported_method.errors.txt
+++ b/config/testdata/error_oidc_unsupported_method.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_unsupported_method.hcl:3:12: Unknown enrollment type "saml" — Known enrollment types: [oidc].

--- a/config/testdata/error_oidc_unsupported_method.hcl
+++ b/config/testdata/error_oidc_unsupported_method.hcl
@@ -1,0 +1,5 @@
+public_url = "https://clawpatrol.example.com"
+
+enrollment "saml" "ci" {
+  profile = "ci"
+}

--- a/config/testdata/feature_oidc_enrollment.hcl
+++ b/config/testdata/feature_oidc_enrollment.hcl
@@ -1,0 +1,37 @@
+listen     = "0.0.0.0:8443"
+ca_dir     = "/opt/clawpatrol/ca"
+public_url = "https://clawpatrol.example.com/"
+
+credential "bearer_token" "github-pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = github-pat
+}
+
+profile "ci-readonly" {
+  endpoints             = [github]
+  allow_ephemeral_oidc  = true
+}
+
+enrollment "oidc" "github-main-ci" {
+  issuer = "https://token.actions.githubusercontent.com"
+
+  profile = "ci-readonly"
+  ttl     = "1h"
+  max_ttl = "2h"
+
+  match = {
+    repository_owner_id = "12345678"
+    repository_id       = "987654321"
+    workflow_ref        = "example-org/example-repo/.github/workflows/ci.yml@refs/heads/main"
+    ref                 = "refs/heads/main"
+    ref_type            = "branch"
+    event_name          = ["push", "workflow_dispatch"]
+  }
+
+  metadata = {
+    provider = "github_actions"
+    label    = "github-main-ci"
+  }
+}

--- a/config/testdata/feature_oidc_enrollment.want.json
+++ b/config/testdata/feature_oidc_enrollment.want.json
@@ -1,0 +1,61 @@
+{
+  "ca_dir": "/opt/clawpatrol/ca",
+  "listen": "0.0.0.0:8443",
+  "policy": {
+    "credentials": {
+      "github-pat": {
+        "body": {
+          "IdempotencyKey": false
+        },
+        "type": "bearer_token"
+      }
+    },
+    "endpoints": {
+      "github": {
+        "body": {
+          "Hosts": [
+            "api.github.com"
+          ],
+          "Credential": "github-pat"
+        },
+        "family": "https",
+        "type": "https"
+      }
+    },
+    "enrollments": {
+      "github-main-ci": {
+        "body": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "profile": "ci-readonly",
+          "ttl": "1h",
+          "max_ttl": "2h",
+          "match": {
+            "event_name": [
+              "push",
+              "workflow_dispatch"
+            ],
+            "ref": "refs/heads/main",
+            "ref_type": "branch",
+            "repository_id": "987654321",
+            "repository_owner_id": "12345678",
+            "workflow_ref": "example-org/example-repo/.github/workflows/ci.yml@refs/heads/main"
+          },
+          "metadata": {
+            "label": "github-main-ci",
+            "provider": "github_actions"
+          }
+        },
+        "type": "oidc"
+      }
+    },
+    "profiles": {
+      "ci-readonly": {
+        "allow_ephemeral_oidc": true,
+        "endpoints": [
+          "github"
+        ]
+      }
+    }
+  },
+  "public_url": "https://clawpatrol.example.com"
+}


### PR DESCRIPTION
## Summary

- Add the config/HCL slice for OIDC ephemeral enrollment via `enrollment "oidc" "<name>"` blocks.
- Add explicit `profile.allow_ephemeral_oidc` opt-in before an enrollment can target a profile.
- Require and normalize top-level `public_url` when OIDC enrollment is configured, using it as the deployment-specific audience and rejecting non-HTTPS values.
- Round-trip OIDC enrollment/profile opt-in through load, dump, and emit, with focused success/error fixtures.

## Scope

This intentionally stops at config grammar and validation. JWT verification, replay/lease storage, WireGuard provisioning, the public onboard endpoint, CLI flags, and runtime claim matching remain follow-up slices.

## Test plan

- [x] `go test ./config -run 'TestLoad/(feature_oidc_enrollment|error_oidc_)|TestNormalizePublicURLForOIDC'`
- [x] `go test ./config/...`
- [x] `(cd www && npm run build)`
- [x] `go test ./...`
- [x] `go run ./tools/docgen --check`
- [x] `git diff --check`
