### PR TITLE
fix(ephemeral): remap agentAddr in handleWSUpgrade

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -100,7 +100,7 @@ func (g *Gateway) dialWSUpstream(ctx context.Context, upstream string, ep *confi
 // The connection stays alive until either side closes; pumpWS
 // observes text frames for codex usage tracking when applicable.
 func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string, rewriteClientPayload wsPayloadRewriter) {
-	agentAddr := peerIP(client) // capture before netstack races to nil
+	agentAddr := g.agentIPFor(client) // capture before netstack races to nil; remap ephemeral → parent
 
 	// dialWSUpstream preserves the existing split: endpoints that require a
 	// client cert (e.g. kubernetes mTLS) use dialUpstream so credential plugins


### PR DESCRIPTION
## Root cause

`ws.go:103` captured `agentAddr` via `peerIP(client)` — the raw ephemeral IP. `agents.track(agentAddr, ...)` then created an `AgentRegistry` entry keyed to the ephemeral IP. Since `agentsList()` returns all entries in `r.agents`, the phantom ephemeral IPs appeared as device rows in the dashboard even though no `devices` table row existed.

All other traffic modes (`mitmHTTPS`, `splice`, `wgRelay`, `handlePostgresConn`, `dispatchConnEndpoint`, `preCreateLLMSession`, `trackLLMUsage`) were already remapped in previous PRs — `handleWSUpgrade` was the remaining gap.

## Fix

Replace `peerIP(client)` with `g.agentIPFor(client)` so WS traffic (Claude streaming, Codex `/backend-api/codex/responses`) is attributed to the parent device alongside all other traffic modes.

## Sequence of ephemeral fixes

| PR | Fix |
|---|---|
| #224 | Separate `ephemeralProfileByIP` map; attribution remapping for most traffic modes |
| #237 | Guard `upsertLocked`; fix migration number |
| #262 | Purge ephemeral WG peers on gateway restart |
| this | Remap `agentAddr` in `handleWSUpgrade` (WS traffic) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)