### PR TITLE
feat: ClickHouse native protocol — ADR + port-based dispatch fallback

### DIFF
--- a/clickhouse_dispatch_test.go
+++ b/clickhouse_dispatch_test.go
@@ -1,0 +1,124 @@
+package main
+
+// Tests for the ClickHouse-native dispatch helpers wired into
+// tcpDispatch. The wire-protocol pump is exhaustively tested in
+// config/plugins/endpoints/clickhouse_native_test.go; this file only
+// pins the policy-walk side of dispatch — pick the right endpoint
+// out of a CompiledPolicy given a device profile.
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// TestFirstClickhouseNativeEndpoint covers the lowest-priority
+// dispatch path in handleClickhouseNativeConn: pick the first
+// clickhouse_native endpoint in the device's profile. Mirrors the
+// shape firstPostgresEndpoint depends on but exercises the type
+// filter explicitly.
+func TestFirstClickhouseNativeEndpoint(t *testing.T) {
+	chPlugin := &config.Plugin{Type: "clickhouse_native", Family: "sql"}
+	pgPlugin := &config.Plugin{Type: "postgres", Family: "sql"}
+
+	chA := &config.CompiledEndpoint{Name: "ch-a", Family: "sql", Plugin: chPlugin}
+	chB := &config.CompiledEndpoint{Name: "ch-b", Family: "sql", Plugin: chPlugin}
+	pg := &config.CompiledEndpoint{Name: "pg", Family: "sql", Plugin: pgPlugin}
+
+	t.Run("nil policy returns nil", func(t *testing.T) {
+		if got := firstClickhouseNativeEndpoint(nil, "any"); got != nil {
+			t.Errorf("nil policy → endpoint %q, want nil", got.Name)
+		}
+	})
+
+	t.Run("profile with ch endpoint wins", func(t *testing.T) {
+		policy := &config.CompiledPolicy{
+			Profiles: map[string]*config.CompiledProfile{
+				"dev": {Name: "dev", Endpoints: map[string]*config.CompiledEndpoint{
+					"ch-a": chA,
+					"pg":   pg,
+				}},
+			},
+		}
+		got := firstClickhouseNativeEndpoint(policy, "dev")
+		if got != chA {
+			t.Errorf("got %v, want ch-a", got)
+		}
+	})
+
+	t.Run("profile without ch endpoint returns nil", func(t *testing.T) {
+		policy := &config.CompiledPolicy{
+			Profiles: map[string]*config.CompiledProfile{
+				"dev": {Name: "dev", Endpoints: map[string]*config.CompiledEndpoint{
+					"pg": pg,
+				}},
+			},
+		}
+		got := firstClickhouseNativeEndpoint(policy, "dev")
+		if got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("unknown profile falls back to any profile's ch endpoint", func(t *testing.T) {
+		// Mirrors firstPostgresEndpoint's single-tenant fallback:
+		// when the device has no profile binding, scan every
+		// profile so a single-tenant deployment without an
+		// explicit profile keeps working.
+		policy := &config.CompiledPolicy{
+			Profiles: map[string]*config.CompiledProfile{
+				"prod": {Name: "prod", Endpoints: map[string]*config.CompiledEndpoint{
+					"ch-b": chB,
+				}},
+			},
+		}
+		got := firstClickhouseNativeEndpoint(policy, "missing")
+		if got != chB {
+			t.Errorf("got %v, want ch-b (single-tenant fallback)", got)
+		}
+	})
+
+	t.Run("type filter excludes postgres", func(t *testing.T) {
+		// Important: firstClickhouseNativeEndpoint must NOT return
+		// a postgres endpoint even if it's the only SQL-family
+		// endpoint in scope. The port-based dispatch on :9000 /
+		// :9440 routes only ClickHouse traffic; mis-dispatching
+		// to a postgres runtime would break the agent.
+		policy := &config.CompiledPolicy{
+			Profiles: map[string]*config.CompiledProfile{
+				"dev": {Name: "dev", Endpoints: map[string]*config.CompiledEndpoint{
+					"pg": pg,
+				}},
+			},
+		}
+		got := firstClickhouseNativeEndpoint(policy, "dev")
+		if got != nil {
+			t.Errorf("got %v, want nil — postgres must not satisfy a ch-native query", got)
+		}
+	})
+}
+
+// TestFirstEndpointOfTypeMissingProfileSingleTenant pins the
+// single-tenant fallback shared by firstPostgresEndpoint and
+// firstClickhouseNativeEndpoint: when the device has no profile
+// binding, scan every profile so single-profile deployments
+// without explicit binding still dispatch. Asserts the order is
+// stable enough to be useful — the first profile iteration is
+// nondeterministic so we only check the type filter applies.
+func TestFirstEndpointOfTypeMissingProfileSingleTenant(t *testing.T) {
+	chPlugin := &config.Plugin{Type: "clickhouse_native", Family: "sql"}
+	chA := &config.CompiledEndpoint{Name: "ch-a", Family: "sql", Plugin: chPlugin}
+	policy := &config.CompiledPolicy{
+		Profiles: map[string]*config.CompiledProfile{
+			"only": {Name: "only", Endpoints: map[string]*config.CompiledEndpoint{
+				"ch-a": chA,
+			}},
+		},
+	}
+	if got := firstEndpointOfType(policy, "", "clickhouse_native"); got != chA {
+		t.Errorf("empty profile → %v, want ch-a", got)
+	}
+	if got := firstEndpointOfType(policy, "anything", "clickhouse_native"); got != chA {
+		t.Errorf("unknown profile → %v, want ch-a", got)
+	}
+}

--- a/config/plugins/endpoints/clickhouse_native_dispatch_test.go
+++ b/config/plugins/endpoints/clickhouse_native_dispatch_test.go
@@ -1,0 +1,339 @@
+package endpoints
+
+// Tests for the ClickHouse native query-pattern matchers and dispatch
+// glue. The wire-level pump tests live in clickhouse_native_test.go;
+// this file pins the SQL-extractor + matcher behaviour the dispatch
+// layer relies on for the protocol shapes called out in the dispatch
+// ADR (site/doc/adr-clickhouse-native-dispatch.md): INSERT … VALUES,
+// SELECT … FORMAT, and SYSTEM commands.
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	chgoproto "github.com/ClickHouse/ch-go/proto"
+	chproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+)
+
+// TestParseChSQLInsertValues covers the INSERT-VALUES shapes a ClickHouse
+// client emits when streaming row literals. The parser must surface
+// verb=insert and the destination table; trailing FORMAT / SETTINGS the
+// real server tolerates after VALUES are stripped before the AST walk
+// so an over-strict parser doesn't drop the whole statement on the floor.
+func TestParseChSQLInsertValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		sql       string
+		wantVerb  string
+		wantTable string
+	}{
+		{
+			name:      "plain values single row",
+			sql:       "INSERT INTO events VALUES (1, 'hello')",
+			wantVerb:  "insert",
+			wantTable: "events",
+		},
+		{
+			name:      "values multi row",
+			sql:       "INSERT INTO events VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+			wantVerb:  "insert",
+			wantTable: "events",
+		},
+		{
+			name:      "named columns",
+			sql:       "INSERT INTO events (ts, body) VALUES (now(), 'x')",
+			wantVerb:  "insert",
+			wantTable: "events",
+		},
+		{
+			name:      "qualified database",
+			sql:       "INSERT INTO analytics.events VALUES (1, 'x')",
+			wantVerb:  "insert",
+			wantTable: "analytics.events",
+		},
+		{
+			name:      "values with settings trailer",
+			sql:       "INSERT INTO events VALUES (1, 'x') SETTINGS async_insert = 1",
+			wantVerb:  "insert",
+			wantTable: "events",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := parseChSQL(tc.sql)
+			if info.Verb != tc.wantVerb {
+				t.Errorf("verb = %q, want %q", info.Verb, tc.wantVerb)
+			}
+			if len(info.Tables) != 1 || info.Tables[0] != tc.wantTable {
+				t.Errorf("tables = %v, want [%q]", info.Tables, tc.wantTable)
+			}
+			if info.Statement != tc.sql {
+				t.Errorf("Statement dropped: got %q, want %q", info.Statement, tc.sql)
+			}
+		})
+	}
+}
+
+// TestParseChSQLSelectFormat covers SELECT-FORMAT — clients use this to
+// request a specific result encoding (JSON, JSONEachRow, TSV, CSV,
+// Pretty, Native, RowBinary, …). The trailing `FORMAT <name>` is one
+// of the inputs the AfterShip parser rejects in some positions, so
+// chSQLTrailerRE strips it before the AST walk.
+func TestParseChSQLSelectFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"format json", "SELECT id, name FROM users FORMAT JSON"},
+		{"format jsoneachrow", "SELECT * FROM events FORMAT JSONEachRow"},
+		{"format tsv", "SELECT count() FROM events FORMAT TSV"},
+		{"format csv with newline", "SELECT id\nFROM users\nFORMAT CSV"},
+		{"format pretty trailing space", "SELECT 1 FROM events FORMAT Pretty "},
+		{"format native", "SELECT * FROM events FORMAT Native"},
+		{"format rowbinary", "SELECT * FROM analytics.events FORMAT RowBinary"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := parseChSQL(tc.sql)
+			if info.Verb != "select" {
+				t.Errorf("verb = %q, want select", info.Verb)
+			}
+			// All forms reference exactly one table; the AST walker
+			// must surface it despite the FORMAT trailer.
+			if len(info.Tables) != 1 {
+				t.Errorf("tables = %v, want exactly one entry", info.Tables)
+			}
+			if info.Statement != tc.sql {
+				t.Errorf("Statement = %q, want untouched %q", info.Statement, tc.sql)
+			}
+		})
+	}
+}
+
+// TestParseChSQLSystemQueries covers operator-side commands that ship as
+// SYSTEM <verb> [<target>]. Some — STOP MERGES, RELOAD DICTIONARIES —
+// the AfterShip parser knows; others — DROP MARK CACHE — it doesn't,
+// in which case the verb-sniffer fallback still surfaces "system" so
+// rule conditions like `sql.verb == 'system'` keep firing.
+//
+// The matcher's contract is loose by design: operators write rules
+// against `sql.verb` and `sql.statement_regex`, not against an exact
+// SYSTEM sub-command enum, so a fallback-derived verb is enough.
+func TestParseChSQLSystemQueries(t *testing.T) {
+	cases := []string{
+		"SYSTEM RELOAD CONFIG",
+		"SYSTEM RELOAD DICTIONARIES",
+		"SYSTEM RELOAD DICTIONARY my_dict",
+		"SYSTEM STOP MERGES",
+		"SYSTEM START MERGES",
+		"SYSTEM STOP DISTRIBUTED SENDS",
+		"SYSTEM FLUSH LOGS",
+		"SYSTEM DROP MARK CACHE",
+		"SYSTEM DROP UNCOMPRESSED CACHE",
+		"SYSTEM SYNC REPLICA replicas.events",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			info := parseChSQL(sql)
+			if info.Verb != "system" {
+				t.Errorf("verb = %q, want system (input: %q)", info.Verb, sql)
+			}
+			if info.Statement != sql {
+				t.Errorf("Statement dropped: got %q, want %q", info.Statement, sql)
+			}
+		})
+	}
+}
+
+// TestParseChSQLShowDescribe verifies the system-shape introspection
+// statements (SHOW / DESCRIBE / EXPLAIN) get their dedicated verbs.
+// Important because operator-side rules often gate these: "agents may
+// SELECT but may not EXPLAIN" is a real anti-leakage stance.
+func TestParseChSQLShowDescribe(t *testing.T) {
+	cases := []struct {
+		sql      string
+		wantVerb string
+	}{
+		{"SHOW DATABASES", "show"},
+		{"SHOW TABLES", "show"},
+		{"SHOW TABLES FROM analytics", "show"},
+		{"DESCRIBE TABLE events", "describe"},
+		{"EXPLAIN SELECT * FROM events", "explain"},
+		{"EXPLAIN PIPELINE SELECT * FROM events", "explain"},
+		{"EXPLAIN AST SELECT * FROM events", "explain"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			info := parseChSQL(tc.sql)
+			if info.Verb != tc.wantVerb {
+				t.Errorf("verb = %q, want %q", info.Verb, tc.wantVerb)
+			}
+			if info.Statement != tc.sql {
+				t.Errorf("Statement dropped: got %q, want %q", info.Statement, tc.sql)
+			}
+		})
+	}
+}
+
+// TestChEvaluateSQLDeniesSystemQueries ties the system-verb extractor
+// to the rule matcher end-to-end. A rule with condition `sql.verb ==
+// 'system'` must fire for every SYSTEM-shaped statement, regardless of
+// whether the underlying AST parser accepted the body or fell through
+// to the verb sniffer.
+func TestChEvaluateSQLDeniesSystemQueries(t *testing.T) {
+	denySystem := chRuleSQL(t, "deny-system",
+		"sql.verb == 'system'", "deny", "system ops blocked", 100)
+	ep := chBuildEndpoint(t, denySystem)
+
+	mock, _ := chNewMockHandle(t, ep)
+
+	for _, sql := range []string{
+		"SYSTEM RELOAD CONFIG",
+		"SYSTEM STOP MERGES",
+		"SYSTEM FLUSH LOGS",
+	} {
+		verdict, reason := chEvaluateSQL(context.Background(), mock.ConnHandle, sql, "ch-cred")
+		if verdict != "deny" {
+			t.Errorf("%q verdict = %q, want deny", sql, verdict)
+		}
+		if reason != "system ops blocked" {
+			t.Errorf("%q reason = %q, want %q", sql, reason, "system ops blocked")
+		}
+	}
+}
+
+// TestChEvaluateSQLAllowsSelectWithFormat is the inverse of the system-
+// deny test: a `sql.verb == 'select'` allow rule must fire for SELECT-
+// FORMAT shapes too, since the FORMAT clause is purely an encoding
+// directive on the server's reply — not a structural change to the
+// statement that policy should care about.
+func TestChEvaluateSQLAllowsSelectWithFormat(t *testing.T) {
+	allowSelect := chRuleSQL(t, "allow-select",
+		"sql.verb == 'select'", "allow", "", 100)
+	ep := chBuildEndpoint(t, allowSelect)
+
+	mock, _ := chNewMockHandle(t, ep)
+
+	for _, sql := range []string{
+		"SELECT * FROM users FORMAT JSON",
+		"SELECT count() FROM events FORMAT JSONEachRow",
+		"SELECT id FROM events FORMAT RowBinary",
+	} {
+		verdict, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, sql, "ch-cred")
+		if verdict != "" {
+			t.Errorf("%q verdict = %q, want allow (empty)", sql, verdict)
+		}
+	}
+}
+
+// TestChEvaluateSQLTableFacetMatchesQualified covers the
+// `sql.tables contains "..."` matcher shape over qualified table names.
+// ClickHouse rule writers commonly gate access to specific tables
+// (e.g. `sql.tables contains "analytics.secrets"`); the extractor must
+// surface the qualifier so the rule fires on `INSERT INTO
+// analytics.secrets VALUES (…)` while letting `INSERT INTO
+// analytics.events VALUES (…)` through.
+func TestChEvaluateSQLTableFacetMatchesQualified(t *testing.T) {
+	rule := chRuleSQL(t, "deny-secrets",
+		`sql.tables.exists(t, t == "analytics.secrets")`,
+		"deny", "secrets table protected", 100)
+	ep := chBuildEndpoint(t, rule)
+
+	mock, _ := chNewMockHandle(t, ep)
+
+	verdict, reason := chEvaluateSQL(context.Background(), mock.ConnHandle,
+		"INSERT INTO analytics.secrets VALUES (1)", "ch-cred")
+	if verdict != "deny" {
+		t.Fatalf("secrets-INSERT verdict = %q, want deny", verdict)
+	}
+	if reason != "secrets table protected" {
+		t.Errorf("reason = %q, want %q", reason, "secrets table protected")
+	}
+
+	verdict, _ = chEvaluateSQL(context.Background(), mock.ConnHandle,
+		"INSERT INTO analytics.events VALUES (1)", "ch-cred")
+	if verdict != "" {
+		t.Errorf("events-INSERT verdict = %q, want allow (empty)", verdict)
+	}
+}
+
+// TestChAgentToServerInsertValuesForwarded round-trips an INSERT
+// Query + one Data block through the agent → server pump. The data
+// block that follows the Query packet is what real clients stream
+// row literals on; this nails down that the Query body lands upstream
+// verbatim and the ClientData header (TableName=events) is preserved.
+func TestChAgentToServerInsertValuesForwarded(t *testing.T) {
+	const revision = 54448
+	const sql = "INSERT INTO events VALUES"
+
+	mock, _ := chNewMockHandle(t, chBuildEndpoint(t))
+	defer func() { _ = mock.Conn.Close() }()
+
+	q := chgoproto.Query{
+		ID:    "qid-1",
+		Body:  sql,
+		Stage: chgoproto.StageComplete,
+		Info: chgoproto.ClientInfo{
+			ProtocolVersion: revision, Major: 24, Minor: 8,
+			Interface:   chgoproto.InterfaceTCP,
+			Query:       chgoproto.ClientQueryInitial,
+			InitialUser: "alice",
+		},
+	}
+	var agentBuf chgoproto.Buffer
+	q.EncodeAware(&agentBuf, revision)
+
+	// One Data packet carrying a single-column block — mirrors what
+	// clickhouse-client streams immediately after the Query for an
+	// INSERT … VALUES statement.
+	agentBuf.PutByte(byte(chgoproto.ClientCodeData))
+	chgoproto.ClientData{TableName: "events"}.EncodeAware(&agentBuf, revision)
+	dataBlock := chBuildSampleBlock(t)
+	if err := dataBlock.Encode(&agentBuf, uint64(revision)); err != nil {
+		t.Fatalf("encode data block: %v", err)
+	}
+
+	reader := chgoproto.NewReader(bytes.NewReader(agentBuf.Buf))
+	var upstream bytes.Buffer
+	chAgentToServer(context.Background(), mock.ConnHandle, reader, &upstream, revision, "ch-cred")
+
+	// Walk the forwarded bytes: Query, then Data(events).
+	r := chgoproto.NewReader(bytes.NewReader(upstream.Bytes()))
+	code, err := r.UInt8()
+	if err != nil {
+		t.Fatalf("read first packet code: %v", err)
+	}
+	if chgoproto.ClientCode(code) != chgoproto.ClientCodeQuery {
+		t.Fatalf("first packet = %d, want ClientCodeQuery", code)
+	}
+	var gotQ chgoproto.Query
+	if err := gotQ.DecodeAware(r, revision); err != nil {
+		t.Fatalf("decode forwarded Query: %v", err)
+	}
+	if gotQ.Body != sql {
+		t.Errorf("forwarded Query body = %q, want %q", gotQ.Body, sql)
+	}
+
+	code, err = r.UInt8()
+	if err != nil {
+		t.Fatalf("read second packet code: %v", err)
+	}
+	if chgoproto.ClientCode(code) != chgoproto.ClientCodeData {
+		t.Fatalf("second packet = %d, want ClientCodeData", code)
+	}
+	var gotHdr chgoproto.ClientData
+	if err := gotHdr.DecodeAware(r, revision); err != nil {
+		t.Fatalf("decode forwarded ClientData: %v", err)
+	}
+	if gotHdr.TableName != "events" {
+		t.Errorf("forwarded TableName = %q, want events", gotHdr.TableName)
+	}
+	gotBlock := chproto.NewBlock()
+	if err := gotBlock.Decode(r, uint64(revision)); err != nil {
+		t.Fatalf("decode forwarded block: %v", err)
+	}
+	if gotBlock.Rows() != dataBlock.Rows() {
+		t.Errorf("forwarded block rows=%d, want %d", gotBlock.Rows(), dataBlock.Rows())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1276,13 +1276,45 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 	}
 }
 
