### PR TITLE
feat: llm facet family + anthropic/openrouter plugins (cl-1yh)

### DIFF
--- a/action_file.go
+++ b/action_file.go
@@ -295,7 +295,7 @@ func stripPort(s string) string {
 // fixture take precedence over derivation.
 func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*match.Request, error) {
 	a := &f.Action
-	req := &match.Request{Family: family, Credential: a.Credential, PeerIP: a.PeerIP}
+	req := &match.Request{Families: []string{family}, Credential: a.Credential, PeerIP: a.PeerIP}
 	switch {
 	case a.HTTP != nil:
 		req.Method = a.HTTP.Method
@@ -313,11 +313,11 @@ func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*mat
 		}
 	case a.K8s != nil:
 		req.URL = &url.URL{Scheme: "https", Host: a.Host}
-		req.Meta = &k8sfacet.Meta{
+		req.SetMeta("k8s", &k8sfacet.Meta{
 			Verb: a.K8s.Verb, Resource: a.K8s.Resource,
 			Namespace: a.K8s.Namespace, Name: a.K8s.Name,
 			Params: a.K8s.Params,
-		}
+		})
 	case a.SQL != nil:
 		stmt := a.SQL.Statement
 		if stmt == "" {
@@ -341,7 +341,7 @@ func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*mat
 				m.Functions = a.SQL.Functions
 			}
 		}
-		req.Meta = meta
+		req.SetMeta("sql", meta)
 	}
 	return req, nil
 }

