### PR TITLE
fix: use double-dash style in CLI help

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// newFlagSet keeps subcommand help consistent with the documented CLI style.
+// Go's flag package accepts both -flag and --flag, but its default help prints
+// single-dash flags. Claw Patrol documents long options with double dashes.
+func newFlagSet(name, usage string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "usage: %s\n\noptions:\n", usage)
+		fs.VisitAll(func(f *flag.Flag) {
+			// Keep short aliases accepted but out of long-option help.
+			if len(f.Name) == 1 {
+				return
+			}
+			value := ""
+			if _, ok := f.Value.(interface{ IsBoolFlag() bool }); !ok {
+				value = " VALUE"
+			}
+			fmt.Fprintf(fs.Output(), "  --%s%s\n", f.Name, value)
+			fmt.Fprintf(fs.Output(), "    \t%s", f.Usage)
+			if f.DefValue != "" && f.DefValue != "false" {
+				fmt.Fprintf(fs.Output(), " (default %s)", strconv.Quote(f.DefValue))
+			}
+			fmt.Fprintln(fs.Output())
+		})
+	}
+	return fs
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFlagSetUsageUsesDoubleDash(t *testing.T) {
+	fs := newFlagSet("gateway", "clawpatrol gateway [--config FILE] [--read-only-config]")
+	fs.String("config", "config.yaml", "config file")
+	fs.Bool("read-only-config", false, "reject dashboard writes to the HCL config file")
+
+	var out bytes.Buffer
+	fs.SetOutput(&out)
+	fs.Usage()
+	help := out.String()
+	for _, want := range []string{"--config VALUE", "--read-only-config"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help output missing %q:\n%s", want, help)
+		}
+	}
+	if strings.Contains(help, "\n  -config") || strings.Contains(help, "\n  -read-only-config") {
+		t.Fatalf("help output used single-dash long flags:\n%s", help)
+	}
+}

--- a/integrations.go
+++ b/integrations.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -167,7 +166,7 @@ func readPeerAPIToken(caDir string) string {
 // overwrites the auth slot at MITM time, so the placeholder bytes
 // never reach the upstream.
 func runEnv(args []string) {
-	fs := flag.NewFlagSet("env", flag.ExitOnError)
+	fs := newFlagSet("env", "clawpatrol env [--ca-dir DIR]")
 	caDir := fs.String("ca-dir", defaultClawpatrolDir(), "directory containing ca.crt")
 	_ = fs.Parse(args)
 

--- a/login.go
+++ b/login.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -80,7 +79,7 @@ type tsPeer struct {
 // straight into the post-join setup (set exit-node, fetch CA, install
 // system trust) — single command, full setup.
 func runJoin(args []string) {
-	fs := flag.NewFlagSet("join", flag.ExitOnError)
+	fs := newFlagSet("join", "clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] <gateway-url>")
 	gwName := fs.String("name", "clawpatrol", "exit-node hostname on the tailnet")
 	caOut := fs.String("ca-dir", defaultClawpatrolDir(), "where to store the fetched CA")
 	skipTrust := fs.Bool("no-trust", false, "fetch CA but skip system trust install (do it manually)")
@@ -182,7 +181,7 @@ func fetchCAHTTP(gateway, dst string) error {
 }
 
 func runLogin(args []string) {
-	fs := flag.NewFlagSet("login", flag.ExitOnError)
+	fs := newFlagSet("login", "clawpatrol login [--name NAME] [--ca-dir DIR] [--no-trust] [--no-exit-node]")
 	gwName := fs.String("name", "clawpatrol", "exit-node hostname to look for on the tailnet")
 	caOut := fs.String("ca-dir", defaultClawpatrolDir(), "where to store the fetched CA")
 	skipTrust := fs.Bool("no-trust", false, "fetch CA but skip system trust install (do it manually)")
@@ -1024,7 +1023,7 @@ func defaultGatewayDataDir() string {
 }
 
 func runGatewayInit(args []string) {
-	fs := flag.NewFlagSet("gateway init", flag.ExitOnError)
+	fs := newFlagSet("gateway init", "clawpatrol gateway init [--data-dir DIR] [--public-url URL] [--public-ip IP] [--wg-port PORT] [--dash-port PORT] [--tls-port PORT] [--subnet CIDR] [--no-firewall]")
 	dataDir := fs.String("data-dir", defaultGatewayDataDir(), "where to put gateway.hcl + CA + state")
 	publicURL := fs.String("public-url", "", "public dashboard URL (auto-detected from public IP if empty)")
 	publicIP := fs.String("public-ip", "", "public IP for the WG endpoint (auto-detected if empty)")
@@ -1259,13 +1258,14 @@ WantedBy=multi-user.target
 // trust, drops the per-user state dirs, and strips the shell-rc
 // env shim.
 func runUninstall(args []string) {
-	fs := flag.NewFlagSet("uninstall", flag.ExitOnError)
+	fs := newFlagSet("uninstall", "clawpatrol uninstall [--keep-ca] [--keep-conf] [--yes]")
 	keepCA := fs.Bool("keep-ca", false, "keep ~/.clawpatrol + system trust")
 	keepConf := fs.Bool("keep-conf", false, "keep ~/.config/clawpatrol/wg.conf")
-	yes := fs.Bool("y", false, "skip the confirmation prompt")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt")
+	yesShort := fs.Bool("y", false, "skip the confirmation prompt")
 	_ = fs.Parse(args)
 
-	if !*yes {
+	if !*yes && !*yesShort {
 		fmt.Print("Uninstall clawpatrol from this machine? [y/N] ")
 		var resp string
 		_, _ = fmt.Scanln(&resp)

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -2153,7 +2152,7 @@ func usage() {
 
 usage:
   clawpatrol gateway init [flags]        bootstrap a new gateway host
-  clawpatrol gateway [-config FILE]      run the gateway server
+  clawpatrol gateway [--config FILE]     run the gateway server
   clawpatrol join [flags] <gateway-url>  onboard this machine via wg device flow
                   --hostname NAME        device name to register (default: os.Hostname)
                   --profile NAME         suggest a profile for the approver
@@ -2187,7 +2186,7 @@ func runGateway(args []string) {
 		runGatewayInit(args[1:])
 		return
 	}
-	fs := flag.NewFlagSet("gateway", flag.ExitOnError)
+	fs := newFlagSet("gateway", "clawpatrol gateway [--config FILE] [--read-only-config]")
 	cfgPath := fs.String("config", "config.yaml", "config file")
 	readOnly := fs.Bool("read-only-config", false,
 		"reject dashboard writes to the HCL config file")

--- a/run_linux.go
+++ b/run_linux.go
@@ -27,7 +27,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -61,7 +60,7 @@ func runRun(args []string) {
 		return
 	}
 
-	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	fs := newFlagSet("run", "clawpatrol run [--conf PATH] -- <cmd> [args...]")
 	confPath := fs.String("conf", defaultRunConf(), "path to wg conf written by `clawpatrol join`")
 	_ = fs.Parse(args)
 	cmd := fs.Args()


### PR DESCRIPTION
## Summary
- Add a shared `newFlagSet` helper so subcommand help consistently renders long options with `--`.
- Switch user-facing subcommand usage strings to double-dash style, including `gateway --config`.
- Add a regression test for double-dash help output.

## Testing
- `go test -tags ts_omit_identityfederation . -run 'TestFlagSetUsageUsesDoubleDash'`
- `go test -tags ts_omit_identityfederation ./...`
- `git diff --check`