### PR TITLE
security: bound decoded response samples

### DIFF
--- a/sampler_test.go
+++ b/sampler_test.go
@@ -135,6 +135,28 @@ func TestSamplerSampleZstd(t *testing.T) {
 	}
 }
 
+func TestMaybeDecodeCapsExpandedGzip(t *testing.T) {
+	const capBytes = 4096
+	const truncatedMarker = "\n[decoded response sample truncated]"
+
+	plain := strings.Repeat("a", capBytes*4)
+	compressed := gzipped(t, plain)
+	if len(compressed) >= capBytes {
+		t.Fatalf("test gzip payload should fit compressed sampler cap: %d >= %d", len(compressed), capBytes)
+	}
+
+	got := maybeDecode(compressed, "gzip")
+	if len(got) > capBytes+len(truncatedMarker) {
+		t.Fatalf("decoded gzip sample length = %d, want <= %d", len(got), capBytes+len(truncatedMarker))
+	}
+	if !bytes.HasSuffix(got, []byte(truncatedMarker)) {
+		t.Fatalf("decoded gzip sample should end with truncation marker %q; got suffix %q", truncatedMarker, string(got[max(0, len(got)-len(truncatedMarker)):]))
+	}
+	if gotPrefix := string(got[:capBytes]); gotPrefix != plain[:capBytes] {
+		t.Fatalf("decoded gzip prefix was not preserved")
+	}
+}
+
 func TestSamplerSamplePlaintext(t *testing.T) {
 	s := newSampler(4096)
 	_, _ = s.Write([]byte(`{"hello":"world"}`))

--- a/web.go
+++ b/web.go
@@ -2243,12 +2243,18 @@ func (s *sampler) sample(encoding string) string {
 	return "binary:" + hex.EncodeToString(raw[:min(64, len(raw))])
 }
 
+const (
+	decodedSampleCap             = 4096
+	decodedSampleTruncatedMarker = "\n[decoded response sample truncated]"
+)
+
 // maybeDecode returns the decompressed prefix of buf when encoding
 // is a compression scheme we recognise, or buf unchanged otherwise.
 // The sampler captures at most cap bytes, so the stream is almost
-// always truncated mid-block — io.ReadAll returns whatever the
-// reader managed before hitting EOF, which is what we want for a
-// preview.
+// always truncated mid-block — decoders return whatever they managed
+// before hitting EOF, which is what we want for a preview. Decoded
+// output is capped separately because tiny compressed inputs can expand
+// far beyond the sampled wire bytes.
 func maybeDecode(buf []byte, encoding string) []byte {
 	var r io.Reader
 	switch strings.ToLower(strings.TrimSpace(encoding)) {
@@ -2282,9 +2288,12 @@ func maybeDecode(buf []byte, encoding string) []byte {
 	default:
 		return buf
 	}
-	out, _ := io.ReadAll(r)
+	out, _ := io.ReadAll(io.LimitReader(r, decodedSampleCap+1))
 	if len(out) == 0 {
 		return buf
+	}
+	if len(out) > decodedSampleCap {
+		out = append(out[:decodedSampleCap:decodedSampleCap], decodedSampleTruncatedMarker...)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- bounds decoded audit-sample expansion in `maybeDecode` for gzip/br/deflate/zstd responses
- appends an explicit truncation marker when decoded content exceeds the cap
- adds a gzip regression test where the compressed sample is small but decoded output expands past the cap

## Test plan
- `go test ./ -run '^TestMaybeDecodeCapsExpandedGzip$' -count=1`
- `go test ./... -count=1`
- `git diff --check`
- independent reviewer: APPROVED

Closes #309