--- a/agents.go
+++ b/agents.go
@@ -922,7 +922,7 @@ func (w *webMux) collectRuleSummaries(profileFilter string) []RuleSummary {
 			for _, r := range ep.Rules {
 				out = append(out, RuleSummary{
 					Name:       r.Name,
-					Family:     ep.Family,
+					Family:     ep.PrimaryFamily(),
 					Endpoint:   epName,
 					Profile:    profileName,
 					Priority:   r.Priority,

--- a/ai.go
+++ b/ai.go
@@ -285,7 +285,7 @@ func availableSymbols(policy *config.CompiledPolicy) string {
 	}
 	endpoints := make([]string, 0, len(policy.Endpoints))
 	for name, ep := range policy.Endpoints {
-		endpoints = append(endpoints, fmt.Sprintf("%s (%s)", name, ep.Family))
+		endpoints = append(endpoints, fmt.Sprintf("%s (%s)", name, ep.PrimaryFamily()))
 	}
 	credentials := make([]string, 0, len(policy.Credentials))
 	for name, ent := range policy.Credentials {

--- a/config/compile.go
+++ b/config/compile.go
@@ -61,10 +61,17 @@ type CompiledProfile struct {
 // CompiledEndpoint flattens an endpoint plus the rules that target it.
 // Body is whatever the endpoint plugin's Build returned (e.g.
 // *endpoints.HTTPSEndpoint) — runtime callers type-assert based on
-// Family.
+// the primary family.
 type CompiledEndpoint struct {
-	Name        string
-	Family      string // "http" | "sql" | "k8s"
+	Name string
+	// Families lists every protocol family this endpoint participates
+	// in. The first entry is the primary family (the underlying wire
+	// — used for transport dispatch, HITL labelling, and the
+	// dashboard's Family column). Additional entries are auxiliary
+	// facets attached to the same action: an `anthropic` endpoint
+	// declares `["http", "llm"]` so HTTP rules and LLM rules both
+	// match against the same request.
+	Families    []string
 	Plugin      *Plugin
 	Body        any
 	Hosts       []string
@@ -76,6 +83,33 @@ type CompiledEndpoint struct {
 	// Populated from the endpoint plugin's optional EndpointTunnel()
 	// accessor.
 	Tunnel *CompiledTunnel
+}
+
+// PrimaryFamily returns the first family on the endpoint, or "".
+// The primary family is the wire protocol the gateway dispatches
+// against (used by main.go's transport routing, the HITL prompt
+// label, and the dashboard's Family column). Auxiliary families
+// (e.g. `llm` on an `anthropic` endpoint) trail in Families[1:].
+func (ce *CompiledEndpoint) PrimaryFamily() string {
+	if ce == nil || len(ce.Families) == 0 {
+		return ""
+	}
+	return ce.Families[0]
+}
+
+// HasFamily reports whether the endpoint carries the named family in
+// any position. Used by rule dispatch to ask "does this endpoint
+// participate in family X?" without caring which position X holds.
+func (ce *CompiledEndpoint) HasFamily(name string) bool {
+	if ce == nil {
+		return false
+	}
+	for _, f := range ce.Families {
+		if f == name {
+			return true
+		}
+	}
+	return false
 }
 
 // RequiresVIP reports whether DNS-VIP allocation should claim this
@@ -324,10 +358,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 
 func compileEndpoint(name string, ent *Entity, p *Policy, cp *CompiledPolicy) (*CompiledEndpoint, error) {
 	ce := &CompiledEndpoint{
-		Name:   name,
-		Family: ent.Plugin.Family,
-		Plugin: ent.Plugin,
-		Body:   ent.Body,
+		Name:     name,
+		Families: ent.Plugin.Families,
+		Plugin:   ent.Plugin,
+		Body:     ent.Body,
 	}
 	// Hosts and credential refs live on the plugin's typed body.
 	// We cross-cut via a small interface so the compile pass doesn't
@@ -385,7 +419,11 @@ func hasResolvableHostname(hosts []string) bool {
 }
 
 func bareHostAlias(ep *CompiledEndpoint, host string) (string, bool) {
-	if ep == nil || (ep.Family != "http" && ep.Family != "k8s") {
+	if ep == nil {
+		return "", false
+	}
+	primary := ep.PrimaryFamily()
+	if primary != "http" && primary != "k8s" {
 		return "", false
 	}
 	bare, port, err := net.SplitHostPort(host)

--- a/config/compile_test.go
+++ b/config/compile_test.go
@@ -79,8 +79,8 @@ func TestCompile(t *testing.T) {
 			writes = r
 		}
 	}
-	getReq := &match.Request{Family: "http", Method: "GET"}
-	postReq := &match.Request{Family: "http", Method: "POST"}
+	getReq := &match.Request{Families: []string{"http"}, Method: "GET"}
+	postReq := &match.Request{Families: []string{"http"}, Method: "POST"}
 	if !reads.Matcher.Match(getReq) {
 		t.Errorf("github-reads should match GET")
 	}

--- a/config/dump.go
+++ b/config/dump.go
@@ -136,8 +136,11 @@ func dumpEntityMap(m map[string]*Entity) map[string]any {
 		if ent.Plugin.Type != "" {
 			row["type"] = ent.Plugin.Type
 		}
-		if ent.Plugin.Family != "" {
-			row["family"] = ent.Plugin.Family
+		if len(ent.Plugin.Families) > 0 {
+			row["family"] = ent.Plugin.Families[0]
+			if len(ent.Plugin.Families) > 1 {
+				row["families"] = ent.Plugin.Families
+			}
 		}
 		row["body"] = ent.Body
 		// Surface framework-level attrs (e.g. tunnel) at the entity

--- a/config/extplugin/adapter.go
+++ b/config/extplugin/adapter.go
@@ -345,7 +345,8 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 	// an action shaped to that facet's variables and the adapter
 	// maps it onto the typed match.Request fields the built-in
 	// matcher reads, instead of stashing the action in Meta.
-	pf := facetFor(ch.Endpoint.Family)
+	primaryFamily := ch.Endpoint.PrimaryFamily()
+	pf := facetFor(primaryFamily)
 
 	// Stream pulling: for each stream field present in ev.Streams,
 	// pull bytes until cap or EOF, then cancel. For plugin facets
@@ -401,15 +402,15 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 	var req *match.Request
 	if pf != nil {
 		req = &match.Request{
-			Family:    ch.Endpoint.Family,
+			Families:  ch.Endpoint.Families,
 			PeerIP:    ch.PeerIP,
 			Method:    stringField(action, "verb"),
 			URL:       &url.URL{Host: ch.UpstreamHost, Path: ev.Summary},
-			Meta:      action,
 			Truncated: truncated,
 		}
+		req.SetMeta(primaryFamily, action)
 	} else {
-		req = builtinRequestFor(ch.Endpoint.Family, ch.PeerIP, ev.Summary, action, streamBytes)
+		req = builtinRequestFor(primaryFamily, ch.PeerIP, ev.Summary, action, streamBytes)
 		req.Truncated = truncated
 	}
 
@@ -499,9 +500,9 @@ func builtinRequestFor(family, peerIP, summary string, action map[string]any, st
 	switch family {
 	case "http":
 		req := &match.Request{
-			Family: family,
-			PeerIP: peerIP,
-			Method: stringField(action, "method"),
+			Families: []string{family},
+			PeerIP:   peerIP,
+			Method:   stringField(action, "method"),
 		}
 		// URL: prefer a full URL if the plugin sent one; otherwise
 		// build a path-only URL (the built-in http facet only reads
@@ -536,12 +537,13 @@ func builtinRequestFor(family, peerIP, summary string, action map[string]any, st
 		}
 		return req
 	}
-	return &match.Request{
-		Family: family,
-		PeerIP: peerIP,
-		URL:    &url.URL{Path: summary},
-		Meta:   action,
+	req := &match.Request{
+		Families: []string{family},
+		PeerIP:   peerIP,
+		URL:      &url.URL{Path: summary},
 	}
+	req.SetMeta(family, action)
+	return req
 }
 
 // facetFor looks up the synthesized *pluginFacet by namespaced name.

--- a/config/extplugin/celenv.go
+++ b/config/extplugin/celenv.go
@@ -45,7 +45,7 @@ func newPluginFacetMatcher(facetName, condition string, streamFields []string) (
 		return nil, fmt.Errorf("plugin facet %q: cel env: %w", facetName, err)
 	}
 	buildAct := func(req *match.Request) map[string]any {
-		m, ok := req.Meta.(map[string]any)
+		m, ok := req.Meta(facetName).(map[string]any)
 		if !ok {
 			return nil
 		}

--- a/config/extplugin/register.go
+++ b/config/extplugin/register.go
@@ -234,9 +234,9 @@ func registerEndpoint(client *Client, pluginName string, decl *pb.EndpointDecl) 
 	}
 
 	plug := &config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   typeName,
-		Family: decl.Family,
+		Kind:     config.KindEndpoint,
+		Type:     typeName,
+		Families: []string{decl.Family},
 		New: func() any {
 			return &dynamicEndpointBody{
 				adapter:      adapter,

--- a/config/match/match.go
+++ b/config/match/match.go
@@ -16,10 +16,17 @@ import (
 
 // Request is the family-tagged request snapshot passed to Matcher.Match.
 // The handler populates whichever family-specific fields apply and
-// stashes any derived per-family metadata on Meta — its concrete type
-// is owned by the facet plugin, which type-asserts inside its matcher.
+// stashes any derived per-family metadata on Metas — each entry's
+// concrete type is owned by the facet plugin that registered the
+// family name, and matchers type-assert inside their family's slot.
 type Request struct {
-	Family string // e.g. "http" | "sql" | "k8s" | future plugins
+	// Families lists every facet family that may match this request.
+	// The first entry is the primary family (the wire protocol the
+	// gateway dispatched against); subsequent entries are auxiliary
+	// facets attached to the same action. A rule's matcher uses its
+	// own family's slot in Metas and falls through cleanly when the
+	// slot is absent.
+	Families []string
 
 	// Common
 	Credential string // bare-name reference of the credential the
@@ -34,14 +41,15 @@ type Request struct {
 	Headers http.Header
 	Body    []byte // populated when at least one rule needed it
 
-	// Meta is the per-family derived metadata. The owning facet
-	// plugin sets the concrete type — *sql.Meta for SQL, *k8s.Meta
-	// for k8s, etc. — either via facet.Runtime.PrepareRequest
+	// Metas holds the per-family derived metadata keyed by family
+	// name. The owning facet plugin sets the concrete type —
+	// *sql.Meta under "sql", *k8s.Meta under "k8s", *llm.Meta under
+	// "llm", and so on — either via facet.Runtime.PrepareRequest
 	// (HTTPS-family handler) or directly from a wire-frame frontend
-	// (postgres/clickhouse). Matchers type-assert and fall through to
-	// "no match" when the assertion fails (e.g. an https-family rule
-	// running against a request whose Meta is *sql.Meta).
-	Meta any
+	// (postgres/clickhouse). Matchers type-assert against their own
+	// family's slot and fall through to "no match" when the slot is
+	// absent.
+	Metas map[string]any
 
 	// Truncated is set by a wire frontend when the bytes it could
 	// expose to the matcher were capped by a per-plugin inspection
@@ -52,6 +60,55 @@ type Request struct {
 	// rules that don't read the truncated facet still fire on their
 	// other predicates.
 	Truncated bool
+}
+
+// PrimaryFamily returns the first family on the request, or "" when
+// none has been set. The primary family is the wire protocol the
+// gateway dispatched against; auxiliary facet families trail in
+// Families[1:].
+func (r *Request) PrimaryFamily() string {
+	if r == nil || len(r.Families) == 0 {
+		return ""
+	}
+	return r.Families[0]
+}
+
+// HasFamily reports whether the request carries the named family in
+// any position. Matchers can use it to short-circuit before
+// type-asserting against Metas.
+func (r *Request) HasFamily(name string) bool {
+	if r == nil {
+		return false
+	}
+	for _, f := range r.Families {
+		if f == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Meta returns the per-family metadata slot for the named family, or
+// nil when the request carries none. Use this from family matchers
+// instead of poking req.Metas directly so a nil map and a missing
+// key both fall through to "no match" cleanly.
+func (r *Request) Meta(family string) any {
+	if r == nil || r.Metas == nil {
+		return nil
+	}
+	return r.Metas[family]
+}
+
+// SetMeta stashes per-family metadata for the named family. Allocates
+// the map on first call so callers don't have to.
+func (r *Request) SetMeta(family string, m any) {
+	if r == nil {
+		return
+	}
+	if r.Metas == nil {
+		r.Metas = make(map[string]any, 2)
+	}
+	r.Metas[family] = m
 }
 
 // Matcher walks a Request and returns true when the rule's match

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -75,12 +75,17 @@ type Plugin struct {
 	// references that must be resolved against the symbol table.
 	Refs []RefSpec
 
-	// Family classifies an endpoint's protocol so rule plugins can
-	// constrain which endpoints they target. Set on KindEndpoint
-	// plugins ("http" | "sql" | "k8s"). KindRule, with a single
-	// unified plugin, leaves these empty — family is inferred from
-	// the rule's resolved endpoints at validate/build time.
-	Family   string
+	// Families classifies an endpoint's protocol families so rule
+	// plugins can constrain which endpoints they target. Set on
+	// KindEndpoint plugins (e.g. ["http"], ["sql"], ["k8s"]). An
+	// endpoint may carry more than one family — an `anthropic`
+	// endpoint declares `["http", "llm"]` so HTTP rules and LLM
+	// rules both match against the same action. The first entry is
+	// the primary family (used for transport routing, HITL labelling,
+	// and the dashboard's Family column). KindRule, with a single
+	// unified plugin, leaves this empty — the families set is
+	// inferred from the rule's resolved endpoints at validate/build
+	// time.
 	Families []string
 
 	// Validate runs after gohcl decode and after Refs are resolved.

--- a/config/plugins/all/all.go
+++ b/config/plugins/all/all.go
@@ -15,6 +15,7 @@ import (
 	// time.
 	_ "github.com/denoland/clawpatrol/config/plugins/facets/https"
 	_ "github.com/denoland/clawpatrol/config/plugins/facets/k8s"
+	_ "github.com/denoland/clawpatrol/config/plugins/facets/llm"
 	_ "github.com/denoland/clawpatrol/config/plugins/facets/sql"
 	_ "github.com/denoland/clawpatrol/config/plugins/rules"
 	_ "github.com/denoland/clawpatrol/config/plugins/tunnels"

--- a/config/plugins/approvers/util.go
+++ b/config/plugins/approvers/util.go
@@ -17,7 +17,7 @@ func buildPending(req runtime.ApproveRequest) runtime.HITLPending {
 	now := time.Now()
 	family := ""
 	if req.Endpoint != nil {
-		family = req.Endpoint.Family
+		family = req.Endpoint.PrimaryFamily()
 	}
 	return runtime.HITLPending{
 		AgentIP:    req.Profile,

--- a/config/plugins/endpoints/anthropic.go
+++ b/config/plugins/endpoints/anthropic.go
@@ -1,0 +1,286 @@
+package endpoints
+
+// anthropic endpoint: HTTPS-shaped provider plugin for
+// api.anthropic.com. Carries both the http facet (so existing
+// http_rule predicates on method / path / headers keep matching) and
+// the llm facet, which the runtime populates from the Anthropic
+// Messages API request + response. Streaming responses are
+// concatenated SSE byte streams; non-streaming responses are JSON.
+//
+// Sample HCL:
+//
+//	credential "bearer_token" "anthropic" {}
+//
+//	endpoint "anthropic" "claude" {
+//	  hosts      = ["api.anthropic.com"]
+//	  credential = anthropic
+//	}
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/config"
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// AnthropicEndpoint is part of the clawpatrol plugin API.
+type AnthropicEndpoint struct {
+	Hosts          []string  `hcl:"hosts,optional"`
+	Credential     string    `hcl:"credential,optional"`
+	CredentialsRaw cty.Value `hcl:"credentials,optional" json:"-"`
+
+	Credentials []CredentialEntry `json:"Credentials,omitempty"`
+}
+
+// EndpointHosts is part of the clawpatrol plugin API. Defaults to
+// api.anthropic.com so the common single-host case is one-line HCL.
+func (e *AnthropicEndpoint) EndpointHosts() []string {
+	if len(e.Hosts) == 0 {
+		return []string{"api.anthropic.com"}
+	}
+	return e.Hosts
+}
+
+// EndpointCredentials is part of the clawpatrol plugin API.
+func (e *AnthropicEndpoint) EndpointCredentials() []config.CredBinding {
+	return bindings(e.Credential, e.Credentials)
+}
+
+func (e *AnthropicEndpoint) credentialAndRaw() (string, cty.Value) {
+	return e.Credential, e.CredentialsRaw
+}
+
+func (e *AnthropicEndpoint) setCredentialEntries(es []CredentialEntry) {
+	e.Credentials = es
+}
+
+// AnthropicEndpointRuntime detects placeholders in the same
+// Authorization / x-api-key headers Anthropic accepts and parses the
+// Messages API for LLM facets.
+type AnthropicEndpointRuntime struct{}
+
+// DetectPlaceholder mirrors the default HTTPS detector but also scans
+// x-api-key (Anthropic's preferred header) — agents that bind their
+// credential placeholder there must still resolve.
+func (AnthropicEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidates []string) string {
+	if req == nil || req.Headers == nil {
+		return ""
+	}
+	hay := req.Headers.Get("Authorization") + "\x00" + req.Headers.Get("x-api-key")
+	for _, c := range candidates {
+		if c != "" && strings.Contains(hay, c) {
+			return c
+		}
+	}
+	return ""
+}
+
+// ParseLLMRequest extracts provider / model / stream from a Messages
+// API request body. Returns nil for non-JSON / unparseable bodies so
+// the dispatcher omits LLM facets cleanly on non-API paths.
+func (AnthropicEndpointRuntime) ParseLLMRequest(reqBody []byte) any {
+	if len(reqBody) == 0 {
+		return nil
+	}
+	var req struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(reqBody, &req); err != nil {
+		return nil
+	}
+	if req.Model == "" {
+		return nil
+	}
+	return &llmfacet.Meta{
+		Provider: "anthropic",
+		Model:    req.Model,
+		Stream:   req.Stream,
+	}
+}
+
+// ParseLLMResponse amends the pre-flight Meta with token counts and
+// stop_reason extracted from the response. Streaming responses
+// arrive as concatenated SSE bytes — the parser walks them
+// line-by-line and lifts usage from the message_delta event and the
+// final message_stop. Non-streaming responses are full JSON.
+func (AnthropicEndpointRuntime) ParseLLMResponse(reqBody, respBody []byte, pre any) any {
+	m, _ := pre.(*llmfacet.Meta)
+	if m == nil {
+		m = &llmfacet.Meta{Provider: "anthropic"}
+	}
+	if len(respBody) == 0 {
+		return m
+	}
+	if isAnthropicSSE(respBody) {
+		fillFromAnthropicSSE(m, respBody)
+		return m
+	}
+	fillFromAnthropicJSON(m, respBody)
+	return m
+}
+
+func isAnthropicSSE(body []byte) bool {
+	// SSE responses begin with `event: ` framing.
+	return bytes.HasPrefix(bytes.TrimLeft(body, " \t\r\n"), []byte("event:"))
+}
+
+// fillFromAnthropicJSON reads usage + stop_reason from a non-streamed
+// /v1/messages response. Schema (subset):
+//
+//	{
+//	  "model": "...",
+//	  "stop_reason": "end_turn|max_tokens|stop_sequence|tool_use",
+//	  "usage": { "input_tokens": N, "output_tokens": N,
+//	             "cache_creation_input_tokens": N,
+//	             "cache_read_input_tokens": N }
+//	}
+func fillFromAnthropicJSON(m *llmfacet.Meta, body []byte) {
+	var r struct {
+		Model      string `json:"model"`
+		StopReason string `json:"stop_reason"`
+		Usage      struct {
+			InputTokens              int64 `json:"input_tokens"`
+			OutputTokens             int64 `json:"output_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return
+	}
+	if m.Model == "" {
+		m.Model = r.Model
+	}
+	if r.StopReason != "" {
+		m.StopReason = r.StopReason
+	}
+	m.InputTokens += r.Usage.InputTokens
+	m.OutputTokens += r.Usage.OutputTokens
+	m.CacheReadTokens += r.Usage.CacheReadInputTokens
+	m.CacheWriteTokens += r.Usage.CacheCreationInputTokens
+}
+
+// fillFromAnthropicSSE walks the concatenated SSE stream the gateway
+// captured. Anthropic emits one usage block on the initial
+// message_start (with input_tokens + cache fields), partial output
+// counts via message_delta events, and a final stop_reason on the
+// terminating message_delta.
+//
+// The parser sums output_tokens across message_delta events and
+// keeps the most recent stop_reason — Anthropic's protocol emits
+// each only once per turn, so summation is a no-op past the final
+// frame; matching the upstream behaviour even if a hostile stream
+// repeats frames stays the right shape.
+func fillFromAnthropicSSE(m *llmfacet.Meta, body []byte) {
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	var event string
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "event:") {
+			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		switch event {
+		case "message_start":
+			fillAnthropicMessageStart(m, payload)
+		case "message_delta":
+			fillAnthropicMessageDelta(m, payload)
+		}
+	}
+}
+
+// fillAnthropicMessageStart pulls the initial usage block and model
+// out of a message_start frame.
+//
+//	data: {"type":"message_start","message":{"model":"...","usage":{
+//	    "input_tokens":N,"cache_creation_input_tokens":N,
+//	    "cache_read_input_tokens":N}}}
+func fillAnthropicMessageStart(m *llmfacet.Meta, payload string) {
+	var f struct {
+		Message struct {
+			Model string `json:"model"`
+			Usage struct {
+				InputTokens              int64 `json:"input_tokens"`
+				OutputTokens             int64 `json:"output_tokens"`
+				CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+				CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+			} `json:"usage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(payload), &f); err != nil {
+		return
+	}
+	if m.Model == "" {
+		m.Model = f.Message.Model
+	}
+	m.InputTokens += f.Message.Usage.InputTokens
+	m.OutputTokens += f.Message.Usage.OutputTokens
+	m.CacheReadTokens += f.Message.Usage.CacheReadInputTokens
+	m.CacheWriteTokens += f.Message.Usage.CacheCreationInputTokens
+}
+
+// fillAnthropicMessageDelta pulls output token counts and the
+// terminating stop_reason out of a message_delta frame.
+//
+//	data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},
+//	       "usage":{"output_tokens":N}}
+func fillAnthropicMessageDelta(m *llmfacet.Meta, payload string) {
+	var f struct {
+		Delta struct {
+			StopReason string `json:"stop_reason"`
+		} `json:"delta"`
+		Usage struct {
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal([]byte(payload), &f); err != nil {
+		return
+	}
+	if f.Delta.StopReason != "" {
+		m.StopReason = f.Delta.StopReason
+	}
+	m.OutputTokens += f.Usage.OutputTokens
+}
+
+func init() {
+	var _ runtime.PlaceholderDetector = AnthropicEndpointRuntime{}
+	var _ runtime.LLMResponseParser = AnthropicEndpointRuntime{}
+	config.Register(&config.Plugin{
+		Kind: config.KindEndpoint,
+		Type: "anthropic",
+		// "http" is primary: the wire is HTTPS, the dashboard
+		// renders the Family column off it, and http_rule keeps
+		// matching method / path / headers. "llm" rides as the
+		// auxiliary facet that the LLMResponseParser populates with
+		// model + token counts.
+		Families: []string{"http", "llm"},
+		New:      func() any { return &AnthropicEndpoint{} },
+		Refs:     singularRef,
+		Validate: multiCredValidate,
+		Runtime:  AnthropicEndpointRuntime{},
+		Build:    passthroughBuild,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			e := body.(*AnthropicEndpoint)
+			if len(e.Hosts) > 0 {
+				b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
+			}
+			emitCredentialBinding(b, e.Credential, e.Credentials, "placeholder")
+		},
+	})
+}

--- a/config/plugins/endpoints/anthropic_test.go
+++ b/config/plugins/endpoints/anthropic_test.go
@@ -1,0 +1,119 @@
+package endpoints
+
+import (
+	"testing"
+
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+)
+
+// TestAnthropicParseLLMRequest pins the pre-flight extraction:
+// model + stream lift cleanly off a Messages API POST body. Empty
+// / non-JSON / model-less bodies return nil so the dispatcher
+// omits llm facets on non-API paths.
+func TestAnthropicParseLLMRequest(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want *llmfacet.Meta
+	}{
+		{"streamed claude opus", `{"model":"claude-opus-4-7-20251001","stream":true,"messages":[]}`,
+			&llmfacet.Meta{Provider: "anthropic", Model: "claude-opus-4-7-20251001", Stream: true}},
+		{"non-streamed sonnet", `{"model":"claude-3-5-sonnet-20240620","messages":[]}`,
+			&llmfacet.Meta{Provider: "anthropic", Model: "claude-3-5-sonnet-20240620"}},
+		{"empty body", ``, nil},
+		{"non-JSON", `not json at all`, nil},
+		{"missing model", `{"messages":[]}`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AnthropicEndpointRuntime{}.ParseLLMRequest([]byte(tc.body))
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			m, ok := got.(*llmfacet.Meta)
+			if !ok {
+				t.Fatalf("expected *llmfacet.Meta, got %T", got)
+			}
+			if *m != *tc.want {
+				t.Errorf("got %+v want %+v", *m, *tc.want)
+			}
+		})
+	}
+}
+
+// TestAnthropicParseLLMResponseJSON exercises the non-streaming
+// response path against the actual Messages API schema, including
+// cache token fields.
+func TestAnthropicParseLLMResponseJSON(t *testing.T) {
+	pre := &llmfacet.Meta{Provider: "anthropic", Model: "claude-opus-4-7-20251001"}
+	resp := `{
+		"model":"claude-opus-4-7-20251001",
+		"stop_reason":"end_turn",
+		"usage":{
+			"input_tokens":120,
+			"output_tokens":45,
+			"cache_creation_input_tokens":300,
+			"cache_read_input_tokens":900
+		}
+	}`
+	got := AnthropicEndpointRuntime{}.ParseLLMResponse(nil, []byte(resp), pre).(*llmfacet.Meta)
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason=%q want end_turn", got.StopReason)
+	}
+	if got.InputTokens != 120 {
+		t.Errorf("input=%d want 120", got.InputTokens)
+	}
+	if got.OutputTokens != 45 {
+		t.Errorf("output=%d want 45", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 900 {
+		t.Errorf("cache_read=%d want 900", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens != 300 {
+		t.Errorf("cache_write=%d want 300", got.CacheWriteTokens)
+	}
+}
+
+// TestAnthropicParseLLMResponseSSE walks a realistic streaming
+// response: message_start carries input + cache tokens; one or more
+// message_delta frames carry partial output tokens; the terminating
+// message_delta carries the final stop_reason and last output
+// chunk. The parser must sum output_tokens across deltas and keep
+// the final stop_reason.
+func TestAnthropicParseLLMResponseSSE(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"model":"claude-opus-4-7-20251001","usage":{"input_tokens":200,"output_tokens":1,"cache_creation_input_tokens":50,"cache_read_input_tokens":800}}}
+
+event: content_block_start
+data: {"type":"content_block_start"}
+
+event: message_delta
+data: {"type":"message_delta","delta":{},"usage":{"output_tokens":12}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	pre := &llmfacet.Meta{Provider: "anthropic", Model: "claude-opus-4-7-20251001"}
+	got := AnthropicEndpointRuntime{}.ParseLLMResponse(nil, []byte(stream), pre).(*llmfacet.Meta)
+	if got.InputTokens != 200 {
+		t.Errorf("input=%d want 200", got.InputTokens)
+	}
+	if got.OutputTokens != 20 {
+		t.Errorf("output=%d want 20 (1+12+7)", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 800 {
+		t.Errorf("cache_read=%d want 800", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens != 50 {
+		t.Errorf("cache_write=%d want 50", got.CacheWriteTokens)
+	}
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason=%q want end_turn", got.StopReason)
+	}
+}

--- a/config/plugins/endpoints/clickhouse_https.go
+++ b/config/plugins/endpoints/clickhouse_https.go
@@ -26,12 +26,12 @@ func (e *ClickhouseHTTPSEndpoint) EndpointCredentials() []config.CredBinding {
 
 func init() {
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "clickhouse_https",
-		Family: "sql",
-		New:    func() any { return &ClickhouseHTTPSEndpoint{} },
-		Refs:   singularRef,
-		Build:  passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "clickhouse_https",
+		Families: []string{"sql"},
+		New:      func() any { return &ClickhouseHTTPSEndpoint{} },
+		Refs:     singularRef,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -128,7 +128,7 @@ func init() {
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "clickhouse_native",
-		Family:   "sql",
+		Families: []string{"sql"},
 		New:      func() any { return &ClickhouseNativeEndpoint{} },
 		Refs:     singularRef,
 		Runtime:  ClickhouseNativeEndpointRuntime{},

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -116,7 +116,7 @@ func chValidCompressedMethod(b byte) bool {
 //     pure copy past the Hello.
 func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
 	defer func() { _ = ch.Conn.Close() }()
-	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
+	if ch.Endpoint == nil || !ch.Endpoint.HasFamily("sql") {
 		err := fmt.Errorf("clickhouse_native runtime invoked on non-sql endpoint %v", ch.Endpoint)
 		chEmitError(ch, "wrong-family", "")
 		return err
@@ -835,17 +835,17 @@ func chRewindReader(head []byte, tail *chgoproto.Reader) *chgoproto.Reader {
 func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName string, truncated bool) (string, string) {
 	info := parseChSQL(sql)
 	mreq := &match.Request{
-		Family:     "sql",
+		Families:   []string{"sql"},
 		PeerIP:     ch.PeerIP,
 		Credential: credName,
-		Meta: &sqlfacet.Meta{
-			Verb:      info.Verb,
-			Tables:    info.Tables,
-			Functions: info.Functions,
-			Statement: info.Statement,
-		},
-		Truncated: truncated,
+		Truncated:  truncated,
 	}
+	mreq.SetMeta("sql", &sqlfacet.Meta{
+		Verb:      info.Verb,
+		Tables:    info.Tables,
+		Functions: info.Functions,
+		Statement: info.Statement,
+	})
 	var facets map[string]any
 	if f := facet.Lookup("sql"); f != nil {
 		facets = f.Report(mreq)

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -378,11 +378,11 @@ func TestChHostPort(t *testing.T) {
 func chBuildEndpoint(t *testing.T, rules ...*config.CompiledRule) *config.CompiledEndpoint {
 	t.Helper()
 	return &config.CompiledEndpoint{
-		Name:   "test-ch",
-		Family: "sql",
-		Body:   &ClickhouseNativeEndpoint{Hosts: []string{"ch.example:9000"}},
-		Hosts:  []string{"ch.example:9000"},
-		Rules:  rules,
+		Name:     "test-ch",
+		Families: []string{"sql"},
+		Body:     &ClickhouseNativeEndpoint{Hosts: []string{"ch.example:9000"}},
+		Hosts:    []string{"ch.example:9000"},
+		Rules:    rules,
 	}
 }
 

--- a/config/plugins/endpoints/https.go
+++ b/config/plugins/endpoints/https.go
@@ -81,7 +81,7 @@ func init() {
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "https",
-		Family:   "http",
+		Families: []string{"http"},
 		New:      func() any { return &HTTPSEndpoint{} },
 		Refs:     singularRef,
 		Validate: multiCredValidate,

--- a/config/plugins/endpoints/kubernetes.go
+++ b/config/plugins/endpoints/kubernetes.go
@@ -47,12 +47,12 @@ func (e *KubernetesEndpoint) EndpointCredentials() []config.CredBinding {
 
 func init() {
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "kubernetes",
-		Family: "k8s",
-		New:    func() any { return &KubernetesEndpoint{} },
-		Refs:   singularRef,
-		Build:  passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "kubernetes",
+		Families: []string{"k8s"},
+		New:      func() any { return &KubernetesEndpoint{} },
+		Refs:     singularRef,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*KubernetesEndpoint)
 			if len(e.Hosts) > 0 {

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -21,6 +21,8 @@ package endpoints
 //	}
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ed25519"
@@ -42,6 +44,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
@@ -157,9 +160,145 @@ func jsonResp(req *http.Request, status int, body []byte) *http.Response {
 	return resp
 }
 
+// ParseLLMRequest extracts model + stream from a chatgpt.com codex
+// /backend-api/codex/responses POST body. Schema mirrors the OpenAI
+// Responses API: {"model":"...","stream":true,"input":[...]}. Empty
+// or non-JSON bodies return nil so the dispatcher skips llm facet
+// emission on non-API paths (e.g. the JWKS GET the synthetic
+// responder handles).
+func (OpenAICodexHTTPSEndpointRuntime) ParseLLMRequest(reqBody []byte) any {
+	if len(reqBody) == 0 {
+		return nil
+	}
+	var req struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(reqBody, &req); err != nil {
+		return nil
+	}
+	if req.Model == "" {
+		return nil
+	}
+	return &llmfacet.Meta{
+		Provider: "openai",
+		Model:    req.Model,
+		Stream:   req.Stream,
+	}
+}
+
+// ParseLLMResponse amends the pre-flight Meta with token counts and
+// stop_reason. The chatgpt.com codex path uses the OpenAI Responses
+// API — usage lands in a `response.completed` SSE event when
+// streaming, and inline as `usage` on the non-streamed body.
+func (OpenAICodexHTTPSEndpointRuntime) ParseLLMResponse(reqBody, respBody []byte, pre any) any {
+	m, _ := pre.(*llmfacet.Meta)
+	if m == nil {
+		m = &llmfacet.Meta{Provider: "openai"}
+	}
+	if len(respBody) == 0 {
+		return m
+	}
+	if isOpenAIResponsesSSE(respBody) {
+		fillFromOpenAIResponsesSSE(m, respBody)
+		return m
+	}
+	fillFromOpenAIResponsesJSON(m, respBody)
+	return m
+}
+
+func isOpenAIResponsesSSE(body []byte) bool {
+	trimmed := bytes.TrimLeft(body, " \t\r\n")
+	return bytes.HasPrefix(trimmed, []byte("event:")) || bytes.HasPrefix(trimmed, []byte("data:"))
+}
+
+// fillFromOpenAIResponsesJSON reads usage from a Responses API
+// non-streamed body:
+//
+//	{
+//	  "model": "...",
+//	  "status": "completed",
+//	  "usage": { "input_tokens": N, "output_tokens": N,
+//	             "input_tokens_details": { "cached_tokens": N } }
+//	}
+func fillFromOpenAIResponsesJSON(m *llmfacet.Meta, body []byte) {
+	var r openAIResponsesPayload
+	if err := json.Unmarshal(body, &r); err != nil {
+		return
+	}
+	mergeOpenAIResponses(m, &r)
+}
+
+// fillFromOpenAIResponsesSSE walks the streamed response. The
+// response.completed event carries the final usage block and status;
+// the parser merges any chunk that lifts one.
+func fillFromOpenAIResponsesSSE(m *llmfacet.Meta, body []byte) {
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		// Streamed events wrap the payload in
+		// {"type":"response.completed","response":{...}}; the
+		// non-wrapping case (some intermediate events) just sends
+		// the bare response object. Try both shapes; whichever
+		// decodes populates the Meta.
+		var wrapped struct {
+			Type     string                 `json:"type"`
+			Response openAIResponsesPayload `json:"response"`
+		}
+		if err := json.Unmarshal([]byte(payload), &wrapped); err == nil && wrapped.Type != "" {
+			mergeOpenAIResponses(m, &wrapped.Response)
+			continue
+		}
+		var bare openAIResponsesPayload
+		if err := json.Unmarshal([]byte(payload), &bare); err == nil {
+			mergeOpenAIResponses(m, &bare)
+		}
+	}
+}
+
+// openAIResponsesPayload is the subset of the OpenAI Responses API
+// (used by chatgpt.com's codex flow) that the LLM facet cares about.
+type openAIResponsesPayload struct {
+	Model  string `json:"model"`
+	Status string `json:"status"`
+	Usage  *struct {
+		InputTokens        int64 `json:"input_tokens"`
+		OutputTokens       int64 `json:"output_tokens"`
+		InputTokensDetails *struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"input_tokens_details"`
+	} `json:"usage"`
+}
+
+func mergeOpenAIResponses(m *llmfacet.Meta, r *openAIResponsesPayload) {
+	if m.Model == "" {
+		m.Model = r.Model
+	}
+	if r.Status != "" {
+		m.StopReason = r.Status
+	}
+	if r.Usage == nil {
+		return
+	}
+	m.InputTokens += r.Usage.InputTokens
+	m.OutputTokens += r.Usage.OutputTokens
+	if r.Usage.InputTokensDetails != nil {
+		m.CacheReadTokens += r.Usage.InputTokensDetails.CachedTokens
+	}
+}
+
 func init() {
 	var _ runtime.PlaceholderDetector = OpenAICodexHTTPSEndpointRuntime{}
 	var _ runtime.HTTPSyntheticResponder = OpenAICodexHTTPSEndpointRuntime{}
+	var _ runtime.LLMResponseParser = OpenAICodexHTTPSEndpointRuntime{}
 	config.Register(&config.Plugin{
 		Kind: config.KindEndpoint,
 		Type: "openai_codex_https",

--- a/config/plugins/endpoints/openai_codex_https.go
+++ b/config/plugins/endpoints/openai_codex_https.go
@@ -161,9 +161,15 @@ func init() {
 	var _ runtime.PlaceholderDetector = OpenAICodexHTTPSEndpointRuntime{}
 	var _ runtime.HTTPSyntheticResponder = OpenAICodexHTTPSEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:     config.KindEndpoint,
-		Type:     "openai_codex_https",
-		Family:   "http",
+		Kind: config.KindEndpoint,
+		Type: "openai_codex_https",
+		// The chatgpt.com codex flow is HTTPS underneath plus LLM-
+		// shaped — both http_rule (path / method / headers) and
+		// llm_rule (model glob, provider gate) match the same
+		// action. Family "http" is primary (https-mitm transport,
+		// dashboard column); "llm" rides as an auxiliary facet
+		// populated post-stream from the Responses API payload.
+		Families: []string{"http", "llm"},
 		New:      func() any { return &OpenAICodexHTTPSEndpoint{} },
 		Refs:     singularRef,
 		Validate: multiCredValidate,

--- a/config/plugins/endpoints/openai_codex_llm_test.go
+++ b/config/plugins/endpoints/openai_codex_llm_test.go
@@ -1,0 +1,88 @@
+package endpoints
+
+import (
+	"testing"
+
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+)
+
+// TestOpenAICodexParseLLMRequest pins pre-flight extraction from a
+// chatgpt.com codex /backend-api/codex/responses POST. The body's
+// model + stream lift; non-JSON / model-less / empty bodies return
+// nil so non-API paths (the JWKS GET the synthetic responder serves)
+// don't fabricate llm facets.
+func TestOpenAICodexParseLLMRequest(t *testing.T) {
+	body := `{"model":"gpt-5-codex","stream":true,"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]}`
+	got := OpenAICodexHTTPSEndpointRuntime{}.ParseLLMRequest([]byte(body))
+	m, ok := got.(*llmfacet.Meta)
+	if !ok {
+		t.Fatalf("expected *llmfacet.Meta, got %T", got)
+	}
+	if m.Provider != "openai" {
+		t.Errorf("provider=%q want openai", m.Provider)
+	}
+	if m.Model != "gpt-5-codex" {
+		t.Errorf("model=%q want gpt-5-codex", m.Model)
+	}
+	if !m.Stream {
+		t.Errorf("stream=false want true")
+	}
+	rt := OpenAICodexHTTPSEndpointRuntime{}
+	if v := rt.ParseLLMRequest([]byte(``)); v != nil {
+		t.Errorf("empty body returned %+v, want nil", v)
+	}
+	if v := rt.ParseLLMRequest([]byte(`not json`)); v != nil {
+		t.Errorf("non-JSON returned %+v, want nil", v)
+	}
+}
+
+// TestOpenAICodexParseLLMResponseJSON pins the non-streamed
+// Responses-API shape (codex sometimes returns the final body
+// directly).
+func TestOpenAICodexParseLLMResponseJSON(t *testing.T) {
+	pre := &llmfacet.Meta{Provider: "openai", Model: "gpt-5-codex"}
+	resp := `{
+		"model":"gpt-5-codex",
+		"status":"completed",
+		"usage":{
+			"input_tokens":300,
+			"output_tokens":80,
+			"input_tokens_details":{"cached_tokens":120}
+		}
+	}`
+	got := OpenAICodexHTTPSEndpointRuntime{}.ParseLLMResponse(nil, []byte(resp), pre).(*llmfacet.Meta)
+	if got.InputTokens != 300 {
+		t.Errorf("input=%d want 300", got.InputTokens)
+	}
+	if got.OutputTokens != 80 {
+		t.Errorf("output=%d want 80", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 120 {
+		t.Errorf("cache_read=%d want 120", got.CacheReadTokens)
+	}
+	if got.StopReason != "completed" {
+		t.Errorf("stop_reason=%q want completed", got.StopReason)
+	}
+}
+
+// TestOpenAICodexParseLLMResponseSSE walks a streamed Responses-API
+// flow. The wrapping `response.completed` event carries the final
+// `response` object with usage; the parser merges it.
+func TestOpenAICodexParseLLMResponseSSE(t *testing.T) {
+	stream := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"model\":\"gpt-5-codex\",\"status\":\"completed\",\"usage\":{\"input_tokens\":250,\"output_tokens\":40,\"input_tokens_details\":{\"cached_tokens\":75}}}}\n\n"
+	pre := &llmfacet.Meta{Provider: "openai", Model: "gpt-5-codex"}
+	got := OpenAICodexHTTPSEndpointRuntime{}.ParseLLMResponse(nil, []byte(stream), pre).(*llmfacet.Meta)
+	if got.InputTokens != 250 {
+		t.Errorf("input=%d want 250", got.InputTokens)
+	}
+	if got.OutputTokens != 40 {
+		t.Errorf("output=%d want 40", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 75 {
+		t.Errorf("cache_read=%d want 75", got.CacheReadTokens)
+	}
+	if got.StopReason != "completed" {
+		t.Errorf("stop_reason=%q want completed", got.StopReason)
+	}
+}

--- a/config/plugins/endpoints/openrouter.go
+++ b/config/plugins/endpoints/openrouter.go
@@ -1,0 +1,239 @@
+package endpoints
+
+// openrouter endpoint: HTTPS-shaped provider plugin for
+// openrouter.ai. OpenRouter exposes an OpenAI-compatible
+// /v1/chat/completions surface that proxies the underlying provider;
+// the response carries an OpenAI-shaped `usage` block with
+// prompt_tokens / completion_tokens and a model string formatted as
+// `<provider>/<model>` (e.g. `anthropic/claude-3-5-sonnet`).
+//
+// Sample HCL:
+//
+//	credential "bearer_token" "openrouter" {}
+//
+//	endpoint "openrouter" "router" {
+//	  hosts      = ["openrouter.ai"]
+//	  credential = openrouter
+//	}
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/config"
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// OpenRouterEndpoint is part of the clawpatrol plugin API.
+type OpenRouterEndpoint struct {
+	Hosts          []string  `hcl:"hosts,optional"`
+	Credential     string    `hcl:"credential,optional"`
+	CredentialsRaw cty.Value `hcl:"credentials,optional" json:"-"`
+
+	Credentials []CredentialEntry `json:"Credentials,omitempty"`
+}
+
+// EndpointHosts is part of the clawpatrol plugin API. Defaults to
+// openrouter.ai when the operator doesn't list explicit hosts.
+func (e *OpenRouterEndpoint) EndpointHosts() []string {
+	if len(e.Hosts) == 0 {
+		return []string{"openrouter.ai"}
+	}
+	return e.Hosts
+}
+
+// EndpointCredentials is part of the clawpatrol plugin API.
+func (e *OpenRouterEndpoint) EndpointCredentials() []config.CredBinding {
+	return bindings(e.Credential, e.Credentials)
+}
+
+func (e *OpenRouterEndpoint) credentialAndRaw() (string, cty.Value) {
+	return e.Credential, e.CredentialsRaw
+}
+
+func (e *OpenRouterEndpoint) setCredentialEntries(es []CredentialEntry) {
+	e.Credentials = es
+}
+
+// OpenRouterEndpointRuntime owns OpenRouter's placeholder detection
+// (Authorization: Bearer) and OpenAI-compatible response parsing.
+type OpenRouterEndpointRuntime struct{}
+
+// DetectPlaceholder reuses the canonical HTTPS Authorization scan.
+func (OpenRouterEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidates []string) string {
+	if req == nil || req.Headers == nil {
+		return ""
+	}
+	hay := req.Headers.Get("Authorization")
+	for _, c := range candidates {
+		if c != "" && strings.Contains(hay, c) {
+			return c
+		}
+	}
+	return ""
+}
+
+// ParseLLMRequest extracts provider / model / stream from a
+// /v1/chat/completions request body. The model string is left
+// untouched (operators write `llm.model.matches("^anthropic/")` if
+// they want to gate by underlying provider).
+func (OpenRouterEndpointRuntime) ParseLLMRequest(reqBody []byte) any {
+	if len(reqBody) == 0 {
+		return nil
+	}
+	var req struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(reqBody, &req); err != nil {
+		return nil
+	}
+	if req.Model == "" {
+		return nil
+	}
+	return &llmfacet.Meta{
+		Provider: "openrouter",
+		Model:    req.Model,
+		Stream:   req.Stream,
+	}
+}
+
+// ParseLLMResponse amends the pre-flight Meta with token counts and
+// finish_reason. OpenRouter mirrors OpenAI's `usage` shape on the
+// final chunk of a streamed response and on the body of a
+// non-streamed one; cached_tokens (when present) maps onto
+// cache_read_tokens.
+func (OpenRouterEndpointRuntime) ParseLLMResponse(reqBody, respBody []byte, pre any) any {
+	m, _ := pre.(*llmfacet.Meta)
+	if m == nil {
+		m = &llmfacet.Meta{Provider: "openrouter"}
+	}
+	if len(respBody) == 0 {
+		return m
+	}
+	if isOpenAISSE(respBody) {
+		fillFromOpenAISSE(m, respBody)
+		return m
+	}
+	fillFromOpenAIJSON(m, respBody)
+	return m
+}
+
+// isOpenAISSE recognises an OpenAI-compatible streamed response by
+// the first non-blank `data:` frame. Anthropic's SSE starts with
+// `event:`; OpenAI ships only `data:` lines, with `[DONE]` as the
+// terminator.
+func isOpenAISSE(body []byte) bool {
+	trimmed := bytes.TrimLeft(body, " \t\r\n")
+	return bytes.HasPrefix(trimmed, []byte("data:"))
+}
+
+// fillFromOpenAIJSON reads usage / finish_reason from the final
+// /v1/chat/completions JSON body.
+//
+//	{
+//	  "model": "anthropic/claude-...",
+//	  "choices": [{"finish_reason": "stop", ...}],
+//	  "usage": { "prompt_tokens": N, "completion_tokens": N,
+//	             "total_tokens": N,
+//	             "prompt_tokens_details": { "cached_tokens": N } }
+//	}
+func fillFromOpenAIJSON(m *llmfacet.Meta, body []byte) {
+	var r openAIChatResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return
+	}
+	mergeOpenAIResponse(m, &r)
+}
+
+// fillFromOpenAISSE walks the SSE stream and merges every
+// chunk that carries a `usage` block. Chunks carrying choices with a
+// finish_reason update StopReason. OpenAI emits usage only on the
+// final chunk (when the request opted in via stream_options.include_usage)
+// or repeatedly per chunk — the merge sums in either case and the
+// final chunk's stop_reason wins because it overwrites.
+func fillFromOpenAISSE(m *llmfacet.Meta, body []byte) {
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var chunk openAIChatResponse
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		mergeOpenAIResponse(m, &chunk)
+	}
+}
+
+// openAIChatResponse is the subset of the OpenAI / OpenRouter chat
+// completions payload the LLM facet cares about. Same shape for
+// final body, terminal SSE chunk, and (when streaming usage is
+// enabled) per-chunk frames.
+type openAIChatResponse struct {
+	Model   string `json:"model"`
+	Choices []struct {
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens        int64 `json:"prompt_tokens"`
+		CompletionTokens    int64 `json:"completion_tokens"`
+		TotalTokens         int64 `json:"total_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+	} `json:"usage"`
+}
+
+func mergeOpenAIResponse(m *llmfacet.Meta, r *openAIChatResponse) {
+	if m.Model == "" {
+		m.Model = r.Model
+	}
+	for _, c := range r.Choices {
+		if c.FinishReason != "" {
+			m.StopReason = c.FinishReason
+		}
+	}
+	if r.Usage == nil {
+		return
+	}
+	m.InputTokens += r.Usage.PromptTokens
+	m.OutputTokens += r.Usage.CompletionTokens
+	if r.Usage.PromptTokensDetails != nil {
+		m.CacheReadTokens += r.Usage.PromptTokensDetails.CachedTokens
+	}
+}
+
+func init() {
+	var _ runtime.PlaceholderDetector = OpenRouterEndpointRuntime{}
+	var _ runtime.LLMResponseParser = OpenRouterEndpointRuntime{}
+	config.Register(&config.Plugin{
+		Kind:     config.KindEndpoint,
+		Type:     "openrouter",
+		Families: []string{"http", "llm"},
+		New:      func() any { return &OpenRouterEndpoint{} },
+		Refs:     singularRef,
+		Validate: multiCredValidate,
+		Runtime:  OpenRouterEndpointRuntime{},
+		Build:    passthroughBuild,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			e := body.(*OpenRouterEndpoint)
+			if len(e.Hosts) > 0 {
+				b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
+			}
+			emitCredentialBinding(b, e.Credential, e.Credentials, "placeholder")
+		},
+	})
+}

--- a/config/plugins/endpoints/openrouter_test.go
+++ b/config/plugins/endpoints/openrouter_test.go
@@ -1,0 +1,84 @@
+package endpoints
+
+import (
+	"testing"
+
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+)
+
+// TestOpenRouterParseLLMRequest pins pre-flight extraction. OpenRouter
+// passes model strings through verbatim (operators write
+// `llm.model.matches("^anthropic/")` to gate underlying provider),
+// so the parser preserves the provider/model shape.
+func TestOpenRouterParseLLMRequest(t *testing.T) {
+	body := `{"model":"anthropic/claude-3-5-sonnet-20240620","stream":true,"messages":[]}`
+	got := OpenRouterEndpointRuntime{}.ParseLLMRequest([]byte(body))
+	m, ok := got.(*llmfacet.Meta)
+	if !ok {
+		t.Fatalf("expected *llmfacet.Meta, got %T", got)
+	}
+	if m.Provider != "openrouter" {
+		t.Errorf("provider=%q want openrouter", m.Provider)
+	}
+	if m.Model != "anthropic/claude-3-5-sonnet-20240620" {
+		t.Errorf("model=%q want passthrough", m.Model)
+	}
+	if !m.Stream {
+		t.Errorf("stream=false want true")
+	}
+}
+
+// TestOpenRouterParseLLMResponseJSON pins the non-streamed OpenAI-
+// compatible response shape, including cached_tokens.
+func TestOpenRouterParseLLMResponseJSON(t *testing.T) {
+	pre := &llmfacet.Meta{Provider: "openrouter", Model: "anthropic/claude-3-5-sonnet-20240620"}
+	resp := `{
+		"model":"anthropic/claude-3-5-sonnet-20240620",
+		"choices":[{"finish_reason":"stop"}],
+		"usage":{
+			"prompt_tokens":150,
+			"completion_tokens":60,
+			"total_tokens":210,
+			"prompt_tokens_details":{"cached_tokens":100}
+		}
+	}`
+	got := OpenRouterEndpointRuntime{}.ParseLLMResponse(nil, []byte(resp), pre).(*llmfacet.Meta)
+	if got.InputTokens != 150 {
+		t.Errorf("input=%d want 150", got.InputTokens)
+	}
+	if got.OutputTokens != 60 {
+		t.Errorf("output=%d want 60", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 100 {
+		t.Errorf("cache_read=%d want 100", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens != 0 {
+		t.Errorf("cache_write=%d want 0 (no write/read split on OpenAI)", got.CacheWriteTokens)
+	}
+	if got.StopReason != "stop" {
+		t.Errorf("stop_reason=%q want stop", got.StopReason)
+	}
+}
+
+// TestOpenRouterParseLLMResponseSSE walks a streamed OpenAI-shaped
+// response. Usage lifts off the final chunk; finish_reason off the
+// last chunk that carries one. [DONE] terminator is ignored.
+func TestOpenRouterParseLLMResponseSSE(t *testing.T) {
+	stream := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":80,\"completion_tokens\":20,\"prompt_tokens_details\":{\"cached_tokens\":40}}}\n\n" +
+		"data: [DONE]\n\n"
+	pre := &llmfacet.Meta{Provider: "openrouter", Model: "openai/gpt-4o"}
+	got := OpenRouterEndpointRuntime{}.ParseLLMResponse(nil, []byte(stream), pre).(*llmfacet.Meta)
+	if got.InputTokens != 80 {
+		t.Errorf("input=%d want 80", got.InputTokens)
+	}
+	if got.OutputTokens != 20 {
+		t.Errorf("output=%d want 20", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 40 {
+		t.Errorf("cache_read=%d want 40", got.CacheReadTokens)
+	}
+	if got.StopReason != "stop" {
+		t.Errorf("stop_reason=%q want stop", got.StopReason)
+	}
+}

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -110,7 +110,7 @@ func (PostgresEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidate
 	if req == nil {
 		return ""
 	}
-	meta, _ := req.Meta.(*sqlfacet.Meta)
+	meta, _ := req.Meta("sql").(*sqlfacet.Meta)
 	if meta == nil {
 		return ""
 	}
@@ -144,7 +144,7 @@ func init() {
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "postgres",
-		Family:   "sql",
+		Families: []string{"sql"},
 		New:      func() any { return &PostgresEndpoint{} },
 		Refs:     singularRef,
 		Validate: multiCredValidate,
@@ -182,7 +182,7 @@ const sslRequestCode = 80877103
 //  7. Bidirectional pump with per-query inspection.
 func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
 	defer func() { _ = ch.Conn.Close() }()
-	if ch.Endpoint == nil || ch.Endpoint.Family != "sql" {
+	if ch.Endpoint == nil || !ch.Endpoint.HasFamily("sql") {
 		return fmt.Errorf("postgres runtime invoked on non-sql endpoint %v", ch.Endpoint)
 	}
 
@@ -501,12 +501,12 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName s
 	remaining := totalWire - have
 
 	mreq := &match.Request{
-		Family:     "sql",
+		Families:   []string{"sql"},
 		PeerIP:     ch.PeerIP,
 		Credential: credName,
-		Meta:       &sqlfacet.Meta{},
 		Truncated:  true,
 	}
+	mreq.SetMeta("sql", &sqlfacet.Meta{})
 	var facets map[string]any
 	if f := facet.Lookup("sql"); f != nil {
 		facets = f.Report(mreq)
@@ -573,16 +573,16 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 	info := parseSQL(sql)
 	summary := pgSummary(info)
 	mreq := &match.Request{
-		Family:     "sql",
+		Families:   []string{"sql"},
 		PeerIP:     ch.PeerIP,
 		Credential: credName,
-		Meta: &sqlfacet.Meta{
-			Verb:      info.Verb,
-			Tables:    info.Tables,
-			Functions: info.Functions,
-			Statement: info.Statement,
-		},
 	}
+	mreq.SetMeta("sql", &sqlfacet.Meta{
+		Verb:      info.Verb,
+		Tables:    info.Tables,
+		Functions: info.Functions,
+		Statement: info.Statement,
+	})
 	// Per-family report payload — the same map the gateway will
 	// stash on Event.Facets so the dashboard renders sql_rule
 	// columns (verb / tables / functions / statement) directly

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -484,8 +484,8 @@ func TestPgEvaluateEmitsAllowOnNoMatch(t *testing.T) {
 	var events []runtime.ConnEvent
 	ch := &runtime.ConnHandle{
 		Endpoint: &config.CompiledEndpoint{
-			Name:   "pg-test",
-			Family: "sql",
+			Name:     "pg-test",
+			Families: []string{"sql"},
 			// Rules is nil — no rule will fire.
 		},
 		Emit: func(ev runtime.ConnEvent) { events = append(events, ev) },

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -114,7 +114,7 @@ func init() {
 	config.Register(&config.Plugin{
 		Kind:     config.KindEndpoint,
 		Type:     "ssh",
-		Family:   "ssh",
+		Families: []string{"ssh"},
 		New:      func() any { return &SSHEndpoint{} },
 		Refs:     singularRef,
 		Validate: multiCredValidate,
@@ -145,7 +145,7 @@ var (
 // HandleConn is part of the clawpatrol plugin API.
 func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHandle) error {
 	defer func() { _ = ch.Conn.Close() }()
-	if ch.Endpoint == nil || ch.Endpoint.Family != "ssh" {
+	if ch.Endpoint == nil || !ch.Endpoint.HasFamily("ssh") {
 		return fmt.Errorf("ssh runtime invoked on non-ssh endpoint %v", ch.Endpoint)
 	}
 	if ch.Blobs == nil {

--- a/config/plugins/facets/https/https_test.go
+++ b/config/plugins/facets/https/https_test.go
@@ -17,10 +17,10 @@ import (
 func httpReq(method, path string) *match.Request {
 	u, _ := url.Parse("https://example.com" + path)
 	return &match.Request{
-		Family:  "http",
-		Method:  method,
-		URL:     u,
-		Headers: http.Header{},
+		Families: []string{"http"},
+		Method:   method,
+		URL:      u,
+		Headers:  http.Header{},
 	}
 }
 

--- a/config/plugins/facets/k8s/k8s.go
+++ b/config/plugins/facets/k8s/k8s.go
@@ -9,7 +9,7 @@
 // HTTPS handler populates match.Request.Method/URL/Headers before
 // calling PrepareRequest. PrepareRequest then decomposes the URL
 // path into (verb, resource, namespace, name, params) and stashes
-// the result on req.Meta for the k8s matcher to read.
+// the result under req.Metas["k8s"] for the k8s matcher to read.
 package k8s
 
 import (
@@ -87,18 +87,18 @@ func (Facet) ReportFields() []facet.ReportFieldSpec {
 }
 
 // PrepareRequest derives the k8s Meta from the request URL and method
-// and stashes it on req.Meta. Called by the gateway before any
-// matcher runs for a k8s-family request.
+// and stashes it under req.Metas["k8s"]. Called by the gateway
+// before any matcher runs for a k8s-family request.
 func (Facet) PrepareRequest(req *match.Request) {
 	if req == nil || req.URL == nil {
 		return
 	}
-	req.Meta = parsePath(req.Method, req.URL.RequestURI())
+	req.SetMeta("k8s", parsePath(req.Method, req.URL.RequestURI()))
 }
 
 // Report extracts the k8s report fields from a request.
 func (Facet) Report(req *match.Request) map[string]any {
-	m, _ := req.Meta.(*Meta)
+	m, _ := req.Meta("k8s").(*Meta)
 	if m == nil {
 		return nil
 	}
@@ -157,7 +157,7 @@ func buildActivation(req *match.Request) map[string]any {
 	if req == nil {
 		return nil
 	}
-	meta, _ := req.Meta.(*Meta)
+	meta, _ := req.Meta("k8s").(*Meta)
 	if meta == nil {
 		return nil
 	}

--- a/config/plugins/facets/k8s/k8s_match_test.go
+++ b/config/plugins/facets/k8s/k8s_match_test.go
@@ -32,7 +32,7 @@ func TestK8sMatcherVerbCaseInsensitive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
-			req := &match.Request{Family: "k8s", Meta: &k8sfacet.Meta{Verb: tc.verb}}
+			req := &match.Request{Families: []string{"k8s"}, Metas: map[string]any{"k8s": &k8sfacet.Meta{Verb: tc.verb}}}
 			if got := m.Match(req); got != tc.want {
 				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
 			}
@@ -59,7 +59,7 @@ func TestK8sMatcherNegationAndGlobs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := &match.Request{Family: "k8s", Meta: tc.meta}
+			req := &match.Request{Families: []string{"k8s"}, Metas: map[string]any{"k8s": tc.meta}}
 			if got := m.Match(req); got != tc.want {
 				t.Errorf("Match=%v want %v", got, tc.want)
 			}
@@ -76,7 +76,7 @@ func TestK8sMatcherParams(t *testing.T) {
 		Verb: "create", Resource: "pods/exec", Name: "x",
 		Params: map[string]string{"stdin": "true"},
 	}
-	req := &match.Request{Family: "k8s", Meta: meta}
+	req := &match.Request{Families: []string{"k8s"}, Metas: map[string]any{"k8s": meta}}
 	if !m.Match(req) {
 		t.Errorf("expected interactive exec to match")
 	}
@@ -95,7 +95,7 @@ func TestK8sMatcherWatchVerbAndParams(t *testing.T) {
 	meta := &k8sfacet.Meta{
 		Verb: "watch", Resource: "pods", Params: map[string]string{"watch": "true"},
 	}
-	req := &match.Request{Family: "k8s", Meta: meta}
+	req := &match.Request{Families: []string{"k8s"}, Metas: map[string]any{"k8s": meta}}
 	if !m.Match(req) {
 		t.Errorf("expected watch pod list to match")
 	}

--- a/config/plugins/facets/llm/llm.go
+++ b/config/plugins/facets/llm/llm.go
@@ -1,0 +1,194 @@
+// Package llm is the LLM protocol-family facet. It rides alongside
+// the http facet on per-provider endpoints (`anthropic`, `openrouter`,
+// `openai_codex_https`) so a single action carries both HTTP fields
+// (method / path / status) and LLM fields (provider / model / token
+// counts).
+//
+// The facet exposes a narrow CEL surface in v1 — only the request-
+// extractable fields (provider / model / stream) are reachable from
+// rule conditions; token counts and stop_reason ship in the Report
+// payload for dashboard visibility but aren't matchable yet. v2 will
+// widen the CEL env to expose post-flight fields plus a streaming-
+// cancellation hook.
+//
+// The provider endpoint plugin populates req.Metas["llm"] with a
+// *Meta in two phases: provider / model / stream from the request
+// body before forwarding, and the token counts / stop_reason after
+// the response stream completes. The HTTPS MITM dispatcher calls the
+// endpoint plugin's optional LLMResponseParser between trackBuf
+// extraction and emitEnd so the end-event carries the token-rich
+// facets the dashboard renders.
+package llm
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+
+	"github.com/denoland/clawpatrol/config/facet"
+	"github.com/denoland/clawpatrol/config/match"
+)
+
+// Meta carries the per-request LLM fields the matcher reads. Provider
+// endpoint plugins build one of these from the request body and the
+// (streamed or non-streamed) response body and assign it via
+// req.SetMeta("llm", …).
+//
+// Pre-flight fields (Provider / Model / Stream) are populated before
+// the request forwards upstream. Post-flight fields (token counts /
+// StopReason) populate after the response completes. The facet's
+// Report emits every field; the CEL env intentionally hides post-
+// flight fields in v1 so a rule that references them fails at
+// compile time instead of pretending to match on bytes that haven't
+// arrived yet.
+type Meta struct {
+	Provider         string // "anthropic" | "openai" | "openrouter"
+	Model            string // e.g. "claude-opus-4-7" or "anthropic/claude-3-5-sonnet"
+	Stream           bool   // request had stream:true
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	StopReason       string // "end_turn" / "stop_sequence" / "tool_use" / provider-specific
+}
+
+// LLMFields is the CEL-facing view exposed to rule conditions. Only
+// the pre-flight subset lands here in v1; v2 widens.
+type LLMFields struct {
+	Provider string `cel:"provider"`
+	Model    string `cel:"model"`
+	Stream   bool   `cel:"stream"`
+}
+
+// Facet is the LLM facet Runtime. Singleton; held by the registry.
+type Facet struct{}
+
+// Name reports the family identifier this facet handles.
+func (Facet) Name() string { return "llm" }
+
+// EndpointFamilies enumerates the endpoint families an llm rule may
+// attach to. LLM-bearing endpoints declare Families ["http", "llm"]
+// (the wire is HTTPS); a bare llm-only endpoint would also be
+// allowed.
+func (Facet) EndpointFamilies() []string { return []string{"llm"} }
+
+// Transport returns "" because llm-family endpoints share the
+// HTTPS-MITM dispatch path with their http facet — the underlying
+// wire is TLS-wrapped HTTP. The "http" facet's Transport() of
+// "https-mitm" handles routing; the llm facet is reporting-only at
+// the dispatch layer.
+func (Facet) Transport() string { return "" }
+
+// HITLQueryLabel is the dashboard / Slack label for an LLM call.
+// Reuses "Path" since the underlying request is HTTP — the
+// dashboard renders the LLM-specific fields (model / tokens) in the
+// per-facet report block, not the HITL prompt body.
+func (Facet) HITLQueryLabel() string { return "Path" }
+
+// HostIsResource reports that an LLM endpoint's Host is the
+// provider's API surface (api.anthropic.com etc.) and meaningful on
+// its own.
+func (Facet) HostIsResource() bool { return true }
+
+// ReportFields declares the per-family columns the LLM facet emits.
+// Token fields are ints (CEL natively supports comparison /
+// arithmetic) per the design doc §3.5. Cache write tokens stay zero
+// for providers that don't surface a write/read split.
+func (Facet) ReportFields() []facet.ReportFieldSpec {
+	return []facet.ReportFieldSpec{
+		{Name: "provider", Kind: facet.ReportString, Label: "Provider"},
+		{Name: "model", Kind: facet.ReportString, Label: "Model"},
+		{Name: "stream", Kind: facet.ReportString, Label: "Stream"},
+		{Name: "input_tokens", Kind: facet.ReportInt, Label: "Input tokens"},
+		{Name: "output_tokens", Kind: facet.ReportInt, Label: "Output tokens"},
+		{Name: "cache_read_tokens", Kind: facet.ReportInt, Label: "Cache read tokens"},
+		{Name: "cache_write_tokens", Kind: facet.ReportInt, Label: "Cache write tokens"},
+		{Name: "stop_reason", Kind: facet.ReportString, Label: "Stop reason"},
+	}
+}
+
+// PrepareRequest is a no-op: the provider endpoint plugin populates
+// req.Metas["llm"] from the parsed request body (and, post-stream,
+// from the response body via LLMResponseParser). The facet itself
+// owns no derivation step beyond the CEL surface and Report.
+func (Facet) PrepareRequest(*match.Request) {}
+
+// Report extracts the LLM report fields from a request. Token counts
+// land on the action even though they're not CEL-matchable in v1 —
+// the dashboard renders them in the request detail page so operators
+// can audit usage without round-tripping through the legacy /api/llm
+// path.
+func (Facet) Report(req *match.Request) map[string]any {
+	m, _ := req.Meta("llm").(*Meta)
+	if m == nil {
+		return nil
+	}
+	streamStr := "false"
+	if m.Stream {
+		streamStr = "true"
+	}
+	return map[string]any{
+		"provider":           m.Provider,
+		"model":              m.Model,
+		"stream":             streamStr,
+		"input_tokens":       m.InputTokens,
+		"output_tokens":      m.OutputTokens,
+		"cache_read_tokens":  m.CacheReadTokens,
+		"cache_write_tokens": m.CacheWriteTokens,
+		"stop_reason":        m.StopReason,
+	}
+}
+
+// celEnv is the LLM CEL environment. Built once at init.
+var celEnv *cel.Env
+
+func init() {
+	env, err := cel.NewEnv(
+		ext.Sets(),
+		ext.NativeTypes(
+			reflect.TypeFor[LLMFields](),
+			ext.ParseStructTags(true),
+		),
+		cel.Variable("llm", cel.ObjectType("llm.LLMFields")),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("llm facet: cel env: %v", err))
+	}
+	celEnv = env
+
+	facet.Register(Facet{})
+}
+
+// LLM facets read no truncatable bytes: provider / model / stream are
+// extracted from the request body the gateway already buffered (and
+// the truncation gate on the http facet covers body overflow), and
+// token / stop_reason fields aren't reachable from CEL in v1.
+var truncatablePaths []string
+
+// NewMatcher compiles a CEL condition into a Matcher. An empty
+// condition is the catch-all match-everything case.
+func (Facet) NewMatcher(condition string) (match.Matcher, error) {
+	if condition == "" {
+		return match.PassThrough{}, nil
+	}
+	return match.CompileCondition(celEnv, condition, buildActivation, nil, truncatablePaths)
+}
+
+func buildActivation(req *match.Request) map[string]any {
+	if req == nil {
+		return nil
+	}
+	meta, _ := req.Meta("llm").(*Meta)
+	if meta == nil {
+		return nil
+	}
+	return map[string]any{
+		"llm": &LLMFields{
+			Provider: meta.Provider,
+			Model:    meta.Model,
+			Stream:   meta.Stream,
+		},
+	}
+}

--- a/config/plugins/facets/llm/llm_test.go
+++ b/config/plugins/facets/llm/llm_test.go
@@ -1,0 +1,108 @@
+package llm_test
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/facet"
+	"github.com/denoland/clawpatrol/config/match"
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+)
+
+// TestLLMMatcherModelGlob pins the headline use case operators care
+// about: gating which model a credential is allowed to call. The CEL
+// runtime exposes llm.model so .matches() / startsWith / == all work.
+func TestLLMMatcherModelGlob(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		model     string
+		want      bool
+	}{
+		{"opus-prefix matches opus-4-7", `llm.model.matches("^claude-opus-")`, "claude-opus-4-7-20251001", true},
+		{"opus-prefix misses sonnet", `llm.model.matches("^claude-opus-")`, "claude-3-5-sonnet-20240620", false},
+		{"openrouter provider prefix", `llm.model.matches("^anthropic/")`, "anthropic/claude-3-5-sonnet-20240620", true},
+		{"exact-match miss", `llm.model == "gpt-5"`, "gpt-4o", false},
+		{"exact-match hit", `llm.model == "gpt-5"`, "gpt-5", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("llm", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{Families: []string{"http", "llm"}}
+			req.SetMeta("llm", &llmfacet.Meta{Provider: "openai", Model: tc.model})
+			if got := m.Match(req); got != tc.want {
+				t.Errorf("Match=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLLMMatcherProviderGate pins the secondary use case: gating by
+// provider name so an operator can write "anthropic only via the
+// anthropic endpoint" rules without redoing the model glob.
+func TestLLMMatcherProviderGate(t *testing.T) {
+	m, err := facet.NewMatcher("llm", `llm.provider == "anthropic" && llm.stream == true`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &match.Request{Families: []string{"http", "llm"}}
+	req.SetMeta("llm", &llmfacet.Meta{Provider: "anthropic", Model: "claude-opus-4-7", Stream: true})
+	if !m.Match(req) {
+		t.Errorf("expected streaming anthropic call to match")
+	}
+
+	req2 := &match.Request{Families: []string{"http", "llm"}}
+	req2.SetMeta("llm", &llmfacet.Meta{Provider: "openrouter", Model: "anthropic/claude-3-5-sonnet"})
+	if m.Match(req2) {
+		t.Errorf("expected openrouter call to miss provider gate")
+	}
+}
+
+// TestLLMMatcherEmptyMetaIsNoMatch pins fail-soft on requests that
+// never reached an LLM-parsing endpoint plugin. Missing slot must
+// behave like "no match" rather than panic.
+func TestLLMMatcherEmptyMetaIsNoMatch(t *testing.T) {
+	m, err := facet.NewMatcher("llm", `llm.model == "anything"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &match.Request{Families: []string{"http"}}
+	if m.Match(req) {
+		t.Errorf("expected no match on request without llm slot")
+	}
+}
+
+// TestLLMReportFieldsCoverMeta keeps the ReportFields declaration in
+// sync with what Report actually emits. If a future contributor adds
+// a Meta field, they must update Report and this test breaks until
+// they update ReportFields.
+func TestLLMReportFieldsCoverMeta(t *testing.T) {
+	f := llmfacet.Facet{}
+	req := &match.Request{Families: []string{"llm"}}
+	req.SetMeta("llm", &llmfacet.Meta{
+		Provider: "anthropic", Model: "claude-opus-4-7", Stream: true,
+		InputTokens: 100, OutputTokens: 20,
+		CacheReadTokens: 50, CacheWriteTokens: 10, StopReason: "end_turn",
+	})
+	report := f.Report(req)
+	declared := f.ReportFields()
+	for _, spec := range declared {
+		if _, ok := report[spec.Name]; !ok {
+			t.Errorf("ReportFields declares %q but Report omits it", spec.Name)
+		}
+	}
+	for k := range report {
+		found := false
+		for _, spec := range declared {
+			if spec.Name == k {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Report emits %q but ReportFields doesn't declare it", k)
+		}
+	}
+}

--- a/config/plugins/facets/sql/sql.go
+++ b/config/plugins/facets/sql/sql.go
@@ -2,15 +2,16 @@
 // environment (verb / tables / functions / statement, exposed as
 // fields on the `sql` variable), the matcher that walks a parsed SQL
 // statement, the Meta type wire-frame frontends (postgres,
-// clickhouse) populate on match.Request.Meta, and the per-family
-// report fields the dashboard shows for a SQL query.
+// clickhouse) populate under match.Request.Metas["sql"], and the
+// per-family report fields the dashboard shows for a SQL query.
 //
 // SQL endpoints derive Meta themselves from the wire frame (the
 // postgres / clickhouse runtimes parse the Query message and stash
-// a *Meta on the request before dispatch), so PrepareRequest is a
-// no-op. The matcher type-asserts req.Meta to *Meta and fails the
-// match cleanly when the assertion fails — e.g. when an https-
-// family request accidentally reaches a sql rule.
+// a *Meta on the request before dispatch via req.SetMeta("sql", …)),
+// so PrepareRequest is a no-op. The matcher type-asserts the "sql"
+// slot to *Meta and fails the match cleanly when the slot is absent
+// or holds a different type — e.g. when an https-family request
+// accidentally reaches a sql rule.
 package sql
 
 import (
@@ -86,11 +87,11 @@ func (Facet) ReportFields() []facet.ReportFieldSpec {
 // directly from the wire frame.
 func (Facet) PrepareRequest(*match.Request) {}
 
-// Report extracts the SQL report fields from a request. When Meta
-// isn't a *Meta (e.g. a request that never ran through a SQL
-// frontend) the result is empty rather than panicking.
+// Report extracts the SQL report fields from a request. When the
+// sql slot isn't a *Meta (e.g. a request that never ran through a
+// SQL frontend) the result is empty rather than panicking.
 func (Facet) Report(req *match.Request) map[string]any {
-	m, _ := req.Meta.(*Meta)
+	m, _ := req.Meta("sql").(*Meta)
 	if m == nil {
 		return nil
 	}
@@ -159,7 +160,7 @@ func buildActivation(req *match.Request) map[string]any {
 	if req == nil {
 		return nil
 	}
-	meta, _ := req.Meta.(*Meta)
+	meta, _ := req.Meta("sql").(*Meta)
 	if meta == nil {
 		return nil
 	}

--- a/config/plugins/facets/sql/sql_match_test.go
+++ b/config/plugins/facets/sql/sql_match_test.go
@@ -17,7 +17,7 @@ func TestSQLMatcherVerbAndTables(t *testing.T) {
 		Verb:   "select",
 		Tables: []string{"users", "github_identities"},
 	}
-	req := &match.Request{Family: "sql", Meta: meta}
+	req := &match.Request{Families: []string{"sql"}, Metas: map[string]any{"sql": meta}}
 	if !m.Match(req) {
 		t.Errorf("expected select on github_identities to match")
 	}
@@ -49,7 +49,7 @@ func TestSQLMatcherVerbCaseInsensitive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
-			req := &match.Request{Family: "sql", Meta: &sqlfacet.Meta{Verb: "select"}}
+			req := &match.Request{Families: []string{"sql"}, Metas: map[string]any{"sql": &sqlfacet.Meta{Verb: "select"}}}
 			if got := m.Match(req); got != tc.want {
 				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
 			}
@@ -63,7 +63,7 @@ func TestSQLMatcherStatementRegex(t *testing.T) {
 		t.Fatal(err)
 	}
 	meta := &sqlfacet.Meta{Verb: "select", Statement: "SELECT secret FROM vault"}
-	req := &match.Request{Family: "sql", Meta: meta}
+	req := &match.Request{Families: []string{"sql"}, Metas: map[string]any{"sql": meta}}
 	if !m.Match(req) {
 		t.Errorf("expected regex hit on bare 'secret'")
 	}

--- a/config/plugins/rules/rules.go
+++ b/config/plugins/rules/rules.go
@@ -34,6 +34,12 @@ type RuleBody struct {
 	Priority  int      `hcl:"priority,optional"`
 	Disabled  bool     `hcl:"disabled,optional"`
 
+	// Family pins the facet whose CEL env the rule compiles against
+	// when the resolved endpoints carry more than one family. Single-
+	// family endpoint sets ignore it and infer from the endpoints.
+	// Empty + multi-family endpoints is a validation error.
+	Family string `hcl:"family,optional"`
+
 	// Condition is a CEL expression evaluated against the
 	// family-specific variable set. An absent / empty condition
 	// matches everything — the catch-all pattern (`rule
@@ -60,16 +66,27 @@ type RuleBody struct {
 // Rule is the canonical, family-stamped record stored in
 // Policy.Rules[name].Body.
 type Rule struct {
-	Name       string                `json:"name"`
-	Family     string                `json:"family"` // "http" | "sql" | "k8s"
-	Endpoints  []string              `json:"endpoints"`
-	Priority   int                   `json:"priority,omitempty"`
-	Disabled   bool                  `json:"disabled,omitempty"`
-	Condition  string                `json:"condition,omitempty"`
-	Credential string                `json:"credential,omitempty"`
-	Verdict    string                `json:"verdict,omitempty"` // "allow" | "deny" | "" (when Approve is set)
-	Reason     string                `json:"reason,omitempty"`
-	Approve    []config.ApproveStage `json:"approve,omitempty"`
+	Name string `json:"name"`
+	// Family is the resolved facet family the rule's CEL condition
+	// compiles against ("http" | "sql" | "k8s" | "llm" | …). Inferred
+	// from the endpoints' family intersection, optionally disambiguated
+	// by ExplicitFamily.
+	Family string `json:"family"`
+	// ExplicitFamily is the literal `family = ...` the operator wrote
+	// in HCL, when present. Kept separate from Family so the emit
+	// path round-trips the operator's intent (multi-family endpoints
+	// without an explicit pin fail validation, so a single-family
+	// rule emitted with `family = "http"` shouldn't gain that line on
+	// the round trip).
+	ExplicitFamily string                `json:"explicit_family,omitempty"`
+	Endpoints      []string              `json:"endpoints"`
+	Priority       int                   `json:"priority,omitempty"`
+	Disabled       bool                  `json:"disabled,omitempty"`
+	Condition      string                `json:"condition,omitempty"`
+	Credential     string                `json:"credential,omitempty"`
+	Verdict        string                `json:"verdict,omitempty"` // "allow" | "deny" | "" (when Approve is set)
+	Reason         string                `json:"reason,omitempty"`
+	Approve        []config.ApproveStage `json:"approve,omitempty"`
 }
 
 // Compile lowers a built rule into the runtime-friendly *CompiledRule
@@ -99,43 +116,111 @@ func (r *Rule) Compile() (*config.CompiledRule, []string, error) {
 	}, r.Endpoints, nil
 }
 
-// inferFamily walks the rule's endpoint list, looks each one up in
-// the symbol table, and reports the common endpoint family. Returns
-// "" plus a diagnostic if the endpoints span more than one family
-// (the rule's CEL env can only bind one facet's variables) or if no
-// endpoint is set (caught separately by the shape check, but a
-// defensive empty-set check keeps the family lookup safe). Unknown
-// endpoint names are skipped — the framework's ref-resolution pass
-// already emitted "unknown endpoint" diagnostics for those.
-func inferFamily(endpoints []string, name string, ctx *config.BuildCtx) (string, *hcl.Diagnostic) {
-	seen := map[string]struct{}{}
+// inferFamily resolves the rule's family by intersecting every
+// endpoint's families set. The result is the set of families every
+// endpoint participates in — multi-family endpoints (e.g. an
+// `anthropic` carrying ["http", "llm"]) widen the candidates, and
+// the intersection narrows them.
+//
+// When the rule declared an explicit `family =` it must be in the
+// intersection; the rule compiles against that facet's CEL env.
+// Otherwise:
+//   - intersection has one entry → use it.
+//   - intersection has many entries → ambiguity. Emit a diagnostic
+//     asking the operator to disambiguate with `family = ...`.
+//   - intersection is empty → endpoints carry no common family; can't
+//     compile a single CEL env.
+//
+// Unknown endpoint names are skipped — the framework's ref-resolution
+// pass already emitted "unknown endpoint" diagnostics for those.
+func inferFamily(endpoints []string, explicit, name string, ctx *config.BuildCtx) (string, *hcl.Diagnostic) {
+	var common []string // intersection of every resolved endpoint's families
+	first := true
 	for _, ep := range endpoints {
 		sym := ctx.Symbols.Get(config.KindEndpoint, ep)
-		if sym == nil || sym.Family == "" {
+		if sym == nil || len(sym.Families) == 0 {
 			continue
 		}
-		seen[sym.Family] = struct{}{}
-	}
-	if len(seen) == 0 {
-		return "", nil
-	}
-	if len(seen) > 1 {
-		fams := make([]string, 0, len(seen))
-		for f := range seen {
-			fams = append(fams, f)
+		if first {
+			common = append(common[:0], sym.Families...)
+			first = false
+			continue
 		}
-		sort.Strings(fams)
+		common = intersect(common, sym.Families)
+	}
+	if first {
+		// No resolved endpoints yet — leave inference pending.
+		// validate() already reports unknown-endpoint cases.
+		return explicit, nil
+	}
+	if len(common) == 0 {
+		fams := collectFamilies(endpoints, ctx)
 		return "", &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Rule %q targets endpoints from mixed families", name),
-			Detail:   fmt.Sprintf("Endpoints span families %v. A rule's CEL condition is evaluated against a single facet's variable set; split into one rule per family.", fams),
+			Summary:  fmt.Sprintf("Rule %q targets endpoints with no common family", name),
+			Detail:   fmt.Sprintf("Endpoints span families %v with empty intersection. A rule's CEL condition is evaluated against a single facet's variable set; split into one rule per family.", fams),
 			Subject:  &ctx.Block.DefRange,
 		}
 	}
-	for f := range seen {
-		return f, nil
+	if explicit != "" {
+		for _, f := range common {
+			if f == explicit {
+				return explicit, nil
+			}
+		}
+		return "", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Rule %q declares family %q which no endpoint provides", name, explicit),
+			Detail:   fmt.Sprintf("Endpoints share families %v; pick one of those (or drop `family = %q`).", common, explicit),
+			Subject:  &ctx.Block.DefRange,
+		}
 	}
-	return "", nil
+	if len(common) == 1 {
+		return common[0], nil
+	}
+	return "", &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  fmt.Sprintf("Rule %q is ambiguous across multiple families", name),
+		Detail:   fmt.Sprintf("Endpoints all support families %v. Pick one with `family = \"<name>\"` on the rule so the CEL env is unambiguous.", common),
+		Subject:  &ctx.Block.DefRange,
+	}
+}
+
+// intersect returns the elements of a that also appear in b, preserving
+// a's order. Tiny lists (single-digit elements); the obvious O(n*m)
+// scan is the right shape.
+func intersect(a, b []string) []string {
+	out := a[:0]
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				out = append(out, x)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// collectFamilies returns every family seen across the rule's
+// endpoints, deduplicated and sorted. Used only to render diagnostics.
+func collectFamilies(endpoints []string, ctx *config.BuildCtx) []string {
+	seen := map[string]struct{}{}
+	for _, ep := range endpoints {
+		sym := ctx.Symbols.Get(config.KindEndpoint, ep)
+		if sym == nil {
+			continue
+		}
+		for _, f := range sym.Families {
+			seen[f] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for f := range seen {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func endpointList(rb *RuleBody) []string {
@@ -170,8 +255,9 @@ func validate(body any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
 	}
 
 	// Infer family from the endpoint set so condition compilation
-	// can pick the right facet env.
-	fam, famDiag := inferFamily(endpointList(rb), name, ctx)
+	// can pick the right facet env. Multi-family endpoints can be
+	// disambiguated with the rule's explicit `family = ...`.
+	fam, famDiag := inferFamily(endpointList(rb), rb.Family, name, ctx)
 	if famDiag != nil {
 		diags = append(diags, famDiag)
 	}
@@ -228,22 +314,23 @@ func build(body any, name string, ctx *config.BuildCtx) (any, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	endpoints := endpointList(rb)
-	fam, famDiag := inferFamily(endpoints, name, ctx)
+	fam, famDiag := inferFamily(endpoints, rb.Family, name, ctx)
 	if famDiag != nil {
 		// Already reported by validate; don't double-emit.
 		_ = famDiag
 	}
 
 	r := &Rule{
-		Name:       name,
-		Family:     fam,
-		Endpoints:  endpoints,
-		Priority:   rb.Priority,
-		Disabled:   rb.Disabled,
-		Condition:  rb.Condition,
-		Credential: rb.Credential,
-		Verdict:    rb.Verdict,
-		Reason:     rb.Reason,
+		Name:           name,
+		Family:         fam,
+		ExplicitFamily: rb.Family,
+		Endpoints:      endpoints,
+		Priority:       rb.Priority,
+		Disabled:       rb.Disabled,
+		Condition:      rb.Condition,
+		Credential:     rb.Credential,
+		Verdict:        rb.Verdict,
+		Reason:         rb.Reason,
 	}
 
 	// Approve chain.
@@ -335,6 +422,9 @@ func emitRule(body any, _ string, b *hclwrite.Body) {
 	}
 	if r.Credential != "" {
 		config.SetIdent(b, "credential", r.Credential)
+	}
+	if r.ExplicitFamily != "" {
+		b.SetAttributeValue("family", cty.StringVal(r.ExplicitFamily))
 	}
 	if r.Condition != "" {
 		b.SetAttributeValue("condition", cty.StringVal(r.Condition))

--- a/config/refs.go
+++ b/config/refs.go
@@ -113,8 +113,8 @@ func resolveRefs(decoded any, name string, plugin *Plugin, table *SymbolTable, b
 			}
 			if len(spec.FamilyConstraint) > 0 {
 				ok := false
-				for _, f := range spec.FamilyConstraint {
-					if sym.Family == f {
+				for _, want := range spec.FamilyConstraint {
+					if sym.HasFamily(want) {
 						ok = true
 						break
 					}
@@ -123,7 +123,7 @@ func resolveRefs(decoded any, name string, plugin *Plugin, table *SymbolTable, b
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  fmt.Sprintf("Incompatible endpoint family for %q", v.value),
-						Detail:   fmt.Sprintf("Rule %q (%s) accepts endpoint families %v but %q is family %q.", name, plugin.Type, spec.FamilyConstraint, v.value, sym.Family),
+						Detail:   fmt.Sprintf("Rule %q (%s) accepts endpoint families %v but %q has families %v.", name, plugin.Type, spec.FamilyConstraint, v.value, sym.Families),
 						Subject:  v.rangePtr,
 					})
 					continue

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -202,7 +202,7 @@ func TestMatchRequest(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := &match.Request{Family: "http", Method: tc.method}
+			req := &match.Request{Families: []string{"http"}, Method: tc.method}
 			r := runtime.MatchRequest(ep, req)
 			if r == nil {
 				if tc.want != "" {
@@ -248,10 +248,8 @@ rule "default-deny" {
 	ep := cp.Endpoints["db"]
 
 	// Untruncated SELECT → allow fires normally.
-	req := &match.Request{
-		Family: "sql",
-		Meta:   newSQLMetaForVerb("select"),
-	}
+	req := &match.Request{Families: []string{"sql"}}
+	req.SetMeta("sql", newSQLMetaForVerb("select"))
 	r := runtime.MatchRequest(ep, req)
 	if r == nil || r.Name != "select-allow" || r.Outcome.Verdict != "allow" {
 		t.Fatalf("untruncated select: got %+v, want select-allow allow", r)
@@ -305,7 +303,7 @@ rule "body-deny" {
 	ep := cp.Endpoints["api"]
 
 	req := &match.Request{
-		Family:     "https",
+		Families:   []string{"http"},
 		Method:     "POST",
 		Credential: "tok",
 		Body:       []byte("anything"),
@@ -328,7 +326,7 @@ rule "body-deny" {
 func TestResolveCredentialSingular(t *testing.T) {
 	cp := compile(t)
 	ep := cp.Endpoints["github"]
-	got := runtime.ResolveCredential(ep, &match.Request{Family: "http", Headers: http.Header{}})
+	got := runtime.ResolveCredential(ep, &match.Request{Families: []string{"http"}, Headers: http.Header{}})
 	if got == nil || got.Credential.Symbol.Name != "pat" {
 		t.Errorf("singular credential resolution wrong: %+v", got)
 	}
@@ -368,7 +366,7 @@ profile "default" { endpoints = [ep] }
 		if authz != "" {
 			h.Set("Authorization", authz)
 		}
-		return &match.Request{Family: "http", Headers: h}
+		return &match.Request{Families: []string{"http"}, Headers: h}
 	}
 
 	got := runtime.ResolveCredential(ep, mkReq("Bearer PH_prod"))

--- a/config/runtime/hitl.go
+++ b/config/runtime/hitl.go
@@ -21,7 +21,7 @@ import (
 func HITLEndpointLabel(req ApproveRequest) string {
 	ep := req.Endpoint
 	if ep != nil && req.Host != "" {
-		if f := facet.Lookup(ep.Family); f != nil && f.HostIsResource() {
+		if f := facet.Lookup(ep.PrimaryFamily()); f != nil && f.HostIsResource() {
 			return req.Host
 		}
 	}
@@ -37,7 +37,7 @@ func HITLEndpointLabel(req ApproveRequest) string {
 // a registered facet.
 func HITLQueryLabel(ep *config.CompiledEndpoint) string {
 	if ep != nil {
-		if f := facet.Lookup(ep.Family); f != nil {
+		if f := facet.Lookup(ep.PrimaryFamily()); f != nil {
 			if label := f.HITLQueryLabel(); label != "" {
 				return label
 			}

--- a/config/runtime/multi_family_test.go
+++ b/config/runtime/multi_family_test.go
@@ -1,0 +1,135 @@
+package runtime_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	llmfacet "github.com/denoland/clawpatrol/config/plugins/facets/llm"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// TestMultiFamilyRoutingHTTPAndLLM pins the headline behaviour the
+// llm-facet design adds: a multi-family endpoint (`anthropic` carries
+// http + llm) lets both http_rule and llm_rule predicates fire on
+// the same action.
+//
+// Two rules on the same anthropic endpoint:
+//   - HTTP-shaped: gate POSTs to /v1/messages
+//   - LLM-shaped (explicit family = "llm"): deny opus-class models
+//
+// The request carries http + llm slots; the higher-priority opus
+// gate fires regardless of method, and at lower priority the
+// method-only rule still fires for non-opus requests.
+func TestMultiFamilyRoutingHTTPAndLLM(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "anthropic-key" {}
+
+endpoint "anthropic" "claude" {
+  hosts      = ["api.anthropic.com"]
+  credential = anthropic-key
+}
+
+profile "default" { endpoints = [claude] }
+
+rule "no-opus" {
+  endpoint  = claude
+  family    = "llm"
+  condition = "llm.model.matches('^claude-opus-')"
+  priority  = 100
+  verdict   = "deny"
+  reason    = "opus-class models gated"
+}
+rule "allow-posts" {
+  endpoint  = claude
+  family    = "http"
+  condition = "http.method == 'POST'"
+  verdict   = "allow"
+}
+rule "default-deny" {
+  endpoint = claude
+  priority = -100
+  family   = "http"
+  verdict  = "deny"
+  reason   = "no policy matched"
+}
+`)
+	ep := cp.Endpoints["claude"]
+	if ep == nil {
+		t.Fatal("expected claude endpoint to compile")
+	}
+	if got := ep.PrimaryFamily(); got != "http" {
+		t.Errorf("primary family = %q, want http", got)
+	}
+	if !ep.HasFamily("llm") {
+		t.Error("expected llm family on anthropic endpoint")
+	}
+
+	// Helper to build an in-flight request with both facets populated.
+	build := func(method, model string) *match.Request {
+		u, _ := url.Parse("https://api.anthropic.com/v1/messages")
+		req := &match.Request{
+			Families: ep.Families,
+			Method:   method,
+			URL:      u,
+		}
+		req.SetMeta("llm", &llmfacet.Meta{Provider: "anthropic", Model: model})
+		return req
+	}
+
+	// Opus model → llm gate fires first (priority 100), denies.
+	r := runtime.MatchRequest(ep, build("POST", "claude-opus-4-7-20251001"))
+	if r == nil || r.Name != "no-opus" || r.Outcome.Verdict != "deny" {
+		t.Errorf("opus POST: got %+v, want no-opus deny", r)
+	}
+
+	// Sonnet POST → llm gate misses; allow-posts fires.
+	r = runtime.MatchRequest(ep, build("POST", "claude-3-5-sonnet-20240620"))
+	if r == nil || r.Name != "allow-posts" || r.Outcome.Verdict != "allow" {
+		t.Errorf("sonnet POST: got %+v, want allow-posts allow", r)
+	}
+
+	// Sonnet GET → both rules miss; default-deny fires.
+	r = runtime.MatchRequest(ep, build("GET", "claude-3-5-sonnet-20240620"))
+	if r == nil || r.Name != "default-deny" {
+		t.Errorf("sonnet GET: got %+v, want default-deny", r)
+	}
+}
+
+// TestRuleFamilyRequiredForAmbiguousEndpoint pins the validation
+// half: a rule attached to a multi-family endpoint without an
+// explicit `family =` is ambiguous, and the loader must surface a
+// diagnostic instead of silently picking one.
+func TestRuleFamilyRequiredForAmbiguousEndpoint(t *testing.T) {
+	src := `
+credential "bearer_token" "anthropic-key" {}
+endpoint "anthropic" "claude" {
+  hosts      = ["api.anthropic.com"]
+  credential = anthropic-key
+}
+profile "default" { endpoints = [claude] }
+
+rule "ambiguous" {
+  endpoint  = claude
+  condition = "http.method == 'POST'"
+  verdict   = "allow"
+}
+`
+	_, diags := config.LoadBytes([]byte(src), "in.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("expected ambiguity diagnostic, got none")
+	}
+	if !containsSubstring(diags.Error(), "ambiguous") {
+		t.Errorf("diagnostic missing 'ambiguous' marker: %v", diags)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -419,6 +419,29 @@ type PlaceholderDetector interface {
 	DetectPlaceholder(req *Request, candidates []string) string
 }
 
+// LLMResponseParser is the optional contract a provider endpoint
+// plugin's runtime implements when its actions should carry LLM
+// facets (provider / model / token counts) alongside the HTTP ones.
+//
+// The dispatcher calls ParseLLMRequest before forwarding so pre-
+// flight fields (provider / model / stream) land on the action in
+// time to be matched by `llm_rule` conditions. After the response
+// stream completes — between the existing trackBuf extraction and
+// emitEnd — it calls ParseLLMResponse with the captured request and
+// response bytes. Streaming responses arrive as the concatenated
+// SSE byte stream; non-streaming responses arrive as the full JSON
+// body. Implementations distinguish based on bytes / content-type /
+// shape — they own that detail.
+//
+// Either method returns a nil *llm.Meta to opt out of LLM facets for
+// a given request (e.g. a non-API path the provider plugin doesn't
+// recognise); ParseLLMResponse is given the pre-flight Meta the
+// request set so it can amend in place rather than replace.
+type LLMResponseParser interface {
+	ParseLLMRequest(reqBody []byte) any
+	ParseLLMResponse(reqBody, respBody []byte, pre any) any
+}
+
 // SQLParser is the optional contract a SQL-family endpoint plugin's
 // runtime implements so a host that received a raw SQL string (rather
 // than a live wire-protocol frame) can populate `match.Request.Meta`

--- a/config/symbols.go
+++ b/config/symbols.go
@@ -9,11 +9,35 @@ import (
 // Symbol is one entry in the flat namespace shared across all named
 // kinds (endpoint, credential, rule, approver, policy, profile).
 type Symbol struct {
-	Name   string
-	Kind   Kind
-	Type   string // "" for one-label kinds
-	Family string // for endpoints: "http"|"sql"|"k8s"; "" otherwise
-	Block  *hcl.Block
+	Name     string
+	Kind     Kind
+	Type     string // "" for one-label kinds
+	Families []string
+	Block    *hcl.Block
+}
+
+// PrimaryFamily returns the first family on the symbol, or "" when
+// the symbol carries none. The first entry is the protocol family
+// the dashboard / HITL / transport layers treat as canonical for the
+// underlying wire.
+func (s *Symbol) PrimaryFamily() string {
+	if s == nil || len(s.Families) == 0 {
+		return ""
+	}
+	return s.Families[0]
+}
+
+// HasFamily reports whether the symbol carries the named family.
+func (s *Symbol) HasFamily(name string) bool {
+	if s == nil {
+		return false
+	}
+	for _, f := range s.Families {
+		if f == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Range is the block's declaration range — handy as a diagnostic
@@ -148,7 +172,8 @@ func buildSymbols(blocks hcl.Blocks) (*SymbolTable, hcl.Diagnostics) {
 			continue
 		}
 
-		var typ, name, family string
+		var typ, name string
+		var families []string
 		switch want {
 		case 1:
 			name = block.Labels[0]
@@ -165,16 +190,16 @@ func buildSymbols(blocks hcl.Blocks) (*SymbolTable, hcl.Diagnostics) {
 				// Still register the name so we don't cascade
 				// "unknown reference" errors for downstream rules.
 			} else {
-				family = plugin.Family
+				families = plugin.Families
 			}
 		}
 
 		sym := &Symbol{
-			Name:   name,
-			Kind:   kind,
-			Type:   typ,
-			Family: family,
-			Block:  block,
+			Name:     name,
+			Kind:     kind,
+			Type:     typ,
+			Families: families,
+			Block:    block,
 		}
 
 		// Global uniqueness across all kinds — names share one flat

--- a/config/testdata/error_family_mismatch.errors.txt
+++ b/config/testdata/error_family_mismatch.errors.txt
@@ -1,1 +1,1 @@
-error: error_family_mismatch.hcl:16:1: Rule "mixed-family" targets endpoints from mixed families — Endpoints span families [http sql]. A rule's CEL condition is evaluated against a single facet's variable set; split into one rule per family.
+error: error_family_mismatch.hcl:16:1: Rule "mixed-family" targets endpoints with no common family — Endpoints span families [http sql] with empty intersection. A rule's CEL condition is evaluated against a single facet's variable set; split into one rule per family.

--- a/dnsvip/dnsvip_test.go
+++ b/dnsvip/dnsvip_test.go
@@ -50,11 +50,11 @@ func fakePolicy(t *testing.T, hosts ...[]string) *config.CompiledPolicy {
 	for i, hh := range hosts {
 		name := "ep" + string(rune('A'+i))
 		p.Endpoints[name] = &config.CompiledEndpoint{
-			Name:   name,
-			Family: "ssh",
-			Plugin: &config.Plugin{Type: "ssh"},
-			Hosts:  hh,
-			Body:   testBody{hosts: hh},
+			Name:     name,
+			Families: []string{"ssh"},
+			Plugin:   &config.Plugin{Type: "ssh"},
+			Hosts:    hh,
+			Body:     testBody{hosts: hh},
 		}
 	}
 	return p
@@ -311,11 +311,11 @@ func TestRebuildResolvesDefaultPortForTLSEndpoint(t *testing.T) {
 		TLS:   true,
 	}
 	ep := &config.CompiledEndpoint{
-		Name:   "ch",
-		Family: "sql",
-		Plugin: &config.Plugin{Type: "clickhouse_native", Family: "sql"},
-		Body:   body,
-		Hosts:  body.EndpointHosts(),
+		Name:     "ch",
+		Families: []string{"sql"},
+		Plugin:   &config.Plugin{Type: "clickhouse_native", Families: []string{"sql"}},
+		Body:     body,
+		Hosts:    body.EndpointHosts(),
 	}
 	pol := &config.CompiledPolicy{
 		Endpoints: map[string]*config.CompiledEndpoint{"ch": ep},

--- a/doc/llm-facet-design.md
+++ b/doc/llm-facet-design.md
@@ -1,0 +1,445 @@
+# `llm` facet family + per-provider LLM endpoint plugins — design
+
+Status: proposed. This doc is the design proposal for adding an `llm`
+facet family alongside `http` / `sql` / `k8s`, and shipping three
+per-provider HTTPS endpoint plugins (`anthropic`, `openai`,
+`openrouter`) whose actions carry both HTTP facets and LLM facets so
+existing HTTP rules keep firing and a new `llm`-family rule can match
+on provider / model / stream / tokens.
+
+The structural decision in [§3.1](#31-multi-family-per-action) is
+load-bearing. Sign-off on that section before implementation lands.
+
+---
+
+## 1. Goal
+
+LLM endpoint plugins should emit action events that carry **token-rich
+LLM metadata** (model, input / output tokens, cache read / write
+tokens) in addition to the HTTP facets they already emit. Three
+coordinated changes:
+
+1. A new facet family `llm` registered alongside the existing
+   `http` / `sql` / `k8s` facets.
+2. Action records that can carry **multiple** facet families on the
+   same request — an LLM endpoint's action carries both `http` and
+   `llm` facets, so existing HTTP rules keep matching and new LLM
+   rules become matchable.
+3. Three per-provider HTTPS endpoint plugins: `anthropic`, `openai`,
+   `openrouter`. Each parses the response (streaming + non-streaming)
+   to extract usage and populates the `llm` facet.
+
+---
+
+## 2. What's there today
+
+Captured during investigation; everything below is the state of
+`origin/main` at the time of writing.
+
+- **Per-family model.** `config/match/match.go`'s `Request` carries a
+  single `Family string` and a single opaque `Meta any`. Per-family
+  fields (verb / tables / functions / statement for SQL; resource /
+  verb / params for k8s) live in family-owned `Meta` types; the
+  facet's matcher type-asserts. `Truncated bool` and the
+  `InspectsTruncatableFacet()` plumbing fails closed on rules that
+  read body bytes that didn't fit the inspection cap.
+
+- **Rule binding.** `config/plugins/rules/rules.go` registers a
+  single `rule` block. Family is **inferred** from each rule's
+  resolved endpoint set; mixed-family endpoint sets are rejected at
+  validate time. A rule's CEL condition is compiled against the
+  facet's `*cel.Env`, so each rule sees exactly one family's
+  variables (`http.*` or `sql.*` or `k8s.*`).
+
+- **Facet registry.** `config/facet/facet.go` exposes a `Runtime`
+  contract: `Name()`, `EndpointFamilies()`, `Transport()`,
+  `NewMatcher(condition)`, `PrepareRequest(req)`, plus the reporting
+  pair `ReportFields()` / `Report(req)`. The HTTPS-MITM dispatcher in
+  `main.go` looks up the endpoint's family in the registry, calls
+  `PrepareRequest`, populates `Event.Family` and `Event.Facets`, then
+  matches against rules.
+
+- **HTTPS endpoint plugins.** `config/plugins/endpoints/https.go` is
+  the canonical baseline (hosts + credential plumbing only). Two
+  HTTPS-shaped variants already exist:
+  - `kubernetes` — k8s family, owns server / ca_cert decoration.
+  - `openai_codex_https` — http family, ships a synthetic Agent
+    Identity JWT pushdown plus a synthetic responder for the JWKS
+    and per-task registration POST so codex's chatgpt.com flow runs
+    against clawpatrol-controlled state.
+
+- **Existing LLM tracking (out of band).** `main.go` already has a
+  parallel observability path:
+  `trackKindFor(host)` → `preCreateLLMSession` (request body, seeds
+  session row) → `trackLLMUsage` (response body, fills token counts)
+  → `g.agents.recordLLMUsage`. It runs alongside the policy
+  dispatcher but doesn't feed `Event.Facets`, doesn't show up on the
+  action record, isn't matchable by policy. The provider parsers
+  (`parseClaudeRequest`, `parseClaudeResponse`, `parseOpenAIResponse`,
+  `codexResponsesRequestTitle`) already cover Anthropic +
+  OpenAI-shaped streaming and non-streaming usage; the new facet
+  reuses those parsers rather than rewriting them.
+
+- **Event shape.** `web.go`'s `Event` already supports two-phase
+  emission: `Phase = "start"` is emitted at request open (HTTP facets
+  + endpoint + rule populated, no response data) and `Phase = "end"`
+  is emitted after `resp.Write` completes (status, response sample,
+  duration). LLM facets land naturally on the end event because the
+  current `trackBuf` parse already happens between response write and
+  `emitEnd`.
+
+---
+
+## 3. Open design questions
+
+### 3.1 Multi-family-per-action
+
+**Three shapes the bead lays out:**
+
+a. `Families []string` (a *set* of families on the request) plus per-
+   family `Meta` slots. Each facet has first-class status; rule
+   dispatch walks every rule whose family is in the set.
+b. Primary family + auxiliary facets bag.
+c. Type-assertion / bitmask over a `MultiFacetRequest` interface.
+
+**Proposal: take option (a), shaped concretely as:**
+
+1. Add `Metas map[string]any` to `match.Request` (or, equivalently, a
+   per-family struct holding `HTTP`, `SQL`, `K8s`, `LLM` pointer
+   fields — same effect, less reflection). The existing `Meta any`
+   field is removed; every site that reads `req.Meta.(*sql.Meta)`
+   becomes `req.Metas["sql"].(*sql.Meta)`. The change is mechanical
+   and contained — three call sites total (sql facet matcher, k8s
+   facet matcher, postgres/clickhouse runtimes that *set* Meta).
+2. Drop the single `Family string` field. Replace with the same set
+   of family slots — presence of a slot ≡ membership in the family
+   set. (Equivalent option: keep `Family` for the *primary* protocol
+   family, used for dashboard column selection and HITL labelling,
+   and treat the slot-presence set as the matcher set.)
+3. Endpoint plugins gain an optional `ExtraFamilies []string` field
+   on `config.Plugin`. The `anthropic` / `openai` / `openrouter`
+   plugins set `Family = "http"` and `ExtraFamilies = []string{"llm"}`.
+   The `https`, `kubernetes`, postgres, clickhouse endpoints keep
+   `ExtraFamilies` empty.
+4. `rules.go` family inference walks `Family ∪ ExtraFamilies` per
+   endpoint and intersects across the rule's endpoint set. A rule
+   whose endpoints all support family `X` is family-`X`. Ambiguity
+   (a rule attached only to LLM-bearing endpoints could be either
+   `http` or `llm`) is resolved by an explicit `family = "llm"`
+   attribute on the rule. Rules without `family` default to the
+   primary `Family` of the endpoint (so the existing fleet of HTTP
+   rules attached to a future `anthropic` endpoint continues to read
+   as HTTP without edits).
+5. `MatchRequest` is unchanged: each rule's matcher already type-
+   asserts against its own meta slot, so a rule whose family isn't
+   represented on the request will return `false` cleanly. (We could
+   add an early continue keyed on rule family ∉ request families set
+   as a perf optim, but it's not correctness-load-bearing.)
+
+**Why (a) over (b) / (c).** `llm_rule` gets first-class status, the
+CEL env stays per-family (single variable per facet — `http`, `sql`,
+`k8s`, `llm`), no special-cased aux bag, no reflection-heavy
+type-assertion dispatch. The cost is a single field rename
+(`Meta any` → `Metas map[string]any`) touching ~6 sites.
+
+**Rejected: option (b)** would keep `Family string` singular and
+hide LLM facets behind `AuxFacets map[string]any`. That makes LLM
+rules second-class — their CEL would have to read from a generic
+map instead of the typed `llm.*` variable, and the rule plugin would
+need a special case for them. Not worth it.
+
+**Rejected: option (c)** is an over-engineered variant of (a). Same
+end state, more reflection.
+
+### 3.2 When LLM facets land on the action
+
+Two options:
+
+- **Two-phase emission.** Emit start with HTTP facets only, then
+  emit end (or a synthetic update) with HTTP **plus** LLM facets.
+- **Single emission post-stream.** Wait until the response completes
+  before emitting anything. Loses in-flight visibility.
+
+**Proposal: two-phase, riding the existing `Phase = "start"` →
+`Phase = "end"` channel.** The dashboard SSE protocol already
+correlates start/end events by `ID`. The current MITM handler
+collects the streamed response into `trackBuf` and reads it
+*before* `emitEnd` — that's exactly where the LLM facet's response
+parser runs and populates the LLM-family slot on `Event.Facets`.
+The start event carries HTTP facets only; the end event carries
+HTTP + LLM. No new `Phase` value is needed.
+
+This matches the existing `parseClaudeResponse` /
+`parseOpenAIResponse` runtime model and means the dashboard's
+request detail page renders LLM facets on the end-of-row state
+without any new SSE protocol concept.
+
+### 3.3 Pre-flight vs post-flight rule semantics
+
+`http_rule` matches **pre-flight**. The LLM-family fields split:
+
+- **Pre-flight matchable** (extractable from the request body before
+  forwarding): `model`, `provider`, `stream`.
+- **Post-flight only** (need the response): `input_tokens`,
+  `output_tokens`, `cache_read_tokens`, `cache_write_tokens`,
+  `stop_reason`.
+
+**Proposal: v1 supports pre-flight LLM facets only.** Per the bead:
+
+- The `llm` CEL env exposes only pre-flight fields (`llm.model`,
+  `llm.provider`, `llm.stream`). Rule conditions that read a post-
+  flight field fail at compile time with "unknown field".
+- Post-flight token counts are emitted on the action via
+  `Report(req)` for visibility / dashboard rendering, but **not**
+  reachable from CEL.
+- v2 adds post-flight CEL fields plus a streaming-cancellation hook
+  for providers that support it (Anthropic streaming can be
+  cancelled mid-flight). Out of scope for v1 — documented in §5.
+
+Pre-flight model gates (`llm.model.matches("^claude-opus-")`,
+`llm.model == "gpt-5"`) cover the common case operators care about
+("don't let codex use opus-class models"). Token-budget gating waits
+for the identity layer (cl-6hk) anyway, so blocking post-flight
+rules on v2 doesn't move the budget-enforcement timeline.
+
+### 3.4 Per-provider plugin scope
+
+Each of `anthropic` / `openai` / `openrouter` is HTTPS underneath.
+Three shapes:
+
+- Sibling plugins (each a top-level endpoint type alongside `https`).
+- Subtype of `https` that delegates to an embedded HTTPSEndpoint.
+- A single `llm_endpoint` plugin parameterized by provider name.
+
+**Proposal: sibling plugins.** Matches the existing
+`openai_codex_https` precedent (sibling of `https`, with its own
+`Runtime` for synthetic JWKS responses and `EnvVars` for codex JWT
+pushdown). Each provider plugin reuses the placeholder-detection
+behaviour of `HTTPSEndpointRuntime` (cred placeholder in
+`Authorization` header) by either embedding it or shipping an
+identical method.
+
+The actual provider-specific work — parsing the response stream for
+usage — lives behind a new optional interface on the endpoint
+plugin's `Runtime`:
+
+```go
+// In config/runtime, alongside PlaceholderDetector / HTTPSyntheticResponder:
+type LLMResponseParser interface {
+    ParseLLMResponse(reqBody, respBody []byte) llm.Meta
+}
+```
+
+The MITM dispatcher (`main.go`) type-asserts `ep.Plugin.Runtime` for
+this interface (in the same pattern as `HTTPSyntheticResponder`) and,
+when present, calls it with the collected request + response bytes
+between `trackBuf` extraction and `emitEnd`. The parser populates the
+`llm` slot in `req.Metas` and the `Event.Facets["llm"]` map.
+
+The default `Hosts` for each plugin:
+- `anthropic` → `["api.anthropic.com"]`
+- `openai` → `["api.openai.com"]`
+- `openrouter` → `["openrouter.ai"]`
+
+Hosts can still be overridden in HCL; defaults exist so the common
+case is one-line:
+
+```hcl
+endpoint "anthropic" "claude" {
+  credential = anthropic
+}
+```
+
+### 3.4.1 Naming: `codex` vs `openai`
+
+The bead names the OpenAI plugin `codex` but flags that the broader
+scope (OpenAI's responses/completions API, which also serves the
+OpenAI Codex CLI, gh Copilot, and custom OpenAI clients) is the
+defensible choice.
+
+**Proposal: name it `openai`, not `codex`.** Reasoning:
+
+- `codex` already exists as `openai_codex_https`, scoped to the
+  *chatgpt.com* path that codex CLI uses under subscription auth.
+  Reusing the name for a *different* provider scope (api.openai.com)
+  would be confusing.
+- The new plugin's host is `api.openai.com` — naming it `openai`
+  matches the host and the credential family.
+- The existing `openai_codex_https` plugin stays as-is for the
+  chatgpt.com subscription flow. It can grow `LLMResponseParser`
+  later for consistency.
+
+If reviewers prefer `codex` to honour the bead's literal text, the
+plugin file/type name is a one-line change.
+
+### 3.5 Facet shape for tokens (numeric vs bucketed)
+
+Today's facets are string-typed (`sql.verb == "select"`,
+`http.method == "post"`). Token counts are integers.
+
+**Proposal: numeric.** Two reasons:
+
+- CEL natively supports numeric comparisons and arithmetic
+  (`llm.input_tokens > 10000`). No matcher refactor needed.
+- The reporting layer already has `facet.ReportInt` (the HTTPS facet
+  reports `status` as an int), so the dashboard rendering pathway
+  already knows how to handle ints.
+
+The bucket option (`tokens = "10k+"`) loses precision and is no
+simpler when CEL handles ints directly.
+
+(This decision only matters for the *v2* CEL exposure of token
+fields — v1 doesn't expose them in CEL at all per §3.3 — but the
+reporting / dashboard path uses the numeric shape from day one.)
+
+### 3.6 Model facet
+
+`llm.model` is a plain string (`"claude-opus-4-7"`,
+`"anthropic/claude-3-5-sonnet-20240620"` for OpenRouter). Glob match
+uses CEL's `.matches(regex)` for prefix patterns and `==` for exact.
+
+No special-cased glob — operators write either:
+
+```
+llm.model == "claude-opus-4-7-20251001"
+llm.model.matches("^claude-opus-")
+```
+
+OpenRouter's `provider/model` shape works as-is — the matcher
+operates on the raw string.
+
+### 3.7 Cost facet
+
+**Out of scope for v1**, per the bead. Per-provider pricing tables
+are maintenance-heavy and pricing changes more often than the
+gateway ships. Documented as a v2 follow-up.
+
+### 3.8 Cache-token facets
+
+Anthropic distinguishes `cache_creation_input_tokens` (write, 1.25×
+list price) from `cache_read_input_tokens` (read, 0.1× list price).
+OpenAI exposes a read-only `cached_tokens` field via
+`prompt_tokens_details`. OpenRouter is OpenAI-compatible.
+
+**Proposal:** expose both on `LLMMeta` and on the action's `llm`
+report payload, using provider-neutral names:
+
+- `cache_read_tokens` — populated by both Anthropic and OpenAI.
+- `cache_write_tokens` — Anthropic only. Stays zero for providers
+  that don't surface a write-vs-read split.
+
+In v1 neither is matchable from CEL (per §3.3) — they only appear
+in `Report`.
+
+---
+
+## 4. Data shapes
+
+### 4.1 `LLMMeta`
+
+Lives in `config/plugins/facets/llm/llm.go`:
+
+```go
+type Meta struct {
+    Provider         string // "anthropic" | "openai" | "openrouter"
+    Model            string
+    Stream           bool   // request had stream:true
+    InputTokens      int64
+    OutputTokens     int64
+    CacheReadTokens  int64
+    CacheWriteTokens int64
+    StopReason       string // "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | provider-specific
+}
+
+type LLMFields struct { // CEL-facing, v1 fields only
+    Provider string `cel:"provider"`
+    Model    string `cel:"model"`
+    Stream   bool   `cel:"stream"`
+}
+```
+
+### 4.2 `ReportFields`
+
+```go
+func (Facet) ReportFields() []facet.ReportFieldSpec {
+    return []facet.ReportFieldSpec{
+        {Name: "provider",           Kind: facet.ReportString, Label: "Provider"},
+        {Name: "model",              Kind: facet.ReportString, Label: "Model"},
+        {Name: "stream",             Kind: facet.ReportString, Label: "Stream"},
+        {Name: "input_tokens",       Kind: facet.ReportInt,    Label: "Input tokens"},
+        {Name: "output_tokens",      Kind: facet.ReportInt,    Label: "Output tokens"},
+        {Name: "cache_read_tokens",  Kind: facet.ReportInt,    Label: "Cache read tokens"},
+        {Name: "cache_write_tokens", Kind: facet.ReportInt,    Label: "Cache write tokens"},
+        {Name: "stop_reason",        Kind: facet.ReportString, Label: "Stop reason"},
+    }
+}
+```
+
+### 4.3 Endpoint plugin runtime interface
+
+In `config/runtime/runtime.go` or a new file alongside
+`PlaceholderDetector`:
+
+```go
+type LLMResponseParser interface {
+    // ParseLLMResponse returns the populated llm.Meta extracted from
+    // a single request/response pair. Streaming responses arrive as
+    // the concatenated SSE byte stream the gateway captured into
+    // trackBuf; non-streaming responses arrive as the full JSON body.
+    // Implementations distinguish based on bytes, content-type, or
+    // body shape — they own that detail.
+    ParseLLMResponse(reqBody, respBody []byte) *llm.Meta
+}
+```
+
+Each provider plugin's `Runtime` implements this. The MITM
+dispatcher calls it once per request between response-write and
+end-event emission.
+
+---
+
+## 5. Out of scope (v1)
+
+Tracked for v2:
+
+- **Post-flight `llm_rule` matching.** v2 widens the CEL env to
+  expose token / stop_reason fields and adds a streaming-
+  cancellation hook for providers that support cancellation
+  (Anthropic streaming, OpenAI Responses API). Until then post-
+  flight fields are emit-only.
+- **Cost / pricing facets.** Per-provider pricing tables maintained
+  separately.
+- **Token-budget enforcement** (per-credential / per-user daily
+  caps). Depends on the identity layer (cl-6hk) and on post-flight
+  matching from above.
+- **Provider extras**: Anthropic tools, OpenAI logprobs, Gemini
+  citations. v2 (and individual additions per plugin).
+- **Other providers**: Gemini, Mistral, Bedrock direct.
+
+## 6. Acceptance criteria (re-stated from the bead)
+
+- An action passing through an `anthropic` / `openai` / `openrouter`
+  endpoint shows both HTTP facets *and* LLM facets on the dashboard
+  request detail page.
+- LLM facets include at minimum: provider, model, input tokens,
+  output tokens, cache read tokens, cache write tokens, stop reason.
+- A rule with `family = "llm"` and `condition = "llm.model.matches(...)"`
+  correctly matches / denies pre-flight against an LLM endpoint.
+- Existing HTTP rules attached to the same endpoint continue to fire
+  correctly (multi-family compatibility).
+- The PR description names the design decisions for each Phase 2
+  question, especially §3.1.
+
+---
+
+## 7. Review focus
+
+The structural decision in §3.1 is **load-bearing** — every other
+section assumes the multi-family-per-action shape it picks. Please
+sign off on §3.1 explicitly before Phase 3 commits land.
+
+Secondary points worth explicit thumbs-up:
+
+- §3.4.1 (`openai` vs `codex` naming)
+- §3.3 (pre-flight-only v1 — confirming that token-budget
+  enforcement waits for v2 is fine).

--- a/doc/llm-facet-design.md
+++ b/doc/llm-facet-design.md
@@ -1,14 +1,23 @@
 # `llm` facet family + per-provider LLM endpoint plugins — design
 
-Status: proposed. This doc is the design proposal for adding an `llm`
-facet family alongside `http` / `sql` / `k8s`, and shipping three
-per-provider HTTPS endpoint plugins (`anthropic`, `openai`,
-`openrouter`) whose actions carry both HTTP facets and LLM facets so
-existing HTTP rules keep firing and a new `llm`-family rule can match
-on provider / model / stream / tokens.
+Status: signed off. This doc is the agreed design for adding an
+`llm` facet family alongside `http` / `sql` / `k8s`, and shipping
+two new per-provider HTTPS endpoint plugins (`anthropic`,
+`openrouter`) plus extending the existing `openai_codex_https`
+plugin with LLM-family support. Actions carry both HTTP facets and
+LLM facets so existing HTTP rules keep firing and a new `llm`-
+family rule can match on provider / model / stream / tokens.
 
-The structural decision in [§3.1](#31-multi-family-per-action) is
-load-bearing. Sign-off on that section before implementation lands.
+Sign-off notes from the reviewer (PR #305 comment):
+
+- §3.1 multi-family shape: the request and the endpoint plugin
+  carry a single `families []string` set — no separate primary
+  `Family` + auxiliary `ExtraFamilies` split.
+- §3.4 per-provider plugins: do **not** ship a separate `openai`
+  plugin. Extend the existing `openai_codex_https` plugin so its
+  action carries both HTTP and LLM facets.
+- All other §3 design points are green-lit and implementation
+  proceeds as proposed.
 
 ---
 
@@ -25,9 +34,11 @@ coordinated changes:
    same request — an LLM endpoint's action carries both `http` and
    `llm` facets, so existing HTTP rules keep matching and new LLM
    rules become matchable.
-3. Three per-provider HTTPS endpoint plugins: `anthropic`, `openai`,
-   `openrouter`. Each parses the response (streaming + non-streaming)
-   to extract usage and populates the `llm` facet.
+3. Per-provider HTTPS endpoint coverage: two new plugins
+   (`anthropic`, `openrouter`) plus an LLM-family extension of the
+   existing `openai_codex_https` plugin. Each parses the response
+   (streaming + non-streaming) to extract usage and populates the
+   `llm` facet.
 
 ---
 
@@ -104,43 +115,51 @@ c. Type-assertion / bitmask over a `MultiFacetRequest` interface.
 
 **Proposal: take option (a), shaped concretely as:**
 
-1. Add `Metas map[string]any` to `match.Request` (or, equivalently, a
-   per-family struct holding `HTTP`, `SQL`, `K8s`, `LLM` pointer
-   fields — same effect, less reflection). The existing `Meta any`
-   field is removed; every site that reads `req.Meta.(*sql.Meta)`
-   becomes `req.Metas["sql"].(*sql.Meta)`. The change is mechanical
-   and contained — three call sites total (sql facet matcher, k8s
-   facet matcher, postgres/clickhouse runtimes that *set* Meta).
-2. Drop the single `Family string` field. Replace with the same set
-   of family slots — presence of a slot ≡ membership in the family
-   set. (Equivalent option: keep `Family` for the *primary* protocol
-   family, used for dashboard column selection and HITL labelling,
-   and treat the slot-presence set as the matcher set.)
-3. Endpoint plugins gain an optional `ExtraFamilies []string` field
-   on `config.Plugin`. The `anthropic` / `openai` / `openrouter`
-   plugins set `Family = "http"` and `ExtraFamilies = []string{"llm"}`.
-   The `https`, `kubernetes`, postgres, clickhouse endpoints keep
-   `ExtraFamilies` empty.
-4. `rules.go` family inference walks `Family ∪ ExtraFamilies` per
-   endpoint and intersects across the rule's endpoint set. A rule
-   whose endpoints all support family `X` is family-`X`. Ambiguity
-   (a rule attached only to LLM-bearing endpoints could be either
-   `http` or `llm`) is resolved by an explicit `family = "llm"`
-   attribute on the rule. Rules without `family` default to the
-   primary `Family` of the endpoint (so the existing fleet of HTTP
-   rules attached to a future `anthropic` endpoint continues to read
-   as HTTP without edits).
+1. Replace `Meta any` on `match.Request` with
+   `Metas map[string]any`. Every site that reads
+   `req.Meta.(*sql.Meta)` becomes `req.Metas["sql"].(*sql.Meta)`;
+   every site that sets `req.Meta = m` becomes
+   `req.Metas["sql"] = m`. The change is mechanical and contained.
+2. Replace `Family string` on `match.Request` with
+   `Families []string`. Presence in the set ≡ that family carries
+   metadata on the request. The HTTP-shaped fields (Method, URL,
+   Headers, Body) stay common-shared regardless of whether the
+   request is HTTP-only, LLM-bearing, or pure SQL.
+3. Replace `Family string` on `config.Plugin` with
+   `Families []string`. The `https`, `kubernetes`, `postgres`,
+   `clickhouse_native`, `clickhouse_https` endpoints declare a
+   single family in the slice. The `anthropic` / `openrouter`
+   plugins and the existing `openai_codex_https` plugin declare
+   `Families = []string{"http", "llm"}`. Endpoints that today
+   register `Family = "http"` migrate to
+   `Families = []string{"http"}` mechanically.
+4. `rules.go` family inference walks each endpoint's `Families`
+   and intersects across the rule's endpoint set. A rule whose
+   endpoints all support family `X` is family-`X`. Ambiguity (a
+   rule attached only to LLM-bearing endpoints could match `http`
+   or `llm`) is resolved by an explicit `family = "llm"` attribute
+   on the rule. Rules without `family` resolve to the unique
+   common family across the endpoint set; if more than one is
+   common and the rule omits `family`, validation rejects the
+   config with a diagnostic naming the candidate families.
 5. `MatchRequest` is unchanged: each rule's matcher already type-
    asserts against its own meta slot, so a rule whose family isn't
-   represented on the request will return `false` cleanly. (We could
-   add an early continue keyed on rule family ∉ request families set
-   as a perf optim, but it's not correctness-load-bearing.)
+   represented on the request will return `false` cleanly. (An
+   early-continue keyed on rule family ∉ request `Families` is an
+   optional perf optim, not correctness-load-bearing.)
 
 **Why (a) over (b) / (c).** `llm_rule` gets first-class status, the
 CEL env stays per-family (single variable per facet — `http`, `sql`,
-`k8s`, `llm`), no special-cased aux bag, no reflection-heavy
-type-assertion dispatch. The cost is a single field rename
-(`Meta any` → `Metas map[string]any`) touching ~6 sites.
+`k8s`, `llm`), no special-cased aux bag, no reflection-heavy type-
+assertion dispatch. The cost is one field rename per side:
+`Meta any` → `Metas map[string]any` and `Family string` →
+`Families []string`, touching ~6 sites total.
+
+**Naming note** (from the reviewer): a single `families` slice is
+preferred over a primary-`Family` + auxiliary-`ExtraFamilies` split.
+Both modelled the same set; the single-slice form keeps endpoint
+plugins, the request snapshot, and the rule-family resolver
+symmetrical and removes one degree of freedom.
 
 **Rejected: option (b)** would keep `Family string` singular and
 hide LLM facets behind `AuxFacets map[string]any`. That makes LLM
@@ -204,17 +223,19 @@ rules on v2 doesn't move the budget-enforcement timeline.
 
 ### 3.4 Per-provider plugin scope
 
-Each of `anthropic` / `openai` / `openrouter` is HTTPS underneath.
-Three shapes:
+Each LLM-bearing endpoint is HTTPS underneath. Three plugin shapes
+were on the table:
 
 - Sibling plugins (each a top-level endpoint type alongside `https`).
 - Subtype of `https` that delegates to an embedded HTTPSEndpoint.
 - A single `llm_endpoint` plugin parameterized by provider name.
 
-**Proposal: sibling plugins.** Matches the existing
+**Proposal: sibling plugins, scoped to two new types
+(`anthropic`, `openrouter`), plus an LLM-family extension to the
+existing `openai_codex_https` plugin.** Matches the existing
 `openai_codex_https` precedent (sibling of `https`, with its own
 `Runtime` for synthetic JWKS responses and `EnvVars` for codex JWT
-pushdown). Each provider plugin reuses the placeholder-detection
+pushdown). Each new plugin reuses the placeholder-detection
 behaviour of `HTTPSEndpointRuntime` (cred placeholder in
 `Authorization` header) by either embedding it or shipping an
 identical method.
@@ -226,7 +247,7 @@ plugin's `Runtime`:
 ```go
 // In config/runtime, alongside PlaceholderDetector / HTTPSyntheticResponder:
 type LLMResponseParser interface {
-    ParseLLMResponse(reqBody, respBody []byte) llm.Meta
+    ParseLLMResponse(reqBody, respBody []byte) *llm.Meta
 }
 ```
 
@@ -236,9 +257,11 @@ when present, calls it with the collected request + response bytes
 between `trackBuf` extraction and `emitEnd`. The parser populates the
 `llm` slot in `req.Metas` and the `Event.Facets["llm"]` map.
 
-The default `Hosts` for each plugin:
+The default `Hosts` for each LLM-bearing plugin:
 - `anthropic` → `["api.anthropic.com"]`
-- `openai` → `["api.openai.com"]`
+- `openai_codex_https` (existing) → keeps its current hosts
+  (`chatgpt.com` + the codex backchannel) and additionally declares
+  `Families = ["http", "llm"]` so its actions carry an `llm` slot.
 - `openrouter` → `["openrouter.ai"]`
 
 Hosts can still be overridden in HCL; defaults exist so the common
@@ -250,27 +273,27 @@ endpoint "anthropic" "claude" {
 }
 ```
 
-### 3.4.1 Naming: `codex` vs `openai`
+### 3.4.1 No separate `openai` plugin
 
-The bead names the OpenAI plugin `codex` but flags that the broader
-scope (OpenAI's responses/completions API, which also serves the
-OpenAI Codex CLI, gh Copilot, and custom OpenAI clients) is the
-defensible choice.
+The bead originally named an `openai` plugin distinct from the
+existing `openai_codex_https`. Per reviewer feedback, the OpenAI-
+shaped provider work happens **inside** `openai_codex_https` rather
+than in a new sibling plugin:
 
-**Proposal: name it `openai`, not `codex`.** Reasoning:
+- `openai_codex_https` keeps its current scope (codex CLI flow
+  against chatgpt.com with synthetic Agent Identity JWT pushdown)
+  and additionally implements `LLMResponseParser` for the OpenAI
+  responses/completions schema.
+- Its `config.Plugin` registration declares
+  `Families = []string{"http", "llm"}`. Actions through this
+  endpoint carry both an `http` and an `llm` facet.
+- No new `openai` plugin file/type is added.
 
-- `codex` already exists as `openai_codex_https`, scoped to the
-  *chatgpt.com* path that codex CLI uses under subscription auth.
-  Reusing the name for a *different* provider scope (api.openai.com)
-  would be confusing.
-- The new plugin's host is `api.openai.com` — naming it `openai`
-  matches the host and the credential family.
-- The existing `openai_codex_https` plugin stays as-is for the
-  chatgpt.com subscription flow. It can grow `LLMResponseParser`
-  later for consistency.
-
-If reviewers prefer `codex` to honour the bead's literal text, the
-plugin file/type name is a one-line change.
+If a future need arises to cover non-codex OpenAI traffic
+(`api.openai.com` direct calls outside the codex subscription flow),
+extending the `openai_codex_https` hosts list — or shipping a
+narrower second plugin then — stays open. v1 does not introduce
+that surface.
 
 ### 3.5 Facet shape for tokens (numeric vs bucketed)
 
@@ -418,9 +441,9 @@ Tracked for v2:
 
 ## 6. Acceptance criteria (re-stated from the bead)
 
-- An action passing through an `anthropic` / `openai` / `openrouter`
-  endpoint shows both HTTP facets *and* LLM facets on the dashboard
-  request detail page.
+- An action passing through an `anthropic` / `openai_codex_https` /
+  `openrouter` endpoint shows both HTTP facets *and* LLM facets on
+  the dashboard request detail page.
 - LLM facets include at minimum: provider, model, input tokens,
   output tokens, cache read tokens, cache write tokens, stop reason.
 - A rule with `family = "llm"` and `condition = "llm.model.matches(...)"`
@@ -432,14 +455,16 @@ Tracked for v2:
 
 ---
 
-## 7. Review focus
+## 7. Review status
 
-The structural decision in §3.1 is **load-bearing** — every other
-section assumes the multi-family-per-action shape it picks. Please
-sign off on §3.1 explicitly before Phase 3 commits land.
+Sign-off received on PR #305:
 
-Secondary points worth explicit thumbs-up:
+- §3.1 multi-family shape — approved with the single-`families`
+  slice form (no `Family` + `ExtraFamilies` split).
+- §3.4 per-provider scope — approved with the change that
+  `openai_codex_https` is extended in-place rather than shipping a
+  sibling `openai` plugin.
+- §3.3 (pre-flight-only v1) and all other §3 points — green-lit
+  as proposed.
 
-- §3.4.1 (`openai` vs `codex` naming)
-- §3.3 (pre-flight-only v1 — confirming that token-budget
-  enforcement waits for v2 is fine).
+Phase 3 implementation proceeds against this signed-off design.

--- a/main.go
+++ b/main.go
@@ -1160,7 +1160,7 @@ func (g *Gateway) handle(raw net.Conn, dstIP string) {
 			pip := peerIP(c)
 			profile := g.profileFor(pip)
 			ep := runtime.HostEndpoint(g.Policy(), profile, dstIP)
-			if ep != nil && isHTTPSMITMFamily(ep.Family) {
+			if ep != nil && isHTTPSMITMFamily(ep.PrimaryFamily()) {
 				log.Printf("sni-fallback: %s → %s", dstIP, ep.Name)
 				g.mitmHTTPS(c, dstIP, ep)
 				return
@@ -1181,7 +1181,7 @@ func (g *Gateway) handle(raw net.Conn, dstIP string) {
 		g.splice(c, host)
 		return
 	}
-	if isHTTPSMITMFamily(ep.Family) {
+	if isHTTPSMITMFamily(ep.PrimaryFamily()) {
 		// Every facet whose Transport() is "https-mitm" — https and
 		// k8s today, future plugins tomorrow — terminates TLS here
 		// and runs the request loop through mitmHTTPS. The facet's
@@ -1195,7 +1195,7 @@ func (g *Gateway) handle(raw net.Conn, dstIP string) {
 	// not through SNI peek on 443. Anything that lands here is
 	// either an unknown family or a family without an HTTPS
 	// transport — splice through.
-	log.Printf("endpoint %s family %q: no https-mitm transport; passthrough", ep.Name, ep.Family)
+	log.Printf("endpoint %s families %v: no https-mitm transport; passthrough", ep.Name, ep.Families)
 	g.splice(c, host)
 }
 
@@ -1211,6 +1211,41 @@ func isHTTPSMITMFamily(family string) bool {
 	}
 	f := facet.Lookup(family)
 	return f != nil && f.Transport() == "https-mitm"
+}
+
+// lookupFacets resolves each family name in families to its registered
+// facet.Runtime, skipping unknown names silently (the rule loader's
+// validate pass would have caught those). Returned in input order so
+// the primary family's facet runs first.
+func lookupFacets(families []string) []facet.Runtime {
+	out := make([]facet.Runtime, 0, len(families))
+	for _, name := range families {
+		if f := facet.Lookup(name); f != nil {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// mergeFacetReports calls Report on each facet and merges the results
+// into a single flat map. Returns nil when every facet reports
+// nothing — avoids emitting an empty extra column in the action
+// log.
+func mergeFacetReports(facets []facet.Runtime, mreq *match.Request) map[string]any {
+	var out map[string]any
+	for _, f := range facets {
+		r := f.Report(mreq)
+		if len(r) == 0 {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]any, len(r))
+		}
+		for k, v := range r {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // handlePostgresConn dispatches an inbound 5432 connection to the
@@ -1283,7 +1318,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 				return
 			}
 			g.sink.Emit(Event{
-				Mode: "pg", Family: ep.Family, Host: dstIP, AgentIP: agentPip,
+				Mode: "pg", Family: ep.PrimaryFamily(), Host: dstIP, AgentIP: agentPip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,
@@ -1442,7 +1477,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 				return
 			}
 			g.sink.Emit(Event{
-				Mode: mode, Family: ep.Family, Host: eventHost, AgentIP: agentPip,
+				Mode: mode, Family: ep.PrimaryFamily(), Host: eventHost, AgentIP: agentPip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,
@@ -1701,7 +1736,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		}
 
 		mreq := &match.Request{
-			Family:    ep.Family,
+			Families:  ep.Families,
 			Method:    req.Method,
 			URL:       req.URL,
 			Headers:   req.Header,
@@ -1709,23 +1744,31 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			PeerIP:    pip,
 			Truncated: truncated,
 		}
-		fac := facet.Lookup(ep.Family)
-		if fac != nil {
-			fac.PrepareRequest(mreq)
+		// PrepareRequest each facet the endpoint participates in
+		// (http for the wire, llm for token-rich providers, etc.) so
+		// every facet's Meta slot is populated before matchers run.
+		facets := lookupFacets(ep.Families)
+		for _, f := range facets {
+			f.PrepareRequest(mreq)
 		}
 
 		ev := Event{
 			ID:     newReqID(),
 			Mode:   "mitm",
-			Family: ep.Family,
+			Family: ep.PrimaryFamily(),
 			Host:   host,
 			Method: req.Method, Path: req.URL.Path,
 			AgentIP:  agentAddr,
 			Endpoint: ep.Name,
 		}
-		if fac != nil {
-			ev.Facets = fac.Report(mreq)
-		}
+		// Each facet contributes its report payload into a flat
+		// Facets map. Names don't collide across families today
+		// (http.method, sql.verb, llm.model — distinct keys) so the
+		// dashboard can read them without prefix awareness; the
+		// merge keeps multi-family endpoints (an `anthropic` carrying
+		// http + llm facets) emitting both payloads onto the same
+		// action record.
+		ev.Facets = mergeFacetReports(facets, mreq)
 		// Emit start event so the dashboard renders the request as
 		// in-flight immediately. The end event with the same ID
 		// arrives when resp.Write finishes — long-poll / SSE / WS

--- a/main.go
+++ b/main.go
@@ -1752,6 +1752,18 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			f.PrepareRequest(mreq)
 		}
 
+		// Pre-flight LLM facet population. Endpoint plugins that
+		// implement LLMResponseParser extract provider / model /
+		// stream from the request body so `llm_rule` predicates can
+		// gate on those before the request forwards. Token counts
+		// land later, after the response stream completes.
+		llmParser, _ := ep.Plugin.Runtime.(runtime.LLMResponseParser)
+		if llmParser != nil {
+			if pre := llmParser.ParseLLMRequest(matchBody); pre != nil {
+				mreq.SetMeta("llm", pre)
+			}
+		}
+
 		ev := Event{
 			ID:     newReqID(),
 			Mode:   "mitm",
@@ -2002,7 +2014,13 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			return
 		}
 		var trackBuf *bytes.Buffer
-		if trackKind != "" && resp.StatusCode == 200 {
+		// Capture the response body for downstream parsers whenever
+		// either the OOB usage tracker (trackKind) or the llm facet
+		// (llmParser, set on endpoints carrying the "llm" family)
+		// needs it. Same gate for both — JSON / SSE Content-Type on
+		// a 200 — so streamed and non-streamed bodies feed both
+		// paths without duplicate captures.
+		if (trackKind != "" || llmParser != nil) && resp.StatusCode == 200 {
 			ct := resp.Header.Get("Content-Type")
 			if strings.Contains(ct, "json") || strings.Contains(ct, "event-stream") {
 				trackBuf = &bytes.Buffer{}
@@ -2036,17 +2054,36 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		writeErr := resp.Write(tc)
 		_ = rtDur
 		_ = resp.Body.Close()
-		if trackBuf != nil && g.agents != nil {
-			body := trackBuf.Bytes()
+		// Post-stream parses for the OOB tracking path and for the
+		// per-action llm facet share the same response bytes — read
+		// trackBuf once, ungzip once, then feed both.
+		var respBody []byte
+		if trackBuf != nil {
+			respBody = trackBuf.Bytes()
 			if strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-				if zr, err := gzip.NewReader(bytes.NewReader(body)); err == nil {
+				if zr, err := gzip.NewReader(bytes.NewReader(respBody)); err == nil {
 					if d, err := io.ReadAll(zr); err == nil {
-						body = d
+						respBody = d
 					}
 					_ = zr.Close()
 				}
 			}
-			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint)
+		}
+		if trackBuf != nil && g.agents != nil {
+			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, respBody, sessionHint)
+		}
+		// llm facet post-flight enrichment. Endpoint plugins that
+		// implement LLMResponseParser amend the existing pre-flight
+		// Meta with token counts + stop_reason extracted from the
+		// (possibly streamed) response. Skip when no body was
+		// captured — happens for non-API paths or pre-trackBuf
+		// short-circuits.
+		if llmParser != nil && len(respBody) > 0 {
+			post := llmParser.ParseLLMResponse(matchBody, respBody, mreq.Meta("llm"))
+			if post != nil {
+				mreq.SetMeta("llm", post)
+			}
+			ev.Facets = mergeFacetReports(facets, mreq)
 		}
 
 		if ev.Action == "" {

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -409,7 +409,7 @@ endpoint "kubernetes" "example" {}
 
 ### `endpoint "openai_codex_https" "<name>"`
 
-Family: `http`.
+Families: `http`, `llm`.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -502,6 +502,7 @@ been inferred from the endpoint refs.
 | `endpoints` | `[]ref(endpoint)` | no |  |
 | `priority` | `int` | no |  |
 | `disabled` | `bool` | no |  |
+| `family` | `string` | no | Pins the facet whose CEL env the rule compiles against when the resolved endpoints carry more than one family. Single- family endpoint sets ignore it and infer from the endpoints. Empty + multi-family endpoints is a validation error. |
 | `condition` | `string` | no | A CEL expression evaluated against the family-specific variable set. An absent / empty condition matches everything — the catch-all pattern (`rule "X-default" { priority = -100; verdict = "deny" }`) relies on this. |
 | `credential` | `ref(credential)` | no | Credential, if set, is a bare-name reference to a credential block. The runtime treats it as an extra match predicate (request must have been dispatched against this credential) evaluated before the CEL expression. |
 | `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -320,7 +320,21 @@ credential "telegram_bot_token" "example" {}
 
 Block syntax: `endpoint "<type>" "<name>" { ... }`
 
-Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
+Registered types: [`anthropic`](#endpoint-anthropic), [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`openrouter`](#endpoint-openrouter), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
+
+### `endpoint "anthropic" "<name>"`
+
+Families: `http`, `llm`.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | no |  |
+| `credential` | `ref(credential)` | no |  |
+| `credentials` | `[]credential` | no |  |
+
+```hcl
+endpoint "anthropic" "example" {}
+```
 
 ### `endpoint "clickhouse_https" "<name>"`
 
@@ -421,6 +435,20 @@ Families: `http`, `llm`.
 endpoint "openai_codex_https" "example" {
   hosts = ["api.example.com"]
 }
+```
+
+### `endpoint "openrouter" "<name>"`
+
+Families: `http`, `llm`.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hosts` | `[]string` | no |  |
+| `credential` | `ref(credential)` | no |  |
+| `credentials` | `[]credential` | no |  |
+
+```hcl
+endpoint "openrouter" "example" {}
 ```
 
 ### `endpoint "postgres" "<name>"`

--- a/test.go
+++ b/test.go
@@ -176,18 +176,18 @@ func matchEquals(got, want Match) bool {
 func fixtureFamily(f *Fixture, ep *config.CompiledEndpoint) (string, error) {
 	switch {
 	case f.Action.HTTP != nil:
-		if ep.Family != "http" {
-			return "", fmt.Errorf("endpoint %q is family %q but fixture has http block", ep.Name, ep.Family)
+		if !ep.HasFamily("http") {
+			return "", fmt.Errorf("endpoint %q has families %v but fixture has http block", ep.Name, ep.Families)
 		}
 		return "http", nil
 	case f.Action.K8s != nil:
-		if ep.Family != "k8s" {
-			return "", fmt.Errorf("endpoint %q is family %q but fixture has k8s block", ep.Name, ep.Family)
+		if !ep.HasFamily("k8s") {
+			return "", fmt.Errorf("endpoint %q has families %v but fixture has k8s block", ep.Name, ep.Families)
 		}
 		return "k8s", nil
 	case f.Action.SQL != nil:
-		if ep.Family != "sql" {
-			return "", fmt.Errorf("endpoint %q is family %q but fixture has sql block", ep.Name, ep.Family)
+		if !ep.HasFamily("sql") {
+			return "", fmt.Errorf("endpoint %q has families %v but fixture has sql block", ep.Name, ep.Families)
 		}
 		return "sql", nil
 	}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -221,8 +221,12 @@ func (r *renderer) writePlugin(kind config.Kind, p *config.Plugin) {
 		r.out.WriteString("\n\n")
 	}
 
-	if kind == config.KindEndpoint && p.Family != "" {
-		fmt.Fprintf(&r.out, "Family: `%s`.\n\n", p.Family)
+	if kind == config.KindEndpoint && len(p.Families) > 0 {
+		if len(p.Families) == 1 {
+			fmt.Fprintf(&r.out, "Family: `%s`.\n\n", p.Families[0])
+		} else {
+			fmt.Fprintf(&r.out, "Families: %s.\n\n", joinTicked(p.Families))
+		}
 	}
 	if kind == config.KindRule && len(p.Families) > 0 {
 		fmt.Fprintf(&r.out, "Targets endpoints of family: %s.\n\n", joinTicked(p.Families))

--- a/web.go
+++ b/web.go
@@ -1461,7 +1461,7 @@ func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
 	}
 
 	fx := &Fixture{Match: m, Action: Action{PeerIP: ev.AgentIP}}
-	switch ep.Family {
+	switch ep.PrimaryFamily() {
 	case "http":
 		fx.Action.Host = ev.Host
 		fx.Action.HTTP = exportHTTP(ev)
@@ -1484,7 +1484,7 @@ func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
 		}
 		fx.Action.SQL = sql
 	default:
-		http.Error(rw, fmt.Sprintf("endpoint family %q is not yet exportable", ep.Family), 501)
+		http.Error(rw, fmt.Sprintf("endpoint family %q is not yet exportable", ep.PrimaryFamily()), 501)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Adds an `llm` facet family alongside `http` / `sql` / `k8s` and ships LLM-aware action emission on per-provider HTTPS endpoints. Actions carry both HTTP facets and LLM facets so existing `http_rule` predicates keep firing and a new `llm`-family rule matches on `provider` / `model` / `stream` pre-flight (token counts ride for visibility; matchable in v2).

Per PR review:
- §3.1 — single `Families []string` on Plugin / Symbol / CompiledEndpoint / match.Request (no `Family + ExtraFamilies` split).
- §3.4 — two new sibling plugins (`anthropic`, `openrouter`) plus the existing `openai_codex_https` extended with `LLMResponseParser`. No separate `openai` plugin.

## What's in the PR

| Layer | Change |
|---|---|
| Plumbing | `match.Request.{Families, Metas}` (was `Family`+`Meta`). `config.{Plugin,Symbol,CompiledEndpoint}` swap `Family string` for `Families []string` + `PrimaryFamily()` / `HasFamily()` helpers. |
| Rule loader | `inferFamily` intersects each endpoint's families. Multi-family endpoints disambiguate via explicit `family = "..."` on the rule; ambiguous rules surface a clear diagnostic. |
| Facet | New `config/plugins/facets/llm`. Pre-flight CEL exposes `llm.provider` / `llm.model` / `llm.stream`. Token counts + `stop_reason` ride in `Report` for the dashboard (matchable in v2). |
| Endpoints | New `anthropic` (api.anthropic.com) and `openrouter` (openrouter.ai). Both parse provider request bodies for pre-flight fields and concatenated SSE / final JSON for usage. `openai_codex_https` grows the same `LLMResponseParser` so chatgpt.com codex traffic emits llm facets too. |
| Runtime | New `LLMResponseParser` interface alongside `PlaceholderDetector` / `SQLParser`. MITM dispatcher type-asserts `ep.Plugin.Runtime` and populates `req.Metas["llm"]` in two phases (request body before forwarding; response body between `trackBuf` extraction and `emitEnd`). |
| Cache tokens | Provider-neutral `cache_read_tokens` / `cache_write_tokens`. Anthropic populates both (`cache_creation_input_tokens` → write, `cache_read_input_tokens` → read); OpenAI-shaped providers populate read only via `cached_tokens`. |

## Tests

- `config/plugins/facets/llm/llm_test.go` — CEL globs over `llm.model`, provider+stream gate, fail-soft on missing slot, Report/ReportFields parity.
- Per-provider parser unit tests against realistic streamed + non-streamed bodies for Anthropic, OpenRouter, and the chatgpt.com codex Responses API.
- `config/runtime/multi_family_test.go` — multi-family rule routing: opus gate (priority 100) → sonnet allow → default deny. Plus the ambiguity diagnostic for unspecified `family = ...` on multi-family endpoints.
- All existing facet / dispatch / compile / dnsvip tests updated for the `Family → Families` rename and pass.

## Out of scope (v1)

Post-flight LLM matching in CEL (token / stop_reason gates), cost facets, token-budget enforcement (waits on identity layer cl-6hk), provider extras (Anthropic tools, OpenAI logprobs), other providers (Gemini, Mistral, Bedrock direct). All documented in §5 of `doc/llm-facet-design.md`.