### PR TITLE
server: add OIDC ephemeral lease store

### DIFF
--- a/migrations/sqlite/0009_oidc_ephemeral_leases.sql
+++ b/migrations/sqlite/0009_oidc_ephemeral_leases.sql
@@ -1,0 +1,34 @@
+-- OIDC ephemeral enrollment replay reservations and peer leases.
+--
+-- Raw OIDC tokens are never stored. Replay prevention keys are derived from
+-- verified claims (`iss`, `sub`, `jti` when present) or from a SHA-256 token
+-- hash when `jti` is absent.
+CREATE TABLE IF NOT EXISTS oidc_replay_reservations (
+  replay_key  TEXT PRIMARY KEY,
+  issuer      TEXT NOT NULL,
+  subject     TEXT NOT NULL,
+  jwt_id      TEXT,
+  token_hash  TEXT NOT NULL,
+  enrollment  TEXT NOT NULL,
+  profile     TEXT NOT NULL,
+  reserved_ns INTEGER NOT NULL,
+  expires_ns  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS oidc_replay_reservations_expires_ns ON oidc_replay_reservations(expires_ns);
+CREATE INDEX IF NOT EXISTS oidc_replay_reservations_subject ON oidc_replay_reservations(issuer, subject);
+
+CREATE TABLE IF NOT EXISTS oidc_ephemeral_leases (
+  peer_ip      TEXT PRIMARY KEY,
+  pubkey       TEXT NOT NULL UNIQUE,
+  replay_key   TEXT NOT NULL UNIQUE REFERENCES oidc_replay_reservations(replay_key) ON DELETE RESTRICT,
+  issuer       TEXT NOT NULL,
+  subject      TEXT NOT NULL,
+  enrollment   TEXT NOT NULL,
+  profile      TEXT NOT NULL,
+  metadata     TEXT,
+  created_ns   INTEGER NOT NULL,
+  expires_ns   INTEGER NOT NULL,
+  revoked_ns   INTEGER
+);
+CREATE INDEX IF NOT EXISTS oidc_ephemeral_leases_expires_ns ON oidc_ephemeral_leases(expires_ns);
+CREATE INDEX IF NOT EXISTS oidc_ephemeral_leases_subject ON oidc_ephemeral_leases(issuer, subject);

--- a/oidc_ephemeral_lease.go
+++ b/oidc_ephemeral_lease.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/oidcverify"
+)
+
+var errOIDCReplayAlreadyUsed = errors.New("oidc replay already used")
+
+type oidcReplayReservation struct {
+	ReplayKey  string
+	Issuer     string
+	Subject    string
+	JWTID      string
+	TokenHash  string
+	Enrollment string
+	Profile    string
+	ReservedAt time.Time
+	ExpiresAt  time.Time
+}
+
+type oidcLeasePeer struct {
+	IP     string
+	PubKey string
+}
+
+type oidcEphemeralLease struct {
+	PeerIP     string
+	PubKey     string
+	ReplayKey  string
+	Issuer     string
+	Subject    string
+	Enrollment string
+	Profile    string
+	Metadata   map[string]any
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	RevokedAt  time.Time
+}
+
+func reserveOIDCReplay(db *sql.DB, verified *oidcverify.VerifiedToken, enrollment, profile string, now time.Time) (*oidcReplayReservation, error) {
+	if db == nil {
+		return nil, errors.New("database is required")
+	}
+	if verified == nil || verified.ReplayKey == "" || verified.Issuer == "" || verified.Subject == "" || verified.TokenHash == "" {
+		return nil, errors.New("verified oidc token is incomplete")
+	}
+	if enrollment == "" || profile == "" {
+		return nil, errors.New("enrollment and profile are required")
+	}
+	expires := verified.Expiry
+	if expires.IsZero() {
+		return nil, errors.New("verified oidc token expiry is required")
+	}
+	res, err := db.Exec(`
+INSERT OR IGNORE INTO oidc_replay_reservations
+  (replay_key, issuer, subject, jwt_id, token_hash, enrollment, profile, reserved_ns, expires_ns)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		verified.ReplayKey, verified.Issuer, verified.Subject, verified.JWTID, verified.TokenHash, enrollment, profile, now.UnixNano(), expires.UnixNano())
+	if err != nil {
+		return nil, fmt.Errorf("insert oidc replay reservation: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("oidc replay reservation result: %w", err)
+	}
+	if rows == 0 {
+		return nil, errOIDCReplayAlreadyUsed
+	}
+	return &oidcReplayReservation{
+		ReplayKey:  verified.ReplayKey,
+		Issuer:     verified.Issuer,
+		Subject:    verified.Subject,
+		JWTID:      verified.JWTID,
+		TokenHash:  verified.TokenHash,
+		Enrollment: enrollment,
+		Profile:    profile,
+		ReservedAt: now,
+		ExpiresAt:  expires,
+	}, nil
+}
+
+func createOIDCEphemeralLease(db *sql.DB, reservation *oidcReplayReservation, peer oidcLeasePeer, metadata map[string]any, now, expires time.Time) (*oidcEphemeralLease, error) {
+	if db == nil {
+		return nil, errors.New("database is required")
+	}
+	if reservation == nil || reservation.ReplayKey == "" {
+		return nil, errors.New("oidc replay reservation is required")
+	}
+	if peer.IP == "" || peer.PubKey == "" {
+		return nil, errors.New("peer ip and pubkey are required")
+	}
+	if expires.IsZero() || expires.After(reservation.ExpiresAt) {
+		expires = reservation.ExpiresAt
+	}
+	metadataJSON, err := marshalOIDCMetadata(metadata)
+	if err != nil {
+		return nil, err
+	}
+	_, err = db.Exec(`
+INSERT INTO oidc_ephemeral_leases
+  (peer_ip, pubkey, replay_key, issuer, subject, enrollment, profile, metadata, created_ns, expires_ns)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		peer.IP, peer.PubKey, reservation.ReplayKey, reservation.Issuer, reservation.Subject, reservation.Enrollment, reservation.Profile, metadataJSON, now.UnixNano(), expires.UnixNano())
+	if err != nil {
+		return nil, fmt.Errorf("insert oidc ephemeral lease: %w", err)
+	}
+	return &oidcEphemeralLease{
+		PeerIP:     peer.IP,
+		PubKey:     peer.PubKey,
+		ReplayKey:  reservation.ReplayKey,
+		Issuer:     reservation.Issuer,
+		Subject:    reservation.Subject,
+		Enrollment: reservation.Enrollment,
+		Profile:    reservation.Profile,
+		Metadata:   cloneMetadata(metadata),
+		CreatedAt:  now,
+		ExpiresAt:  expires,
+	}, nil
+}
+
+func activeOIDCEphemeralLeaseForPeer(db *sql.DB, peerIP string, now time.Time) (*oidcEphemeralLease, error) {
+	if db == nil || peerIP == "" {
+		return nil, nil
+	}
+	row := db.QueryRow(`
+SELECT peer_ip, pubkey, replay_key, issuer, subject, enrollment, profile, metadata, created_ns, expires_ns, COALESCE(revoked_ns, 0)
+FROM oidc_ephemeral_leases
+WHERE peer_ip = ? AND revoked_ns IS NULL AND expires_ns > ?`, peerIP, now.UnixNano())
+	lease, err := scanOIDCEphemeralLease(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return lease, err
+}
+
+func revokeOIDCEphemeralLease(db *sql.DB, peerIP string, now time.Time) error {
+	if db == nil || peerIP == "" {
+		return nil
+	}
+	_, err := db.Exec(`UPDATE oidc_ephemeral_leases SET revoked_ns = ? WHERE peer_ip = ? AND revoked_ns IS NULL`, now.UnixNano(), peerIP)
+	if err != nil {
+		return fmt.Errorf("revoke oidc ephemeral lease: %w", err)
+	}
+	return nil
+}
+
+func scanOIDCEphemeralLease(row interface{ Scan(dest ...any) error }) (*oidcEphemeralLease, error) {
+	var lease oidcEphemeralLease
+	var metadata sql.NullString
+	var createdNS, expiresNS, revokedNS int64
+	if err := row.Scan(&lease.PeerIP, &lease.PubKey, &lease.ReplayKey, &lease.Issuer, &lease.Subject, &lease.Enrollment, &lease.Profile, &metadata, &createdNS, &expiresNS, &revokedNS); err != nil {
+		return nil, err
+	}
+	lease.CreatedAt = time.Unix(0, createdNS).UTC()
+	lease.ExpiresAt = time.Unix(0, expiresNS).UTC()
+	if revokedNS != 0 {
+		lease.RevokedAt = time.Unix(0, revokedNS).UTC()
+	}
+	if metadata.Valid && metadata.String != "" {
+		if err := json.Unmarshal([]byte(metadata.String), &lease.Metadata); err != nil {
+			return nil, fmt.Errorf("decode oidc lease metadata: %w", err)
+		}
+	}
+	if lease.Metadata == nil {
+		lease.Metadata = map[string]any{}
+	}
+	return &lease, nil
+}
+
+func marshalOIDCMetadata(metadata map[string]any) (sql.NullString, error) {
+	if len(metadata) == 0 {
+		return sql.NullString{}, nil
+	}
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("encode oidc lease metadata: %w", err)
+	}
+	return sql.NullString{String: string(b), Valid: true}, nil
+}
+
+func cloneMetadata(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/oidc_ephemeral_lease_test.go
+++ b/oidc_ephemeral_lease_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/oidcverify"
+)
+
+func TestReserveOIDCReplayIsAtomicAndExpires(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	expires := now.Add(10 * time.Minute)
+	verified := &oidcverify.VerifiedToken{Issuer: "https://token.actions.githubusercontent.com", Subject: "repo:denoland/clawpatrol", JWTID: "run-1", TokenHash: "hash-1", ReplayKey: "issuer\x00sub\x00run-1", Expiry: expires}
+
+	reservation, err := reserveOIDCReplay(db, verified, "gha", "ci", now)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if reservation.ExpiresAt != expires || reservation.Enrollment != "gha" || reservation.Profile != "ci" {
+		t.Fatalf("reservation = %+v", reservation)
+	}
+
+	_, err = reserveOIDCReplay(db, verified, "gha", "ci", now.Add(time.Second))
+	if !errors.Is(err, errOIDCReplayAlreadyUsed) {
+		t.Fatalf("second reserve error = %v", err)
+	}
+}
+
+func TestCreateOIDCEphemeralLeaseAndActiveLookup(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	expires := now.Add(30 * time.Minute)
+	verified := &oidcverify.VerifiedToken{Issuer: "https://issuer.example.com", Subject: "sub", JWTID: "jti", TokenHash: "hash", ReplayKey: "replay", Expiry: expires}
+	reservation, err := reserveOIDCReplay(db, verified, "gha", "ci", now)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	lease, err := createOIDCEphemeralLease(db, reservation, oidcLeasePeer{IP: "10.55.0.42", PubKey: "pubkey"}, map[string]any{"repository": "denoland/clawpatrol"}, now, expires)
+	if err != nil {
+		t.Fatalf("create lease: %v", err)
+	}
+	if lease.PeerIP != "10.55.0.42" || lease.Profile != "ci" || lease.ExpiresAt != expires {
+		t.Fatalf("lease = %+v", lease)
+	}
+
+	active, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	if active == nil || active.PeerIP != "10.55.0.42" || active.Metadata["repository"] != "denoland/clawpatrol" {
+		t.Fatalf("active lease = %+v", active)
+	}
+
+	expired, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", expires.Add(time.Nanosecond))
+	if err != nil {
+		t.Fatalf("expired lookup: %v", err)
+	}
+	if expired != nil {
+		t.Fatalf("expected no active lease after expiry, got %+v", expired)
+	}
+}
+
+func TestRevokeOIDCEphemeralLease(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	verified := &oidcverify.VerifiedToken{Issuer: "https://issuer.example.com", Subject: "sub", JWTID: "jti", TokenHash: "hash", ReplayKey: "replay", Expiry: now.Add(time.Hour)}
+	reservation, err := reserveOIDCReplay(db, verified, "gha", "ci", now)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, err := createOIDCEphemeralLease(db, reservation, oidcLeasePeer{IP: "10.55.0.42", PubKey: "pubkey"}, nil, now, now.Add(time.Hour)); err != nil {
+		t.Fatalf("create lease: %v", err)
+	}
+	if err := revokeOIDCEphemeralLease(db, "10.55.0.42", now.Add(time.Minute)); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	active, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	if active != nil {
+		t.Fatalf("expected revoked lease to be inactive, got %+v", active)
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}


### PR DESCRIPTION
## Summary

- Adds SQLite schema for OIDC replay reservations and OIDC-backed ephemeral peer leases.
- Stores derived replay identifiers and token hashes only; raw OIDC tokens are never persisted.
- Adds helpers for atomic replay reservation, lease creation, active lease lookup, and revocation.
- Caps lease expiration to the verified token expiry carried by the replay reservation.

Stack: this PR is stacked on #257 (`agent/oidc-verifier`).

## Testing

- `(cd www && npm ci && npm run build)`
- `go test . -run 'TestReserveOIDCReplay|TestCreateOIDCEphemeralLease|TestRevokeOIDC' -v`
- `go test ./config/... ./internal/oidcverify`
- `go test ./...`
- `git diff --check`
- `go run ./tools/docgen --check`
