### PR TITLE
Renumber gateway-state migration 0008 → 0010

### DIFF
--- a/migrations/sqlite/0010_gateway_state.sql
+++ b/migrations/sqlite/0010_gateway_state.sql
@@ -1,4 +1,4 @@
--- 0008_gateway_state — collapse on-disk gateway state into sqlite.
+-- 0010_gateway_state — collapse on-disk gateway state into sqlite.
 --
 -- Before this migration the gateway scattered state across the
 -- filesystem alongside its sqlite db:
@@ -66,4 +66,4 @@ CREATE TABLE dnsvip_allocations (
   v6        TEXT NOT NULL UNIQUE
 );
 
-INSERT INTO _schema (version) VALUES (8);
+INSERT INTO _schema (version) VALUES (10);

--- a/state_import.go
+++ b/state_import.go
@@ -1,6 +1,6 @@
 package main
 
-// Legacy-state import. Before 0008_gateway_state, the gateway
+// Legacy-state import. Before 0010_gateway_state, the gateway
 // scattered six small pieces of state across the filesystem next to
 // its sqlite db (CA cert+key, WG server key, per-endpoint SSH host
 // keys, codex JWT keys, telemetry instance id, dnsvip allocations).


### PR DESCRIPTION
* `0008_gateway_state.sql` was added in #222 but main had already
  shipped `0008_ephemeral_peers.sql` and
  `0009_action_endpoint_rule.sql`. On any DB with
  `_schema.version >= 8` the new migration silently no-ops
  (`n <= current → skip` in `db.go`), so the tables it needs —
  `ca_material`, `wg_server_key`, `telemetry_state`,
  `gateway_blobs`, `dnsvip_allocations` — never get created.
  `state_import.go` then crashes the gateway on every boot with
  `no such table: ca_material`.

* Rename the file to `0010_*` and bump the embedded
  `INSERT INTO _schema` row to match. Fresh DBs are unaffected
  (they apply 0010 alongside the rest); existing DBs that landed
  at version 9 now see `n=10 > current=9` and run the migration.

This is what's currently keeping `prod.example.com` up — the
binary running there was built from this branch and patched in by
hand. CI deploy will pick it up via the usual flow once this lands.