### PR TITLE
Rename HTTPS facet family identifier to "http"

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -873,7 +873,7 @@ func (w *webMux) apiProfiles(rw http.ResponseWriter, _ *http.Request) {
 // itself.
 type RuleSummary struct {
 	Name       string                `json:"name"`
-	Family     string                `json:"family"` // "https" | "sql" | "k8s"
+	Family     string                `json:"family"` // "http" | "sql" | "k8s"
 	Endpoint   string                `json:"endpoint"`
 	Profile    string                `json:"profile,omitempty"`
 	Priority   int                   `json:"priority,omitempty"`

--- a/config/compile.go
+++ b/config/compile.go
@@ -64,7 +64,7 @@ type CompiledProfile struct {
 // Family.
 type CompiledEndpoint struct {
 	Name        string
-	Family      string // "https" | "sql" | "k8s"
+	Family      string // "http" | "sql" | "k8s"
 	Plugin      *Plugin
 	Body        any
 	Hosts       []string
@@ -385,7 +385,7 @@ func hasResolvableHostname(hosts []string) bool {
 }
 
 func bareHostAlias(ep *CompiledEndpoint, host string) (string, bool) {
-	if ep == nil || (ep.Family != "https" && ep.Family != "k8s") {
+	if ep == nil || (ep.Family != "http" && ep.Family != "k8s") {
 		return "", false
 	}
 	bare, port, err := net.SplitHostPort(host)

--- a/config/compile_test.go
+++ b/config/compile_test.go
@@ -79,8 +79,8 @@ func TestCompile(t *testing.T) {
 			writes = r
 		}
 	}
-	getReq := &match.Request{Family: "https", Method: "GET"}
-	postReq := &match.Request{Family: "https", Method: "POST"}
+	getReq := &match.Request{Family: "http", Method: "GET"}
+	postReq := &match.Request{Family: "http", Method: "POST"}
 	if !reads.Matcher.Match(getReq) {
 		t.Errorf("github-reads should match GET")
 	}

--- a/config/facet/facet.go
+++ b/config/facet/facet.go
@@ -5,7 +5,7 @@
 // derived from the request snapshot, and which fields the family
 // contributes to the event/log reporting layer.
 //
-// Built-in facets (https, sql, k8s) live under config/plugins/facets/;
+// Built-in facets (http, sql, k8s) live under config/plugins/facets/;
 // each registers itself at init() via facet.Register. The rules
 // plugin (config/plugins/rules) and the request handler look facets up
 // by name through this registry rather than switching on family
@@ -27,9 +27,9 @@ import (
 // request handled by the gateway, so implementations must be
 // goroutine-safe (which is trivial when they hold no mutable state).
 type Runtime interface {
-	// Name returns the family identifier — "https", "sql", "k8s",
-	// and so on. Must match the Type used at registration and the
-	// `family` string carried on endpoints and rules.
+	// Name returns the family identifier — "http", "sql", "k8s",
+	// and so on. Must match the `family` string carried on endpoints
+	// and rules.
 	Name() string
 
 	// EndpointFamilies lists the endpoint families a rule of this

--- a/config/match/match.go
+++ b/config/match/match.go
@@ -19,7 +19,7 @@ import (
 // stashes any derived per-family metadata on Meta — its concrete type
 // is owned by the facet plugin, which type-asserts inside its matcher.
 type Request struct {
-	Family string // e.g. "https" | "sql" | "k8s" | future plugins
+	Family string // e.g. "http" | "sql" | "k8s" | future plugins
 
 	// Common
 	Credential string // bare-name reference of the credential the

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -65,7 +65,7 @@ type Plugin struct {
 
 	// Family classifies an endpoint's protocol so rule plugins can
 	// constrain which endpoints they target. Set on KindEndpoint
-	// plugins ("https" | "sql" | "k8s"). KindRule, with a single
+	// plugins ("http" | "sql" | "k8s"). KindRule, with a single
 	// unified plugin, leaves these empty — family is inferred from
 	// the rule's resolved endpoints at validate/build time.
 	Family   string

--- a/config/plugins/endpoints/https.go
+++ b/config/plugins/endpoints/https.go
@@ -66,7 +66,7 @@ func init() {
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "https",
-		Family:   "https",
+		Family:   "http",
 		New:      func() any { return &HTTPSEndpoint{} },
 		Refs:     singularRef,
 		Validate: multiCredValidate,

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -165,7 +165,7 @@ func init() {
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "openai_codex_https",
-		Family:   "https",
+		Family:   "http",
 		New:      func() any { return &OpenAICodexHTTPSEndpoint{} },
 		Refs:     singularRef,
 		Validate: multiCredValidate,

--- a/config/plugins/facets/https/https.go
+++ b/config/plugins/facets/https/https.go
@@ -26,9 +26,9 @@ import (
 
 // HttpsFields is the CEL-facing view of an HTTPS request. Exposed
 // as the `http` variable in rule conditions (`http.method`,
-// `http.path`, `http.body_json`, etc.). The variable name is short
-// (`http`, not `https`) to keep conditions readable; the facet name
-// is `https` because the wire is TLS.
+// `http.path`, `http.body_json`, etc.). The facet name matches the
+// CEL variable (`http`); the endpoint plugin keeps the HCL label
+// `https` since that names the wire (TLS).
 //
 // BodyJson is *structpb.Value rather than `any` because cel-go's
 // NativeTypes converter drops interface-typed struct fields silently;
@@ -49,13 +49,11 @@ type HttpsFields struct {
 type Facet struct{}
 
 // Name reports the family identifier this facet handles.
-func (Facet) Name() string { return "https" }
+func (Facet) Name() string { return "http" }
 
 // EndpointFamilies enumerates endpoint families a rule of this facet
-// may attach to. Kubernetes endpoints are also `https`-family because
-// the kubernetes API is HTTPS-shaped; they get their k8s-specific
-// matchers through the k8s facet, not through http rules.
-func (Facet) EndpointFamilies() []string { return []string{"https"} }
+// may attach to.
+func (Facet) EndpointFamilies() []string { return []string{"http"} }
 
 // Transport reports the gateway-side dispatch handler this facet uses.
 func (Facet) Transport() string { return "https-mitm" }

--- a/config/plugins/facets/https/https_test.go
+++ b/config/plugins/facets/https/https_test.go
@@ -17,7 +17,7 @@ import (
 func httpReq(method, path string) *match.Request {
 	u, _ := url.Parse("https://example.com" + path)
 	return &match.Request{
-		Family:  "https",
+		Family:  "http",
 		Method:  method,
 		URL:     u,
 		Headers: http.Header{},
@@ -82,7 +82,7 @@ func TestHTTPMatcherMethodAndPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := facet.NewMatcher("https", tc.condition)
+			m, err := facet.NewMatcher("http", tc.condition)
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
@@ -128,7 +128,7 @@ func TestHTTPMatcherMethodCaseInsensitive(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := facet.NewMatcher("https", tc.condition)
+			m, err := facet.NewMatcher("http", tc.condition)
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
@@ -140,7 +140,7 @@ func TestHTTPMatcherMethodCaseInsensitive(t *testing.T) {
 }
 
 func TestHTTPMatcherBodyJSON(t *testing.T) {
-	m, err := facet.NewMatcher("https", "http.method == 'PATCH' && http.body_json.archived == true")
+	m, err := facet.NewMatcher("http", "http.method == 'PATCH' && http.body_json.archived == true")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/plugins/rules/rules.go
+++ b/config/plugins/rules/rules.go
@@ -61,7 +61,7 @@ type RuleBody struct {
 // Policy.Rules[name].Body.
 type Rule struct {
 	Name       string                `json:"name"`
-	Family     string                `json:"family"` // "https" | "sql" | "k8s"
+	Family     string                `json:"family"` // "http" | "sql" | "k8s"
 	Endpoints  []string              `json:"endpoints"`
 	Priority   int                   `json:"priority,omitempty"`
 	Disabled   bool                  `json:"disabled,omitempty"`

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -196,7 +196,7 @@ func TestMatchRequest(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := &match.Request{Family: "https", Method: tc.method}
+			req := &match.Request{Family: "http", Method: tc.method}
 			r := runtime.MatchRequest(ep, req)
 			if r == nil {
 				if tc.want != "" {
@@ -216,7 +216,7 @@ func TestMatchRequest(t *testing.T) {
 func TestResolveCredentialSingular(t *testing.T) {
 	cp := compile(t)
 	ep := cp.Endpoints["github"]
-	got := runtime.ResolveCredential(ep, &match.Request{Family: "https", Headers: http.Header{}})
+	got := runtime.ResolveCredential(ep, &match.Request{Family: "http", Headers: http.Header{}})
 	if got == nil || got.Credential.Symbol.Name != "pat" {
 		t.Errorf("singular credential resolution wrong: %+v", got)
 	}
@@ -256,7 +256,7 @@ profile "default" { endpoints = [ep] }
 		if authz != "" {
 			h.Set("Authorization", authz)
 		}
-		return &match.Request{Family: "https", Headers: h}
+		return &match.Request{Family: "http", Headers: h}
 	}
 
 	got := runtime.ResolveCredential(ep, mkReq("Bearer PH_prod"))

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -362,7 +362,7 @@ type HITLPending struct {
 	// called. HITLEndpointLabel-derived: hostname for HTTPS, resource
 	// name for SQL / k8s where Host is a virtual IP.
 	Endpoint string `json:"endpoint,omitempty"`
-	// Family is the endpoint family ("https" | "sql" | "k8s") so the
+	// Family is the endpoint family ("http" | "sql" | "k8s") so the
 	// dashboard can pick a matching label for Path ("Query" /
 	// "Resource" / "Path"). Empty when no endpoint metadata is set.
 	Family     string    `json:"family,omitempty"`

--- a/config/symbols.go
+++ b/config/symbols.go
@@ -12,7 +12,7 @@ type Symbol struct {
 	Name   string
 	Kind   Kind
 	Type   string // "" for one-label kinds
-	Family string // for endpoints: "https"|"sql"|"k8s"; "" otherwise
+	Family string // for endpoints: "http"|"sql"|"k8s"; "" otherwise
 	Block  *hcl.Block
 }
 

--- a/config/testdata/error_family_mismatch.errors.txt
+++ b/config/testdata/error_family_mismatch.errors.txt
@@ -1,1 +1,1 @@
-error: error_family_mismatch.hcl:16:1: Rule "mixed-family" targets endpoints from mixed families — Endpoints span families [https sql]. A rule's CEL condition is evaluated against a single facet's variable set; split into one rule per family.
+error: error_family_mismatch.hcl:16:1: Rule "mixed-family" targets endpoints from mixed families — Endpoints span families [http sql]. A rule's CEL condition is evaluated against a single facet's variable set; split into one rule per family.

--- a/config/testdata/feature_example.want.json
+++ b/config/testdata/feature_example.want.json
@@ -40,7 +40,7 @@
           ],
           "Credential": "github-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       }
     },
@@ -55,7 +55,7 @@
       "github-reads": {
         "body": {
           "name": "github-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "github"
           ],
@@ -66,7 +66,7 @@
       "github-writes": {
         "body": {
           "name": "github-writes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "github"
           ],

--- a/config/testdata/feature_minimal.want.json
+++ b/config/testdata/feature_minimal.want.json
@@ -32,7 +32,7 @@
           ],
           "Credential": "github-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       }
     },
@@ -47,7 +47,7 @@
       "github-reads": {
         "body": {
           "name": "github-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "github"
           ],
@@ -58,7 +58,7 @@
       "github-writes": {
         "body": {
           "name": "github-writes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "github"
           ],

--- a/config/testdata/feature_tunnel.want.json
+++ b/config/testdata/feature_tunnel.want.json
@@ -30,7 +30,7 @@
           ],
           "Credential": "github-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       }
     },

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -302,7 +302,7 @@
           ],
           "Credential": "amem-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "anthropic-avocet": {
@@ -322,7 +322,7 @@
             }
           ]
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "ch-o11y-https": {
@@ -356,7 +356,7 @@
           ],
           "Credential": "checkly-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "deno-deploy": {
@@ -366,7 +366,7 @@
           ],
           "Credential": "deno-deploy-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "gemini-mira": {
@@ -376,7 +376,7 @@
           ],
           "Credential": "gemini-mira-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "github-avocet": {
@@ -387,7 +387,7 @@
           ],
           "Credential": "github-avocet-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "github-kaju": {
@@ -398,7 +398,7 @@
           ],
           "Credential": "github-kaju-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "github-mira": {
@@ -409,7 +409,7 @@
           ],
           "Credential": "github-mira-pat"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "grafana": {
@@ -419,7 +419,7 @@
           ],
           "Credential": "grafana-token"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "honeycomb": {
@@ -429,7 +429,7 @@
           ],
           "Credential": "honeycomb-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "k8s-dev-ams": {
@@ -474,7 +474,7 @@
           ],
           "Credential": "deno-support-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "notion": {
@@ -485,7 +485,7 @@
           ],
           "Credential": "notion-deno"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "openai-codex-divy": {
@@ -496,7 +496,7 @@
           ],
           "Credential": "openai-codex-divy-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "openai-codex-mira": {
@@ -507,7 +507,7 @@
           ],
           "Credential": "openai-codex-mira-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "orb": {
@@ -527,7 +527,7 @@
             }
           ]
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "pagerduty": {
@@ -537,7 +537,7 @@
           ],
           "Credential": "pagerduty-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "pg-deployng": {
@@ -578,7 +578,7 @@
           ],
           "Credential": "posthog-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "slack-avocet": {
@@ -590,7 +590,7 @@
           ],
           "Credential": "slack-avocet-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "slack-kaju": {
@@ -602,7 +602,7 @@
           ],
           "Credential": "slack-kaju-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "slack-mira": {
@@ -614,7 +614,7 @@
           ],
           "Credential": "slack-mira-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "smithery": {
@@ -624,7 +624,7 @@
           ],
           "Credential": "smithery-kaju"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "stripe": {
@@ -634,7 +634,7 @@
           ],
           "Credential": "stripe-live-key"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "telegram-divy": {
@@ -644,7 +644,7 @@
           ],
           "Credential": "telegram-divy-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       },
       "telegram-mira": {
@@ -654,7 +654,7 @@
           ],
           "Credential": "telegram-mira-cred"
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
       }
     },
@@ -756,7 +756,7 @@
       "deno-deploy-default": {
         "body": {
           "name": "deno-deploy-default",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "deno-deploy"
           ],
@@ -768,7 +768,7 @@
       "deno-deploy-reads": {
         "body": {
           "name": "deno-deploy-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "deno-deploy"
           ],
@@ -779,7 +779,7 @@
       "deno-deploy-reply-on-behalf": {
         "body": {
           "name": "deno-deploy-reply-on-behalf",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "deno-deploy"
           ],
@@ -797,7 +797,7 @@
       "deno-deploy-ticket-mutations": {
         "body": {
           "name": "deno-deploy-ticket-mutations",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "deno-deploy"
           ],
@@ -812,7 +812,7 @@
       "grafana-annotations-snapshots": {
         "body": {
           "name": "grafana-annotations-snapshots",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "grafana"
           ],
@@ -823,7 +823,7 @@
       "grafana-dashboard-writes": {
         "body": {
           "name": "grafana-dashboard-writes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "grafana"
           ],
@@ -838,7 +838,7 @@
       "grafana-no-destructive-deletes": {
         "body": {
           "name": "grafana-no-destructive-deletes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "grafana"
           ],
@@ -850,7 +850,7 @@
       "grafana-reads": {
         "body": {
           "name": "grafana-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "grafana"
           ],
@@ -1063,7 +1063,7 @@
       "notion-archive-route": {
         "body": {
           "name": "notion-archive-route",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "notion"
           ],
@@ -1079,7 +1079,7 @@
       "notion-create-update": {
         "body": {
           "name": "notion-create-update",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "notion"
           ],
@@ -1090,7 +1090,7 @@
       "notion-deletes": {
         "body": {
           "name": "notion-deletes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "notion"
           ],
@@ -1105,7 +1105,7 @@
       "notion-reads": {
         "body": {
           "name": "notion-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "notion"
           ],
@@ -1116,7 +1116,7 @@
       "notion-search": {
         "body": {
           "name": "notion-search",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "notion"
           ],
@@ -1127,7 +1127,7 @@
       "orb-prod-no-deletes": {
         "body": {
           "name": "orb-prod-no-deletes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "orb"
           ],
@@ -1140,7 +1140,7 @@
       "orb-prod-reads": {
         "body": {
           "name": "orb-prod-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "orb"
           ],
@@ -1152,7 +1152,7 @@
       "orb-prod-writes": {
         "body": {
           "name": "orb-prod-writes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "orb"
           ],
@@ -1168,7 +1168,7 @@
       "orb-test-allow-all": {
         "body": {
           "name": "orb-test-allow-all",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "orb"
           ],
@@ -1364,7 +1364,7 @@
       "slack-avocet-approve-reply-shape": {
         "body": {
           "name": "slack-avocet-approve-reply-shape",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "slack-avocet"
           ],
@@ -1379,7 +1379,7 @@
       "stripe-default": {
         "body": {
           "name": "stripe-default",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "stripe"
           ],
@@ -1390,7 +1390,7 @@
       "stripe-ephemeral-keys": {
         "body": {
           "name": "stripe-ephemeral-keys",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "stripe"
           ],
@@ -1402,7 +1402,7 @@
       "stripe-extra-scrutiny": {
         "body": {
           "name": "stripe-extra-scrutiny",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "stripe"
           ],
@@ -1418,7 +1418,7 @@
       "stripe-no-deletes": {
         "body": {
           "name": "stripe-no-deletes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "stripe"
           ],
@@ -1430,7 +1430,7 @@
       "stripe-other-writes": {
         "body": {
           "name": "stripe-other-writes",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "stripe"
           ],
@@ -1445,7 +1445,7 @@
       "stripe-reads": {
         "body": {
           "name": "stripe-reads",
-          "family": "https",
+          "family": "http",
           "endpoints": [
             "stripe"
           ],

--- a/main.go
+++ b/main.go
@@ -1175,7 +1175,7 @@ func (g *Gateway) handle(raw net.Conn, dstIP string) {
 
 // isHTTPSMITMFamily reports whether the facet registered for family
 // drives its wire through the HTTPS MITM handler. Replaces what used
-// to be a hardcoded `case "https", "k8s"` so new HTTPS-shaped
+// to be a hardcoded `case "http", "k8s"` so new HTTPS-shaped
 // protocol facets (e.g. a future "openai" or "anthropic" family that
 // wants per-family report fields beyond what http_rule offers) drop
 // in without touching the dispatch switch.

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -412,7 +412,7 @@ endpoint "clickhouse_native" "example" {
 
 Is part of the clawpatrol plugin API.
 
-Family: `https`.
+Family: `http`.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -448,7 +448,7 @@ endpoint "kubernetes" "example" {}
 
 Is part of the clawpatrol plugin API.
 
-Family: `https`.
+Family: `http`.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/web.go
+++ b/web.go
@@ -1693,7 +1693,7 @@ type Event struct {
 	Direction string `json:"direction,omitempty"`
 
 	// Family identifies which protocol-family facet emitted this
-	// event ("https", "sql", "k8s", or a future plugin's name).
+	// event ("http", "sql", "k8s", or a future plugin's name).
 	// Persisted as a dedicated column on actions so analytics can
 	// filter by family; drives dashboard column selection via
 	// /api/facets. Empty for splice events and pre-migration rows.


### PR DESCRIPTION
* The HTTPS facet exposes its CEL variable as `http` (so rule
  conditions read `http.method`, `http.path`, etc.) but was
  registered under family `https`. Rename the family to `http` so
  the facet name and CEL variable match.
* The endpoint plugin's HCL label stays `endpoint "https" "..."`
  since that names the wire (TLS); only the internal family
  classification changes.
* Endpoint `Family` fields, `Facet.Name()` /
  `EndpointFamilies()`, `match.Request.Family`, the dashboard
  `RuleSummary.Family` tag, and all comment / doc references move
  from `"https"` to `"http"`.
* Testdata goldens and the generated config reference are
  regenerated.