### PR TITLE
audit: decode br/deflate/zstd response bodies for action samples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/AfterShip/clickhouse-sql-parser v0.5.1
 	github.com/ClickHouse/ch-go v0.71.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
+	github.com/andybalholm/brotli v1.2.0
 	github.com/google/cel-go v0.28.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/klauspost/compress v1.18.3
 	github.com/miekg/dns v1.1.72
 	github.com/refraction-networking/utls v1.8.2
 	github.com/zclconf/go-cty v1.16.3
@@ -37,7 +39,6 @@ require (
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
-	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.0 // indirect
@@ -73,7 +74,6 @@ require (
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"strings"
 	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 )
 
 func gzipped(t *testing.T, s string) []byte {
@@ -20,6 +25,64 @@ func gzipped(t *testing.T, s string) []byte {
 	return buf.Bytes()
 }
 
+func brotlied(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	if _, err := bw.Write([]byte(s)); err != nil {
+		t.Fatalf("brotli write: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("brotli close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zlibbed(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write([]byte(s)); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func rawDeflated(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	if err != nil {
+		t.Fatalf("flate writer: %v", err)
+	}
+	if _, err := fw.Write([]byte(s)); err != nil {
+		t.Fatalf("flate write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("flate close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zstdded(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("zstd writer: %v", err)
+	}
+	if _, err := zw.Write([]byte(s)); err != nil {
+		t.Fatalf("zstd write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zstd close: %v", err)
+	}
+	return buf.Bytes()
+}
+
 func TestSamplerSampleGzip(t *testing.T) {
 	want := `{"hello":"world","arr":[1,2,3]}`
 	s := newSampler(4096)
@@ -27,6 +90,48 @@ func TestSamplerSampleGzip(t *testing.T) {
 	got := s.sample("gzip")
 	if got != want {
 		t.Fatalf("gzip sample\n  want %q\n   got %q", want, got)
+	}
+}
+
+func TestSamplerSampleBrotli(t *testing.T) {
+	want := `{"hello":"world","arr":[1,2,3]}`
+	s := newSampler(4096)
+	_, _ = s.Write(brotlied(t, want))
+	got := s.sample("br")
+	if got != want {
+		t.Fatalf("br sample\n  want %q\n   got %q", want, got)
+	}
+}
+
+func TestSamplerSampleDeflateZlib(t *testing.T) {
+	want := `{"hello":"world"}`
+	s := newSampler(4096)
+	_, _ = s.Write(zlibbed(t, want))
+	got := s.sample("deflate")
+	if got != want {
+		t.Fatalf("zlib-deflate sample\n  want %q\n   got %q", want, got)
+	}
+}
+
+func TestSamplerSampleDeflateRaw(t *testing.T) {
+	// Some servers send raw deflate under "Content-Encoding: deflate"
+	// despite the RFC requiring zlib framing.
+	want := `{"hello":"world"}`
+	s := newSampler(4096)
+	_, _ = s.Write(rawDeflated(t, want))
+	got := s.sample("deflate")
+	if got != want {
+		t.Fatalf("raw-deflate sample\n  want %q\n   got %q", want, got)
+	}
+}
+
+func TestSamplerSampleZstd(t *testing.T) {
+	want := `{"hello":"world","arr":[1,2,3]}`
+	s := newSampler(4096)
+	_, _ = s.Write(zstdded(t, want))
+	got := s.sample("zstd")
+	if got != want {
+		t.Fatalf("zstd sample\n  want %q\n   got %q", want, got)
 	}
 }
 
@@ -48,12 +153,11 @@ func TestSamplerSampleBinaryFallback(t *testing.T) {
 	}
 }
 
-func TestSamplerSampleNonGzipEncodingIgnored(t *testing.T) {
-	// br/deflate aren't decoded yet; falling through to printable
-	// check on the raw bytes is the documented behaviour.
+func TestSamplerSampleUnknownEncodingIgnored(t *testing.T) {
+	// Unknown encoding falls through to the printable check on raw bytes.
 	s := newSampler(4096)
-	_, _ = s.Write([]byte{0x1f, 0x8b, 0x08, 0x00}) // gzip-magic but unknown encoding
-	got := s.sample("br")
+	_, _ = s.Write([]byte{0x1f, 0x8b, 0x08, 0x00})
+	got := s.sample("compress")
 	if !strings.HasPrefix(got, "binary:") {
 		t.Fatalf("expected binary: for unknown encoding, got %q", got)
 	}

--- a/web.go
+++ b/web.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -29,7 +31,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/andybalholm/brotli"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/facet"
@@ -2217,11 +2221,10 @@ func (s *sampler) sha() string {
 }
 
 // sample returns the audit-log preview of the captured body. When
-// encoding names a compression we know how to decode (currently only
-// gzip — the encoding most agents request via Accept-Encoding and
-// most upstreams reply with), the buffered prefix is decompressed
-// first so a JSON response doesn't get rendered as "binary:<hex>"
-// just because it's still on the wire as gzip.
+// encoding names a compression we know how to decode (gzip, br,
+// deflate, zstd), the buffered prefix is decompressed first so a
+// JSON response doesn't get rendered as "binary:<hex>" just because
+// it's still on the wire compressed.
 func (s *sampler) sample(encoding string) string {
 	if s.buf.Len() == 0 {
 		return ""
@@ -2234,21 +2237,46 @@ func (s *sampler) sample(encoding string) string {
 	return "binary:" + hex.EncodeToString(raw[:min(64, len(raw))])
 }
 
-// maybeDecode returns the decompressed prefix of buf when encoding is
-// gzip, or buf unchanged otherwise. The sampler captures at most cap
-// bytes, so the gzip stream is almost always truncated mid-block —
-// io.ReadAll returns whatever the reader managed before hitting
-// io.ErrUnexpectedEOF, which is exactly what we want for a preview.
+// maybeDecode returns the decompressed prefix of buf when encoding
+// is a compression scheme we recognise, or buf unchanged otherwise.
+// The sampler captures at most cap bytes, so the stream is almost
+// always truncated mid-block — io.ReadAll returns whatever the
+// reader managed before hitting EOF, which is what we want for a
+// preview.
 func maybeDecode(buf []byte, encoding string) []byte {
-	if !strings.EqualFold(strings.TrimSpace(encoding), "gzip") {
+	var r io.Reader
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "gzip", "x-gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(buf))
+		if err != nil {
+			return buf
+		}
+		defer func() { _ = zr.Close() }()
+		r = zr
+	case "br":
+		r = brotli.NewReader(bytes.NewReader(buf))
+	case "deflate":
+		// RFC 7230 says "deflate" is zlib-wrapped deflate, but some
+		// servers send raw deflate. Try zlib first, fall back to raw.
+		if zr, err := zlib.NewReader(bytes.NewReader(buf)); err == nil {
+			defer func() { _ = zr.Close() }()
+			r = zr
+		} else {
+			fr := flate.NewReader(bytes.NewReader(buf))
+			defer func() { _ = fr.Close() }()
+			r = fr
+		}
+	case "zstd":
+		zd, err := zstd.NewReader(bytes.NewReader(buf))
+		if err != nil {
+			return buf
+		}
+		defer zd.Close()
+		r = zd
+	default:
 		return buf
 	}
-	zr, err := gzip.NewReader(bytes.NewReader(buf))
-	if err != nil {
-		return buf
-	}
-	defer func() { _ = zr.Close() }()
-	out, _ := io.ReadAll(zr)
+	out, _ := io.ReadAll(r)
 	if len(out) == 0 {
 		return buf
 	}


### PR DESCRIPTION
The action sampler only knew how to decompress gzip, so responses
served with `Content-Encoding: br` / `deflate` / `zstd` were
rendered in the dashboard as `binary:<hex>` even when the
underlying payload was JSON (e.g. Slack's `auth.test` response,
which is brotli-encoded).

* Extend `maybeDecode` with `br` (`andybalholm/brotli`), `deflate`
  (zlib with raw-`flate` fallback, since some servers send raw
  deflate despite RFC 7230 specifying zlib framing), and `zstd`
  (`klauspost/compress/zstd`).
* Promote `brotli` and `klauspost/compress` from indirect to
  direct deps — both were already pulled in transitively, so
  `go.sum` is unchanged.
* Cover each encoding in `sampler_test.go`, plus a raw-deflate
  path and an unknown-encoding fallback.