### PR TITLE
fix: clawpatrol run on Linux creates new WireGuard device per invocation instead of reusing

### DIFF
--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -1,21 +1,33 @@
 package main
 
-// Ephemeral peer support: each `clawpatrol run` on Linux gets its own
-// WireGuard keypair and IP rather than sharing the device's permanent
-// identity. Without this, concurrent runs on the same machine fight
-// over a single WireGuard session — keepalives from one process
-// invalidate the other's session causing intermittent packet loss.
+// Ephemeral peer support: each machine running `clawpatrol run` on
+// Linux gets its own WireGuard keypair and IP rather than sharing the
+// permanent device's identity. Concurrent runs on a single host would
+// otherwise contend for one WG session — keepalives from one process
+// invalidate the other's session, causing intermittent packet loss —
+// and unconditionally allocating a fresh ephemeral per invocation
+// piles dozens of throwaway device rows onto the gateway dashboard.
 //
-// The client POSTs an ephemeral pubkey; the gateway allocates a fresh
-// IP, wires it up, and inherits the parent device's profile. On clean
-// exit the client DELETEs the peer. The permanent device record
-// (from `clawpatrol join`) is untouched.
+// Lifecycle:
+//   - First `clawpatrol run` on a host: client generates a keypair and
+//     POSTs the pubkey. Gateway evicts any prior ephemeral owned by the
+//     same parent device, allocates a /32, and returns it.
+//   - Subsequent runs on the same host (the client persisted the
+//     keypair to disk): client POSTs the SAME pubkey. Gateway finds it
+//     already registered as this parent's ephemeral and returns the
+//     cached IP unchanged — no new device row.
+//   - The DELETE handler is retained for clients that explicitly drop
+//     their ephemeral identity (uninstall / `clawpatrol leave`). Normal
+//     `run` exits no longer call it: persistence across runs is the
+//     whole point.
 
 import (
+	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
 	"net/netip"
+	"strings"
 	"sync"
 )
 
@@ -57,7 +69,68 @@ func allocateEphemeralIP(subnetCIDR string) (string, error) {
 	return "", fmt.Errorf("wireguard subnet %s exhausted", subnetCIDR)
 }
 
-// apiEphemeralPeer dispatches POST (add) and DELETE (remove) on
+// lookupEphemeralPeer returns (ip, parentIP, exists) for an ephemeral
+// peer pubkey already in wg_peers. exists is false for unknown keys
+// AND for non-ephemeral pubkeys — we deliberately refuse to clobber a
+// parent device's pubkey through this endpoint.
+func lookupEphemeralPeer(db *sql.DB, pubkeyHex string) (string, string, bool) {
+	if db == nil || pubkeyHex == "" {
+		return "", "", false
+	}
+	var (
+		ip        string
+		ephemeral int
+		parentIP  sql.NullString
+	)
+	err := db.QueryRow(
+		"SELECT ip, ephemeral, parent_ip FROM wg_peers WHERE pubkey = ?",
+		pubkeyHex,
+	).Scan(&ip, &ephemeral, &parentIP)
+	if err != nil || ephemeral != 1 {
+		return "", "", false
+	}
+	return ip, parentIP.String, true
+}
+
+// evictEphemeralsForParent drops every existing ephemeral peer that
+// belongs to parentIP — the wg-go peer entry, the wg_peers row, the
+// onboard ephemeral-profile mapping, and the agents-registry entry.
+// Called when a new pubkey arrives for a parent that already has an
+// ephemeral; one parent owns at most one ephemeral at a time so a
+// host that lost its on-disk keypair doesn't leak the previous IP.
+func evictEphemeralsForParent(g *Gateway, parentIP string) {
+	if g == nil || g.db == nil || parentIP == "" {
+		return
+	}
+	rows, err := g.db.Query(
+		"SELECT ip FROM wg_peers WHERE ephemeral = 1 AND parent_ip = ?",
+		parentIP,
+	)
+	if err != nil {
+		return
+	}
+	var ips []string
+	for rows.Next() {
+		var ip string
+		if err := rows.Scan(&ip); err == nil {
+			ips = append(ips, ip)
+		}
+	}
+	_ = rows.Close()
+	for _, ip := range ips {
+		if globalWG != nil {
+			globalWG.RevokePeerByIP(ip)
+		}
+		if g.onboard != nil {
+			g.onboard.ForgetIP(ip)
+		}
+		if g.agents != nil {
+			g.agents.Delete(ip)
+		}
+	}
+}
+
+// apiEphemeralPeer dispatches POST (add/reuse) and DELETE (remove) on
 // /api/peer/ephemeral. Both require a valid per-peer bearer token.
 func (w *webMux) apiEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 	switch r.Method {
@@ -81,11 +154,38 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "wireguard not active", http.StatusServiceUnavailable)
 		return
 	}
