### PR TITLE
clawpatrol validate: schema-check loaded plugins

### DIFF
--- a/config/extplugin/facet.go
+++ b/config/extplugin/facet.go
@@ -1,10 +1,21 @@
 package extplugin
 
 import (
+	"fmt"
+	"regexp"
+
 	pb "github.com/denoland/clawpatrol/config/extplugin/proto"
 	"github.com/denoland/clawpatrol/config/facet"
 	"github.com/denoland/clawpatrol/config/match"
+	"github.com/hashicorp/hcl/v2"
 )
+
+// validCELIdent matches the CEL identifier production: ASCII letter
+// or underscore, followed by letters / digits / underscores. Facet
+// names and field names appear directly in rule conditions
+// (`<facet>.<field>`), so anything outside this set means rules
+// can't be written against the facet at all.
+var validCELIdent = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // pluginFacet is the synthetic facet.Runtime the gateway registers
 // for each FacetDecl a plugin manifest carries. Data flows through
@@ -49,17 +60,45 @@ func (p *pluginFacet) NewMatcher(condition string) (match.Matcher, error) {
 }
 
 // registerFacet synthesizes a pluginFacet from a FacetDecl and
-// installs it under the bare name from the decl. Idempotent across
-// hot-reloads (skips re-registration if a pluginFacet by that name
-// is already present); duplicate names from different plugins or a
-// collision with a built-in facet panic at startup so the operator
-// notices.
-func registerFacet(decl *pb.FacetDecl) *pluginFacet {
-	if existing := facet.Lookup(decl.Name); existing != nil {
-		if pf, ok := existing.(*pluginFacet); ok {
-			return pf
+// installs it under the bare name from the decl. Returns a
+// diagnostic when the name collides with another already-registered
+// facet (built-in like "http", or another plugin's facet) so the
+// operator sees a clean error from `clawpatrol validate` instead of
+// a process panic from facet.Register.
+func registerFacet(pluginName string, decl *pb.FacetDecl) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	if !validCELIdent.MatchString(decl.Name) {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Plugin %q facet %q: name is not a valid CEL identifier", pluginName, decl.Name),
+			Detail:   "Facet names appear directly in rule conditions (`<facet>.<field>`); the name must match [A-Za-z_][A-Za-z0-9_]*.",
+		})
+	}
+	for _, f := range decl.Fields {
+		if f.Name == "" {
+			continue // already reported by validateManifestShape
 		}
-		return nil
+		if !validCELIdent.MatchString(f.Name) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Plugin %q facet %q field %q: name is not a valid CEL identifier", pluginName, decl.Name, f.Name),
+				Detail:   "Facet field names appear directly in rule conditions; must match [A-Za-z_][A-Za-z0-9_]*.",
+			})
+		}
+	}
+	if diags.HasErrors() {
+		return diags
+	}
+	if existing := facet.Lookup(decl.Name); existing != nil {
+		owner := "built-in"
+		if _, ok := existing.(*pluginFacet); ok {
+			owner = "another plugin"
+		}
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Plugin %q facet %q collides with existing %s facet", pluginName, decl.Name, owner),
+			Detail:   "Pick a different facet name in the plugin's manifest, or remove the duplicate registration.",
+		}}
 	}
 	kindByField := make(map[string]pb.FacetKind, len(decl.Fields))
 	optional := make(map[string]bool)
@@ -81,7 +120,7 @@ func registerFacet(decl *pb.FacetDecl) *pluginFacet {
 		streamFields:   streams,
 	}
 	facet.Register(pf)
