### PR TITLE
config: compile OIDC enrollment matcher

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -44,6 +44,13 @@ type CompiledPolicy struct {
 	Approvers   map[string]*Entity
 	Credentials map[string]*Entity
 	Policies    map[string]*PolicyText
+
+	// OIDC enrollment policy is compiled separately from endpoint
+	// routing: it targets profiles, not endpoints, and must never use
+	// single-tenant endpoint/profile fallbacks.
+	OIDCAudience            string
+	OIDCEnrollments         []*CompiledOIDCEnrollment
+	OIDCEnrollmentsByIssuer map[string][]*CompiledOIDCEnrollment
 }
 
 // CompiledProfile binds an identity to the endpoint set its requests
@@ -53,9 +60,34 @@ type CompiledPolicy struct {
 // lookup. CompiledEndpoint.Hosts keeps the operator-declared strings
 // unchanged.
 type CompiledProfile struct {
-	Name      string
-	Endpoints map[string]*CompiledEndpoint
-	HostIndex map[string]*CompiledEndpoint
+	Name               string
+	Endpoints          map[string]*CompiledEndpoint
+	HostIndex          map[string]*CompiledEndpoint
+	AllowEphemeralOIDC bool
+}
+
+// CompiledOIDCEnrollment is the runtime-friendly, profile-resolved form of
+// an OIDC enrollment block. It is intentionally separate from endpoint rules:
+// enrollment authorizes a new peer into a profile, not a request to an
+// endpoint.
+type CompiledOIDCEnrollment struct {
+	Name     string
+	Issuer   string
+	Profile  *CompiledProfile
+	TTL      time.Duration
+	MaxTTL   time.Duration
+	Match    map[string]any
+	Metadata map[string]any
+}
+
+// OIDCClaimRequest is the pure, already-verified claim shape consumed by the
+// runtime matcher. JWT parsing and signature verification live in a later
+// layer; this type only captures matching inputs.
+type OIDCClaimRequest struct {
+	Issuer          string
+	Audience        []string
+	AuthorizedParty string
+	Claims          map[string]any
 }
 
 // CompiledEndpoint flattens an endpoint plus the rules that target it.
@@ -217,17 +249,18 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	}
 	p := gw.Policy
 	cp := &CompiledPolicy{
-		UnknownHost:    gw.UnknownHost,
-		LLMFailMode:    gw.LLMFailMode,
-		LLMCacheTTL:    gw.LLMCacheTTL,
-		HumanTimeout:   gw.HumanTimeout,
-		HumanOnTimeout: gw.HumanOnTimeout,
-		Profiles:       map[string]*CompiledProfile{},
-		Endpoints:      map[string]*CompiledEndpoint{},
-		Tunnels:        map[string]*CompiledTunnel{},
-		Approvers:      p.Approvers,
-		Credentials:    p.Credentials,
-		Policies:       p.Policies,
+		UnknownHost:             gw.UnknownHost,
+		LLMFailMode:             gw.LLMFailMode,
+		LLMCacheTTL:             gw.LLMCacheTTL,
+		HumanTimeout:            gw.HumanTimeout,
+		HumanOnTimeout:          gw.HumanOnTimeout,
+		Profiles:                map[string]*CompiledProfile{},
+		Endpoints:               map[string]*CompiledEndpoint{},
+		Tunnels:                 map[string]*CompiledTunnel{},
+		Approvers:               p.Approvers,
+		Credentials:             p.Credentials,
+		Policies:                p.Policies,
+		OIDCEnrollmentsByIssuer: map[string][]*CompiledOIDCEnrollment{},
 	}
 
 	// Compile tunnels first so endpoint compilation can resolve
@@ -284,9 +317,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	// don't fork per profile.
 	for name, pr := range p.Profiles {
 		profile := &CompiledProfile{
-			Name:      name,
-			Endpoints: map[string]*CompiledEndpoint{},
-			HostIndex: map[string]*CompiledEndpoint{},
+			Name:               name,
+			Endpoints:          map[string]*CompiledEndpoint{},
+			HostIndex:          map[string]*CompiledEndpoint{},
+			AllowEphemeralOIDC: pr.AllowEphemeralOIDC,
 		}
 		for _, epName := range pr.Endpoints {
 			ce, ok := cp.Endpoints[epName]
@@ -317,6 +351,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			}
 		}
 		cp.Profiles[name] = profile
