### PR TITLE
docs: post-#222 sqlite-state catch-up in non-site docs

### DIFF
--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -58,7 +58,7 @@ public UDP port, no WireGuard keypair management, no subnet allocation
 | **Device IP** | Assigned by Tailscale control plane | Allocated from `wg_subnet_cidr` |
 | **Dashboard auth** | Tailscale user identity (no proxy needed) | Falls back to `admin_email`; needs auth proxy for multi-user |
 | **Client command** | `clawpatrol login` | `clawpatrol join <gw-url>` |
-| **State** | `state_dir` (tsnet) | `oauth_dir` (wg-server.key, wg-peers.json) |
+| **State** | tsnet state inside sqlite via `state_dir`; tsnet machine key + ipn state are blob-stored | sqlite (`<state_dir>/clawpatrol.db`) — WG server key, peer map, sessions |
 
 ## Operator setup
 
@@ -84,7 +84,6 @@ state_dir           = "/opt/clawpatrol/ts-state"
 EOF
 
 mkdir -p /opt/clawpatrol
-clawpatrol init-ca /opt/clawpatrol/ca
 
 # OAuth client: create at https://login.tailscale.com/admin/settings/oauth
 # Grant: write:auth_keys (to mint device keys), read:devices

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -92,9 +92,6 @@ EOF
 
 mkdir -p /opt/clawpatrol
 
-# `clawpatrol init-ca` is gone — the CA is lazy-minted into the
-# gateway's sqlite DB on first boot.
-
 iptables -I INPUT -p udp --dport 51820 -j ACCEPT
 iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
 clawpatrol gateway /etc/clawpatrol/gateway.hcl

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -33,10 +33,11 @@ in promiscuous mode — same shape as unclaw's `boringtun` + `smoltcp`
 
 - `clawpatrol gateway gateway.hcl` boots WG endpoint on UDP 51820,
   dashboard + MITM ride the same forwarder.
-- Server keypair persisted at `<oauth_dir>/wg-server.key`. Pubkey
-  derived via curve25519 at boot. Peer (pubkey → IP) map persisted
-  at `<oauth_dir>/wg-peers.json`, replayed on every restart so
-  existing clients survive gateway redeploys.
+- Server keypair persisted in the gateway's sqlite DB (see
+  migration `0008_gateway_state`). Pubkey derived via curve25519
+  at boot. Peer (pubkey → IP) map also lives in sqlite; both are
+  replayed on every restart so existing clients survive gateway
+  redeploys.
 - `clawpatrol join <gw>` runs once: prints user-code, opens
   dashboard URL, server mints a fresh keypair, allocates a /32 from
   the configured subnet, registers the peer with wireguard-go,
