### PR TITLE
Rename sql facet `function` -> `functions`

### DIFF
--- a/action_file.go
+++ b/action_file.go
@@ -76,14 +76,14 @@ type K8sAction struct {
 }
 
 // SQLAction carries the `sql.*` CEL view. Only `statement` needs to
-// be set in practice; the loader derives verb / tables / function
+// be set in practice; the loader derives verb / tables / functions
 // via the endpoint's runtime.SQLParser. Explicit verb / tables /
-// function are accepted and take precedence over derivation.
+// functions are accepted and take precedence over derivation.
 type SQLAction struct {
 	Statement string   `json:"statement,omitempty"`
 	Verb      string   `json:"verb,omitempty"`
 	Tables    []string `json:"tables,omitempty"`
-	Function  []string `json:"function,omitempty"`
+	Functions []string `json:"functions,omitempty"`
 }
 
 var validVerdicts = map[string]bool{
@@ -323,7 +323,7 @@ func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*mat
 		if stmt == "" {
 			break
 		}
-		// Derive verb / tables / function via SQLParser, then let
+		// Derive verb / tables / functions via SQLParser, then let
 		// any explicit fixture fields override. Keeps SQL fixtures
 		// hand-editable (one field) while accepting full structs.
 		if parseSQL == nil {
@@ -337,8 +337,8 @@ func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*mat
 			if len(a.SQL.Tables) > 0 {
 				m.Tables = a.SQL.Tables
 			}
-			if len(a.SQL.Function) > 0 {
-				m.Functions = a.SQL.Function
+			if len(a.SQL.Functions) > 0 {
+				m.Functions = a.SQL.Functions
 			}
 		}
 		req.Meta = meta

--- a/ai.go
+++ b/ai.go
@@ -52,7 +52,7 @@ https endpoints:  http.method, http.path,
                   http.headers (map<string,list<string>>),
                   http.body (string), http.body_json (dyn)
 sql endpoints:    sql.verb (lower-case), sql.tables (list<string>),
-                  sql.function (list<string>), sql.statement (string)
+                  sql.functions (list<string>), sql.statement (string)
 k8s endpoints:    k8s.resource, k8s.verb (lower-case),
                   k8s.namespace, k8s.name,
                   k8s.params (map<string,string>)

--- a/config/README.md
+++ b/config/README.md
@@ -178,7 +178,7 @@ types, each constrained to a matching endpoint family:
 | Rule type | Endpoint families | Match facets |
 |-----------|------------------|-------------|
 | `http_rule` | `https` | `method` / `path` / `query` / `headers` / `body_json` / `body_contains` / `credential` |
-| `sql_rule` | `sql` | `verb` / `tables` / `function` / `statement` / `statement_regex` / `credential` |
+| `sql_rule` | `sql` | `verb` / `tables` / `functions` / `statement` / `statement_regex` / `credential` |
 | `k8s_rule` | `k8s` | `resource` / `verb` / `namespace` / `name` / `params` / `credential` |
 
 Rule body shape:

--- a/config/match/match.go
+++ b/config/match/match.go
@@ -61,7 +61,7 @@ type Request struct {
 // InspectsTruncatableFacet reports whether the matcher's compiled
 // condition reads any field of the request whose value could be
 // truncated by a wire frontend's inspection buffer (HTTPS body /
-// body_json, SQL verb / tables / function / statement). The
+// body_json, SQL verb / tables / functions / statement). The
 // dispatcher gates on this together with Request.Truncated to fail
 // closed on policy-bypass-by-truncation: a rule that asks about the
 // body of a request whose body was capped is auto-denied; a rule

--- a/config/plugins/facets/sql/sql.go
+++ b/config/plugins/facets/sql/sql.go
@@ -1,5 +1,5 @@
 // Package sql is the SQL protocol-family facet. It owns the SQL CEL
-// environment (verb / tables / function / statement, exposed as
+// environment (verb / tables / functions / statement, exposed as
 // fields on the `sql` variable), the matcher that walks a parsed SQL
 // statement, the Meta type wire-frame frontends (postgres,
 // clickhouse) populate on match.Request.Meta, and the per-family
@@ -27,13 +27,13 @@ import (
 
 // SqlFields is the CEL-facing view of a SQL statement. Exposed as
 // the `sql` variable in rule conditions (`sql.verb`, `sql.tables`,
-// `sql.function`, `sql.statement`). The Go-level Function field is
-// named in singular to match the CEL field; the dashboard column
-// stays plural ("functions") for readability.
+// `sql.functions`, `sql.statement`). The plural `functions` matches
+// the multi-valued shape (a statement can reference multiple
+// functions) and parallels `tables`.
 type SqlFields struct {
 	Verb      string   `cel:"verb"`
 	Tables    []string `cel:"tables"`
-	Function  []string `cel:"function"`
+	Functions []string `cel:"functions"`
 	Statement string   `cel:"statement"`
 }
 
@@ -132,7 +132,7 @@ var lowercasedPaths = []string{"sql.verb"}
 // truncatablePaths declares every SQL field, because the wire
 // frontends (postgres pgClientToServer, clickhouse_native
 // chHandleQuery) feed the matcher one piece of text — the raw
-// statement — and every CEL field (verb, tables, function,
+// statement — and every CEL field (verb, tables, functions,
 // statement) is derived from the same parsed bytes. When the
 // frontend caps the frame, all four fields are simultaneously
 // untrustworthy, so any condition reading any of them must fail
@@ -144,7 +144,7 @@ var lowercasedPaths = []string{"sql.verb"}
 // truncated request still evaluates correctly. The dispatcher
 // applies r.Credential before the matcher runs (config/runtime/
 // dispatch.go), and that path is unaffected by Truncated.
-var truncatablePaths = []string{"sql.verb", "sql.tables", "sql.function", "sql.statement"}
+var truncatablePaths = []string{"sql.verb", "sql.tables", "sql.functions", "sql.statement"}
 
 // NewMatcher compiles a CEL condition into a Matcher. An empty
 // condition is the catch-all match-everything case.
@@ -167,7 +167,7 @@ func buildActivation(req *match.Request) map[string]any {
 		"sql": &SqlFields{
 			Verb:      strings.ToLower(meta.Verb),
 			Tables:    coalesceList(meta.Tables),
-			Function:  coalesceList(meta.Functions),
+			Functions: coalesceList(meta.Functions),
 			Statement: meta.Statement,
 		},
 	}

--- a/config/plugins/facets/sql/sql_truncated_test.go
+++ b/config/plugins/facets/sql/sql_truncated_test.go
@@ -25,7 +25,7 @@ func TestSQLMatcherInspectsTruncatableFacet(t *testing.T) {
 	}{
 		{"verb only", "sql.verb == 'select'", true},
 		{"tables", "'users' in sql.tables", true},
-		{"function list", "'pg_terminate_backend' in sql.function", true},
+		{"functions list", "'pg_terminate_backend' in sql.functions", true},
 		{"statement contains", "sql.statement.contains('drop')", true},
 		{"statement regex", "sql.statement.matches('(?i)secret')", true},
 		{"compound with sql field", "sql.verb == 'select' && true", true},

--- a/config/testdata/full.hcl
+++ b/config/testdata/full.hcl
@@ -238,12 +238,12 @@
 #
 #   https → http.method, http.path, http.query, http.headers,
 #           http.body, http.body_json
-#   sql   → sql.verb, sql.tables, sql.function, sql.statement
+#   sql   → sql.verb, sql.tables, sql.functions, sql.statement
 #   k8s   → k8s.verb, k8s.resource, k8s.namespace, k8s.name,
 #           k8s.params
 #
 # `verb` (sql, k8s) and `method` (http) are unary strings. `tables`
-# and `function` (sql) are list[string]; `query` and `headers`
+# and `functions` (sql) are list[string]; `query` and `headers`
 # (http) are map[string]list[string]; `params` (k8s) is
 # map[string]string. `body` is the raw request body as string;
 # `body_json` is its parsed-JSON shape (dyn).
@@ -257,9 +257,9 @@
 #     `http.body.contains('approve_')`.
 #   - Regex (for what globs and startsWith can't express):
 #     `sql.statement.matches('(?i)\\bsecret\\b')`.
-#   - List intersection (sql `tables` / `function` against a
+#   - List intersection (sql `tables` / `functions` against a
 #     deny-list):
-#     `sets.intersects(sql.function, ['pg_read_file', ...])`.
+#     `sets.intersects(sql.functions, ['pg_read_file', ...])`.
 #     The `sets` extension is registered on every facet env.
 #
 #
@@ -1008,7 +1008,7 @@ rule "pg-banned-verbs" {
 }
 rule "pg-banned-functions" {
   endpoints = [pg-deployng, pg-scheduler]
-  condition = "sets.intersects(sql.function, ['pg_terminate_backend', 'pg_cancel_backend', 'pg_read_file', 'pg_read_binary_file', 'lo_get']) || sql.function.exists(f, f.startsWith('dblink_'))"
+  condition = "sets.intersects(sql.functions, ['pg_terminate_backend', 'pg_cancel_backend', 'pg_read_file', 'pg_read_binary_file', 'lo_get']) || sql.functions.exists(f, f.startsWith('dblink_'))"
   verdict   = "deny"
   reason    = "Disallowed function for agent access"
 }

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -1210,7 +1210,7 @@
             "pg-deployng",
             "pg-scheduler"
           ],
-          "condition": "sets.intersects(sql.function, ['pg_terminate_backend', 'pg_cancel_backend', 'pg_read_file', 'pg_read_binary_file', 'lo_get']) || sql.function.exists(f, f.startsWith('dblink_'))",
+          "condition": "sets.intersects(sql.functions, ['pg_terminate_backend', 'pg_cancel_backend', 'pg_read_file', 'pg_read_binary_file', 'lo_get']) || sql.functions.exists(f, f.startsWith('dblink_'))",
           "verdict": "deny",
           "reason": "Disallowed function for agent access"
         }

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -68,7 +68,7 @@ statement the agent sends.
 |----------|------|-------------|
 | `sql.verb` | `string` | First verb of the statement (lower-case: `"select"`, …) |
 | `sql.tables` | `list<string>` | Tables referenced by the statement |
-| `sql.function` | `list<string>` | Functions called by the statement |
+| `sql.functions` | `list<string>` | Functions called by the statement |
 | `sql.statement` | `string` | The full lower-cased statement text |
 
 ```hcl
@@ -78,11 +78,11 @@ condition = "sets.intersects(sql.tables, ['users', 'audit_log'])"
 condition = "sql.statement.matches('(?i)\\bpassword\\b')"
 ```
 
-`verb`, `tables`, and `function` are extracted by a best-effort
+`verb`, `tables`, and `functions` are extracted by a best-effort
 lexer over a lower-cased copy of the statement — see
 [Case sensitivity](#case-sensitivity-by-variable) below.
 
-`tables` and `function` are **multi-valued** facets: a single
+`tables` and `functions` are **multi-valued** facets: a single
 statement can name several tables (`SELECT ... FROM a JOIN b`) and
 call several functions. Use CEL's `in` operator for a single name
 (`'secrets' in sql.tables`) or `sets.intersects(...)` for an overlap
@@ -177,7 +177,7 @@ Each endpoint plugin claims the requests it owns and emits an
 **action** in its family — `http` actions for HTTPS endpoints, `sql`
 actions for postgres / clickhouse, `k8s` actions for kubernetes.
 Each action populates the family's CEL variables (method/path/headers
-for HTTP, verb/tables/function for SQL, resource/verb/namespace for
+for HTTP, verb/tables/functions for SQL, resource/verb/namespace for
 k8s). The rule's `condition` is evaluated against those variables.
 
 How an endpoint claims a given connection (SNI peek, destination IP,
@@ -224,7 +224,7 @@ accessed with dot notation. Common idioms:
 | `http.method`                 | lower-case (rule-source literals normalized at compile time) |
 | `http.path`, `http.query`, `http.headers`, `http.body` | as on the wire |
 | `sql.verb`                    | lower-case (normalized) |
-| `sql.tables`, `sql.function`  | lower-case (extracted from a lower-cased copy of the statement) |
+| `sql.tables`, `sql.functions` | lower-case (extracted from a lower-cased copy of the statement) |
 | `sql.statement`               | as on the wire (raw text, no case folding) |
 | `k8s.verb`                    | lower-case (normalized) |
 | `k8s.resource`, `k8s.namespace`, `k8s.name`, `k8s.params` | as on the wire |

--- a/site/doc/clawpatrol-test.md
+++ b/site/doc/clawpatrol-test.md
@@ -220,7 +220,7 @@ facet's vocabulary — the same fields your CEL rule conditions read.
 ```
 
 For SQL, only `statement` is required — the runner derives `verb`,
-`tables`, and `function` from the SQL the same way the live
+`tables`, and `functions` from the SQL the same way the live
 dispatch path does. You can override them by adding explicit fields
 if you want to test the matcher's view directly.
 
@@ -285,7 +285,7 @@ of scope for replay.
 |-------|--------|
 | `http` | `method`, `path`, `query`, `headers`, `body`, `body_b64` |
 | `k8s`  | `verb`, `resource`, `namespace`, `name`, `params` |
-| `sql`  | `statement` (required); `verb`, `tables`, `function` (optional, derived from `statement` if omitted) |
+| `sql`  | `statement` (required); `verb`, `tables`, `functions` (optional, derived from `statement` if omitted) |
 
 Every field is optional except SQL's `statement`. Missing fields
 default to zero values — rules that match on them just return

--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -93,10 +93,10 @@ A single named matchable property exposed to a [rule](#rule)'s CEL
 [`condition`](#cel-condition). Each protocol family exposes its own
 top-level struct-typed variable: `http.method` / `http.path` /
 `http.query` / `http.headers` / `http.body` / `http.body_json`;
-`sql.verb` / `sql.tables` / `sql.function` / `sql.statement`;
+`sql.verb` / `sql.tables` / `sql.functions` / `sql.statement`;
 `k8s.verb` / `k8s.resource` / `k8s.namespace` / `k8s.name` /
 `k8s.params`. Per-facet types vary — `method` and `verb` are scalar
-strings, `tables` / `function` are lists, `query` / `headers` /
+strings, `tables` / `functions` are lists, `query` / `headers` /
 `params` are maps, and `body_json` is parsed-JSON `dyn`.
 
 ### CEL condition

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -196,7 +196,7 @@ Declaration order is the tiebreaker. Default-deny catch-all:
 | Variable | Type |
 |---|---|
 | `verb` | string (lowercased) — `'select'`, `'insert'`, `'drop'`, … |
-| `tables` / `function` | `list<string>` (lowercased) |
+| `tables` / `functions` | `list<string>` (lowercased) |
 | `statement` | string (raw SQL) |
 
 **`k8s.*`**

--- a/web.go
+++ b/web.go
@@ -1575,7 +1575,7 @@ func exportK8s(ev *Event) *K8sAction {
 }
 
 // exportSQL pulls the raw statement out of Event.Facets (set by
-// sqlfacet.Report). The loader re-derives verb / tables / function
+// sqlfacet.Report). The loader re-derives verb / tables / functions
 // from the statement via SQLParser at replay time.
 func exportSQL(ev *Event) *SQLAction {
 	stmt, _ := ev.Facets["statement"].(string)


### PR DESCRIPTION
## Summary

Rename the SQL facet's `function` CEL field to `functions` to match the multi-valued shape and parallel the existing `tables` facet.

- `sql.function` → `sql.functions` everywhere it's referenced as a CEL key.
- `SqlFields.Function` (Go) → `Functions`; struct tag `cel:"function"` → `cel:"functions"`.
- `truncatablePaths` updated.
- `SQLAction.Function` JSON field (action fixture format, which carries the `sql.*` CEL view) renamed in sync: `"function"` → `"functions"`.
- Docs (`config/README.md`, `site/doc/approval-rules.md`, `glossary.md`, `skill.md`, `clawpatrol-test.md`), inline AI prompt schema, and the `full.want.json` golden are updated.

`Meta.Functions` is untouched — it was already plural.

## Backwards compatibility

**Hard rename**, no dual-syntax. The SQL facet schema is pre-stable and no shipped configs use the old name. Existing CEL conditions written against `sql.function` will fail to compile with a clear CEL "no such attribute" error pointing at the new key, which is the cleanest signal for operators to migrate.

## Files touched

- `action_file.go` — `SQLAction.Function` → `Functions` (JSON tag + field name + consumer in `ToMatchRequest`)
- `ai.go` — inline schema string in the AI prompt
- `config/README.md` — rule-type/facet table row
- `config/match/match.go` — `InspectsTruncatableFacet` doc comment
- `config/plugins/facets/sql/sql.go` — `SqlFields.Function` → `Functions`, `cel` tag, `truncatablePaths`, `buildActivation` site, package + struct comments
- `config/plugins/facets/sql/sql_truncated_test.go` — test case literal
- `config/testdata/full.hcl` — `pg-banned-functions` rule condition + comment header
- `config/testdata/full.want.json` — regenerated golden
- `site/doc/approval-rules.md`, `site/doc/clawpatrol-test.md`, `site/doc/glossary.md`, `site/doc/skill.md` — doc tables and prose
- `web.go` — comment on `exportSQL`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (clean)
- [x] `npx oxfmt --check` for the dashboard (clean)
- [x] `full.want.json` golden regenerated with `-update` and matches the new schema