### PR TITLE
feat: structured plugin diagnostic log tab in dashboard

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,12 @@ type Gateway struct {
 	// and DO_NOT_TRACK=1 also work.
 	Telemetry *bool `hcl:"telemetry,optional"`
 
+	// PluginLogBufferSize caps the dashboard /logs tab's in-memory
+	// ring buffer. Default 1000 entries; raise on busy gateways
+	// whose operators want longer scrollback when debugging a
+	// chatty plugin. 0 keeps the default.
+	PluginLogBufferSize int `hcl:"plugin_log_buffer_size,optional"`
+
 	// SessionKeep is the hard retention floor for the sessions table.
 	// Sessions whose last_at is older than this get deleted by the
 	// background sweeper. Sessions can revive on new activity at any

--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -12,7 +12,6 @@ package approvers
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
@@ -62,6 +61,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 	id, ch := req.Pool.Add(pending)
 	defer req.Pool.Discard(id)
 
+	plg := runtime.LoggerFrom(ctx)
 	if h.Channel != "" && h.Credential != "" && req.Policy != nil {
 		ent, ok := req.Policy.Credentials[h.Credential]
 		if ok {
@@ -76,14 +76,24 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {
-						log.Printf("human approver %s: notify: %v", req.ApproverName, err)
+						runtime.Warn(plg, "notify failed", map[string]any{
+							"approver":   req.ApproverName,
+							"credential": h.Credential,
+							"err":        err.Error(),
+						})
 					}
 				}()
 			} else {
-				log.Printf("human approver %s: credential %q does not implement HITLNotifier", req.ApproverName, h.Credential)
+				runtime.Warn(plg, "credential lacks notifier", map[string]any{
+					"approver":   req.ApproverName,
+					"credential": h.Credential,
+				})
 			}
 		} else {
-			log.Printf("human approver %s: credential %q not declared", req.ApproverName, h.Credential)
+			runtime.Warn(plg, "credential not declared", map[string]any{
+				"approver":   req.ApproverName,
+				"credential": h.Credential,
+			})
 		}
 	}
 

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -40,7 +40,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"regexp"
 	"strconv"
@@ -440,7 +439,10 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 						verdict, reason := pgEvaluate(ch, sql, credName)
 						if verdict == "deny" {
 							pgWriteDeny(ch.Conn, reason)
-							log.Printf("pg-deny %s: %s", ch.PeerIP, reason)
+							runtime.Info(ch.Logger, "query denied", map[string]any{
+								"peer_ip": ch.PeerIP,
+								"reason":  reason,
+							})
 							continue
 						}
 					}
@@ -539,7 +541,10 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName s
 		emit(ch, runtime.ConnEvent{
 			Action: "deny", Reason: reason, Summary: summary, Facets: facets,
 		})
-		log.Printf("pg-deny-truncated %s: %s", ch.PeerIP, reason)
+		runtime.Info(ch.Logger, "query denied (inspection buffer overflow)", map[string]any{
+			"peer_ip": ch.PeerIP,
+			"reason":  reason,
+		})
 		return rest, true
 	}
 

--- a/config/runtime/logger.go
+++ b/config/runtime/logger.go
@@ -1,0 +1,163 @@
+package runtime
+
+import (
+	"context"
+	"time"
+)
+
+// LogLevel names a plugin diagnostic severity. Strings instead of an
+// int enum so the dashboard can filter by query-param value directly
+// and so JSON consumers don't need a translation table.
+type LogLevel string
+
+// Plugin diagnostic severities. Order matters for "min level"
+// filtering: debug < info < warn < error.
+const (
+	LogDebug LogLevel = "debug"
+	LogInfo  LogLevel = "info"
+	LogWarn  LogLevel = "warn"
+	LogError LogLevel = "error"
+)
+
+// Logger is the structured-diagnostic contract the gateway hands to
+// plugins at request-handling time. Plugins call Log (or the package
+// helpers Debug / Info / Warn / Error) instead of writing to stderr;
+// the gateway buffers the events and surfaces them in the dashboard's
+// /logs tab.
+//
+// Implementations must be safe for concurrent use — a single Logger
+// is reused across goroutines (ConnEndpointRuntime spawns reader +
+// writer pumps that both log against the same instance).
+//
+// Plugin authors do not implement Logger; they receive an instance
+// from the host (via ConnHandle.Logger or LoggerFrom(ctx) for HTTP
+// credential injection paths) and call its methods. fields must
+// never carry credential bytes or other secret material — credential
+// names/refs are fine.
+type Logger interface {
+	Log(level LogLevel, msg string, fields map[string]any)
+}
+
+// LogEntry is the on-wire shape of a buffered plugin diagnostic. The
+// dashboard renders these directly; the SSE stream ships them as
+// JSON. Plugins do not construct LogEntry values themselves — they
+// invoke Logger methods and the gateway fills in Plugin / Ts.
+type LogEntry struct {
+	// Ts is when the gateway captured the event (UTC wall clock).
+	Ts time.Time `json:"ts"`
+	// Plugin is the registered plugin identifier — the (Kind, Type)
+	// pair flattened as "credential/bearer_token",
+	// "endpoint/postgres", etc. "gateway" for host-side log calls
+	// that aren't attributable to a plugin.
+	Plugin string `json:"plugin"`
+	// Level is debug/info/warn/error.
+	Level LogLevel `json:"level"`
+	// Msg is the human-readable message body.
+	Msg string `json:"msg"`
+	// ReqID, when set, correlates the log entry to a request shown
+	// on the live-requests page (UUIDv7 action_id). Empty for
+	// session-scoped or startup-time events.
+	ReqID string `json:"req_id,omitempty"`
+	// AgentIP, when set, identifies the originating peer; the
+	// dashboard uses it to scope the log tail to one device.
+	AgentIP string `json:"agent_ip,omitempty"`
+	// Fields carries arbitrary structured context. Plugins log
+	// credential names/refs only — never secret bytes.
+	Fields map[string]any `json:"fields,omitempty"`
+}
+
+// LevelAtLeast returns true when level is at or above min. Used by
+// the dashboard's "min severity" filter on /api/logs.
+func LevelAtLeast(level, min LogLevel) bool {
+	return levelRank(level) >= levelRank(min)
+}
+
+func levelRank(l LogLevel) int {
+	switch l {
+	case LogDebug:
+		return 0
+	case LogInfo:
+		return 1
+	case LogWarn:
+		return 2
+	case LogError:
+		return 3
+	}
+	// Unknown level — treat as info so callers don't silently drop
+	// it under the typical default min=info filter.
+	return 1
+}
+
+// loggerCtxKey is the context value used by LoggerFrom / WithLogger.
+// Plugins that handle one request at a time (HTTPCredentialRuntime
+// Inject*, HTTPSyntheticResponder RespondHTTP, ApproverRuntime
+// Approve) read the per-request logger out of the context handed to
+// them; the host installs the logger before dispatch.
+type loggerCtxKey struct{}
+
+// WithLogger returns a copy of ctx that carries lg. Host code calls
+// this once per request before dispatching into plugin runtime hooks.
+// Nil lg is a no-op (returns ctx unchanged) so callers don't need to
+// branch.
+func WithLogger(ctx context.Context, lg Logger) context.Context {
+	if lg == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, loggerCtxKey{}, lg)
+}
+
+// LoggerFrom returns the plugin logger attached to ctx by WithLogger,
+// or a no-op logger when none is set. Plugins always get a usable
+// Logger — they never need to nil-check.
+func LoggerFrom(ctx context.Context) Logger {
+	if ctx == nil {
+		return nopLogger{}
+	}
+	if lg, ok := ctx.Value(loggerCtxKey{}).(Logger); ok && lg != nil {
+		return lg
+	}
+	return nopLogger{}
+}
+
+// Debug / Info / Warn / Error are convenience wrappers so plugin
+// call sites read naturally:
+//
+//	runtime.Info(lg, "inject ok", map[string]any{"cred": name})
+//
+// rather than every caller spelling out lg.Log(runtime.LogInfo, ...).
+// Nil-safe: a nil Logger discards.
+func Debug(lg Logger, msg string, fields map[string]any) {
+	if lg != nil {
+		lg.Log(LogDebug, msg, fields)
+	}
+}
+
+// Info records an informational diagnostic.
+func Info(lg Logger, msg string, fields map[string]any) {
+	if lg != nil {
+		lg.Log(LogInfo, msg, fields)
+	}
+}
+
+// Warn records a warning diagnostic.
+func Warn(lg Logger, msg string, fields map[string]any) {
+	if lg != nil {
+		lg.Log(LogWarn, msg, fields)
+	}
+}
+
+// Error records an error diagnostic.
+func Error(lg Logger, msg string, fields map[string]any) {
+	if lg != nil {
+		lg.Log(LogError, msg, fields)
+	}
+}
+
+type nopLogger struct{}
+
+func (nopLogger) Log(LogLevel, string, map[string]any) {}
+
+// NopLogger returns a Logger that discards every entry. Useful for
+// tests that exercise plugin runtimes without standing up the
+// gateway's log sink.
+func NopLogger() Logger { return nopLogger{} }

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -178,6 +178,14 @@ type ConnHandle struct {
 	// SNI the client sent. nil when the dispatcher can't mint
 	// (gateway has no CA).
 	MintCert func(host string) (*tls.Certificate, error)
+	// Logger is the structured-diagnostic sink the plugin writes to.
+	// Always non-nil — the dispatcher installs a no-op Logger when
+	// no log buffer is available (tests, --no-dashboard mode). Plugins
+	// emit per-session diagnostics (failed startup, dropped query,
+	// credential lookup miss) here; the gateway buffers them and
+	// surfaces them on the dashboard's /logs tab. Never log credential
+	// bytes — credential names/refs only.
+	Logger Logger
 }
 
 // ApproveCallRequest is what a ConnEndpointRuntime hands to

