### PR TITLE
feat(hitl): rich Slack notifications via classifier on human_approver

### DIFF
--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -40,6 +40,12 @@ type HumanApprover struct {
 	// dashboard AND Slack's Interactivity URL pointed at the gateway.
 	// Default false: message includes only an "Open dashboard" link.
 	Interactive bool `hcl:"interactive,optional"`
+	// Classifier optionally references an llm_approver by name. When set,
+	// the approver calls the classifier's Summarize method before posting
+	// the HITL notification, enriching the Slack card with classification
+	// metadata. Classifier failures are non-fatal — the generic card is
+	// used as fallback.
+	Classifier string `hcl:"classifier,optional"`
 }
 
 // HumanApproverChannel + HumanApproverCredential expose the fields
@@ -62,6 +68,19 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 	id, ch := req.Pool.Add(pending)
 	defer req.Pool.Discard(id)
 
+	var summary *runtime.HITLSummary
+	if h.Classifier != "" && req.Policy != nil {
+		if ent, ok := req.Policy.Approvers[h.Classifier]; ok {
+			if clf, ok := ent.Body.(runtime.HITLClassifier); ok {
+				if s, err := clf.Summarize(ctx, req); err == nil {
+					summary = s
+				} else {
+					log.Printf("human approver %s: classifier %q: %v", req.ApproverName, h.Classifier, err)
+				}
+			}
+		}
+	}
+
 	if h.Channel != "" && h.Credential != "" && req.Policy != nil {
 		ent, ok := req.Policy.Credentials[h.Credential]
 		if ok {
@@ -73,6 +92,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					PendingID:      id,
 					DashboardURL:   req.DashboardURL,
 					ThreadTS:       req.ThreadTS,
+					Summary:        summary,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {
@@ -121,6 +141,7 @@ func init() {
 		Runtime: (*HumanApprover)(nil),
 		Refs: []config.RefSpec{
 			{Path: "Credential", Kind: config.KindCredential, Optional: true},
+			{Path: "Classifier", Kind: config.KindApprover, Optional: true},
 		},
 		Build: func(d any, _ string, _ *config.BuildCtx) (any, hcl.Diagnostics) { return d, nil },
 		Emit: func(body any, _ string, b *hclwrite.Body) {
@@ -137,6 +158,9 @@ func init() {
 			}
 			if a.Interactive {
 				b.SetAttributeValue("interactive", cty.True)
+			}
+			if a.Classifier != "" {
+				config.SetIdent(b, "classifier", a.Classifier)
 			}
 		},
 	})

--- a/config/plugins/approvers/llm.go
+++ b/config/plugins/approvers/llm.go
@@ -35,6 +35,11 @@ Then a brief one-line reason on the second line.
 
 Be conservative — when the policy is ambiguous about whether the request is permitted, deny.`
 
+const llmClassifierSystem = `You are a request classifier. Analyze the request against the policy and return a JSON classification.
+
+Reply with JSON only — no markdown fences, no other text:
+{"ticket_id":"<ticket id from path or body, or empty string>","classification":"<label per policy>","confidence":<0-100>,"summary":"<one sentence>"}`
+
 // LLMApprover carries the model + the credential used to authenticate
 // the call to the model API + the policy text the model judges
 // against. Inline `policy` is a bare-name reference to a `policy
@@ -77,9 +82,9 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	)
 	switch {
 	case strings.HasPrefix(a.Model, "claude-"):
-		hreq, decode = anthropicJudgeRequest(ctx, a.Model, user)
+		hreq, decode = anthropicJudgeRequest(ctx, a.Model, llmJudgeSystem, user)
 	case strings.HasPrefix(a.Model, "gpt-"), strings.HasPrefix(a.Model, "o"):
-		hreq, decode = openaiJudgeRequest(ctx, a.Model, user)
+		hreq, decode = openaiJudgeRequest(ctx, a.Model, llmJudgeSystem, user)
 	default:
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "unknown model family: " + a.Model}, nil
 	}
