### PR TITLE
fix: normalize matcher want-values to lowercase for case-insensitive paths

### DIFF
--- a/config/match/cel.go
+++ b/config/match/cel.go
@@ -2,9 +2,11 @@ package match
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 )
 
@@ -21,13 +23,32 @@ type ActivationBuilder func(req *Request) map[string]any
 //
 // The compiled expression must produce a bool — anything else is an
 // error at compile time, mirroring the old per-key shape checks.
-func CompileCondition(env *cel.Env, condition string, buildAct ActivationBuilder) (Matcher, error) {
+//
+// lowercasedPaths names the dotted identifier paths (e.g.
+// "http.method", "sql.verb") whose got-values the facet guarantees to
+// be lowercase at activation time. CompileCondition walks the AST and
+// lowercases every string literal that's compared against one of
+// these paths via ==, !=, in, startsWith, endsWith, or contains. The
+// normalization happens once at compile time, so case-insensitive
+// rule sources like `http.method == "POST"` keep working without any
+// per-match cost.
+//
+// Paths must be of the form "<var>.<field>" — single-level selection
+// off a top-level identifier. That's all the facets need today.
+func CompileCondition(env *cel.Env, condition string, buildAct ActivationBuilder, lowercasedPaths []string) (Matcher, error) {
 	ast, issues := env.Compile(condition)
 	if issues != nil && issues.Err() != nil {
 		return nil, fmt.Errorf("cel compile: %w", issues.Err())
 	}
 	if ast.OutputType() != cel.BoolType {
 		return nil, fmt.Errorf("cel condition must yield bool, got %s", ast.OutputType())
+	}
+	if len(lowercasedPaths) > 0 {
+		paths, err := parseLowercasedPaths(lowercasedPaths)
+		if err != nil {
+			return nil, err
+		}
+		normalizeWantLiterals(ast.NativeRep().Expr(), paths)
 	}
 	prog, err := env.Program(ast)
 	if err != nil {
@@ -136,4 +157,158 @@ func collectReferencedVars(e celast.Expr) map[string]bool {
 	}
 	walk(e)
 	return refs
+}
+
+// lowercasedPath is the parsed form of a "<var>.<field>" entry in the
+// lowercasedPaths argument to CompileCondition.
+type lowercasedPath struct {
+	ident string
+	field string
+}
+
+func parseLowercasedPaths(paths []string) ([]lowercasedPath, error) {
+	out := make([]lowercasedPath, 0, len(paths))
+	for _, p := range paths {
+		ident, field, ok := strings.Cut(p, ".")
+		if !ok || ident == "" || field == "" || strings.Contains(field, ".") {
+			return nil, fmt.Errorf("lowercased path %q must be of the form \"<var>.<field>\"", p)
+		}
+		out = append(out, lowercasedPath{ident: ident, field: field})
+	}
+	return out, nil
+}
+
+// normalizeWantLiterals walks the AST and lowercases string literals
+// compared against any of the declared lowercase paths. The mutation
+// happens in place via SetKindCase, which preserves node IDs (and
+// therefore the type-check metadata cel.Program relies on).
+//
+// Recognised shapes — for each, the literal is normalized:
+//
+//	<path> == "X"           // and the symmetric "X" == <path>
+//	<path> != "X"           // and the symmetric "X" != <path>
+//	<path> in ["X", "Y"]    // every string literal in the list
+//	<path>.startsWith("X")  // member-call args
+//	<path>.endsWith("X")
+//	<path>.contains("X")
+//
+// matches() is deliberately not normalized — its argument is a regex,
+// where case classes like `[A-Z]` are meaningful and the operator can
+// opt into case-insensitivity with `(?i)`.
+func normalizeWantLiterals(root celast.Expr, paths []lowercasedPath) {
+	if root == nil || len(paths) == 0 {
+		return
+	}
+	var walk func(celast.Expr)
+	walk = func(n celast.Expr) {
+		if n == nil {
+			return
+		}
+		if n.Kind() == celast.CallKind {
+			c := n.AsCall()
+			switch c.FunctionName() {
+			case operators.Equals, operators.NotEquals:
+				args := c.Args()
+				if len(args) == 2 {
+					if matchesPath(args[0], paths) {
+						lowercaseStringLiteral(args[1])
+					} else if matchesPath(args[1], paths) {
+						lowercaseStringLiteral(args[0])
+					}
+				}
+			case operators.In:
+				args := c.Args()
+				if len(args) == 2 && matchesPath(args[0], paths) && args[1].Kind() == celast.ListKind {
+					for _, el := range args[1].AsList().Elements() {
+						lowercaseStringLiteral(el)
+					}
+				}
+			case "startsWith", "endsWith", "contains":
+				if c.IsMemberFunction() && matchesPath(c.Target(), paths) {
+					for _, a := range c.Args() {
+						lowercaseStringLiteral(a)
+					}
+				}
+			}
+		}
+		// Recurse so we hit comparisons composed under && / || / ?: /
+		// inside list literals, comprehensions, etc.
+		switch n.Kind() {
+		case celast.CallKind:
+			c := n.AsCall()
+			if c.Target() != nil {
+				walk(c.Target())
+			}
+			for _, a := range c.Args() {
+				walk(a)
+			}
+		case celast.SelectKind:
+			walk(n.AsSelect().Operand())
+		case celast.ListKind:
+			for _, el := range n.AsList().Elements() {
+				walk(el)
+			}
+		case celast.MapKind:
+			for _, en := range n.AsMap().Entries() {
+				me := en.AsMapEntry()
+				walk(me.Key())
+				walk(me.Value())
+			}
+		case celast.StructKind:
+			for _, f := range n.AsStruct().Fields() {
+				walk(f.AsStructField().Value())
+			}
+		case celast.ComprehensionKind:
+			cm := n.AsComprehension()
+			walk(cm.IterRange())
+			walk(cm.AccuInit())
+			walk(cm.LoopCondition())
+			walk(cm.LoopStep())
+			walk(cm.Result())
+		}
+	}
+	walk(root)
+}
+
+// matchesPath reports whether e is a single-level Select expression
+// off a top-level Ident whose (ident, field) matches any of paths.
+func matchesPath(e celast.Expr, paths []lowercasedPath) bool {
+	if e == nil || e.Kind() != celast.SelectKind {
+		return false
+	}
+	sel := e.AsSelect()
+	op := sel.Operand()
+	if op == nil || op.Kind() != celast.IdentKind {
+		return false
+	}
+	ident := op.AsIdent()
+	field := sel.FieldName()
+	for _, p := range paths {
+		if p.ident == ident && p.field == field {
+			return true
+		}
+	}
+	return false
+}
+
+// lowercaseStringLiteral rewrites e in place into a lowercased string
+// literal when it currently is a string literal. Non-string literals
+// and non-literals are left alone — a rule that compares a lowercase
+// field to a dynamic value (e.g. a header lookup) has no static
+// want-value to normalize at compile time.
+func lowercaseStringLiteral(e celast.Expr) {
+	if e == nil || e.Kind() != celast.LiteralKind {
+		return
+	}
+	v := e.AsLiteral()
+	s, ok := v.(types.String)
+	if !ok {
+		return
+	}
+	lower := strings.ToLower(string(s))
+	if lower == string(s) {
+		return
+	}
+	fac := celast.NewExprFactory()
+	e.SetKindCase(fac.NewLiteral(e.ID(), types.String(lower)))
 }

--- a/config/plugins/facets/https/https.go
+++ b/config/plugins/facets/https/https.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
@@ -113,21 +114,31 @@ func init() {
 	facet.Register(Facet{})
 }
 
+// lowercasedPaths declares the HTTPS fields whose activation values
+// are always lowercase. CompileCondition uses this to normalize the
+// matching string literals in the rule source at compile time, so
+// `http.method == "POST"` matches a POST request even though the
+// activation reports `method = "post"`.
+var lowercasedPaths = []string{"http.method"}
+
 // NewMatcher compiles a CEL condition into a Matcher. An empty
 // condition is the catch-all match-everything case.
 func (Facet) NewMatcher(condition string) (match.Matcher, error) {
 	if condition == "" {
 		return match.PassThrough{}, nil
 	}
-	return match.CompileCondition(celEnv, condition, buildActivation)
+	return match.CompileCondition(celEnv, condition, buildActivation, lowercasedPaths)
 }
 
 func buildActivation(req *match.Request) map[string]any {
 	if req == nil {
 		return nil
 	}
+	// HTTP method is lowercased here (and declared in lowercasedPaths)
+	// so rules can write either "POST" or "post" — CompileCondition
+	// normalizes the want-side literals to lowercase at rule-load time.
 	f := &HttpsFields{
-		Method:  req.Method,
+		Method:  strings.ToLower(req.Method),
 		Path:    match.PathOf(req.URL),
 		Headers: mapToCEL(req.Headers),
 		Body:    string(req.Body),

--- a/config/plugins/facets/https/https_test.go
+++ b/config/plugins/facets/https/https_test.go
@@ -93,6 +93,52 @@ func TestHTTPMatcherMethodAndPath(t *testing.T) {
 	}
 }
 
+// TestHTTPMatcherMethodCaseInsensitive locks in that the matcher
+// normalizes the want-side string literal of a method comparison to
+// lowercase at rule-load time. Without that normalization a rule
+// written as `http.method == "POST"` would silently never match,
+// because the activation always reports `method = "post"`.
+func TestHTTPMatcherMethodCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		method    string
+		want      bool
+	}{
+		{"uppercase want, uppercase got", `http.method == 'POST'`, "POST", true},
+		{"uppercase want, lowercase got", `http.method == 'POST'`, "post", true},
+		{"lowercase want, uppercase got", `http.method == 'post'`, "POST", true},
+		{"mixed-case want, uppercase got", `http.method == 'Post'`, "POST", true},
+		{"!= uppercase, GET got",
+			`http.method != 'POST'`, "GET", true},
+		{"!= uppercase, POST got",
+			`http.method != 'POST'`, "POST", false},
+		{"in uppercase list, lowercase got",
+			`http.method in ['GET', 'POST']`, "post", true},
+		{"in uppercase list, miss",
+			`http.method in ['GET', 'POST']`, "PUT", false},
+		{"in mixed-case list",
+			`http.method in ['Get', 'Post', 'put']`, "POST", true},
+		{"startsWith uppercase",
+			`http.method.startsWith('PO')`, "POST", true},
+		{"endsWith uppercase",
+			`http.method.endsWith('ST')`, "POST", true},
+		{"reversed equality (literal LHS)",
+			`'POST' == http.method`, "POST", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("https", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			if got := m.Match(httpReq(tc.method, "/x")); got != tc.want {
+				t.Errorf("Match=%v want %v (condition=%q method=%q)", got, tc.want, tc.condition, tc.method)
+			}
+		})
+	}
+}
+
 func TestHTTPMatcherBodyJSON(t *testing.T) {
 	m, err := facet.NewMatcher("https", "http.method == 'PATCH' && http.body_json.archived == true")
 	if err != nil {

--- a/config/plugins/facets/k8s/k8s.go
+++ b/config/plugins/facets/k8s/k8s.go
@@ -131,13 +131,20 @@ func init() {
 	facet.Register(Facet{})
 }
 
+// lowercasedPaths declares the k8s fields whose activation values
+// are always lowercase. CompileCondition uses this to normalize the
+// matching string literals in the rule source at compile time, so
+// `k8s.verb == "GET"` matches a get request even though the
+// activation reports `verb = "get"`.
+var lowercasedPaths = []string{"k8s.verb"}
+
 // NewMatcher compiles a CEL condition into a Matcher. An empty
 // condition is the catch-all match-everything case.
 func (Facet) NewMatcher(condition string) (match.Matcher, error) {
 	if condition == "" {
 		return match.PassThrough{}, nil
 	}
-	return match.CompileCondition(celEnv, condition, buildActivation)
+	return match.CompileCondition(celEnv, condition, buildActivation, lowercasedPaths)
 }
 
 func buildActivation(req *match.Request) map[string]any {

--- a/config/plugins/facets/k8s/k8s_match_test.go
+++ b/config/plugins/facets/k8s/k8s_match_test.go
@@ -8,6 +8,38 @@ import (
 	k8sfacet "github.com/denoland/clawpatrol/config/plugins/facets/k8s"
 )
 
+// TestK8sMatcherVerbCaseInsensitive locks in that a rule written as
+// `k8s.verb == "GET"` matches a list/get request even though the
+// activation normalizes the got value to lowercase. CompileCondition
+// lowercases the want-side string literals at rule-load time.
+func TestK8sMatcherVerbCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		verb      string
+		want      bool
+	}{
+		{"uppercase want, get got", "k8s.verb == 'GET'", "get", true},
+		{"mixed-case want, get got", "k8s.verb == 'Get'", "get", true},
+		{"uppercase list, watch got",
+			"k8s.verb in ['WATCH', 'LIST']", "watch", true},
+		{"uppercase list, create got",
+			"k8s.verb in ['WATCH', 'LIST']", "create", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("k8s", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{Family: "k8s", Meta: &k8sfacet.Meta{Verb: tc.verb}}
+			if got := m.Match(req); got != tc.want {
+				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			}
+		})
+	}
+}
+
 func TestK8sMatcherNegationAndGlobs(t *testing.T) {
 	m, err := facet.NewMatcher("k8s",
 		"k8s.verb in ['create', 'update', 'patch', 'delete'] && !k8s.name.startsWith('debug-') "+

--- a/config/plugins/facets/sql/sql.go
+++ b/config/plugins/facets/sql/sql.go
@@ -122,13 +122,20 @@ func init() {
 	facet.Register(Facet{})
 }
 
+// lowercasedPaths declares the SQL fields whose activation values
+// are always lowercase. CompileCondition uses this to normalize the
+// matching string literals in the rule source at compile time, so
+// `sql.verb == "SELECT"` matches a select statement even though the
+// activation reports `verb = "select"`.
+var lowercasedPaths = []string{"sql.verb"}
+
 // NewMatcher compiles a CEL condition into a Matcher. An empty
 // condition is the catch-all match-everything case.
 func (Facet) NewMatcher(condition string) (match.Matcher, error) {
 	if condition == "" {
 		return match.PassThrough{}, nil
 	}
-	return match.CompileCondition(celEnv, condition, buildActivation)
+	return match.CompileCondition(celEnv, condition, buildActivation, lowercasedPaths)
 }
 
 func buildActivation(req *match.Request) map[string]any {

--- a/config/plugins/facets/sql/sql_match_test.go
+++ b/config/plugins/facets/sql/sql_match_test.go
@@ -27,6 +27,36 @@ func TestSQLMatcherVerbAndTables(t *testing.T) {
 	}
 }
 
+// TestSQLMatcherVerbCaseInsensitive locks in that a rule written as
+// `sql.verb == "SELECT"` matches a select statement even though the
+// activation normalizes the got value to lowercase. CompileCondition
+// lowercases the want-side string literals at rule-load time.
+func TestSQLMatcherVerbCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		want      bool
+	}{
+		{"uppercase want", "sql.verb == 'SELECT'", true},
+		{"mixed-case want", "sql.verb == 'Select'", true},
+		{"lowercase want (already)", "sql.verb == 'select'", true},
+		{"upper-case list", "sql.verb in ['SELECT', 'INSERT']", true},
+		{"miss after normalization", "sql.verb == 'UPDATE'", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("sql", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{Family: "sql", Meta: &sqlfacet.Meta{Verb: "select"}}
+			if got := m.Match(req); got != tc.want {
+				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			}
+		})
+	}
+}
+
 func TestSQLMatcherStatementRegex(t *testing.T) {
 	m, err := facet.NewMatcher("sql", `sql.verb == 'select' && sql.statement.matches('(?i)\\b(secret|password|token)\\b')`)
 	if err != nil {


### PR DESCRIPTION
Matcher `got` values for HTTP method, SQL verb, and k8s verb are always lowercased at the facet layer, but the matcher did a case-sensitive comparison against user-supplied `want` values. A rule like `method = "POST"` would silently never match because the got value is `post`.

## Changes

- `config/match/cel.go`: `CompileCondition` now accepts a `lowercasedPaths []string`. Walks the CEL AST once at rule-load time and lowercases string literals compared against those paths via `==`, `!=`, `in`, `startsWith`, `endsWith`, `contains`. The `matches()` operator is intentionally excluded (it takes a regex).
- `config/plugins/facets/https/https.go`: declares `lowercasedPaths = []string{"http.method"}`, lowercases `req.Method` in the activation.
- `config/plugins/facets/sql/sql.go`: declares `lowercasedPaths = []string{"sql.verb"}`.
- `config/plugins/facets/k8s/k8s.go`: declares `lowercasedPaths = []string{"k8s.verb"}`.

Tests in all three facets cover `==`, `!=`, `in`, `startsWith`/`endsWith`, the reversed `'X' == path` shape, and miss-after-normalization cases.

Closes example/orchestrator#17