### PR TITLE
refactor: drop ca_dir/oauth_dir; state_dir is the only knob

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -18,9 +18,8 @@ blocks dispatch to plugins by their first label.
 # Top-level singletons — read by the gateway daemon at boot.
 # Listen / paths / public URL:
 listen      = "0.0.0.0:8443"
-ca_dir      = "/opt/clawpatrol/ca"
 log_path    = "/opt/clawpatrol/gateway.log"
-oauth_dir   = "/opt/clawpatrol/oauth"
+state_dir   = "/opt/clawpatrol/state"
 public_url  = "http://gateway.internal:8080"
 admin_email = "ops@example.com"
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,21 +24,12 @@ type Gateway struct {
 	InfoListen string `hcl:"info_listen,optional"`
 	PublicURL  string `hcl:"public_url,optional"`
 	AdminEmail string `hcl:"admin_email,optional"`
-	// CADir is the legacy path the gateway used to keep the CA cert
-	// + ssh host keys on disk. Kept for backwards compat so existing
-	// configs still parse and state_dir resolution can fall back to
-	// ${ca_dir}/../oauth. New deployments should set state_dir
-	// instead — the gateway keeps everything in sqlite.
-	CADir string `hcl:"ca_dir,optional"`
-	// StateDir is the directory holding clawpatrol.db. Falls back to
-	// OAuthDir (historical name) or ${CADir}/../oauth or
-	// ${HOME}/.clawpatrol/state, in that order.
-	StateDir string `hcl:"state_dir,optional"`
-	Resolver string `hcl:"resolver,optional"`
-	LogPath  string `hcl:"log_path,optional"`
-	// OAuthDir is the historical state directory name. Equivalent to
-	// state_dir and kept for backwards compat.
-	OAuthDir        string `hcl:"oauth_dir,optional"`
+	// StateDir is the directory holding clawpatrol.db (and anything
+	// else a plugin persists to disk under it). Defaults to
+	// ${HOME}/.clawpatrol/state when unset.
+	StateDir        string `hcl:"state_dir,optional"`
+	Resolver        string `hcl:"resolver,optional"`
+	LogPath         string `hcl:"log_path,optional"`
 	DashboardSecret string `hcl:"dashboard_secret,optional"`
 	// InsecureNoDashboardSecret opts out of dashboard auth. Required
 	// (alongside an empty DashboardSecret) for the gateway to serve

--- a/config/dump.go
+++ b/config/dump.go
@@ -26,14 +26,8 @@ func (g *Gateway) Dump() ([]byte, error) {
 	if g.AdminEmail != "" {
 		out["admin_email"] = g.AdminEmail
 	}
-	if g.CADir != "" {
-		out["ca_dir"] = g.CADir
-	}
 	if g.LogPath != "" {
 		out["log_path"] = g.LogPath
-	}
-	if g.OAuthDir != "" {
-		out["oauth_dir"] = g.OAuthDir
 	}
 	if g.Resolver != "" {
 		out["resolver"] = g.Resolver

--- a/config/emit.go
+++ b/config/emit.go
@@ -61,10 +61,8 @@ func emitOperational(body *hclwrite.Body, gw *Gateway) {
 	setStr("info_listen", gw.InfoListen)
 	setStr("public_url", gw.PublicURL)
 	setStr("admin_email", gw.AdminEmail)
-	setStr("ca_dir", gw.CADir)
 	setStr("resolver", gw.Resolver)
 	setStr("log_path", gw.LogPath)
-	setStr("oauth_dir", gw.OAuthDir)
 	setStr("dashboard_secret", gw.DashboardSecret)
 	if gw.InsecureNoDashboardSecret {
 		body.SetAttributeValue("insecure_no_dashboard_secret", cty.BoolVal(true))

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -1,7 +1,8 @@
 // Package config loads and validates clawpatrol's HCL gateway config.
 //
-// The config has two layers. Operational fields (listen / ca_dir /
-// tailscale {} / ...) live at the top of the file and decode via
+// The config has two layers. Operational fields (listen /
+// state_dir / tailscale {} / ...) live at the top of the file and
+// decode via
 // gohcl into the Gateway struct. Policy blocks (defaults / approver /
 // policy / credential / endpoint / rule / profile) are dispatched to
 // plugins by their first label; each plugin owns its body schema, the

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -123,11 +123,11 @@ func (t *TailscaleTunnel) Open(ctx context.Context, host runtime.TunnelHost, _ r
 		return nil, fmt.Errorf("tailscale tunnel %q: no authkey (set HCL `authkey = ...`, env %s, or wire a `credential = ...` reference)", host.Name, envAuthKey(host.Name))
 	}
 	stateDir := t.StateDir
-	if stateDir == "" && host.CADir != "" {
-		stateDir = filepath.Join(host.CADir, "tunnels", "tailscale", host.Name)
+	if stateDir == "" && host.StateDir != "" {
+		stateDir = filepath.Join(host.StateDir, "tunnels", "tailscale", host.Name)
 	}
 	if stateDir == "" {
-		return nil, errors.New("tailscale tunnel: state_dir is required (HCL `state_dir = ...` or set the gateway's ca_dir so a default can be derived)")
+		return nil, errors.New("tailscale tunnel: state_dir is required (HCL `state_dir = ...` on the tunnel or the gateway)")
 	}
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return nil, fmt.Errorf("tailscale tunnel %q: state dir: %w", host.Name, err)

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -148,11 +148,12 @@ type ConnHandle struct {
 	// support HITL for this conn family — plugins must default to
 	// deny in that case.
 	Approve func(req ApproveCallRequest) ApproveVerdict
-	// CADir is the gateway's persistent state root (matches
-	// cfg.CADir). Kept on the handle for tunnel plugins (Tailscale's
-	// tsnet state dir is derived from it). Endpoint plugins should
-	// persist material through Blobs instead — see ConnHandle.Blobs.
-	CADir string
+	// StateDir is the gateway's persistent state root (matches
+	// cfg.StateDir). Kept on the handle for tunnel plugins
+	// (Tailscale's tsnet state dir is derived from it). Endpoint
+	// plugins should persist material through Blobs instead — see
+	// ConnHandle.Blobs.
+	StateDir string
 	// Blobs is the gateway's plugin-blob store. Endpoint plugins
 	// that need persistent bytes (SSH host keys, JWT signing keys)
 	// read / write through it instead of touching the filesystem.

--- a/config/runtime/tunnel.go
+++ b/config/runtime/tunnel.go
@@ -106,12 +106,12 @@ type TunnelHost struct {
 	// credentials expose a known shape).
 	Credential *TunnelCredential
 
-	// CADir is the gateway's persistent state root (cfg.CADir).
+	// StateDir is the gateway's persistent state root (cfg.StateDir).
 	// Tunnel plugins that need to persist material between policy
 	// reloads — e.g. tailscale tsnet's state directory — derive
-	// paths from this. Empty when the gateway hasn't been configured
-	// with one.
-	CADir string
+	// paths from this. Always non-empty (the host resolves a default
+	// when no explicit StateDir is configured).
+	StateDir string
 
 	// Logger is a per-tunnel logger pre-tagged with the tunnel name.
 	// Plugins should prefer it over package-level log.Printf so the

--- a/config/testdata/error_dashboard_no_auth.hcl
+++ b/config/testdata/error_dashboard_no_auth.hcl
@@ -5,4 +5,3 @@
 
 listen      = "0.0.0.0:8443"
 info_listen = "0.0.0.0:8080"
-ca_dir      = "/opt/clawpatrol/ca"

--- a/config/testdata/error_invalid_control.hcl
+++ b/config/testdata/error_invalid_control.hcl
@@ -3,6 +3,5 @@
 # in a degraded fallback mode.
 
 listen = "0.0.0.0:8443"
-ca_dir = "/opt/clawpatrol/ca"
 
 control = "kubernetes"

--- a/config/testdata/error_stale_defaults_block.errors.txt
+++ b/config/testdata/error_stale_defaults_block.errors.txt
@@ -1,1 +1,1 @@
-error: error_stale_defaults_block.hcl:8:1: Unsupported block type — Blocks of type "defaults" are not expected here.
+error: error_stale_defaults_block.hcl:7:1: Unsupported block type — Blocks of type "defaults" are not expected here.

--- a/config/testdata/error_stale_defaults_block.hcl
+++ b/config/testdata/error_stale_defaults_block.hcl
@@ -3,7 +3,6 @@
 # silently drop the block.
 
 listen = "0.0.0.0:8443"
-ca_dir = "/opt/clawpatrol/ca"
 
 defaults {
   unknown_host  = "passthrough"

--- a/config/testdata/error_stale_gateway_block.errors.txt
+++ b/config/testdata/error_stale_gateway_block.errors.txt
@@ -1,1 +1,1 @@
-error: error_stale_gateway_block.hcl:8:1: Unsupported block type — Blocks of type "gateway" are not expected here.
+error: error_stale_gateway_block.hcl:7:1: Unsupported block type — Blocks of type "gateway" are not expected here.

--- a/config/testdata/error_stale_gateway_block.hcl
+++ b/config/testdata/error_stale_gateway_block.hcl
@@ -3,7 +3,6 @@
 # silently drop the block.
 
 listen = "0.0.0.0:8443"
-ca_dir = "/opt/clawpatrol/ca"
 
 gateway {
   control     = "wireguard"

--- a/config/testdata/error_wireguard_missing_fields.hcl
+++ b/config/testdata/error_wireguard_missing_fields.hcl
@@ -3,6 +3,5 @@
 # clients dial an unknown endpoint.
 
 listen = "0.0.0.0:8443"
-ca_dir = "/opt/clawpatrol/ca"
 
 control = "wireguard"

--- a/config/testdata/feature_example.hcl
+++ b/config/testdata/feature_example.hcl
@@ -5,7 +5,7 @@
 #     clawpatrol gateway -config /etc/clawpatrol/gateway.hcl
 #
 # Hot-reloadable: every policy block + admin_email. Listen ports /
-# ca_dir / oauth_dir / tailscale block need a restart.
+# state_dir / tailscale block need a restart.
 #
 # Top-level kinds:
 #
@@ -31,9 +31,8 @@ listen           = "0.0.0.0:8443"
 info_listen      = "0.0.0.0:8080"
 public_url       = "http://66.42.120.196:8080"
 admin_email      = "test@example.com"
-ca_dir           = "/opt/clawpatrol/ca"
 log_path         = "/opt/clawpatrol/gateway.log"
-oauth_dir        = "/opt/clawpatrol/oauth"
+state_dir        = "/opt/clawpatrol/oauth"
 dashboard_secret = "test-secret"
 
 control        = "wireguard"

--- a/config/testdata/feature_example.want.json
+++ b/config/testdata/feature_example.want.json
@@ -1,6 +1,5 @@
 {
   "admin_email": "test@example.com",
-  "ca_dir": "/opt/clawpatrol/ca",
   "control": "wireguard",
   "human_on_timeout": "deny",
   "human_timeout": 600,
@@ -9,7 +8,6 @@
   "llm_cache_ttl": 300,
   "llm_fail_mode": "closed",
   "log_path": "/opt/clawpatrol/gateway.log",
-  "oauth_dir": "/opt/clawpatrol/oauth",
   "policy": {
     "approvers": {
       "ops": {
@@ -81,6 +79,7 @@
     }
   },
   "public_url": "http://66.42.120.196:8080",
+  "state_dir": "/opt/clawpatrol/oauth",
   "unknown_host": "passthrough",
   "wg_endpoint": "66.42.120.196:51820",
   "wg_subnet_cidr": "10.55.0.0/24"

--- a/config/testdata/feature_minimal.hcl
+++ b/config/testdata/feature_minimal.hcl
@@ -1,5 +1,4 @@
 listen     = "0.0.0.0:8443"
-ca_dir     = "/opt/clawpatrol/ca"
 
 unknown_host  = "passthrough"
 llm_fail_mode = "closed"

--- a/config/testdata/feature_minimal.want.json
+++ b/config/testdata/feature_minimal.want.json
@@ -1,5 +1,4 @@
 {
-  "ca_dir": "/opt/clawpatrol/ca",
   "listen": "0.0.0.0:8443",
   "llm_fail_mode": "closed",
   "policy": {

--- a/config/testdata/feature_tunnel.hcl
+++ b/config/testdata/feature_tunnel.hcl
@@ -1,5 +1,4 @@
 listen = "0.0.0.0:8443"
-ca_dir = "/opt/clawpatrol/ca"
 
 credential "bearer_token" "github-pat" {}
 

--- a/config/testdata/feature_tunnel.want.json
+++ b/config/testdata/feature_tunnel.want.json
@@ -1,5 +1,4 @@
 {
-  "ca_dir": "/opt/clawpatrol/ca",
   "listen": "0.0.0.0:8443",
   "policy": {
     "credentials": {

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -58,7 +58,7 @@ public UDP port, no WireGuard keypair management, no subnet allocation
 | **Device IP** | Assigned by Tailscale control plane | Allocated from `wg_subnet_cidr` |
 | **Dashboard auth** | Tailscale user identity (no proxy needed) | Falls back to `admin_email`; needs auth proxy for multi-user |
 | **Client command** | `clawpatrol login` | `clawpatrol join <gw-url>` |
-| **State** | `state_dir` (tsnet) | `oauth_dir` (wg-server.key, wg-peers.json) |
+| **State** | `state_dir` — tsnet machine key + ipn state in sqlite | `state_dir` — WG server key, peer map, sessions in sqlite |
 
 ## Operator setup
 
@@ -71,8 +71,7 @@ listen       = "0.0.0.0:8443"
 info_listen  = "0.0.0.0:8080"
 public_url   = "http://clawpatrol-gateway"    # tailnet hostname suffices
 admin_email  = "you@example.com"
-ca_dir       = "/opt/clawpatrol/ca"
-oauth_dir    = "/opt/clawpatrol/oauth"
+state_dir    = "/opt/clawpatrol/state"
 integrations = ["claude", "codex", "github"]
 
 control             = "tailscale"

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -33,10 +33,11 @@ in promiscuous mode — same shape as unclaw's `boringtun` + `smoltcp`
 
 - `clawpatrol gateway gateway.hcl` boots WG endpoint on UDP 51820,
   dashboard + MITM ride the same forwarder.
-- Server keypair persisted at `<oauth_dir>/wg-server.key`. Pubkey
-  derived via curve25519 at boot. Peer (pubkey → IP) map persisted
-  at `<oauth_dir>/wg-peers.json`, replayed on every restart so
-  existing clients survive gateway redeploys.
+- Server keypair persisted in the gateway's sqlite DB (see
+  migration `0008_gateway_state`). Pubkey derived via curve25519
+  at boot. Peer (pubkey → IP) map also lives in sqlite; both are
+  replayed on every restart so existing clients survive gateway
+  redeploys.
 - `clawpatrol join <gw>` runs once: prints user-code, opens
   dashboard URL, server mints a fresh keypair, allocates a /32 from
   the configured subnet, registers the peer with wireguard-go,
@@ -77,9 +78,8 @@ listen       = "0.0.0.0:8443"
 info_listen  = "0.0.0.0:8080"
 public_url   = "http://your-gw.example.com:8080"
 admin_email  = "you@example.com"
-ca_dir       = "/opt/clawpatrol/ca"
 log_path     = "/opt/clawpatrol/gateway.log"
-oauth_dir    = "/opt/clawpatrol/oauth"
+state_dir    = "/opt/clawpatrol/state"
 integrations = ["claude", "codex", "github"]
 
 tailscale {

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -5,7 +5,7 @@
 #     clawpatrol gateway /etc/clawpatrol/gateway.hcl
 #
 # Hot-reloadable: every policy block + admin_email. Listen ports /
-# ca_dir / oauth_dir / tailscale block need a restart.
+# state_dir / tailscale block need a restart.
 #
 # Labeled blocks:
 #
@@ -29,8 +29,7 @@ listen      = "0.0.0.0:8443"
 info_listen = "0.0.0.0:8080"
 public_url  = "http://66.42.120.196:8080"
 admin_email = "test@example.com"
-ca_dir      = "/opt/clawpatrol/ca"
-oauth_dir   = "/opt/clawpatrol/oauth"
+state_dir   = "/opt/clawpatrol/oauth"
 
 # Dashboard auth — pick exactly one. The gateway refuses to serve the
 # dashboard / APIs until one of these is set, to avoid silently
@@ -110,12 +109,12 @@ rule "github-writes" {
 # the gateway recovers the hostname, terminates SSH on both halves,
 # and uses the credential below for upstream auth.
 #
-# VIPs are persisted under <state_dir>/dnsvip.json so they survive
-# restarts AND policy reloads — clients' cached DNS answers stay
-# valid through gateway hops. Each SSH endpoint also gets its own
-# persisted host key under <ca_dir>/ssh/<endpoint>.key on first use;
-# add the printed fingerprint to the user's known_hosts file (the
-# dashboard surfaces it per endpoint).
+# VIPs are persisted in sqlite so they survive restarts AND policy
+# reloads — clients' cached DNS answers stay valid through gateway
+# hops. Each SSH endpoint also gets its own persisted host key
+# (also in sqlite, via the plugin blob store) on first use; add the
+# printed fingerprint to the user's known_hosts file (the dashboard
+# surfaces it per endpoint).
 
 credential "ssh" "build-host-cred" {
   # private_key + (optional) passphrase + (optional) host_pubkey live

--- a/main.go
+++ b/main.go
@@ -43,23 +43,15 @@ import (
 type JoinConfig = config.JoinConfig
 
 // resolveStateDir picks the directory where the gateway keeps its
-// sqlite DB. Priority: cfg.StateDir (new canonical name) →
-// cfg.OAuthDir (the historical name, kept for backwards compat) →
-// ${cfg.CADir}/../oauth (the original layout that put state next to
-// the CA materials).
+// sqlite DB. The HCL `state_dir` attribute is the only knob;
+// defaults to ${HOME}/.clawpatrol/state when unset.
 func resolveStateDir(cfg *config.Gateway) string {
 	if cfg.StateDir != "" {
 		return cfg.StateDir
 	}
-	if cfg.OAuthDir != "" {
-		return cfg.OAuthDir
-	}
-	if cfg.CADir != "" {
-		return filepath.Join(cfg.CADir, "..", "oauth")
-	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
-		log.Fatalf("state_dir / oauth_dir / ca_dir all unset and $HOME unavailable")
+		log.Fatalf("state_dir unset and $HOME unavailable")
 	}
 	return filepath.Join(home, ".clawpatrol", "state")
 }
@@ -265,17 +257,18 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 }
 
 type Gateway struct {
-	cfg     *config.Gateway
-	cfgPath string // path the HCL config was loaded from
-	db      *sql.DB
-	policy  atomic.Pointer[config.CompiledPolicy]
-	certs   *CertCache
-	dialer  *net.Dialer
-	sink    *Sink
-	oauth   *OAuthRegistry
-	agents  *AgentRegistry
-	hitl    *HITLRegistry
-	onboard *onboardRegistry
+	cfg      *config.Gateway
+	cfgPath  string // path the HCL config was loaded from
+	stateDir string // resolved gateway state dir (sqlite + plugin blobs)
+	db       *sql.DB
+	policy   atomic.Pointer[config.CompiledPolicy]
+	certs    *CertCache
+	dialer   *net.Dialer
+	sink     *Sink
+	oauth    *OAuthRegistry
+	agents   *AgentRegistry
+	hitl     *HITLRegistry
+	onboard  *onboardRegistry
 	// readOnlyConfig, when set via --read-only-config, rejects every
 	// dashboard write that mutates cfgPath. The dashboard reads the
 	// flag from /api/state and hides its editor affordances; the
@@ -1418,7 +1411,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 		Profile:      profile,
 		PeerIP:       pip,
 		Secrets:      g.secrets,
-		CADir:        g.cfg.CADir,
+		StateDir:     g.stateDir,
 		DstPort:      dstPort,
 		UpstreamHost: hostname,
 		MintCert: func(host string) (*tls.Certificate, error) {
@@ -2296,16 +2289,11 @@ func runGateway(args []string) {
 	if err != nil {
 		log.Fatalf("log: %v", err)
 	}
-	oauthDir := cfg.OAuthDir
-	if oauthDir == "" {
-		oauthDir = filepath.Join(cfg.CADir, "..", "oauth")
-	}
 	// OAuthRegistry seed list is empty for now — credential plugins
 	// own credential discovery in the new policy. The registry stays
 	// in place because per-owner token persistence + refresh logic
 	// is reused by the credential-plugin runtime bridge (lands when
 	// the credential injection path is wired into mitmHTTPS).
-	_ = oauthDir
 	oauthReg, err := NewOAuthRegistry(nil, db)
 	if err != nil {
 		log.Fatalf("oauth: %v", err)
@@ -2313,6 +2301,7 @@ func runGateway(args []string) {
 	g := &Gateway{
 		cfg:            cfg,
 		cfgPath:        cfgPath,
+		stateDir:       stateDir,
 		readOnlyConfig: *readOnly,
 		db:             db,
 		certs:          certs,
@@ -2327,7 +2316,7 @@ func runGateway(args []string) {
 		log.Printf("config: read-only mode (dashboard writes rejected)")
 	}
 	g.secrets = newGatewaySecretStore(db, oauthReg)
-	g.tunnels = NewTunnelManager(g.secrets, cfg.CADir)
+	g.tunnels = NewTunnelManager(g.secrets, stateDir)
 	registerOAuthCredentials(oauthReg, policy)
 	g.policy.Store(policy)
 	g.connIdx.Store(runtime.BuildConnIndex(policy))
@@ -2393,7 +2382,7 @@ func runGateway(args []string) {
 	startTelemetry(g)
 
 	if cfg.InfoListen != "" {
-		mux := newWebMux(g, cfg.CADir, cfg.Join(), cfg.PublicURL)
+		mux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 		go serveHTTPLogged("dashboard", cfg.InfoListen, mux)
 		printDashboardURL(cfg.InfoListen)
 	}
@@ -2416,7 +2405,7 @@ func runGateway(args []string) {
 			log.Fatalf("wireguard: %v", err)
 		}
 		setWGServer(wg)
-		dashMux := newWebMux(g, cfg.CADir, cfg.Join(), cfg.PublicURL)
+		dashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 		dashPort := portOf(cfg.InfoListen)
 		tcpDispatch := func(c net.Conn, dstIP string, dstPort uint16) {
 			log.Printf("wg-fwd: %s:%d", dstIP, dstPort)

--- a/setup.go
+++ b/setup.go
@@ -1043,16 +1043,11 @@ func runGatewayInit(args []string) {
 	_ = fs.Parse(args)
 
 	// 1. data dir ----------------------------------------------------------
-	// The gateway lazy-mints its CA into sqlite on first boot, so
-	// there's nothing to pre-create here besides the state directory
-	// itself. ${dataDir}/ca is kept (empty for now) so the generated
-	// gateway.hcl's ca_dir path resolves to a real directory — the
-	// CA materials themselves live in the DB.
-	if err := os.MkdirAll(filepath.Join(*dataDir, "ca"), 0o700); err != nil {
-		fail("mkdir ca: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(*dataDir, "oauth"), 0o700); err != nil {
-		fail("mkdir oauth: %v", err)
+	// The gateway lazy-mints its CA into sqlite on first boot, so all
+	// we need is the state directory itself; the sqlite DB is created
+	// on demand.
+	if err := os.MkdirAll(filepath.Join(*dataDir, "state"), 0o700); err != nil {
+		fail("mkdir state: %v", err)
 	}
 
 	// 2. detect public IP if not given -------------------------------------
@@ -1074,9 +1069,8 @@ func runGatewayInit(args []string) {
 listen      = "0.0.0.0:%d"
 info_listen = "0.0.0.0:%d"
 public_url  = "%s"
-ca_dir      = "%s"
 log_path    = "%s"
-oauth_dir   = "%s"
+state_dir   = "%s"
 
 control        = "wireguard"
 wg_endpoint    = "%s:%d"
@@ -1112,9 +1106,8 @@ profile "default" {
 }
 `,
 		*tlsPort, *dashPort, url,
-		filepath.Join(*dataDir, "ca"),
 		filepath.Join(*dataDir, "gateway.log"),
-		filepath.Join(*dataDir, "oauth"),
+		filepath.Join(*dataDir, "state"),
 		ip, *wgPort, *subnet,
 	)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -30,11 +30,9 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 | `info_listen` | `string` | no |  |
 | `public_url` | `string` | no |  |
 | `admin_email` | `string` | no |  |
-| `ca_dir` | `string` | no | The legacy path the gateway used to keep the CA cert + ssh host keys on disk. Kept for backwards compat so existing configs still parse and state_dir resolution can fall back to ${ca_dir}/../oauth. New deployments should set state_dir instead — the gateway keeps everything in sqlite. |
-| `state_dir` | `string` | no | The directory holding clawpatrol.db. Falls back to OAuthDir (historical name) or ${CADir}/../oauth or ${HOME}/.clawpatrol/state, in that order. |
+| `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything else a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol/state when unset. |
 | `resolver` | `string` | no |  |
 | `log_path` | `string` | no |  |
-| `oauth_dir` | `string` | no | The historical state directory name. Equivalent to state_dir and kept for backwards compat. |
 | `dashboard_secret` | `string` | no |  |
 | `insecure_no_dashboard_secret` | `bool` | no | Opts out of dashboard auth. Required (alongside an empty DashboardSecret) for the gateway to serve the dashboard at all — otherwise the secret gate replies with a misconfiguration page on every request. Verbose by design so you can't disable auth by accident. |
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -107,7 +107,7 @@ profile "default" { endpoints = [github] }
 | `info_listen` | Dashboard + API bind. |
 | `public_url` | Dashboard URL handed out at join time. |
 | `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |
-| `state_dir` | Directory holding `clawpatrol.db`. `ca_dir` / `oauth_dir` are legacy names kept for backwards compat. |
+| `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol/state`. |
 | `control` | `"wireguard"` or `"tailscale"`. |
 | `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet. |
 | `unknown_host` | `"passthrough"` (default) or `"deny"` for traffic no endpoint claims. |

--- a/tunnel.go
+++ b/tunnel.go
@@ -41,8 +41,8 @@ import (
 
 // TunnelManager is the single owner of every live tunnel instance.
 type TunnelManager struct {
-	secrets runtime.SecretStore
-	cadir   string
+	secrets  runtime.SecretStore
+	stateDir string
 
 	mu      sync.Mutex
 	entries map[mgrKey]*tunnelEntry
@@ -88,12 +88,12 @@ type tunnelEntry struct {
 
 // NewTunnelManager constructs an empty manager. SetPolicy must be
 // called once at boot to populate keepalive=always pins.
-func NewTunnelManager(secrets runtime.SecretStore, cadir string) *TunnelManager {
+func NewTunnelManager(secrets runtime.SecretStore, stateDir string) *TunnelManager {
 	return &TunnelManager{
-		secrets: secrets,
-		cadir:   cadir,
-		entries: map[mgrKey]*tunnelEntry{},
-		pinned:  map[mgrKey]func(){},
+		secrets:  secrets,
+		stateDir: stateDir,
+		entries:  map[mgrKey]*tunnelEntry{},
+		pinned:   map[mgrKey]func(){},
 	}
 }
 
@@ -151,7 +151,7 @@ func (m *TunnelManager) Acquire(ctx context.Context, ct *config.CompiledTunnel, 
 		host := runtime.TunnelHost{
 			Name:        ct.Name,
 			SecretStore: m.secrets,
-			CADir:       m.cadir,
+			StateDir:    m.stateDir,
 			Logger:      log.New(log.Writer(), "tunnel/"+ct.Name+": ", log.LstdFlags),
 		}
 		if ct.Credential != nil {

--- a/web.go
+++ b/web.go
@@ -52,7 +52,6 @@ var errConfigRevisionConflict = errors.New("config revision conflict")
 
 type webMux struct {
 	g         *Gateway
-	caDir     string
 	ts        JoinConfig // for onboarding key minting
 	publicURL string
 	mu        sync.Mutex
@@ -187,8 +186,8 @@ func (w *webMux) skipsTailnetGate(path string) bool {
 	return w.authRequirementForPath(path) == authPublic
 }
 
-func newWebMux(g *Gateway, caDir string, ts JoinConfig, publicURL string) http.Handler {
-	w := &webMux{g: g, caDir: caDir, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
+func newWebMux(g *Gateway, ts JoinConfig, publicURL string) http.Handler {
+	w := &webMux{g: g, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
 	return w.handler()
 }
 

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -25,7 +25,7 @@ func newOnboardAuthTestWebMuxForControl(control string) *webMux {
 		cfg:     cfg,
 		onboard: newOnboardRegistry(),
 	}
-	w := &webMux{g: g, caDir: "", ts: cfg.Join(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
+	w := &webMux{g: g, ts: cfg.Join(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard, previews: map[string]configPreviewToken{}}
 	w.routeAuth = routeAuthIndex(w.routes())
 	return w
 }


### PR DESCRIPTION
## Summary

`ca_dir` and `oauth_dir` were kept as deprecated aliases after PR #222 moved all host-managed state into sqlite. They have no behavior left — `resolveStateDir()` just walked the fallback chain to compute `state_dir`. This PR removes them.

After this:
- `gateway.hcl` has exactly one knob for state location: `state_dir` (default `~/.clawpatrol/state`).
- The runtime concept formerly called `CADir` is renamed `StateDir` everywhere — it always *was* a state-directory pointer; the old name was a leftover from when the CA lived on disk.

## Schema (`config.Gateway`)

- Drop `CADir` (HCL: `ca_dir`)
- Drop `OAuthDir` (HCL: `oauth_dir`)
- Keep `StateDir` (HCL: `state_dir`)

## Runtime API rename

- `runtime.ConnHandle.CADir` → `StateDir`
- `runtime.TunnelInitCtx.CADir` → `StateDir`
- `Gateway.cfg.CADir` → `Gateway.stateDir` field, populated once at boot

Tailscale tunnel plugin reads `host.StateDir` for its tsnet state derivation. ABI break for out-of-tree consumers; in-tree updated.

## Templates + tests

- `gateway init` writes `state_dir = <data-dir>/state` and creates exactly that one dir (no empty `ca/` or `oauth/` placeholders).
- `scripts/deploy.sh` emits `state_dir = ${REMOTE_DIR}/state`.
- `gateway.example.hcl`, `dev.hcl`, `config/README.md`, `doc/wireguard.md`, `doc/tailscale.md`: example configs + comments updated.
- All `config/testdata/*.hcl` + `*.want.json` fixtures cleaned; two `*.errors.txt` line numbers bumped.
- `site/doc/config-reference.md` auto-regenerated via `tools/docgen`.

## Deployment caveat — production rollout sequence

The deployed gateway at `prod.example.com` currently has:

```hcl
ca_dir    = "/opt/clawpatrol/ca"
oauth_dir = "/opt/clawpatrol/oauth"
```

After this PR merges, the next binary deploy will fail to parse that HCL. **Production HCL must be migrated first** — swap to:

```hcl
state_dir = "/opt/clawpatrol/oauth"
```

(`state_dir` is already a working attribute on the current binary, so the migration can happen with zero downtime against the old code. Drop `ca_dir` entirely; keep the `oauth/` path until you want to rename the directory.)

Order I'm planning to run it:

1. CI on this PR turns green.
2. SSH to production, take HCL backup, swap `oauth_dir` → `state_dir`, drop `ca_dir`, `systemctl restart clawpatrol-gateway`, verify dashboard + traffic.
3. Merge this PR.
4. Deploy the new binary. HCL already matches the new schema.

## Test plan

- [x] `go test ./...` green
- [x] `gofmt -l .` empty
- [x] `tools/docgen` drift test green
- [ ] Production HCL migrated before merge
- [ ] Visual review of regenerated `site/doc/config-reference.md`