-	pubkeyHex := r.URL.Query().Get("pubkey")
+	pubkeyHex := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("pubkey")))
 	if pubkeyHex == "" {
 		http.Error(rw, "missing pubkey", http.StatusBadRequest)
 		return
 	}
+
+	// Reuse path: the client persists its ephemeral keypair across
+	// invocations and POSTs the same pubkey each run. If it's already
+	// registered as THIS parent's ephemeral, return the existing IP
+	// unchanged.
+	//
+	// A pubkey bound to a different parent is rejected with 409 — that
+	// would otherwise let one machine hijack another's IP just by
+	// guessing its pubkey.
+	if existingIP, existingParent, ok := lookupEphemeralPeer(w.g.db, pubkeyHex); ok {
+		if existingParent == parentIP {
+			profile := w.g.onboard.ProfileForIP(parentIP)
+			w.g.onboard.setEphemeralProfile(existingIP, parentIP, profile)
+			ip6 := wg6FromV4(netip.MustParseAddr(existingIP)).String()
+			writeJSON(rw, map[string]string{"ip": existingIP, "ip6": ip6})
+			return
+		}
+		http.Error(rw, "pubkey already bound", http.StatusConflict)
+		return
+	}
+
+	// Different pubkey but same parent → the client lost its keypair
+	// cache (reboot, profile wipe). Drop the prior ephemeral entirely
+	// so this parent owns at most one ephemeral IP at a time. Without
+	// this every cache loss leaks an IP into wg_peers.
+	evictEphemeralsForParent(w.g, parentIP)
+
 	ip, err := allocateEphemeralIP(w.ts.WGSubnetCIDR)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -111,7 +211,9 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 
 // apiRemoveEphemeralPeer handles DELETE /api/peer/ephemeral?pubkey=<hex>.
 // Only the parent device (identified by bearer token) may remove its
-// own ephemeral peers.
+// own ephemeral peers. Normal `clawpatrol run` exits no longer call
+// this — ephemerals persist across runs — but it's retained so an
+// uninstall or explicit `leave` flow can drop the lingering identity.
 func (w *webMux) apiRemoveEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
 	parentIP := peerIPForAPIToken(w.g.db, token)