--- a/main.go
+++ b/main.go
@@ -269,6 +269,11 @@ type Gateway struct {
 	certs   *CertCache
 	dialer  *net.Dialer
 	sink    *Sink
+	// logs buffers the last N structured plugin diagnostic events
+	// for the dashboard's /logs tab. Distinct from sink (request
+	// events): operators tail logs to debug a misbehaving plugin,
+	// not to audit traffic.
+	logs    *LogSink
 	oauth   *OAuthRegistry
 	agents  *AgentRegistry
 	hitl    *HITLRegistry
@@ -1264,6 +1269,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 		Profile:  profile,
 		PeerIP:   pip,
 		Secrets:  g.secrets,
+		Logger:   g.LoggerFor(pluginID("endpoint", ep.Plugin.Type), "", agentPip),
 		DialUpstream: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			// Plugin asks for ep.Hosts[0]:port; we bypass DNS by
 			// dialing the original upstream IP the WG forwarder
@@ -1418,6 +1424,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 		CADir:        g.cfg.CADir,
 		DstPort:      dstPort,
 		UpstreamHost: hostname,
+		Logger:       g.LoggerFor(pluginID("endpoint", ep.Plugin.Type), "", agentPip),
 		MintCert: func(host string) (*tls.Certificate, error) {
 			return g.certs.mint(host)
 		},
@@ -1813,8 +1820,13 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// Identity flow on hosts we MITM. Endpoints without a
 		// responder (the default https plugin) fall through.
 		if responder, ok := ep.Plugin.Runtime.(runtime.HTTPSyntheticResponder); ok {
-			if r, handled, err := responder.RespondHTTP(req.Context(), req); err != nil {
-				log.Printf("respond %s: %v", ep.Name, err)
+			respLg := g.LoggerFor(pluginID("endpoint", ep.Plugin.Type), ev.ID, ev.AgentIP)
+			respCtx := runtime.WithLogger(req.Context(), respLg)
+			if r, handled, err := responder.RespondHTTP(respCtx, req); err != nil {
+				runtime.Error(respLg, "synthetic response failed", map[string]any{
+					"endpoint": ep.Name,
+					"err":      err.Error(),
+				})
 			} else if handled {
 				if r.Body != nil {
 					defer func() { _ = r.Body.Close() }()
@@ -1858,21 +1870,39 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			injector, wantsHTTP := cc.Credential.Body.(runtime.HTTPCredentialRuntime)
 			wsRewriter, wantsWS := cc.Credential.Body.(runtime.WebSocketCredentialRuntime)
 			if wantsHTTP || (wantsWS && isWSUpgrade(req)) {
-				sec, err := g.secrets.Get(cc.Credential.Symbol.Name, profile)
+				credName := cc.Credential.Symbol.Name
+				lg := g.LoggerFor(pluginID("credential", cc.Credential.Symbol.Type), ev.ID, ev.AgentIP)
+				injCtx := runtime.WithLogger(req.Context(), lg)
+				sec, err := g.secrets.Get(credName, profile)
 				if err != nil {
-					log.Printf("secret %s/%s: %v — forwarding without injection", cc.Credential.Symbol.Name, profile, err)
+					runtime.Warn(lg, "secret lookup failed — forwarding without injection", map[string]any{
+						"credential": credName,
+						"profile":    profile,
+						"err":        err.Error(),
+					})
 				} else if len(sec.Bytes) == 0 && len(sec.Extras) == 0 {
-					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
+					runtime.Warn(lg, "secret not configured", map[string]any{
+						"credential": credName,
+						"profile":    profile,
+						"env":        "CLAWPATROL_SECRET_" + secretEnvName(credName),
+					})
 				} else {
 					if wantsHTTP {
-						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
-							log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+						if err := injector.InjectHTTP(injCtx, req, sec); err != nil {
+							runtime.Error(lg, "credential injection failed", map[string]any{
+								"credential": credName,
+								"err":        err.Error(),
+							})
+						} else {
+							runtime.Debug(lg, "credential injected", map[string]any{
+								"credential": credName,
+							})
 						}
 					}
 					if wantsWS && isWSUpgrade(req) {
 						wsSec := sec
 						rewriteWSPayload = func(payload []byte) ([]byte, bool, error) {
-							return wsRewriter.RewriteWebSocketPayload(req.Context(), payload, wsSec)
+							return wsRewriter.RewriteWebSocketPayload(injCtx, payload, wsSec)
 						}
 					}
 				}
@@ -2094,7 +2124,13 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			DashboardURL: g.cfg.PublicURL,
 			Policy:       policy,
 		}
-		v, err := ar.Approve(ctx, req)
+		// Attach a per-approver logger so plugin runtimes that
+		// call runtime.LoggerFrom(ctx) (e.g. human approver's notify
+		// failure path) land in the dashboard /logs tab. ReqID is
+		// empty here — the approve chain runs before / parallel to
+		// the request's event ID; we attribute by approver name.
+		stCtx := runtime.WithLogger(ctx, g.LoggerFor(pluginID("approver", approverType(policy, st.Name)), "", c.AgentIP))
+		v, err := ar.Approve(stCtx, req)
 		if err != nil {
 			return runtime.ApproveVerdict{Decision: "deny", Reason: err.Error(), By: "gateway"}
 		}
@@ -2109,6 +2145,25 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 		}
 	}
 	return runtime.ApproveVerdict{Decision: "allow"}
+}
+
+// approverType returns the registered plugin Type for an approver
+// declared in the policy. Falls back to the bare name for the built-in
+// "dashboard" approver (no policy entry) and for any approver whose
+// symbol is somehow missing — the dashboard's /logs filter still
+// shows a meaningful identifier in that case.
+func approverType(policy *config.CompiledPolicy, name string) string {
+	if name == "dashboard" {
+		return "dashboard"
+	}
+	if policy == nil {
+		return name
+	}
+	ent, ok := policy.Approvers[name]
+	if !ok || ent.Plugin == nil {
+		return name
+	}
+	return ent.Plugin.Type
 }
 
 // ifNotEmpty returns f(v) when v != nil, else "".
@@ -2292,6 +2347,7 @@ func runGateway(args []string) {
 	if err != nil {
 		log.Fatalf("log: %v", err)
 	}
+	logs := NewLogSink(cfg.PluginLogBufferSize)
 	oauthDir := cfg.OAuthDir
 	if oauthDir == "" {
 		oauthDir = filepath.Join(cfg.CADir, "..", "oauth")
@@ -2314,6 +2370,7 @@ func runGateway(args []string) {
 		certs:          certs,
 		dialer:         newUpstreamDialer(cfg.Resolver),
 		sink:           sink,
+		logs:           logs,
 		oauth:          oauthReg,
 		agents:         NewAgentRegistry(),
 		hitl:           newHITLRegistry(sink),

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -38,6 +38,7 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 | `dashboard_secret` | `string` | no |  |
 | `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
+| `plugin_log_buffer_size` | `int` | no | Caps the dashboard /logs tab's in-memory ring buffer. Default 1000 entries; raise on busy gateways whose operators want longer scrollback when debugging a chatty plugin. 0 keeps the default. |
 | `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Sessions can revive on new activity at any time, so there's no "closed but kept" intermediate state — only last_at matters. Default 720h (30d), "0" / "off" disables. Format accepts time.ParseDuration strings ("30m", "168h", etc.). |
 | `authkey` | `string` | no |  |
 | `control_url` | `string` | no |  |

--- a/web.go
+++ b/web.go
@@ -239,6 +239,8 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/credentials/set", Auth: authDashboard, Handler: w.apiCredentialsSet},
 		{Method: http.MethodPost, Path: "/api/credentials/clear", Auth: authDashboard, Handler: w.apiCredentialsClear},
 		{Method: http.MethodGet, Path: "/api/events", Auth: authDashboard, Handler: w.apiEventsSSE},
+		{Method: http.MethodGet, Path: "/api/logs", Auth: authDashboard, Handler: w.apiLogs},
+		{Method: http.MethodGet, Path: "/api/logs/stream", Auth: authDashboard, Handler: w.apiLogsSSE},
 		{Method: http.MethodPost, Path: "/api/actions/", Auth: authDashboard, Handler: w.apiActionByID},
 		{Method: http.MethodGet, Path: "/api/analytics", Auth: authDashboard, Handler: w.apiAnalytics},
 		{Method: http.MethodGet, Path: "/api/facets", Auth: authDashboard, Handler: w.apiFacets},

--- a/web_logs.go
+++ b/web_logs.go
@@ -1,0 +1,556 @@
+package main
+
+// Plugin-diagnostic log sink. Plugins write structured events via the
+// runtime.Logger interface; the gateway buffers the last N entries
+// (LogSink.cap, default 1000) in memory and serves them to the
+// dashboard's /logs tab via:
+//
+//   - GET /api/logs           filtered snapshot (plugin / severity / range)
+//   - GET /api/logs/stream    SSE live tail
+//
+// Mirrors the existing Sink (events) shape — ring buffer + subscriber
+// fan-out, marshaled once per entry. Distinct from Sink because
+// diagnostic logs are not persisted to SQLite (operators want a fast
+// rolling tail, not a forever-history; the request actions table
+// already carries request-correlated metadata).
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// defaultLogBufferSize is the cap on LogSink's in-memory ring buffer
+// when the gateway doesn't override it. Matches the issue spec's
+// "default 1000" so an operator running the stock binary sees a
+// reasonable scrollback without tuning anything.
+const defaultLogBufferSize = 1000
+
+// LogSink buffers plugin diagnostic events in a fixed-size ring and
+// fans them out to dashboard SSE subscribers. Drop policy: if a
+// subscriber falls behind by more than its channel buffer, packets
+// are dropped for that subscriber (counted in `drops`) — the gateway
+// stays responsive and the dashboard reconnects on its own.
+type LogSink struct {
+	ch    chan runtime.LogEntry
+	drops atomic.Uint64
+
+	mu   sync.Mutex
+	subs []chan logPacket
+
+	// ring storage; recentNext / recentLen track lazy fill before
+	// the buffer wraps.
+	recent     []runtime.LogEntry
+	recentNext int
+	recentLen  int
+	recentCap  int
+}
+
+type logPacket struct {
+	entry runtime.LogEntry
+	raw   []byte
+}
+
+// NewLogSink starts a goroutine that drains the input channel and
+// fans entries out to subscribers. cap is the ring-buffer size; 0
+// falls back to defaultLogBufferSize.
+func NewLogSink(cap int) *LogSink {
+	if cap <= 0 {
+		cap = defaultLogBufferSize
+	}
+	s := &LogSink{
+		ch:        make(chan runtime.LogEntry, 256),
+		recent:    make([]runtime.LogEntry, cap),
+		recentCap: cap,
+	}
+	go s.drain()
+	return s
+}
+
+// Emit pushes an entry into the sink's drain channel. Drops on full
+// channel to keep the gateway snappy — drops are counted but not
+// surfaced (operators see a gap; the next entry still arrives).
+//
+// Sets Ts to now if the caller left it zero so plugin code paths
+// don't have to fill it in.
+func (s *LogSink) Emit(e runtime.LogEntry) {
+	if s == nil {
+		return
+	}
+	if e.Ts.IsZero() {
+		e.Ts = time.Now().UTC()
+	}
+	if e.Level == "" {
+		e.Level = runtime.LogInfo
+	}
+	select {
+	case s.ch <- e:
+	default:
+		s.drops.Add(1)
+	}
+}
+
+// Drops returns the cumulative count of entries dropped because the
+// drain channel or a subscriber channel was full. Surfaced via
+// /api/logs?meta=1 so operators can spot a runaway plugin.
+func (s *LogSink) Drops() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.drops.Load()
+}
+
+func (s *LogSink) drain() {
+	for e := range s.ch {
+		raw, err := json.Marshal(e)
+		if err != nil {
+			continue
+		}
+		pkt := logPacket{entry: e, raw: raw}
+
+		s.mu.Lock()
+		s.recent[s.recentNext] = e
+		s.recentNext = (s.recentNext + 1) % s.recentCap
+		if s.recentLen < s.recentCap {
+			s.recentLen++
+		}
+		subs := append([]chan logPacket(nil), s.subs...)
+		s.mu.Unlock()
+
+		for _, sub := range subs {
+			select {
+			case sub <- pkt:
+			default:
+				s.drops.Add(1)
+			}
+		}
+	}
+}
+
+// Snapshot returns a copy of the ring buffer in oldest→newest order.
+// Caller may filter / re-order without holding the sink's lock.
+func (s *LogSink) Snapshot() []runtime.LogEntry {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.recentLen == 0 {
+		return nil
+	}
+	out := make([]runtime.LogEntry, s.recentLen)
+	if s.recentLen < s.recentCap {
+		copy(out, s.recent[:s.recentLen])
+		return out
+	}
+	for i := 0; i < s.recentCap; i++ {
+		out[i] = s.recent[(s.recentNext+i)%s.recentCap]
+	}
+	return out
+}
+
+// SnapshotAndSubscribe atomically snapshots the buffer and registers
+// a subscriber under the same lock so no event is missed or
+// duplicated between the two. Same pattern as
+// Sink.RecentAndSubscribe.
+func (s *LogSink) SnapshotAndSubscribe() ([]runtime.LogEntry, <-chan logPacket, func()) {
+	if s == nil {
+		ch := make(chan logPacket)
+		close(ch)
+		return nil, ch, func() {}
+	}
+	ch := make(chan logPacket, 64)
+	s.mu.Lock()
+	snap := s.snapshotLocked()
+	s.subs = append(s.subs, ch)
+	s.mu.Unlock()
+	cancel := func() {
+		s.mu.Lock()
+		for i, c := range s.subs {
+			if c == ch {
+				s.subs = append(s.subs[:i], s.subs[i+1:]...)
+				break
+			}
+		}
+		s.mu.Unlock()
+	}
+	return snap, ch, cancel
+}
+
+func (s *LogSink) snapshotLocked() []runtime.LogEntry {
+	if s.recentLen == 0 {
+		return nil
+	}
+	out := make([]runtime.LogEntry, s.recentLen)
+	if s.recentLen < s.recentCap {
+		copy(out, s.recent[:s.recentLen])
+		return out
+	}
+	for i := 0; i < s.recentCap; i++ {
+		out[i] = s.recent[(s.recentNext+i)%s.recentCap]
+	}
+	return out
+}
+
+// pluginLogger is the gateway's runtime.Logger implementation. Each
+// per-request / per-session logger captures the binding (plugin name,
+// request id, agent ip) up front so plugin call sites stay terse:
+// they invoke .Log on whatever Logger they were handed without
+// needing to plumb identification.
+type pluginLogger struct {
+	sink    *LogSink
+	plugin  string
+	reqID   string
+	agentIP string
+	// mirror, when set, writes a line to the host's traditional log
+	// (log.Default) for warn / error entries. Keeps backwards compat
+	// with operators who watch journalctl / stderr; debug / info stay
+	// dashboard-only to avoid stderr spam.
+	mirror func(level runtime.LogLevel, plugin, msg string, fields map[string]any)
+}
+
+func (l *pluginLogger) Log(level runtime.LogLevel, msg string, fields map[string]any) {
+	if l == nil {
+		return
+	}
+	// Redact once, before either consumer sees the payload: the
+	// stderr mirror is just as likely to leak credentials as the
+	// dashboard buffer.
+	redacted := redactFields(fields)
+	if l.sink != nil {
+		l.sink.Emit(runtime.LogEntry{
+			Plugin:  l.plugin,
+			Level:   level,
+			Msg:     msg,
+			ReqID:   l.reqID,
+			AgentIP: l.agentIP,
+			Fields:  redacted,
+		})
+	}
+	if l.mirror != nil {
+		l.mirror(level, l.plugin, msg, redacted)
+	}
+}
+
+// LoggerFor returns a pluginLogger scoped to (plugin, reqID, agentIP).
+// Empty strings are fine — they're omitted from the rendered entry.
+// The returned Logger is safe for concurrent use (writes are
+// serialized through the sink's drain channel) so endpoint runtimes
+// can hand the same instance to reader + writer pumps.
+func (g *Gateway) LoggerFor(plugin, reqID, agentIP string) runtime.Logger {
+	if g == nil {
+		return runtime.NopLogger()
+	}
+	return &pluginLogger{
+		sink:    g.logs,
+		plugin:  plugin,
+		reqID:   reqID,
+		agentIP: agentIP,
+		mirror:  mirrorPluginLog,
+	}
+}
+
+// pluginID builds the "kind/type" identifier surfaced on log entries.
+// kind is the lowercase plugin kind ("credential" / "endpoint" /
+// "approver" / "tunnel"); typ is the plugin's registered Type
+// ("bearer_token", "postgres", etc.). When typ is empty (legacy /
+// schema-only plugins), the bare kind keeps the format readable.
+func pluginID(kind, typ string) string {
+	if typ == "" {
+		return kind
+	}
+	return kind + "/" + typ
+}
+
+// mirrorPluginLog writes warn/error plugin diagnostics to the host's
+// traditional log so operators still see them in journalctl. Debug /
+// info entries stay dashboard-only — the new tab is the system of
+// record for the chatty stuff.
+func mirrorPluginLog(level runtime.LogLevel, plugin, msg string, fields map[string]any) {
+	if level != runtime.LogWarn && level != runtime.LogError {
+		return
+	}
+	if len(fields) == 0 {
+		// One-line log with no kv tail; stdlib log adds its own
+		// timestamp, so we only carry plugin + msg.
+		log.Printf("plugin %s %s: %s", level, plugin, msg)
+		return
+	}
+	log.Printf("plugin %s %s: %s %s", level, plugin, msg, joinFields(fields))
+}
+
+// joinFields renders structured fields as `key=value` pairs for the
+// stdlib-log mirror. Stable ordering would be nice but isn't worth
+// the sort allocation on every warn line — plugin logs are tail-only.
+func joinFields(fields map[string]any) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	first := true
+	for k, v := range fields {
+		if !first {
+			b.WriteByte(' ')
+		}
+		first = false
+		b.WriteString(k)
+		b.WriteByte('=')
+		fmt.Fprintf(&b, "%v", v)
+	}
+	return b.String()
+}
+
+// redactFields ensures we never accidentally surface raw secret
+// bytes in the log buffer. Defense in depth — plugin authors are
+// expected to log credential names/refs only, but if someone passes
+// a `[]byte` or a value flagged with a sensitive-looking key, we
+// replace it with "***" before the entry enters the buffer.
+//
+// Keys flagged: anything matching the existing sensitiveHeader
+// regex (auth/token/secret/key/password/cookie). `[]byte` values
+// are redacted unconditionally — the plugin should not be passing
+// raw bytes through structured logs.
+func redactFields(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return in
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if isSensitiveLogKey(k) {
+			out[k] = "***"
+			continue
+		}
+		switch v.(type) {
+		case []byte:
+			out[k] = "***"
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func isSensitiveLogKey(k string) bool {
+	return sensitiveHeader.MatchString(k)
+}
+
+// apiLogs returns the filtered snapshot of the log buffer.
+// Query params:
+//
+//	plugin  — exact plugin identifier; repeatable as comma list
+//	min     — min severity (debug|info|warn|error); default info
+//	since   — RFC3339 / unix-seconds lower bound on Ts
+//	until   — RFC3339 / unix-seconds upper bound on Ts
+//	agent   — agent IP filter
+//	limit   — cap on returned entries (newest-first up to limit; default 500)
+//	meta    — when "1", include {drops,buffer_size,buffer_cap}
+func (w *webMux) apiLogs(rw http.ResponseWriter, r *http.Request) {
+	if w.g.logs == nil {
+		writeJSON(rw, map[string]any{"entries": []runtime.LogEntry{}, "buffer_cap": 0})
+		return
+	}
+	q := r.URL.Query()
+	min := runtime.LogLevel(strings.ToLower(q.Get("min")))
+	if min == "" {
+		min = runtime.LogInfo
+	}
+	plugins := splitCSV(q.Get("plugin"))
+	agent := q.Get("agent")
+	since := parseTimeParam(q.Get("since"))
+	until := parseTimeParam(q.Get("until"))
+	limit := 500
+	if l := q.Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			if n > 5000 {
+				n = 5000
+			}
+			limit = n
+		}
+	}
+
+	snap := w.g.logs.Snapshot()
+	out := make([]runtime.LogEntry, 0, len(snap))
+	for _, e := range snap {
+		if !runtime.LevelAtLeast(e.Level, min) {
+			continue
+		}
+		if !since.IsZero() && e.Ts.Before(since) {
+			continue
+		}
+		if !until.IsZero() && e.Ts.After(until) {
+			continue
+		}
+		if agent != "" && e.AgentIP != agent {
+			continue
+		}
+		if len(plugins) > 0 && !containsString(plugins, e.Plugin) {
+			continue
+		}
+		out = append(out, e)
+	}
+	// Truncate newest-first when oversized. The snapshot is already
+	// oldest→newest; we want the most recent N entries.
+	if len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+
+	body := map[string]any{
+		"entries":    out,
+		"buffer_cap": w.g.logs.recentCap,
+	}
+	if q.Get("meta") == "1" {
+		body["drops"] = w.g.logs.Drops()
+		body["buffer_size"] = w.g.logs.recentLen
+		body["plugins"] = pluginsInBuffer(snap)
+	}
+	writeJSON(rw, body)
+}
+
+// apiLogsSSE streams live log entries to the dashboard. Same shape
+// as apiEventsSSE: connected header, snapshot backlog as one
+// `event: backlog` payload, then one `data:` line per live entry.
+func (w *webMux) apiLogsSSE(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "text/event-stream")
+	rw.Header().Set("Cache-Control", "no-cache")
+	rw.Header().Set("Connection", "keep-alive")
+	rw.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := rw.(http.Flusher)
+	if !ok {
+		http.Error(rw, "streaming unsupported", 500)
+		return
+	}
+	if w.g.logs == nil {
+		_, _ = fmt.Fprintf(rw, ": no log sink\n\n")
+		flusher.Flush()
+		return
+	}
+
+	q := r.URL.Query()
+	min := runtime.LogLevel(strings.ToLower(q.Get("min")))
+	if min == "" {
+		min = runtime.LogDebug
+	}
+	plugins := splitCSV(q.Get("plugin"))
+	agent := q.Get("agent")
+	keep := func(e runtime.LogEntry) bool {
+		if !runtime.LevelAtLeast(e.Level, min) {
+			return false
+		}
+		if agent != "" && e.AgentIP != agent {
+			return false
+		}
+		if len(plugins) > 0 && !containsString(plugins, e.Plugin) {
+			return false
+		}
+		return true
+	}
+
+	backlog, ch, cancel := w.g.logs.SnapshotAndSubscribe()
+	defer cancel()
+
+	_, _ = fmt.Fprint(rw, ": connected\n\n")
+	if len(backlog) > 0 {
+		filtered := backlog[:0]
+		for _, e := range backlog {
+			if keep(e) {
+				filtered = append(filtered, e)
+			}
+		}
+		if len(filtered) > 0 {
+			b, err := json.Marshal(filtered)
+			if err == nil {
+				_, _ = fmt.Fprintf(rw, "event: backlog\ndata: %s\n\n", b)
+			}
+		}
+	}
+	flusher.Flush()
+
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepalive.C:
+			_, _ = fmt.Fprint(rw, ": ka\n\n")
+			flusher.Flush()
+		case pkt, ok := <-ch:
+			if !ok {
+				return
+			}
+			if !keep(pkt.entry) {
+				continue
+			}
+			_, _ = fmt.Fprintf(rw, "data: %s\n\n", pkt.raw)
+			flusher.Flush()
+		}
+	}
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// parseTimeParam accepts an RFC3339 timestamp or a unix-seconds
+// integer; returns zero Time when the input is unparseable.
+func parseTimeParam(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Unix(n, 0).UTC()
+	}
+	return time.Time{}
+}
+
+func pluginsInBuffer(entries []runtime.LogEntry) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, e := range entries {
+		if e.Plugin == "" {
+			continue
+		}
+		if _, ok := seen[e.Plugin]; ok {
+			continue
+		}
+		seen[e.Plugin] = struct{}{}
+		out = append(out, e.Plugin)
+	}
+	return out
+}