@@ -90,7 +91,9 @@ tailscale {
 EOF
 
 mkdir -p /opt/clawpatrol
-clawpatrol init-ca /opt/clawpatrol/ca
+
+# `clawpatrol init-ca` is gone — the CA is lazy-minted into the
+# gateway's sqlite DB on first boot.
 
 iptables -I INPUT -p udp --dport 51820 -j ACCEPT
 iptables -I INPUT -p tcp --dport 8080 -j ACCEPT

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -59,13 +59,10 @@ say "build linux/amd64 (stripped)"
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o dist/gateway-linux-amd64 .
 ls -lh dist/gateway-linux-amd64 | awk '{print "  -- size:",$5}'
 
-# --- 2. ensure CA ---------------------------------------------------------
-if [[ ! -f ca/ca.crt ]]; then
-  say "init local CA"
-  go run . -init-ca ./ca
-fi
+# --- 2. render config + scripts ------------------------------------------
+# (CA is lazy-minted into the gateway's sqlite DB on first boot — no
+# need to pre-build CA material locally and ship it. PR #222.)
 
-# --- 3. render config + scripts ------------------------------------------
 # Default PUBLIC_URL prefers the funnel hostname (https://<host>.<tailnet>.ts.net).
 # Fall back to the raw IP only if funnel isn't enabled. We learn the
 # tailnet hostname after `tailscale up` so this is computed lazily on
@@ -118,9 +115,7 @@ HCL
 esac
 
 # v14 typed-block grammar: credentials + endpoints + profile, instead
-# of the legacy `integrations = [...]` shortcut. Operator-managed
-# device "<ip>" {} blocks land at the bottom of the file via the
-# dashboard's per-device editor.
+# of the legacy `integrations = [...]` shortcut.
 cat > dist/deno.hcl <<EOF
 listen      = "0.0.0.0:${PORT}"
 info_listen = "0.0.0.0:8080"
@@ -283,14 +278,12 @@ LimitNOFILE=65536
 WantedBy=multi-user.target
 EOF
 
-# --- 4. ship (skip identical via rsync checksum; temp-file-rename handles
+# --- 3. ship (skip identical via sha256; temp-file-rename handles
 #         the running-binary "Text file busy" trap automatically) --------
 say "ship to ${TARGET}:${REMOTE_DIR}"
-remote "mkdir -p ${REMOTE_DIR}/ca"
+remote "mkdir -p ${REMOTE_DIR}/ca ${REMOTE_DIR}/oauth"
 ship_if_changed dist/gateway-linux-amd64 "${REMOTE_DIR}/gateway"
 remote "chmod +x ${REMOTE_DIR}/gateway"
-ship_if_changed ca/ca.crt "${REMOTE_DIR}/ca/ca.crt"
-ship_if_changed ca/ca.key "${REMOTE_DIR}/ca/ca.key"
 ship_if_changed dist/deno.hcl "${REMOTE_DIR}/deno.hcl"
 ship_if_changed dist/remote-modules.sh "${REMOTE_DIR}/remote-modules.sh"
 ship_if_changed dist/remote-nft.sh "${REMOTE_DIR}/remote-nft.sh"
@@ -334,4 +327,4 @@ remote '
 
 say "done."
 echo "  client mac:  tailscale set --exit-node=${HOSTNAME_TAG}"
-echo "  trust CA:    sudo security add-trusted-cert -d -p ssl -k /Library/Keychains/System.keychain ca/ca.crt"
+echo "  trust CA:    clawpatrol login --name=${HOSTNAME_TAG}   # fetches CA from the running gateway"


### PR DESCRIPTION
## Summary

PR #222 moved the CA cert + key, WG server key, SSH host keys, telemetry UUID, and DNS-VIP allocations into sqlite, and deleted the `clawpatrol init-ca` subcommand. The user-facing site docs caught up in #303; these non-site docs + the deploy script were still pointing at the dead file layout. This finishes the cleanup.

## Changes

- **`doc/wireguard.md`** — WG server key + peer map now in sqlite, not `<oauth_dir>/wg-server.key` / `wg-peers.json`. Dropped the `clawpatrol init-ca` line from the setup recipe.
- **`doc/tailscale.md`** — state-row in the wg-vs-ts comparison table updated; `init-ca` removed from setup recipe.
- **`scripts/deploy.sh`** —
  - Drop the local CA pre-build (`go run . -init-ca ./ca`) and the `ship_if_changed` lines for `ca.crt` + `ca.key`. None of those files exist locally or are read by the gateway anymore.
  - Create `${REMOTE_DIR}/oauth` on the target (that's where the sqlite DB lives by current convention).
  - Final "trust CA" hint now points at `clawpatrol login` instead of `security add-trusted-cert ... ca/ca.crt` (the file doesn't exist anymore; `clawpatrol login` fetches the CA over HTTP from the running gateway).

## Out of scope

The deploy script's emitted HCL still uses `ca_dir` / `oauth_dir`. Those are still valid attributes on the current binary. The schema-refactor PR that drops them is staged separately — it needs a coordinated production HCL edit first (the deployed gateway at prod.example.com relies on `oauth_dir`).

## Test plan

- [x] `bash -n scripts/deploy.sh` syntax-clean.
- [x] `go test ./...` green (no Go code touched, but kept honest).
- [ ] Visual review of `doc/wireguard.md`, `doc/tailscale.md`.
