### PR TITLE
feat: clawpatrol test subcommand + per-action JSON fixtures

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,3 +21,35 @@ output per locale (`5/11/2026` in en-US, `11/05/2026` in en-GB,
 `11.5.2026` in de-DE), which makes log entries unreadable across a
 team. Number formatting (`Intl.NumberFormat`, `Number.toLocaleString`)
 is fine — the rule is about dates and times.
+
+## Formatting gates
+
+CI fails fast on unformatted code. Before pushing, run the same
+checks the lint job runs:
+
+- Go: `gofmt -l .` from the repo root. Empty output means clean;
+  any filename listed is a fail. Fix with `gofmt -w .`.
+- Dashboard (TS/JS/HTML/JSON in `www/`):
+  `cd www && npx oxfmt --check src index.html login.html package.json tsconfig.json vite.config.ts tailwind.config.js postcss.config.js`.
+  Fix by dropping `--check`.
+
+Either fail will block the `test` workflow before the actual tests
+run. Cheap to check locally; expensive in CI round-trips.
+
+## `testdata/`
+
+The self-test corpus for `clawpatrol test` (see `doc/test.md`).
+`example.hcl` is the policy under test; the `*.json` files are
+action fixtures. The intent is one fixture per CEL branch in
+`example.hcl` — every rule's `allow` and `deny` arm exercised at
+least once. Adding a rule means adding fixtures.
+
+Generating new fixtures: run the gateway against `example.hcl`,
+issue the request you want to capture, click "Download action"
+on the dashboard's request detail page, drop the file into
+`testdata/`. Don't hand-edit recorded JSON; if the format
+changes, regenerate.
+
+Scope: keep it minimal and synthetic — public hostnames, no real
+IPs, no production credentials. Real-world breadth lives in the
+`deno.clawpatrol.dev` repo, not here.

