### PR TITLE
dashboard: breadcrumb shows UUIDv7 tail, not the timestamp prefix

### DIFF
--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -245,7 +245,9 @@ function Breadcrumbs({
       {requestId && (
         <>
           <span className="text-[13px] text-[#a3a3a3]">/</span>
-          <span className="text-[13px] text-[#525252] font-mono">{requestId.slice(0, 8)}</span>
+          <span className="text-[13px] text-[#525252] font-mono" title={requestId}>
+            {requestId.split("-").pop()}
+          </span>
         </>
       )}
     </nav>


### PR DESCRIPTION
## Summary
The action-detail breadcrumb showed `requestId.slice(0, 8)`, which is the UUIDv7 timestamp prefix — identical across every request recorded in the same ~256ms window. Switch to the last `-`-segment (the random tail) and add the full ID as a `title` tooltip.

## Test plan
- [ ] Visit `/#/request/<uuidv7>` and confirm the breadcrumb shows the random tail (e.g. `156a0e9372fc` for `019e1c9c-b11b-7ec5-8699-156a0e9372fc`).
- [ ] Hover the tail; tooltip shows the full UUID.
- [ ] Open two requests recorded close in time; their breadcrumb tails differ.
