### PR TITLE
docs(site): skill page rendering polish + post-sqlite-state cleanup

### DIFF
--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -165,11 +165,6 @@ your shell rc if you need them outside `clawpatrol run`.
 eval "$(clawpatrol env)"
 ```
 
-### `clawpatrol init-ca DIR`
-
-Generate a fresh CA into `DIR`. Used by `gateway init`; rarely
-needed standalone.
-
 ### `clawpatrol version`
 
 Print the version. Also accepts `-v` and `--version`.
@@ -194,13 +189,16 @@ Where state lives, by role:
 **Gateway host** (set up by `gateway init`):
 
 ```
-/etc/clawpatrol/          (root) — or ~/.clawpatrol (non-root)
-  gateway.hcl             HCL config
-  ca/ca.crt               Generated CA cert
-  ca/ca.key               Generated CA private key
-  oauth/clawpatrol.db     SQLite — devices, sessions, audit log
-  oauth/wg-server.key     WireGuard server private key
+/etc/clawpatrol/                (root) — or ~/.clawpatrol (non-root)
+  gateway.hcl                   HCL config (operator-edited)
+  oauth/clawpatrol.db           SQLite — everything else
 ```
+
+The sqlite DB holds the CA cert + key, WireGuard server key, SSH
+host keys, sessions, audit log, telemetry UUID, and DNS-VIP
+allocations. Path is configurable via the top-level `state_dir`
+attribute (defaults to `oauth/` next to `gateway.hcl` for
+historical layout compat).
 
 **Device** (set up by `join` / `login`):
 

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -1,6 +1,6 @@
 ---
 name: claw-patrol
-title: Operating Claw Patrol
+title: Skill File
 description: Set up and operate Claw Patrol, a firewall for AI agents. Write the gateway HCL config (credentials, endpoints, rules, approvers, profiles), run the gateway, onboard devices, wrap agent commands with `clawpatrol run`. Use when the user wants to install or operate Claw Patrol, write or modify a `gateway.hcl` policy, add allow / deny / approve rules over HTTPS / Postgres / Kubernetes / ClickHouse / SSH traffic, gate agent actions behind a human or an LLM judge, or debug Claw Patrol behavior.
 ---
 
@@ -24,7 +24,7 @@ Agent ─→ Device ──WireGuard──→ Gateway ──→ Upstream
 
 Same binary, gateway + devices:
 
-```bash
+```
 curl -fsSL https://clawpatrol.dev/install.sh | sh
 ```
 
@@ -34,7 +34,7 @@ macOS / Linux on amd64 / arm64. Lands in `~/.local/bin/clawpatrol`.
 
 Bootstrap (once):
 
-```bash
+```
 clawpatrol gateway init
 ```
 
@@ -46,14 +46,14 @@ WireGuard.
 
 Then run:
 
-```bash
+```
 systemctl enable --now clawpatrol-gateway       # systemd
 clawpatrol gateway /etc/clawpatrol/gateway.hcl  # otherwise
 ```
 
 Validate or regression-test a policy change:
 
-```bash
+```
 clawpatrol validate gateway.hcl        # parse + compile
 clawpatrol test gateway.hcl fixtures/  # replay recorded actions
 ```
@@ -107,7 +107,7 @@ profile "default" { endpoints = [github] }
 | `info_listen` | Dashboard + API bind. |
 | `public_url` | Dashboard URL handed out at join time. |
 | `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |
-| `ca_dir` / `oauth_dir` | CA + SQLite state DB locations. |
+| `state_dir` | Directory holding `clawpatrol.db`. `ca_dir` / `oauth_dir` are legacy names kept for backwards compat. |
 | `control` | `"wireguard"` or `"tailscale"`. |
 | `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet. |
 | `unknown_host` | `"passthrough"` (default) or `"deny"` for traffic no endpoint claims. |
@@ -290,7 +290,7 @@ without paging.
 
 ## Onboard a device
 
-```bash
+```
 clawpatrol join http://<gateway-host>:9080
 ```
 
@@ -308,7 +308,7 @@ Settings → Privacy & Security**.
 
 ## Run an agent
 
-```bash
+```
 clawpatrol run -- claude
 clawpatrol run -- gh pr create
 clawpatrol run -- psql 'host=db user=agent'
@@ -326,11 +326,15 @@ sees a normal network — no proxy URL, no CA bundle.
 **Gateway** (`/etc/clawpatrol/` root, or `~/.clawpatrol` non-root):
 
 ```
-gateway.hcl
-ca/ca.crt, ca/ca.key
-oauth/clawpatrol.db    # SQLite — devices, sessions, audit log
-oauth/wg-server.key
+gateway.hcl                  # operator-edited
+<state_dir>/clawpatrol.db    # everything else — CA material, WG keys,
+                             # devices, sessions, audit log
 ```