@@ -119,7 +221,7 @@ func (w *webMux) apiRemoveEphemeralPeer(rw http.ResponseWriter, r *http.Request)
 		http.Error(rw, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	pubkeyHex := r.URL.Query().Get("pubkey")
+	pubkeyHex := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("pubkey")))
 	if pubkeyHex == "" {
 		http.Error(rw, "missing pubkey", http.StatusBadRequest)
 		return

--- a/ephemeral_peer_test.go
+++ b/ephemeral_peer_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestLookupEphemeralPeerIgnoresNonEphemeralRows ensures the reuse
+// check refuses to clobber a parent device's pubkey row — only rows
+// flagged ephemeral=1 are eligible.
+func TestLookupEphemeralPeerIgnoresNonEphemeralRows(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(
+		`INSERT INTO wg_peers (pubkey, ip, added_ns, ephemeral) VALUES (?, ?, ?, 0)`,
+		"parentpub", "10.55.0.10", time.Now().UnixNano(),
+	); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	if _, _, ok := lookupEphemeralPeer(db, "parentpub"); ok {
+		t.Error("non-ephemeral row matched ephemeral lookup")
+	}
+
+	if _, err := db.Exec(
+		`INSERT INTO wg_peers (pubkey, ip, added_ns, ephemeral, parent_ip) VALUES (?, ?, ?, 1, ?)`,
+		"ephpub", "10.55.0.42", time.Now().UnixNano(), "10.55.0.10",
+	); err != nil {
+		t.Fatalf("seed ephemeral: %v", err)
+	}
+	ip, parent, ok := lookupEphemeralPeer(db, "ephpub")
+	if !ok || ip != "10.55.0.42" || parent != "10.55.0.10" {
+		t.Errorf("lookupEphemeralPeer = (%q, %q, %v); want (10.55.0.42, 10.55.0.10, true)",
+			ip, parent, ok)
+	}
+
+	if _, _, ok := lookupEphemeralPeer(db, "unknown"); ok {
+		t.Error("unknown pubkey matched")
+	}
+}
+
+// TestEvictEphemeralsForParentScoping ensures eviction is scoped to
+// one parent_ip — sibling devices on the same gateway keep their
+// ephemerals when this parent's cache is invalidated, and the parent
+// device row itself is never touched.
+func TestEvictEphemeralsForParentScoping(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	type row struct {
+		pub, ip, parent string
+		ephemeral       int
+	}
+	for _, r := range []row{
+		{"hostA_eph", "10.55.0.20", "10.55.0.5", 1},
+		{"hostB_eph", "10.55.0.21", "10.55.0.6", 1},
+		{"hostA_perm", "10.55.0.5", "", 0}, // parent itself; must NOT be evicted
+	} {
+		var parent any = r.parent
+		if r.parent == "" {
+			parent = nil
+		}
+		if _, err := db.Exec(
+			`INSERT INTO wg_peers (pubkey, ip, added_ns, ephemeral, parent_ip) VALUES (?, ?, ?, ?, ?)`,
+			r.pub, r.ip, time.Now().UnixNano(), r.ephemeral, parent,
+		); err != nil {
+			t.Fatalf("seed %s: %v", r.pub, err)
+		}
+	}
+
+	g := &Gateway{db: db, onboard: newOnboardRegistry()}
+	// Mark the ephemeral profile so we can confirm the onboard mapping
+	// is cleared on eviction. globalWG is nil in tests — that's fine,
+	// the helper skips wg-go ops when it isn't running.
+	g.onboard.setEphemeralProfile("10.55.0.20", "10.55.0.5", "default")
+
+	evictEphemeralsForParent(g, "10.55.0.5")
+
+	// hostB's ephemeral belongs to a different parent — must survive.
+	if !rowExists(t, db, "hostB_eph") {
+		t.Error("hostB_eph evicted; should have stayed (different parent)")
+	}
+	// The parent device row is never ephemeral=1; must survive.
+	if !rowExists(t, db, "hostA_perm") {
+		t.Error("hostA parent row deleted; eviction must not touch non-ephemeral rows")
+	}
+	// The onboard ephemeral-profile mapping for the evicted ephemeral
+	// should be cleared so a fresh registration doesn't inherit stale
+	// state.
+	if got := g.onboard.ProfileForIP("10.55.0.20"); got != "" {
+		t.Errorf("ProfileForIP(evicted)=%q; want empty", got)
+	}
+}
+
+func rowExists(t *testing.T, db *sql.DB, pubkey string) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM wg_peers WHERE pubkey = ?`, pubkey).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return n > 0
+}

--- a/run_linux.go
+++ b/run_linux.go
@@ -520,11 +520,29 @@ func (t *rawFDTun) Close() error {
 
 // --- ephemeral peer --------------------------------------------------
 
-// ephemeralPeer registers a fresh per-run WireGuard keypair with the
-// gateway, mutates cfg to use the ephemeral private key and address,
-// and sets CLAWPATROL_EPHEMERAL_ADDR so the re-exec'd child uses the
-// ephemeral IP for `ip addr add`. Returns a cleanup func that removes
-// the ephemeral peer from the gateway on exit.
+// ephemeralCacheFile is the on-disk record of this host's ephemeral
+// WireGuard identity. Concurrent and sequential `clawpatrol run`
+// invocations on the same host share it: the first run generates the
+// keypair + registers it with the gateway; every subsequent run reads
+// the cache and POSTs the SAME pubkey so the gateway returns the
+// existing /32 instead of allocating a new one. Without this every
+// invocation produced a fresh peer + a new dashboard row.
+const ephemeralCacheFile = "wg-ephemeral.json"
+
+type ephemeralCache struct {
+	GatewayURL string `json:"gateway_url"` // invalidates the cache when the host re-joins a different gateway
+	PrivateKey string `json:"private_key"` // base64
+	PublicHex  string `json:"public_hex"`  // hex (the form sent to gateway)
+	IP         string `json:"ip"`          // v4 /32 assigned by gateway
+	IP6        string `json:"ip6"`         // v6 /128
+}
+
+// ephemeralPeer registers (or reuses) this host's ephemeral WireGuard
+// identity with the gateway, mutates cfg to use the ephemeral private
+// key and address, and sets CLAWPATROL_EPHEMERAL_ADDR so the re-exec'd
+// child uses the ephemeral IP for `ip addr add`. Returns a cleanup
+// func — currently a no-op, since the identity is persisted across
+// runs and a normal exit must not invalidate concurrent siblings.
 //
 // Best-effort: any failure logs a warning and returns a no-op cleanup
 // so the caller falls back to the shared permanent identity.
@@ -544,53 +562,164 @@ func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
 		return noop, err
 	}
 
-	privB64, pubHex, _, err := wgGenKeypair()
+	// Acquire a flock on the cache so concurrent runs serialize their
+	// read-or-mint step. With this in place the second run sees the
+	// first run's keypair in the cache and reuses it instead of
+	// generating its own — that's the whole point of the cache.
+	cachePath := filepath.Join(dir, ephemeralCacheFile)
+	unlock, err := acquireEphemeralLock(cachePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: keygen: %v (using shared identity)\n", err)
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: lock cache: %v (using shared identity)\n", err)
+		return noop, err
+	}
+	defer unlock()
+
+	cached, _ := readEphemeralCache(cachePath)
+	if cached != nil && cached.GatewayURL != gwURL {
+		// Gateway URL changed (host re-joined a different gateway) —
+		// the cached pubkey is bound to a parent on the old gateway
+		// and would be rejected on the new one. Discard.
+		cached = nil
+	}
+
+	var (
+		privB64 string
+		pubHex  string
+	)
+	if cached != nil {
+		privB64 = cached.PrivateKey
+		pubHex = cached.PublicHex
+	} else {
+		privB64, pubHex, _, err = wgGenKeypair()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: keygen: %v (using shared identity)\n", err)
+			return noop, err
+		}
+	}
+
+	ip, ip6, err := postEphemeralPeer(client, gwURL, token, pubHex)
+	if err != nil && cached != nil {
+		// Cache was stale (gateway-side eviction, DB wipe, peer manually
+		// removed). Mint a fresh keypair and retry exactly once.
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: reuse failed (%v); minting fresh keypair\n", err)
+		privB64, pubHex, _, err = wgGenKeypair()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: keygen: %v (using shared identity)\n", err)
+			return noop, err
+		}
+		ip, ip6, err = postEphemeralPeer(client, gwURL, token, pubHex)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: %v (using shared identity)\n", err)
 		return noop, err
 	}
 
+	writeEphemeralCache(cachePath, &ephemeralCache{
+		GatewayURL: gwURL,
+		PrivateKey: privB64,
+		PublicHex:  pubHex,
+		IP:         ip,
+		IP6:        ip6,
+	})
+
+	cfg.PrivateKey = privB64
+	cfg.Address = ip + "/32, " + ip6 + "/128"
+	_ = os.Setenv("CLAWPATROL_EPHEMERAL_ADDR", cfg.Address)
+
+	// Cleanup is intentionally a no-op. The ephemeral identity persists
+	// across runs (that's the whole reuse story), so an exit MUST NOT
+	// DELETE it: a sibling `clawpatrol run` may still be using the
+	// tunnel. The gateway evicts the identity when a different pubkey
+	// arrives from the same parent (cache invalidation path) or when
+	// the parent device itself is revoked.
+	return noop, nil
+}
+
+// postEphemeralPeer POSTs to /api/peer/ephemeral?pubkey=<hex>. Returns
+// the (v4, v6) addresses the gateway assigned.
+func postEphemeralPeer(client *http.Client, gwURL, token, pubHex string) (string, string, error) {
 	req, err := http.NewRequest(http.MethodPost,
 		gwURL+"/api/peer/ephemeral?pubkey="+pubHex, nil)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: build request: %v (using shared identity)\n", err)
-		return noop, err
+		return "", "", fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: register: %v (using shared identity)\n", err)
-		return noop, err
+		return "", "", fmt.Errorf("register: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: gateway returned %d (using shared identity)\n", resp.StatusCode)
-		return noop, fmt.Errorf("gateway %d", resp.StatusCode)
+		return "", "", fmt.Errorf("gateway returned %d", resp.StatusCode)
 	}
-
 	var result struct {
 		IP  string `json:"ip"`
 		IP6 string `json:"ip6"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		fmt.Fprintf(os.Stderr, "⚠ ephemeral peer: decode response: %v (using shared identity)\n", err)
-		return noop, err
+		return "", "", fmt.Errorf("decode response: %w", err)
 	}
