### PR TITLE
security: validate dashboard login redirects

### DIFF
--- a/web.go
+++ b/web.go
@@ -341,6 +341,17 @@ func checkDashboardSecret(r *http.Request, want string) bool {
 	return false
 }
 
+func safeDashboardLoginNext(next string) string {
+	if next == "" || strings.Contains(next, "\\") || strings.HasPrefix(next, "//") {
+		return "/"
+	}
+	u, err := url.Parse(next)
+	if err != nil || u.Scheme != "" || u.Host != "" || !strings.HasPrefix(u.Path, "/") {
+		return "/"
+	}
+	return next
+}
+
 // apiDashboardLogin renders a one-field form (GET) and validates +
 // sets the cp_dash cookie (POST). Plain HTML, no JS — keeps the
 // login surface small.
@@ -350,10 +361,7 @@ func (w *webMux) apiDashboardLogin(rw http.ResponseWriter, r *http.Request) {
 		http.Redirect(rw, r, "/", http.StatusFound)
 		return
 	}
-	next := r.URL.Query().Get("next")
-	if next == "" || !strings.HasPrefix(next, "/") {
-		next = "/"
-	}
+	next := safeDashboardLoginNext(r.URL.Query().Get("next"))
 	if r.Method == "POST" {
 		if err := r.ParseForm(); err != nil {
 			http.Error(rw, "bad form", 400)

--- a/web_dashboard_auth_test.go
+++ b/web_dashboard_auth_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/denoland/clawpatrol/config"
@@ -33,5 +34,57 @@ func TestDashboardLoginGetDoesNotAcceptSecretQueryParam(t *testing.T) {
 	}
 	if cookies := rw.Result().Cookies(); len(cookies) != 0 {
 		t.Fatalf("GET /__login?secret=... set cookies: %+v", cookies)
+	}
+}
+
+func TestDashboardLoginRejectsProtocolRelativeNext(t *testing.T) {
+	tests := []struct {
+		name      string
+		queryNext string
+		want      string
+	}{
+		{
+			name:      "valid dashboard path",
+			queryNext: "/dashboard",
+			want:      "/dashboard",
+		},
+		{
+			name:      "protocol-relative URL",
+			queryNext: "//evil.example/path",
+			want:      "/",
+		},
+		{
+			name:      "encoded protocol-relative URL",
+			queryNext: "%2F%2Fevil.example%2Fpath",
+			want:      "/",
+		},
+		{
+			name:      "encoded backslash authority",
+			queryNext: "%2F%5C%5Cevil.example%2Fpath",
+			want:      "/",
+		},
+		{
+			name:      "absolute URL",
+			queryNext: "https%3A%2F%2Fevil.example%2Fpath",
+			want:      "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &webMux{g: &Gateway{cfg: &config.Gateway{DashboardSecret: "s3cr3t"}}}
+			r := httptest.NewRequest(http.MethodPost, "/__login?next="+tt.queryNext, strings.NewReader("secret=s3cr3t"))
+			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rw := httptest.NewRecorder()
+
+			w.apiDashboardLogin(rw, r)
+
+			if rw.Code != http.StatusFound {
+				t.Fatalf("status = %d, want %d", rw.Code, http.StatusFound)
+			}
+			if got := rw.Result().Header.Get("Location"); got != tt.want {
+				t.Fatalf("Location = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- validates dashboard login `next` redirects before issuing the post-login redirect
- rejects protocol-relative, absolute-URL, and backslash authority-style values while preserving valid same-origin paths
- adds regression coverage for the protocol-relative open redirect and adjacent URL edge cases

## Test plan
- `go test ./ -run '^TestDashboardLoginRejectsProtocolRelativeNext$' -count=1`
- `go test ./... -count=1`
- `git diff --check`
- independent reviewer: APPROVED

Closes #310