--- a/action_file.go
+++ b/action_file.go
@@ -1,0 +1,345 @@
+package main
+
+// Action-fixture format for `clawpatrol test`. Top-level shape:
+//
+//	{ "match": { ... }, "action": { ... } }
+//
+// `match` is the runner's assertion (verdict + rule + endpoint).
+// `action` is the recorded request: a host, optional credential /
+// peer_ip, and exactly one facet-keyed block (`http`, `k8s`, `sql`).
+// Each facet block carries ONLY that facet's CEL-visible fields —
+// the same vocabulary rules read in `condition = "<facet>.<field>"`.
+// Connection-level fields (host, credential, peer_ip) sit outside
+// the facet block on `action` itself. See doc/test.md.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	k8sfacet "github.com/denoland/clawpatrol/config/plugins/facets/k8s"
+	sqlfacet "github.com/denoland/clawpatrol/config/plugins/facets/sql"
+)
+
+// Fixture is the on-disk shape.
+type Fixture struct {
+	Match  Match  `json:"match"`
+	Action Action `json:"action"`
+}
+
+// Match is what the rule engine produced (or what the runner
+// should assert). Approve is terminal — see doc/test.md.
+type Match struct {
+	Verdict  string `json:"verdict"` // allow | deny | approve | passthrough
+	Rule     string `json:"rule,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// Action is the recorded request. Exactly one of HTTP / K8s / SQL
+// is set (validated by UnmarshalJSON).
+type Action struct {
+	Host       string      `json:"host,omitempty"`
+	Credential string      `json:"credential,omitempty"`
+	PeerIP     string      `json:"peer_ip,omitempty"`
+	HTTP       *HTTPAction `json:"http,omitempty"`
+	K8s        *K8sAction  `json:"k8s,omitempty"`
+	SQL        *SQLAction  `json:"sql,omitempty"`
+}
+
+// HTTPAction carries the `http.*` CEL view: method / path / query /
+// headers / body. body_b64 is the alternative byte-encoded form.
+type HTTPAction struct {
+	Method  string              `json:"method,omitempty"`
+	Path    string              `json:"path,omitempty"`
+	Query   map[string][]string `json:"query,omitempty"`
+	Headers map[string][]string `json:"headers,omitempty"`
+	Body    string              `json:"body,omitempty"`
+	BodyB64 string              `json:"body_b64,omitempty"`
+}
+
+// K8sAction carries the `k8s.*` CEL view.
+type K8sAction struct {
+	Verb      string            `json:"verb,omitempty"`
+	Resource  string            `json:"resource,omitempty"`
+	Namespace string            `json:"namespace,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Params    map[string]string `json:"params,omitempty"`
+}
+
+// SQLAction carries the `sql.*` CEL view. Only `statement` needs to
+// be set in practice; the loader derives verb / tables / function
+// via the endpoint's runtime.SQLParser. Explicit verb / tables /
+// function are accepted and take precedence over derivation.
+type SQLAction struct {
+	Statement string   `json:"statement,omitempty"`
+	Verb      string   `json:"verb,omitempty"`
+	Tables    []string `json:"tables,omitempty"`
+	Function  []string `json:"function,omitempty"`
+}
+
+var validVerdicts = map[string]bool{
+	"allow": true, "deny": true, "approve": true, "passthrough": true,
+}
+
+// UnmarshalJSON enforces: exactly one facet block under `action`,
+// body xor body_b64, valid match.verdict, no unknown keys anywhere.
+func (f *Fixture) UnmarshalJSON(data []byte) error {
+	type rawFixture struct {
+		Match  json.RawMessage `json:"match"`
+		Action json.RawMessage `json:"action"`
+	}
+	var raw rawFixture
+	if err := strictDecode(data, "fixture", &raw); err != nil {
+		return err
+	}
+	if len(raw.Match) == 0 {
+		return fmt.Errorf("fixture: match is required")
+	}
+	if err := strictDecode(raw.Match, "match", &f.Match); err != nil {
+		return err
+	}
+	if !validVerdicts[f.Match.Verdict] {
+		return fmt.Errorf("fixture: match.verdict %q must be one of allow|deny|approve|passthrough", f.Match.Verdict)
+	}
+	if len(raw.Action) == 0 {
+		return fmt.Errorf("fixture: action is required")
+	}
+	return f.Action.unmarshal(raw.Action)
+}
+
+func (a *Action) unmarshal(data []byte) error {
+	type rawAction struct {
+		Host       string          `json:"host"`
+		Credential string          `json:"credential"`
+		PeerIP     string          `json:"peer_ip"`
+		HTTP       json.RawMessage `json:"http,omitempty"`
+		K8s        json.RawMessage `json:"k8s,omitempty"`
+		SQL        json.RawMessage `json:"sql,omitempty"`
+	}
+	var raw rawAction
+	if err := strictDecode(data, "action", &raw); err != nil {
+		return err
+	}
+	a.Host = raw.Host
+	a.Credential = raw.Credential
+	a.PeerIP = raw.PeerIP
+	count := 0
+	if len(raw.HTTP) > 0 {
+		count++
+		if err := strictDecode(raw.HTTP, "http", &a.HTTP); err != nil {
+			return err
+		}
+		if a.HTTP.Body != "" && a.HTTP.BodyB64 != "" {
+			return fmt.Errorf("http: body and body_b64 are mutually exclusive")
+		}
+	}
+	if len(raw.K8s) > 0 {
+		count++
+		if err := strictDecode(raw.K8s, "k8s", &a.K8s); err != nil {
+			return err
+		}
+	}
+	if len(raw.SQL) > 0 {
+		count++
+		if err := strictDecode(raw.SQL, "sql", &a.SQL); err != nil {
+			return err
+		}
+		if a.SQL.Statement == "" {
+			return fmt.Errorf("sql: statement is required")
+		}
+	}
+	if count != 1 {
+		return fmt.Errorf("action: exactly one of http/k8s/sql is required, found %d", count)
+	}
+	return nil
+}
+
+func strictDecode(raw json.RawMessage, block string, out any) error {
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		return fmt.Errorf("%s: %w", block, err)
+	}
+	return nil
+}
+
+func decodedBody(body, b64 string) ([]byte, error) {
+	switch {
+	case body != "":
+		return []byte(body), nil
+	case b64 != "":
+		return base64.StdEncoding.DecodeString(b64)
+	}
+	return nil, nil
+}
+
+// encodeBody picks `body` when bytes are printable UTF-8, else
+// `body_b64`. Returns exactly one non-empty (or both empty when b
+// is empty).
+func encodeBody(b []byte) (body, b64 string) {
+	if len(b) == 0 {
+		return "", ""
+	}
+	if utf8.Valid(b) && !hasBinaryControlBytes(b) {
+		return string(b), ""
+	}
+	return "", base64.StdEncoding.EncodeToString(b)
+}
+
+func hasBinaryControlBytes(b []byte) bool {
+	for _, c := range b {
+		if c < 0x09 || (c > 0x0d && c < 0x20) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchFromCompiledRule produces the Match a fixture should carry
+// given a dispatch outcome. Approve-chain rules collapse to
+// `approve` (the human chain is never invoked under the runner).
+func MatchFromCompiledRule(cr *config.CompiledRule, ep *config.CompiledEndpoint) Match {
+	m := Match{}
+	if ep != nil {
+		m.Endpoint = ep.Name
+	}
+	if cr == nil {
+		m.Verdict = "allow"
+		return m
+	}
+	m.Rule = cr.Name
+	m.Reason = cr.Outcome.Reason
+	switch {
+	case len(cr.Outcome.Approve) > 0:
+		m.Verdict = "approve"
+	case cr.Outcome.Verdict == "deny":
+		m.Verdict = "deny"
+	case cr.Outcome.Verdict == "allow":
+		m.Verdict = "allow"
+	default:
+		panic(fmt.Sprintf("rule %q has unknown Outcome.Verdict %q", cr.Name, cr.Outcome.Verdict))
+	}
+	return m
+}
+
+// ResolveEndpoint picks the CompiledEndpoint to dispatch into.
+// match.endpoint wins when set; otherwise action.host is scanned
+// against policy.Endpoints for a unique match. Ambiguous hosts
+// error with the candidate list.
+func (f *Fixture) ResolveEndpoint(policy *config.CompiledPolicy) (*config.CompiledEndpoint, error) {
+	if f.Match.Endpoint != "" {
+		ep := policy.Endpoints[f.Match.Endpoint]
+		if ep == nil {
+			return nil, fmt.Errorf("endpoint %q not in compiled policy", f.Match.Endpoint)
+		}
+		return ep, nil
+	}
+	host := f.Action.Host
+	if host == "" {
+		return nil, fmt.Errorf("cannot resolve endpoint: no `action.host` and no `match.endpoint`")
+	}
+	var matches []*config.CompiledEndpoint
+	for _, ep := range policy.Endpoints {
+		if endpointClaimsHost(ep, host) {
+			matches = append(matches, ep)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no endpoint claims host %q", host)
+	case 1:
+		return matches[0], nil
+	}
+	names := make([]string, 0, len(matches))
+	for _, ep := range matches {
+		names = append(names, ep.Name)
+	}
+	return nil, fmt.Errorf("host %q is claimed by multiple endpoints %v; set `match.endpoint` to disambiguate", host, names)
+}
+
+// endpointClaimsHost matches `host` and `host:port` forms either
+// way (mirrors compile.go's HostIndex normalisation).
+func endpointClaimsHost(ep *config.CompiledEndpoint, host string) bool {
+	hostBare := stripPort(host)
+	for _, h := range ep.Hosts {
+		hBare := stripPort(h)
+		if h == host || h == hostBare || hBare == host || hBare == hostBare {
+			return true
+		}
+	}
+	return false
+}
+
+func stripPort(s string) string {
+	if !strings.Contains(s, ":") {
+		return s
+	}
+	if i := strings.LastIndex(s, ":"); i > 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// ToMatchRequest builds the match.Request the rule engine sees.
+// For SQL fixtures with only `statement` set, parseSQL is called
+// to derive verb / tables / function. Explicit fields on the
+// fixture take precedence over derivation.
+func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*match.Request, error) {
+	a := &f.Action
+	req := &match.Request{Family: family, Credential: a.Credential, PeerIP: a.PeerIP}
+	switch {
+	case a.HTTP != nil:
+		req.Method = a.HTTP.Method
+		req.Headers = http.Header(a.HTTP.Headers)
+		b, err := decodedBody(a.HTTP.Body, a.HTTP.BodyB64)
+		if err != nil {
+			return nil, fmt.Errorf("http.body_b64: %w", err)
+		}
+		req.Body = b
+		req.URL = &url.URL{
+			Scheme:   "https",
+			Host:     a.Host,
+			Path:     a.HTTP.Path,
+			RawQuery: url.Values(a.HTTP.Query).Encode(),
+		}
+	case a.K8s != nil:
+		req.URL = &url.URL{Scheme: "https", Host: a.Host}
+		req.Meta = &k8sfacet.Meta{
+			Verb: a.K8s.Verb, Resource: a.K8s.Resource,
+			Namespace: a.K8s.Namespace, Name: a.K8s.Name,
+			Params: a.K8s.Params,
+		}
+	case a.SQL != nil:
+		stmt := a.SQL.Statement
+		if stmt == "" {
+			break
+		}
+		// Derive verb / tables / function via SQLParser, then let
+		// any explicit fixture fields override. Keeps SQL fixtures
+		// hand-editable (one field) while accepting full structs.
+		if parseSQL == nil {
+			return nil, fmt.Errorf("sql: endpoint runtime does not implement SQLParser")
+		}
+		meta := parseSQL(stmt)
+		if m, ok := meta.(*sqlfacet.Meta); ok {
+			if a.SQL.Verb != "" {
+				m.Verb = a.SQL.Verb
+			}
+			if len(a.SQL.Tables) > 0 {
+				m.Tables = a.SQL.Tables
+			}
+			if len(a.SQL.Function) > 0 {
+				m.Functions = a.SQL.Function
+			}
+		}
+		req.Meta = meta
+	}
+	return req, nil
+}

--- a/action_file_test.go
+++ b/action_file_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestFixtureUnmarshalAcceptsMissingEndpoint(t *testing.T) {
+	body := `{"match":{"verdict":"allow"},"action":{"host":"api.github.com","http":{"method":"GET","path":"/user"}}}`
+	var f Fixture
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("endpoint should be optional, got %v", err)
+	}
+	if f.Match.Endpoint != "" {
+		t.Fatalf("expected empty match.endpoint, got %q", f.Match.Endpoint)
+	}
+}
+
+// passthrough is a valid verdict at parse time; the runner rejects it
+// at replay (see test.go) but the fixture format accepts it so old
+// exports don't fail to load.
+func TestFixtureUnmarshalAcceptsPassthrough(t *testing.T) {
+	body := `{"match":{"verdict":"passthrough"},"action":{"host":"x","http":{}}}`
+	var f Fixture
+	if err := json.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("passthrough should parse, got %v", err)
+	}
+	if f.Match.Verdict != "passthrough" {
+		t.Fatalf("verdict=%q want passthrough", f.Match.Verdict)
+	}
+}
+
+func TestFixtureUnmarshalRejections(t *testing.T) {
+	cases := []struct {
+		name, body, wantSubstr string
+	}{
+		{"zero families",
+			`{"match":{"verdict":"allow"},"action":{"host":"x"}}`,
+			"exactly one of http/k8s/sql"},
+		{"two families",
+			`{"match":{"verdict":"allow"},"action":{"host":"x","http":{},"sql":{"statement":"select 1"}}}`,
+			"exactly one of http/k8s/sql"},
+		{"unknown key in family",
+			`{"match":{"verdict":"allow"},"action":{"host":"x","http":{"banana":1}}}`,
+			"banana"},
+		{"unknown top-level key",
+			`{"match":{"verdict":"allow"},"action":{"host":"x","http":{}},"novel":1}`,
+			"novel"},
+		{"unknown key in action",
+			`{"match":{"verdict":"allow"},"action":{"host":"x","http":{},"novel":1}}`,
+			"novel"},
+		{"body and body_b64 both set",
+			`{"match":{"verdict":"allow"},"action":{"host":"x","http":{"body":"hi","body_b64":"aGk="}}}`,
+			"mutually exclusive"},
+		{"sql without statement",
+			`{"match":{"verdict":"allow"},"action":{"host":"x","sql":{}}}`,
+			"statement is required"},
+		{"bad match.verdict",
+			`{"match":{"verdict":"maybe"},"action":{"host":"x","http":{}}}`,
+			"match.verdict"},
+		{"missing match",
+			`{"action":{"host":"x","http":{}}}`,
+			"match is required"},
+		{"missing action",
+			`{"match":{"verdict":"allow"}}`,
+			"action is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f Fixture
+			err := json.Unmarshal([]byte(tc.body), &f)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("err=%v, want substring %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestMatchFromCompiledRule(t *testing.T) {
+	ep := &config.CompiledEndpoint{Name: "ep"}
+	cases := []struct {
+		name string
+		cr   *config.CompiledRule
+		want Match
+	}{
+		{"nil-rule", nil, Match{Verdict: "allow", Endpoint: "ep"}},
+		{"explicit-allow",
+			&config.CompiledRule{Name: "r1", Outcome: config.Outcome{Verdict: "allow"}},
+			Match{Verdict: "allow", Rule: "r1", Endpoint: "ep"}},
+		{"deny",
+			&config.CompiledRule{Name: "r2", Outcome: config.Outcome{Verdict: "deny", Reason: "no"}},
+			Match{Verdict: "deny", Rule: "r2", Endpoint: "ep", Reason: "no"}},
+		{"approve-chain",
+			&config.CompiledRule{Name: "r3", Outcome: config.Outcome{Approve: []config.ApproveStage{{}}}},
+			Match{Verdict: "approve", Rule: "r3", Endpoint: "ep"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchFromCompiledRule(tc.cr, ep)
+			if got != tc.want {
+				t.Fatalf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeBodyRoundTrip(t *testing.T) {
+	for _, in := range [][]byte{
+		nil,
+		[]byte("hello world"),
+		[]byte("{\n  \"k\": 1\n}"),
+		{0x00, 0x01, 0x02, 0xff},
+	} {
+		body, b64 := encodeBody(in)
+		out, err := decodedBody(body, b64)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if string(out) != string(in) {
+			t.Fatalf("round-trip mismatch: in=%q out=%q (body=%q b64=%q)", in, out, body, b64)
+		}
+	}
+}

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
+	sqlfacet "github.com/denoland/clawpatrol/config/plugins/facets/sql"
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
@@ -108,8 +109,22 @@ func (e *ClickhouseNativeEndpoint) port() int {
 // HandleConn is implemented in clickhouse_native_runtime.go.
 type ClickhouseNativeEndpointRuntime struct{}
 
+// ParseStatement satisfies runtime.SQLParser so the action-fixture
+// loader can populate match.Request.Meta from a raw statement using
+// the same AST extractor live dispatch uses.
+func (ClickhouseNativeEndpointRuntime) ParseStatement(sql string) any {
+	info := parseChSQL(sql)
+	return &sqlfacet.Meta{
+		Verb:      info.Verb,
+		Tables:    info.Tables,
+		Functions: info.Functions,
+		Statement: info.Statement,
+	}
+}
+
 func init() {
 	var _ runtime.ConnEndpointRuntime = ClickhouseNativeEndpointRuntime{}
+	var _ runtime.SQLParser = ClickhouseNativeEndpointRuntime{}
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "clickhouse_native",

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -703,12 +703,13 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName st
 		return "", ""
 	}
 	summary := chSummary(info)
+	rule := cr.Name
 
 	if len(cr.Outcome.Approve) > 0 {
 		if ch.Approve == nil {
 			chEmit(ch, runtime.ConnEvent{
 				Action: "deny", Reason: "HITL not configured",
-				Verb: info.Verb, Summary: summary, Facets: facets,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 			})
 			return "deny", "approval required but HITL is not configured"
 		}
@@ -723,12 +724,12 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName st
 			}
 			chEmit(ch, runtime.ConnEvent{
 				Action: "hitl_deny", Reason: reason,
-				Verb: info.Verb, Summary: summary, Facets: facets,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 			})
 			return "deny", reason
 		}
 		chEmit(ch, runtime.ConnEvent{
-			Action: "hitl_allow", Verb: info.Verb, Summary: summary, Facets: facets,
+			Action: "hitl_allow", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 		})
 		return "", ""
 	}
@@ -740,12 +741,12 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName st
 		}
 		chEmit(ch, runtime.ConnEvent{
 			Action: "deny", Reason: reason,
-			Verb: info.Verb, Summary: summary, Facets: facets,
+			Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 		})
 		return "deny", reason
 	}
 	chEmit(ch, runtime.ConnEvent{
-		Action: "allow", Verb: info.Verb, Summary: summary, Facets: facets,
+		Action: "allow", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 	})
 	_ = ctx
 	return "", ""

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -123,8 +123,24 @@ func (PostgresEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidate
 	return ""
 }
 
+// ParseStatement satisfies runtime.SQLParser so the action-fixture
+// loader can populate match.Request.Meta from a raw statement using
+// the same regex extractor pgEvaluate uses on live wire traffic.
+// Returns *sqlfacet.Meta as `any` to keep the runtime interface free
+// of the facets-package import.
+func (PostgresEndpointRuntime) ParseStatement(sql string) any {
+	info := parseSQL(sql)
+	return &sqlfacet.Meta{
+		Verb:      info.Verb,
+		Tables:    info.Tables,
+		Functions: info.Functions,
+		Statement: info.Statement,
+	}
+}
+
 func init() {
 	var _ runtime.PlaceholderDetector = PostgresEndpointRuntime{}
+	var _ runtime.SQLParser = PostgresEndpointRuntime{}
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "postgres",
@@ -455,6 +471,7 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 		})
 		return "", ""
 	}
+	rule := cr.Name
 
 	// Approve chain. ConnHandle.Approve dispatches through the
 	// host's HITL machinery (same one HTTPS uses) — the postgres
@@ -466,7 +483,7 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 		if ch.Approve == nil {
 			emit(ch, runtime.ConnEvent{
 				Action: "deny", Reason: "HITL not configured",
-				Verb: info.Verb, Summary: summary, Facets: facets,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 			})
 			return "deny", "approval required but HITL is not configured"
 		}
@@ -481,12 +498,12 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 			}
 			emit(ch, runtime.ConnEvent{
 				Action: "hitl_deny", Reason: reason,
-				Verb: info.Verb, Summary: summary, Facets: facets,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 			})
 			return "deny", reason
 		}
 		emit(ch, runtime.ConnEvent{
-			Action: "hitl_allow", Verb: info.Verb, Summary: summary, Facets: facets,
+			Action: "hitl_allow", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 		})
 		return "", ""
 	}
@@ -498,12 +515,12 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 		}
 		emit(ch, runtime.ConnEvent{
 			Action: "deny", Reason: reason,
-			Verb: info.Verb, Summary: summary, Facets: facets,
+			Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 		})
 		return "deny", reason
 	}
 	emit(ch, runtime.ConnEvent{
-		Action: "allow", Verb: info.Verb, Summary: summary, Facets: facets,
+		Action: "allow", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 	})
 	return "", ""
 }

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -207,6 +207,11 @@ type ConnEvent struct {
 	Summary string // human-readable one-liner for the event log
 	Bytes   int64  // approximate request size for billing / quotas
 	Facets  map[string]any
+	// Rule is the matched CompiledRule.Name, "" when no rule fired.
+	// The host's Emit closure copies it onto the dashboard Event so
+	// the action-fixture exporter can pin a downloaded action to a
+	// specific rule (doc/test.md §1.3).
+	Rule string
 }
 
 // Secret is what credential plugins receive at injection time. The
