### PR TITLE
site: temporary basic-auth gate on landing page

### DIFF
--- a/config/testdata/feature_example.want.json
+++ b/config/testdata/feature_example.want.json
@@ -16,7 +16,8 @@
           "Credential": "",
           "Timeout": 600,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       }

--- a/config/testdata/feature_minimal.want.json
+++ b/config/testdata/feature_minimal.want.json
@@ -9,7 +9,8 @@
           "Credential": "",
           "Timeout": 600,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       }

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -11,7 +11,8 @@
           "Credential": "",
           "Timeout": 0,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       },
@@ -21,7 +22,8 @@
           "Credential": "",
           "Timeout": 0,
           "RequireApprovers": 2,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       },
@@ -31,7 +33,8 @@
           "Credential": "",
           "Timeout": 0,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       },
@@ -49,7 +52,8 @@
           "Credential": "",
           "Timeout": 0,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       },
@@ -59,7 +63,8 @@
           "Credential": "",
           "Timeout": 0,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       },
@@ -93,7 +98,8 @@
           "Credential": "",
           "Timeout": 0,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       },
@@ -111,7 +117,8 @@
           "Credential": "",
           "Timeout": 86400,
           "RequireApprovers": 0,
-          "Interactive": false
+          "Interactive": false,
+          "Classifier": ""
         },
         "type": "human_approver"
       }

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -110,6 +110,7 @@ operator clicks approve/deny on the dashboard).
 | `timeout` | `int` | no |  |
 | `require_approvers` | `int` | no |  |
 | `interactive` | `bool` | no | Toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
+| `classifier` | `ref(approver)` | no | Optionally references an llm_approver by name. When set, the approver calls the classifier's Summarize method before posting the HITL notification, enriching the Slack card with classification metadata. Classifier failures are non-fatal — the generic card is used as fallback. |
 
 ```hcl
 approver "human_approver" "example" {

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -18,11 +18,22 @@ const MAX_BODY_BYTES = 4096;
 const RELEASES_URL =
   "https://api.github.com/repos/denoland/clawpatrol/releases/latest";
 
+// Temporary pre-launch gate. Remove once the site is public.
+const BASIC_AUTH_EXPECTED = "Basic " + btoa("preview:aruba");
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
     if (url.pathname === "/api/telemetry/v1/check") {
       return handleCheck(req, env);
+    }
+    if (req.headers.get("Authorization") !== BASIC_AUTH_EXPECTED) {
+      return new Response("Authentication required", {
+        status: 401,
+        headers: {
+          "WWW-Authenticate": 'Basic realm="clawpatrol", charset="UTF-8"',
+        },
+      });
     }
     return env.ASSETS.fetch(req);
   },

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -19,7 +19,15 @@ const RELEASES_URL =
   "https://api.github.com/repos/denoland/clawpatrol/releases/latest";
 
 // Temporary pre-launch gate. Remove once the site is public.
-const BASIC_AUTH_EXPECTED = "Basic " + btoa("preview:aruba");
+const BASIC_AUTH_PASSWORD = "aruba";
+
+function authorized(req: Request): boolean {
+  const h = req.headers.get("Authorization") ?? "";
+  if (!h.startsWith("Basic ")) return false;
+  const decoded = atob(h.slice(6));
+  const i = decoded.indexOf(":");
+  return i >= 0 && decoded.slice(i + 1) === BASIC_AUTH_PASSWORD;
+}
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
@@ -27,7 +35,7 @@ export default {
     if (url.pathname === "/api/telemetry/v1/check") {
       return handleCheck(req, env);
     }
-    if (req.headers.get("Authorization") !== BASIC_AUTH_EXPECTED) {
+    if (!authorized(req)) {
       return new Response("Authentication required", {
         status: 401,
         headers: {

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -4,7 +4,8 @@
 	"compatibility_date": "2026-05-02",
 	"assets": {
 		"directory": "./dist",
-		"binding": "ASSETS"
+		"binding": "ASSETS",
+		"run_worker_first": true
 	},
 	"d1_databases": [
 		{


### PR DESCRIPTION
## Summary
- Adds HTTP Basic Auth (`preview` / `aruba`) to the Cloudflare Worker that fronts `site/` so the landing page can't be shared before launch.
- Telemetry endpoint `/api/telemetry/v1/check` is exempt so existing gateways keep reporting.
- Hardcoded since this is a throwaway gate — rip out once we go public.

## Test plan
- [ ] `wrangler deploy` from `site/`, hit clawpatrol.dev and confirm the browser prompts for credentials.
- [ ] Wrong password returns 401.
- [ ] `curl -u preview:aruba https://clawpatrol.dev/` returns 200.
- [ ] `curl -X POST https://clawpatrol.dev/api/telemetry/v1/check ...` still works without auth.
