### PR TITLE
docs(site): strip YAML frontmatter; render skill page properly

### DIFF
--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -1,5 +1,6 @@
 ---
 name: claw-patrol
+title: Operating Claw Patrol
 description: Set up and operate Claw Patrol, a firewall for AI agents. Write the gateway HCL config (credentials, endpoints, rules, approvers, profiles), run the gateway, onboard devices, wrap agent commands with `clawpatrol run`. Use when the user wants to install or operate Claw Patrol, write or modify a `gateway.hcl` policy, add allow / deny / approve rules over HTTPS / Postgres / Kubernetes / ClickHouse / SSH traffic, gate agent actions behind a human or an LLM judge, or debug Claw Patrol behavior.
 ---
 

--- a/site/docs-render.ts
+++ b/site/docs-render.ts
@@ -208,17 +208,40 @@ export interface Doc {
   description: string;
 }
 
+// Strip a leading `---\n...\n---\n` YAML frontmatter block off a
+// markdown source. Only the simple SKILL.md shape is supported:
+// `key: value` lines, one per key, no nested structures. That's the
+// shape Anthropic's Agent Skills spec mandates, which is all we need
+// here — pulling in a real YAML parser for two fields would be
+// overkill.
+function parseFrontmatter(
+  raw: string,
+): { meta: Record<string, string>; body: string } {
+  if (!raw.startsWith("---\n")) return { meta: {}, body: raw };
+  const end = raw.indexOf("\n---\n", 4);
+  if (end < 0) return { meta: {}, body: raw };
+  const block = raw.slice(4, end);
+  const body = raw.slice(end + 5);
+  const meta: Record<string, string> = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^([a-zA-Z_][\w-]*):\s*(.+)$/);
+    if (m) meta[m[1]] = m[2].trim();
+  }
+  return { meta, body };
+}
+
 export function loadDocs(docsDir: string): Doc[] {
   const toc = JSON.parse(
     readFileSync(join(docsDir, "toc.json"), "utf-8"),
   ) as string[];
   return toc.map((slug) => {
     const raw = readFileSync(join(docsDir, `${slug}.md`), "utf-8");
-    const h1 = raw.match(/^#\s+(.+)$/m);
-    const title = h1 ? h1[1] : slug.replace(/-/g, " ");
-    const html = marked.parse(raw, { async: false }) as string;
-    const description = extractDescription(
-      raw,
+    const { meta, body } = parseFrontmatter(raw);
+    const h1 = body.match(/^#\s+(.+)$/m);
+    const title = meta.title ?? (h1 ? h1[1] : slug.replace(/-/g, " "));
+    const html = marked.parse(body, { async: false }) as string;
+    const description = meta.description ?? extractDescription(
+      body,
       `${title} — Claw Patrol documentation.`,
     );
     return { slug, title, html, raw, description };


### PR DESCRIPTION
## Summary

Three rendering problems on `clawpatrol.dev/docs/skill/`:

1. The YAML frontmatter (`name`, `description`) was rendering as body text — a wall of unformatted output above the actual H1.
2. The sidebar entry said `Claw Patrol`, which collides with the product name. Users naturally thought it was the home page.
3. Same root cause as 2 — no way to give any doc a sidebar title distinct from its H1.

## Fix

In `site/docs-render.ts`:

- New `parseFrontmatter()` peels a leading `---\n...\n---\n` block off the markdown source before handing the body to `marked`. Simple line-based parser; the Anthropic Skills spec mandates `key: value` only.
- `loadDocs()` now uses `meta.title` for the sidebar entry when present (else falls back to H1 extraction) and `meta.description` for the page's `<meta description>` (else falls back to extracting the first paragraph).

In `site/doc/skill.md`:

- Added `title: Operating Claw Patrol` to the frontmatter. Sidebar now shows "Operating Claw Patrol" (gerund per [Anthropic's skill-naming guidance](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#naming-conventions)); the page H1 stays "Claw Patrol".

## Smoke test

```
$ npx tsx -e 'import { loadDocs } from "./docs-render"; const docs = loadDocs("./doc"); for (const d of docs) console.log(d.slug.padEnd(20), "->", d.title);'
introduction         -> Introduction
getting-started      -> Getting Started
skill                -> Operating Claw Patrol
glossary             -> Glossary
architecture         -> Architecture
cli                  -> CLI Reference
clawpatrol-test      -> `clawpatrol test`
security-model       -> Security model
approval-rules       -> Approval rules
config-reference     -> HCL config reference
competitors          -> Competitor Analysis
```

Rendered HTML for the skill page now opens at `<h1 id="claw-patrol">Claw Patrol</h1><p>A firewall for AI agents...` — frontmatter cleanly stripped. Other docs (no frontmatter) parse unchanged.

## Test plan

- [ ] Visual review on clawpatrol.dev/docs/skill/ after merge.
- [ ] Confirm sidebar entry reads "Operating Claw Patrol" and is distinct from any other entry.
- [ ] Confirm the page starts with the H1, not the frontmatter dump.
- [ ] Spot-check another doc (e.g. `/docs/introduction/`) for regression.