+	return result.IP, result.IP6, nil
+}
 
-	cfg.PrivateKey = privB64
-	cfg.Address = result.IP + "/32, " + result.IP6 + "/128"
-	_ = os.Setenv("CLAWPATROL_EPHEMERAL_ADDR", cfg.Address)
+// readEphemeralCache loads the on-disk ephemeral identity. Returns nil
+// on any error (missing / malformed / unreadable) — the caller mints
+// a fresh keypair.
+func readEphemeralCache(path string) (*ephemeralCache, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c ephemeralCache
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, err
+	}
+	if c.PrivateKey == "" || c.PublicHex == "" {
+		return nil, fmt.Errorf("cache missing keypair")
+	}
+	return &c, nil
+}
 
+// writeEphemeralCache persists c atomically (write-then-rename). 0600
+// because c.PrivateKey is the WG private key for this host's
+// ephemeral identity — leaking it lets anyone register as this peer.
+func writeEphemeralCache(path string, c *ephemeralCache) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}
+
+// acquireEphemeralLock serializes the read-or-mint window between
+// concurrent `clawpatrol run` invocations. Uses LOCK_EX so the second
+// run blocks until the first one finishes its POST + cache write; the
+// second run then reads the freshly-written cache and reuses the
+// keypair instead of generating its own (which would have raced to
+// register a separate IP, defeating the whole reuse mechanism).
+func acquireEphemeralLock(cachePath string) (func(), error) {
+	lockPath := cachePath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
 	return func() {
-		dreq, err := http.NewRequest(http.MethodDelete,
-			gwURL+"/api/peer/ephemeral?pubkey="+pubHex, nil)
-		if err != nil {
-			return
-		}
-		dreq.Header.Set("Authorization", "Bearer "+token)
-		if dr, derr := client.Do(dreq); derr == nil {
-			_ = dr.Body.Close()
-		}
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
 	}, nil
 }
 

