### PR TITLE
gateway: fix --read-only-config position in help text

### DIFF
--- a/main.go
+++ b/main.go
@@ -2207,7 +2207,7 @@ Documentation: https://clawpatrol.dev/docs/`)
 // gatewayHelp is shown for `clawpatrol gateway -h` and any wrong
 // invocation. The pointer to `gateway init` + the config-reference
 // URL is the discoverability path for first-time users.
-const gatewayHelp = `usage: clawpatrol gateway <config.hcl> [--read-only-config]
+const gatewayHelp = `usage: clawpatrol gateway [--read-only-config] <config.hcl>
 
 The gateway needs an HCL policy file. To create one, run:
   clawpatrol gateway init


### PR DESCRIPTION
* The flag has to come before the positional config path, since
  Go's std \`flag.Parse\` stops at the first non-flag argument.
* The current docs showed it in the documented-but-broken order,
  which is how the production unit file on
  \`prod.example.com\` ended up landing the broken form and
  failing to start.