### PR TITLE
fix: support GitHub smart HTTP credentials

### DIFF
--- a/config/plugins/credentials/github.go
+++ b/config/plugins/credentials/github.go
@@ -5,7 +5,9 @@ package credentials
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
+	"strings"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/runtime"
@@ -19,8 +21,48 @@ func (g *GitHubOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runti
 	if len(sec.Bytes) == 0 {
 		return nil
 	}
+	if isGitHubSmartHTTP(req) {
+		username := githubBasicUsername(req.Header.Get("Authorization"))
+		if username == "" {
+			username = "x-access-token"
+		}
+		token := base64.StdEncoding.EncodeToString([]byte(username + ":" + string(sec.Bytes)))
+		req.Header.Set("Authorization", "Basic "+token)
+		return nil
+	}
 	req.Header.Set("Authorization", "Bearer "+string(sec.Bytes))
 	return nil
+}
+
+func isGitHubSmartHTTP(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if !strings.EqualFold(req.URL.Hostname(), "github.com") {
+		return false
+	}
+	path := req.URL.EscapedPath()
+	if strings.HasSuffix(path, ".git/info/refs") {
+		svc := req.URL.Query().Get("service")
+		return svc == "git-upload-pack" || svc == "git-receive-pack"
+	}
+	return strings.HasSuffix(path, ".git/git-upload-pack") || strings.HasSuffix(path, ".git/git-receive-pack")
+}
+
+func githubBasicUsername(authz string) string {
+	scheme, payload, ok := strings.Cut(authz, " ")
+	if !ok || !strings.EqualFold(scheme, "Basic") {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(payload))
+	if err != nil {
+		return ""
+	}
+	username, _, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return ""
+	}
+	return username
 }
 
 // EnvVars is part of the clawpatrol plugin API.