@@ -409,6 +414,23 @@ var ErrUnsupported = errors.New("plugin runtime not implemented")
 // calling it.
 type PlaceholderDetector interface {
 	DetectPlaceholder(req *Request, candidates []string) string
+}
+
+// SQLParser is the optional contract a SQL-family endpoint plugin's
+// runtime implements so a host that received a raw SQL string (rather
+// than a live wire-protocol frame) can populate `match.Request.Meta`
+// using the same parser the live dispatch path uses. The fixture
+// loader behind `clawpatrol test` reads only `"statement": "..."`
+// from each fixture and calls this to recover verb / tables /
+// functions before running rule matching, so the format stays
+// operator-friendly (doc/test.md §4).
+//
+// Implementations return the per-family `*sqlfacet.Meta` value the
+// SQL matcher expects on `match.Request.Meta`. Endpoints whose
+// runtime doesn't implement this aren't usable as SQL test
+// fixtures.
+type SQLParser interface {
+	ParseStatement(sql string) any
 }
 
 // Request is re-exported here so callers don't have to import

--- a/doc/test.md
+++ b/doc/test.md
@@ -1,0 +1,158 @@
+# `clawpatrol test`
+
+A CLI that replays recorded gateway actions against a candidate HCL
+policy and reports any verdict drift. Pure CLI — no gateway, no DB,
+no auth.
+
+```
+clawpatrol test <config.hcl> <fixture.json | fixture-dir>
+```
+
+Exit 0 when every fixture matches; 1 on any mismatch or fixture
+load error; 2 on usage / config-load error.
+
+## Fixture format
+
+Two top-level keys: `match` is the assertion (what the rule engine
+should produce); `action` is the recorded request (what the agent
+did). Every fixture has exactly one facet block under `action`
+(`http` / `k8s` / `sql`) carrying that facet's CEL vocabulary.
+Connection-level fields (`host`, `credential`, `peer_ip`) live on
+`action` itself.
+
+```json
+// HTTPS
+{
+  "match": {
+    "verdict":  "allow",
+    "rule":     "public-readonly",
+    "endpoint": "github"
+  },
+  "action": {
+    "host":       "api.github.com",
+    "credential": "github_pat",
+    "peer_ip":    "100.64.0.7",
+    "http": {
+      "method":  "POST",
+      "path":    "/repos/...",
+      "query":   { "per_page": ["100"] },
+      "headers": { "Authorization": ["***"] },
+      "body":    "..."
+    }
+  }
+}
+
+// K8s
+{
+  "match": { "endpoint": "k8s-dev-ams", "rule": "k8s-no-secrets", "verdict": "deny" },
+  "action": {
+    "host": "209.250.247.66",
+    "k8s": {
+      "verb":      "get",
+      "resource":  "secrets",
+      "namespace": "default",
+      "name":      "mysecret"
+    }
+  }
+}
+
+// SQL
+{
+  "match": { "endpoint": "pg-deploy-classic-staging", "rule": "pg-staging-reads", "verdict": "allow" },
+  "action": {
+    "host": "main-pg14.denosr-staging.internal:5432",
+    "sql": {
+      "statement": "SELECT id, name FROM workflows WHERE id = 1"
+    }
+  }
+}
+```
+
+### `match`
+
+What the rule engine produced (or what the runner should assert).
+
+- `verdict` — one of `allow`, `deny`, `approve`, `passthrough`.
+  Required. `passthrough` parses but the runner rejects it at
+  replay (no upstream to dial, no policy to assert) — drop or
+  re-pin to a terminal verdict before checking the fixture in.
+- `rule` — name of the matched `CompiledRule`. Empty when no rule
+  fired and the endpoint default was used.
+- `endpoint` — optional. When set, pins dispatch (under hosts
+  shared by multiple endpoints, e.g. `api.anthropic.com` in deno.hcl)
+  and asserts the matched endpoint on replay.
+- `reason` — informational; not compared by the runner.
+
+### `action`
+
+The recorded request. Connection-level fields plus one facet block.
+
+- `host` — the host the agent dialed. Used by the loader for
+  endpoint resolution when `match.endpoint` is absent. For SQL,
+  required (no URL at wire level). For HTTPS/k8s, redundant with
+  the family block's path but extracted out to keep the facet
+  block aligned with its CEL vocabulary.
+- `credential`, `peer_ip` — `match.Request` scalars; optional.
+- Exactly one facet block: `http`, `k8s`, or `sql`. The block name
+  matches `Facet.Name()`. Block content is **only** the facet's
+  CEL-visible fields (the vocabulary rules read via
+  `<facet>.<field>` in their `condition`).
+
+### Facet blocks
+
+| Block | CEL vocabulary |
+|-------|----------------|
+| `http` | `method`, `path`, `query`, `headers`, `body`, `body_b64` |
+| `k8s` | `verb`, `resource`, `namespace`, `name`, `params` |
+| `sql` | `statement` (required); `verb`, `tables`, `function` (optional, derived from `statement` by the endpoint's `runtime.SQLParser` if omitted) |
+
+Every field inside a facet block is optional except SQL's
+`statement`. Missing fields default to zero values — rules that
+match on them just return false. Fixtures that include the full
+struct (e.g. SQL with explicit verb/tables/function) are accepted;
+explicit values take precedence over derivation.
+
+`approve` is terminal — the runner doesn't invoke the approver
+chain. A rule routing to an approver records
+`match.verdict = "approve"`; the human's eventual allow/deny is
+out of scope.
+
+### Conventions
+
+- `body` is raw UTF-8; `body_b64` is base64. Mutually exclusive.
+- Headers and query maps are `map<string, list<string>>` to match
+  `http.Header` and `url.Values`.
+- Unknown keys anywhere in the file are load errors.
+
+### Redaction
+
+The exporter reads from the `actions` SQLite table. Whatever
+redaction the sink applied at write time is what the fixture
+carries.
+
+- Headers: redacted. `flatHeaders` replaces values of
+  `Authorization`, `Cookie`, `X-Api-Key`, etc. with `"***"` before
+  the headers JSON hits SQLite.
+- Bodies: not redacted. For well-behaved agents the body is what
+  the agent sent (a placeholder like `{{github_pat}}`); for agents
+  that inline secrets, it's the secret. Review fixture files
+  before checking them in.
+
+## Local workflow
+
+1. **Start a local gateway** with a small config pointing at a
+   real upstream (e.g. `clawpatrol gateway -config test.hcl`).
+2. **Send real requests** through it. Mix verdicts —
+   `allow` / `deny` / `approve` — so the corpus covers every
+   comparison branch.
+3. **Click "Download action"** on each row's detail page. The
+   browser saves a single `.json` file per action.
+4. **Drop the files into `fixtures/`** and check them into the
+   repo.
+5. **Run `clawpatrol test test.hcl fixtures/`**. Expect exit 0
+   with `N actions checked, 0 mismatches`.
+6. **Mutate the config** — flip an `allow` to `deny`, rename a
+   rule — and re-run. Expect non-zero exit and a printed diff
+   naming the affected fixture files.
+
+The same fixtures become CI's regression set on every push.

--- a/main.go
+++ b/main.go
@@ -1260,7 +1260,8 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 				Mode: "pg", Family: ep.Family, Host: dstIP, AgentIP: agentPip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
-				Facets: ev.Facets,
+				Facets:   ev.Facets,
+				Endpoint: ep.Name, Rule: ev.Rule,
 			})
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
@@ -1418,7 +1419,8 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 				Mode: mode, Family: ep.Family, Host: eventHost, AgentIP: agentPip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
-				Facets: ev.Facets,
+				Facets:   ev.Facets,
+				Endpoint: ep.Name, Rule: ev.Rule,
 			})
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
@@ -1663,7 +1665,8 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			Family: ep.Family,
 			Host:   host,
 			Method: req.Method, Path: req.URL.Path,
