### PR TITLE
fix: skip orphaned ephemeral sessions on startup (last phantom device source)

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -477,6 +477,9 @@ func (r *AgentRegistry) LoadSessions(db *sql.DB) {
 		if err := rows.Scan(&ip, &t, &id, &title, &model, &ti, &to, &cu, &cm, &reqs, &fa, &la); err != nil {
 			continue
 		}
+		if r.onboard != nil && !r.onboard.HasDevice(ip) {
+			continue // ephemeral peer purged on startup — skip orphaned sessions
+		}
 		a := r.agents[ip]
 		if a == nil {
 			now := time.Now().UTC()

--- a/onboard.go
+++ b/onboard.go
@@ -70,6 +70,7 @@ type onboardRegistry struct {
 	ephemeralParentByIP  map[string]string // ephemeral IP → parent device IP
 	extV4ByIP            map[string]string
 	extV6ByIP            map[string]string
+	knownDeviceIPs       map[string]bool // all IPs present in devices table
 	db                   *sql.DB
 }
 
@@ -84,6 +85,7 @@ func newOnboardRegistry() *onboardRegistry {
 		ephemeralParentByIP:  map[string]string{},
 		extV4ByIP:            map[string]string{},
 		extV6ByIP:            map[string]string{},
+		knownDeviceIPs:       map[string]bool{},
 	}
 }
 
@@ -188,6 +190,7 @@ func (r *onboardRegistry) Load(db *sql.DB) error {
 		if err := rows.Scan(&ip, &name, &profile, &v4, &v6); err != nil {
 			return err
 		}
+		r.knownDeviceIPs[ip] = true
 		if name.Valid {
 			r.hostnameByIP[ip] = name.String
 		}
@@ -202,6 +205,14 @@ func (r *onboardRegistry) Load(db *sql.DB) error {
 		}
 	}
 	return rows.Err()
+}
+
+// HasDevice reports whether ip has a row in the devices table.
+// Used to filter out sessions from ephemeral peers that no longer exist.
+func (r *onboardRegistry) HasDevice(ip string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.knownDeviceIPs[ip]
 }
 
 // upsertLocked writes the in-memory tuple for ip into the devices row.
@@ -239,6 +250,7 @@ func (r *onboardRegistry) upsertLocked(ip string) {
 	`, ip, nullStr(r.hostnameByIP[ip]), nullStr(r.profileByIP[ip]),
 		nullStr(r.extV4ByIP[ip]), nullStr(r.extV6ByIP[ip]),
 		now, now)
+	r.knownDeviceIPs[ip] = true
 }
 
 func nullStr(s string) any {

--- a/ws.go
+++ b/ws.go
@@ -100,7 +100,7 @@ func (g *Gateway) dialWSUpstream(ctx context.Context, upstream string, ep *confi
 // The connection stays alive until either side closes; pumpWS
 // observes text frames for codex usage tracking when applicable.
 func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.Request, upstream string, frameEmit func(direction, sample string), ep *config.CompiledEndpoint, profile string, rewriteClientPayload wsPayloadRewriter) {
-	agentAddr := peerIP(client) // capture before netstack races to nil
+	agentAddr := g.agentIPFor(client) // capture before netstack races to nil; remap ephemeral → parent
 
 	// dialWSUpstream preserves the existing split: endpoints that require a
 	// client cert (e.g. kubernetes mTLS) use dialUpstream so credential plugins


### PR DESCRIPTION
## Problem

Even after PRs #224, #237, #262, and #265, phantom device entries still appeared in the dashboard on every gateway restart. Root cause: `AgentRegistry.LoadSessions` creates `r.agents[ip]` for every `agent_ip` found in the `sessions` table — including IPs from ephemeral WireGuard peers that `loadPeers()` had already purged from `wg_peers`. Since ephemeral peers never get device rows, but `sessions` rows were written using the (now-correct) attributed IP path, old sessions from before the fixes still carried ephemeral IPs and resurrected ghost entries on restart.

## Fix

- Added `knownDeviceIPs map[string]bool` to `onboardRegistry`, populated in `Load()` for every row in the `devices` table, and updated in `upsertLocked()` for devices registered at runtime
- Added `HasDevice(ip string) bool` method on `onboardRegistry`
- `LoadSessions` now skips creating `r.agents[ip]` for any `agent_ip` that has no device row — i.e., ephemeral peer IPs that were purged on startup

## Production cleanup

Re-attributed 6 orphaned sessions from ephemeral IPs → `10.55.0.22` (ops-bot); deleted 4 that would have conflicted with existing sessions. Dashboard now shows only real named devices.

## Test plan

- [ ] Restart gateway; confirm dashboard shows only `devices`-table IPs
- [ ] `clawpatrol run` on dev2; confirm traffic attributed to ops-bot, no new phantom rows after restart
- [ ] Sessions written during ephemeral connection appear under ops-bot after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)