### PR TITLE
security: redact credential request body samples

### DIFF
--- a/main.go
+++ b/main.go
@@ -1852,6 +1852,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// Schema-only credential types leave Runtime nil; we pass through
 		// verbatim and rely on policy alone.
 		var rewriteWSPayload wsPayloadRewriter
+		var reqBodySecretRedactions []string
 		if cc := runtime.ResolveCredential(ep, mreq); cc != nil {
 			// Plugin.Runtime is a typed-nil sentinel used only for
 			// interface-compliance assertions; the actual decoded HCL
@@ -1868,6 +1869,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
 				} else {
 					if wantsHTTP {
+						reqBodySecretRedactions = appendCredentialSecretRedactions(reqBodySecretRedactions, sec)
 						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
 							log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
 						}
@@ -1953,7 +1955,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Reason = err.Error()
 			ev.Ms = time.Since(start).Milliseconds()
 			ev.ReqSha = reqS.sha()
-			ev.ReqBody = reqS.sample(req.Header.Get("Content-Encoding"))
+			ev.ReqBody = redactCredentialSample(reqS.sample(req.Header.Get("Content-Encoding")), reqBodySecretRedactions)
 			ev.In = reqS.n
 			g.emitEnd(ev)
 			return
@@ -2014,7 +2016,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()
-		ev.ReqBody = reqS.sample(req.Header.Get("Content-Encoding"))
+		ev.ReqBody = redactCredentialSample(reqS.sample(req.Header.Get("Content-Encoding")), reqBodySecretRedactions)
 		ev.RespSha = respS.sha()
 		ev.RespBody = respS.sample(resp.Header.Get("Content-Encoding"))
 		ev.Ms = time.Since(start).Milliseconds()

--- a/sample_redact.go
+++ b/sample_redact.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+const credentialSampleRedaction = "[REDACTED credential]"
+
+func appendCredentialSecretRedactions(dst []string, sec runtime.Secret) []string {
+	dst = appendCredentialSecretRedaction(dst, string(sec.Bytes))
+	for _, extra := range sec.Extras {
+		dst = appendCredentialSecretRedaction(dst, extra)
+	}
+	return dst
+}
+
+func appendCredentialSecretRedaction(dst []string, secret string) []string {
+	if secret == "" {
+		return dst
+	}
+	for _, existing := range dst {
+		if existing == secret {
+			return dst
+		}
+	}
+	return append(dst, secret)
+}
+
+func redactCredentialSample(sample string, secrets []string) string {
+	for _, secret := range secrets {
+		if secret == "" {
+			continue
+		}
+		sample = strings.ReplaceAll(sample, secret, credentialSampleRedaction)
+	}
+	return sample
+}

--- a/telegram_request_body_redaction_test.go
+++ b/telegram_request_body_redaction_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+const telegramTestPlaceholder = "0000000000:clawpatrol-placeholder-do-not-use"
+
+var fakeTelegramRequestBodyToken = []byte("999999999:FAKE_REDACTED_TELEGRAM_TOKEN_DO_NOT_USE")
+
+type telegramRequestBodySecretStore struct{}
+
+func (telegramRequestBodySecretStore) Get(string, string) (runtime.Secret, error) {
+	return runtime.Secret{Bytes: fakeTelegramRequestBodyToken}, nil
+}
+
+func TestTelegramInjectedTokenRedactedFromRequestBodyAuditSample(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(`
+credential "telegram_bot_token" "telegram_cred" {}
+endpoint "https" "telegram_api" {
+  hosts      = ["api.telegram.org"]
+  credential = telegram_cred
+}
+profile "default" { endpoints = [telegram_api] }
+rule "allow-telegram" {
+  endpoint = telegram_api
+  verdict  = "allow"
+}
+`), "telegram-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ep := policy.Endpoints["telegram_api"]
+
+	upstreamBodies := make(chan string, 1)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream body: %v", err)
+		}
+		upstreamBodies <- string(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	upstreamAddr := upstream.Listener.Addr().String()
+	tr := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upstreamAddr)
+		},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: false,
+	}
+	defer tr.CloseIdleConnections()
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	defer close(sink.ch)
+	events, cancel := sink.Subscribe()
+	defer cancel()
+
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{
+		cfg:     gw,
+		certs:   certs,
+		sink:    sink,
+		secrets: telegramRequestBodySecretStore{},
+	}
+	g.policy.Store(policy)
+	g.transports.Store(ep, tr)
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.mitmHTTPS(serverConn, "api.telegram.org", ep)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: "api.telegram.org"})
+	defer func() { _ = clientTLS.Close() }()
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+
+	requestBody := "url=https://agent.example/hook/" + telegramTestPlaceholder + "&drop_pending_updates=true"
+	req, err := http.NewRequest(http.MethodPost, "https://api.telegram.org/bot"+telegramTestPlaceholder+"/setWebhook", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if err := req.Write(clientTLS); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientTLS), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	var upstreamBody string
+	select {
+	case upstreamBody = <-upstreamBodies:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream request body")
+	}
+	if !strings.Contains(upstreamBody, string(fakeTelegramRequestBodyToken)) {
+		t.Fatal("upstream body did not receive injected Telegram token")
+	}
+
+	var end Event
+	select {
+	case end = <-endEvent(events):
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for terminal audit event")
+	}
+	if strings.Contains(end.ReqBody, string(fakeTelegramRequestBodyToken)) {
+		t.Fatal("request body audit sample contains injected Telegram token")
+	}
+	if !strings.Contains(end.ReqBody, telegramTestPlaceholder) && !strings.Contains(strings.ToLower(end.ReqBody), "redact") {
+		t.Fatalf("request body audit sample = %q, want placeholder or redaction marker", end.ReqBody)
+	}
+
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
+	}
+}
+
+func endEvent(events <-chan eventPacket) <-chan Event {
+	out := make(chan Event, 1)
+	go func() {
+		defer close(out)
+		for pkt := range events {
+			if pkt.ev.Phase == "end" {
+				out <- pkt.ev
+				return
+			}
+		}
+	}()
+	return out
+}


### PR DESCRIPTION
## Summary
- redacts configured HTTP credential secret material from request-body audit samples after injection
- adds a regression test for the Telegram bot-token body rewrite path: the fake injected token reaches upstream, but does not appear in `Event.ReqBody`
- covers both terminal event paths that persist request-body samples

## Test plan
- `go test ./ -run '^TestTelegramInjectedTokenRedactedFromRequestBodyAuditSample$' -count=1`
- `go test ./... -count=1`
- `git diff --check`
- independent reviewer: APPROVED

Closes #308
