### PR TITLE
fix(ephemeral): purge ephemeral WG peers on gateway restart

### DIFF
--- a/wireguard.go
+++ b/wireguard.go
@@ -602,6 +602,11 @@ func (s *WGServer) loadPeers() map[string]string {
 	if s.db == nil {
 		return out
 	}
+	// Ephemeral peers are owned by client processes that exit when the
+	// gateway restarts. Purge them so they don't accumulate in the WG
+	// trie or leak device rows via SetExternalIPs.
+	_, _ = s.db.Exec("DELETE FROM devices WHERE id IN (SELECT ip FROM wg_peers WHERE ephemeral=1)")
+	_, _ = s.db.Exec("DELETE FROM wg_peers WHERE ephemeral=1")
 	rows, err := s.db.Query("SELECT pubkey, ip FROM wg_peers")
 	if err != nil {
 		return out


### PR DESCRIPTION
## Root cause

On gateway restart `ephemeralProfileByIP` is empty — the in-memory ephemeral state is lost. `loadPeers` re-adds all `wg_peers` rows to WG (including ephemeral ones). `SetExternalIPs` then fires for each re-added peer, which sets `extV4ByIP[ephemeralIP]` and calls `upsertLocked`. Even with the `ephemeralProfileByIP` guard from PR #237, this guard is bypassed because the map is empty at restart time.

## Fix

`loadPeers()` now deletes ephemeral peers from `wg_peers` and their leaked `devices` rows before building the peer list. Ephemeral peers are alive only while the client process that registered them is running — when the gateway restarts, those processes are gone, so purging on boot is correct in every case.

## Sequence of all three ephemeral fixes

| PR | Fix |
|---|---|
| #224 | Separate `ephemeralProfileByIP` map so `upsertLocked` skips ephemeral IPs |
| #237 | Guard at top of `upsertLocked` so `extV4ByIP` path can't bypass it; fix migration numbering |
| this | Purge ephemeral peers from DB on restart so the guard is never needed for them |

## Test plan

- [ ] Restart gateway with live ephemeral peers registered → dashboard shows no new rows for those IPs
- [ ] Fresh `clawpatrol run` after restart works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)