--- a/web_logs_test.go
+++ b/web_logs_test.go
@@ -388,4 +388,3 @@ func waitForBufferFill(t *testing.T, s *LogSink, n int) {
 	}
 	t.Fatalf("buffer never reached %d entries", n)
 }
-

--- a/web_logs_test.go
+++ b/web_logs_test.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestLogSinkRingBuffer(t *testing.T) {
+	s := NewLogSink(3)
+	for i := 0; i < 5; i++ {
+		s.Emit(runtime.LogEntry{
+			Plugin: "test",
+			Level:  runtime.LogInfo,
+			Msg:    "m" + string(rune('0'+i)),
+		})
+	}
+	waitForBufferFill(t, s, 3)
+
+	snap := s.Snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("ring buffer len: want 3, got %d", len(snap))
+	}
+	got := make([]string, 0, len(snap))
+	for _, e := range snap {
+		got = append(got, e.Msg)
+	}
+	want := []string{"m2", "m3", "m4"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entry %d: want %q got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestLogSinkDefaultTsAndLevel(t *testing.T) {
+	s := NewLogSink(8)
+	s.Emit(runtime.LogEntry{Plugin: "x", Msg: "hi"}) // no Ts, no Level
+	waitForBufferFill(t, s, 1)
+
+	snap := s.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("len: want 1 got %d", len(snap))
+	}
+	if snap[0].Level != runtime.LogInfo {
+		t.Fatalf("default level: want info, got %q", snap[0].Level)
+	}
+	if snap[0].Ts.IsZero() {
+		t.Fatalf("Ts not auto-populated")
+	}
+	if time.Since(snap[0].Ts) > time.Minute {
+		t.Fatalf("Ts looks stale: %v", snap[0].Ts)
+	}
+}
+
+func TestPluginLoggerRedactsSensitiveKeys(t *testing.T) {
+	g := &Gateway{logs: NewLogSink(8)}
+	lg := g.LoggerFor("credential/test", "", "")
+	runtime.Warn(lg, "leaked", map[string]any{
+		"credential":   "github-oauth", // ref by name: keep
+		"token":        "ghp_xxx",      // sensitive key: redact
+		"password":     "swordfish",    // sensitive key: redact
+		"raw_bytes":    []byte("abc"),  // []byte value: redact
+		"plain_string": "ok",
+	})
+	waitForBufferFill(t, g.logs, 1)
+
+	got := g.logs.Snapshot()[0].Fields
+	if got["credential"] != "github-oauth" {
+		t.Errorf("credential ref must pass through: got %v", got["credential"])
+	}
+	if got["token"] != "***" {
+		t.Errorf("token: want redacted, got %v", got["token"])
+	}
+	if got["password"] != "***" {
+		t.Errorf("password: want redacted, got %v", got["password"])
+	}
+	if got["raw_bytes"] != "***" {
+		t.Errorf("raw_bytes: want redacted, got %v", got["raw_bytes"])
+	}
+	if got["plain_string"] != "ok" {
+		t.Errorf("plain string: want passthrough, got %v", got["plain_string"])
+	}
+}
+
+func TestLogSinkSubscriberFanout(t *testing.T) {
+	s := NewLogSink(8)
+	_, ch, cancel := s.SnapshotAndSubscribe()
+	defer cancel()
+
+	s.Emit(runtime.LogEntry{Plugin: "p", Level: runtime.LogInfo, Msg: "live"})
+
+	select {
+	case pkt := <-ch:
+		if pkt.entry.Msg != "live" {
+			t.Fatalf("got %q", pkt.entry.Msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no entry on subscriber channel")
+	}
+}
+
+func TestLogSinkSnapshotAndSubscribeOrdering(t *testing.T) {
+	s := NewLogSink(8)
+	s.Emit(runtime.LogEntry{Plugin: "p", Level: runtime.LogInfo, Msg: "before"})
+	waitForBufferFill(t, s, 1)
+
+	backlog, ch, cancel := s.SnapshotAndSubscribe()
+	defer cancel()
+	if len(backlog) != 1 || backlog[0].Msg != "before" {
+		t.Fatalf("backlog snapshot lost the pre-subscribe entry: %+v", backlog)
+	}
+
+	s.Emit(runtime.LogEntry{Plugin: "p", Level: runtime.LogInfo, Msg: "after"})
+	select {
+	case pkt := <-ch:
+		if pkt.entry.Msg != "after" {
+			t.Fatalf("want 'after', got %q", pkt.entry.Msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("post-subscribe entry never arrived")
+	}
+}
+
+func TestLevelAtLeast(t *testing.T) {
+	cases := []struct {
+		level, min runtime.LogLevel
+		want       bool
+	}{
+		{runtime.LogDebug, runtime.LogInfo, false},
+		{runtime.LogInfo, runtime.LogInfo, true},
+		{runtime.LogWarn, runtime.LogInfo, true},
+		{runtime.LogError, runtime.LogWarn, true},
+		{runtime.LogDebug, runtime.LogDebug, true},
+	}
+	for _, c := range cases {
+		if got := runtime.LevelAtLeast(c.level, c.min); got != c.want {
+			t.Errorf("LevelAtLeast(%q, min=%q): got %v want %v", c.level, c.min, got, c.want)
+		}
+	}
+}
+
+func TestApiLogsFilters(t *testing.T) {
+	g := &Gateway{logs: NewLogSink(16)}
+	w := &webMux{g: g}
+
+	now := time.Now().UTC()
+	emit := func(plugin string, level runtime.LogLevel, ts time.Time) {
+		g.logs.Emit(runtime.LogEntry{
+			Plugin: plugin, Level: level, Msg: "m",
+			Ts: ts, AgentIP: "10.0.0.1",
+		})
+	}
+	emit("credential/bearer_token", runtime.LogDebug, now.Add(-2*time.Minute))
+	emit("credential/bearer_token", runtime.LogInfo, now.Add(-90*time.Second))
+	emit("endpoint/postgres", runtime.LogWarn, now.Add(-60*time.Second))
+	emit("endpoint/postgres", runtime.LogError, now.Add(-30*time.Second))
+	waitForBufferFill(t, g.logs, 4)
+
+	// min=warn → only warn+error
+	r := httptest.NewRequest("GET", "/api/logs?min=warn", nil)
+	rw := httptest.NewRecorder()
+	w.apiLogs(rw, r)
+	got := decodeLogsResp(t, rw)
+	if len(got.Entries) != 2 {
+		t.Fatalf("min=warn: want 2 entries got %d (%+v)", len(got.Entries), got.Entries)
+	}
+	for _, e := range got.Entries {
+		if !runtime.LevelAtLeast(e.Level, runtime.LogWarn) {
+			t.Errorf("min=warn filter let through %q", e.Level)
+		}
+	}
+
+	// plugin filter
+	r = httptest.NewRequest("GET", "/api/logs?min=debug&plugin=endpoint/postgres", nil)
+	rw = httptest.NewRecorder()
+	w.apiLogs(rw, r)
+	got = decodeLogsResp(t, rw)
+	if len(got.Entries) != 2 {
+		t.Fatalf("plugin=endpoint/postgres: want 2 entries got %d", len(got.Entries))
+	}
+	for _, e := range got.Entries {
+		if e.Plugin != "endpoint/postgres" {
+			t.Errorf("plugin filter let through %q", e.Plugin)
+		}
+	}
+
+	// since= filter — 45s ago should keep only the last two
+	since := now.Add(-45 * time.Second).Format(time.RFC3339)
+	r = httptest.NewRequest("GET", "/api/logs?min=debug&since="+url.QueryEscape(since), nil)
+	rw = httptest.NewRecorder()
+	w.apiLogs(rw, r)
+	got = decodeLogsResp(t, rw)
+	if len(got.Entries) != 1 {
+		t.Fatalf("since= filter: want 1 entry got %d", len(got.Entries))
+	}
+}
+
+func TestApiLogsMetaShape(t *testing.T) {
+	g := &Gateway{logs: NewLogSink(8)}
+	w := &webMux{g: g}
+	g.logs.Emit(runtime.LogEntry{Plugin: "p1", Level: runtime.LogInfo, Msg: "m"})
+	g.logs.Emit(runtime.LogEntry{Plugin: "p2", Level: runtime.LogInfo, Msg: "m"})
+	waitForBufferFill(t, g.logs, 2)
+
+	r := httptest.NewRequest("GET", "/api/logs?meta=1", nil)
+	rw := httptest.NewRecorder()
+	w.apiLogs(rw, r)
+
+	var body map[string]any
+	if err := json.NewDecoder(rw.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["drops"]; !ok {
+		t.Fatalf("meta=1: missing drops field; body=%+v", body)
+	}
+	plugins, _ := body["plugins"].([]any)
+	if len(plugins) != 2 {
+		t.Fatalf("plugins list: want 2 got %v", plugins)
+	}
+}
+
+func TestGatewayLoggerForRoutesToSink(t *testing.T) {
+	g := &Gateway{logs: NewLogSink(8)}
+	lg := g.LoggerFor("credential/bearer_token", "req-123", "10.0.0.5")
+	runtime.Info(lg, "test message", map[string]any{"k": "v"})
+	waitForBufferFill(t, g.logs, 1)
+
+	got := g.logs.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry got %d", len(got))
+	}
+	e := got[0]
+	if e.Plugin != "credential/bearer_token" {
+		t.Errorf("Plugin: got %q", e.Plugin)
+	}
+	if e.ReqID != "req-123" {
+		t.Errorf("ReqID: got %q", e.ReqID)
+	}
+	if e.AgentIP != "10.0.0.5" {
+		t.Errorf("AgentIP: got %q", e.AgentIP)
+	}
+	if e.Level != runtime.LogInfo {
+		t.Errorf("Level: got %q", e.Level)
+	}
+	if e.Fields["k"] != "v" {
+		t.Errorf("Fields: got %v", e.Fields)
+	}
+}
+
+func TestNilGatewayLoggerFor(t *testing.T) {
+	var g *Gateway
+	lg := g.LoggerFor("p", "", "")
+	// must not panic
+	runtime.Info(lg, "msg", nil)
+}
+
+func TestRuntimeWithLoggerRoundTrip(t *testing.T) {
+	s := NewLogSink(4)
+	g := &Gateway{logs: s}
+	lg := g.LoggerFor("endpoint/http", "rid", "1.2.3.4")
+	ctx := runtime.WithLogger(t.Context(), lg)
+	back := runtime.LoggerFrom(ctx)
+	runtime.Warn(back, "warn from ctx", nil)
+	waitForBufferFill(t, s, 1)
+
+	got := s.Snapshot()
+	if len(got) != 1 || got[0].Level != runtime.LogWarn || got[0].ReqID != "rid" {
+		t.Fatalf("ctx-bound logger lost identity: %+v", got)
+	}
+}
+
+func TestApiLogsSSEBacklogAndLive(t *testing.T) {
+	g := &Gateway{logs: NewLogSink(8)}
+	w := &webMux{g: g}
+	g.logs.Emit(runtime.LogEntry{Plugin: "p", Level: runtime.LogInfo, Msg: "backlog-entry"})
+	waitForBufferFill(t, g.logs, 1)
+
+	r := httptest.NewRequest("GET", "/api/logs/stream", nil)
+	rw := &flushableRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	// Run SSE handler in a goroutine; cancel the request ctx after
+	// we've grabbed the backlog so the handler returns.
+	ctx, cancel := context.WithCancel(context.Background())
+	r = r.WithContext(ctx)
+	done := make(chan struct{})
+	go func() {
+		w.apiLogsSSE(rw, r)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if strings.Contains(rw.Snapshot(), "backlog-entry") {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatalf("SSE never delivered backlog; got body=%q", rw.Snapshot())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if !strings.Contains(rw.Snapshot(), "event: backlog") {
+		t.Errorf("missing `event: backlog` framing in SSE output: %q", rw.Snapshot())
+	}
+
+	// Live entry after backlog.
+	g.logs.Emit(runtime.LogEntry{Plugin: "p", Level: runtime.LogInfo, Msg: "live-entry"})
+	deadline = time.After(2 * time.Second)
+	for {
+		if strings.Contains(rw.Snapshot(), "live-entry") {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatalf("SSE never delivered live entry; got body=%q", rw.Snapshot())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	cancel()
+	<-done
+}
+
+// --- helpers ---
+
+type flushableRecorder struct {
+	*httptest.ResponseRecorder
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (r *flushableRecorder) Flush() {}
+
+func (r *flushableRecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	r.buf.Write(b)
+	r.mu.Unlock()
+	return r.ResponseRecorder.Write(b)
+}
+
+func (r *flushableRecorder) Snapshot() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.String()
+}
+
+type logsRespFixture struct {
+	Entries   []runtime.LogEntry `json:"entries"`
+	BufferCap int                `json:"buffer_cap"`
+}
+
+func decodeLogsResp(t *testing.T, rw *httptest.ResponseRecorder) logsRespFixture {
+	t.Helper()
+	var got logsRespFixture
+	if err := json.NewDecoder(rw.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return got
+}
+
+// waitForBufferFill blocks until the sink's drain goroutine has
+// pushed at least n entries into the ring buffer, or 1 s elapses.
+// The sink's emit channel is buffered, so an Emit returns before the
+// entry is observable — tests need a barrier rather than a sleep.
+func waitForBufferFill(t *testing.T, s *LogSink, n int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		got := s.recentLen
+		s.mu.Unlock()
+		if got >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("buffer never reached %d entries", n)
+}
+

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -4,6 +4,7 @@ import { AnalyticsPage } from "./components/AnalyticsPage";
 import { ConnectModal } from "./components/ConnectModal";
 import { DevicePage } from "./components/DevicePage";
 import { LiveRequests } from "./components/LiveRequests";
+import { LogsPage } from "./components/LogsPage";
 import { OnboardPage } from "./components/OnboardPage";
 import { RequestDetailPage } from "./components/RequestDetailPage";
 import { AddDeviceModal } from "./components/AddDeviceModal";
@@ -15,6 +16,7 @@ type Route =
   | { name: "main" }
   | { name: "device"; ip: string }
   | { name: "analytics"; ip?: string }
+  | { name: "logs" }
   | { name: "onboard"; code: string }
   | { name: "request"; id: string };
 
@@ -27,6 +29,7 @@ function parseRoute(): Route {
     return { name: "onboard", code: decodeURIComponent(h.slice("#/onboard/".length)) };
   const r = h.match(/^#\/request\/([^/]+)$/);
   if (r) return { name: "request", id: decodeURIComponent(r[1]) };
+  if (h === "#/logs") return { name: "logs" };
   if (h === "#/analytics") return { name: "analytics" };
   const a = h.match(/^#\/analytics\/([^/]+)$/);
   if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
@@ -118,6 +121,27 @@ export default function App() {
                 <path d="m7 16 4-8 4 4 4-6" />
               </svg>
             </a>
+            <a
+              href="#/logs"
+              className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
+              title="plugin logs"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                <path d="M14 2v6h6" />
+                <path d="M8 13h8" />
+                <path d="M8 17h5" />
+              </svg>
+            </a>
             <button
               onClick={() => setShowSettings(true)}
               className="w-[36px] h-[36px] rounded-full border border-[#e5e5e5] text-[#525252] flex items-center justify-center hover:border-[#171717] hover:text-[#171717] transition-colors"
@@ -152,6 +176,8 @@ export default function App() {
         </main>
       ) : route.name === "analytics" ? (
         <AnalyticsPage ip={route.ip} agents={agents} />
+      ) : route.name === "logs" ? (
+        <LogsPage onBack={() => navigate("")} />
       ) : route.name === "request" ? (
         <RequestDetailPage id={route.id} agents={agents} />
       ) : route.name === "onboard" ? (

--- a/www/src/components/LogsPage.tsx
+++ b/www/src/components/LogsPage.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { type LogEntry, type LogLevel, type LogsResp } from "../lib/api";
+import { fmtDateTime } from "../lib/format";
+
+// Plugin diagnostic log tail. Streams from /api/logs/stream over SSE;
+// falls back to the static /api/logs snapshot for the initial backlog
+// + on connection errors. Filters apply client-side so the user can
+// flip between min severities without dropping the SSE subscription —
+// the server already ships everything at the dashboard's chosen
+// resolution (default debug).
+
+const LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const LEVEL_COLOR: Record<LogLevel, string> = {
+  debug: "text-[#a3a3a3]",
+  info: "text-[#525252]",
+  warn: "text-[#c2410c]",
+  error: "text-[#dc2626]",
+};
+
+const LEVEL_BADGE: Record<LogLevel, string> = {
+  debug: "bg-[#f5f5f5] text-[#737373]",
+  info: "bg-[#eff6ff] text-[#1d4ed8]",
+  warn: "bg-[#fef3c7] text-[#a16207]",
+  error: "bg-[#fee2e2] text-[#b91c1c]",
+};
+
+export function LogsPage({ onBack }: { onBack: () => void }) {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [knownPlugins, setKnownPlugins] = useState<string[]>([]);
+  const [minLevel, setMinLevel] = useState<LogLevel>("info");
+  const [pluginFilter, setPluginFilter] = useState<string>("");
+  const [paused, setPaused] = useState(false);
+  const [bufferCap, setBufferCap] = useState(0);
+  const [drops, setDrops] = useState(0);
+  const [streaming, setStreaming] = useState(false);
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+
+  // SSE subscription. Server ships a `backlog` event (single batch)
+  // up front, then per-entry `data:` messages. Same shape as
+  // /api/events — see LiveRequests for the comment about why we
+  // batch through requestAnimationFrame.
+  useEffect(() => {
+    const es = new EventSource("/api/logs/stream");
+    let pending: LogEntry[] = [];
+    let raf = 0;
+    const cap = 2000;
+    const flush = () => {
+      raf = 0;
+      if (pending.length === 0) return;
+      const batch = pending;
+      pending = [];
+      if (pausedRef.current) return;
+      setEntries((prev) => {
+        const next = prev.concat(batch);
+        if (next.length > cap) return next.slice(next.length - cap);
+        return next;
+      });
+    };
+    es.addEventListener("backlog", (e) => {
+      try {
+        const arr = JSON.parse((e as MessageEvent).data) as LogEntry[];
+        setEntries((prev) => {
+          const next = prev.concat(arr);
+          if (next.length > cap) return next.slice(next.length - cap);
+          return next;
+        });
+      } catch {
+        /* ignore */
+      }
+    });
+    es.onmessage = (e) => {
+      try {
+        const entry = JSON.parse(e.data) as LogEntry;
+        pending.push(entry);
+        if (raf === 0) raf = requestAnimationFrame(flush);
+      } catch {
+        /* ignore */
+      }
+    };
+    es.onopen = () => setStreaming(true);
+    es.onerror = () => setStreaming(false);
+    return () => {
+      es.close();
+      if (raf !== 0) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  // Periodically refresh meta (buffer cap, drops, plugins). Static
+  // snapshot, cheap; runs every 5 s so the filter dropdown picks up
+  // newly-active plugins as soon as they emit.
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetch("/api/logs?meta=1&limit=1")
+        .then((r) => r.json() as Promise<LogsResp>)
+        .then((r) => {
+          if (cancelled) return;
+          setBufferCap(r.buffer_cap || 0);
+          setDrops(r.drops || 0);
+          if (r.plugins) {
+            setKnownPlugins((prev) => mergeUnique(prev, r.plugins ?? []));
+          }
+        })
+        .catch(() => {});
+    };
+    load();
+    const t = setInterval(load, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  // Surface plugins seen in the live stream too — covers the case
+  // where a plugin first logs after the dashboard loaded.
+  useEffect(() => {
+    if (entries.length === 0) return;
+    const seen = new Set<string>();
+    for (const e of entries) if (e.plugin) seen.add(e.plugin);
+    setKnownPlugins((prev) => mergeUnique(prev, Array.from(seen)));
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    const minRank = LEVEL_RANK[minLevel];
+    const wantPlugin = pluginFilter;
+    return entries.filter((e) => {
+      if (LEVEL_RANK[e.level] < minRank) return false;
+      if (wantPlugin && e.plugin !== wantPlugin) return false;
+      return true;
+    });
+  }, [entries, minLevel, pluginFilter]);
+
+  function clear() {
+    setEntries([]);
+  }
+
+  return (
+    <main className="flex-1 mx-auto w-full max-w-[1200px] px-4 sm:px-6 py-8 space-y-4">
+      <div className="flex items-center gap-4 flex-wrap">
+        <button
+          onClick={onBack}
+          className="text-[#525252] hover:text-[#171717] text-[14px]"
+          title="back"
+        >
+          ←
+        </button>
+        <h1 className="font-serif text-[32px] leading-none tracking-tight text-[#171717]">
+          plugin logs
+        </h1>
+        <span
+          className="flex items-center gap-1.5 text-[11px] text-[#737373]"
+          title="SSE live tail"
+        >
+          <span
+            className={
+              "inline-block w-[7px] h-[7px] rounded-full " +
+              (streaming ? "bg-[#22c55e]" : "bg-[#d4d4d4]")
+            }
+          />
+          {streaming ? "live" : "reconnecting"}
+        </span>
+      </div>
+
+      <div className="bg-white border border-[#e5e5e5] rounded p-3 flex flex-wrap items-center gap-3 text-[12px]">
+        <label className="flex items-center gap-2">
+          <span className="text-[#737373]">min severity</span>
+          <select
+            value={minLevel}
+            onChange={(e) => setMinLevel(e.target.value as LogLevel)}
+            className="border border-[#e5e5e5] rounded px-2 py-1 bg-white"
+          >
+            {LEVELS.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="text-[#737373]">plugin</span>
+          <select
+            value={pluginFilter}
+            onChange={(e) => setPluginFilter(e.target.value)}
+            className="border border-[#e5e5e5] rounded px-2 py-1 bg-white min-w-[160px]"
+          >
+            <option value="">all</option>
+            {knownPlugins.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          onClick={() => setPaused((p) => !p)}
+          className="border border-[#e5e5e5] rounded px-2 py-1 hover:border-[#171717] hover:text-[#171717]"
+          title={paused ? "resume live updates" : "freeze the tail"}
+        >
+          {paused ? "▶ resume" : "❚❚ pause"}
+        </button>
+        <button
+          onClick={clear}
+          className="border border-[#e5e5e5] rounded px-2 py-1 hover:border-[#171717] hover:text-[#171717]"
+          title="clear visible entries (does not flush the server buffer)"
+        >
+          clear
+        </button>
+        <div className="ml-auto text-[11px] text-[#a3a3a3] tabular-nums">
+          {filtered.length} / {entries.length} entries · buffer {bufferCap}
+          {drops > 0 ? ` · ${drops.toLocaleString()} dropped` : ""}
+        </div>
+      </div>
+
+      <div className="bg-white border border-[#e5e5e5] rounded overflow-hidden">
+        <div className="grid grid-cols-[200px_70px_220px_1fr] text-[10px] uppercase tracking-[.12em] text-[#a3a3a3] px-3 py-2 border-b border-[#e5e5e5]">
+          <div>time</div>
+          <div>level</div>
+          <div>plugin</div>
+          <div>message</div>
+        </div>
+        <div className="max-h-[70vh] overflow-y-auto font-mono text-[12px]">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-6 text-center text-[#a3a3a3]">
+              no log entries match the current filters
+            </div>
+          ) : (
+            filtered
+              .slice()
+              .reverse()
+              .map((e, i) => <LogRow key={i} entry={e} />)
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function LogRow({ entry }: { entry: LogEntry }) {
+  const [open, setOpen] = useState(false);
+  const hasFields = entry.fields && Object.keys(entry.fields).length > 0;
+  const hasContext = entry.req_id || entry.agent_ip;
+  const expandable = hasFields || hasContext;
+  return (
+    <div
+      className={
+        "grid grid-cols-[200px_70px_220px_1fr] px-3 py-1.5 border-b border-[#f5f5f5] " +
+        (expandable ? "cursor-pointer hover:bg-[#fafafa]" : "")
+      }
+      onClick={() => expandable && setOpen((o) => !o)}
+    >
+      <div className="text-[#737373] tabular-nums">{fmtDateTime(entry.ts)}</div>
+      <div>
+        <span
+          className={
+            "inline-block px-1.5 py-[1px] rounded text-[10px] uppercase tracking-wide " +
+            LEVEL_BADGE[entry.level]
+          }
+        >
+          {entry.level}
+        </span>
+      </div>
+      <div className="text-[#525252] truncate">{entry.plugin || "—"}</div>
+      <div className={LEVEL_COLOR[entry.level] + " break-words"}>
+        {entry.msg}
+        {open && (
+          <div className="mt-1 text-[11px] text-[#737373] space-y-0.5">
+            {entry.req_id && (
+              <div>
+                req_id:{" "}
+                <a
+                  href={`#/request/${encodeURIComponent(entry.req_id)}`}
+                  className="text-[#1d4ed8] hover:underline"
+                  onClick={(ev) => ev.stopPropagation()}
+                >
+                  {entry.req_id}
+                </a>
+              </div>
+            )}
+            {entry.agent_ip && <div>agent: {entry.agent_ip}</div>}
+            {hasFields &&
+              Object.entries(entry.fields ?? {}).map(([k, v]) => (
+                <div key={k} className="break-all">
+                  {k}: <span className="text-[#525252]">{formatField(v)}</span>
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatField(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+function mergeUnique(prev: string[], next: string[]): string[] {
+  if (next.length === 0) return prev;
+  const seen = new Set(prev);
+  let changed = false;
+  for (const n of next) {
+    if (!seen.has(n)) {
+      seen.add(n);
+      changed = true;
+    }
+  }
+  if (!changed) return prev;
+  return Array.from(seen).sort();
+}

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -524,6 +524,52 @@ export async function getAnalytics(params: {
   return r.json();
 }
 
+// Plugin diagnostic logs (/api/logs and /api/logs/stream).
+// Operators tail these to debug a misbehaving plugin without SSHing
+// to the host. Backend buffers the last N events in memory (default
+// 1000); credential values are never logged — only credential names.
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogEntry = {
+  ts: string;
+  plugin: string;
+  level: LogLevel;
+  msg: string;
+  req_id?: string;
+  agent_ip?: string;
+  fields?: Record<string, unknown>;
+};
+
+export type LogsResp = {
+  entries: LogEntry[];
+  buffer_cap: number;
+  buffer_size?: number;
+  drops?: number;
+  plugins?: string[];
+};
+
+export async function getLogs(params: {
+  min?: LogLevel;
+  plugin?: string;
+  agent?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  meta?: boolean;
+}): Promise<LogsResp> {
+  const p = new URLSearchParams();
+  if (params.min) p.set("min", params.min);
+  if (params.plugin) p.set("plugin", params.plugin);
+  if (params.agent) p.set("agent", params.agent);
+  if (params.since) p.set("since", params.since);
+  if (params.until) p.set("until", params.until);
+  if (params.limit) p.set("limit", String(params.limit));
+  if (params.meta) p.set("meta", "1");
+  const r = await api(`/api/logs?${p}`);
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
 export async function oauthExchange(
   state: string,
   code: string,


### PR DESCRIPTION
Adds a `/#/logs` tab to the dashboard that tails structured plugin diagnostic events, with filter controls for plugin, severity, time range, and agent.

## Changes

- `config/runtime/logger.go`: new `runtime.Logger` interface
- Ring-buffered `LogSink` (default 1000 entries, configurable via `plugin_log_buffer_size` HCL field)
- `GET /api/logs` — filtered snapshot; `GET /api/logs/stream` — SSE live tail
- HTTP credential injection, synthetic responders, approver notify, and postgres deny paths now route through the logger
- Two-layer credential redaction: auth/token/secret/key/password/cookie keys and `[]byte` values become `***` before reaching the buffer or stderr mirror
- 13 new tests, all passing under `-race`

Closes example/orchestrator#21