+
+`state_dir` defaults to `<data-dir>/oauth/` for `gateway init`-created
+hosts (legacy layout, still works). The CA cert + key, WireGuard
+server key, SSH host keys, telemetry UUID, and DNS-VIP allocations
+all live inside `clawpatrol.db` — nothing else on disk.
 
 **Device:**
 

--- a/site/doc/toc.json
+++ b/site/doc/toc.json
@@ -1,7 +1,6 @@
 [
   "introduction",
   "getting-started",
-  "skill",
   "glossary",
   "architecture",
   "cli",
@@ -9,5 +8,6 @@
   "security-model",
   "approval-rules",
   "config-reference",
-  "competitors"
+  "competitors",
+  "skill"
 ]

--- a/site/docs-render.ts
+++ b/site/docs-render.ts
@@ -1,8 +1,43 @@
 // Shared rendering used by both vite dev and build for the docs pages,
 // and by build-docs.ts to prerender the landing page.
 
-import hljs from "highlight.js";
+import hljs, { type HLJSApi, type LanguageFn } from "highlight.js";
 import { Marked } from "marked";
+
+// highlight.js doesn't ship an HCL grammar, so docs that use `hcl`
+// fences fall back to plain text. Register a minimal one — enough
+// to colourise the operator-facing examples in skill.md and friends.
+const hclLang: LanguageFn = (h: HLJSApi) => ({
+  name: "HCL",
+  aliases: ["terraform", "tf"],
+  case_insensitive: false,
+  keywords: {
+    keyword:
+      "approver credential endpoint policy profile rule tunnel " +
+      "device defaults",
+    literal: "true false null",
+    built_in: "var local module data resource",
+  },
+  contains: [
+    h.HASH_COMMENT_MODE,
+    h.C_LINE_COMMENT_MODE,
+    h.C_BLOCK_COMMENT_MODE,
+    h.QUOTE_STRING_MODE,
+    h.NUMBER_MODE,
+    {
+      // Heredoc: <<EOT … EOT  or  <<-EOT … EOT
+      className: "string",
+      begin: /<<-?\s*([A-Za-z_]\w*)/,
+      end: /^\s*\w+$/,
+    },
+    {
+      // Block label string (after a known keyword + space).
+      className: "type",
+      begin: /\b[a-z_][a-z0-9_]*\b(?=\s+"[^"]+"\s*"[^"]+"\s*\{)/,
+    },
+  ],
+});
+hljs.registerLanguage("hcl", hclLang);
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { h } from "preact";


### PR DESCRIPTION
## Summary

Polish + correctness fixes on the user-facing docs site. Four changes, all under `site/`:

1. **Sidebar label for the skill page is "Skill File"** via `title:` in the YAML frontmatter. PR #293's squash merge dropped the original rename commit; this re-lands it.
2. **`skill` is now last in the toc**, not third — it's the cheatsheet you reach for after the conceptual + operator pages.
3. **HCL syntax highlighting works.** highlight.js doesn't ship an HCL grammar, so `hcl` fences fell through to plain text. Register a minimal grammar (block keywords, strings, heredocs, numbers, the `block "<type>" "<name>"` shape).
4. **Bash code-block tags stripped from `skill.md`'s command blocks.** highlight.js was treating `test` and `enable` as bash builtins, which is technically right but misleading in `clawpatrol test` / `systemctl enable` contexts. The blocks are `program arg flag` shapes with no real bash syntax to highlight.

Also, post-#222 cleanup of stale state-directory claims:

- Drop `clawpatrol init-ca DIR` from `cli.md` — that subcommand was deleted; the CA is now lazy-minted into the sqlite DB on first boot.
- Update the Data directories layout on `cli.md` + `skill.md`: no more `ca/ca.crt`, `ca/ca.key`, `oauth/wg-server.key` on disk. The skill page's top-level-fields table now points at `state_dir`.

## Test plan

- [ ] Visual review on `clawpatrol.dev/docs/skill/`: HCL examples are colorized, command blocks are plain monospace (no false-positive keyword highlighting), sidebar shows "Skill File" at the bottom.
- [ ] `clawpatrol.dev/docs/cli/` no longer has an `init-ca` section.
- [ ] Spot-check a non-skill page (`/docs/introduction/`) renders unchanged.

## Out of scope

A larger schema refactor — dropping `ca_dir` and `oauth_dir` from `gateway.hcl` in favor of `state_dir` — is staged but not in this PR. The deployed gateway at `prod.example.com` still relies on `oauth_dir` so that's coordinated work for a follow-up.
