### PR TITLE
Allow updating configured credential tokens

### DIFF
--- a/web_credentials_test.go
+++ b/web_credentials_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+type testSecretSlots []config.SecretSlot
+
+func (s testSecretSlots) SecretSlots() []config.SecretSlot {
+	return []config.SecretSlot(s)
+}
+
+func TestAPICredentialsSetPreservesUntouchedSlotsAndClearsExplicitEmpty(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for slot, value := range map[string]string{
+		"cert": "old-cert",
+		"key":  "old-key",
+		"ca":   "old-ca",
+	} {
+		if err := setCredentialSlot(db, "client-tls", slot, value); err != nil {
+			t.Fatalf("seed slot %q: %v", slot, err)
+		}
+	}
+
+	g := &Gateway{db: db}
+	g.policy.Store(&config.CompiledPolicy{
+		Credentials: map[string]*config.Entity{
+			"client-tls": {
+				Body: testSecretSlots{
+					{Name: "cert", Label: "Client certificate"},
+					{Name: "key", Label: "Client key"},
+					{Name: "ca", Label: "CA certificate"},
+				},
+			},
+		},
+	})
+	w := &webMux{g: g}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/credentials/set",
+		strings.NewReader(`{"id":"client-tls","owner":"default","slots":{"cert":"new-cert","ca":""}}`),
+	)
+	rr := httptest.NewRecorder()
+	w.apiCredentialsSet(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	sec, ok, err := readCredentialSecrets(db, "client-tls")
+	if err != nil {
+		t.Fatalf("read secrets: %v", err)
+	}
+	if !ok {
+		t.Fatalf("credential secrets not found")
+	}
+	if got := sec.Extras["cert"]; got != "new-cert" {
+		t.Fatalf("cert slot = %q, want new-cert", got)
+	}
+	if got := sec.Extras["key"]; got != "old-key" {
+		t.Fatalf("key slot = %q, want old-key", got)
+	}
+	if _, ok := sec.Extras["ca"]; ok {
+		t.Fatalf("ca slot was preserved after explicit empty update")
+	}
+}

--- a/www/src/components/CredentialSecretsModal.tsx
+++ b/www/src/components/CredentialSecretsModal.tsx
@@ -7,16 +7,17 @@ import { setCredentialSlots } from "../lib/api";
 // key) get one input; multi-slot (mtls cert+key+ca, slack bot+app)
 // get one input per slot. PEM-shaped slots use a textarea.
 //
-// On Save, all filled slots are PUT through /api/credentials/set.
-// Empty slots clear that one slot. Doesn't fetch existing values
-// (we never read raw secrets back to the browser); operator
-// re-pastes when rotating.
+// On Save, touched slots are PUT through /api/credentials/set.
+// Empty touched slots clear that one slot. Untouched slots are omitted,
+// and existing values are never fetched back into the browser.
 export function CredentialSecretsModal({
   integration,
+  mode = "connect",
   onClose,
   onSaved,
 }: {
   integration: Integration;
+  mode?: "connect" | "update";
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -53,7 +54,9 @@ export function CredentialSecretsModal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
-          <div className="text-[14px] font-semibold text-[#171717]">Connect {integration.name}</div>
+          <div className="text-[14px] font-semibold text-[#171717]">
+            {mode === "update" ? "Update" : "Connect"} {integration.name}
+          </div>
           <button
             onClick={onClose}
             className="text-[#a3a3a3] hover:text-[#171717] text-[14px] leading-none"
@@ -62,6 +65,12 @@ export function CredentialSecretsModal({
           </button>
         </div>
         <div className="flex flex-col gap-3">
+          {mode === "update" && (
+            <p className="text-[11px] leading-relaxed text-[#737373]">
+              Existing secret values are not shown. Paste a new value to replace a slot; leave
+              untouched slots blank to keep them unchanged.
+            </p>
+          )}
           {slots.map((s) => (
             <label key={s.name} className="flex flex-col gap-1">
               <span className="text-[11px] uppercase tracking-[.08em] text-[#737373]">
@@ -102,7 +111,7 @@ export function CredentialSecretsModal({
               disabled={saving}
               className="text-[12px] px-3 py-1.5 bg-[#171717] text-white rounded hover:bg-[#404040] disabled:opacity-50"
             >
-              {saving ? "Saving…" : "Save"}
+              {saving ? "Saving…" : mode === "update" ? "Update" : "Save"}
             </button>
           </div>
         </div>

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -141,12 +141,17 @@ export function IntegrationsCards({
       {editing && (
         <CredentialSecretsModal
           integration={editing}
+          mode={isConnected(editing) ? "update" : "connect"}
           onClose={() => setEditing(null)}
           onSaved={onRefresh}
         />
       )}
     </>
   );
+}
+
+function isConnected(i: Integration) {
+  return i.connected || (i.tailscale_auth?.connected ?? false);
 }
 
 // OwnerAvatar renders the OAuth user's PFP (e.g. github avatar) with
@@ -191,9 +196,9 @@ function Card({
   onConnect: () => void;
   onDisconnect: () => void;
 }) {
-  const connected = i.connected || (i.tailscale_auth?.connected ?? false);
+  const connected = isConnected(i);
   const hasSlots = (i.slots?.length ?? 0) > 0;
-  const clickable = (i.has_oauth || i.has_tailscale_auth || hasSlots) && !connected;
+  const clickable = i.has_oauth || hasSlots || (i.has_tailscale_auth && !connected);
   const subtitle = connected
     ? i.expires_at
       ? "expires " + fmtExpiry(i.expires_at)
@@ -210,7 +215,8 @@ function Card({
       className={
         "group relative flex flex-col items-start gap-2 px-3 py-2.5 bg-white border rounded text-left transition-colors " +
         (connected
-          ? "border-[#bbf7d0] bg-[#f0fdf4]"
+          ? "border-[#bbf7d0] bg-[#f0fdf4] " +
+            (clickable ? "hover:border-[#16a34a] cursor-pointer" : "cursor-default")
           : clickable
             ? "border-[#e5e5e5] hover:border-[#171717] cursor-pointer"
             : "border-[#e5e5e5] cursor-default")


### PR DESCRIPTION
## Summary

- allow connected OAuth credential cards to rerun the existing authorization flow
- allow connected manual secret-slot credentials to open the secrets modal in update mode
- document that existing secret values are not shown and untouched slots stay unchanged
- add a backend regression test for partial secret-slot updates preserving untouched slots and clearing explicitly empty submitted slots

Closes #323

## Test plan

- `cd www && npm run format:check`
- `cd www && npm run build`
- `gofmt -l .`
- `GOCACHE=/tmp/clawpatrol-go-build go test -run TestAPICredentialsSetPreservesUntouchedSlotsAndClearsExplicitEmpty .`
- `GOCACHE=/tmp/clawpatrol-go-build go test ./...`
- `git diff --check`
- static security scan: no findings
- independent pre-commit review: passed with no blocking findings
