### PR TITLE
docs: refresh public documentation

### DIFF
--- a/config/plugins/tunnels/kubernetes_port_forward.go
+++ b/config/plugins/tunnels/kubernetes_port_forward.go
@@ -77,30 +77,37 @@ import (
 
 // KubernetesPortForwardTunnel configures the tunnel runtime.
 type KubernetesPortForwardTunnel struct {
-	Context   string `hcl:"context,optional"`
+	// Context selects a kubeconfig context; empty uses the current context.
+	Context string `hcl:"context,optional"`
+	// Namespace selects the Kubernetes namespace for kubectl commands.
 	Namespace string `hcl:"namespace,optional"`
 
-	// Exactly one of Pod / Service / Selector / Template must be set.
-	Pod      string            `hcl:"pod,optional"`
-	Service  string            `hcl:"service,optional"`
+	// Pod names an existing pod to port-forward to.
+	Pod string `hcl:"pod,optional"`
+	// Service names a service to port-forward to.
+	Service string `hcl:"service,optional"`
+	// Selector matches a ready pod to port-forward to.
 	Selector map[string]string `hcl:"selector,optional"`
-	Template string            `hcl:"template,optional"`
+	// Template is a pod manifest to apply and port-forward to.
+	Template string `hcl:"template,optional"`
 
 	// Port is the pod-side port the forwarder targets. For service
 	// mode it's the *service* port; kubectl resolves the matching
 	// targetPort.
 	Port int `hcl:"port"`
 
-	// Cleanup is meaningful only in template mode — controls whether
-	// the pod the plugin applied at Open is deleted on tunnel
-	// teardown. "delete" (default) is right for the common create-on-
-	// demand case; "keep" disables deletion.
+	// Controls whether a template-created pod is deleted on tunnel teardown.
+	// "delete" (default) is right for the common create-on-demand case;
+	// "keep" disables deletion.
 	Cleanup string `hcl:"cleanup,optional"`
 
-	// Framework-level common attrs.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains kubectl access through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an optional credential block for Kubernetes access.
 	Credential string `hcl:"credential,optional"`
 }
 

--- a/config/plugins/tunnels/local_command.go
+++ b/config/plugins/tunnels/local_command.go
@@ -45,18 +45,24 @@ import (
 
 // LocalCommandTunnel configures the tunnel runtime.
 type LocalCommandTunnel struct {
-	Command      []string          `hcl:"command"`
-	Listen       string            `hcl:"listen"`
-	ReadyProbe   string            `hcl:"ready_probe,optional"`
-	ReadyTimeout string            `hcl:"ready_timeout,optional"`
-	Env          map[string]string `hcl:"env,optional"`
+	// Command is the argv vector to spawn for the tunnel process.
+	Command []string `hcl:"command"`
+	// Listen is the local address the spawned command exposes.
+	Listen string `hcl:"listen"`
+	// ReadyProbe is an optional TCP address to poll before the tunnel is ready.
+	ReadyProbe string `hcl:"ready_probe,optional"`
+	// ReadyTimeout overrides the default readiness wait duration.
+	ReadyTimeout string `hcl:"ready_timeout,optional"`
+	// Env adds environment variables to the spawned command.
+	Env map[string]string `hcl:"env,optional"`
 
-	// Framework-level common attrs (share / keepalive / via /
-	// credential). Restated on every tunnel plugin's body so gohcl
-	// decodes them; the compile pass reads via TunnelCommonRead.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains this tunnel through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an optional credential block for the tunnel runtime.
 	Credential string `hcl:"credential,optional"`
 }
 

--- a/config/plugins/tunnels/ssh_port_forward.go
+++ b/config/plugins/tunnels/ssh_port_forward.go
@@ -44,13 +44,18 @@ import (
 
 // SSHPortForwardTunnel configures the tunnel runtime.
 type SSHPortForwardTunnel struct {
-	Bastion string `hcl:"bastion,optional"` // host:port; required when Via is unset
-	User    string `hcl:"user"`
+	// Bastion is the SSH server host:port; required when via is unset.
+	Bastion string `hcl:"bastion,optional"`
+	// User is the SSH username for the bastion login.
+	User string `hcl:"user"`
 
-	// Framework-level common attrs.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains the SSH connection through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an ssh credential block used for bastion authentication.
 	Credential string `hcl:"credential"`
 }
 

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -51,16 +51,24 @@ import (
 
 // TailscaleTunnel configures the tunnel runtime.
 type TailscaleTunnel struct {
-	AuthKey    string   `hcl:"authkey,optional"`
-	ControlURL string   `hcl:"control_url,optional"`
-	Hostname   string   `hcl:"hostname,optional"`
-	StateDir   string   `hcl:"state_dir,optional"`
-	Tags       []string `hcl:"tags,optional"`
+	// AuthKey is the Tailscale auth key; env fallback is CLAWPATROL_TUNNEL_<NAME>_AUTHKEY.
+	AuthKey string `hcl:"authkey,optional"`
+	// ControlURL overrides the Tailscale control-plane URL.
+	ControlURL string `hcl:"control_url,optional"`
+	// Hostname is the tsnet node name; defaults to clawpatrol-tunnel-<name>.
+	Hostname string `hcl:"hostname,optional"`
+	// StateDir stores tsnet node state; defaults under the gateway CA directory.
+	StateDir string `hcl:"state_dir,optional"`
+	// Tags are Tailscale tags requested for the tsnet node.
+	Tags []string `hcl:"tags,optional"`
 
-	// Framework-level common attrs.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains this tunnel through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an optional credential block for the tunnel runtime.
 	Credential string `hcl:"credential,optional"`
 }
 

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -18,13 +18,23 @@ Bootstrap a gateway data directory with a starter `gateway.hcl`, CA material,
 and gateway state.
 
 ```bash
-clawpatrol gateway init [--data-dir DIR]
+clawpatrol gateway init [--data-dir DIR] [--public-url URL] [--public-ip IP] [--wg-port PORT] [--dash-port PORT] [--tls-port PORT] [--subnet CIDR] [--no-firewall]
 ```
 
 Options:
 
 - `--data-dir DIR` — where to write gateway config, CA, and state. Defaults to
   the platform gateway data directory.
+- `--public-url URL` — public dashboard/join URL to write into the generated
+  config. When omitted, `gateway init` derives one from the public IP and
+  dashboard port.
+- `--public-ip IP` — public IP to use for the WireGuard endpoint. When omitted,
+  `gateway init` attempts to detect it.
+- `--wg-port PORT` — WireGuard UDP port. Defaults to `51820`.
+- `--dash-port PORT` — dashboard and join HTTP port. Defaults to `9080`.
+- `--tls-port PORT` — TLS gateway port on the host. Defaults to `8443`.
+- `--subnet CIDR` — WireGuard subnet pool. Defaults to `10.55.0.0/24`.
+- `--no-firewall` — skip adding iptables `ACCEPT` rules.
 
 After editing `gateway.hcl`, start the gateway with `clawpatrol gateway`.
 
@@ -52,7 +62,7 @@ Register the current machine with an existing gateway and prepare it for
 Claw Patrol-routed agent traffic.
 
 ```bash
-clawpatrol join <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine] [--no-trust] [--ca-dir DIR] [--name NAME]
+clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] [--no-trust] [--ca-dir DIR] [--name NAME] <gateway-url>
 ```
 
 Options:

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -6,132 +6,212 @@
 curl -fsSL https://clawpatrol.dev/install.sh | sh
 ```
 
-The installer drops a single statically linked Go binary in
-`~/.local/bin`. The `clawpatrol` command is the unified entry point for
-both the proxy server and the client tools.
+The installer drops a single Go binary in `~/.local/bin`. The
+`clawpatrol` command contains both gateway/operator commands and client
+commands for joining and running agent processes.
 
 ## Commands
 
-### `clawpatrol onboard`
+### `clawpatrol gateway init`
 
-Interactive setup wizard. Starts a local proxy, scans for API
-keys, and configures your system.
+Bootstrap a gateway data directory with a starter `gateway.hcl`, CA material,
+and gateway state.
 
 ```bash
-clawpatrol onboard [--server URL]
+clawpatrol gateway init [--data-dir DIR]
 ```
 
 Options:
-- `--server URL` — skip the gateway selector and connect to a
-  specific server (e.g. `--server https://gateway.example.com`)
 
-### `clawpatrol run`
+- `--data-dir DIR` — where to write gateway config, CA, and state. Defaults to
+  the platform gateway data directory.
 
-Run a command with its traffic routed through the proxy.
-
-```bash
-clawpatrol run [--name NAME] [--profile PROFILE] [--no-expose] [--sub-user] [--fs-access PATH]... <command> [args...]
-```
-
-Options:
-- `--name NAME` — session name (defaults to the command name)
-- `--profile PROFILE` — use a specific integration profile
-- `--no-expose` — don't tunnel the wrapped command's TCP
-  listeners back to the host (Linux only; default is to
-  auto-tunnel)
-- `--sub-user` — run the wrapped command under a subordinate
-  UID for filesystem isolation (Linux only; requires an
-  `/etc/subuid` entry). By default the command runs as the
-  calling user so it can read `~/.claude`, `~/.config`, git
-  credentials, ssh keys, and other per-user state. Opt into
-  `--sub-user` when you want the command sandboxed away from
-  your home directory.
-- `--fs-access PATH` — expose a host file or directory to the
-  wrapped command at the same absolute path (Linux only).
-  Repeatable. Only meaningful with `--sub-user`; otherwise the
-  wrapped command already runs as you and has native access.
-
-Examples:
-```bash
-clawpatrol run claude
-clawpatrol run --name my-agent python agent.py
-clawpatrol run --profile production gh pr create
-```
-
-The proxy injects API keys and logs all traffic for the
-duration of the command. When the command exits, the session
-ends.
-
-If you omit the `run` subcommand, clawpatrol treats the arguments
-as a wrapped command automatically:
-
-```bash
-clawpatrol claude            # equivalent to: clawpatrol run claude
-```
+After editing `gateway.hcl`, start the gateway with `clawpatrol gateway`.
 
 ### `clawpatrol gateway`
 
-Start the proxy server directly (without the onboard wizard).
+Run the long-lived gateway daemon.
 
 ```bash
-clawpatrol gateway
-```
-
-This starts the CONNECT proxy on port 8443 and the
-dashboard/API on port 8080. Useful for running clawpatrol as a
-persistent service or in Docker.
-
-### `clawpatrol offboard`
-
-Remove clawpatrol from this machine.
-
-```bash
-clawpatrol offboard [-y] [--delete-data] [--keep-data]
+clawpatrol gateway [-config FILE] [--read-only-config]
 ```
 
 Options:
-- `-y`, `--yes` — skip confirmation prompt
-- `--delete-data` — remove all data in `~/.clawpatrol`
-- `--keep-data` — keep data (don't ask)
+
+- `-config FILE` — gateway HCL file to load. Defaults to `config.yaml` for
+  compatibility with older invocations.
+- `--read-only-config` — reject dashboard writes to the HCL config file.
+
+The daemon loads `gateway.hcl`, starts the dashboard/API listener when
+`info_listen` is configured, starts data-plane forwarding, and watches the
+config file for reloads.
 
 ### `clawpatrol join`
 
-Register this device with an existing gateway. The URL is the only
-positional argument; `--hostname`, `--profile`, `--whole-machine`,
-and `--no-trust` are optional flags.
+Register the current machine with an existing gateway and prepare it for
+Claw Patrol-routed agent traffic.
 
 ```bash
-clawpatrol join <gateway-url>
+clawpatrol join <gateway-url> [--hostname NAME] [--profile NAME] [--whole-machine] [--no-trust] [--ca-dir DIR] [--name NAME]
 ```
 
-### `clawpatrol --version`
+Options:
 
-Print the version and exit. Also accepts `-V`.
+- `--hostname NAME` — device name shown to gateway approvers. Defaults to
+  `os.Hostname()`.
+- `--profile NAME` — suggested profile for the device; the approver can still
+  change it in the dashboard.
+- `--whole-machine` — bring up the generated WireGuard config with `wg-quick`
+  so all host traffic routes through the gateway. Without this flag, the join
+  persists config and `clawpatrol run` provides per-process routing.
+- `--no-trust` — fetch the gateway CA but skip installing it into system trust.
+- `--ca-dir DIR` — directory where `ca.crt` and local client state are stored.
+- `--name NAME` — Tailscale gateway hostname to look for when the gateway uses
+  the Tailscale control plane. Defaults to `clawpatrol`.
 
-## Environment Variables
+### `clawpatrol login`
 
-| Variable | Default | Description |
-|---|---|---|
-| `CLAWPATROL_DATA` | `~/.clawpatrol` | Data directory (database, CA certs, keys) |
-| `CLAWPATROL_HOSTNAME` | — | Public hostname for the gateway |
-| `PROXY_PORT` | `8443` | CONNECT proxy listen port |
-| `API_PORT` | `8080` | Dashboard/API listen port |
-| `API_HOST` | `127.0.0.1` | Dashboard/API bind address |
-| `DEV_AUTH_EMAIL` | — | Skip OAuth, auto-login as this email |
-| `AUTH_PROVIDER` | — | Path to auth provider module |
-| `CLAWPATROL_SESSION_SECRET` | — | Session signing key |
-| `SITE_DIR` | — | Landing site directory for unauthenticated visitors |
-| `ANALYTICS_RETENTION_DAYS` | `7` | Days to retain request logs |
-| `ALLOWED_EMAIL_DOMAIN` | — | Restrict login to a specific email domain |
+Complete local Tailscale-oriented setup against a gateway that is already
+reachable on the tailnet.
 
-## Data Directory
-
-Claw Patrol stores all state in `~/.clawpatrol/` (or `$CLAWPATROL_DATA`):
-
+```bash
+clawpatrol login [--name NAME] [--ca-dir DIR] [--no-trust] [--no-exit-node]
 ```
-~/.clawpatrol/
-  clients.db          SQLite database (devices, sessions, integrations)
-  ca/                 Generated CA certificate and key
-  wg/                 WireGuard server keys
-  gateway.log         Gateway stdout/stderr (when run via launchd/systemd)
+
+Options:
+
+- `--name NAME` — exit-node hostname to look for on the tailnet.
+- `--ca-dir DIR` — directory where the fetched CA is stored.
+- `--no-trust` — skip installing the CA into system trust.
+- `--no-exit-node` — do not set the Tailscale exit node automatically.
+
+Most users should start with `clawpatrol join <gateway-url>`; it delegates to
+`login` only when the gateway's control plane requires the Tailscale path.
+
+### `clawpatrol run`
+
+Run one command with per-process Claw Patrol routing.
+
+```bash
+clawpatrol run [-conf FILE] <command> [args...]
 ```
+
+Options:
+
+- `-conf FILE` — WireGuard config written by `clawpatrol join`. Defaults to the
+  standard per-user Claw Patrol config path.
+
+On Linux, `run` creates an isolated network namespace for the child process,
+brings up WireGuard inside that namespace, and executes the command there. Use
+`join --whole-machine` instead when you want all host traffic routed through the
+gateway without wrapping individual commands.
+
+Examples:
+
+```bash
+clawpatrol run claude
+clawpatrol run python agent.py
+```
+
+### `clawpatrol env`
+
+Print shell exports that point common AI/API clients at Claw Patrol-managed
+placeholders and the installed CA.
+
+```bash
+clawpatrol env [--ca-dir DIR]
+```
+
+Options:
+
+- `--ca-dir DIR` — directory containing `ca.crt`.
+
+The command is meant to be sourced from a shell profile or evaluated for a
+single session:
+
+```bash
+eval "$(clawpatrol env)"
+```
+
+Set `CLAWPATROL_NO_ENV=1` to disable env pushdown in shells that source this
+helper.
+
+### `clawpatrol status`
+
+Report local install and tunnel state.
+
+```bash
+clawpatrol status
+```
+
+`status` is read-only and prints the signals that usually explain why traffic
+is not flowing: local config presence, CA/trust state, tunnel state, and gateway
+reachability.
+
+### `clawpatrol validate`
+
+Parse and compile a gateway HCL config without starting the gateway.
+
+```bash
+clawpatrol validate <config.hcl>
+```
+
+Use this in CI or before restarting a gateway to catch syntax, reference, and
+policy compilation errors.
+
+### `clawpatrol init-ca`
+
+Generate a standalone CA in a directory.
+
+```bash
+clawpatrol init-ca DIR
+```
+
+This writes `ca.crt` and `ca.key`. Most installations should use
+`clawpatrol gateway init` instead, which creates a complete gateway data
+directory.
+
+### `clawpatrol uninstall`
+
+Remove local Claw Patrol client setup.
+
+```bash
+clawpatrol uninstall [--keep-ca]
+```
+
+Options:
+
+- `--keep-ca` — keep local Claw Patrol state and system trust entries.
+
+Without `--keep-ca`, uninstall removes local state directories and trust/env
+configuration that were added during setup.
+
+### `clawpatrol version`
+
+Print the build version and git SHA when available.
+
+```bash
+clawpatrol version
+```
+
+## Configuration and state
+
+Gateway behavior is controlled by `gateway.hcl`; see the
+[HCL config reference](/docs/config-reference/). Client commands store local
+state under the platform Claw Patrol config directory, including the fetched
+`ca.crt` and generated WireGuard config.
+
+## Environment variables
+
+Claw Patrol recognizes a small set of operational environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `CLAWPATROL_NO_ENV` | Set to `1` to disable `clawpatrol env` pushdown. |
+| `CLAWPATROL_TELEMETRY` | Set to `0` to disable telemetry. |
+| `DO_NOT_TRACK` | Set to `1` to disable telemetry. |
+| `CLAWPATROL_SECRET_<NAME>` | Fallback secret source for credential blocks. Hyphens in names become underscores. |
+| `CLAWPATROL_SECRET_<NAME>_CERT`, `_KEY`, `_CA` | mTLS secret material for credential blocks. Values may be inline PEM or `@/path/to/file`. |
+| `CLAWPATROL_TUNNEL_<NAME>_AUTHKEY` | Tailscale tunnel auth key fallback. Hyphens in names become underscores. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Export OpenTelemetry metrics when configured. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Override OpenTelemetry metric export interval. |

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -2,7 +2,7 @@
 
 A clawpatrol gateway config mixes **operational** fields (top-level
 plumbing) with **policy** blocks. Operational fields are top-level
-attributes; policy blocks (`approver`, `credential`, `endpoint`, `rule`)
+attributes; policy blocks (`approver`, `credential`, `tunnel`, `endpoint`, `rule`)
 dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
@@ -17,7 +17,7 @@ Each block section lists the attributes the loader accepts, with:
 - **Required** — `yes` if the loader rejects the block when the
   attribute is missing.
 
-Plugin-dispatched kinds (`approver`, `credential`, `endpoint`, `rule`)
+Plugin-dispatched kinds (`approver`, `credential`, `tunnel`, `endpoint`, `rule`)
 list one subsection per registered type.
 
 ## Top-level fields
@@ -345,6 +345,100 @@ _No configurable attributes._
 
 ```hcl
 credential "telegram_bot_token" "example" {}
+```
+
+## `tunnel` blocks
+
+Block syntax: `tunnel "<type>" "<name>" { ... }`
+
+Registered types: [`kubernetes_port_forward`](#tunnel-kubernetesportforward), [`local_command`](#tunnel-localcommand), [`ssh_port_forward`](#tunnel-sshportforward), [`tailscale`](#tunnel-tailscale).
+
+### `tunnel "kubernetes_port_forward" "<name>"`
+
+Configures the tunnel runtime.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `context` | `string` | no | Selects a kubeconfig context; empty uses the current context. |
+| `namespace` | `string` | no | Selects the Kubernetes namespace for kubectl commands. |
+| `pod` | `string` | no | Names an existing pod to port-forward to. |
+| `service` | `string` | no | Names a service to port-forward to. |
+| `selector` | `map[string]string` | no | Matches a ready pod to port-forward to. |
+| `template` | `string` | no | A pod manifest to apply and port-forward to. |
+| `port` | `int` | yes | The pod-side port the forwarder targets. For service mode it's the *service* port; kubectl resolves the matching targetPort. |
+| `cleanup` | `string` | no | Controls whether a template-created pod is deleted on tunnel teardown. "delete" (default) is right for the common create-on-demand case; "keep" disables deletion. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `string` | no | Chains kubectl access through another tunnel. |
+| `credential` | `string` | no | References an optional credential block for Kubernetes access. |
+
+```hcl
+tunnel "kubernetes_port_forward" "example" {
+  port = 30
+}
+```
+
+### `tunnel "local_command" "<name>"`
+
+Configures the tunnel runtime.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | `[]string` | yes | The argv vector to spawn for the tunnel process. |
+| `listen` | `string` | yes | The local address the spawned command exposes. |
+| `ready_probe` | `string` | no | An optional TCP address to poll before the tunnel is ready. |
+| `ready_timeout` | `string` | no | Overrides the default readiness wait duration. |
+| `env` | `map[string]string` | no | Adds environment variables to the spawned command. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `string` | no | Chains this tunnel through another tunnel. |
+| `credential` | `string` | no | References an optional credential block for the tunnel runtime. |
+
+```hcl
+tunnel "local_command" "example" {
+  command = ["example"]
+  listen = "example"
+}
+```
+
+### `tunnel "ssh_port_forward" "<name>"`
+
+Configures the tunnel runtime.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `bastion` | `string` | no | The SSH server host:port; required when via is unset. |
+| `user` | `string` | yes | The SSH username for the bastion login. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `string` | no | Chains the SSH connection through another tunnel. |
+| `credential` | `string` | yes | References an ssh credential block used for bastion authentication. |
+
+```hcl
+tunnel "ssh_port_forward" "example" {
+  user = "example"
+  credential = example-credential
+}
+```
+
+### `tunnel "tailscale" "<name>"`
+
+Configures the tunnel runtime.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | `string` | no | The Tailscale auth key; env fallback is CLAWPATROL_TUNNEL_<NAME>_AUTHKEY. |
+| `control_url` | `string` | no | Overrides the Tailscale control-plane URL. |
+| `hostname` | `string` | no | The tsnet node name; defaults to clawpatrol-tunnel-<name>. |
+| `state_dir` | `string` | no | Stores tsnet node state; defaults under the gateway CA directory. |
+| `tags` | `[]string` | no | Tailscale tags requested for the tsnet node. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `string` | no | Chains this tunnel through another tunnel. |
+| `credential` | `string` | no | References an optional credential block for the tunnel runtime. |
+
+```hcl
+tunnel "tailscale" "example" {}
 ```
 
 ## `endpoint` blocks

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -369,8 +369,8 @@ Configures the tunnel runtime.
 | `cleanup` | `string` | no | Controls whether a template-created pod is deleted on tunnel teardown. "delete" (default) is right for the common create-on-demand case; "keep" disables deletion. |
 | `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
 | `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
-| `via` | `string` | no | Chains kubectl access through another tunnel. |
-| `credential` | `string` | no | References an optional credential block for Kubernetes access. |
+| `via` | `ref(tunnel)` | no | Chains kubectl access through another tunnel. |
+| `credential` | `ref(credential)` | no | References an optional credential block for Kubernetes access. |
 
 ```hcl
 tunnel "kubernetes_port_forward" "example" {
@@ -391,8 +391,8 @@ Configures the tunnel runtime.
 | `env` | `map[string]string` | no | Adds environment variables to the spawned command. |
 | `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
 | `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
-| `via` | `string` | no | Chains this tunnel through another tunnel. |
-| `credential` | `string` | no | References an optional credential block for the tunnel runtime. |
+| `via` | `ref(tunnel)` | no | Chains this tunnel through another tunnel. |
+| `credential` | `ref(credential)` | no | References an optional credential block for the tunnel runtime. |
 
 ```hcl
 tunnel "local_command" "example" {
@@ -411,11 +411,12 @@ Configures the tunnel runtime.
 | `user` | `string` | yes | The SSH username for the bastion login. |
 | `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
 | `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
-| `via` | `string` | no | Chains the SSH connection through another tunnel. |
-| `credential` | `string` | yes | References an ssh credential block used for bastion authentication. |
+| `via` | `ref(tunnel)` | no | Chains the SSH connection through another tunnel. |
+| `credential` | `ref(credential)` | yes | References an ssh credential block used for bastion authentication. |
 
 ```hcl
 tunnel "ssh_port_forward" "example" {
+  bastion = "bastion.example:22"
   user = "example"
   credential = example-credential
 }
@@ -434,8 +435,8 @@ Configures the tunnel runtime.
 | `tags` | `[]string` | no | Tailscale tags requested for the tsnet node. |
 | `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
 | `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
-| `via` | `string` | no | Chains this tunnel through another tunnel. |
-| `credential` | `string` | no | References an optional credential block for the tunnel runtime. |
+| `via` | `ref(tunnel)` | no | Chains this tunnel through another tunnel. |
+| `credential` | `ref(credential)` | no | References an optional credential block for the tunnel runtime. |
 
 ```hcl
 tunnel "tailscale" "example" {}

--- a/site/doc/gateway.md
+++ b/site/doc/gateway.md
@@ -1,97 +1,121 @@
 # Gateway
 
-Reverse proxy for clients that can't use WireGuard or CONNECT
-(e.g. Cloudflare Workers, serverless functions, mobile apps).
+The Claw Patrol gateway is the policy and data-plane process. It owns the
+trusted credentials, accepts enrolled devices, routes traffic from those
+devices, applies endpoint/rule policy, injects credentials, and serves the
+operator dashboard.
 
-```
-POST https://gateway.example.com/gw/api.openai.com/v1/chat/completions
-X-Claw Patrol-Token: <client-token>
-Content-Type: application/json
+## Responsibilities
 
-{"model": "gpt-4", ...}
-```
+A running gateway:
 
-The worker doesn't need API keys. Claw Patrol holds them server-side
-via endpoint configs and injects them into the forwarded request.
+- loads `gateway.hcl` and compiles profiles, credentials, endpoints, tunnels,
+  approvers, and rules;
+- serves the dashboard and JSON API on `info_listen` when configured;
+- handles device onboarding through `/api/onboard/*` routes;
+- accepts WireGuard-routed or Tailscale-routed client traffic;
+- dispatches connections to configured endpoint plugins;
+- evaluates rules and human/LLM approval chains;
+- injects secrets from credential storage or environment fallbacks;
+- records request/action/session activity for the dashboard and telemetry.
 
+## Starting a gateway
 
-## URL format
+Operators usually bootstrap a data directory first:
 
-```
-https://gateway.example.com/gw/{upstream-host}/{path}
-```
-
-Examples:
-```
-/gw/api.openai.com/v1/chat/completions
-/gw/api.anthropic.com/v1/messages
-/gw/api.github.com/repos/org/repo/issues
-```
-
-
-## Authentication
-
-Clients authenticate with `X-Claw Patrol-Token: <token>` header.
-The token is the same client token from `POST /api/register`.
-The client must be approved.
-
-`Authorization` passes through to upstream untouched -- it's
-not consumed by clawpatrol. This means secrets can inject API keys
-into the Authorization header via endpoint configs.
-
-
-## How it works
-
-```
-CF Worker              gateway.example.com/gw         api.openai.com
-   |                         |                           |
-   |-- POST /gw/api.openai.com/v1/chat/completions ---->|
-   |   X-Claw Patrol-Token: abc                               |
-   |   Authorization: Bearer PLACEHOLDER_OPENAI          |
-   |                         |                           |
-   |                   1. Auth client                    |
-   |                   2. Strip X-Claw Patrol-Token           |
-   |                   3. Inject secrets                 |
-   |                      (replace PLACEHOLDER_OPENAI    |
-   |                       with real sk-...)             |
-   |                   4. Forward to upstream ---------->|
-   |                   5. Log to analytics store         |
-   |                         |<-- 200 response ---------|
-   |<-- 200 response -------|                           |
+```bash
+clawpatrol gateway init --data-dir /var/lib/clawpatrol
 ```
 
+Then run the daemon with the generated config:
 
-## Secret injection
+```bash
+clawpatrol gateway -config /var/lib/clawpatrol/gateway.hcl
+```
 
-Same endpoint configs as the CONNECT proxy. Secrets defined in
-`/opt/clawpatrol/data/endpoints/*.ts` apply to gateway requests
-targeting the same hosts.
+Useful flags:
 
-If no endpoint config exists for the target host, the request
-forwards as-is (no secret injection, still logged).
+- `-config FILE` — gateway HCL file to load.
+- `--read-only-config` — let the dashboard preview config changes but reject
+  writes back to disk.
 
+## Control plane and data plane
 
-## Differences from CONNECT proxy
+The gateway can expose different control-plane modes from `gateway.hcl`.
+Clients discover the selected mode during `clawpatrol join`.
 
-| | CONNECT proxy | Gateway |
-|---|---|---|
-| Client sends | raw TCP via CONNECT | HTTP to /gw/ |
-| TLS to upstream | server terminates | server initiates |
-| Auth | Proxy-Authorization | X-Claw Patrol-Token |
-| Streaming | yes (chunked) | buffered |
-| WebSocket | yes | no |
-| Client needs | WireGuard or CONNECT support | HTTP client |
+In WireGuard mode, the gateway runs an embedded userspace WireGuard server.
+Approved peers receive generated WireGuard configuration. Client traffic enters
+at the gateway and is dispatched by destination port and endpoint policy:
 
+- HTTPS traffic is MITM-terminated for endpoint matching and credential
+  injection.
+- PostgreSQL and other protocol-specific endpoints are dispatched to their
+  registered endpoint runtime.
+- DNS/VIP routes support endpoint families that require stable virtual IPs.
+- Non-matching traffic can pass through according to the active gateway
+  forwarding path and policy.
 
-## Deployment
+In Tailscale-oriented setups, the gateway can use tailnet identity and exit-node
+routing for enrolled clients while still keeping Claw Patrol policy and secret
+injection at the gateway.
 
-The gateway runs on the same API listener (port 8080, behind
-Caddy on 443). No additional ports or config needed.
+## Dashboard and API
 
-A reverse proxy in front of the gateway (e.g. Caddy, nginx)
-routes `/gw/*` to `localhost:8080` alongside the dashboard and
-API.
+When `info_listen` is set, the gateway serves dashboard/API routes from the
+same HTTP listener. Important route families include:
 
-Local-gateway install modes (launchd on macOS, systemd system/user/linger
-on Linux, ephemeral per-invocation) are documented in
-[Onboarding](/docs/onboarding/).
+| Route family | Purpose |
+| --- | --- |
+| `/info`, `/ca.crt` | Public discovery and CA download. |
+| `/api/onboard/*` | Device enrollment start, poll, approval, lookup, and claim. |
+| `/api/state`, `/api/status` | Dashboard state and device status. |
+| `/api/config/*` | Config read, preview, and save. |
+| `/api/rules*` | Rule listing and AI-assisted rule generation. |
+| `/api/hitl/*` | Human-in-the-loop pending requests and decisions. |
+| `/api/oauth/*`, `/api/credentials/*`, `/api/cred/*` | Credential OAuth, manual secret, and webhook flows. |
+| `/api/events`, `/api/actions/*`, `/api/analytics`, `/api/facets` | Live events, action details, analytics, and facets. |
+| `/api/env-pushdown` | Authenticated client environment pushdown. |
+| `/api/peer/ephemeral` | Authenticated ephemeral peer registration. |
+
+Dashboard routes are protected by the configured dashboard secret and/or
+operator identity, depending on the deployment mode. Self-authenticating client
+routes use per-peer API tokens issued during onboarding.
+
+## Request path
+
+A typical enrolled agent flow is:
+
+```text
+agent process
+  -> local per-process or whole-machine tunnel
+  -> gateway data plane
+  -> endpoint plugin selected from gateway.hcl
+  -> rule / approval chain
+  -> credential injection
+  -> upstream service
+```
+
+The agent does not need the real upstream credential locally. It can run with
+placeholder values from `clawpatrol env`; matching credential plugins replace
+those placeholders at the gateway before the request reaches the upstream.
+
+## Config as source of truth
+
+`gateway.hcl` is the source of truth for gateway behavior. The dashboard can
+help inspect, preview, and edit it, but the HCL config remains the canonical
+artifact for review and deployment.
+
+Key block kinds:
+
+- `profile` — maps enrolled devices/owners to allowed endpoint sets.
+- `credential` — describes secret shape and injection behavior.
+- `endpoint` — describes upstream service/protocol handling.
+- `tunnel` — optionally creates shared upstream tunnels such as SSH port
+  forwards, local commands, Kubernetes port-forwards, or Tailscale tsnet
+  clients.
+- `rule` — attaches policy to endpoint families.
+- `approver` — handles human or LLM approval stages.
+
+See the [HCL config reference](/docs/config-reference/) for every registered
+field and plugin type.

--- a/site/doc/onboarding.md
+++ b/site/doc/onboarding.md
@@ -1,160 +1,152 @@
 # Onboarding
 
-`clawpatrol onboard` is an interactive setup wizard that prepares your machine
-to run AI agents through Claw Patrol. It connects to an Claw Patrol gateway, discovers
-your existing API keys, imports them into the gateway, and configures your
-system so that `clawpatrol run` can transparently inject those secrets into
-agent traffic.
+Onboarding connects a machine to a Claw Patrol gateway, installs the gateway CA
+locally, and prepares either per-process or whole-machine traffic routing.
 
-## Onboard walkthrough
+For most client machines the flow is:
 
 ```bash
 curl -fsSL https://clawpatrol.dev/install.sh | sh
-clawpatrol onboard
+clawpatrol join https://gateway.example.com
 ```
 
-The wizard walks you through a series of prompts. On a typical run it will:
+An operator must approve the device from the gateway dashboard before the join
+finishes.
 
-1. **Select a gateway** — local or a remote (self-hosted)
-   instance.
-2. **Start the gateway** — on macOS this is a launchd background service; on
-   Linux you choose between a systemd unit or an ephemeral process.
-3. **Register this machine** as a device on the gateway.
-4. **Install the CA certificate** so the gateway can intercept HTTPS traffic.
-5. **Discover secrets** — scans environment variables and config files for
-   known API keys (Anthropic, OpenAI, Gemini, OpenRouter, GitHub, Slack,
-   Grafana, Telegram, Notion, and others). You pick which ones to import.
-6. **Replace local credentials with placeholders** — the originals are
-   backed up, and the files that held them now contain
-   `CLAWPATROL_PLACEHOLDER_*` tokens. This way the agent never sees your real
-   keys; they are injected by the gateway at request time.
+## What `join` does
 
-When the wizard finishes you'll have:
+`clawpatrol join <gateway-url>` runs a device-flow enrollment against the
+gateway:
 
-| Path | Contents |
-| --- | --- |
-| `~/.clawpatrol/device.json` | Device registration (server URL + device token) |
-| `~/.clawpatrol/ca.pem` | Gateway CA certificate |
-| `~/.clawpatrol/ca-bundle.pem` (macOS) | System roots + Claw Patrol CA, used by `SSL_CERT_FILE` |
-| `~/.clawpatrol/env.sh` (macOS) | Shell exports for the CA bundle |
-| `~/.clawpatrol/data/gateway.json` | Persisted bind address chosen during onboarding |
+1. Downloads the gateway CA into the local Claw Patrol config directory.
+2. Starts an onboard request with the gateway, including the local hostname and
+   optional profile suggestion.
+3. Prints or opens the approval URL for an operator.
+4. Polls until the operator approves the device.
+5. Writes local tunnel/client configuration.
+6. Installs the CA into system trust unless `--no-trust` is set.
+7. For Tailscale-backed gateways, completes the Tailscale-specific `login`
+   path and can set the gateway as an exit node.
 
-The dashboard is available at `http://localhost:8080`.
-
-### macOS note
-
-On first run macOS will prompt you to approve the Claw Patrol Network Extension
-in **System Settings → Privacy & Security**. The wizard waits for this
-approval before continuing.
-
-## Running agents
-
-Once onboarded, wrap any command with `clawpatrol run`:
+Common flags:
 
 ```bash
-clawpatrol run --name openclaw -- openclaw gateway
-clawpatrol run -- python agent.py
+clawpatrol join https://gateway.example.com \
+  --hostname ci-runner-42 \
+  --profile default
 ```
 
-The gateway intercepts the agent's HTTPS requests, matches them against your
-configured integrations (by hostname), injects the real API key, forwards
-the request upstream, and logs it. When the command exits, the session ends.
+- `--hostname NAME` — device name shown in the dashboard.
+- `--profile NAME` — suggested profile for this device.
+- `--whole-machine` — route all host traffic through the gateway with the
+  generated WireGuard config.
+- `--no-trust` — fetch the CA but do not install it into system trust.
+- `--ca-dir DIR` — choose where local CA/client state is written.
 
-Options:
+## Per-process routing
 
-- `--name NAME` — label for this session (defaults to the command name).
-- `--profile PROFILE` — select a specific integration profile instead of the
-  default one.
-- `--no-expose` — (Linux only) don't tunnel the wrapped command's TCP
-  listeners back to the host network. By default Claw Patrol auto-tunnels them.
-
-If you set up a local gateway but it is not running when you call
-`clawpatrol run`, Claw Patrol automatically spawns an ephemeral gateway for the
-lifetime of the command. No manual restart needed.
-
-## OpenClaw integration
-
-If OpenClaw is installed on your machine, `clawpatrol onboard` detects it and
-offers to wrap its daemon so that all OpenClaw agent traffic goes through
-the Claw Patrol gateway automatically.
-
-### Automatic setup
-
-During onboarding, the wizard looks for an existing OpenClaw daemon:
-
-- **macOS** — checks for a launchd agent at
-  `~/Library/LaunchAgents/ai.openclaw.gateway.plist`. If found, it rewrites
-  the plist's `ProgramArguments` to prepend `clawpatrol --name openclaw --` and
-  updates `NODE_EXTRA_CA_CERTS` to point to the Claw Patrol CA bundle. The
-  original plist is backed up with a `.bak` extension. The daemon is then
-  reloaded automatically.
-- **Linux** — checks for `openclaw*.service` user systemd units. If found,
-  it writes a systemd drop-in override at
-  `~/.config/systemd/user/<unit>.d/clawpatrol.conf` that prepends
-  `clawpatrol run --name openclaw --` to the unit's `ExecStart`. The unit is
-  reloaded and restarted automatically.
-
-In both cases the wizard confirms before making changes.
-
-### Manual setup
-
-If you installed OpenClaw after onboarding, or prefer to set it up
-yourself, run the OpenClaw daemon through `clawpatrol run` directly:
+The default join mode writes local config but does not route the whole host.
+Wrap an agent command with `clawpatrol run` when you want that command's
+traffic to go through the gateway:
 
 ```bash
-clawpatrol run --name openclaw -- openclaw gateway
+clawpatrol run claude
+clawpatrol run python agent.py
 ```
 
-For a persistent setup, modify the OpenClaw service definition to prepend
-`clawpatrol run --name openclaw --` to the existing command. For example, in a
-systemd unit:
+On Linux, `run` creates a network namespace, brings up WireGuard inside it, and
+executes the child command there. The rest of the machine keeps its normal
+network path. This is the recommended mode for agent sessions because it scopes
+routing to the process tree you explicitly launched.
 
-```ini
-ExecStart=/path/to/clawpatrol run --name openclaw -- /path/to/openclaw gateway
-```
+## Whole-machine routing
 
-## Linux gateway options
-
-On Linux, `clawpatrol onboard` asks how you want to run the gateway. The
-choices are:
-
-**Systemd user unit** — runs as your user, managed by `systemctl --user`.
-Optionally enable *linger* so the gateway starts at boot and survives
-logout. Best for single-user machines or personal dev setups.
-
-**Systemd system unit** — runs as a dedicated `clawpatrol` system user, managed
-by `systemctl` (requires sudo). Data lives in `/var/lib/clawpatrol/`. Best for
-shared machines or server deployments.
-
-**Ephemeral** — no persistent service. The gateway is spawned on demand by
-`clawpatrol onboard` or `clawpatrol run` and dies when the parent process exits.
-Good for quick experiments, but concurrent `clawpatrol run` invocations share a
-single gateway that stops when the first one exits. Use a systemd unit if
-you need concurrent sessions.
-
-You also choose a bind address (loopback, LAN IP, or custom). Loopback is
-the default and doesn't require authentication beyond the local dev token.
-A non-loopback bind requires browser-based OAuth sign-in.
-
-## Remote gateways
-
-Instead of running a local gateway you can point at a self-hosted
-Claw Patrol gateway URL. Remote onboarding skips local gateway setup
-entirely. You authenticate via an OAuth device-code flow (a
-browser window opens for sign-in), then the wizard registers your
-device and discovers secrets as usual.
-
-## Managing secrets
-
-After onboarding, open the dashboard at `http://localhost:8080` to add,
-remove, or edit integrations. You can also re-run `clawpatrol onboard` to
-re-discover secrets that were added since the initial setup.
-
-## Uninstalling
+Use whole-machine mode when the entire host should route through Claw Patrol:
 
 ```bash
-clawpatrol offboard
+clawpatrol join https://gateway.example.com --whole-machine
 ```
 
-This stops the gateway, removes the Network Extension (macOS) or systemd
-service (Linux), and optionally deletes all data in `~/.clawpatrol/`.
+This brings up the generated WireGuard configuration with host-level routing.
+It is useful for dedicated workers, shared jump boxes, or environments where
+wrapping each process is impractical. Be careful when enabling it over SSH: the
+CLI includes safeguards, but changing the default route can interrupt remote
+sessions if the host network is unusual.
+
+## Tailscale-backed gateways
+
+Some gateways use Tailscale as the control plane. `clawpatrol join` detects
+that mode from the gateway response and delegates to the Tailscale setup path.
+You can also run that path directly when the gateway is already reachable on
+the tailnet:
+
+```bash
+clawpatrol login --name clawpatrol
+```
+
+Useful flags:
+
+- `--name NAME` — Tailscale exit-node hostname to locate.
+- `--no-exit-node` — skip automatically selecting the gateway as an exit node.
+- `--no-trust` — skip CA trust installation.
+
+## Gateway bootstrap for operators
+
+Gateway operators start by creating a gateway data directory:
+
+```bash
+clawpatrol gateway init --data-dir /var/lib/clawpatrol
+```
+
+Then edit the generated `gateway.hcl` and start the daemon:
+
+```bash
+clawpatrol gateway -config /var/lib/clawpatrol/gateway.hcl
+```
+
+The dashboard/API listener is controlled by the `info_listen` field in
+`gateway.hcl`. Public URL, control plane, WireGuard, Tailscale, policy,
+credential, endpoint, tunnel, and rule settings are documented in the
+[HCL config reference](/docs/config-reference/).
+
+## Approving devices
+
+When a user runs `clawpatrol join`, the gateway creates a pending onboard
+request. Operators approve it from the dashboard. The approver can assign or
+change the device profile before approval. Profiles select the endpoints a
+device may reach; rules attached to those endpoints still enforce policy at
+request time.
+
+## Agent environment
+
+After joining, shells can evaluate the generated environment helper:
+
+```bash
+eval "$(clawpatrol env)"
+```
+
+The helper points common clients at the Claw Patrol CA and placeholder-based
+credential values. Set `CLAWPATROL_NO_ENV=1` to disable this env pushdown for a
+shell.
+
+Secrets themselves live on the gateway side in credential blocks, OAuth-backed
+credential storage, or `CLAWPATROL_SECRET_<NAME>` environment fallbacks. The
+agent sees placeholders; the gateway injects real credentials when a matching
+endpoint handles the request.
+
+## Checking and removing setup
+
+Use `status` to diagnose local setup:
+
+```bash
+clawpatrol status
+```
+
+Remove local client setup with:
+
+```bash
+clawpatrol uninstall
+```
+
+Pass `--keep-ca` if you need to preserve local Claw Patrol state and trust
+entries while removing other setup pieces.

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -1,631 +1,178 @@
 # Plugin System
 
-## Overview
+Claw Patrol's gateway policy is built from typed Go plugins registered at
+startup. Plugins provide the schema and runtime behavior behind HCL blocks such
+as `credential`, `endpoint`, `tunnel`, `rule`, and `approver`.
 
-Claw Patrol's functionality is extended through plugins. A plugin module is a
-TypeScript file that registers one or more typed plugins via a registration
-API.
+The source of truth for public configuration is `gateway.hcl`; see the
+[HCL config reference](/docs/config-reference/) for generated field tables and
+examples from the live plugin registry.
 
-There are two plugin types:
+## Plugin kinds
 
-- **Integration plugins** -- intercept traffic for specific hostnames and
-  inject credentials. Each integration has its own config schema, dashboard
-  form layout, and endpoint handlers.
-- **Credential plugins** -- manage dynamic credentials (OAuth tokens,
-  device-code tokens) with login flows and automatic refresh.
+| Kind | HCL syntax | Purpose |
+| --- | --- | --- |
+| Approver | `approver "<type>" "<name>" { ... }` | Decide or notify during approval chains. |
+| Credential | `credential "<type>" "<name>" { ... }` | Define how secrets are loaded and injected. |
+| Endpoint | `endpoint "<type>" "<name>" { ... }` | Handle an upstream service or protocol. |
+| Tunnel | `tunnel "<type>" "<name>" { ... }` | Open or share an upstream tunnel used by endpoints. |
+| Rule | `rule "<type>" "<name>" { ... }` | Attach policy to endpoint families. |
 
-Source of truth: `src/plugins/types.ts`, `src/plugins/registry.ts`.
+Each block's first label selects the registered plugin type; the second label is
+the local name referenced by other blocks.
 
----
+## Runtime flow
 
-## Plugin Module Format
+A request entering the gateway is matched against the compiled policy:
 
-A plugin module's default export is either:
+1. The connection or hostname selects an `endpoint`.
+2. Endpoint-family `rule` blocks evaluate request details.
+3. If the rule requires review, one or more `approver` stages run.
+4. The endpoint asks its `credential` for the secret shape it needs.
+5. If the endpoint references a `tunnel`, the tunnel manager opens or reuses the
+   configured tunnel before dialing upstream.
+6. The endpoint runtime injects credentials and forwards the request.
 
-### Object form (recommended)
+Plugins are typed Go structs. Their HCL tags define accepted fields, and their
+runtime interfaces define behavior for HTTP, WebSocket payload rewriting,
+PostgreSQL, SSH, ClickHouse, Kubernetes, tunnels, and approval flows.
 
-```typescript
-import { definePlugin } from "clawpatrol/plugins/types.ts";
+## Registered plugin inventory
 
-export default definePlugin({
-  id: "my-plugin",       // optional; used in log prefixes
-  name: "My Plugin",     // optional
-  version: "1.0.0",      // optional; informational
-  register(api) {
-    api.registerCredential({ ... });
-    api.registerIntegration({ ... });
-  },
-});
+Current built-in plugin types include:
+
+### Approvers
+
+- `human_approver`
+- `llm_approver`
+
+### Credentials
+
+- `anthropic_manual_key`
+- `anthropic_oauth_subscription`
+- `aws_eks_credential`
+- `bearer_token`
+- `clickhouse_credential`
+- `cookie_token`
+- `discord_bot_token`
+- `gemini_api_key`
+- `github_oauth`
+- `header_token`
+- `mtls_credential`
+- `notion_oauth`
+- `openai_codex_oauth`
+- `postgres_credential`
+- `slack_tokens`
+- `ssh`
+- `telegram_bot_token`
+
+### Endpoints
+
+- `clickhouse_https`
+- `clickhouse_native`
+- `https`
+- `kubernetes`
+- `openai_codex_https`
+- `postgres`
+- `ssh`
+
+### Tunnels
+
+- `kubernetes_port_forward`
+- `local_command`
+- `ssh_port_forward`
+- `tailscale`
+
+The generated [HCL config reference](/docs/config-reference/) lists exact fields
+for each type.
+
+## Credentials and secret sources
+
+Credential plugins describe how an endpoint obtains real secret material. At
+runtime, secrets can come from OAuth-backed gateway storage, manual dashboard
+entries, or environment fallbacks.
+
+Environment fallback names are derived from the credential block name:
+
+```bash
+CLAWPATROL_SECRET_<NAME>
 ```
 
-### Function form
+Hyphens in `<NAME>` become underscores and the name is uppercased. For mTLS
+credentials, Claw Patrol also recognizes:
 
-```typescript
-export default (api: Claw PatrolPluginApi) => {
-  api.registerIntegration({ ... });
-};
+```bash
+CLAWPATROL_SECRET_<NAME>_CERT
+CLAWPATROL_SECRET_<NAME>_KEY
+CLAWPATROL_SECRET_<NAME>_CA
 ```
 
-### Type definitions
+These values may be inline material or `@/path/to/file` references, depending
+on the credential type.
 
-```typescript
-type Claw PatrolPluginModule =
-  | Claw PatrolPluginDefinition
-  | ((api: Claw PatrolPluginApi) => void | Promise<void>);
+## Endpoints
 
-interface Claw PatrolPluginDefinition {
-  id?: string;
-  name?: string;
-  version?: string;
-  register?: (api: Claw PatrolPluginApi) => void | Promise<void>;
-}
+Endpoint plugins own protocol-specific routing and injection. Examples:
+
+- `https` handles generic HTTPS targets and header/cookie-style credentials.
+- `openai_codex_https` handles OpenAI Codex/ChatGPT traffic and OAuth-derived
+  credentials.
+- `postgres`, `clickhouse_native`, and `clickhouse_https` handle database
+  protocols and SQL-aware request facets.
+- `ssh` handles SSH sessions, exec, port forwarding, and SFTP through a stable
+  virtual-IP path.
+- `kubernetes` handles Kubernetes API access with configured credentials.
+
+Endpoints can expose facets for rule matching and dashboard analytics. Rules
+attach to endpoint families rather than to arbitrary traffic.
+
+## Tunnels
+
+Tunnel plugins create reusable upstream paths for endpoints. An endpoint can
+reference a tunnel with `tunnel = <name>` in HCL.
+
+Built-in tunnel types cover common private-network access patterns:
+
+- `local_command` — start a local helper command that exposes a listener.
+- `ssh_port_forward` — dial through an SSH bastion.
+- `kubernetes_port_forward` — run `kubectl port-forward` to a pod, service, or
+  generated helper pod.
+- `tailscale` — dial upstream through an embedded tsnet client.
+
+Tunnels can be shared according to their `share` mode, kept alive with
+`keepalive`, and chained through another tunnel via `via` when supported.
+
+## Approvers and rules
+
+Approvers implement approval stages used by rules. The built-in human approver
+routes decisions through configured human-in-the-loop targets, while the LLM
+approver asks a model to judge whether a request should be allowed according to
+policy text.
+
+Rules are endpoint-family specific. They extract facts from requests — HTTP
+metadata, SQL operations, SSH activity, Kubernetes operations, and similar
+facets — and return allow/deny/review decisions.
+
+## Developing built-ins
+
+Built-in plugins live under `config/plugins/`. A plugin registers itself with
+`config.Register` from an `init` path imported by `config/plugins/all`.
+
+Relevant source areas:
+
+| Path | Purpose |
+| --- | --- |
+| `config/framework.go` | Shared HCL/framework field handling. |
+| `config/runtime/` | Runtime interfaces used by endpoint, credential, tunnel, and approver plugins. |
+| `config/plugins/credentials/` | Built-in credential plugin schemas/runtimes. |
+| `config/plugins/endpoints/` | Built-in endpoint plugin schemas/runtimes. |
+| `config/plugins/tunnels/` | Built-in tunnel plugin schemas/runtimes. |
+| `config/plugins/approvers/` | Built-in approvers. |
+| `tools/docgen/` | Generates `site/doc/config-reference.md` from the live registry. |
+
+After changing plugin schemas, regenerate and verify the public reference:
+
+```bash
+go generate ./config/plugins/all
+go test ./tools/docgen ./tools/docgen/internal/render
 ```
-
-`definePlugin()` is an identity function that provides type inference. It has
-no runtime effect.
-
-A single module can register multiple plugins of different types by calling
-multiple `api.register*()` methods. For example, the OpenAI plugin registers
-both a credential plugin and an integration plugin.
-
----
-
-## Plugin Registration API (`Claw PatrolPluginApi`)
-
-The `register` function receives an API object with these methods:
-
-```typescript
-interface Claw PatrolPluginApi {
-  /** Register an integration plugin. */
-  registerIntegration<C>(plugin: IntegrationPlugin<C>): void;
-
-  /** Register a credential plugin. */
-  registerCredential(plugin: CredentialPlugin): void;
-
-  /**
-   * Return a Zod schema for a credential-backed config field.
-   * The credential plugin must be registered first.
-   */
-  credentialField(credentialPluginId: string): ZodType;
-
-  /** Scoped logger. Messages are prefixed with the module ID. */
-  log: {
-    info(msg: string): void;
-    warn(msg: string): void;
-    error(msg: string): void;
-  };
-}
-```
-
-### Registration rules
-
-- **Duplicate IDs are rejected.** If an integration or credential with the
-  same ID is already registered, the second registration is silently skipped
-  with a warning.
-- **Order matters for `credentialField()`.** The credential plugin must be
-  registered before any integration calls `api.credentialField("that-id")`.
-  Within a single module, register credentials first.
-- **Credential fields are auto-detected.** When an integration is registered,
-  the registry walks its `configSchema` looking for schemas returned by
-  `credentialField()`. Matches are merged into the integration's `credentials`
-  map automatically.
-
----
-
-## Integration Plugins
-
-```typescript
-interface IntegrationPlugin<C = any> {
-  id: string;
-  name: string;
-  description: string;
-  icon?: string;                     // SVG markup for the dashboard
-  configSchema: ZodType<C, any, any>;
-  configLayout?: LayoutItem[];
-  credentials?: Record<string, string>;  // field name -> credential plugin ID
-  endpoints: Endpoint<C>[];
-}
-```
-
-### Endpoints (layered hook model)
-
-Each endpoint declares which hostnames to intercept and can hook into the
-connection at one or more layers:
-
-```
-Client --[TCP]--> conn hook --[TLS terminate]--> tls hook --[HTTP parse]--> fetch hook
-                                                                              |
-                                                                        connect hook
-                                                                              |
-                                                                           Upstream
-```
-
-**Inbound (peel layers):**
-- `conn` -- raw TCP stream from the client
-- `tls` -- plaintext stream after TLS termination
-- `fetch` -- parsed HTTP request/response
-
-**Outbound:**
-- `connect` -- upstream connection factory (called by `fn.fetch()`)
-
-Each hook is optional. The framework provides defaults:
-- No `conn`: terminate TLS, call `tls` hook
-- No `tls`: parse HTTP, call `fetch` hook per request
-- No `fetch`: `fn.fetch(req)` (passthrough)
-- No `connect`: default TLS connection to upstream
-- No hooks at all: transparent TCP pipe to upstream
-
-```typescript
-interface Endpoint<C = Record<string, unknown>> {
-  /** Whether this endpoint is active. Default: true. */
-  enabled?: (config: C) => boolean;
-  /** Hostnames this endpoint handles. */
-  domains: string[] | ((config: C) => string[]);
-  /** Port (default: 443). */
-  port?: number | ((config: C) => number);
-
-  /** Layer 1: raw TCP stream from client. */
-  conn?: (config: C, fn: EndpointFn, stream: DuplexStream, info: ConnInfo)
-    => Promise<void>;
-  /** Layer 2: plaintext stream after TLS termination. */
-  tls?: (config: C, fn: EndpointFn, stream: DuplexStream, info: ConnInfo)
-    => Promise<void>;
-  /** Layer 3: HTTP request/response. */
-  fetch?: (config: C, fn: EndpointFn, req: Request, info: ConnInfo)
-    => Response | Promise<Response>;
-  /** Upstream connection factory. Called by fn.fetch(). */
-  connect?: (config: C, fn: EndpointFn, info: ConnInfo)
-    => Promise<DuplexStream>;
-}
-```
-
-All hooks receive `config` first, `fn` second, then layer-specific inputs,
-then `info` last.
-
-### The `fn` object
-
-Provides methods for forwarding traffic and connecting upstream:
-
-```typescript
-interface EndpointFn {
-  /** Forward an HTTP request upstream. Uses the connect hook if present. */
-  fetch(req: Request): Promise<Response>;
-
-  /** Open a raw TCP connection. */
-  connectTcp(addr: { hostname: string; port: number }): Promise<DuplexStream>;
-
-  /** Open a TLS connection to an upstream server. */
-  connectTls(opts: TlsConnectOptions): Promise<DuplexStream>;
-}
-
-interface TlsConnectOptions {
-  hostname: string;
-  port?: number;
-  caCerts?: string[];  // custom CA certificates (PEM)
-  cert?: string;       // client certificate (PEM)
-  key?: string;        // client private key (PEM)
-}
-```
-
-When a `connect` hook is present, `fn.fetch()` uses it for upstream
-connections. When the `connect` hook returns TLS options (via
-`fn.connectTls()`), the framework extracts those options and applies them to
-the HTTP client directly.
-
-### Supporting types
-
-```typescript
-interface DuplexStream {
-  readable: ReadableStream<Uint8Array>;
-  writable: WritableStream<Uint8Array>;
-}
-
-interface ConnInfo {
-  hostname: string;    // target hostname (from SNI or CONNECT)
-  port: number;        // target port
-  remoteAddr: string;  // client IP address
-}
-```
-
-### DNS entries (automatic)
-
-Endpoints with `port !== 443` automatically get DNS entries registered. The
-framework scans endpoint `domains` and `port` to build the DNS entry table.
-WireGuard clients querying DNS for matching hostnames receive a virtual IP
-from `10.78.0.0/16`. Connections to those VIPs are routed to the proxy via
-iptables DNAT. See [Architecture](/docs/architecture/) for details.
-
-### Config schema
-
-Each integration declares a Zod schema that defines the config shape. This
-schema is used for validation, form generation, and defaults:
-
-```typescript
-const configSchema = z.object({
-  domains: z.array(z.string())
-    .default(["api.github.com"])
-    .describe("GitHub API hostnames to intercept"),
-  placeholder: z.string()
-    .default("CLAWPATROL_PLACEHOLDER_github")
-    .describe("Placeholder string agents use in Authorization header"),
-  token: z.string()
-    .describe("GitHub PAT (classic or fine-grained)"),
-});
-```
-
-### Config layout (`LayoutItem[]`)
-
-Controls how the config form is rendered in the dashboard. Without a layout,
-fields render in schema order with default widgets.
-
-```typescript
-type LayoutItem = string | LayoutObject;
-
-interface LayoutObject {
-  key?: string;                // config field path
-  type?: "fieldset";           // container type
-  title?: string;              // section title
-  expandable?: boolean;        // collapsible section
-  expanded?: boolean;          // initial state (default: false)
-  sensitive?: boolean;         // masked input
-  multiline?: boolean;         // textarea
-  items?: LayoutItem[];        // children (for fieldsets)
-  condition?: {                // conditional visibility
-    functionBody: string;      // JS receiving `model`, return true to show
-  };
-  description?: string;        // override schema description
-  placeholder?: string;        // input placeholder text
-}
-```
-
----
-
-## Credential Plugins
-
-A credential plugin manages dynamic credentials with login flows and
-optional automatic refresh.
-
-```typescript
-interface CredentialPlugin {
-  id: string;
-  label: string;
-  schema: ZodType;           // Zod schema for the credential data shape
-  flow?: AuthorizationCodeFlow | DeviceCodeFlow;
-  refresh?: (params: {
-    credential: Record<string, unknown>;
-    config: Record<string, unknown>;
-  }) => Promise<Record<string, unknown>>;
-  refreshMarginSeconds?: number;  // default: 300
-}
-```
-
-Two flow types are supported:
-
-### Authorization code flow (OAuth 2.0)
-
-Standard redirect-based OAuth. The dashboard shows a "Connect" button.
-
-```typescript
-interface AuthorizationCodeFlow {
-  type: "authorization-code";
-  authorizeUrl(params: {
-    config: Record<string, unknown>;
-    callbackUrl: string;
-    state: string;
-  }): string | Promise<string>;
-  exchangeCode(params: {
-    code: string;
-    config: Record<string, unknown>;
-    callbackUrl: string;
-  }): Promise<Record<string, unknown>>;
-}
-```
-
-### Device code flow (RFC 8628)
-
-For headless/device authentication. The dashboard shows a user code and
-verification URL, then polls until the user completes authentication.
-
-```typescript
-interface DeviceCodeFlow {
-  type: "device-code";
-  start(): Promise<{
-    deviceAuthId: string;
-    userCode: string;
-    verificationUrl: string;
-    interval: number;
-  }>;
-  poll(params: {
-    deviceAuthId: string;
-    userCode: string;
-  }): Promise<
-    | { status: "pending" }
-    | { status: "ok"; credential: Record<string, unknown> }
-  >;
-}
-```
-
-### Linking credentials to integrations
-
-Use `api.credentialField()` in the integration's config schema. The framework
-auto-detects credential fields, stores credentials separately from config, and
-merges credential data into config before calling endpoint handlers.
-
-```typescript
-register(api) {
-  // 1. Register credential plugin first
-  api.registerCredential({
-    id: "my-oauth",
-    label: "My Service OAuth",
-    schema: z.object({
-      access_token: z.string(),
-      refresh_token: z.string(),
-      expires_at: z.number(),
-    }),
-    flow: { type: "authorization-code", ... },
-    refresh: async ({ credential }) => { ... },
-  });
-
-  // 2. Use credentialField() in the integration schema
-  const configSchema = z.object({
-    domains: z.array(z.string()).default(["api.example.com"]),
-    auth: api.credentialField("my-oauth"),
-  });
-
-  // 3. Register the integration
-  api.registerIntegration({
-    id: "my-service",
-    configSchema,
-    endpoints: [{
-      domains: (config) => config.domains,
-      fetch: (config, fn, req) => {
-        // config.auth contains the credential data (merged by framework)
-        const token = config.auth?.access_token;
-        // ...
-      },
-    }],
-  });
-}
-```
-
-Static credentials (API keys) don't need credential plugins -- they remain
-as regular config fields.
-
----
-
-## Examples
-
-### Simple header injection (GitHub)
-
-```typescript
-endpoints: [{
-  domains: (config) => config.domains,
-  fetch: (config, fn, req) => {
-    const headers = new Headers(req.headers);
-    replacePlaceholder(headers, "authorization",
-      config.placeholder, config.token);
-    return fn.fetch(new Request(req, { headers }));
-  },
-}]
-```
-
-### TCP passthrough (GitHub SSH)
-
-An endpoint with no hooks -- the framework pipes TCP bidirectionally.
-
-```typescript
-endpoints: [
-  {
-    // HTTP interception
-    domains: (config) => config.domains,
-    fetch: (config, fn, req) => { ... },
-  },
-  {
-    // SSH passthrough -- port 22, no hooks needed
-    domains: ["github.com"],
-    port: 22,
-  },
-]
-```
-
-### mTLS upstream (Kubernetes)
-
-```typescript
-endpoints: [{
-  enabled: (config) => !!config.server,
-  domains: (config) => [config.server.trim()],
-  connect: (config, fn, info) =>
-    fn.connectTls({
-      hostname: info.hostname,
-      port: info.port,
-      caCerts: [config.ca_cert],
-      cert: config.client_cert,
-      key: config.client_key,
-    }),
-}]
-```
-
-### Binary protocol over TLS (ClickHouse native)
-
-```typescript
-endpoints: [{
-  enabled: (config) => config.enable_native,
-  domains: (config) => config.native_hosts,
-  port: (config) => config.native_port,
-  tls: async (config, fn, stream, info) => {
-    const { data, reader } = await readFirst(stream);
-    const hello = parseHello(data);
-
-    // Inject credentials
-    hello.username = config.username;
-    hello.password = config.password;
-
-    // Connect upstream and pipe
-    const upstream = await fn.connectTls({
-      hostname: info.hostname,
-      port: info.port,
-    });
-    await writeAll(upstream, serializeHello(hello));
-    await pipeBidi(reader, stream.writable, upstream);
-  },
-}]
-```
-
-### mTLS + HTTP credential injection (ClickHouse HTTPS)
-
-```typescript
-endpoints: [{
-  enabled: (config) => config.enable_https,
-  domains: (config) => config.https_hosts,
-  fetch: (config, fn, req) => {
-    const url = new URL(req.url);
-    const path = url.pathname + url.search;
-    const newPath = path
-      .replaceAll(config.user_placeholder, encodeURIComponent(config.username))
-      .replaceAll(config.pass_placeholder, encodeURIComponent(config.password));
-    return fn.fetch(new Request(new URL(newPath, url.origin), req));
-  },
-  connect: (config, fn, info) =>
-    fn.connectTls({
-      hostname: info.hostname,
-      port: info.port,
-      caCerts: config.server_ca_cert ? [config.server_ca_cert] : undefined,
-      cert: config.client_cert || undefined,
-      key: config.client_key || undefined,
-    }),
-}]
-```
-
-### OAuth credential plugin (OpenAI device-code)
-
-```typescript
-register(api) {
-  api.registerCredential({
-    id: "openai-oauth",
-    label: "OpenAI Account",
-    schema: z.object({
-      access_token: z.string(),
-      refresh_token: z.string(),
-      expires_at: z.number(),
-      account_id: z.string().optional(),
-    }),
-    flow: {
-      type: "device-code",
-      start: async () => {
-        // Start device auth flow with provider
-        const res = await fetch("https://auth.openai.com/.../usercode", ...);
-        const data = await res.json();
-        return {
-          deviceAuthId: data.device_auth_id,
-          userCode: data.user_code,
-          verificationUrl: "https://auth.openai.com/codex/device",
-          interval: data.interval || 5,
-        };
-      },
-      poll: async ({ deviceAuthId, userCode }) => {
-        // Poll for completion
-        const res = await fetch("https://auth.openai.com/.../token", ...);
-        if (res.status === 202) return { status: "pending" };
-        // Exchange code for tokens...
-        return { status: "ok", credential: { ... } };
-      },
-    },
-    refresh: async ({ credential }) => {
-      // Use refresh_token to get a new access_token
-      // ...
-      return { access_token: newToken, ... };
-    },
-    refreshMarginSeconds: 60,
-  });
-
-  const configSchema = z.object({
-    domains: z.array(z.string()).default(["api.openai.com"]),
-    placeholder: z.string().default("CLAWPATROL_PLACEHOLDER_openai"),
-    auth: api.credentialField("openai-oauth"),
-  });
-
-  api.registerIntegration({
-    id: "openai",
-    configSchema,
-    configLayout: ["domains", "placeholder"],
-    endpoints: [{
-      domains: (config) => config.domains,
-      fetch: (config, fn, req) => {
-        if (!config.auth?.access_token) return fn.fetch(req);
-        const headers = new Headers(req.headers);
-        replacePlaceholder(headers, "authorization",
-          config.placeholder, config.auth.access_token);
-        return fn.fetch(new Request(req, { headers }));
-      },
-    }],
-  });
-}
-```
-
----
-
-## Loading and Installation
-
-Plugins are loaded from two sources at startup:
-
-1. **Built-in plugins** -- compiled into the server (12 currently):
-
-   | Plugin | Type | Auth mechanism |
-   |--------|------|----------------|
-   | `apikey` | Integration | Generic header injection |
-   | `anthropic` | Integration | `x-api-key` header |
-   | `clickhouse` | Integration | URL params + native protocol (`tls` hook) |
-   | `gemini` | Integration | Header injection |
-   | `github` | Integration | `Authorization` header + SSH passthrough (port 22) |
-   | `grafana` | Integration | `Authorization: Bearer` header |
-   | `kubernetes` | Integration | mTLS client certificates (`connect` hook) |
-   | `notion` | Credential + Integration | OAuth 2.0 authorization code |
-   | `openai` | Credential + Integration | OAuth 2.0 device code |
-   | `openrouter` | Integration | Header injection |
-   | `slack` | Integration | `Authorization` header |
-   | `telegram` | Integration | Header injection |
-
-2. **External plugins** -- `.ts` files in `data/plugins/`, loaded via
-   dynamic import after built-in plugins.
-
-Duplicate integration IDs are rejected with a warning.
-
-On `SIGHUP`, endpoint and DNS caches are invalidated so config changes take
-effect without a full restart.
-
----
-
-## Configuration
-
-Integration plugins are configured through the dashboard:
-
-1. An admin creates an **integration** -- an instance of an integration plugin
-   with filled-in config values (e.g. a specific GitHub PAT)
-2. Integrations are assigned to **profiles**
-3. Agents are assigned to profiles, inheriting all the profile's integrations
-
-Multiple instances of the same plugin can coexist (e.g. two different GitHub
-PATs for different accounts).
-
-Config is validated against the integration's Zod schema on creation and
-update. Sensitive fields are masked in API responses.
-
-Dynamic credentials (OAuth tokens, etc.) are stored in a separate
-`credentials` table, not in the integration config. The framework loads
-and merges credential data into config before calling endpoint handlers,
-and proactively refreshes credentials before expiry.
-
----
-
-## Key Source Files
-
-| File | Purpose |
-| ---- | ------- |
-| `src/plugins/types.ts` | All type definitions |
-| `src/plugins/registry.ts` | Module loading and registration |
-| `src/plugins/endpoint-fn.ts` | `EndpointFn` implementation |
-| `src/plugins/*/index.ts` | Built-in plugin implementations |
-| `src/endpoints.ts` | Hostname-to-handler resolution |
-| `src/credentials.ts` | Credential storage, caching, and refresh |
-| `src/dns.ts` | DNS entry collection and virtual IP listeners |
-| `src/proxy.ts` | Hook invocation (tls, fetch) and traffic forwarding |

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -64,6 +64,7 @@ Current built-in plugin types include:
 - `postgres_credential`
 - `slack_tokens`
 - `ssh`
+- `tailscale`
 - `telegram_bot_token`
 
 ### Endpoints

--- a/site/doc/token-usage.md
+++ b/site/doc/token-usage.md
@@ -1,89 +1,82 @@
-# LLM Token Usage & Cost Tracking
+# LLM Token Usage & Session Tracking
 
-## Overview
+Claw Patrol tracks LLM activity while proxying agent traffic. The current
+implementation focuses on live and persisted agent sessions: model names,
+request counts, input/output token totals, and context-window usage.
 
-Claw Patrol extracts token usage from LLM API responses at proxy
-time, estimates cost via OpenRouter pricing data, and attaches
-the result to each request log. This enables cost tracking,
-cache hit analysis, and model usage breakdowns without post-hoc
-log parsing.
+## What is tracked
 
-## How It Works
+Each detected LLM session records:
 
-1. Response bodies are already captured for logging
-2. `extractTokenUsage()` checks if the upstream host is a
-   known LLM provider and parses the usage JSON
-3. Cost is computed using cached pricing from OpenRouter
-4. Token counts + cost are written to the configured
-   analytics store alongside the request
+| Field | Meaning |
+| --- | --- |
+| `type` | Session family, currently `claude` or `codex` depending on the detected client/API shape. |
+| `id` | Stable session identifier derived from provider metadata, request IDs, or request content. |
+| `title` | Latest useful user prompt/tool/completion summary shown in the dashboard. |
+| `model` | Model name reported by the request or response. |
+| `tokens_in` | Accumulated input/prompt tokens. |
+| `tokens_out` | Accumulated output/completion/reasoning tokens. |
+| `ctx_used` | Tokens used by the most recent accounting update. |
+| `ctx_max` | Model context-window size when known. |
+| `reqs` | Session request count. |
+| `first_at`, `last_at` | Session activity timestamps. |
 
-Currently supported providers:
-- **OpenAI** (`*.openai.com`) — `usage.prompt_tokens`,
-  `completion_tokens`, `prompt_tokens_details.cached_tokens`
-- **Anthropic** (`*.anthropic.com`) — `usage.input_tokens`,
-  `output_tokens`, `cache_read_input_tokens`,
-  `cache_creation_input_tokens`
+The gateway stores these rows in the `sessions` table and reloads them on
+restart so the dashboard does not lose recent agent context.
 
-Extraction is zero-cost for non-LLM requests (hostname check
-short-circuits). Parse failures silently produce zeros.
+## Supported traffic shapes
 
-## Pricing via OpenRouter
+The gateway extracts usage from provider response/request shapes it already
+sees while proxying traffic:
 
-Pricing data is fetched from OpenRouter's public API:
-```
-GET https://openrouter.ai/api/v1/models
-```
+- Anthropic Messages API (`/v1/messages`) JSON and SSE responses.
+- OpenAI-compatible chat completions and Responses API JSON/SSE responses.
+- Codex/ChatGPT Responses API frames, including streamed WebSocket/SSE events
+  that report usage or tool activity.
 
-No authentication required. Returns model pricing as USD per
-token in fields: `pricing.prompt`, `pricing.completion`,
-`pricing.input_cache_read`, `pricing.input_cache_write`.
+For Anthropic, cache creation/read input tokens are counted as input tokens.
+For Codex/OpenAI Responses API, cached input and reasoning output tokens are
+included when the response shape reports them.
 
-The pricing cache refreshes every hour. If the fetch fails,
-the stale cache is used (or empty = $0 cost). Model lookup
-tries `{provider}/{model}` first (e.g. `openai/gpt-4o`),
-then the bare model name.
+Non-LLM requests simply do not update an LLM session.
 
-## Logged Fields
+## Context-window lookup
 
-The following fields are attached to each request log and
-persisted to the SQLite analytics store.
+Claw Patrol refreshes model context-window metadata from LiteLLM's public model
+metadata:
 
-| Field | Description |
-| ----- | ----------- |
-| `LlmProvider` | `openai`, `anthropic`, or `""` |
-| `LlmModel` | Model ID from the response |
-| `LlmInputTokens` | Prompt / input tokens |
-| `LlmOutputTokens` | Completion / output tokens |
-| `LlmCacheReadTokens` | Tokens read from cache |
-| `LlmCacheCreationTokens` | Tokens written to cache |
-| `LlmCostUsd` | Estimated cost in USD |
-
-See the `RequestRow` type in `src/analytics.ts` for the
-canonical definition.
-
-## Future: Plugin Response Hooks
-
-The current implementation uses hostname-based detection in
-`src/token_usage.ts`. A natural evolution is to add a
-response hook to the plugin system:
-
-```ts
-// IntegrationEndpoint (future)
-extractUsage?: (resp: Response, body: string) =>
-  TokenUsage | null;
+```text
+https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
 ```
 
-This would move OpenAI/Anthropic extraction into their
-plugins and support custom/self-hosted LLMs via third-party
-plugins. The `extractTokenUsage()` function serves as a
-reference implementation.
+The refresh runs at gateway startup and periodically afterward. Values from
+`max_input_tokens` populate `ctx_max` when the active model can be matched. If
+the lookup is missing or the refresh fails, token totals still work; the
+context maximum is just unknown.
 
-## Key Files
+## Persistence and retention
+
+Session updates are debounced before being written to SQLite. Streaming Codex
+traffic can produce many frames per second, so the in-memory state is treated as
+authoritative and database writes are coalesced to avoid write amplification.
+
+The gateway reloads session rows on boot and sweeps old rows according to
+`session_keep` in `gateway.hcl`. The default keep window is 30 days; set
+`session_keep = "0"` or `"off"` to disable sweeping.
+
+## What this is not
+
+The current public implementation does not compute per-request USD cost, and it
+does not attach cost fields to every request log. Cost reporting can be layered
+on top of the existing session/token accounting later, but today the source of
+truth is session token usage in the gateway/dashboard.
+
+## Key files
 
 | File | Purpose |
-| ---- | ------- |
-| `src/token_usage.ts` | Provider parsing + OpenRouter pricing |
-| `src/proxy.ts` | WireGuard proxy — calls extractTokenUsage |
-| `src/gateway.ts` | Gateway proxy — calls extractTokenUsage |
-| `src/analytics.ts` | `RequestRow` type and SQLite-backed query API |
-| `src/token_usage_test.ts` | Unit tests |
+| --- | --- |
+| `main.go` | Parses Anthropic/OpenAI/Codex request and response usage shapes. |
+| `agents.go` | Maintains in-memory agent/session state and persists session rows. |
+| `integrations.go` | Refreshes LiteLLM model context-window metadata. |
+| `web.go` | Serves dashboard state, analytics, events, and session-facing API data. |
+| `migrations/sqlite/` | SQLite schema for persisted gateway state. |

--- a/site/src/sections/IntegrationsSection.tsx
+++ b/site/src/sections/IntegrationsSection.tsx
@@ -26,9 +26,7 @@ export function IntegrationsSection() {
           {INTEGRATIONS.map(({ name, id }, i) => (
             <a
               key={id}
-              href={`https://github.com/denoland/clawpatrol/tree/main/src/plugins/${id}`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/docs/plugins/"
               class="integration-tile flex flex-col items-center aspect-square
                 justify-between py-4 px-2 squircle-md
                 transition-transform hover:scale-[1.03] focus-visible:scale-[1.03]
@@ -56,7 +54,7 @@ export function IntegrationsSection() {
         </p>
         <div class="text-center mt-12 sm:mt-16 mb-8">
           <Button href="/docs/plugins/" variant="normal" size="lg">
-            Write your own plugin in one TypeScript file{" "}
+            Explore the current Go/HCL plugin model{" "}
             <span class="ml-1" aria-hidden="true">
               &rarr;
             </span>

--- a/tools/docgen/internal/render/godoc.go
+++ b/tools/docgen/internal/render/godoc.go
@@ -37,6 +37,7 @@ func loadGoDocs() (*goDocs, error) {
 		filepath.Join(root, "config"),
 		filepath.Join(root, "config", "plugins", "approvers"),
 		filepath.Join(root, "config", "plugins", "credentials"),
+		filepath.Join(root, "config", "plugins", "tunnels"),
 		filepath.Join(root, "config", "plugins", "endpoints"),
 		filepath.Join(root, "config", "plugins", "rules"),
 	}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -47,6 +47,7 @@ func (r *renderer) run() (string, error) {
 	for _, kind := range []config.Kind{
 		config.KindApprover,
 		config.KindCredential,
+		config.KindTunnel,
 		config.KindEndpoint,
 		config.KindRule,
 	} {
@@ -60,7 +61,7 @@ func (r *renderer) writeHeader() {
 
 A clawpatrol gateway config mixes **operational** fields (top-level
 plumbing) with **policy** blocks. Operational fields are top-level
-attributes; policy blocks (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
+attributes; policy blocks (` + "`approver`, `credential`, `tunnel`, `endpoint`, `rule`" + `)
 dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
@@ -75,7 +76,7 @@ Each block section lists the attributes the loader accepts, with:
 - **Required** — ` + "`yes`" + ` if the loader rejects the block when the
   attribute is missing.
 
-Plugin-dispatched kinds (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
+Plugin-dispatched kinds (` + "`approver`, `credential`, `tunnel`, `endpoint`, `rule`" + `)
 list one subsection per registered type.
 
 `)

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -352,7 +352,7 @@ func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fi
 func (r *renderer) fieldRefs(pkgName, typeName string) map[string]string {
 	out := map[string]string{}
 	for _, kind := range []config.Kind{
-		config.KindApprover, config.KindCredential, config.KindEndpoint, config.KindRule,
+		config.KindApprover, config.KindCredential, config.KindTunnel, config.KindEndpoint, config.KindRule,
 	} {
 		for _, p := range config.AllPlugins(kind) {
 			rt := pluginStructType(p)
@@ -407,7 +407,7 @@ func (r *renderer) writeExample(kind, typ string, rt reflect.Type, typed bool) {
 		head = kind
 	}
 
-	body := exampleBody(rt)
+	body := exampleBody(kind, typ, rt)
 	if strings.TrimSpace(body) == "" {
 		fmt.Fprintf(&r.out, "```hcl\n%s {}\n```\n\n", head)
 		return
@@ -415,8 +415,13 @@ func (r *renderer) writeExample(kind, typ string, rt reflect.Type, typed bool) {
 	fmt.Fprintf(&r.out, "```hcl\n%s {\n%s}\n```\n\n", head, body)
 }
 
-func exampleBody(rt reflect.Type) string {
+func exampleBody(kind, typ string, rt reflect.Type) string {
 	var sb strings.Builder
+	if kind == "tunnel" && typ == "ssh_port_forward" {
+		// bastion is optional in HCL because it can be replaced by via, but a
+		// standalone generated example needs one or the runtime rejects it.
+		fmt.Fprintln(&sb, `  bastion = "bastion.example:22"`)
+	}
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
 		if !f.IsExported() {


### PR DESCRIPTION
## Summary
- refresh public docs for current CLI, onboarding, gateway, plugin, and LLM session/token tracking behavior
- generate tunnel block coverage in the HCL config reference
- add tunnel plugin Go comments and include tunnel sources in docgen so generated field descriptions are populated

## Test Plan
- `go generate ./config/plugins/all`
- `go test ./tools/docgen ./tools/docgen/internal/render ./config/plugins/tunnels`
- `npm --prefix site run build`
- `git diff --check`