-			AgentIP: agentAddr,
+			AgentIP:  agentAddr,
+			Endpoint: ep.Name,
 		}
 		if fac != nil {
 			ev.Facets = fac.Report(mreq)
@@ -1678,6 +1681,9 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		g.emit(startEv)
 
 		cr := runtime.MatchRequest(ep, mreq)
+		if cr != nil {
+			ev.Rule = cr.Name
+		}
 
 		// Approve chain — dispatch each stage to its approver
 		// runtime (config/plugins/approvers). All stages must
@@ -2080,6 +2086,8 @@ func main() {
 		runInitCA(os.Args[2:])
 	case "validate":
 		runValidate(os.Args[2:])
+	case "test":
+		runTest(os.Args[2:])
 	case "uninstall":
 		runUninstall(os.Args[2:])
 	case "status":
@@ -2165,6 +2173,7 @@ usage:
   clawpatrol env                         print shell exports for sourcing
   clawpatrol init-ca DIR                 generate a new CA in DIR
   clawpatrol validate <config.hcl>       parse + compile a config and exit
+  clawpatrol test <config> <path>        replay action fixtures against a candidate policy
   clawpatrol version`)
 	os.Exit(2)
 }

--- a/migrations/sqlite/0009_action_endpoint_rule.sql
+++ b/migrations/sqlite/0009_action_endpoint_rule.sql
@@ -1,0 +1,10 @@
+-- Carry the dispatching endpoint name and matched rule name on every
+-- action row. Needed by `clawpatrol test` (doc/test.md) so the
+-- dashboard's per-action exporter can pin fixtures to a specific
+-- endpoint and assert the matched rule. Both NULL for pre-existing
+-- rows; emitters fill them going forward.
+
+ALTER TABLE actions ADD COLUMN endpoint TEXT;
+ALTER TABLE actions ADD COLUMN rule     TEXT;
+
+INSERT INTO _schema (version) VALUES (9);

--- a/test.go
+++ b/test.go
@@ -1,0 +1,185 @@
+package main
+
+// `clawpatrol test <config> <file-or-dir>` — replay recorded gateway
+// actions against a candidate policy and report any verdict
+// differences. Pure CLI: no gateway, no DB, no auth. See doc/test.md.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// runTest is the CLI entry: prints any output to stdout/stderr and
+// exits with the right code. The pure logic lives in testCmd so the
+// integration tests can drive it without touching stdio.
+func runTest(args []string) {
+	stdout, stderr, code := testCmd(args)
+	if stdout != "" {
+		fmt.Println(stdout)
+	}
+	if stderr != "" {
+		fmt.Fprintln(os.Stderr, stderr)
+	}
+	os.Exit(code)
+}
+
+// testCmd loads the candidate policy, resolves the fixture path
+// argument, replays each fixture, and reports mismatches. Exit codes:
+// 0 ok (all fixtures matched), 1 verdict mismatch or load error on a
+// fixture, 2 usage / config-load error.
+func testCmd(args []string) (stdout, stderr string, code int) {
+	if len(args) != 2 || args[0] == "-h" || args[0] == "--help" {
+		return "", "usage: clawpatrol test <config.hcl> <fixture.json | fixture-dir>", 2
+	}
+	cfgPath, target := args[0], args[1]
+
+	_, policy, err := loadConfig(cfgPath)
+	if err != nil {
+		return "", fmt.Sprintf("load config: %v", err), 2
+	}
+
+	files, err := resolveFixtures(target)
+	if err != nil {
+		return "", fmt.Sprintf("resolve fixtures: %v", err), 2
+	}
+	if len(files) == 0 {
+		return "", fmt.Sprintf("no .json fixtures under %s", target), 2
+	}
+
+	var out strings.Builder
+	mismatches := 0
+	for _, f := range files {
+		ok, msg, err := runOneFixture(policy, f)
+		switch {
+		case err != nil:
+			fmt.Fprintf(&out, "FAIL %s: %v\n", f, err)
+			mismatches++
+		case !ok:
+			fmt.Fprintf(&out, "FAIL %s\n", f)
+			out.WriteString(msg)
+			mismatches++
+		default:
+			fmt.Fprintf(&out, "ok   %s\n", f)
+		}
+	}
+	fmt.Fprintf(&out, "%d action(s) checked, %d mismatch(es)\n", len(files), mismatches)
+	final := strings.TrimRight(out.String(), "\n")
+	if mismatches > 0 {
+		return "", final, 1
+	}
+	return final, "", 0
+}
+
+func resolveFixtures(target string) ([]string, error) {
+	st, err := os.Stat(target)
+	if err != nil {
+		return nil, err
+	}
+	if !st.IsDir() {
+		return []string{target}, nil
+	}
+	matches, err := filepath.Glob(filepath.Join(target, "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// runOneFixture loads one fixture, dispatches it through the compiled
+// policy, and returns (matched?, mismatch-diff, err). err is non-nil
+// for load / setup failures; (false, diff, nil) is a clean verdict
+// mismatch.
+func runOneFixture(policy *config.CompiledPolicy, path string) (bool, string, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return false, "", err
+	}
+	var f Fixture
+	if err := json.Unmarshal(body, &f); err != nil {
+		return false, "", err
+	}
+	ep, err := f.ResolveEndpoint(policy)
+	if err != nil {
+		return false, "", err
+	}
+	if f.Match.Verdict == "passthrough" {
+		return false, "", fmt.Errorf(
+			"passthrough fixtures aren't yet replayable — pin to a named endpoint or remove",
+		)
+	}
+
+	family, err := fixtureFamily(&f, ep)
+	if err != nil {
+		return false, "", err
+	}
+
+	var parseSQL func(string) any
+	if p, ok := ep.Plugin.Runtime.(runtime.SQLParser); ok {
+		parseSQL = p.ParseStatement
+	}
+	req, err := f.ToMatchRequest(family, parseSQL)
+	if err != nil {
+		return false, "", err
+	}
+	cr := runtime.MatchRequest(ep, req)
+	got := MatchFromCompiledRule(cr, ep)
+
+	if matchEquals(got, f.Match) {
+		return true, "", nil
+	}
+	return false, formatMismatch(got, f.Match), nil
+}
+
+// matchEquals compares the runner's produced match against the
+// fixture's asserted match. Reason is informational and not part of
+// the comparison — it drifts under safe edits.
+func matchEquals(got, want Match) bool {
+	if got.Verdict != want.Verdict || got.Rule != want.Rule {
+		return false
+	}
+	// Endpoint assertion is optional: an empty want.Endpoint means
+	// the fixture didn't pin an endpoint, so don't fail on it.
+	if want.Endpoint != "" && got.Endpoint != want.Endpoint {
+		return false
+	}
+	return true
+}
+
+func fixtureFamily(f *Fixture, ep *config.CompiledEndpoint) (string, error) {
+	switch {
+	case f.Action.HTTP != nil:
+		if ep.Family != "http" {
+			return "", fmt.Errorf("endpoint %q is family %q but fixture has http block", ep.Name, ep.Family)
+		}
+		return "http", nil
+	case f.Action.K8s != nil:
+		if ep.Family != "k8s" {
+			return "", fmt.Errorf("endpoint %q is family %q but fixture has k8s block", ep.Name, ep.Family)
+		}
+		return "k8s", nil
+	case f.Action.SQL != nil:
+		if ep.Family != "sql" {
+			return "", fmt.Errorf("endpoint %q is family %q but fixture has sql block", ep.Name, ep.Family)
+		}
+		return "sql", nil
+	}
+	return "", fmt.Errorf("fixture has no family block")
+}
+
+func formatMismatch(got, want Match) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "  want verdict=%-12q rule=%-30q endpoint=%q\n", want.Verdict, want.Rule, want.Endpoint)
+	fmt.Fprintf(&b, "  got  verdict=%-12q rule=%-30q endpoint=%q\n", got.Verdict, got.Rule, got.Endpoint)
+	if got.Reason != "" && got.Reason != want.Reason {
+		fmt.Fprintf(&b, "  reason: %s\n", strings.TrimSpace(got.Reason))
+	}
+	return b.String()
+}

--- a/test_test.go
+++ b/test_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+// loadExamplePolicy compiles testdata/example.hcl. A typo there
+// surfaces here, not as a downstream fixture-mismatch failure.
+func loadExamplePolicy(t *testing.T) *config.CompiledPolicy {
+	t.Helper()
+	gw, diags := config.Load("testdata/example.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load testdata/example.hcl: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile testdata/example.hcl: %v", err)
+	}
+	return policy
+}
+
+// TestExampleConfigCompiles gates the rest: a clean HCL parse +
+// compile of the shipped sample.
+func TestExampleConfigCompiles(t *testing.T) {
+	policy := loadExamplePolicy(t)
+	if policy.Endpoints["github"] == nil {
+		t.Fatal("expected endpoint 'github' in compiled policy")
+	}
+}
+
+// TestExampleFixturesPass replays the shipped fixtures end-to-end.
+func TestExampleFixturesPass(t *testing.T) {
+	policy := loadExamplePolicy(t)
+	matches, err := filepath.Glob("testdata/*.json")
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("glob fixtures: %v len=%d", err, len(matches))
+	}
+	for _, f := range matches {
+		ok, msg, err := runOneFixture(policy, f)
+		if err != nil {
+			t.Errorf("%s: load error %v", f, err)
+			continue
+		}
+		if !ok {
+			t.Errorf("%s: verdict mismatch:\n%s", f, msg)
+		}
+	}
+}
+
+// Mutate a fixture's expected verdict; runner must report mismatch.
+func TestExampleFixtureDetectsDrift(t *testing.T) {
+	policy := loadExamplePolicy(t)
+	body, err := os.ReadFile("testdata/get-user.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var f Fixture
+	if err := json.Unmarshal(body, &f); err != nil {
+		t.Fatal(err)
+	}
+	f.Match.Verdict = "deny"
+	f.Match.Rule = "github-writes"
+	out, _ := json.Marshal(&f)
+	tmp := filepath.Join(t.TempDir(), "flipped.json")
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, _, err := runOneFixture(policy, tmp)
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected mismatch, got match")
+	}
+}
+
+// Host-resolution paths: unique, ambiguous (errors + disambiguated
+// via match.endpoint), unknown. Compiles an ad-hoc policy with
+// shared hosts since testdata/example.hcl has only one endpoint.
+func TestResolveEndpointByHost(t *testing.T) {
+	hcl := `
+admin_email = "x@example.com"
+credential "bearer_token" "a" {}
+credential "bearer_token" "b" {}
+endpoint "https" "alpha" {
+  hosts      = ["api.example.com"]
+  credential = a
+}
+endpoint "https" "beta" {
+  hosts      = ["api.example.com"]
+  credential = b
+}
+endpoint "https" "gamma" {
+  hosts      = ["solo.example.com"]
+  credential = a
+}
+profile "default" { endpoints = [alpha, beta, gamma] }
+`
+	gw, diags := config.LoadBytes([]byte(hcl), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	mk := func(t *testing.T, body string) *Fixture {
+		t.Helper()
+		var f Fixture
+		if err := json.Unmarshal([]byte(body), &f); err != nil {
+			t.Fatal(err)
+		}
+		return &f
+	}
+
+	t.Run("unique host", func(t *testing.T) {
+		f := mk(t, `{"match":{"verdict":"allow"},"action":{"host":"solo.example.com","http":{"path":"/x"}}}`)
+		ep, err := f.ResolveEndpoint(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ep.Name != "gamma" {
+			t.Fatalf("got %q want gamma", ep.Name)
+		}
+	})
+
+	t.Run("ambiguous host errors with candidates", func(t *testing.T) {
+		f := mk(t, `{"match":{"verdict":"allow"},"action":{"host":"api.example.com","http":{"path":"/x"}}}`)
+		_, err := f.ResolveEndpoint(policy)
+		if err == nil || !strings.Contains(err.Error(), "claimed by multiple endpoints") {
+			t.Fatalf("want ambiguity error, got %v", err)
+		}
+	})
+
+	t.Run("ambiguous host disambiguated by match.endpoint", func(t *testing.T) {
+		f := mk(t, `{"match":{"verdict":"allow","endpoint":"beta"},"action":{"host":"api.example.com","http":{"path":"/x"}}}`)
+		ep, err := f.ResolveEndpoint(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ep.Name != "beta" {
+			t.Fatalf("got %q want beta", ep.Name)
+		}
+	})
+
+	t.Run("unknown host", func(t *testing.T) {
+		f := mk(t, `{"match":{"verdict":"allow"},"action":{"host":"nope.example.com","http":{"path":"/x"}}}`)
+		_, err := f.ResolveEndpoint(policy)
+		if err == nil || !strings.Contains(err.Error(), "no endpoint claims") {
+			t.Fatalf("want unknown-host error, got %v", err)
+		}
+	})
+}
+
+// File vs directory vs missing argument path resolution.
+func TestResolveFixtures(t *testing.T) {
+	got, err := resolveFixtures("testdata/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) < 2 {
+		t.Fatalf("dir mode: want ≥2 fixtures, got %d (%v)", len(got), got)
+	}
+	if !strings.HasSuffix(got[0], "delete-issue.json") {
+		t.Fatalf("expected sorted order, got %v", got)
+	}
+	single, err := resolveFixtures("testdata/get-user.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(single) != 1 {
+		t.Fatalf("file mode: want 1, got %d", len(single))
+	}
+	if _, err := resolveFixtures("testdata/does-not-exist"); err == nil {
+		t.Fatal("missing path: expected error, got nil")
+	}
+}

--- a/testdata/delete-issue.json
+++ b/testdata/delete-issue.json
@@ -1,0 +1,18 @@
+{
+  "match": {
+    "verdict":  "deny",
+    "rule":     "github-writes",
+    "endpoint": "github",
+    "reason":   "writes go through PR review"
+  },
+  "action": {
+    "host": "api.github.com",
+    "http": {
+      "method": "DELETE",
+      "path":   "/repos/denoland/clawpatrol/issues/1",
+      "headers": {
+        "Authorization": ["***"]
+      }
+    }
+  }
+}

--- a/testdata/example.hcl
+++ b/testdata/example.hcl
@@ -1,0 +1,33 @@
+// Sample config for `clawpatrol test` (see doc/test.md §5). Pair
+// with the *.json fixtures alongside it to verify the runner
+// end-to-end:
+//
+//   ./clawpatrol test testdata/example.hcl testdata/
+//
+// Edit any rule below and re-run to see a mismatch.
+
+// admin_email is required by config.Compile; the runner doesn't
+// consult it.
+admin_email = "you@example.com"
+
+credential "bearer_token" "github_pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = github_pat
+}
+
+rule "github-reads" {
+  endpoint  = github
+  condition = "http.method in ['GET', 'HEAD']"
+  verdict   = "allow"
+}
+
+rule "github-writes" {
+  endpoint  = github
+  condition = "http.method in ['POST', 'PATCH', 'PUT', 'DELETE']"
+  verdict   = "deny"
+  reason    = "writes go through PR review"
+}
+
+profile "default" { endpoints = [github] }

--- a/testdata/get-user.json
+++ b/testdata/get-user.json
@@ -1,0 +1,18 @@
+{
+  "match": {
+    "verdict":  "allow",
+    "rule":     "github-reads",
+    "endpoint": "github"
+  },
+  "action": {
+    "host": "api.github.com",
+    "http": {
+      "method": "GET",
+      "path":   "/user",
+      "headers": {
+        "Authorization": ["***"],
+        "User-Agent":    ["clawpatrol-test/sample"]
+      }
+    }
+  }
+}

--- a/web.go
+++ b/web.go
@@ -1368,13 +1368,16 @@ func (w *webMux) apiActionByID(
 		reqHeaders  sql.NullString
 		respHeaders sql.NullString
 		extra       sql.NullString
+		endpoint    sql.NullString
+		rule        sql.NullString
 	)
 	err := w.g.db.QueryRow(`
 		SELECT ts_ns, mode, family, agent_ip, host, method, path,
 		       status, bytes_in, bytes_out, ms, action,
 		       reason, req_sha, resp_sha,
 		       req_body, resp_body,
-		       req_headers, resp_headers, extra
+		       req_headers, resp_headers, extra,
+		       endpoint, rule
 		FROM actions WHERE action_id = ?`, actionID,
 	).Scan(
 		&tsNs, &mode, &family, &agentIP, &e.Host,
@@ -1382,6 +1385,7 @@ func (w *webMux) apiActionByID(
 		&action, &reason, &reqSha, &respSha,
 		&reqBody, &respBody,
 		&reqHeaders, &respHeaders, &extra,
+		&endpoint, &rule,
 	)
 	if err == sql.ErrNoRows {
 		http.Error(rw, "not found", 404)
@@ -1413,7 +1417,175 @@ func (w *webMux) apiActionByID(
 	if extra.String != "" {
 		_ = json.Unmarshal([]byte(extra.String), &e.Facets)
 	}
+	e.Endpoint = endpoint.String
+	e.Rule = rule.String
+	if r.URL.Query().Get("fmt") == "fixture" {
+		w.writeActionFixture(rw, &e)
+		return
+	}
 	writeJSON(rw, e)
+}
+
+// writeActionFixture emits the Action JSON for `clawpatrol test`
+// (doc/test.md). 400s on events that pre-date endpoint tracking or
+// can't be mapped to a terminal verdict.
+func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
+	policy := w.g.Policy()
+	if policy == nil {
+		http.Error(rw, "policy not loaded", 503)
+		return
+	}
+	if ev.Endpoint == "" {
+		http.Error(rw, "action predates endpoint tracking; cannot export as fixture", 400)
+		return
+	}
+	ep := policy.Endpoints[ev.Endpoint]
+	if ep == nil {
+		http.Error(rw, fmt.Sprintf("endpoint %q no longer in policy", ev.Endpoint), 400)
+		return
+	}
+	m, ok := matchFromEvent(ev)
+	if !ok {
+		http.Error(rw, fmt.Sprintf("event action %q is not exportable as a fixture", ev.Action), 400)
+		return
+	}
+
+	fx := &Fixture{Match: m, Action: Action{PeerIP: ev.AgentIP}}
+	switch ep.Family {
+	case "http":
+		fx.Action.Host = ev.Host
+		fx.Action.HTTP = exportHTTP(ev)
+	case "k8s":
+		fx.Action.Host = ev.Host
+		fx.Action.K8s = exportK8s(ev)
+	case "sql":
+		sql := exportSQL(ev)
+		if sql == nil {
+			http.Error(rw, "sql action has no statement recorded; cannot export", 400)
+			return
+		}
+		// Host for SQL comes from the endpoint's HCL declaration —
+		// the recorded Event.Host is the dst IP / tunnel listener,
+		// not what the resolver scans against. For multi-host
+		// endpoints pick the first; the runner short-circuits on
+		// match.endpoint anyway, so host is informational here.
+		if len(ep.Hosts) > 0 {
+			fx.Action.Host = ep.Hosts[0]
+		}
+		fx.Action.SQL = sql
+	default:
+		http.Error(rw, fmt.Sprintf("endpoint family %q is not yet exportable", ep.Family), 501)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.json"`, ev.ID))
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(fx)
+}
+
+// matchFromEvent maps post-chain Event.Action onto the fixture's
+// terminal verdict vocabulary. hitl_* collapses to "approve".
+// Empty Event.Action maps to "allow" — that's the legacy default
+// for rows written before per-action verdicts were tracked.
+func matchFromEvent(ev *Event) (Match, bool) {
+	m := Match{Rule: ev.Rule, Endpoint: ev.Endpoint, Reason: ev.Reason}
+	switch ev.Action {
+	case "deny":
+		m.Verdict = "deny"
+	case "hitl_allow", "hitl_deny":
+		m.Verdict = "approve"
+	case "allow", "":
+		m.Verdict = "allow"
+	case "passthrough":
+		m.Verdict = "passthrough"
+	default:
+		return Match{}, false
+	}
+	return m, true
+}
+
+// exportHTTP populates the http.* CEL view from a recorded Event.
+// Host lives on Action (not in the http block) since `http.host`
+// isn't a CEL variable. Path comes straight from the recorded URL.
+func exportHTTP(ev *Event) *HTTPAction {
+	body, b64 := encodeBody([]byte(ev.ReqBody))
+	path, query := splitPathQuery(ev.Path)
+	return &HTTPAction{
+		Method:  ev.Method,
+		Path:    path,
+		Query:   query,
+		Headers: headersToMultiValue(ev.ReqHeaders),
+		Body:    body,
+		BodyB64: b64,
+	}
+}
+
+// splitPathQuery separates a recorded Event.Path (which may carry
+// `?query=...` already encoded) into path + parsed-query.
+func splitPathQuery(raw string) (string, map[string][]string) {
+	q := strings.IndexByte(raw, '?')
+	if q < 0 {
+		return raw, nil
+	}
+	vals, err := url.ParseQuery(raw[q+1:])
+	if err != nil || len(vals) == 0 {
+		return raw[:q], nil
+	}
+	return raw[:q], vals
+}
+
+// exportK8s recovers the parsed k8s tuple from Event.Facets, set
+// by the k8s facet's Report at live-dispatch time. Only CEL-visible
+// fields land in the k8s block.
+func exportK8s(ev *Event) *K8sAction {
+	a := &K8sAction{}
+	if v, ok := ev.Facets["verb"].(string); ok {
+		a.Verb = v
+	}
+	if v, ok := ev.Facets["resource"].(string); ok {
+		a.Resource = v
+	}
+	if v, ok := ev.Facets["namespace"].(string); ok {
+		a.Namespace = v
+	}
+	if v, ok := ev.Facets["name"].(string); ok {
+		a.Name = v
+	}
+	if p, ok := ev.Facets["params"].(map[string]any); ok {
+		a.Params = map[string]string{}
+		for k, val := range p {
+			if s, ok := val.(string); ok {
+				a.Params[k] = s
+			}
+		}
+	}
+	return a
+}
+
+// exportSQL pulls the raw statement out of Event.Facets (set by
+// sqlfacet.Report). The loader re-derives verb / tables / function
+// from the statement via SQLParser at replay time.
+func exportSQL(ev *Event) *SQLAction {
+	stmt, _ := ev.Facets["statement"].(string)
+	if stmt == "" {
+		return nil
+	}
+	return &SQLAction{Statement: stmt}
+}
+
+// headersToMultiValue widens the Sink's single-value header map to
+// http.Header's multi-value shape.
+func headersToMultiValue(h map[string]string) map[string][]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(h))
+	for k, v := range h {
+		out[k] = []string{v}
+	}
+	return out
 }
 
 // apiAnalytics returns a randomly-sampled set of events for the