-	return pf
+	return nil
 }
 
 func protoFacetFieldsToSpec(in []*pb.FacetFieldDecl) []facet.ReportFieldSpec {

--- a/config/extplugin/manager.go
+++ b/config/extplugin/manager.go
@@ -7,10 +7,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"sort"
 	"sync"
 
 	"github.com/denoland/clawpatrol/config"
 	pb "github.com/denoland/clawpatrol/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/config/facet"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/hcl/v2"
@@ -101,6 +103,7 @@ func (m *Manager) Start(ctx context.Context, source string) (*Client, *pb.Manife
 		return nil, nil, fmt.Errorf("plugin %q: empty manifest name", source)
 	}
 	c.name = manifest.Name
+	c.manifest = manifest
 
 	m.mu.Lock()
 	if _, dup := m.plugins[manifest.Name]; dup {
@@ -162,6 +165,79 @@ func (m *Manager) LoadPlugins(specs []config.PluginSource) hcl.Diagnostics {
 	return diags
 }
 
+// Verify runs post-load schema validation against every spawned
+// plugin's manifest. Catches problems that wouldn't surface
+// otherwise until a rule happened to target a particular facet or
+// an HCL block happened to use a particular type:
+//
+//   - Each declared facet's CEL env is built eagerly (with a probe
+//     condition) so an invalid identifier in a facet or field name
+//     fails the validate command instead of waiting for a rule.
+//   - Each declared endpoint's Family is resolved against the
+//     facet registry (built-in or another plugin's). A typo in
+//     Family that no rule references would otherwise just silently
+//     route every request to default-deny at runtime.
+//
+// Returns hcl.Diagnostics with one entry per problem.
+func (m *Manager) Verify() hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	for _, c := range m.Plugins() {
+		mf := c.Manifest()
+		if mf == nil {
+			continue
+		}
+		for _, f := range mf.Facets {
+			if _, err := newPluginFacetMatcher(f.Name, "true", facetStreamFieldNames(f)); err != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("Plugin %q facet %q: invalid schema", mf.Name, f.Name),
+					Detail:   err.Error(),
+				})
+			}
+		}
+		for _, e := range mf.Endpoints {
+			if e.Family == "" {
+				continue // already reported by validateManifestShape
+			}
+			if facet.Lookup(e.Family) == nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("Plugin %q endpoint %q: family %q does not resolve", mf.Name, e.TypeName, e.Family),
+					Detail:   "Family must name a built-in facet (\"http\", \"sql\", \"k8s\") or one of this plugin's declared facets. Rules attached to this endpoint cannot compile against an unknown family.",
+				})
+			}
+		}
+	}
+	return diags
+}
+
+// facetStreamFieldNames extracts FACET_STREAM field names from a
+// FacetDecl — pulled out as a helper so Verify can build the same
+// CEL env newPluginFacetMatcher does at NewMatcher time.
+func facetStreamFieldNames(decl *pb.FacetDecl) []string {
+	var out []string
+	for _, f := range decl.Fields {
+		if f.Kind == pb.FacetKind_FACET_STREAM {
+			out = append(out, f.Name)
+		}
+	}
+	return out
+}
+
+// Plugins returns every loaded plugin's *Client, sorted by name.
+// Used by callers (clawpatrol validate, dashboard surfaces, etc.)
+// that want to enumerate manifests after LoadPlugins has run.
+func (m *Manager) Plugins() []*Client {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*Client, 0, len(m.plugins))
+	for _, c := range m.plugins {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out
+}
+
 // Stop tears down every spawned subprocess. Idempotent.
 func (m *Manager) Stop() {
 	m.mu.Lock()
@@ -177,6 +253,7 @@ func (m *Manager) Stop() {
 type Client struct {
 	name      string
 	source    string
+	manifest  *pb.ManifestResponse
 	gp        *plugin.Client
 	conn      *grpc.ClientConn
 	pluginCli pb.PluginClient
@@ -189,6 +266,11 @@ func (c *Client) Name() string { return c.name }
 
 // Source returns the binary path the manager was started with.
 func (c *Client) Source() string { return c.source }
+
+// Manifest returns the manifest the subprocess reported at startup.
+// Stable across the plugin's lifetime (manifests aren't refreshed
+// in v1).
+func (c *Client) Manifest() *pb.ManifestResponse { return c.manifest }
 
 // PluginRPC exposes the Build RPC; used by the registration helper.
 func (c *Client) PluginRPC() pb.PluginClient { return c.pluginCli }

--- a/config/extplugin/register.go
+++ b/config/extplugin/register.go
@@ -22,29 +22,77 @@ import (
 // the caller should attach the source range of the `plugin` block.
 func RegisterManifest(client *Client, resp *pb.ManifestResponse) hcl.Diagnostics {
 	var diags hcl.Diagnostics
+	// Up-front shape checks: empty names everywhere, reserved
+	// characters in the plugin's own name, etc. Catches the
+	// "manifest declares garbage" cases without waiting for an
+	// HCL block to use the type.
+	diags = append(diags, validateManifestShape(resp)...)
+	if diags.HasErrors() {
+		return diags
+	}
 	// Facets register first so endpoints below can bind to them by
 	// name. Endpoint Family values are taken verbatim — a plugin
 	// that wants to use a built-in facet (e.g. "http") sets
 	// Family="http"; one that ships its own facet sets
 	// Family="<own-name>". Collisions with built-in facets or
-	// across plugins fail loudly at registration; that's the
-	// plugin author's concern, not the framework's.
+	// across plugins surface as diagnostics from registerFacet.
 	for _, f := range resp.Facets {
-		registerFacet(f)
+		diags = append(diags, registerFacet(resp.Name, f)...)
 	}
 	for _, c := range resp.Credentials {
-		if d := registerCredential(client, resp.Name, c); d != nil {
-			diags = append(diags, d...)
-		}
+		diags = append(diags, registerCredential(client, resp.Name, c)...)
 	}
 	for _, t := range resp.Tunnels {
-		if d := registerTunnel(client, resp.Name, t); d != nil {
-			diags = append(diags, d...)
-		}
+		diags = append(diags, registerTunnel(client, resp.Name, t)...)
 	}
 	for _, e := range resp.Endpoints {
-		if d := registerEndpoint(client, resp.Name, e); d != nil {
-			diags = append(diags, d...)
+		diags = append(diags, registerEndpoint(client, resp.Name, e)...)
+	}
+	return diags
+}
+
+// validateManifestShape rejects manifests with empty / reserved
+// names before the per-type registers see them. The plugin
+// subprocess is already running by the time this runs (Manager.Start
+// already validated resp.Name is non-empty); this catches per-type
+// shape problems.
+func validateManifestShape(resp *pb.ManifestResponse) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	pluginName := resp.Name
+	for i, f := range resp.Facets {
+		if f.Name == "" {
+			diags = append(diags, &hcl.Diagnostic{Severity: hcl.DiagError,
+				Summary: fmt.Sprintf("Plugin %q manifest: facet #%d has empty name", pluginName, i)})
+			continue
+		}
+		for j, fld := range f.Fields {
+			if fld.Name == "" {
+				diags = append(diags, &hcl.Diagnostic{Severity: hcl.DiagError,
+					Summary: fmt.Sprintf("Plugin %q facet %q field #%d has empty name", pluginName, f.Name, j)})
+			}
+		}
+	}
+	for i, c := range resp.Credentials {
+		if c.TypeName == "" {
+			diags = append(diags, &hcl.Diagnostic{Severity: hcl.DiagError,
+				Summary: fmt.Sprintf("Plugin %q manifest: credential #%d has empty type_name", pluginName, i)})
+		}
+	}
+	for i, t := range resp.Tunnels {
+		if t.TypeName == "" {
+			diags = append(diags, &hcl.Diagnostic{Severity: hcl.DiagError,
+				Summary: fmt.Sprintf("Plugin %q manifest: tunnel #%d has empty type_name", pluginName, i)})
+		}
+	}
+	for i, e := range resp.Endpoints {
+		if e.TypeName == "" {
+			diags = append(diags, &hcl.Diagnostic{Severity: hcl.DiagError,
+				Summary: fmt.Sprintf("Plugin %q manifest: endpoint #%d has empty type_name", pluginName, i)})
+		}
+		if e.Family == "" {
+			diags = append(diags, &hcl.Diagnostic{Severity: hcl.DiagError,
+				Summary: fmt.Sprintf("Plugin %q endpoint %q has empty family", pluginName, e.TypeName),
+				Detail:  "Set Family to either a built-in facet (\"http\", \"sql\", \"k8s\") or to one of the plugin's own declared facet names so rules know which CEL env to use."})
 		}
 	}
 	return diags

--- a/validate.go
+++ b/validate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/extplugin"
@@ -24,15 +25,37 @@ func runValidate(args []string) {
 // gateway uses at startup — anything that would crash the daemon
 // shows up here first. Exit codes: 0 ok, 1 validation failure,
 // 2 usage error.
+//
+// Also performs schema-level validation against any external
+// plugins the config loads: every declared facet's CEL env is
+// compiled eagerly, every plugin endpoint's Family is resolved
+// against the facet registry. Catches plugin authoring bugs that
+// the operator's HCL didn't happen to exercise.
 func validateCmd(args []string) (string, int) {
 	if len(args) != 1 || args[0] == "-h" || args[0] == "--help" {
 		return "usage: clawpatrol validate <config.hcl>", 2
 	}
-	config.SetPluginLoader(extplugin.New(nil))
+	mgr := extplugin.New(nil)
+	defer mgr.Stop()
+	config.SetPluginLoader(mgr)
 	_, cp, err := loadConfig(args[0])
 	if err != nil {
 		return fmt.Sprintf("%s: %v", args[0], err), 1
 	}
-	return fmt.Sprintf("ok: %s — %d endpoints across %d profile(s)",
-		args[0], len(cp.Endpoints), len(cp.Profiles)), 0
+	if d := mgr.Verify(); d.HasErrors() {
+		return fmt.Sprintf("%s: %s", args[0], d.Error()), 1
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "ok: %s — %d endpoints across %d profile(s)",
+		args[0], len(cp.Endpoints), len(cp.Profiles))
+	for _, c := range mgr.Plugins() {
+		mf := c.Manifest()
+		if mf == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "\n  plugin %q v%s: %d facet(s), %d credential type(s), %d tunnel type(s), %d endpoint type(s)",
+			mf.Name, mf.Version,
+			len(mf.Facets), len(mf.Credentials), len(mf.Tunnels), len(mf.Endpoints))
+	}
+	return b.String(), 0
 }


### PR DESCRIPTION
\`validate\` already spawned plugins because it runs the same
\`loadConfig\` path as the gateway — but it only exercised the
schemas the operator's HCL happened to use. Two whole classes of
plugin authoring bug went silent until a request actually hit the
wrong endpoint or a rule actually targeted the wrong family.

\`Manager\` grows two methods:

* \`Plugins()\` — sorted enumeration of loaded \`*Client\`, each
  carrying its Manifest. Lets external callers (\`validate\` today,
  dashboard surfaces tomorrow) report on what loaded.
* \`Verify()\` — post-load schema validation:
    * Each declared facet's CEL env is built eagerly with a probe
      condition; combined with a CEL-identifier regex check on
      facet + field names, this catches \`bad-name\` / empty /
      non-identifier inputs that would otherwise only fail at
      first-rule-compile.
    * Each declared endpoint's \`Family\` is resolved against the
      facet registry. A typo in \`Family\` that no rule references
      otherwise just routed every request to default-deny at
      runtime — silent policy bypass is bad. Now it's a clean
      validate-time error.

\`RegisterManifest\` also tightens up:

* \`validateManifestShape\` rejects empty facet / type / field
  names and an empty endpoint \`Family\` before the per-type
  registers see them, so partially-broken manifests don't
  half-register.
* \`registerFacet\` returns a diagnostic on collision with a
  built-in facet (e.g. a plugin trying to declare \`http\`) or
  another plugin's facet, instead of silently dropping the
  registration.

\`validate.go\` calls \`Verify\` after \`loadConfig\` and adds one
summary line per loaded plugin so the operator can see what came
up:

\`\`\`
ok: testdata/plugin-example.hcl — 3 endpoints across 1 profile(s)
  plugin "example" v0.1: 2 facet(s), 1 credential type(s),
  1 tunnel type(s), 3 endpoint type(s)
\`\`\`