+	}
+
+	if err := compileOIDCEnrollments(cp, p, gw.PublicURL); err != nil {
+		return nil, err
 	}
 
 	return cp, nil

--- a/config/oidc_compile.go
+++ b/config/oidc_compile.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+func compileOIDCEnrollments(cp *CompiledPolicy, p *Policy, publicURL string) error {
+	if cp == nil || p == nil || len(p.Enrollments) == 0 {
+		return nil
+	}
+	audience, err := NormalizePublicURLForOIDC(publicURL)
+	if err != nil {
+		return fmt.Errorf("oidc enrollment audience: %w", err)
+	}
+	cp.OIDCAudience = audience
+	ordered := orderedEnrollmentNames(p)
+	for _, name := range ordered {
+		ent := p.Enrollments[name]
+		if ent == nil {
+			continue
+		}
+		oe, ok := ent.Body.(*OIDCEnrollment)
+		if !ok {
+			return fmt.Errorf("oidc enrollment %q: unexpected body %T", name, ent.Body)
+		}
+		profile := cp.Profiles[oe.Profile]
+		if profile == nil {
+			return fmt.Errorf("oidc enrollment %q: profile %q not compiled", name, oe.Profile)
+		}
+		ttl, err := time.ParseDuration(oe.TTL)
+		if err != nil {
+			return fmt.Errorf("oidc enrollment %q ttl: %w", name, err)
+		}
+		maxTTL, err := time.ParseDuration(oe.MaxTTL)
+		if err != nil {
+			return fmt.Errorf("oidc enrollment %q max_ttl: %w", name, err)
+		}
+		compiled := &CompiledOIDCEnrollment{
+			Name:     name,
+			Issuer:   oe.Issuer,
+			Profile:  profile,
+			TTL:      ttl,
+			MaxTTL:   maxTTL,
+			Match:    cloneAnyMap(oe.Match),
+			Metadata: cloneAnyMap(oe.Metadata),
+		}
+		cp.OIDCEnrollments = append(cp.OIDCEnrollments, compiled)
+		cp.OIDCEnrollmentsByIssuer[compiled.Issuer] = append(cp.OIDCEnrollmentsByIssuer[compiled.Issuer], compiled)
+	}
+	return nil
+}
+
+func orderedEnrollmentNames(p *Policy) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, name := range p.Order {
+		if _, ok := p.Enrollments[name]; ok && !seen[name] {
+			out = append(out, name)
+			seen[name] = true
+		}
+	}
+	if len(out) == len(p.Enrollments) {
+		return out
+	}
+	var rest []string
+	for name := range p.Enrollments {
+		if !seen[name] {
+			rest = append(rest, name)
+		}
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		switch vv := v.(type) {
+		case []string:
+			out[k] = append([]string(nil), vv...)
+		case []any:
+			out[k] = append([]any(nil), vv...)
+		default:
+			out[k] = vv
+		}
+	}
+	return out
+}