--- a/run_linux_test.go
+++ b/run_linux_test.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -70,5 +72,88 @@ func TestSplitWGAddresses(t *testing.T) {
 				t.Fatalf("splitWGAddresses(%q) = %#v, want %#v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestEphemeralCacheRoundTrip persists an entry, reads it back, and
+// confirms the marshalled form survives. Guards against a future
+// refactor silently changing the on-disk schema (which would force
+// every host's `clawpatrol run` to mint a fresh keypair on upgrade).
+func TestEphemeralCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wg-ephemeral.json")
+	in := &ephemeralCache{
+		GatewayURL: "https://gw.example",
+		PrivateKey: "aGVsbG8td29ybGQ=", // arbitrary base64
+		PublicHex:  "abcdef0123456789",
+		IP:         "10.55.0.42",
+		IP6:        "fd77::42",
+	}
+	writeEphemeralCache(path, in)
+	out, err := readEphemeralCache(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("round trip mismatch:\n got: %#v\nwant: %#v", out, in)
+	}
+}
+
+// TestEphemeralCacheRejectsIncomplete covers the "client wrote a
+// half-baked cache and crashed" path — read must reject so the next
+// run mints a fresh keypair rather than POSTing garbage.
+func TestEphemeralCacheRejectsIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wg-ephemeral.json")
+	writeEphemeralCache(path, &ephemeralCache{
+		GatewayURL: "https://gw.example",
+		// PrivateKey + PublicHex missing.
+		IP: "10.55.0.42",
+	})
+	if _, err := readEphemeralCache(path); err == nil {
+		t.Fatal("read accepted cache with no keypair")
+	}
+}
+
+// TestEphemeralLockSerializesConcurrentRuns confirms two siblings
+// can't both hold the lock at once. The second goroutine must block
+// until the first releases — this is what guarantees the second run
+// reads the freshly-written cache instead of racing to mint its own.
+func TestEphemeralLockSerializesConcurrentRuns(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "wg-ephemeral.json")
+
+	unlock1, err := acquireEphemeralLock(cachePath)
+	if err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+
+	gotSecond := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		unlock2, err := acquireEphemeralLock(cachePath)
+		if err != nil {
+			t.Errorf("second lock: %v", err)
+			return
+		}
+		close(gotSecond)
+		unlock2()
+	}()
+
+	// The lock is process-wide on Linux (flock); the second
+	// goroutine should block while we hold it.
+	select {
+	case <-gotSecond:
+		t.Fatal("second lock acquired while first still held")
+	default:
+	}
+
+	unlock1()
+	wg.Wait()
+	select {
+	case <-gotSecond:
+	default:
+		t.Fatal("second lock never acquired after first released")
 	}
 }


### PR DESCRIPTION
Closes example/orchestrator#37