--- a/config/plugins/credentials/github_test.go
+++ b/config/plugins/credentials/github_test.go
@@ -1,0 +1,97 @@
+package credentials
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestGitHubOAuthInjectHTTPUsesBearerForAPIRequests(t *testing.T) {
+	plugin := &GitHubOAuth{}
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/denoland/deployng", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err := plugin.InjectHTTP(req.Context(), req, runtime.Secret{Bytes: []byte("real.github.token")}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer real.github.token" {
+		t.Fatalf("Authorization = %q, want Bearer real.github.token", got)
+	}
+}
+
+func TestGitHubOAuthInjectHTTPUsesBasicForSmartHTTPGit(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "upload-pack advertisement",
+			url:  "https://github.com/denoland/deployng.git/info/refs?service=git-upload-pack",
+		},
+		{
+			name: "receive-pack advertisement",
+			url:  "https://github.com/denoland/deployng.git/info/refs?service=git-receive-pack",
+		},
+		{
+			name: "upload-pack RPC",
+			url:  "https://github.com/denoland/deployng.git/git-upload-pack",
+		},
+		{
+			name: "receive-pack RPC",
+			url:  "https://github.com/denoland/deployng.git/git-receive-pack",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &GitHubOAuth{}
+			req, err := http.NewRequest("GET", tt.url, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			placeholder := base64.StdEncoding.EncodeToString([]byte("avocet-bot:" + phGitHub))
+			req.Header.Set("Authorization", "Basic "+placeholder)
+
+			if err := plugin.InjectHTTP(req.Context(), req, runtime.Secret{Bytes: []byte("real.github.token")}); err != nil {
+				t.Fatalf("inject: %v", err)
+			}
+			got := req.Header.Get("Authorization")
+			if !strings.HasPrefix(got, "Basic ") {
+				t.Fatalf("Authorization = %q, want Basic auth", got)
+			}
+			decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(got, "Basic "))
+			if err != nil {
+				t.Fatalf("decode Basic auth: %v", err)
+			}
+			if string(decoded) != "avocet-bot:real.github.token" {
+				t.Fatalf("decoded Basic auth = %q, want avocet-bot:real.github.token", decoded)
+			}
+		})
+	}
+}
+
+func TestGitHubOAuthInjectHTTPUsesFallbackUsernameForSmartHTTPGit(t *testing.T) {
+	plugin := &GitHubOAuth{}
+	req, err := http.NewRequest("GET", "https://github.com/denoland/deployng.git/info/refs?service=git-upload-pack", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err := plugin.InjectHTTP(req.Context(), req, runtime.Secret{Bytes: []byte("real.github.token")}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	got := req.Header.Get("Authorization")
+	if !strings.HasPrefix(got, "Basic ") {
+		t.Fatalf("Authorization = %q, want Basic auth", got)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(got, "Basic "))
+	if err != nil {
+		t.Fatalf("decode Basic auth: %v", err)
+	}
+	if string(decoded) != "x-access-token:real.github.token" {
+		t.Fatalf("decoded Basic auth = %q, want x-access-token:real.github.token", decoded)
+	}
+}

--- a/config/plugins/endpoints/https.go
+++ b/config/plugins/endpoints/https.go
@@ -6,6 +6,7 @@ package endpoints
 // metadata HTTPS doesn't.
 
 import (
+	"encoding/base64"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -42,9 +43,9 @@ func (e *HTTPSEndpoint) setCredentialEntries(es []CredentialEntry) { e.Credentia
 // HTTPSEndpointRuntime detects placeholders in an HTTP request's
 // Authorization header. Plain-substring scan rather than strict
 // equality because agents send placeholders embedded in
-// `Bearer <PH>` or `Basic <base64(<PH>:)>` shapes; we only need to
+// `Bearer <PH>` or `Basic <base64(user:<PH>)>` shapes; we only need to
 // recognize that the agent picked one of our placeholders, not parse
-// the auth scheme.
+// the auth scheme beyond safe Basic decoding.
 type HTTPSEndpointRuntime struct{}
 
 // DetectPlaceholder is part of the clawpatrol plugin API.
@@ -52,13 +53,27 @@ func (HTTPSEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidates [
 	if req == nil || req.Headers == nil {
 		return ""
 	}
-	hay := req.Headers.Get("Authorization") + "\x00" + req.Headers.Get("Cookie")
+	hay := req.Headers.Get("Authorization") +
+		"\x00" + basicAuthPayload(req.Headers.Get("Authorization")) +
+		"\x00" + req.Headers.Get("Cookie")
 	for _, c := range candidates {
 		if c != "" && strings.Contains(hay, c) {
 			return c
 		}
 	}
 	return ""
+}
+
+func basicAuthPayload(authz string) string {
+	scheme, payload, ok := strings.Cut(authz, " ")
+	if !ok || !strings.EqualFold(scheme, "Basic") {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(payload))
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
 }
 
 func init() {

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"encoding/base64"
 	"net/http"
 	"testing"
 
@@ -262,6 +263,11 @@ profile "default" { endpoints = [ep] }
 	got := runtime.ResolveCredential(ep, mkReq("Bearer PH_prod"))
 	if got == nil || got.Credential.Symbol.Name != "prod" {
 		t.Errorf("Authorization=Bearer PH_prod should select prod, got %+v", got)
+	}
+	basicPlaceholder := base64.StdEncoding.EncodeToString([]byte("git-user:PH_test"))
+	got = runtime.ResolveCredential(ep, mkReq("Basic "+basicPlaceholder))
+	if got == nil || got.Credential.Symbol.Name != "test" {
+		t.Errorf("Authorization=Basic base64(git-user:PH_test) should select test, got %+v", got)
 	}
 	got = runtime.ResolveCredential(ep, mkReq("Bearer something-else"))
 	if got == nil || got.Credential.Symbol.Name != "fallback" {


### PR DESCRIPTION
## Summary
- make `github_oauth` inject Basic `username:token` auth for GitHub smart-HTTP Git endpoints on `github.com`
- keep Bearer injection for GitHub API/raw HTTP requests
- decode Basic auth during HTTPS placeholder detection so multi-credential endpoints can select placeholders embedded as `base64(user:placeholder)`

## Test Plan
- `npm ci` and `npm run build` in `www/`
- `go test ./config/plugins/credentials ./config/plugins/endpoints ./config/runtime -count=1`
- `go test ./...`
- `go run . validate /home/exedev/ghq/github.com/example/prod-deploy-worktrees/github-host-endpoint/gateway.hcl`