+// handleClickhouseNativeConn dispatches an inbound :9000 / :9440 flow
+// to the clickhouse_native endpoint runtime. Mirrors handlePostgresConn:
+// ConnIndex lookup by dst IP first (so multi-cluster profiles dispatch
+// to the right binding), fall back to the first clickhouse_native
+// endpoint in the device's profile (single-cluster profiles), fall
+// through to wgRelay when neither applies.
+//
+// Hostname-bound clickhouse_native endpoints reach the runtime via
+// handleVIPConn instead (DNS-VIP path); this handler covers IP-literal
+// and freshly-resolved-but-unindexed upstreams.
+func (g *Gateway) handleClickhouseNativeConn(c net.Conn, dstIP string, dstPort uint16) {
+	defer otelTrackConn("ch_native_relay")()
+	pip := peerIP(c)
+	profile := g.profileFor(pip)
+	policy := g.Policy()
+
+	var ep *config.CompiledEndpoint
+	if idx := g.connIdx.Load(); idx != nil {
+		candidates := idx.Lookup(dstIP)
+		ep = pickEndpointForProfile(candidates, policy, profile)
+	}
+	if ep == nil {
+		ep = firstClickhouseNativeEndpoint(policy, profile)
+	}
+	if ep == nil {
+		log.Printf("ch_native %s:%d: no clickhouse_native endpoint in profile %q; relaying", dstIP, dstPort, profile)
+		g.wgRelay(c, dstIP, int(dstPort))
+		return
+	}
+
+	g.dispatchConnEndpoint(c, dstIP, dstPort, ep, "")
+}
+
 // handleVIPConn dispatches an inbound TCP connection whose dst IP
 // falls in the dnsvip range. The VIP table maps the IP back to the
 // hostname → endpoints that claimed a VIP at policy build; profile
