### PR TITLE
fix: accept join flags after gateway URL

### DIFF
--- a/login.go
+++ b/login.go
@@ -25,6 +25,38 @@ type tsStatus struct {
 	User           map[string]tsUser  `json:"User"`
 }
 
+// reorderJoinArgsForFlagParse lets `clawpatrol join` accept flags either
+// before or after the gateway URL. Go's flag package stops parsing at the
+// first positional argument, but the CLI help historically showed the URL
+// first followed by optional flags.
+func reorderJoinArgsForFlagParse(args []string) []string {
+	var flags []string
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+		if arg == "-" || !strings.HasPrefix(arg, "-") {
+			positional = append(positional, arg)
+			continue
+		}
+
+		name := strings.TrimLeft(arg, "-")
+		name, _, hasValue := strings.Cut(name, "=")
+		flags = append(flags, arg)
+		switch name {
+		case "hostname", "profile", "name", "ca-dir":
+			if !hasValue && i+1 < len(args) {
+				i++
+				flags = append(flags, args[i])
+			}
+		}
+	}
+	return append(flags, positional...)
+}
+
 type tsTailnet struct {
 	Name string `json:"Name"`
 }
@@ -55,10 +87,10 @@ func runJoin(args []string) {
 	wholeMachine := fs.Bool("whole-machine", false, "bring up wg-quick to route ALL host traffic through the gateway (default: persist conf only, use `clawpatrol run` for per-process routing)")
 	profile := fs.String("profile", "", "profile to assign at approval time (defaults to the gateway's default profile if the approver doesn't pick one)")
 	hostname := fs.String("hostname", "", "device name to register with the gateway (defaults to os.Hostname)")
-	_ = fs.Parse(args)
+	_ = fs.Parse(reorderJoinArgsForFlagParse(args))
 	rest := fs.Args()
 	if len(rest) != 1 || rest[0] == "" {
-		fail("usage: clawpatrol join <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine]")
+		fail("usage: clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] <gateway-url>")
 	}
 	gatewayURL := rest[0]
 	// Fetch CA + write shell rc BEFORE the VPN goes up. Once

--- a/login_test.go
+++ b/login_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReorderJoinArgsForFlagParseAcceptsFlagsAfterURL(t *testing.T) {
+	got := reorderJoinArgsForFlagParse([]string{
+		"https://deno.clawpatrol.dev",
+		"--hostname", "magurobot",
+		"--profile", "magurobot",
+		"--whole-machine",
+	})
+	want := []string{
+		"--hostname", "magurobot",
+		"--profile", "magurobot",
+		"--whole-machine",
+		"https://deno.clawpatrol.dev",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reordered args mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestReorderJoinArgsForFlagParsePreservesLeadingFlags(t *testing.T) {
+	got := reorderJoinArgsForFlagParse([]string{
+		"--hostname=magurobot",
+		"--profile", "magurobot",
+		"https://deno.clawpatrol.dev",
+	})
+	want := []string{
+		"--hostname=magurobot",
+		"--profile", "magurobot",
+		"https://deno.clawpatrol.dev",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reordered args mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2154,10 +2154,10 @@ func usage() {
 usage:
   clawpatrol gateway init [flags]        bootstrap a new gateway host
   clawpatrol gateway [-config FILE]      run the gateway server
-  clawpatrol join <gateway-url>          onboard this machine via wg device flow
-                  [--hostname NAME]      device name to register (default: os.Hostname)
-                  [--profile NAME]       suggest a profile for the approver
-                  [--whole-machine]      bring up wg-quick (route all traffic)
+  clawpatrol join [flags] <gateway-url>  onboard this machine via wg device flow
+                  --hostname NAME        device name to register (default: os.Hostname)
+                  --profile NAME         suggest a profile for the approver
+                  --whole-machine        bring up wg-quick (route all traffic)
   clawpatrol login                       onboard this machine (tailscale path)
   clawpatrol run -- <cmd> [args...]      route one process tree through gateway
   clawpatrol status                      report install + tunnel state


### PR DESCRIPTION
## Summary
- Allow `clawpatrol join` flags to appear after the gateway URL, matching the previous usage text people naturally followed.
- Add shared subcommand flag help that documents long options with double dashes, while preserving Go flag parsing compatibility for single-dash forms.
- Update top-level/subcommand usage strings for consistent `--flag` style.
- Add focused tests for URL-first join args and double-dash help output.

## Test plan
- `go test -tags ts_omit_identityfederation . -run 'Test(ReorderJoinArgsForFlagParse|FlagSetUsageUsesDoubleDash)'`
- `go build -tags ts_omit_identityfederation -o /tmp/clawpatrol-help-style .`
- `/tmp/clawpatrol-help-style gateway --help`
- `/tmp/clawpatrol-help-style uninstall --help`
- `go test -tags ts_omit_identityfederation ./...`
- `git diff --check`