@@ -1704,6 +1876,14 @@ type Event struct {
 	// request. Keys correspond to the family's ReportFields().
 	// Serialised as JSON into the actions table's `extra` column.
 	Facets map[string]any `json:"facets,omitempty"`
+
+	// Endpoint is the dispatching CompiledEndpoint.Name; Rule is the
+	// matched CompiledRule.Name (empty when no rule fired). Populated
+	// at the existing dispatch sites so the action-fixture exporter
+	// can pin a downloaded action to a specific endpoint and assert
+	// the rule that produced its verdict (doc/test.md §1.3).
+	Endpoint string `json:"endpoint,omitempty"`
+	Rule     string `json:"rule,omitempty"`
 }
 
 // eventPacket carries an event plus its marshaled JSON bytes. drain()
@@ -1757,7 +1937,8 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 	rows, err := db.Query(`
 		SELECT action_id, ts_ns, mode, family, agent_ip, host,
 		       method, path, status, bytes_in, bytes_out,
-		       ms, action, reason, req_sha, resp_sha, extra
+		       ms, action, reason, req_sha, resp_sha, extra,
+		       endpoint, rule
 		FROM actions ORDER BY id DESC LIMIT ?`, n)
 	if err != nil {
 		return nil, err
@@ -1782,11 +1963,14 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 			reqSha   sql.NullString
 			respSha  sql.NullString
 			extra    sql.NullString
+			endpoint sql.NullString
+			rule     sql.NullString
 		)
 		if err := rows.Scan(
 			&actionID, &tsNs, &mode, &family, &agentIP, &e.Host,
 			&method, &path, &status, &in, &ot, &ms,
 			&action, &reason, &reqSha, &respSha, &extra,
+			&endpoint, &rule,
 		); err != nil {
 			return nil, err
 		}
