### PR TITLE
docs: fill generated tunnel config reference

### DIFF
--- a/config/plugins/tunnels/kubernetes_port_forward.go
+++ b/config/plugins/tunnels/kubernetes_port_forward.go
@@ -77,30 +77,38 @@ import (
 
 // KubernetesPortForwardTunnel configures the tunnel runtime.
 type KubernetesPortForwardTunnel struct {
-	Context   string `hcl:"context,optional"`
+	// Context selects a kubeconfig context; empty uses the current context.
+	Context string `hcl:"context,optional"`
+	// Namespace selects the Kubernetes namespace for kubectl commands.
 	Namespace string `hcl:"namespace,optional"`
 
-	// Exactly one of Pod / Service / Selector / Template must be set.
-	Pod      string            `hcl:"pod,optional"`
-	Service  string            `hcl:"service,optional"`
+	// Pod names an existing pod to port-forward to. Exactly one of pod,
+	// service, selector, or template must be set.
+	Pod string `hcl:"pod,optional"`
+	// Service names a service to port-forward to.
+	Service string `hcl:"service,optional"`
+	// Selector matches a ready pod to port-forward to.
 	Selector map[string]string `hcl:"selector,optional"`
-	Template string            `hcl:"template,optional"`
+	// Template is a pod manifest to apply and port-forward to.
+	Template string `hcl:"template,optional"`
 
 	// Port is the pod-side port the forwarder targets. For service
 	// mode it's the *service* port; kubectl resolves the matching
 	// targetPort.
 	Port int `hcl:"port"`
 
-	// Cleanup is meaningful only in template mode — controls whether
-	// the pod the plugin applied at Open is deleted on tunnel
-	// teardown. "delete" (default) is right for the common create-on-
-	// demand case; "keep" disables deletion.
+	// Cleanup controls whether a template-created pod is deleted on tunnel
+	// teardown. "delete" (default) is right for the common create-on-demand
+	// case; "keep" disables deletion.
 	Cleanup string `hcl:"cleanup,optional"`
 
-	// Framework-level common attrs.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains kubectl access through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an optional credential block for Kubernetes access.
 	Credential string `hcl:"credential,optional"`
 }
 

--- a/config/plugins/tunnels/local_command.go
+++ b/config/plugins/tunnels/local_command.go
@@ -45,18 +45,24 @@ import (
 
 // LocalCommandTunnel configures the tunnel runtime.
 type LocalCommandTunnel struct {
-	Command      []string          `hcl:"command"`
-	Listen       string            `hcl:"listen"`
-	ReadyProbe   string            `hcl:"ready_probe,optional"`
-	ReadyTimeout string            `hcl:"ready_timeout,optional"`
-	Env          map[string]string `hcl:"env,optional"`
+	// Command is the argv vector to spawn for the tunnel process.
+	Command []string `hcl:"command"`
+	// Listen is the local address the spawned command exposes.
+	Listen string `hcl:"listen"`
+	// ReadyProbe is an optional TCP address to poll before the tunnel is ready.
+	ReadyProbe string `hcl:"ready_probe,optional"`
+	// ReadyTimeout overrides the default readiness wait duration.
+	ReadyTimeout string `hcl:"ready_timeout,optional"`
+	// Env adds environment variables to the spawned command.
+	Env map[string]string `hcl:"env,optional"`
 
-	// Framework-level common attrs (share / keepalive / via /
-	// credential). Restated on every tunnel plugin's body so gohcl
-	// decodes them; the compile pass reads via TunnelCommonRead.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains this tunnel through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an optional credential block for the tunnel runtime.
 	Credential string `hcl:"credential,optional"`
 }
 

--- a/config/plugins/tunnels/ssh_port_forward.go
+++ b/config/plugins/tunnels/ssh_port_forward.go
@@ -44,13 +44,18 @@ import (
 
 // SSHPortForwardTunnel configures the tunnel runtime.
 type SSHPortForwardTunnel struct {
-	Bastion string `hcl:"bastion,optional"` // host:port; required when Via is unset
-	User    string `hcl:"user"`
+	// Bastion is the SSH server host:port; required when via is unset.
+	Bastion string `hcl:"bastion,optional"`
+	// User is the SSH username for the bastion login.
+	User string `hcl:"user"`
 
-	// Framework-level common attrs.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains the SSH connection through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an ssh credential block used for bastion authentication.
 	Credential string `hcl:"credential"`
 }
 

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -51,16 +51,24 @@ import (
 
 // TailscaleTunnel configures the tunnel runtime.
 type TailscaleTunnel struct {
-	AuthKey    string   `hcl:"authkey,optional"`
-	ControlURL string   `hcl:"control_url,optional"`
-	Hostname   string   `hcl:"hostname,optional"`
-	StateDir   string   `hcl:"state_dir,optional"`
-	Tags       []string `hcl:"tags,optional"`
+	// AuthKey is the Tailscale auth key; env fallback is CLAWPATROL_TUNNEL_<NAME>_AUTHKEY.
+	AuthKey string `hcl:"authkey,optional"`
+	// ControlURL overrides the Tailscale control-plane URL.
+	ControlURL string `hcl:"control_url,optional"`
+	// Hostname is the tsnet node name; defaults to clawpatrol-tunnel-<name>.
+	Hostname string `hcl:"hostname,optional"`
+	// StateDir stores tsnet node state; defaults under the gateway CA directory.
+	StateDir string `hcl:"state_dir,optional"`
+	// Tags are Tailscale tags requested for the tsnet node.
+	Tags []string `hcl:"tags,optional"`
 
-	// Framework-level common attrs.
-	Share      string `hcl:"share,optional"`
-	Keepalive  string `hcl:"keepalive,optional"`
-	Via        string `hcl:"via,optional"`
+	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
+	Share string `hcl:"share,optional"`
+	// Keepalive keeps an idle tunnel runtime warm for the given duration.
+	Keepalive string `hcl:"keepalive,optional"`
+	// Via chains this tunnel through another tunnel.
+	Via string `hcl:"via,optional"`
+	// Credential references an optional credential block for the tunnel runtime.
 	Credential string `hcl:"credential,optional"`
 }
 

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -2,7 +2,7 @@
 
 A clawpatrol gateway config mixes **operational** fields (top-level
 plumbing) with **policy** blocks. Operational fields are top-level
-attributes; policy blocks (`approver`, `credential`, `endpoint`, `rule`)
+attributes; policy blocks (`approver`, `credential`, `tunnel`, `endpoint`, `rule`)
 dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
@@ -17,7 +17,7 @@ Each block section lists the attributes the loader accepts, with:
 - **Required** — `yes` if the loader rejects the block when the
   attribute is missing.
 
-Plugin-dispatched kinds (`approver`, `credential`, `endpoint`, `rule`)
+Plugin-dispatched kinds (`approver`, `credential`, `tunnel`, `endpoint`, `rule`)
 list one subsection per registered type.
 
 ## Top-level fields
@@ -519,20 +519,22 @@ Registered types: [`kubernetes_port_forward`](#tunnel-kubernetesportforward), [`
 
 ### `tunnel "kubernetes_port_forward" "<name>"`
 
+Configures the tunnel runtime.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `context` | `string` | no |  |
-| `namespace` | `string` | no |  |
-| `pod` | `string` | no |  |
-| `service` | `string` | no |  |
-| `selector` | `map[string]string` | no |  |
-| `template` | `string` | no |  |
-| `port` | `int` | yes |  |
-| `cleanup` | `string` | no |  |
-| `share` | `string` | no |  |
-| `keepalive` | `string` | no |  |
-| `via` | `string` | no |  |
-| `credential` | `string` | no |  |
+| `context` | `string` | no | Selects a kubeconfig context; empty uses the current context. |
+| `namespace` | `string` | no | Selects the Kubernetes namespace for kubectl commands. |
+| `pod` | `string` | no | Names an existing pod to port-forward to. Exactly one of pod, service, selector, or template must be set. |
+| `service` | `string` | no | Names a service to port-forward to. |
+| `selector` | `map[string]string` | no | Matches a ready pod to port-forward to. |
+| `template` | `string` | no | A pod manifest to apply and port-forward to. |
+| `port` | `int` | yes | The pod-side port the forwarder targets. For service mode it's the *service* port; kubectl resolves the matching targetPort. |
+| `cleanup` | `string` | no | Controls whether a template-created pod is deleted on tunnel teardown. "delete" (default) is right for the common create-on-demand case; "keep" disables deletion. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `ref(tunnel)` | no | Chains kubectl access through another tunnel. |
+| `credential` | `ref(credential)` | no | References an optional credential block for Kubernetes access. |
 
 ```hcl
 tunnel "kubernetes_port_forward" "example" {
@@ -542,17 +544,19 @@ tunnel "kubernetes_port_forward" "example" {
 
 ### `tunnel "local_command" "<name>"`
 
+Configures the tunnel runtime.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `command` | `[]string` | yes |  |
-| `listen` | `string` | yes |  |
-| `ready_probe` | `string` | no |  |
-| `ready_timeout` | `string` | no |  |
-| `env` | `map[string]string` | no |  |
-| `share` | `string` | no |  |
-| `keepalive` | `string` | no |  |
-| `via` | `string` | no |  |
-| `credential` | `string` | no |  |
+| `command` | `[]string` | yes | The argv vector to spawn for the tunnel process. |
+| `listen` | `string` | yes | The local address the spawned command exposes. |
+| `ready_probe` | `string` | no | An optional TCP address to poll before the tunnel is ready. |
+| `ready_timeout` | `string` | no | Overrides the default readiness wait duration. |
+| `env` | `map[string]string` | no | Adds environment variables to the spawned command. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `ref(tunnel)` | no | Chains this tunnel through another tunnel. |
+| `credential` | `ref(credential)` | no | References an optional credential block for the tunnel runtime. |
 
 ```hcl
 tunnel "local_command" "example" {
@@ -563,17 +567,20 @@ tunnel "local_command" "example" {
 
 ### `tunnel "ssh_port_forward" "<name>"`
 
+Configures the tunnel runtime.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `bastion` | `string` | no |  |
-| `user` | `string` | yes |  |
-| `share` | `string` | no |  |
-| `keepalive` | `string` | no |  |
-| `via` | `string` | no |  |
-| `credential` | `string` | yes |  |
+| `bastion` | `string` | no | The SSH server host:port; required when via is unset. |
+| `user` | `string` | yes | The SSH username for the bastion login. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `ref(tunnel)` | no | Chains the SSH connection through another tunnel. |
+| `credential` | `ref(credential)` | yes | References an ssh credential block used for bastion authentication. |
 
 ```hcl
 tunnel "ssh_port_forward" "example" {
+  bastion = "bastion.example:22"
   user = "example"
   credential = example-credential
 }
@@ -581,17 +588,19 @@ tunnel "ssh_port_forward" "example" {
 
 ### `tunnel "tailscale" "<name>"`
 
+Configures the tunnel runtime.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `authkey` | `string` | no |  |
-| `control_url` | `string` | no |  |
-| `hostname` | `string` | no |  |
-| `state_dir` | `string` | no |  |
-| `tags` | `[]string` | no |  |
-| `share` | `string` | no |  |
-| `keepalive` | `string` | no |  |
-| `via` | `string` | no |  |
-| `credential` | `string` | no |  |
+| `authkey` | `string` | no | The Tailscale auth key; env fallback is CLAWPATROL_TUNNEL_<NAME>_AUTHKEY. |
+| `control_url` | `string` | no | Overrides the Tailscale control-plane URL. |
+| `hostname` | `string` | no | The tsnet node name; defaults to clawpatrol-tunnel-<name>. |
+| `state_dir` | `string` | no | Stores tsnet node state; defaults under the gateway CA directory. |
+| `tags` | `[]string` | no | Tailscale tags requested for the tsnet node. |
+| `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
+| `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
+| `via` | `ref(tunnel)` | no | Chains this tunnel through another tunnel. |
+| `credential` | `ref(credential)` | no | References an optional credential block for the tunnel runtime. |
 
 ```hcl
 tunnel "tailscale" "example" {}

--- a/site/src/sections/IntegrationsSection.tsx
+++ b/site/src/sections/IntegrationsSection.tsx
@@ -26,9 +26,7 @@ export function IntegrationsSection() {
           {INTEGRATIONS.map(({ name, id }) => (
             <a
               key={id}
-              href={`https://github.com/denoland/clawpatrol/tree/main/src/plugins/${id}`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/docs/config-reference/#endpoint-blocks"
               class="flex flex-col items-center aspect-square
                 justify-between py-4 px-2 squircle-md
                 transition-transform hover:scale-[1.03] focus-visible:scale-[1.03]
@@ -52,8 +50,8 @@ export function IntegrationsSection() {
           — OR —
         </p>
         <div class="text-center mt-12 sm:mt-16 mb-8">
-          <Button href="/docs/plugins/" variant="normal" size="lg">
-            Write your own plugin in one TypeScript file{" "}
+          <Button href="/docs/config-reference/#endpoint-blocks" variant="normal" size="lg">
+            Explore the current Go/HCL plugin model{" "}
             <span class="ml-1" aria-hidden="true">
               &rarr;
             </span>

--- a/tools/docgen/internal/render/godoc.go
+++ b/tools/docgen/internal/render/godoc.go
@@ -37,6 +37,7 @@ func loadGoDocs() (*goDocs, error) {
 		filepath.Join(root, "config"),
 		filepath.Join(root, "config", "plugins", "approvers"),
 		filepath.Join(root, "config", "plugins", "credentials"),
+		filepath.Join(root, "config", "plugins", "tunnels"),
 		filepath.Join(root, "config", "plugins", "endpoints"),
 		filepath.Join(root, "config", "plugins", "rules"),
 	}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -61,7 +61,7 @@ func (r *renderer) writeHeader() {
 
 A clawpatrol gateway config mixes **operational** fields (top-level
 plumbing) with **policy** blocks. Operational fields are top-level
-attributes; policy blocks (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
+attributes; policy blocks (` + "`approver`, `credential`, `tunnel`, `endpoint`, `rule`" + `)
 dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
@@ -76,7 +76,7 @@ Each block section lists the attributes the loader accepts, with:
 - **Required** — ` + "`yes`" + ` if the loader rejects the block when the
   attribute is missing.
 
-Plugin-dispatched kinds (` + "`approver`, `credential`, `endpoint`, `rule`" + `)
+Plugin-dispatched kinds (` + "`approver`, `credential`, `tunnel`, `endpoint`, `rule`" + `)
 list one subsection per registered type.
 
 `)
@@ -368,7 +368,7 @@ func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fi
 func (r *renderer) fieldRefs(pkgName, typeName string) map[string]string {
 	out := map[string]string{}
 	for _, kind := range []config.Kind{
-		config.KindApprover, config.KindCredential, config.KindEndpoint, config.KindRule,
+		config.KindApprover, config.KindCredential, config.KindTunnel, config.KindEndpoint, config.KindRule,
 	} {
 		for _, p := range config.AllPlugins(kind) {
 			rt := pluginStructType(p)
@@ -423,7 +423,7 @@ func (r *renderer) writeExample(kind, typ string, rt reflect.Type, typed bool) {
 		head = kind
 	}
 
-	body := exampleBody(rt)
+	body := exampleBody(kind, typ, rt)
 	if strings.TrimSpace(body) == "" {
 		fmt.Fprintf(&r.out, "```hcl\n%s {}\n```\n\n", head)
 		return
@@ -431,8 +431,13 @@ func (r *renderer) writeExample(kind, typ string, rt reflect.Type, typed bool) {
 	fmt.Fprintf(&r.out, "```hcl\n%s {\n%s}\n```\n\n", head, body)
 }
 
-func exampleBody(rt reflect.Type) string {
+func exampleBody(kind, typ string, rt reflect.Type) string {
 	var sb strings.Builder
+	if kind == "tunnel" && typ == "ssh_port_forward" {
+		// bastion is optional in HCL because it can be replaced by via, but a
+		// standalone generated example needs one or the runtime rejects it.
+		fmt.Fprintln(&sb, `  bastion = "bastion.example:22"`)
+	}
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
 		if !f.IsExported() {


### PR DESCRIPTION
## Summary
- keep the post-#285 docs structure and only carry forward the useful #272 leftovers
- include tunnel plugin packages in docgen, collect tunnel refs, and generate populated tunnel field descriptions
- remove stale landing-page links/copy that pointed at the old TypeScript plugin model

Supersedes the useful subset of #272 without resurrecting the stale public docs pages that have since been replaced on `main`.

## Test Plan
- `go generate ./config/plugins/all`
- `go test ./tools/docgen ./tools/docgen/internal/render ./config/plugins/tunnels`
- `npm --prefix site ci`
- `npm --prefix site run build`
- `git diff --check`
