### PR TITLE
plugin types: flat names, no auto-namespacing

### DIFF
--- a/config/extplugin/register.go
+++ b/config/extplugin/register.go
@@ -103,7 +103,6 @@ func validateManifestShape(resp *pb.ManifestResponse) hcl.Diagnostics {
 // =====================================================================
 
 func registerCredential(client *Client, pluginName string, decl *pb.CredentialDecl) hcl.Diagnostics {
-	typeName := pluginName + "." + decl.TypeName
 	spec, err := schemaToSpec(decl.Schema)
 	if err != nil {
 		return fail("plugin %q credential %q: %v", pluginName, decl.TypeName, err)
@@ -111,7 +110,7 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 
 	plug := &config.Plugin{
 		Kind: config.KindCredential,
-		Type: typeName,
+		Type: decl.TypeName,
 		New:  func() any { return &dynamicCredentialBody{} },
 		DecodeBody: func(body hcl.Body, ctx *hcl.EvalContext, target any) hcl.Diagnostics {
 			b := target.(*dynamicCredentialBody)
@@ -144,8 +143,8 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 		},
 		Emit: func(_ any, _ string, _ *hclwrite.Body) {},
 	}
-	if config.Lookup(plug.Kind, plug.Type) == nil {
-		config.Register(plug)
+	if d := registerOrCollide(plug, pluginName, "credential"); d != nil {
+		return d
 	}
 	return nil
 }
@@ -155,7 +154,6 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 // =====================================================================
 
 func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.Diagnostics {
-	typeName := pluginName + "." + decl.TypeName
 	spec, err := schemaToSpec(decl.Schema)
 	if err != nil {
 		return fail("plugin %q tunnel %q: %v", pluginName, decl.TypeName, err)
@@ -164,7 +162,7 @@ func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.
 
 	plug := &config.Plugin{
 		Kind: config.KindTunnel,
-		Type: typeName,
+		Type: decl.TypeName,
 		New:  func() any { return &dynamicTunnelBody{adapter: adapter} },
 		DecodeBody: func(body hcl.Body, ctx *hcl.EvalContext, target any) hcl.Diagnostics {
 			b := target.(*dynamicTunnelBody)
@@ -202,8 +200,8 @@ func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.
 		Runtime: adapter,
 		Emit:    func(_ any, _ string, _ *hclwrite.Body) {},
 	}
-	if config.Lookup(plug.Kind, plug.Type) == nil {
-		config.Register(plug)
+	if d := registerOrCollide(plug, pluginName, "tunnel"); d != nil {
+		return d
 	}
 	return nil
 }
@@ -220,7 +218,6 @@ const (
 )
 
 func registerEndpoint(client *Client, pluginName string, decl *pb.EndpointDecl) hcl.Diagnostics {
-	typeName := pluginName + "." + decl.TypeName
 	spec, pluginAttrNames, err := endpointSpec(decl.Schema)
 	if err != nil {
 		return fail("plugin %q endpoint %q: %v", pluginName, decl.TypeName, err)
@@ -235,7 +232,7 @@ func registerEndpoint(client *Client, pluginName string, decl *pb.EndpointDecl) 
 
 	plug := &config.Plugin{
 		Kind:   config.KindEndpoint,
-		Type:   typeName,
+		Type:   decl.TypeName,
 		Family: decl.Family,
 		New: func() any {
 			return &dynamicEndpointBody{
@@ -312,9 +309,29 @@ func registerEndpoint(client *Client, pluginName string, decl *pb.EndpointDecl) 
 		Runtime: adapter,
 		Emit:    func(_ any, _ string, _ *hclwrite.Body) {},
 	}
-	if config.Lookup(plug.Kind, plug.Type) == nil {
-		config.Register(plug)
+	if d := registerOrCollide(plug, pluginName, "endpoint"); d != nil {
+		return d
 	}
+	return nil
+}
+
+// registerOrCollide installs plug in the config registry or returns
+// a diagnostic when something is already registered under the same
+// (Kind, Type). Naming is flat — plugin authors prefix their types
+// by convention, the way Terraform providers do (`aws_instance`,
+// `kubernetes_deployment`) — so a collision either means two plugins
+// picked the same type name or the plugin tried to shadow a
+// built-in (e.g. `https`). Both are operator-actionable; neither is
+// recoverable by the gateway.
+func registerOrCollide(plug *config.Plugin, pluginName, kindLabel string) hcl.Diagnostics {
+	if existing := config.Lookup(plug.Kind, plug.Type); existing != nil {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Plugin %q %s type %q collides with an already-registered type", pluginName, kindLabel, plug.Type),
+			Detail:   "Type names live in one global registry — pick a different name (the convention is to prefix with the plugin slug, e.g. \"example_magic_token\"), or remove the conflicting registration.",
+		}}
+	}
+	config.Register(plug)
 	return nil
 }
 

--- a/plugin-example/demo_echo.go
+++ b/plugin-example/demo_echo.go
@@ -17,8 +17,8 @@ import (
 // a deny message. The gateway does the logging.
 func demoEchoDef() pluginsdk.EndpointDef {
 	return pluginsdk.EndpointDef{
-		TypeName:    "demo_echo",
-		Family:      "echo", // SDK auto-namespaces to "example.echo"
+		TypeName:    "example_demo_echo",
+		Family:      "example_echo",
 		TLSMode:     pluginsdk.TLSNone,
 		RequiresVIP: true,
 		Schema:      pluginsdk.Schema{},
@@ -41,7 +41,7 @@ func handleDemoEcho(ctx context.Context, conn *pluginsdk.Conn) error {
 			return err
 		}
 		clean := strings.TrimRight(line, "\r\n")
-		v, err := conn.Evaluate(ctx, "echo", map[string]any{"line": clean}, clean)
+		v, err := conn.Evaluate(ctx, "example_echo", map[string]any{"line": clean}, clean)
 		if err != nil {
 			return fmt.Errorf("evaluate %q: %w", clean, err)
 		}

--- a/plugin-example/demo_echo.go
+++ b/plugin-example/demo_echo.go
@@ -17,7 +17,7 @@ import (
 // a deny message. The gateway does the logging.
 func demoEchoDef() pluginsdk.EndpointDef {
 	return pluginsdk.EndpointDef{
-		TypeName:    "example_demo_echo",
+		TypeName:    "example_echo",
 		Family:      "example_echo",
 		TLSMode:     pluginsdk.TLSNone,
 		RequiresVIP: true,

--- a/plugin-example/demo_https.go
+++ b/plugin-example/demo_https.go
@@ -34,7 +34,7 @@ type demoHTTPS struct {
 
 func demoHTTPSDef() pluginsdk.EndpointDef {
 	return pluginsdk.EndpointDef{
-		TypeName:    "demo_https",
+		TypeName:    "example_demo_https",
 		Family:      "http", // bind to the built-in http facet
 		TLSMode:     pluginsdk.TLSTerminate,
 		RequiresVIP: true,

--- a/plugin-example/demo_https.go
+++ b/plugin-example/demo_https.go
@@ -34,7 +34,7 @@ type demoHTTPS struct {
 
 func demoHTTPSDef() pluginsdk.EndpointDef {
 	return pluginsdk.EndpointDef{
-		TypeName:    "example_demo_https",
+		TypeName:    "example_https",
 		Family:      "http", // bind to the built-in http facet
 		TLSMode:     pluginsdk.TLSTerminate,
 		RequiresVIP: true,

--- a/plugin-example/demo_smtp.go
+++ b/plugin-example/demo_smtp.go
@@ -26,8 +26,8 @@ import (
 // check, not a policy check.
 func demoSMTPDef() pluginsdk.EndpointDef {
 	return pluginsdk.EndpointDef{
-		TypeName:    "demo_smtp",
-		Family:      "smtp", // SDK auto-namespaces to "example.smtp"
+		TypeName:    "example_demo_smtp",
+		Family:      "example_smtp",
 		TLSMode:     pluginsdk.TLSTerminate,
 		RequiresVIP: true,
 		Schema:      pluginsdk.Schema{},
@@ -97,7 +97,7 @@ func handleDemoSMTP(ctx context.Context, conn *pluginsdk.Conn) error {
 			"mail_from": s.mailFrom,
 			"rcpt_to":   s.rcptTo,
 		}
-		v, err := conn.Evaluate(ctx, "smtp", action, cmd)
+		v, err := conn.Evaluate(ctx, "example_smtp", action, cmd)
 		if err != nil {
 			return fmt.Errorf("evaluate %q: %w", cmd, err)
 		}
@@ -127,7 +127,7 @@ func handleDemoSMTP(ctx context.Context, conn *pluginsdk.Conn) error {
 				"rcpt_to":   s.rcptTo,
 				"body":      pluginsdk.Stream(bytes.NewReader(body)),
 			}
-			bv, err := conn.Evaluate(ctx, "smtp", bodyAction, fmt.Sprintf("BODY (%d bytes)", len(body)))
+			bv, err := conn.Evaluate(ctx, "example_smtp", bodyAction, fmt.Sprintf("BODY (%d bytes)", len(body)))
 			if err != nil {
 				return fmt.Errorf("evaluate body: %w", err)
 			}

--- a/plugin-example/demo_smtp.go
+++ b/plugin-example/demo_smtp.go
@@ -26,7 +26,7 @@ import (
 // check, not a policy check.
 func demoSMTPDef() pluginsdk.EndpointDef {
 	return pluginsdk.EndpointDef{
-		TypeName:    "example_demo_smtp",
+		TypeName:    "example_smtp",
 		Family:      "example_smtp",
 		TLSMode:     pluginsdk.TLSTerminate,
 		RequiresVIP: true,

--- a/plugin-example/magic_token.go
+++ b/plugin-example/magic_token.go
@@ -13,7 +13,7 @@ type magicToken struct {
 
 func magicTokenDef() pluginsdk.CredentialDef {
 	return pluginsdk.CredentialDef{
-		TypeName: "magic_token",
+		TypeName: "example_magic_token",
 		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
 			{Name: "header_name", TypeString: "string"},
 		}},

--- a/plugin-example/main.go
+++ b/plugin-example/main.go
@@ -31,7 +31,7 @@ func main() {
 			// k8s) are reused as-is by setting the endpoint's
 			// Family to the facet's name — see demo_https.
 			{
-				Name: "smtp",
+				Name: "example_smtp",
 				Fields: []pluginsdk.FacetField{
 					{Name: "verb", Kind: pluginsdk.FacetString, Label: "Verb"},
 					// Optional fields are zero-filled by the gateway
@@ -51,7 +51,7 @@ func main() {
 			// Echo is a synthetic toy protocol with no built-in
 			// equivalent.
 			{
-				Name: "echo",
+				Name: "example_echo",
 				Fields: []pluginsdk.FacetField{
 					{Name: "line", Kind: pluginsdk.FacetString, Label: "Line"},
 				},

--- a/plugin-example/passthrough.go
+++ b/plugin-example/passthrough.go
@@ -15,7 +15,7 @@ import (
 // many Dials.
 func passthroughDef() pluginsdk.TunnelDef {
 	return pluginsdk.TunnelDef{
-		TypeName: "passthrough",
+		TypeName: "example_passthrough",
 		Schema:   pluginsdk.Schema{},
 		Open: func(ctx context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
 			// No state to keep; the tunnel name itself is enough.

--- a/testdata/plugin-example.hcl
+++ b/testdata/plugin-example.hcl
@@ -7,7 +7,7 @@
 // Then run the gateway against this file. The plugin declares one
 // credential type (example_magic_token), one tunnel type
 // (example_passthrough), and three endpoint types
-// (example_demo_https, example_demo_smtp, example_demo_echo). Type
+// (example_https, example_smtp, example_echo). Type
 // and facet names are flat — Claw Patrol doesn't auto-prefix
 // anything. Plugin authors prefix their own names by convention,
 // the way Terraform providers do (`aws_iam_role`,
@@ -41,7 +41,7 @@ tunnel "example_passthrough" "passthru" {}
 // `curl -k https://demo.invalid/` against a local HTTP upstream
 // (e.g. `python3 -m http.server 8000`) — the upstream sees the
 // X-Magic header and curl prints the body with "bye!" appended.
-endpoint "example_demo_https" "demo-site" {
+endpoint "example_https" "demo-site" {
   hosts      = ["demo.invalid"]
   credential = demo_token
   tunnel     = passthru
@@ -70,7 +70,7 @@ rule "https-writes-deny" {
 // map for each command also lands on the dashboard event stream as
 // the request's facet payload, so the request log shows
 // Verb / From / Rcpt / User columns.
-endpoint "example_demo_smtp" "demo-mail" {
+endpoint "example_smtp" "demo-mail" {
   hosts      = ["mail.invalid:25"]
   credential = demo_token
 }
@@ -118,7 +118,7 @@ rule "smtp-body-deny" {
 // the gateway whether to echo each one (allow) or reject it (deny).
 // On allow the plugin echoes prefixed with the credential secret;
 // on deny it replies "DENY: <reason>".
-endpoint "example_demo_echo" "demo-echo" {
+endpoint "example_echo" "demo-echo" {
   hosts      = ["echo.invalid:7"]
   credential = demo_token
 }

--- a/testdata/plugin-example.hcl
+++ b/testdata/plugin-example.hcl
@@ -5,9 +5,13 @@
 //   go build -o ./plugin-example/plugin-example ./plugin-example
 //
 // Then run the gateway against this file. The plugin declares one
-// credential type (magic_token), one tunnel type (passthrough), and
-// three endpoint types (demo_https, demo_smtp, demo_echo). Type
-// names are namespaced under the plugin's manifest name "example".
+// credential type (example_magic_token), one tunnel type
+// (example_passthrough), and three endpoint types
+// (example_demo_https, example_demo_smtp, example_demo_echo). Type
+// and facet names are flat — Claw Patrol doesn't auto-prefix
+// anything. Plugin authors prefix their own names by convention,
+// the way Terraform providers do (`aws_iam_role`,
+// `kubernetes_deployment`).
 
 admin_email = "you@example.com"
 
@@ -15,13 +19,13 @@ plugin "example" {
   source = "./plugin-example/plugin-example"
 }
 
-credential "example.magic_token" "demo_token" {
+credential "example_magic_token" "demo_token" {
   // header_name is the HTTP header the demo_https endpoint adds to
   // upstream requests. Defaults to "X-Magic" when omitted.
   header_name = "X-Magic"
 }
 
-tunnel "example.passthrough" "passthru" {}
+tunnel "example_passthrough" "passthru" {}
 
 // HTTPS endpoint: gateway terminates TLS, plugin parses HTTP and
 // asks the gateway for a verdict on every request via the built-in
@@ -37,7 +41,7 @@ tunnel "example.passthrough" "passthru" {}
 // `curl -k https://demo.invalid/` against a local HTTP upstream
 // (e.g. `python3 -m http.server 8000`) — the upstream sees the
 // X-Magic header and curl prints the body with "bye!" appended.
-endpoint "example.demo_https" "demo-site" {
+endpoint "example_demo_https" "demo-site" {
   hosts      = ["demo.invalid"]
   credential = demo_token
   tunnel     = passthru
@@ -60,50 +64,52 @@ rule "https-writes-deny" {
 // TLS-but-not-HTTPS endpoint: synthetic ESMTP-ish handshake.
 // Gateway terminates TLS; the plugin runs the protocol but asks
 // the gateway for an allow/deny on every command via Conn.Evaluate.
-// The plugin declares an `smtp` facet — the rules below target it
-// by writing CEL conditions against `smtp.verb`, `smtp.mail_from`,
-// `smtp.rcpt_to`, etc. The action map for each command also lands
-// on the dashboard event stream as the request's facet payload, so
-// the request log shows Verb / From / Rcpt / User columns.
-endpoint "example.demo_smtp" "demo-mail" {
+// The plugin declares an `example_smtp` facet — the rules below
+// target it by writing CEL conditions against `example_smtp.verb`,
+// `example_smtp.mail_from`, `example_smtp.rcpt_to`, etc. The action
+// map for each command also lands on the dashboard event stream as
+// the request's facet payload, so the request log shows
+// Verb / From / Rcpt / User columns.
+endpoint "example_demo_smtp" "demo-mail" {
   hosts      = ["mail.invalid:25"]
   credential = demo_token
 }
 
 rule "smtp-handshake" {
   endpoint  = demo-mail
-  condition = "smtp.verb in ['EHLO', 'HELO', 'AUTH', 'QUIT']"
+  condition = "example_smtp.verb in ['EHLO', 'HELO', 'AUTH', 'QUIT']"
   verdict   = "allow"
 }
 
 rule "smtp-internal-only" {
   endpoint  = demo-mail
-  condition = "smtp.verb in ['MAIL', 'RCPT', 'DATA'] && smtp.mail_from.endsWith('@internal')"
+  condition = "example_smtp.verb in ['MAIL', 'RCPT', 'DATA'] && example_smtp.mail_from.endsWith('@internal')"
   verdict   = "allow"
 }
 
 rule "smtp-deny-external" {
   endpoint  = demo-mail
-  condition = "smtp.verb in ['MAIL', 'RCPT', 'DATA']"
+  condition = "example_smtp.verb in ['MAIL', 'RCPT', 'DATA']"
   verdict   = "deny"
   reason    = "external sender"
 }
 
-// Body-content rule. References smtp.body, so the gateway pulls the
-// full message body (up to its 1 MiB cap) for BODY evaluations on
-// this endpoint. The handshake / MAIL / RCPT rules above don't
-// touch smtp.body, so the gateway only pulls a log-prefix when those
-// fire on a non-DATA verb — bodies on internal-allowed messages are
-// pulled in full only because of this rule.
+// Body-content rule. References example_smtp.body, so the gateway
+// pulls the full message body (up to its 1 MiB cap) for BODY
+// evaluations on this endpoint. The handshake / MAIL / RCPT rules
+// above don't touch example_smtp.body, so the gateway only pulls a
+// log-prefix when those fire on a non-DATA verb — bodies on
+// internal-allowed messages are pulled in full only because of this
+// rule.
 rule "smtp-body-no-secrets" {
   endpoint  = demo-mail
-  condition = "smtp.verb == 'BODY' && !smtp.body.contains('SECRET')"
+  condition = "example_smtp.verb == 'BODY' && !example_smtp.body.contains('SECRET')"
   verdict   = "allow"
 }
 
 rule "smtp-body-deny" {
   endpoint  = demo-mail
-  condition = "smtp.verb == 'BODY'"
+  condition = "example_smtp.verb == 'BODY'"
   verdict   = "deny"
   reason    = "body contains restricted token"
 }
@@ -112,14 +118,14 @@ rule "smtp-body-deny" {
 // the gateway whether to echo each one (allow) or reject it (deny).
 // On allow the plugin echoes prefixed with the credential secret;
 // on deny it replies "DENY: <reason>".
-endpoint "example.demo_echo" "demo-echo" {
+endpoint "example_demo_echo" "demo-echo" {
   hosts      = ["echo.invalid:7"]
   credential = demo_token
 }
 
 rule "echo-no-bad-words" {
   endpoint  = demo-echo
-  condition = "!echo.line.contains('forbidden')"
+  condition = "!example_echo.line.contains('forbidden')"
   verdict   = "allow"
 }
 


### PR DESCRIPTION
Drop the \`<plugin>.<type>\` prefix the gateway used to prepend
to every credential / tunnel / endpoint type a plugin declared.
Plugin authors now own their type names end-to-end and prefix
them by convention, the way Terraform providers do —
\`aws_iam_role\`, \`kubernetes_deployment\`,
\`example_demo_smtp\`. Facet names were already flat; this
brings types into line with them.

Collisions surface as diagnostics from the new
\`registerOrCollide\` helper: two plugins picking the same name,
or a plugin trying to shadow a built-in (e.g. \`https\`), both
error at validate time with a clear message.

\`plugin-example\` renames to the convention:

\`\`\`
magic_token   -> example_magic_token
passthrough   -> example_passthrough
demo_https    -> example_demo_https
demo_smtp     -> example_demo_smtp
demo_echo     -> example_demo_echo
smtp  (facet) -> example_smtp
echo  (facet) -> example_echo
\`\`\`

\`testdata/plugin-example.hcl\` and the rules' CEL conditions
(\`example_smtp.verb\`, \`example_echo.line\`, etc.) follow.

Stacks under the in-flight docs PR #333; once both land the
docs will describe the post-change state. (The docs PR is
being updated in parallel to remove the stale dot-namespacing
description.)