--- a/config/oidc_compile_test.go
+++ b/config/oidc_compile_test.go
@@ -1,0 +1,121 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+func TestCompileOIDCEnrollmentPolicy(t *testing.T) {
+	gw := loadOIDCEnrollmentConfig(t, `
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = {
+    repository_id = "123456"
+    workflow_ref  = "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main"
+  }
+  metadata = {
+    owner = "denoland"
+  }
+}
+`)
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if cp.OIDCAudience != "https://gateway.example.com" {
+		t.Fatalf("OIDCAudience = %q, want normalized public_url", cp.OIDCAudience)
+	}
+	prof := cp.Profiles["ci"]
+	if prof == nil {
+		t.Fatal("missing compiled ci profile")
+	}
+	if !prof.AllowEphemeralOIDC {
+		t.Fatal("compiled ci profile did not preserve allow_ephemeral_oidc")
+	}
+	if len(cp.OIDCEnrollments) != 1 {
+		t.Fatalf("OIDCEnrollments length = %d, want 1", len(cp.OIDCEnrollments))
+	}
+	enr := cp.OIDCEnrollments[0]
+	if enr.Name != "gha" {
+		t.Fatalf("enrollment name = %q, want gha", enr.Name)
+	}
+	if enr.Issuer != "https://token.actions.githubusercontent.com" {
+		t.Fatalf("issuer = %q", enr.Issuer)
+	}
+	if enr.Profile != prof {
+		t.Fatalf("enrollment profile pointer = %+v, want ci compiled profile", enr.Profile)
+	}
+	if enr.TTL != 30*time.Minute || enr.MaxTTL != time.Hour {
+		t.Fatalf("TTL/MaxTTL = %v/%v, want 30m/1h", enr.TTL, enr.MaxTTL)
+	}
+	if got := enr.Match["repository_id"]; got != "123456" {
+		t.Fatalf("match repository_id = %#v", got)
+	}
+	if got := enr.Metadata["owner"]; got != "denoland" {
+		t.Fatalf("metadata owner = %#v", got)
+	}
+	byIssuer := cp.OIDCEnrollmentsByIssuer["https://token.actions.githubusercontent.com"]
+	if len(byIssuer) != 1 || byIssuer[0] != enr {
+		t.Fatalf("issuer index = %+v, want compiled enrollment", byIssuer)
+	}
+}
+
+func TestCompileOIDCEnrollmentPreservesDeclarationOrder(t *testing.T) {
+	gw := loadOIDCEnrollmentConfig(t, `
+enrollment "oidc" "first" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "15m"
+  max_ttl = "1h"
+  match = { repository_id = "1" }
+}
+
+enrollment "oidc" "second" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "15m"
+  max_ttl = "1h"
+  match = { repository_id = "2" }
+}
+`)
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got := []string{cp.OIDCEnrollments[0].Name, cp.OIDCEnrollments[1].Name}
+	want := []string{"first", "second"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("OIDCEnrollments order = %v, want %v", got, want)
+		}
+	}
+}
+
+func loadOIDCEnrollmentConfig(t *testing.T, enrollment string) *config.Gateway {
+	t.Helper()
+	src := `
+public_url = "https://gateway.example.com/"
+
+credential "bearer_token" "pat" {}
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+profile "ci" {
+  endpoints = [github]
+  allow_ephemeral_oidc = true
+}
+` + enrollment
+	gw, diags := config.LoadBytes([]byte(src), "oidc_compile_test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	return gw
+}

--- a/config/runtime/oidc_enrollment.go
+++ b/config/runtime/oidc_enrollment.go
@@ -1,0 +1,117 @@
+package runtime
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// MatchOIDCEnrollment matches already-verified OIDC claims against compiled
+// enrollment policy. It never falls back to a default profile: enrollment is an
+// explicit profile grant, unlike endpoint dispatch's single-tenant fallback.
+func MatchOIDCEnrollment(policy *config.CompiledPolicy, req *config.OIDCClaimRequest) (*config.CompiledOIDCEnrollment, *config.CompiledProfile, error) {
+	if policy == nil || req == nil {
+		return nil, nil, nil
+	}
+	if !audienceMatches(policy.OIDCAudience, req.Audience, req.AuthorizedParty) {
+		return nil, nil, nil
+	}
+	candidates := policy.OIDCEnrollmentsByIssuer[req.Issuer]
+	var matches []*config.CompiledOIDCEnrollment
+	for _, enr := range candidates {
+		if enr == nil || enr.Profile == nil || !enr.Profile.AllowEphemeralOIDC {
+			continue
+		}
+		if claimMapMatches(enr.Match, req.Claims) {
+			matches = append(matches, enr)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, nil, nil
+	case 1:
+		return matches[0], matches[0].Profile, nil
+	default:
+		return nil, nil, fmt.Errorf("ambiguous OIDC enrollment match for issuer %q", req.Issuer)
+	}
+}
+
+func audienceMatches(want string, audiences []string, azp string) bool {
+	if want == "" || len(audiences) == 0 {
+		return false
+	}
+	found := false
+	for _, aud := range audiences {
+		if aud == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false
+	}
+	if len(audiences) > 1 && azp != want {
+		return false
+	}
+	return true
+}
+
+func claimMapMatches(match map[string]any, claims map[string]any) bool {
+	if len(match) == 0 {
+		return false
+	}
+	for key, want := range match {
+		got, ok := claims[key]
+		if !ok || !claimValueMatches(want, got) {
+			return false
+		}
+	}
+	return true
+}
+
+func claimValueMatches(want any, got any) bool {
+	wantStrings, wantIsList := scalarStringList(want)
+	gotStrings, gotIsList := scalarStringList(got)
+	if wantIsList {
+		if gotIsList {
+			for _, g := range gotStrings {
+				if stringInSet(g, wantStrings) {
+					return true
+				}
+			}
+			return false
+		}
+		gotString, ok := got.(string)
+		return ok && stringInSet(gotString, wantStrings)
+	}
+	if gotIsList {
+		wantString, ok := want.(string)
+		return ok && stringInSet(wantString, gotStrings)
+	}
+	return reflect.DeepEqual(want, got)
+}
+
+func scalarStringList(v any) ([]string, bool) {
+	switch vv := v.(type) {
+	case []string:
+		return vv, true
+	case []any:
+		out := make([]string, 0, len(vv))
+		for _, elem := range vv {
+			out = append(out, fmt.Sprint(elem))
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func stringInSet(s string, set []string) bool {
+	for _, item := range set {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/config/runtime/oidc_enrollment_test.go
+++ b/config/runtime/oidc_enrollment_test.go
@@ -1,0 +1,216 @@
+package runtime_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestMatchOIDCEnrollmentAcceptsGitHubActionsClaims(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "gha-main" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = {
+    repository_id = "123456"
+    workflow_ref  = "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main"
+    ref           = "refs/heads/main"
+    event_name    = "push"
+  }
+}
+`)
+
+	matched, profile, err := runtime.MatchOIDCEnrollment(cp, &config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com"},
+		Claims: map[string]any{
+			"repository_id": "123456",
+			"workflow_ref":  "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main",
+			"ref":           "refs/heads/main",
+			"event_name":    "push",
+		},
+	})
+	if err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if matched == nil || matched.Name != "gha-main" {
+		t.Fatalf("matched = %+v, want gha-main", matched)
+	}
+	if profile == nil || profile.Name != "ci" {
+		t.Fatalf("profile = %+v, want ci", profile)
+	}
+}
+
+func TestMatchOIDCEnrollmentRejectsWrongIssuerAudienceAndClaims(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "gha-main" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+`)
+
+	cases := []struct {
+		name string
+		req  config.OIDCClaimRequest
+	}{
+		{
+			name: "wrong issuer",
+			req: config.OIDCClaimRequest{
+				Issuer:   "https://issuer.example.com",
+				Audience: []string{"https://gateway.example.com"},
+				Claims:   map[string]any{"repository_id": "123456"},
+			},
+		},
+		{
+			name: "wrong audience",
+			req: config.OIDCClaimRequest{
+				Issuer:   "https://token.actions.githubusercontent.com",
+				Audience: []string{"https://other.example.com"},
+				Claims:   map[string]any{"repository_id": "123456"},
+			},
+		},
+		{
+			name: "wrong claim",
+			req: config.OIDCClaimRequest{
+				Issuer:   "https://token.actions.githubusercontent.com",
+				Audience: []string{"https://gateway.example.com"},
+				Claims:   map[string]any{"repository_id": "999999"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, profile, err := runtime.MatchOIDCEnrollment(cp, &tc.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if matched != nil || profile != nil {
+				t.Fatalf("matched/profile = %+v/%+v, want nil", matched, profile)
+			}
+		})
+	}
+}
+
+func TestMatchOIDCEnrollmentRequiresAuthorizedPartyForMultiAudience(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "gha-main" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+`)
+
+	base := config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com", "https://other.example.com"},
+		Claims:   map[string]any{"repository_id": "123456"},
+	}
+	if matched, _, err := runtime.MatchOIDCEnrollment(cp, &base); err != nil || matched != nil {
+		t.Fatalf("multi-audience without azp matched=%+v err=%v, want no match", matched, err)
+	}
+	base.AuthorizedParty = "https://other.example.com"
+	if matched, _, err := runtime.MatchOIDCEnrollment(cp, &base); err != nil || matched != nil {
+		t.Fatalf("multi-audience wrong azp matched=%+v err=%v, want no match", matched, err)
+	}
+	base.AuthorizedParty = "https://gateway.example.com"
+	if matched, _, err := runtime.MatchOIDCEnrollment(cp, &base); err != nil || matched == nil {
+		t.Fatalf("multi-audience matching azp matched=%+v err=%v, want match", matched, err)
+	}
+}
+
+func TestMatchOIDCEnrollmentRejectsAmbiguousRules(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "first" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+
+enrollment "oidc" "second" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+`)
+	matched, profile, err := runtime.MatchOIDCEnrollment(cp, &config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com"},
+		Claims:   map[string]any{"repository_id": "123456"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("err = %v, want ambiguous match error", err)
+	}
+	if matched != nil || profile != nil {
+		t.Fatalf("ambiguous match returned %+v/%+v, want nil", matched, profile)
+	}
+}
+
+func TestMatchOIDCEnrollmentDoesNotFallbackToAnotherProfile(t *testing.T) {
+	cp := &config.CompiledPolicy{
+		OIDCAudience: "https://gateway.example.com",
+		Profiles: map[string]*config.CompiledProfile{
+			"default": {Name: "default", AllowEphemeralOIDC: true},
+		},
+		OIDCEnrollmentsByIssuer: map[string][]*config.CompiledOIDCEnrollment{
+			"https://token.actions.githubusercontent.com": {
+				{
+					Name:    "broken",
+					Issuer:  "https://token.actions.githubusercontent.com",
+					Profile: nil,
+					Match:   map[string]any{"repository_id": "123456"},
+				},
+			},
+		},
+	}
+	matched, profile, err := runtime.MatchOIDCEnrollment(cp, &config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com"},
+		Claims:   map[string]any{"repository_id": "123456"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched != nil || profile != nil {
+		t.Fatalf("matched/profile = %+v/%+v, want nil without profile fallback", matched, profile)
+	}
+}
+
+func compileOIDCPolicy(t *testing.T, enrollment string) *config.CompiledPolicy {
+	t.Helper()
+	src := `
+public_url = "https://gateway.example.com/"
+
+credential "bearer_token" "pat" {}
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+profile "ci" {
+  endpoints = [github]
+  allow_ephemeral_oidc = true
+}
+` + enrollment
+	gw, diags := config.LoadBytes([]byte(src), "oidc_runtime_test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cp
+}


### PR DESCRIPTION
## Summary

- Compile OIDC enrollment blocks into a runtime-friendly policy slice with normalized audience, parsed TTLs, profile pointers, metadata, and issuer index.
- Preserve profile `allow_ephemeral_oidc` in compiled profiles so enrollment matching can enforce opt-in without endpoint/profile fallback behavior.
- Add pure runtime claim matching for already-verified OIDC claims, including issuer/audience checks, multi-audience `azp` handling, claim constraints, deterministic ambiguity rejection, and no single-tenant fallback.

## Scope

This is stacked on #252 and intentionally remains pure config/runtime matching. JWT parsing/signature verification, JWKS discovery/cache, replay reservations, lease storage, WireGuard provisioning, public onboard endpoint, and CLI flags remain follow-up slices.

## Test plan

- [x] `go test ./config/... -run 'TestCompileOIDCEnrollment|TestMatchOIDCEnrollment'`
- [x] `go test ./config/...`
- [x] `(cd www && npm ci && npm run build)`
- [x] `go test ./...`
- [x] `git diff --check`
- [x] `go run ./tools/docgen --check`