@@ -1794,6 +1978,8 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		e.Ts = time.Unix(0, tsNs).UTC()
 		e.Mode = mode.String
 		e.Family = family.String
+		e.Endpoint = endpoint.String
+		e.Rule = rule.String
 		e.AgentIP = agentIP.String
 		e.Method = method.String
 		e.Path = path.String
@@ -1869,15 +2055,17 @@ func (s *Sink) drain() {
 				  method, path, status, bytes_in, bytes_out,
 				  ms, action, reason, req_sha, resp_sha,
 				  req_body, resp_body,
-				  req_headers, resp_headers, extra)
-				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+				  req_headers, resp_headers, extra,
+				  endpoint, rule)
+				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 			`, e.ID, e.Ts.UnixNano(), e.Mode, e.Family, e.AgentIP,
 				e.Host, e.Method, e.Path, e.Status,
 				e.In, e.Out, e.Ms, e.Action, e.Reason,
 				e.ReqSha, e.RespSha,
 				e.ReqBody, e.RespBody,
 				string(rqhJSON), string(rshJSON),
-				string(extraJSON))
+				string(extraJSON),
+				e.Endpoint, e.Rule)
 		}
 
 		// Marshal once per event regardless of subscriber count. Old

--- a/web_fixture_export_test.go
+++ b/web_fixture_export_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+// gatewayWithPolicy builds a minimal *Gateway whose Policy() returns
+// the compiled HCL. Enough for the exporter, which is invoked
+// directly here (bypassing route + auth).
+func gatewayWithPolicy(t *testing.T, hcl string) *Gateway {
+	t.Helper()
+	gw, diags := config.LoadBytes([]byte(hcl), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	g := &Gateway{}
+	g.policy.Store(policy)
+	return g
+}
+
+const fixtureHCL = `
+admin_email = "x@example.com"
+credential "bearer_token" "tok" {}
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = tok
+}
+profile "default" { endpoints = [github] }
+`
+
+// TestExporterHTTPSHappyPath: a recorded HTTPS Event reshapes into
+// an Action JSON that re-parses cleanly with the expected fields.
+func TestExporterHTTPSHappyPath(t *testing.T) {
+	w := &webMux{g: gatewayWithPolicy(t, fixtureHCL)}
+	ev := &Event{
+		ID:       "evt-1",
+		Mode:     "mitm",
+		Family:   "https",
+		Host:     "api.github.com",
+		Method:   "GET",
+		Path:     "/user",
+		AgentIP:  "100.64.0.7",
+		Action:   "allow",
+		Endpoint: "github",
+		Rule:     "github-reads",
+		ReqHeaders: map[string]string{
+			"Authorization": "***",
+			"User-Agent":    "clawpatrol-test",
+		},
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	if got := rw.Header().Get("Content-Disposition"); !strings.Contains(got, `filename="evt-1.json"`) {
+		t.Errorf("missing/incorrect Content-Disposition: %q", got)
+	}
+
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatalf("emitted body doesn't reparse as Fixture: %v\nbody=%s", err, rw.Body.String())
+	}
+	if f.Action.HTTP == nil {
+		t.Fatal("expected http block, got nil")
+	}
+	if f.Action.Host != "api.github.com" {
+		t.Errorf("host=%q want api.github.com", f.Action.Host)
+	}
+	if f.Action.HTTP.Method != "GET" {
+		t.Errorf("method=%q want GET", f.Action.HTTP.Method)
+	}
+	if f.Action.HTTP.Path != "/user" {
+		t.Errorf("path=%q want /user", f.Action.HTTP.Path)
+	}
+	want := Match{Verdict: "allow", Rule: "github-reads", Endpoint: "github"}
+	if f.Match != want {
+		t.Errorf("match=%+v want %+v", f.Match, want)
+	}
+}
+
+// Events recorded before the Endpoint column was populated have
+// no endpoint to find; the exporter must 400 with a clear reason.
+func TestExporterRejectsEmptyEndpoint(t *testing.T) {
+	w := &webMux{g: gatewayWithPolicy(t, fixtureHCL)}
+	ev := &Event{ID: "evt-2", Action: "allow"} // Endpoint == ""
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+
+	if rw.Code != 400 {
+		t.Fatalf("status=%d want 400; body=%s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "predates endpoint tracking") {
+		t.Errorf("body=%q want explanatory error", rw.Body.String())
+	}
+}
+
+// match.endpoint is always emitted (the exporter knows it at
+// write time); the runner can rely on it for shared-host dispatch.
+func TestExporterAlwaysEmitsEndpoint(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "bearer_token" "a" {}
+credential "bearer_token" "b" {}
+endpoint "https" "alpha" {
+  hosts      = ["api.example.com"]
+  credential = a
+}
+endpoint "https" "beta" {
+  hosts      = ["api.example.com"]
+  credential = b
+}
+profile "default" { endpoints = [alpha, beta] }
+`
+	w := &webMux{g: gatewayWithPolicy(t, hcl)}
+	ev := &Event{
+		ID: "evt-3", Mode: "mitm", Family: "https",
+		Host: "api.example.com", Method: "GET", Path: "/x",
+		Action: "allow", Endpoint: "beta", Rule: "",
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatal(err)
+	}
+	if f.Match.Endpoint != "beta" {
+		t.Errorf("expected match.endpoint=beta, got %q", f.Match.Endpoint)
+	}
+}
+
+// hitl_allow / hitl_deny collapse to "approve" in the fixture
+// (the chain is terminal — see doc/test.md). in_flight is a start
+// event and isn't exportable.
+func TestExporterEventActionMapping(t *testing.T) {
+	for _, action := range []string{"hitl_allow", "hitl_deny"} {
+		m, ok := matchFromEvent(&Event{Action: action, Rule: "r", Endpoint: "ep"})
+		if !ok || m.Verdict != "approve" {
+			t.Errorf("%s → (%+v, %v), want approve", action, m, ok)
+		}
+	}
+	if _, ok := matchFromEvent(&Event{Action: "in_flight"}); ok {
+		t.Error("in_flight should not be exportable")
+	}
+}
+
+// SQL exporter pulls the raw statement out of Event.Facets and pins
+// host to the endpoint's HCL-declared address (not Event.Host, which
+// is the dst IP). 400 when the recorded event has no statement.
+func TestExporterSQLHappyPath(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "postgres_credential" "pg-cred" { user = "agent" }
+endpoint "postgres" "pg" {
+  host       = "pg.internal:5432"
+  database   = "postgres"
+  credential = pg-cred
+}
+profile "default" { endpoints = [pg] }
+`
+	w := &webMux{g: gatewayWithPolicy(t, hcl)}
+	ev := &Event{
+		ID: "evt-sql-1", Mode: "pg", Family: "sql",
+		Host: "10.0.0.5", Action: "allow", Endpoint: "pg",
+		Rule:   "pg-reads",
+		Facets: map[string]any{"statement": "SELECT 1"},
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatalf("reparse: %v\nbody=%s", err, rw.Body.String())
+	}
+	if f.Action.SQL == nil || f.Action.SQL.Statement != "SELECT 1" {
+		t.Errorf("sql=%+v want statement=SELECT 1", f.Action.SQL)
+	}
+	if f.Action.Host != "pg.internal:5432" {
+		t.Errorf("host=%q want pg.internal:5432 (HCL host, not Event.Host)", f.Action.Host)
+	}
+}
+
+func TestExporterSQLRejectsMissingStatement(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "postgres_credential" "pg-cred" { user = "agent" }
+endpoint "postgres" "pg" {
+  host       = "pg.internal:5432"
+  database   = "postgres"
+  credential = pg-cred
+}
+profile "default" { endpoints = [pg] }
+`
+	w := &webMux{g: gatewayWithPolicy(t, hcl)}
+	ev := &Event{ID: "evt-sql-2", Action: "allow", Endpoint: "pg"}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 400 {
+		t.Fatalf("status=%d want 400; body=%s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "no statement recorded") {
+		t.Errorf("body=%q want explanatory error", rw.Body.String())
+	}
+}
+
+// k8s exporter reads verb/resource/namespace/name/params from
+// Event.Facets — the same shape the live k8s facet's Report emits.
+// Params is map[string]any in JSON; the exporter flattens it to
+// map[string]string.
+func TestExporterK8sHappyPath(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "mtls_credential" "kube-mtls" {}
+endpoint "kubernetes" "kube" {
+  server     = "10.0.0.7"
+  hosts      = ["10.0.0.7"]
+  credential = kube-mtls
+}
+profile "default" { endpoints = [kube] }
+`
+	w := &webMux{g: gatewayWithPolicy(t, hcl)}
+	ev := &Event{
+		ID: "evt-k8s-1", Mode: "mitm", Family: "k8s",
+		Host: "10.0.0.7", Action: "deny", Endpoint: "kube",
+		Rule: "k8s-no-secrets",
+		Facets: map[string]any{
+			"verb": "get", "resource": "secrets",
+			"namespace": "default", "name": "mysecret",
+			"params": map[string]any{"watch": "true"},
+		},
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatalf("reparse: %v\nbody=%s", err, rw.Body.String())
+	}
+	if f.Action.K8s == nil {
+		t.Fatal("expected k8s block")
+	}
+	got := *f.Action.K8s
+	want := K8sAction{
+		Verb: "get", Resource: "secrets",
+		Namespace: "default", Name: "mysecret",
+		Params: map[string]string{"watch": "true"},
+	}
+	if got.Verb != want.Verb || got.Resource != want.Resource ||
+		got.Namespace != want.Namespace || got.Name != want.Name {
+		t.Errorf("k8s=%+v want %+v", got, want)
+	}
+	if got.Params["watch"] != "true" {
+		t.Errorf("params=%v want flattened watch=true", got.Params)
+	}
+	if f.Match.Verdict != "deny" {
+		t.Errorf("verdict=%q want deny", f.Match.Verdict)
+	}
+}
+
+// End-to-end contract between exporter and runner: an Event written
+// by the dispatch path → exporter JSON → runOneFixture → the same
+// match the exporter recorded. Catches contract drift between the
+// two halves of the feature.
+func TestExporterRunnerRoundTrip(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "bearer_token" "tok" {}
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = tok
+}
+rule "reads" {
+  endpoint  = github
+  condition = "http.method == 'GET'"
+  verdict   = "allow"
+}
+profile "default" { endpoints = [github] }
+`
+	gw := gatewayWithPolicy(t, hcl)
+	w := &webMux{g: gw}
+	ev := &Event{
+		ID: "evt-rt", Mode: "mitm", Family: "https",
+		Host: "api.github.com", Method: "GET", Path: "/user",
+		AgentIP: "100.64.0.7", Action: "allow",
+		Endpoint: "github", Rule: "reads",
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("export status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	tmp := filepath.Join(t.TempDir(), "rt.json")
+	if err := os.WriteFile(tmp, rw.Body.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, msg, err := runOneFixture(gw.Policy(), tmp)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !ok {
+		t.Fatalf("round-trip mismatch:\n%s", msg)
+	}
+}
+
+// passthrough fixtures parse fine but the runner rejects them at
+// replay (doc/test.md). Lock in both halves so a future change has
+// to pick one side intentionally.
+func TestRunnerRejectsPassthrough(t *testing.T) {
+	gw := gatewayWithPolicy(t, fixtureHCL)
+	body := `{"match":{"verdict":"passthrough","endpoint":"github"},` +
+		`"action":{"host":"api.github.com","http":{"method":"GET","path":"/x"}}}`
+	tmp := filepath.Join(t.TempDir(), "pt.json")
+	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, _, err := runOneFixture(gw.Policy(), tmp)
+	if ok {
+		t.Fatal("expected runner to reject passthrough fixture")
+	}
+	if err == nil || !strings.Contains(err.Error(), "passthrough") {
+		t.Fatalf("err=%v, want passthrough rejection", err)
+	}
+}

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from "react";
-import { getAction, type Agent, type EventRecord, type FacetSchema } from "../lib/api";
+import {
+  getAction,
+  downloadActionFixture,
+  type Agent,
+  type EventRecord,
+  type FacetSchema,
+} from "../lib/api";
 import { formatFacetValue, useFacets } from "../lib/facets";
 import { fmtDateTime } from "../lib/format";
 
@@ -84,11 +90,16 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
           <span className="text-[13px] text-[#171717] break-all font-mono" title={fullUrl}>
             {fullUrl}
           </span>
+          <span className="ml-auto">
+            <DownloadActionButton ev={ev} />
+          </span>
         </div>
         <div className="flex items-center gap-4 text-[11px] text-[#737373] flex-wrap">
           <span>{time}</span>
           <span>{ev.ms}ms</span>
           {ev.agent_ip && <span>{ev.agent_ip}</span>}
+          {ev.in != null && ev.in > 0 && <span>in: {fmtBytes(ev.in)}</span>}
+          {ev.out != null && ev.out > 0 && <span>out: {fmtBytes(ev.out)}</span>}
         </div>
         {(ev.action || ev.reason) && (
           <div className="flex items-center gap-2 text-[11px]">
@@ -146,23 +157,53 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
           {ev.mode === "splice" && " (spliced connection)"}
         </div>
       )}
-
-      {/* footer */}
-      <div className="flex items-center gap-6 text-[10px] text-[#a3a3a3] flex-wrap">
-        {ev.in != null && ev.in > 0 && <span>in: {fmtBytes(ev.in)}</span>}
-        {ev.out != null && ev.out > 0 && <span>out: {fmtBytes(ev.out)}</span>}
-        {ev.req_sha && (
-          <span className="font-mono" title={ev.req_sha}>
-            req_sha: {ev.req_sha.slice(0, 12)}
-          </span>
-        )}
-        {ev.resp_sha && (
-          <span className="font-mono" title={ev.resp_sha}>
-            resp_sha: {ev.resp_sha.slice(0, 12)}
-          </span>
-        )}
-      </div>
     </Shell>
+  );
+}
+
+// DownloadActionButton triggers a server-side reshape of this event
+// into a `clawpatrol test` fixture and saves it as a .json file. The
+// runner reads files in this exact format — drop the download into a
+// fixtures/ directory and `clawpatrol test config.hcl fixtures/` will
+// replay it against a candidate policy. See doc/test.md §5.
+function DownloadActionButton({ ev }: { ev: EventRecord }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  if (!ev.id) return null;
+  if (!ev.endpoint) return null;
+  if (ev.action === "in_flight") return null;
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={async () => {
+        setBusy(true);
+        setErr(null);
+        try {
+          const blob = await downloadActionFixture(ev.id!);
+          const href = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = href;
+          a.download = `${ev.id}.json`;
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(href);
+        } catch (e) {
+          setErr((e as Error).message || "download failed");
+        } finally {
+          setBusy(false);
+        }
+      }}
+      className={
+        "text-[10px] uppercase tracking-wide px-2 py-1 rounded border " +
+        "border-[#e5e5e5] text-[#525252] hover:text-[#171717] hover:border-[#a3a3a3] " +
+        "disabled:opacity-50"
+      }
+      title={err ?? "Download as a clawpatrol test fixture"}
+    >
+      {busy ? "Downloading…" : "Download action"}
+    </button>
   );
 }
 

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -469,7 +469,20 @@ export type EventRecord = {
   // method/path/status; SQL: verb/tables/...; k8s: verb/resource/...).
   family?: string;
   facets?: Record<string, unknown>;
+  // endpoint/rule are populated at dispatch time; needed by the
+  // Download action button (doc/test.md §5).
+  endpoint?: string;
+  rule?: string;
 };
+
+// downloadActionFixture fetches the action reshaped as a
+// `clawpatrol test` fixture. Returns a Blob so the caller can
+// trigger a browser download.
+export async function downloadActionFixture(id: string): Promise<Blob> {
+  const r = await api(`/api/actions/${id}?fmt=fixture`);
+  if (!r.ok) throw new Error(await r.text());
+  return r.blob();
+}
 
 // FacetSchema mirrors the JSON returned by GET /api/facets — the
 // dashboard fetches it once at boot and uses it to render


### PR DESCRIPTION
## Summary

`clawpatrol test <config> <fixtures>` — a CLI that replays recorded gateway actions against a candidate HCL policy and reports verdict drift. Companion to the existing `clawpatrol validate`. Dashboard "Download action" button + `?fmt=fixture` exporter generates fixtures from live traffic; `runtime.SQLParser` interface lets SQL fixtures carry just a raw statement.

This is a re-open of #235, which was accidentally merged into `rename-https-facet-to-http` (a stacking helper for #275) instead of `main`. Same content, same single squashed commit, but now targeting `main` directly. The bad merge into `rename-https-facet-to-http` is harmless — that branch is moribund — but `main` doesn't have this work yet.

## Fixture format

Two top-level keys: `match` (assertion) and `action` (recorded request). Facet block named after `Facet.Name()` (`http` / `k8s` / `sql`) holds only that facet's CEL vocabulary. See `doc/test.md` for the full spec.

```json
{
  "match":  { "verdict": "allow", "rule": "...", "endpoint": "..." },
  "action": {
    "host":  "api.github.com",
    "http":  { "method": "POST", "path": "/...", "headers": {...}, "body": "..." }
  }
}
```

## What's in here

- `clawpatrol test` subcommand (test.go) + fixture format (action_file.go).
- Event extension: `Endpoint` + `Rule` plumbed through all three dispatch sites (HTTPS mitm, postgres, clickhouse_native). Migration 0009 adds the columns.
- `runtime.SQLParser` interface — Postgres + ClickHouse runtimes implement it via their existing parsers.
- Dashboard exporter (`/api/actions/<id>?fmt=fixture`) + "Download action" button on the request detail page.
- testdata/example.hcl + 2 sample fixtures + AGENTS.md note on scope.
- Unit + integration tests + an exporter test suite via httptest.

## Validation

End-to-end loop with [prod.example.com/tests/](https://github.com/example/prod-deploy/tree/main/tests) — 36 fixtures covering every rule in `gateway.hcl`. `./clawpatrol test gateway.hcl tests/` reports `36 actions checked, 0 mismatches`.

## Test plan

- [ ] `go test ./...` green
- [ ] `gofmt -l .` empty
- [ ] `cd www && npx oxfmt --check ...` clean
- [ ] `clawpatrol test testdata/example.hcl testdata/` returns `2 actions checked, 0 mismatches`
- [ ] Mutate `testdata/example.hcl` and confirm the runner reports drift
- [ ] Click "Download action" on the dashboard, drop into a fixtures/ dir, `clawpatrol test` against the live config returns 0 mismatches
