### PR TITLE
server: add OIDC onboarding endpoint

### DIFF
--- a/oidc_onboard.go
+++ b/oidc_onboard.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+
+	configruntime "github.com/denoland/clawpatrol/config/runtime"
+)
+
+const maxOIDCOnboardBodyBytes = 1 << 20
+
+type oidcOnboardRequest struct {
+	IDToken    string `json:"id_token"`
+	PubKey     string `json:"pubkey"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
+}
+
+type oidcOnboardResponse struct {
+	IP          string `json:"ip"`
+	IP6         string `json:"ip6"`
+	Profile     string `json:"profile"`
+	Enrollment  string `json:"enrollment"`
+	APIEndpoint string `json:"api_endpoint"`
+	APIToken    string `json:"api_token"`
+	WGEndpoint  string `json:"wg_endpoint"`
+	WGInterface string `json:"wg_interface"`
+	ServerPub   string `json:"server_pub"`
+	ExpiresAt   int64  `json:"expires_at"`
+}
+
+func (w *webMux) apiOnboardOIDC(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.Body == nil {
+		http.Error(rw, "missing body", http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+	var req oidcOnboardRequest
+	dec := json.NewDecoder(io.LimitReader(r.Body, maxOIDCOnboardBodyBytes))
+	if err := dec.Decode(&req); err != nil {
+		http.Error(rw, "invalid json", http.StatusBadRequest)
+		return
+	}
+	resp, err := w.provisionOIDCOnboard(r.Context(), req)
+	if err != nil {
+		status := http.StatusBadRequest
+		switch {
+		case errors.Is(err, errOIDCReplayAlreadyUsed):
+			status = http.StatusConflict
+		case errors.Is(err, errOIDCOnboardUnavailable):
+			status = http.StatusServiceUnavailable
+		case errors.Is(err, errOIDCOnboardUnauthorized):
+			status = http.StatusUnauthorized
+		}
+		http.Error(rw, err.Error(), status)
+		return
+	}
+	writeJSON(rw, resp)
+}
+
+var (
+	errOIDCOnboardUnavailable  = errors.New("oidc onboarding unavailable")
+	errOIDCOnboardUnauthorized = errors.New("oidc onboarding unauthorized")
+)
+
+func (w *webMux) provisionOIDCOnboard(ctx context.Context, req oidcOnboardRequest) (*oidcOnboardResponse, error) {
+	if w == nil || w.g == nil || w.g.db == nil || w.g.onboard == nil {
+		return nil, errOIDCOnboardUnavailable
+	}
+	if globalWG == nil || w.ts.WGSubnetCIDR == "" || w.ts.WGEndpoint == "" {
+		return nil, fmt.Errorf("%w: wireguard not active", errOIDCOnboardUnavailable)
+	}
+	if req.IDToken == "" || req.PubKey == "" {
+		return nil, errors.New("id_token and pubkey are required")
+	}
+	policy := w.g.Policy()
+	if policy == nil {
+		return nil, fmt.Errorf("%w: policy not loaded", errOIDCOnboardUnavailable)
+	}
+	verifier := w.oidcVerifier
+	if verifier == nil {
+		return nil, errOIDCOnboardUnavailable
+	}
+	verified, err := verifier.Verify(ctx, policy, req.IDToken)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid oidc token", errOIDCOnboardUnauthorized)
+	}
+	enrollment, profile, err := configruntime.MatchOIDCEnrollment(policy, &verified.Claims)
+	if err != nil {
+		return nil, fmt.Errorf("%w: oidc enrollment rejected", errOIDCOnboardUnauthorized)
+	}
+	if profile == nil || !profile.AllowEphemeralOIDC {
+		return nil, fmt.Errorf("%w: profile does not allow oidc enrollment", errOIDCOnboardUnauthorized)
+	}
+	now := time.Now().UTC()
+	reservation, err := reserveOIDCReplay(w.g.db, verified, enrollment.Name, profile.Name, now)
+	if err != nil {
+		return nil, err
+	}
+	ip, err := allocateEphemeralIP(w.ts.WGSubnetCIDR)
+	if err != nil {
+		return nil, err
+	}
+	if err := globalWG.AddPeer(req.PubKey, ip); err != nil {
+		return nil, fmt.Errorf("add wireguard peer: %w", err)
+	}
+	leaseExpires := reservation.ExpiresAt
+	if req.TTLSeconds > 0 {
+		requested := now.Add(time.Duration(req.TTLSeconds) * time.Second)
+		if requested.Before(leaseExpires) {
+			leaseExpires = requested
+		}
+	}
+	lease, err := createOIDCEphemeralLease(w.g.db, reservation, oidcLeasePeer{IP: ip, PubKey: req.PubKey}, enrollment.Metadata, now, leaseExpires)
+	if err != nil {
+		globalWG.RevokePeerByIP(ip)
+		return nil, err
+	}
+	_, _ = w.g.db.Exec("UPDATE wg_peers SET ephemeral=1 WHERE pubkey=?", req.PubKey)
+	w.g.onboard.setEphemeralProfile(ip, "", profile.Name)
+	if w.g.agents != nil {
+		w.g.agents.Seed(ip)
+	}
+	apiToken, err := mintAndPersistPeerAPIToken(w.g.db, ip)
+	if err != nil {
+		globalWG.RevokePeerByIP(ip)
+		_ = revokeOIDCEphemeralLease(w.g.db, ip, now)
+		return nil, fmt.Errorf("mint api token: %w", err)
+	}
+	serverPub, err := globalWG.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("wireguard server pub: %w", err)
+	}
+	serverPubB64, err := hexToB64(serverPub)
+	if err != nil {
+		return nil, err
+	}
+	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
+	return &oidcOnboardResponse{
+		IP:          lease.PeerIP,
+		IP6:         ip6,
+		Profile:     profile.Name,
+		Enrollment:  enrollment.Name,
+		APIEndpoint: strings.TrimRight(w.publicURL, "/"),
+		APIToken:    apiToken,
+		WGEndpoint:  w.ts.WGEndpoint,
+		WGInterface: oidcWGInterface(w.ts),
+		ServerPub:   serverPubB64,
+		ExpiresAt:   lease.ExpiresAt.Unix(),
+	}, nil
+}
+
+func oidcWGInterface(ts JoinConfig) string {
+	if ts.WGInterface != "" {
+		return ts.WGInterface
+	}
+	return "clawpatrol"
+}

--- a/web.go
+++ b/web.go
@@ -34,6 +34,7 @@ import (
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/facet"
 	"github.com/denoland/clawpatrol/config/runtime"
+	"github.com/denoland/clawpatrol/internal/oidcverify"
 )
 
 //go:embed all:www/dist
@@ -47,15 +48,16 @@ var loginTpl = template.Must(template.New("login").Parse(loginHTML))
 var errConfigRevisionConflict = errors.New("config revision conflict")
 
 type webMux struct {
-	g         *Gateway
-	caDir     string
-	ts        JoinConfig // for onboarding key minting
-	publicURL string
-	mu        sync.Mutex
-	sessions  map[string]*oauthSession
-	onboard   *onboardRegistry
-	previews  map[string]configPreviewToken
-	routeAuth map[string]authRequirement
+	g            *Gateway
+	caDir        string
+	ts           JoinConfig // for onboarding key minting
+	publicURL    string
+	mu           sync.Mutex
+	sessions     map[string]*oauthSession
+	onboard      *onboardRegistry
+	previews     map[string]configPreviewToken
+	routeAuth    map[string]authRequirement
+	oidcVerifier *oidcverify.Verifier
 
 	// stateCache: per-caller TTL'd memo for /api/state. RWMutex
 	// because reads vastly outnumber writes — every dashboard tab
@@ -184,7 +186,7 @@ func (w *webMux) skipsTailnetGate(path string) bool {
 }
 
 func newWebMux(g *Gateway, caDir string, ts JoinConfig, publicURL string) http.Handler {
-	w := &webMux{g: g, caDir: caDir, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
+	w := &webMux{g: g, caDir: caDir, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}, oidcVerifier: oidcverify.New(oidcverify.Options{})}
 	return w.handler()
 }
 
@@ -240,6 +242,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/onboard/approve", Auth: authDashboardOrTailnetOperator, Handler: w.apiOnboardApprove},
 		{Method: http.MethodGet, Path: "/api/onboard/lookup", Auth: authTailnetOperator, Handler: w.apiOnboardLookup},
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
+		{Method: http.MethodPost, Path: "/api/onboard/oidc", Auth: authPublic, Handler: w.apiOnboardOIDC},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
 		{Method: http.MethodGet, Path: "/__login", Auth: authTailnetOperator, Handler: w.apiDashboardLogin},

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -139,6 +139,7 @@ func TestRouteAuthRequirementsDocumentOnboardingBoundary(t *testing.T) {
 		{path: "/api/onboard/start", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/api/onboard/poll", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/api/onboard/claim", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
+		{path: "/api/onboard/oidc", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/api/onboard/lookup", want: authTailnetOperator, wantDashboardPublic: true, wantTailnetPublic: false},
 		{path: "/api/onboard/approve", want: authDashboardOrTailnetOperator, wantDashboardPublic: false, wantTailnetPublic: false},
 		{path: "/api/config/save", want: authDashboard, wantDashboardPublic: false, wantTailnetPublic: false},


### PR DESCRIPTION
## Summary

- Adds public, self-authenticating `POST /api/onboard/oidc` for unattended OIDC ephemeral enrollment.
- Verifies the OIDC ID token, matches it against compiled enrollment policy, reserves replay once, provisions a WireGuard peer, creates an ephemeral lease, and returns the peer connection material needed by the CLI.
- Returns only derived/sanitized token data server-side; raw OIDC tokens are not persisted.
- Keeps the route public at the dashboard/tailnet gates because the OIDC token is the request proof for disposable compute before it has tunnel identity.

Stack: this PR is stacked on #258 (`agent/oidc-ephemeral-leases`).

## Testing

- `(cd www && npm ci && npm run build)`
- `go test . -run 'TestRouteAuthRequirementsDocumentOnboardingBoundary'`
- `go test ./config/... ./internal/oidcverify`
- `go test ./...`
- `git diff --check`
- `go run ./tools/docgen --check`