-// filter picks the one for this device. Today the only RequiresVIP
-// plugin is "ssh", but the path is generic so future binary
-// protocols (clickhouse_native with a hostname-keyed dispatch quirk,
-// for instance) can plug in without a separate forwarder branch.
+// filter picks the one for this device. RequiresVIP plugins include
+// ssh and clickhouse_native — handleVIPConn dispatches to either via
+// the endpoint's plugin Runtime, no per-plugin branching needed here.
 func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 	defer otelTrackConn("vip_conn")()
 
@@ -1477,15 +1509,31 @@ func pickEndpointForProfile(candidates []*config.CompiledEndpoint, policy *confi
 }
 
 func firstPostgresEndpoint(policy *config.CompiledPolicy, profile string) *config.CompiledEndpoint {
+	return firstEndpointOfType(policy, profile, "postgres")
+}
+
+// firstClickhouseNativeEndpoint mirrors firstPostgresEndpoint for the
+// clickhouse_native plugin. It is the lowest-priority dispatch in
+// handleClickhouseNativeConn — used when a flow lands on :9000 / :9440
+// from an upstream IP that isn't in ConnIndex (typical of Cloud
+// ClickHouse where DNS rotates faster than policy reload).
+func firstClickhouseNativeEndpoint(policy *config.CompiledPolicy, profile string) *config.CompiledEndpoint {
+	return firstEndpointOfType(policy, profile, "clickhouse_native")
+}
+
+// firstEndpointOfType returns the first endpoint of the given plugin
+// type in the device's profile, falling back to a scan of every
+// profile when the device has no profile binding (single-tenant
+// deployments). nil when no such endpoint exists anywhere.
+func firstEndpointOfType(policy *config.CompiledPolicy, profile, pluginType string) *config.CompiledEndpoint {
 	if policy == nil {
 		return nil
 	}
 	prof, ok := policy.Profiles[profile]
 	if !ok {
-		// Single-tenant fallback: scan every profile.
 		for _, p := range policy.Profiles {
 			for _, ep := range p.Endpoints {
-				if ep.Plugin.Type == "postgres" {
+				if ep.Plugin.Type == pluginType {
 					return ep
 				}
 			}
@@ -1493,7 +1541,7 @@ func firstPostgresEndpoint(policy *config.CompiledPolicy, profile string) *confi
 		return nil
 	}
 	for _, ep := range prof.Endpoints {
-		if ep.Plugin.Type == "postgres" {
+		if ep.Plugin.Type == pluginType {
 			return ep
 		}
 	}
@@ -2321,19 +2369,28 @@ func runGateway(args []string) {
 			case dstPort == 53:
 				g.handleDNSTCPConn(c, dstIP)
 			case g.dnsvip.IsVIP(dstIP):
-				// Any port on a VIP belongs to the SSH endpoint that
-				// hostname maps to. Future RequiresVIP plugins can
-				// branch on ep.Plugin.Type inside handleVIPConn.
+				// Any port on a VIP belongs to a hostname-bound
+				// endpoint (ssh, clickhouse_native). handleVIPConn
+				// dispatches by plugin Runtime — no branching here.
 				g.handleVIPConn(c, dstIP, dstPort)
+			case dstPort == 9000 || dstPort == 9440:
+				// ClickHouse native: port-based fallback that mirrors
+				// :5432 for postgres. ConnIndex wins when the dst IP
+				// is registered; otherwise fall back to the first
+				// clickhouse_native endpoint in the device's profile;
+				// otherwise relay (so unrelated services on these
+				// ports — Portainer agent, kdb+ — keep working when
+				// no CH policy is declared).
+				g.handleClickhouseNativeConn(c, dstIP, dstPort)
 			case dashPort != 0 && int(dstPort) == dashPort:
 				_ = http.Serve(&oneShotListener{c: c}, dashMux)
 			default:
-				// Direct-IP dispatch via conn-index: catches
-				// clickhouse_native and friends when the operator
-				// binds them to IP-literal hosts (dnsvip skips
-				// those — they don't need DNS interception). Falls
-				// through to transparent relay when no endpoint
-				// claims the dst.
+				// Direct-IP dispatch via conn-index: catches any
+				// ConnEndpointRuntime plugin (clickhouse_native bound
+				// to IP-literal hosts on a non-default port, future
+				// plugins) when the operator binds them to bare IPs
+				// dnsvip skips. Falls through to transparent relay
+				// when no endpoint claims the dst.
 				if g.tryDirectIPConn(c, dstIP, dstPort) {
 					return
 				}
@@ -2350,7 +2407,7 @@ func runGateway(args []string) {
 		if err := wg.EnablePromiscuousForwarder(tcpDispatch, udpDispatch); err != nil {
 			log.Fatalf("wireguard forwarder: %v", err)
 		}
-		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :53=dns-vip, VIP=ssh|ch_native, :%d=dash, plugins=conn-index, else=relay)", dashPort)
+		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :53=dns-vip, VIP=ssh|ch_native, :9000/:9440=ch_native, :%d=dash, plugins=conn-index, else=relay)", dashPort)
 	}
 
 	ln, err := openListener(cfg)

--- a/site/doc/adr-clickhouse-native-dispatch.md
+++ b/site/doc/adr-clickhouse-native-dispatch.md
@@ -1,0 +1,292 @@
+# ADR: ClickHouse native protocol dispatch
+
+**Status:** accepted
+
+**Decision:** terminate the ClickHouse native protocol in
+`config/plugins/endpoints/clickhouse_native`, and reach that
+runtime through **three** dispatch paths layered in priority
+order — DNS-VIP for hostname bindings, a direct-IP `ConnIndex`
+lookup for IP-literal bindings, and a port-based dispatch on
+`:9000` / `:9440` that mirrors the `:5432` postgres path. The
+prior framing of "direct-IP **versus** VIP" was a false dilemma:
+the question is not which dispatch wins, but how a flow that
+might be ClickHouse is steered into the same protocol terminator.
+
+## Context
+
+The promiscuous WireGuard forwarder accepts SYNs to any
+destination IP/port (`main.go:tcpDispatch`). For each flow it
+must pick one of:
+
+- terminate a known wire protocol in a plugin,
+- relay bytes verbatim to the real upstream (`wgRelay`).
+
+`https` and `kubernetes` recover endpoint identity at TLS time by
+peeking the SNI. Postgres has no SNI but uses a well-known port
+(`:5432`) plus a profile lookup. SSH is hostname-identified —
+`ssh build.example.com` and `ssh prod.example.com` both arrive on
+`:22` of distinct upstreams — so it leans on DNS-VIP to recover
+the agent-dialed name from the destination IP.
+
+ClickHouse native sits awkwardly in this space:
+
+- **No SNI.** Plaintext on `:9000` and TLS on `:9440`, but the
+  TLS variant carries no application-layer hostname. The Hello
+  packet, which the client sends *after* the TCP/TLS handshake,
+  carries the username/database, not the cluster identity.
+- **Multi-host clusters.** ClickHouse Cloud and managed
+  deployments expose one logical cluster behind a hostname whose
+  DNS rotates between many IPs. Pre-resolving every IP at policy
+  build is fragile.
+- **Multiple agent shapes.** The official `clickhouse-client`
+  CLI, `clickhouse-driver` (Python), `clickhouse-go`,
+  JetBrains DataGrip, and Grafana's CH plugin each dial differently
+  — some use the cluster hostname, some accept an IP literal in a
+  connection string, some negotiate compression up front, some
+  toggle compression per query.
+
+The dispatch decision **must** happen before the first agent byte
+is read, since picking the wrong handler closes (or worse,
+mis-frames) the connection.
+
+## Options considered
+
+### Option A — TCP passthrough with sidecar inspection ("VIP packet-sniff")
+
+The wording in the inbox issue described "VIP approach: intercept
+at the TCP level using a virtual IP, inspect packets without full
+protocol termination". Concretely this would mean:
+
+1. Allocate a VIP per hostname (already done by `dnsvip`).
+2. Forward bytes both ways with `io.Copy`.
+3. Sniff query strings opportunistically out of the byte stream.
+
+Tried in a scratch branch; rejected on three counts.
+
+1. **Correctness.** ClickHouse native is variable-length
+   VarInt-framed with optional LZ4/ZSTD compression. There is no
+   reliable text fragment to grep for. A Query packet is
+   `code:VarInt | id:string | client_info:VarInt+blob | settings | … | body:string | compression:VarInt | data_blocks…`.
+   Recovering the SQL body needs full VarInt + ClientInfo decode
+   anyway — i.e. exactly the work the terminator does.
+2. **Credential injection becomes impossible.** The Hello packet
+   embeds the agent's username and password as length-prefixed
+   strings. Passthrough cannot rewrite those without re-emitting
+   the surrounding VarInt frame, which means partial
+   termination. Once we're partial we own the rest of the wire
+   anyway.
+3. **Deny semantics are broken.** Postgres signals a denial with
+   a Backend `ErrorResponse` followed by `ReadyForQuery` so the
+   client stays in the session. The ClickHouse equivalent is a
+   `ServerCodeException` with a structured error code (we use
+   `497 ACCESS_DENIED`). A sniff-only path can drop bytes on the
+   floor but cannot synthesise that packet without taking over
+   the session — which is what termination *is*.
+
+### Option B — direct-IP only
+
+Drop the VIP allocation; require operators to pre-declare upstream
+IPs. The forwarder reads `dstIP`, consults `ConnIndex`, finds the
+endpoint, terminates the protocol.
+
+Pros:
+
+- One dispatch surface; no DNS interception.
+- No VIP allocator state to persist.
+
+Cons:
+
+- **Cloud ClickHouse breaks.** Managed clusters expose a hostname
+  whose A records change behind the scenes. Pre-resolving at
+  policy build pins to whatever the gateway saw at that moment;
+  the next failover lands outside the index and the flow
+  passthroughs (no policy enforcement).
+- **Operators have to enumerate.** A multi-shard self-hosted
+  cluster typically has 3–9 IPs. `hosts = ["10.0.0.5",
+  "10.0.0.6", …]` is brittle when one is added or rotated.
+- **Pod IPs.** In Kubernetes the upstream IP is a Service or
+  ClusterIP, and Service VIPs can be reassigned across cluster
+  restores; even worse, operators sometimes want to dial pod IPs
+  directly.
+
+### Option C — VIP only
+
+The DNS responder answers ClickHouse hostnames with a stable VIP;
+the forwarder routes any port on that VIP to the runtime
+(`handleVIPConn`). VIPs persist to `dnsvip.json` so they survive
+restart.
+
+Pros:
+
+- Hostnames resolved at *dial time* — DNS rotation is opaque to
+  the gateway. The terminator dials the real upstream when the
+  session begins, so the freshest A record wins.
+- One stable identity per cluster (the hostname), so a single
+  endpoint binding covers all replicas.
+
+Cons:
+
+- **IP-literal bindings fall through.** A self-hosted ClickHouse
+  reached as `hosts = ["172.17.0.1:9000"]` has no DNS query to
+  intercept, so there's no VIP. The flow has to be picked up by
+  *some* other path.
+- **Trust model.** DNS is the recovery key for endpoint identity.
+  If an agent bypasses the gateway's resolver (hardcoded
+  `1.1.1.1`, etc.) the VIP table is never consulted — but in
+  practice the WG netstack routes any `:53` datagram into the
+  gateway regardless of the agent's resolver setting, so this is
+  defended in depth.
+
+### Option D — port-based dispatch ("postgres model")
+
+The forwarder special-cases `:9000` and `:9440` and unconditionally
+calls a `handleClickhouseNativeConn` that picks the first
+ClickHouse-native endpoint in the device's profile (like
+`handlePostgresConn` + `firstPostgresEndpoint`).
+
+Pros:
+
+- Catches *all* ClickHouse traffic from a profile that has any
+  `clickhouse_native` endpoint, regardless of how the agent
+  reached the upstream (hostname, IP literal, freshly-rotated
+  Cloud IP not in the index).
+- Simple to reason about: "does the profile have a CH endpoint?
+  yes → terminate; no → relay."
+
+Cons:
+
+- **Single-endpoint heuristic.** When two `clickhouse_native`
+  endpoints in the same profile point at different clusters,
+  "first wins" picks one arbitrarily for any flow whose dst IP
+  isn't in `ConnIndex`. Mitigated by trying `ConnIndex` first.
+- **Port collision.** Some operators run unrelated services on
+  9000 (Portainer agent, kdb+ legacy ports). Mitigated by
+  fall-through to relay when no CH endpoint is in the profile —
+  i.e. the dispatch only fires when an operator has explicitly
+  declared they want ClickHouse policy on this profile.
+
+## Decision
+
+Adopt **all three real options layered**:
+
+1. **DNS-VIP** (highest priority). ClickHouse endpoints with
+   hostname `hosts` claim a VIP per hostname. The forwarder
+   recognises VIP destinations before anything else and routes to
+   `handleVIPConn`. Hostnames stay the cluster identity; DNS
+   rotation is opaque to clawpatrol.
+2. **Direct-IP via `ConnIndex`** (medium). ClickHouse endpoints
+   with IP-literal `hosts` fold into `ConnIndex` at policy build.
+   In the port-based handler (and in the catch-all branch) the
+   index lookup wins over the first-endpoint fallback, so
+   multi-endpoint profiles still dispatch to the right binding
+   for known upstream IPs.
+3. **Port-based fallback on `:9000` / `:9440`** (lowest). A new
+   `handleClickhouseNativeConn` mirrors `handlePostgresConn`:
+   consult `ConnIndex` first, fall back to the first
+   `clickhouse_native` endpoint in the device's profile, fall
+   through to `wgRelay` when neither applies.
+
+A single `HandleConn` in `clickhouse_native_runtime.go` services
+all three. Every flow that reaches it terminates the native
+protocol fully: parse Hello, swap placeholder credentials, dial
+upstream, mediate Query/Data packets through the SQL rule matcher,
+synthesise `ServerCodeException` on deny.
+
+## Consequences
+
+### Correctness
+
+| concern                       | how it's handled                                                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| TLS handshake on `:9440`      | gateway terminates with an on-the-fly leaf minted off the gateway CA; agent trust comes from `SSL_CERT_FILE` pushdown by `clawpatrol run`.                              |
+| Multi-host cluster            | hostname → one VIP → one endpoint binding; replicas resolved at dial time.                                                                                              |
+| IP-literal upstream           | declared `hosts = ["172.17.0.1:9000"]` lands in `ConnIndex`; profile filter prevents cross-profile leakage.                                                              |
+| Untracked upstream IP         | port-based fallback fires when a `clickhouse_native` endpoint exists in the profile; pure relay otherwise.                                                              |
+| Compressed Data blocks        | opaque CityHash-discriminator probe (no LZ4/ZSTD decompression on the path); preserves agent's compression flag verbatim.                                               |
+| Deny                          | `ServerCodeException` packet, error code 497 (`ACCESS_DENIED`), pump continues so a denied statement can't smuggle past an allowed one.                                  |
+
+### Latency
+
+- Steady-state per-query overhead is one VarInt decode of the
+  Query packet plus rule evaluation. The query path in
+  `chAgentToServer` runs at well under a millisecond on the loopback
+  pipe used by the existing unit tests.
+- Compressed Data blocks do **not** decompress — frames walk
+  opaquely past the probe at near memcpy speed.
+- Hello injection adds one round-trip of bytes the agent already
+  was going to send; no extra RTT.
+- Port-based fallback adds one map lookup vs. the prior
+  `wgRelay` fast path; negligible.
+
+### Implementation complexity
+
+- The VIP path was already in place for SSH; ClickHouse just
+  declares `RequiresVIP()` and `ConnRouteHosts()` and falls in.
+- The direct-IP path reuses `ConnIndex` / `tryDirectIPConn`
+  unchanged.
+- The port-based fallback is ~30 lines mirroring
+  `handlePostgresConn` and `firstPostgresEndpoint`.
+
+The plugin's own runtime carries the protocol cost. That code
+exists today and is exercised by the test suite in
+`config/plugins/endpoints/clickhouse_native_test.go`.
+
+### Failure modes and observability
+
+- **Unknown packet code mid-session.** Future ClickHouse protocol
+  additions surface as `unknown-client-packet` error events and
+  tear the session down (rather than blindly forwarding a packet
+  with unknown body length). Operators see this in the dashboard
+  immediately; the fix is to add the packet code to
+  `chAgentToServer`'s switch.
+- **Probe slow-path timeout (`200ms`).** Headerless 1-byte
+  packets (Ping = 4, Cancel = 3) immediately after a compressed
+  Data block don't carry 24 more bytes; the probe relies on a
+  read deadline to recognise the boundary. The deadline is
+  generous over WG and well under any client-side Pong timeout
+  we've seen.
+- **VIP collision after CIDR rebinding.** Operators changing the
+  VIP CIDR mid-deployment force a fresh allocation; the
+  allocator drops persisted entries outside the new range
+  (already handled in `dnsvip.load`).
+- **Port collision with non-CH services on `:9000`.** The
+  port-based fallback only fires when a `clickhouse_native`
+  endpoint is declared in the device's profile. Profiles that
+  declare none fall through to relay.
+
+## Alternatives revisited and rejected
+
+- **eBPF redirect.** Cross-platform reach is the project goal
+  (Linux *and* macOS via Network Extension); cBPF/eBPF only
+  carries weight on Linux and rules out the macOS path.
+- **An HTTP-shaped front door for ClickHouse (`:8123` /
+  `clickhouse_https`).** Useful and *separately implemented*,
+  but it is not a substitute for native — `clickhouse-client`
+  defaults to native and many production agents speak it.
+- **Per-agent shim.** A library-level intercept (LD_PRELOAD,
+  Python `sys.settrace`) inside the agent dodges the dispatch
+  question but breaks the "agent doesn't know clawpatrol exists"
+  contract and is infeasible for closed-source agents.
+
+## Related code
+
+- `main.go:tcpDispatch` — the forwarder switch.
+- `main.go:handlePostgresConn` — the model
+  `handleClickhouseNativeConn` follows.
+- `main.go:handleVIPConn`, `main.go:tryDirectIPConn` — the other
+  two dispatch surfaces.
+- `config/plugins/endpoints/clickhouse_native.go` — schema and
+  registration.
+- `config/plugins/endpoints/clickhouse_native_runtime.go` —
+  protocol termination.
+- `dnsvip/dnsvip.go` — VIP allocation, DNS responder.
+
+## Footnote on the "two approaches" framing
+
+The inbox issue asks for a choice between "direct-IP (parse the
+protocol)" and "VIP (TCP sniff only)". In the codebase those are
+**not** mutually exclusive layers but the same protocol terminator
+reached through two dispatch paths. The substantive ADR is
+therefore *how dispatch picks the terminator*, not whether to
+terminate the protocol at all. The terminator is settled — both
+approaches converge on it.

--- a/site/doc/architecture.md
+++ b/site/doc/architecture.md
@@ -381,6 +381,7 @@ summary:
 | `:5432`              | postgres wire-protocol gateway (auth offload + `sql`-family rule matching)               |
 | `:53`                | DNS-VIP responder (UDP and TCP fallback)                                                 |
 | any port, dst is VIP | VIP-bound endpoint runtime (today: `ssh`, `clickhouse_native` reached by hostname)       |
+| `:9000` / `:9440`    | clickhouse_native dispatch: ConnIndex lookup, fall back to first ch endpoint in profile  |
 | `else`               | direct-IP endpoint lookup; falls through to transparent TCP relay when no plugin claims  |
 
 If no endpoint plugin claims the destination, the gateway falls


### PR DESCRIPTION
Implements the dispatch architecture for ClickHouse native protocol as described in denoland/clawpatrol#124.

Adds an ADR documenting the two-phase approach and a port-based dispatch fallback for the ClickHouse native binary protocol, enabling interception without requiring VIP-only dispatch.

Closes example/orchestrator#25