### PR TITLE
gateway: serve /ca.crt from in-memory CertCache, not disk

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -18,11 +18,16 @@ import (
 )
 
 type CertCache struct {
-	caCert *x509.Certificate
-	caKey  *ecdsa.PrivateKey
-	mu     sync.RWMutex
-	cache  map[string]*tls.Certificate
+	caCert    *x509.Certificate
+	caKey     *ecdsa.PrivateKey
+	caCertPEM []byte
+	mu        sync.RWMutex
+	cache     map[string]*tls.Certificate
 }
+
+// CertPEM returns the PEM-encoded root certificate. Safe to share
+// publicly — it never includes the private key.
+func (c *CertCache) CertPEM() []byte { return c.caCertPEM }
 
 // loadOrMintCA returns the gateway's MITM CA, materializing it on
 // first call. If the ca_material row is absent, mints a fresh
@@ -60,7 +65,12 @@ func parseCertCache(certPEM, keyPEM []byte) (*CertCache, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &CertCache{caCert: cert, caKey: key, cache: map[string]*tls.Certificate{}}, nil
+	return &CertCache{
+		caCert:    cert,
+		caKey:     key,
+		caCertPEM: certPEM,
+		cache:     map[string]*tls.Certificate{},
+	}, nil
 }
 
 func (c *CertCache) mint(host string) (*tls.Certificate, error) {

--- a/ca_test.go
+++ b/ca_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// inMemoryCertCache mints a throwaway CA suitable for handler tests.
+// Mirrors mintAndStoreCA's shape but skips the database round-trip so
+// tests don't need a sqlite fixture.
+func inMemoryCertCache(t *testing.T) (*CertCache, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "clawpatrol test CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	kb, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: kb})
+	cc, err := parseCertCache(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("parseCertCache: %v", err)
+	}
+	return cc, certPEM
+}
+
+func TestServeCAServesInMemoryPEM(t *testing.T) {
+	cc, certPEM := inMemoryCertCache(t)
+	w := &webMux{g: &Gateway{certs: cc}}
+
+	rr := httptest.NewRecorder()
+	w.serveCA(rr, httptest.NewRequest(http.MethodGet, "/ca.crt", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %q", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/x-pem-file" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if !bytes.Equal(rr.Body.Bytes(), certPEM) {
+		t.Fatalf("body mismatch\n got: %q\nwant: %q", rr.Body.Bytes(), certPEM)
+	}
+}
+
+func TestServeCAUnavailableBeforeMint(t *testing.T) {
+	// An empty CertCache (no minted material yet) should not 200 with
+	// an empty body — clients expect to write the bytes to disk and
+	// trust them.
+	w := &webMux{g: &Gateway{certs: &CertCache{}}}
+
+	rr := httptest.NewRecorder()
+	w.serveCA(rr, httptest.NewRequest(http.MethodGet, "/ca.crt", nil))
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/web.go
+++ b/web.go
@@ -558,9 +558,15 @@ func (w *webMux) staticHandler() http.Handler {
 	return http.FileServer(http.FS(sub))
 }
 
-func (w *webMux) serveCA(rw http.ResponseWriter, r *http.Request) {
+func (w *webMux) serveCA(rw http.ResponseWriter, _ *http.Request) {
+	pemBytes := w.g.certs.CertPEM()
+	if len(pemBytes) == 0 {
+		http.Error(rw, "ca not initialized", http.StatusServiceUnavailable)
+		return
+	}
 	rw.Header().Set("Content-Type", "application/x-pem-file")
-	http.ServeFile(rw, r, w.caDir+"/ca.crt")
+	rw.Header().Set("Content-Length", strconv.Itoa(len(pemBytes)))
+	_, _ = rw.Write(pemBytes)
 }
 
 func (w *webMux) serveInfo(rw http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
* When the gateway moved its persistent state into sqlite (#222),
  the MITM root CA went with it but the `/ca.crt` handler kept
  reading from `\${ca_dir}/ca.crt` — a file that no longer exists
  on fresh deploys (and that the legacy-state importer removed on
  migrated deploys once it had copied the material into
  \`ca_material\`). Result: every new \`clawpatrol join <gateway>\`
  failed with \`ca fetch: status 404\`.
* Stash the cert PEM on \`CertCache\` at parse time and expose it
  via \`CertPEM()\`; the private key stays internal.
* \`serveCA\` writes those bytes directly with the correct content
  type. Returns 503 if the CA has not been minted yet, instead of
  the previous 200-with-empty-body or implicit 404.
* Add \`ca_test.go\` covering both the happy path and the
  uninitialized-cache case so the file-vs-memory regression can't
  re-land.