@@ -186,11 +191,11 @@ func parseJudgeVerdict(text string) (string, string) {
 // anthropicJudgeRequest builds a /v1/messages call. The credential
 // plugin's InjectHTTP stamps Authorization + the OAuth beta header
 // when needed; we just frame the body.
-func anthropicJudgeRequest(ctx context.Context, model, user string) (*http.Request, func(io.Reader) (string, error)) {
+func anthropicJudgeRequest(ctx context.Context, model, system, user string) (*http.Request, func(io.Reader) (string, error)) {
 	body, _ := json.Marshal(map[string]any{
 		"model":      model,
 		"max_tokens": 512,
-		"system":     llmJudgeSystem,
+		"system":     system,
 		"messages": []map[string]any{
 			{"role": "user", "content": user},
 		},
@@ -222,11 +227,11 @@ func anthropicJudgeRequest(ctx context.Context, model, user string) (*http.Reque
 // openaiJudgeRequest builds a /v1/responses call (the modern GPT
 // API). Authorization is supplied by the credential plugin's
 // InjectHTTP.
-func openaiJudgeRequest(ctx context.Context, model, user string) (*http.Request, func(io.Reader) (string, error)) {
+func openaiJudgeRequest(ctx context.Context, model, system, user string) (*http.Request, func(io.Reader) (string, error)) {
 	body, _ := json.Marshal(map[string]any{
 		"model": model,
 		"input": []map[string]any{
-			{"role": "system", "content": []map[string]any{{"type": "input_text", "text": llmJudgeSystem}}},
+			{"role": "system", "content": []map[string]any{{"type": "input_text", "text": system}}},
 			{"role": "user", "content": []map[string]any{{"type": "input_text", "text": user}}},
 		},
 	})
@@ -257,6 +262,106 @@ func openaiJudgeRequest(ctx context.Context, model, user string) (*http.Request,
 	}
 	return req, decode
 }
+
+// Summarize implements runtime.HITLClassifier. It calls the LLM in
+// "summary mode" — sends the classifier system prompt and asks for a
+// structured JSON classification instead of an allow/deny verdict.
+// On parse failure or LLM error, returns nil, err so the caller can
+// fall back to the generic card.
+func (a *LLMApprover) Summarize(ctx context.Context, req runtime.ApproveRequest) (*runtime.HITLSummary, error) {
+	if a.Model == "" {
+		return nil, fmt.Errorf("llm classifier has no model")
+	}
+	if a.Credential == "" {
+		return nil, fmt.Errorf("llm classifier has no credential")
+	}
+	if req.Policy == nil {
+		return nil, fmt.Errorf("no policy on request")
+	}
+	var policyText string
+	if a.Policy != "" {
+		pt, ok := req.Policy.Policies[a.Policy]
+		if !ok {
+			return nil, fmt.Errorf("policy %s not declared", a.Policy)
+		}
+		policyText = pt.Text
+	}
+	if _, ok := req.Policy.Credentials[a.Credential]; !ok {
+		return nil, fmt.Errorf("credential %s not declared", a.Credential)
+	}
+
+	user := buildClassifierPrompt(req, policyText)
+
+	var (
+		hreq   *http.Request
+		decode func(io.Reader) (string, error)
+	)
+	switch {
+	case strings.HasPrefix(a.Model, "claude-"):
+		hreq, decode = anthropicJudgeRequest(ctx, a.Model, llmClassifierSystem, user)
+	case strings.HasPrefix(a.Model, "gpt-"), strings.HasPrefix(a.Model, "o"):
+		hreq, decode = openaiJudgeRequest(ctx, a.Model, llmClassifierSystem, user)
+	default:
+		return nil, fmt.Errorf("unknown model family: %s", a.Model)
+	}
+
+	credEnt := req.Policy.Credentials[a.Credential]
+	injector, ok := credEnt.Body.(runtime.HTTPCredentialRuntime)
+	if !ok {
+		return nil, fmt.Errorf("credential %s does not satisfy HTTPCredentialRuntime", a.Credential)
+	}
+	sec, err := req.Secrets.Get(a.Credential, req.Profile)
+	if err != nil {
+		return nil, fmt.Errorf("secret fetch: %w", err)
+	}
+	if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
+		return nil, fmt.Errorf("credential inject: %w", err)
+	}
+	c := &http.Client{Timeout: 30 * time.Second}
+	resp, err := c.Do(hreq)
+	if err != nil {
+		return nil, fmt.Errorf("llm call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("llm http %d: %s", resp.StatusCode, string(body))
+	}
+	text, err := decode(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("llm response decode: %w", err)
+	}
+	text = strings.TrimSpace(text)
+	var summary runtime.HITLSummary
+	if err := json.Unmarshal([]byte(text), &summary); err != nil {
+		return nil, fmt.Errorf("classifier json parse: %w (raw: %s)", err, truncate(text, 200))
+	}
+	return &summary, nil
+}
+
+func buildClassifierPrompt(req runtime.ApproveRequest, policyText string) string {
+	var sb strings.Builder
+	sb.WriteString("Policy:\n")
+	if policyText != "" {
+		sb.WriteString(policyText)
+	} else if req.Reason != "" {
+		sb.WriteString(req.Reason)
+	} else {
+		sb.WriteString("(none)")
+	}
+	sb.WriteString("\n\nRequest:\n")
+	fmt.Fprintf(&sb, "  method: %s\n  host: %s\n  path: %s\n", req.Method, req.Host, req.Path)
+	if req.UA != "" {
+		fmt.Fprintf(&sb, "  user-agent: %s\n", req.UA)
+	}
+	if req.BodySample != "" {
+		fmt.Fprintf(&sb, "  body:\n%s\n", indent(truncate(req.BodySample, 4000), "    "))
+	}
+	return sb.String()
+}
+
+// compile-time assertion that LLMApprover satisfies HITLClassifier.
+var _ runtime.HITLClassifier = (*LLMApprover)(nil)
 
 func init() {
 	config.Register(&config.Plugin{

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -124,12 +124,30 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 	queryLabel := runtime.HITLQueryLabel(req.Endpoint)
 
 	title := slackTrunc(runtime.HITLTitle(req.Method, endpoint), 140)
-	blocks := []map[string]any{
-		{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
-		{"type": "section", "text": map[string]any{
-			"type": "mrkdwn",
-			"text": "*" + queryLabel + "*\n```" + slackTrunc(req.Path, 800) + "```",
-		}},
+	var blocks []map[string]any
+	if s := target.Summary; s != nil {
+		headerText := s.TicketID
+		if headerText == "" {
+			headerText = title
+		}
+		emoji := hitlClassificationEmoji(s.Classification)
+		classLine := emoji + " " + s.Classification
+		if s.Confidence > 0 {
+			classLine += fmt.Sprintf(" (%d%%)", s.Confidence)
+		}
+		sectionText := "*Classification:* " + classLine + "\n*Summary:* " + slackTrunc(s.Text, 500)
+		blocks = []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": slackTrunc(headerText, 140)}},
+			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": sectionText}},
+		}
+	} else {
+		blocks = []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
+			{"type": "section", "text": map[string]any{
+				"type": "mrkdwn",
+				"text": "*" + queryLabel + "*\n```" + slackTrunc(req.Path, 800) + "```",
+			}},
+		}
 	}
 	ctx := []map[string]any{}
 	if req.Profile != "" {
@@ -224,6 +242,17 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 		return fmt.Errorf("slack chat.postMessage error: %s", result.Error)
 	}
 	return nil
+}
+
+func hitlClassificationEmoji(c string) string {
+	switch strings.ToLower(c) {
+	case "spam":
+		return ":no_entry_sign:"
+	case "legit", "legitimate":
+		return ":white_check_mark:"
+	default:
+		return ":question:"
+	}
 }
 
 func slackTrunc(s string, n int) string {

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -260,6 +260,9 @@ type HITLTarget struct {
 	PendingID      string // pool's pending entry id
 	DashboardURL   string // for fallback dashboard link in non-interactive mode
 	ThreadTS       string // if set, post as a reply in this Slack thread
+	// Summary is an optional pre-computed classification. When non-nil,
+	// notifiers render a richer card instead of the generic method/path display.
+	Summary *HITLSummary
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.
@@ -388,6 +391,23 @@ type HITLDecision struct {
 	Allow  bool
 	Reason string
 	By     string
+}
+
+// HITLSummary is an optional pre-computed classification from a
+// classifier LLM. When set on HITLTarget, notifiers build a richer
+// approval card instead of the generic method/path display.
+type HITLSummary struct {
+	TicketID       string `json:"ticket_id"`
+	Classification string `json:"classification"` // "Spam", "Legit", "Unclear", etc.
+	Confidence     int    `json:"confidence"`     // 0–100; 0 = not provided
+	Text           string `json:"summary"`
+}
+
+// HITLClassifier is the optional interface an approver plugin
+// implements to generate a HITLSummary before the HITL notification
+// is sent.
+type HITLClassifier interface {
+	Summarize(ctx context.Context, req ApproveRequest) (*HITLSummary, error)
 }
 
 // ErrUnsupported is returned by a plugin's runtime hook when the


### PR DESCRIPTION
## Summary

- Adds optional `classifier` field to `human_approver` referencing an `llm_approver` by name
- Before posting the HITL Slack notification, calls `classifier.Summarize()` to get structured JSON: `{ticket_id, classification, confidence, summary}`
- When summary is present, Slack Block Kit card shows rich format: ticket ID header, classification with emoji + confidence %, one-sentence summary
- Falls back to existing generic card on classifier error (non-fatal)
- `LLMApprover` implements new `runtime.HITLClassifier` interface

## HCL usage

\`\`\`hcl
approver "human_approver" "support-ops" {
  channel     = "#agent-support"
  credential  = slack-token
  interactive = true
  timeout     = 86400
  classifier  = support-ticket-classifier
}

approver "llm_approver" "support-ticket-classifier" {
  model      = "claude-haiku-4-5-20251001"
  credential = anthropic-key
  policy     = support-ticket-summary
}
\`\`\`

## Test plan

- [ ] `human_approver` without `classifier` — generic card unchanged
- [ ] `human_approver` with `classifier` — rich card with ticket ID, classification emoji, confidence, summary
- [ ] Classifier LLM error — falls back to generic card, logs error, does not block HITL

🤖 Generated with [Claude Code](https://claude.com/claude-code)