### PR TITLE
Credentials carry one secret, not one per profile

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -574,19 +574,21 @@ type IntegrationRow struct {
 	HasOAuth         bool                   `json:"has_oauth"`
 	OAuth            *OAuthIntegrationUI    `json:"oauth,omitempty"`
 	Slots            []config.SecretSlot    `json:"slots,omitempty"`
-	Owners           []Owner                `json:"owners"`
+	Connected        bool                   `json:"connected"`
+	ExpiresAt        int64                  `json:"expires_at,omitempty"`
+	DisplayName      string                 `json:"display_name,omitempty"`
+	AvatarURL        string                 `json:"avatar_url,omitempty"`
 	HasTailscaleAuth bool                   `json:"has_tailscale_auth,omitempty"`
 	TailscaleAuth    *TailscaleAuthStatusUI `json:"tailscale_auth,omitempty"`
 }
 
 // TailscaleAuthStatusUI is the dashboard-facing slice of a
 // tailscale-node-auth credential's live state. Connected reflects
-// whether tsnet has persisted node identity for the credential
-// (gateway-wide; owner is always "" for tailscale). PendingURL is the
-// live Tailscale login URL emitted by tsnet when no identity is stored
-// yet — the dashboard's "Connect" button redirects to it. Endpoint
-// paths are surfaced so the dashboard renders the connect flow
-// without hard-coding the route layout.
+// whether tsnet has persisted node identity for the credential.
+// PendingURL is the live Tailscale login URL emitted by tsnet when
+// no identity is stored yet — the dashboard's "Connect" button
+// redirects to it. Endpoint paths are surfaced so the dashboard
+// renders the connect flow without hard-coding the route layout.
 type TailscaleAuthStatusUI struct {
 	Connected     bool   `json:"connected"`
 	PendingURL    string `json:"pending_url,omitempty"`
@@ -601,14 +603,6 @@ type TailscaleAuthStatusUI struct {
 type OAuthIntegrationUI struct {
 	BaseScopes     []string                    `json:"base_scopes"`
 	OptionalScopes []config.OptionalScopeGroup `json:"optional_scopes,omitempty"`
-}
-
-type Owner struct {
-	Owner       string `json:"owner"`
-	Connected   bool   `json:"connected"`
-	ExpiresAt   int64  `json:"expires_at,omitempty"`
-	DisplayName string `json:"display_name,omitempty"`
-	AvatarURL   string `json:"avatar_url,omitempty"`
 }
 
 func (w *webMux) apiStatus(rw http.ResponseWriter, r *http.Request) {
@@ -635,7 +629,6 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	selectedProfile, _ := w.credentialProfileKeyForRequest(r)
 	for _, name := range names {
 		ent := policy.Credentials[name]
 		row := IntegrationRow{ID: name, Name: name, Type: ent.Plugin.Type}
@@ -647,28 +640,24 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 					OptionalScopes: flow.OptionalScopes,
 				}
 			}
-			for _, owner := range w.g.oauth.Owners(name) {
-				connected, exp := w.g.oauth.Status(name, owner)
-				o := Owner{Owner: owner, Connected: connected}
+			if connected, exp := w.g.oauth.Status(name); connected {
+				row.Connected = true
 				if !exp.IsZero() {
-					o.ExpiresAt = exp.Unix()
+					row.ExpiresAt = exp.Unix()
 				}
-				o.DisplayName, o.AvatarURL = w.g.oauth.Profile(name, owner)
-				row.Owners = append(row.Owners, o)
+				row.DisplayName, row.AvatarURL = w.g.oauth.Profile(name)
 			}
 		}
 		if sp, ok := ent.Body.(config.SecretSlotsProvider); ok {
 			row.Slots = sp.SecretSlots()
-			if selectedProfile != "" {
-				present, _ := credentialSlotPresence(w.g.db, name, selectedProfile)
-				if len(present) > 0 {
-					row.Owners = append(row.Owners, Owner{Owner: selectedProfile, Connected: true})
-				}
+			present, _ := credentialSlotPresence(w.g.db, name)
+			if len(present) > 0 {
+				row.Connected = true
 			}
 		}
 		if _, ok := ent.Body.(tailscaleproto.TailscaleAuthProvider); ok {
 			row.HasTailscaleAuth = true
-			present, _ := credentialSlotPresence(w.g.db, name, "")
+			present, _ := credentialSlotPresence(w.g.db, name)
 			row.TailscaleAuth = &TailscaleAuthStatusUI{
 				Connected:     len(present) > 0,
 				PendingURL:    tailscaleproto.Default.Get(name),
@@ -751,51 +740,40 @@ func (w *webMux) agentsList() []*Agent {
 		v4, v6 := w.onboard.ExternalIPs(a.IP)
 		a.ExternalIPv4, a.ExternalIPv6 = v4, v6
 	}
-	// enrich with connected integrations per agent's user. Re-run on
-	// every snapshot — caching by `Integrations != nil` would freeze
-	// the list at first sighting (a freshly-onboarded device whose
-	// user later connects Claude wouldn't reflect the new connection).
+	// Surface the legacy display owner on agents whose User column is
+	// still the tailnet "tagged-devices" stub, so the dashboard can
+	// render something more meaningful.
 	for _, a := range snap {
-		// Per-profile credentials: the agent's Integrations list
-		// reflects what the device's bound profile has connected. Falls
-		// back to the legacy per-user lookup for tailnet-control-mode
-		// installs that still bucket creds by login.
-		profile := w.onboard.ProfileForIP(a.IP)
-		if profile == "" {
-			if a.User == "" || a.User == "tagged-devices" {
-				if owner := w.onboard.OwnerForIP(a.IP); owner != "" {
-					a.User = owner
-				}
-			}
-			profile = a.User
-		}
-		if profile == "" {
-			continue
-		}
-		// Walk every declared credential — connected if either an
-		// OAuth token exists OR the operator pasted a secret slot via
-		// the dashboard. Was hardcoded to the claude/codex/github
-		// legacy trio, which silently hid every other credential type
-		// from the agents table.
-		var ids []string
-		if policy := w.g.Policy(); policy != nil {
-			names := make([]string, 0, len(policy.Credentials))
-			for name := range policy.Credentials {
-				names = append(names, name)
-			}
-			sort.Strings(names)
-			for _, name := range names {
-				if conn, _ := w.g.oauth.Status(name, profile); conn {
-					ids = append(ids, name)
-					continue
-				}
-				present, _ := credentialSlotPresence(w.g.db, name, profile)
-				if len(present) > 0 {
-					ids = append(ids, name)
-				}
+		if a.User == "" || a.User == "tagged-devices" {
+			if owner := w.onboard.OwnerForIP(a.IP); owner != "" {
+				a.User = owner
 			}
 		}
-		if ids != nil {
+	}
+	// Walk every declared credential — connected if either an OAuth
+	// token exists OR the operator pasted a secret slot via the
+	// dashboard. Credentials are global (one secret per credential),
+	// so the connected set is the same for every agent.
+	var ids []string
+	if policy := w.g.Policy(); policy != nil {
+		names := make([]string, 0, len(policy.Credentials))
+		for name := range policy.Credentials {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if conn, _ := w.g.oauth.Status(name); conn {
+				ids = append(ids, name)
+				continue
+			}
+			present, _ := credentialSlotPresence(w.g.db, name)
+			if len(present) > 0 {
+				ids = append(ids, name)
+			}
+		}
+	}
+	if ids != nil {
+		for _, a := range snap {
 			a.Integrations = ids
 		}
 	}

--- a/ai.go
+++ b/ai.go
@@ -174,19 +174,12 @@ operator sees a confusing error.`
 // to parse it returns an error instead, so the dashboard can show a
 // clean "AI returned invalid HCL" rather than splatting prose into
 // the editor.
-func generateRuleHCL(ctx context.Context, g *Gateway, agent, owner, prompt, currentHCL, scope string) (newHCL, refused string, err error) {
+func generateRuleHCL(ctx context.Context, g *Gateway, agent, prompt, currentHCL, scope string) (newHCL, refused string, err error) {
 	reg := g.oauth
 	if agent == "" {
 		for _, id := range []string{"claude", "codex"} {
-			if owners := reg.Owners(id); len(owners) > 0 {
-				for _, o := range owners {
-					if o == owner {
-						agent = id
-						break
-					}
-				}
-			}
-			if agent != "" {
+			if conn, _ := reg.Status(id); conn {
+				agent = id
 				break
 			}
 		}
@@ -202,9 +195,9 @@ func generateRuleHCL(ctx context.Context, g *Gateway, agent, owner, prompt, curr
 	var raw string
 	switch agent {
 	case "claude":
-		raw, err = callClaude(ctx, reg, owner, user)
+		raw, err = callClaude(ctx, reg, user)
 	case "codex":
-		raw, err = callCodex(ctx, reg, owner, user)
+		raw, err = callCodex(ctx, reg, user)
 	default:
 		return "", "", fmt.Errorf("unknown agent: %s", agent)
 	}
@@ -313,7 +306,7 @@ func scopeLabel(_ string) string { return "global" }
 // callClaude hits Anthropic's /v1/messages with the rule system prompt.
 // Uses the operator's OAuth credential — Inject() adds the Authorization
 // header to a freshly-built request.
-func callClaude(ctx context.Context, reg *OAuthRegistry, owner, user string) (string, error) {
+func callClaude(ctx context.Context, reg *OAuthRegistry, user string) (string, error) {
 	body, _ := json.Marshal(map[string]any{
 		"model":      "claude-haiku-4-5",
 		"max_tokens": 4096,
@@ -330,7 +323,7 @@ func callClaude(ctx context.Context, reg *OAuthRegistry, owner, user string) (st
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("anthropic-version", "2023-06-01")
 	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
-	if _, err := reg.Inject("claude", owner, req); err != nil {
+	if _, err := reg.Inject("claude", req); err != nil {
 		return "", err
 	}
 	resp, err := http.DefaultClient.Do(req)
@@ -362,7 +355,7 @@ func callClaude(ctx context.Context, reg *OAuthRegistry, owner, user string) (st
 // callCodex routes through the OpenAI Responses API. Mirrors callClaude
 // for the Codex OAuth integration. Uses gpt-5-mini (fast, cheap) for
 // rule generation.
-func callCodex(ctx context.Context, reg *OAuthRegistry, owner, user string) (string, error) {
+func callCodex(ctx context.Context, reg *OAuthRegistry, user string) (string, error) {
 	body, _ := json.Marshal(map[string]any{
 		"model": "gpt-5-mini",
 		"input": []map[string]any{
@@ -376,7 +369,7 @@ func callCodex(ctx context.Context, reg *OAuthRegistry, owner, user string) (str
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if _, err := reg.Inject("codex", owner, req); err != nil {
+	if _, err := reg.Inject("codex", req); err != nil {
 		return "", err
 	}
 	resp, err := http.DefaultClient.Do(req)

--- a/config/extplugin/adapter.go
+++ b/config/extplugin/adapter.go
@@ -112,7 +112,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 		c := ch.Endpoint.Credentials[0].Credential
 		credName = c.Symbol.Name
 		credType = c.Symbol.Type
-		secret, err := ch.Secrets.Get(credName, ch.Profile)
+		secret, err := ch.Secrets.Get(credName)
 		if err == nil {
 			credSec = secret.Bytes
 			credExtra = secret.Extras
@@ -680,7 +680,7 @@ func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ run
 		credExtra map[string]string
 	)
 	if host.Credential != nil {
-		secret, err := host.SecretStore.Get(host.Credential.Name, "")
+		secret, err := host.SecretStore.Get(host.Credential.Name)
 		if err == nil {
 			credSec = secret.Bytes
 			credExtra = secret.Extras

--- a/config/plugins/approvers/llm.go
+++ b/config/plugins/approvers/llm.go
@@ -94,7 +94,7 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	if !ok {
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential " + a.Credential + " does not satisfy HTTPCredentialRuntime"}, nil
 	}
-	sec, err := req.Secrets.Get(a.Credential, req.Profile)
+	sec, err := req.Secrets.Get(a.Credential)
 	if err != nil {
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
 	}
@@ -310,7 +310,7 @@ func (a *LLMApprover) Summarize(ctx context.Context, req runtime.ApproveRequest)
 	if !ok {
 		return nil, fmt.Errorf("credential %s does not satisfy HTTPCredentialRuntime", a.Credential)
 	}
-	sec, err := req.Secrets.Get(a.Credential, req.Profile)
+	sec, err := req.Secrets.Get(a.Credential)
 	if err != nil {
 		return nil, fmt.Errorf("secret fetch: %w", err)
 	}

--- a/config/plugins/approvers/util.go
+++ b/config/plugins/approvers/util.go
@@ -20,7 +20,7 @@ func buildPending(req runtime.ApproveRequest) runtime.HITLPending {
 		family = req.Endpoint.Family
 	}
 	return runtime.HITLPending{
-		AgentIP:    req.Profile,
+		AgentIP:    req.AgentIP,
 		Host:       req.Host,
 		Method:     req.Method,
 		Path:       req.Path,

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -107,7 +107,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 	if req.Secrets == nil {
 		return fmt.Errorf("no secret store on request")
 	}
-	sec, err := req.Secrets.Get(target.CredentialName, req.Profile)
+	sec, err := req.Secrets.Get(target.CredentialName)
 	if err != nil {
 		return fmt.Errorf("fetch credential %s: %w", target.CredentialName, err)
 	}
@@ -150,10 +150,10 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 		}
 	}
 	ctx := []map[string]any{}
-	if req.Profile != "" {
+	if req.AgentIP != "" {
 		ctx = append(ctx, map[string]any{
 			"type": "mrkdwn",
-			"text": "agent `" + req.Profile + "`",
+			"text": "agent `" + req.AgentIP + "`",
 		})
 	}
 	if r := strings.TrimSpace(req.Reason); r != "" {
@@ -301,22 +301,12 @@ func slackInteractive(ctx runtime.WebhookCtx, rw http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Walk every (this credential, profile) signing_secret — secrets
-	// are per-profile in the dashboard, but Slack doesn't know which
-	// profile a click came from. First match wins.
 	verified := false
-	for _, prof := range append([]string{""}, ctx.Profiles...) {
-		sec, err := ctx.Secrets.Get(ctx.CredentialName, prof)
-		if err != nil {
-			continue
-		}
+	sec, secErr := ctx.Secrets.Get(ctx.CredentialName)
+	if secErr == nil {
 		signingSecret := sec.Extras["signing_secret"]
-		if signingSecret == "" {
-			continue
-		}
-		if verifySlackSig(signingSecret, ts, body, sig) {
+		if signingSecret != "" && verifySlackSig(signingSecret, ts, body, sig) {
 			verified = true
-			break
 		}
 	}
 	if !verified {

--- a/config/plugins/credentials/tailscale.go
+++ b/config/plugins/credentials/tailscale.go
@@ -67,8 +67,7 @@ func (*TailscaleCredential) TailscaleAuth() *tailscaleproto.TailscaleAuthIntegra
 
 // secretStateStore adapts the gateway's credential_secrets store to
 // tsnet's ipn.StateStore. Every tsnet identity blob is one slot row;
-// slot name = the StateKey string. Owner is "" — node identity is
-// gateway-wide, not per-owner.
+// slot name = the StateKey string.
 type secretStateStore struct {
 	name   string
 	store  runtime.SecretStore
@@ -76,7 +75,7 @@ type secretStateStore struct {
 }
 
 func (s *secretStateStore) ReadState(id ipn.StateKey) ([]byte, error) {
-	sec, err := s.store.Get(s.name, "")
+	sec, err := s.store.Get(s.name)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +86,7 @@ func (s *secretStateStore) ReadState(id ipn.StateKey) ([]byte, error) {
 }
 
 func (s *secretStateStore) WriteState(id ipn.StateKey, bs []byte) error {
-	return s.writer.SetCredentialSlot(s.name, "", string(id), string(bs))
+	return s.writer.SetCredentialSlot(s.name, string(id), string(bs))
 }
 
 func init() {

--- a/config/plugins/credentials/tailscale_test.go
+++ b/config/plugins/credentials/tailscale_test.go
@@ -23,7 +23,7 @@ func newFakeStore() *fakeWritableStore {
 	return &fakeWritableStore{slots: map[string]map[string]string{}}
 }
 
-func (f *fakeWritableStore) Get(name, _ string) (runtime.Secret, error) {
+func (f *fakeWritableStore) Get(name string) (runtime.Secret, error) {
 	m, ok := f.slots[name]
 	if !ok {
 		return runtime.Secret{}, nil
@@ -35,7 +35,7 @@ func (f *fakeWritableStore) Get(name, _ string) (runtime.Secret, error) {
 	return sec, nil
 }
 
-func (f *fakeWritableStore) SetCredentialSlot(name, _, slot, value string) error {
+func (f *fakeWritableStore) SetCredentialSlot(name, slot, value string) error {
 	m, ok := f.slots[name]
 	if !ok {
 		m = map[string]string{}

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -186,7 +186,7 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 			return fmt.Errorf("clickhouse_native: credential %q does not implement ClickhouseAuthCredential",
 				cc.Credential.Symbol.Name)
 		}
-		sec, secErr := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
+		sec, secErr := ch.Secrets.Get(cc.Credential.Symbol.Name)
 		if secErr != nil {
 			chEmitError(ch, "secret-fetch", fmt.Sprintf("%s: %v", cc.Credential.Symbol.Name, secErr))
 			return fmt.Errorf("clickhouse_native: fetch secret %q: %w", cc.Credential.Symbol.Name, secErr)

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -237,7 +237,7 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 		pgWriteError(ch.Conn, "credential plugin does not implement postgres auth")
 		return fmt.Errorf("credential %q has no PostgresAuth", cc.Credential.Symbol.Name)
 	}
-	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
+	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name)
 	if err != nil {
 		pgWriteError(ch.Conn, "fetch secret: "+err.Error())
 		return err

--- a/config/plugins/endpoints/ssh.go
+++ b/config/plugins/endpoints/ssh.go
@@ -312,7 +312,7 @@ func (rt *SSHEndpointRuntime) upstreamClientConfig(ch *runtime.ConnHandle, cc *c
 	if !ok {
 		return nil, fmt.Errorf("does not implement sshproto.AuthCredential (use credential type \"ssh\")")
 	}
-	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name, ch.Profile)
+	sec, err := ch.Secrets.Get(cc.Credential.Symbol.Name)
 	if err != nil {
 		return nil, fmt.Errorf("fetch secret: %w", err)
 	}

--- a/config/plugins/tailscaleproto/tailscaleproto.go
+++ b/config/plugins/tailscaleproto/tailscaleproto.go
@@ -130,11 +130,8 @@ var Default = &PendingNodeAuth{}
 // side store implements it via the credential_secrets table. Other
 // stores (EnvSecretStore, in-memory test fakes) don't, and the
 // credential errors with a clear message at StateStore time.
-//
-// Owner is intentionally the empty string for tailscale state — node
-// identity is gateway-wide, not per-owner.
 type SecretWriter interface {
-	SetCredentialSlot(name, owner, slot, value string) error
+	SetCredentialSlot(name, slot, value string) error
 }
 
 // Teach the runtime's credential checker about NodeIdentity and the

--- a/config/plugins/tunnels/ssh_port_forward.go
+++ b/config/plugins/tunnels/ssh_port_forward.go
@@ -86,7 +86,7 @@ func (t *SSHPortForwardTunnel) Open(ctx context.Context, host runtime.TunnelHost
 	if !ok {
 		return nil, fmt.Errorf("ssh_port_forward: credential %q is not an ssh credential (got %T)", host.Credential.Name, host.Credential.Body)
 	}
-	sec, err := host.SecretStore.Get(host.Credential.Name, "")
+	sec, err := host.SecretStore.Get(host.Credential.Name)
 	if err != nil {
 		return nil, fmt.Errorf("ssh_port_forward: secret %q: %w", host.Credential.Name, err)
 	}

--- a/config/plugins/tunnels/ssh_port_forward_test.go
+++ b/config/plugins/tunnels/ssh_port_forward_test.go
@@ -32,7 +32,7 @@ func (f *fakeSSHCred) SSHAuth(_ cruntime.Secret) (sshproto.Creds, error) {
 // the struct, not in the env.
 type fakeSecretStore struct{}
 
-func (fakeSecretStore) Get(_, _ string) (cruntime.Secret, error) {
+func (fakeSecretStore) Get(_ string) (cruntime.Secret, error) {
 	return cruntime.Secret{}, nil
 }
 

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -124,10 +124,12 @@ type ConnHandle struct {
 	Endpoint *config.CompiledEndpoint
 	Policy   *config.CompiledPolicy
 	// Profile is the device's profile name, looked up from peer IP
-	// before dispatch.
+	// before dispatch. Informational — the host uses it for logging
+	// and exposes it to external plugins; it is no longer keyed into
+	// credential lookups.
 	Profile string
-	// PeerIP is the agent's source IP, used as the "owner" key when
-	// fetching credentials from the secret store.
+	// PeerIP is the agent's source IP. Informational identifier of
+	// the originating peer.
 	PeerIP string
 	// Secrets is the host's SecretStore; plugins use it to fetch
 	// credential material at session-start time (postgres) or per
@@ -290,9 +292,10 @@ type ApproveRequest struct {
 	// approver should use against Pool / Secrets when it needs to
 	// disambiguate per-approver state.
 	ApproverName string
-	// Profile of the originating peer; SecretStore lookup key for
-	// per-profile credentials.
-	Profile string
+	// AgentIP is the WireGuard source IP of the originating peer.
+	// Approvers use it as a display label / log key; it carries no
+	// credential-lookup meaning.
+	AgentIP string
 	// Method / Host / Path / UA / BodySample carry the request shape
 	// for HITL prompts. Endpoint plugins fill these so approvers
 	// don't have to know the family-specific Request internals.

--- a/config/runtime/secrets.go
+++ b/config/runtime/secrets.go
@@ -13,19 +13,20 @@ import (
 var envParts = []string{"CA", "CERT", "KEY"}
 
 // SecretStore returns the secret material a credential plugin's
-// InjectHTTP / InjectPostgres needs at request time. Lookups are
-// keyed by the credential's bare name (e.g. "github-pat") plus the
-// owner — typically the agent's tailnet identity, so the same
-// credential type can hold per-user secrets.
+// InjectHTTP / InjectPostgres needs at request time. Lookup key is
+// the credential's bare name (e.g. "github-pat"). A credential
+// declared in HCL maps to exactly one secret — operators wanting
+// distinct material for two callers should declare two credentials
+// and bind each to its own endpoint.
 //
 // Implementations live outside the config package because the secret
 // store is a host concern, not a policy concern. The default env-var
-// store is lightweight enough for development; a follow-up wires the
+// store is lightweight enough for development; the gateway wires the
 // existing OAuthRegistry behind this interface for OAuth-flow
-// credentials (anthropic / codex / notion / etc.) so refresh + per-
-// owner persistence flow through the same path.
+// credentials (anthropic / codex / notion / etc.) so refresh + token
+// persistence flow through the same path.
 type SecretStore interface {
-	Get(name, owner string) (Secret, error)
+	Get(name string) (Secret, error)
 }
 
 // EnvSecretStore reads secret material from process env vars. Lookup
@@ -33,13 +34,10 @@ type SecretStore interface {
 // underscores. Returns an empty Secret (no error) when the var
 // isn't set so the dispatcher can decide between fail-closed and
 // passthrough at the policy level.
-//
-// Owner is ignored — env-var-backed stores are single-tenant. A
-// per-owner extension would key on `_<OWNER>` suffix.
 type EnvSecretStore struct{}
 
 // Get is part of the clawpatrol plugin API.
-func (EnvSecretStore) Get(name, _ string) (Secret, error) {
+func (EnvSecretStore) Get(name string) (Secret, error) {
 	if name == "" {
 		return Secret{}, fmt.Errorf("empty credential name")
 	}

--- a/config/runtime/webhook.go
+++ b/config/runtime/webhook.go
@@ -44,5 +44,4 @@ type WebhookCtx struct {
 	Secrets        SecretStore
 	HITL           HITLPool
 	Policy         *config.CompiledPolicy
-	Profiles       []string
 }

--- a/dial.go
+++ b/dial.go
@@ -94,7 +94,7 @@ func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName st
 			if !ok {
 				continue
 			}
-			sec, err := g.secrets.Get(cc.Credential.Symbol.Name, profile)
+			sec, err := g.secrets.Get(cc.Credential.Symbol.Name)
 			if err != nil {
 				log.Printf("tls-secret %s: %v — dialing without client cert", cc.Credential.Symbol.Name, err)
 				break

--- a/dial_test.go
+++ b/dial_test.go
@@ -24,7 +24,7 @@ func (c *fakeTLSCredential) ConfigureUpstreamTLS(_ *tls.Config, _ runtime.Secret
 
 type fakeSecretStore struct{}
 
-func (fakeSecretStore) Get(string, string) (runtime.Secret, error) {
+func (fakeSecretStore) Get(string) (runtime.Secret, error) {
 	return runtime.Secret{}, nil
 }
 

--- a/doc/tailscale-oauth-credential.md
+++ b/doc/tailscale-oauth-credential.md
@@ -80,10 +80,10 @@ unchanged.
   package (config/runtime/checker.go).
 - **Closest template — dashboard "Connect" UX (with caveats):** the existing
   `OAuthFlowProvider` plugins (anthropic_oauth.go, github.go, openai_codex.go).
-  They drive per-owner browser redirects against an IdP and stash a per-owner
-  token in `OAuthRegistry`. Tailscale's case is *visually* identical from the
-  dashboard's POV ("click Connect, follow a redirect, come back authed"), but
-  the underlying primitive is wrong — see Q4.
+  They drive browser redirects against an IdP and stash a token in
+  `OAuthRegistry`. Tailscale's case is *visually* identical from the dashboard's
+  POV ("click Connect, follow a redirect, come back authed"), but the underlying
+  primitive is wrong — see Q4.
 
 ### Secret-store wiring (already in place)
 
@@ -185,9 +185,10 @@ back its StateStore by sqlite instead of a filesystem dir.
   - `OAuthFlow()` returns a *static* `OAuthIntegration` with hardcoded
     `AuthURL`/`TokenURL`/`Scopes`. Tailscale's URL is *dynamic*, minted by
     tsnet per attempt, and there is no clawpatrol-side token exchange.
-  - `OAuthRegistry` stores per-owner tokens. Tailscale node identity is
-    *gateway-wide* (one node per tunnel, shared across owners) — per-owner
-    partitioning is actively wrong here.
+  - `OAuthRegistry` stores a single OAuth access/refresh token per
+    credential. Tailscale's persistence shape is different — tsnet writes
+    a multi-slot identity bundle (machine key, node key, login profile)
+    through `ipn.StateStore`, and the registry has no notion of that.
 - Introduce `TailscaleAuthProvider` in `config/plugins/tailscaleproto/`
   (lives next to the `NodeIdentity` interface — both are the protocol-
   specific contract between the tailscale tunnel/credential plugins and

--- a/main.go
+++ b/main.go
@@ -1854,11 +1854,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			injector, wantsHTTP := cc.Credential.Body.(runtime.HTTPCredentialRuntime)
 			wsRewriter, wantsWS := cc.Credential.Body.(runtime.WebSocketCredentialRuntime)
 			if wantsHTTP || (wantsWS && isWSUpgrade(req)) {
-				sec, err := g.secrets.Get(cc.Credential.Symbol.Name, profile)
+				sec, err := g.secrets.Get(cc.Credential.Symbol.Name)
 				if err != nil {
-					log.Printf("secret %s/%s: %v — forwarding without injection", cc.Credential.Symbol.Name, profile, err)
+					log.Printf("secret %s: %v — forwarding without injection", cc.Credential.Symbol.Name, err)
 				} else if len(sec.Bytes) == 0 && len(sec.Extras) == 0 {
-					log.Printf("secret %s/%s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, profile, secretEnvName(cc.Credential.Symbol.Name))
+					log.Printf("secret %s: not configured (set CLAWPATROL_SECRET_%s)", cc.Credential.Symbol.Name, secretEnvName(cc.Credential.Symbol.Name))
 				} else {
 					if wantsHTTP {
 						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
@@ -2077,7 +2077,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			Endpoint:     c.Endpoint,
 			Rule:         c.Rule,
 			ApproverName: st.Name,
-			Profile:      c.Profile,
+			AgentIP:      c.AgentIP,
 			Method:       c.Method,
 			Host:         c.Host,
 			Path:         c.Path,

--- a/migrations/sqlite/0011_credentials_global.sql
+++ b/migrations/sqlite/0011_credentials_global.sql
@@ -1,0 +1,63 @@
+-- 0011_credentials_global — credentials carry one secret, not one per
+-- profile. Before this migration `credential_secrets` and `credentials`
+-- were both keyed by (… , profile, …) so a single HCL credential
+-- declaration silently fanned out into N secret rows, one per profile
+-- that referenced it. That implicit fan-out hides intent: if two
+-- profiles need different secret material, the operator should declare
+-- two credentials in HCL and bind each to its own endpoint.
+--
+-- This migration collapses both tables to one row per credential by
+-- keeping the most recently updated row per credential (resp. per
+-- credential+slot for credential_secrets). Operators on a single
+-- profile (the common case) are unaffected; operators who had distinct
+-- secrets on multiple profiles for the same credential keep whichever
+-- one they last touched, and need to re-enter the others against
+-- separately declared credentials.
+
+CREATE TABLE credential_secrets_v2 (
+  credential TEXT NOT NULL,
+  slot       TEXT NOT NULL,
+  value      TEXT NOT NULL,
+  updated_ns INTEGER NOT NULL,
+  PRIMARY KEY (credential, slot)
+);
+
+INSERT INTO credential_secrets_v2 (credential, slot, value, updated_ns)
+SELECT cs.credential, cs.slot, cs.value, cs.updated_ns
+  FROM credential_secrets cs
+  JOIN (
+    SELECT credential, slot, MAX(updated_ns) AS mx
+      FROM credential_secrets
+     GROUP BY credential, slot
+  ) m
+    ON m.credential = cs.credential
+   AND m.slot       = cs.slot
+   AND m.mx         = cs.updated_ns;
+
+DROP TABLE credential_secrets;
+ALTER TABLE credential_secrets_v2 RENAME TO credential_secrets;
+
+CREATE TABLE credentials_v2 (
+  id             TEXT PRIMARY KEY,
+  access_token   TEXT,
+  token_type     TEXT,
+  refresh_token  TEXT,
+  expiry_ns      INTEGER,
+  updated_ns     INTEGER NOT NULL,
+  display_name   TEXT,
+  avatar_url     TEXT
+);
+
+INSERT INTO credentials_v2 (id, access_token, token_type, refresh_token, expiry_ns, updated_ns, display_name, avatar_url)
+SELECT c.id, c.access_token, c.token_type, c.refresh_token, c.expiry_ns, c.updated_ns, c.display_name, c.avatar_url
+  FROM credentials c
+  JOIN (
+    SELECT id, MAX(updated_ns) AS mx
+      FROM credentials
+     GROUP BY id
+  ) m
+    ON m.id = c.id
+   AND m.mx = c.updated_ns;
+
+DROP TABLE credentials;
+ALTER TABLE credentials_v2 RENAME TO credentials;

--- a/oauth.go
+++ b/oauth.go
@@ -30,27 +30,26 @@ type (
 	OAuthIntegration = config.OAuthIntegration
 )
 
-// oauthState is one credential: tokens for a single (integration, owner).
-// Persisted in the credentials table; one row per (id, owner).
+// oauthState is one credential: tokens for a single integration.
+// Persisted in the credentials table; one row per id.
 type oauthState struct {
 	cfg         *oauth2.Config
 	source      oauth2.TokenSource
 	header      string
 	prefix      string
 	id          string
-	owner       string
 	displayName string // human-readable name (e.g. github login)
 	avatarURL   string // dashboard pfp
 	db          *sql.DB
 	mu          sync.Mutex
 }
 
-// OAuthRegistry holds all configured OAuth integrations and a per-owner
-// state map. Keyed by (integration_id, owner-string).
+// OAuthRegistry holds all configured OAuth integrations and one token
+// state per integration. Keyed by integration_id.
 type OAuthRegistry struct {
 	mu           sync.RWMutex
 	integrations map[string]*OAuthIntegration
-	states       map[string]*oauthState // key: id + "|" + owner
+	states       map[string]*oauthState // key: id
 	db           *sql.DB
 }
 
@@ -85,35 +84,20 @@ func (r *OAuthRegistry) IntegrationIDs() []string {
 	return ids
 }
 
-func stateKey(id, owner string) string { return id + "|" + owner }
-
-func (r *OAuthRegistry) get(id, owner string) *oauthState {
+func (r *OAuthRegistry) get(id string) *oauthState {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.states[stateKey(id, owner)]
+	return r.states[id]
 }
 
-func (r *OAuthRegistry) Owners(id string) []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	out := []string{}
-	for k, s := range r.states {
-		if s.id == id && s.source != nil {
-			_ = k
-			out = append(out, s.owner)
-		}
-	}
-	return out
-}
-
-// Inject sets the auth header on req using the (id, owner) credential.
+// Inject sets the auth header on req using the named credential.
 // Returns (overrode, err). overrode=false means no token yet; caller
 // may pass agent's existing header through, or fail.
-func (r *OAuthRegistry) Inject(id, owner string, req *http.Request) (bool, error) {
+func (r *OAuthRegistry) Inject(id string, req *http.Request) (bool, error) {
 	if id == "" {
 		return false, nil
 	}
-	s := r.get(id, owner)
+	s := r.get(id)
 	if s == nil || s.source == nil {
 		return false, nil
 	}
@@ -125,21 +109,21 @@ func (r *OAuthRegistry) Inject(id, owner string, req *http.Request) (bool, error
 	return true, nil
 }
 
-// Token returns the current access token for (id, owner) — refreshing
-// it through the underlying oauth2.TokenSource if it's stale. Empty
-// string + nil error means no token has been captured yet for this
-// owner; the caller decides between fail-closed and pass-through.
+// Token returns the current access token for the credential —
+// refreshing it through the underlying oauth2.TokenSource if it's
+// stale. Empty string + nil error means no token has been captured
+// yet; the caller decides between fail-closed and pass-through.
 //
 // Used by the runtime SecretStore bridge so credential plugins
 // (which know how to format Authorization / x-api-key / cookie)
 // can stamp the bytes onto the request — OAuthRegistry.Inject
 // hardcodes the header shape and predates the per-credential plugin
 // model.
-func (r *OAuthRegistry) Token(id, owner string) (string, error) {
+func (r *OAuthRegistry) Token(id string) (string, error) {
 	if id == "" {
 		return "", nil
 	}
-	s := r.get(id, owner)
+	s := r.get(id)
 	if s == nil || s.source == nil {
 		return "", nil
 	}
@@ -165,9 +149,9 @@ func (r *OAuthRegistry) Register(id string, def OAuthIntegration) {
 	r.integrations[id] = &def
 }
 
-// Status returns connected info for a given (id, owner).
-func (r *OAuthRegistry) Status(id, owner string) (connected bool, expiry time.Time) {
-	s := r.get(id, owner)
+// Status returns connected info for the named credential.
+func (r *OAuthRegistry) Status(id string) (connected bool, expiry time.Time) {
+	s := r.get(id)
 	if s == nil || s.source == nil {
 		return false, time.Time{}
 	}
@@ -179,11 +163,12 @@ func (r *OAuthRegistry) Status(id, owner string) (connected bool, expiry time.Ti
 }
 
 // Profile returns the (display_name, avatar_url) the dashboard
-// renders for this owner. Empty strings when no userinfo enricher ran
-// for this provider, when the row pre-dates 0003_credential_profile,
-// or when the userinfo fetch failed at exchange time.
-func (r *OAuthRegistry) Profile(id, owner string) (displayName, avatarURL string) {
-	s := r.get(id, owner)
+// renders for this credential. Empty strings when no userinfo
+// enricher ran for this provider, when the row pre-dates
+// 0003_credential_profile, or when the userinfo fetch failed at
+// exchange time.
+func (r *OAuthRegistry) Profile(id string) (displayName, avatarURL string) {
+	s := r.get(id)
 	if s == nil {
 		return "", ""
 	}
@@ -192,31 +177,31 @@ func (r *OAuthRegistry) Profile(id, owner string) (displayName, avatarURL string
 	return s.displayName, s.avatarURL
 }
 
-// Revoke deletes the (id, owner) credential and its DB row.
-func (r *OAuthRegistry) Revoke(id, owner string) {
+// Revoke deletes the credential's token and its DB row.
+func (r *OAuthRegistry) Revoke(id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.states[stateKey(id, owner)]; !ok {
+	if _, ok := r.states[id]; !ok {
 		return
 	}
 	if r.db != nil {
-		_, _ = r.db.Exec("DELETE FROM credentials WHERE id=? AND profile=?", id, owner)
+		_, _ = r.db.Exec("DELETE FROM credentials WHERE id=?", id)
 	}
-	delete(r.states, stateKey(id, owner))
+	delete(r.states, id)
 }
 
 // Set stores tokens captured externally (browser auth flow callback).
-func (r *OAuthRegistry) Set(id, owner string, tok *oauth2.Token) error {
+func (r *OAuthRegistry) Set(id string, tok *oauth2.Token) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	it, ok := r.integrations[id]
 	if !ok {
 		return fmt.Errorf("unknown integration: %s", id)
 	}
-	s := r.states[stateKey(id, owner)]
+	s := r.states[id]
 	if s == nil {
-		s = newState(it, owner, r.db)
-		r.states[stateKey(id, owner)] = s
+		s = newState(it, r.db)
+		r.states[id] = s
 	}
 	s.setToken(tok)
 	if name, avatar := fetchOAuthProfile(id, tok.AccessToken); name != "" || avatar != "" {
@@ -269,7 +254,7 @@ func fetchOAuthProfile(id, accessToken string) (string, string) {
 	return "", ""
 }
 
-func newState(it *OAuthIntegration, owner string, db *sql.DB) *oauthState {
+func newState(it *OAuthIntegration, db *sql.DB) *oauthState {
 	cfg := &oauth2.Config{
 		ClientID:     resolveTemplate(it.OAuth.ClientID),
 		ClientSecret: resolveTemplate(it.OAuth.ClientSecret),
@@ -290,7 +275,6 @@ func newState(it *OAuthIntegration, owner string, db *sql.DB) *oauthState {
 		header: header,
 		prefix: prefix,
 		id:     it.ID,
-		owner:  owner,
 		db:     db,
 	}
 }
@@ -390,10 +374,10 @@ func (p *persistingSource) Token() (*oauth2.Token, error) {
 }
 
 // persistProfile updates the human-identity columns for this
-// (id, owner) row. Called after fetchOAuthProfile populates them post-
-// exchange. UPDATE-only — relies on persist() having INSERTed the
-// row first. Best-effort: a failed write surfaces only as missing
-// avatar on the dashboard.
+// credential's row. Called after fetchOAuthProfile populates them
+// post-exchange. UPDATE-only — relies on persist() having INSERTed
+// the row first. Best-effort: a failed write surfaces only as
+// missing avatar on the dashboard.
 func (s *oauthState) persistProfile(displayName, avatarURL string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -403,8 +387,8 @@ func (s *oauthState) persistProfile(displayName, avatarURL string) {
 	_, _ = s.db.Exec(`
 		UPDATE credentials
 		   SET display_name = ?, avatar_url = ?
-		 WHERE id = ? AND profile = ?
-	`, displayName, avatarURL, s.id, s.owner)
+		 WHERE id = ?
+	`, displayName, avatarURL, s.id)
 	s.displayName = displayName
 	s.avatarURL = avatarURL
 }
@@ -420,53 +404,53 @@ func (s *oauthState) persist(t *oauth2.Token) {
 		expiryNs = t.Expiry.UnixNano()
 	}
 	_, _ = s.db.Exec(`
-		INSERT INTO credentials (id, profile, access_token, token_type, refresh_token, expiry_ns, updated_ns)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id, profile) DO UPDATE SET
+		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
 			access_token  = excluded.access_token,
 			token_type    = excluded.token_type,
 			refresh_token = excluded.refresh_token,
 			expiry_ns     = excluded.expiry_ns,
 			updated_ns    = excluded.updated_ns
-	`, s.id, s.owner, t.AccessToken, t.TokenType, t.RefreshToken, expiryNs, time.Now().UnixNano())
+	`, s.id, t.AccessToken, t.TokenType, t.RefreshToken, expiryNs, time.Now().UnixNano())
 }
 
-// LoadFromDB rehydrates every (id, owner) credential row whose
-// integration is currently registered. Safe to call repeatedly —
-// re-running after registerOAuthCredentials picks up tokens for IDs
-// that were registered after NewOAuthRegistry's initial pass.
-// Idempotent: existing in-memory state for an (id, owner) is
-// overwritten with the DB-stored token.
+// LoadFromDB rehydrates every credential row whose integration is
+// currently registered. Safe to call repeatedly — re-running after
+// registerOAuthCredentials picks up tokens for IDs that were
+// registered after NewOAuthRegistry's initial pass. Idempotent:
+// existing in-memory state for an id is overwritten with the
+// DB-stored token.
 func (r *OAuthRegistry) LoadFromDB() error {
 	return r.loadFromDB()
 }
 
-// loadFromDB rehydrates every (id, owner) credential row whose
-// integration is still declared in r.integrations.
+// loadFromDB rehydrates every credential row whose integration is
+// still declared in r.integrations.
 func (r *OAuthRegistry) loadFromDB() error {
 	if r.db == nil {
 		return nil
 	}
-	rows, err := r.db.Query("SELECT id, profile, access_token, token_type, refresh_token, expiry_ns, display_name, avatar_url FROM credentials")
+	rows, err := r.db.Query("SELECT id, access_token, token_type, refresh_token, expiry_ns, display_name, avatar_url FROM credentials")
 	if err != nil {
 		return err
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var (
-			id, owner           string
+			id                  string
 			access, typ, refr   sql.NullString
 			expiryNs            sql.NullInt64
 			displayName, avatar sql.NullString
 		)
-		if err := rows.Scan(&id, &owner, &access, &typ, &refr, &expiryNs, &displayName, &avatar); err != nil {
+		if err := rows.Scan(&id, &access, &typ, &refr, &expiryNs, &displayName, &avatar); err != nil {
 			return err
 		}
 		it, ok := r.integrations[id]
 		if !ok {
 			continue
 		}
-		s := newState(it, owner, r.db)
+		s := newState(it, r.db)
 		tok := &oauth2.Token{
 			AccessToken:  access.String,
 			TokenType:    typ.String,
@@ -478,7 +462,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 		s.setToken(tok)
 		s.displayName = displayName.String
 		s.avatarURL = avatar.String
-		r.states[stateKey(id, owner)] = s
+		r.states[id] = s
 	}
 	return rows.Err()
 }
@@ -488,7 +472,6 @@ type oauthSession struct {
 	state    string
 	cfg      *oauth2.Config
 	id       string
-	owner    string
 	created  time.Time
 }
 
@@ -549,11 +532,6 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "no oauth integration: "+id, 400)
 		return
 	}
-	owner, ownerLabel := w.credentialProfileKeyForRequest(r)
-	if owner == "" {
-		http.Error(rw, "could not determine profile", 400)
-		return
-	}
 	// User may opt into additional scopes (e.g. SSH/GPG key management
 	// for github_oauth) at connect time. Merge into base scopes so the
 	// declared defaults remain mandatory — narrowing scope at the UI
@@ -565,11 +543,11 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 	flow = &mergedFlow
 	// Branch: device flow vs auth-code+PKCE.
 	if flow.Flow == "device" {
-		w.startDeviceFlow(rw, id, flow, owner, ownerLabel)
+		w.startDeviceFlow(rw, id, flow)
 		return
 	}
 	if flow.Flow == "openai_device" {
-		w.startOpenAIDeviceFlow(rw, id, flow, owner, ownerLabel)
+		w.startOpenAIDeviceFlow(rw, id, flow)
 		return
 	}
 
@@ -589,14 +567,14 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
 	)
 	w.mu.Lock()
-	w.sessions[state] = &oauthSession{verifier: verifier, state: state, cfg: cfg, id: id, owner: owner, created: time.Now()}
+	w.sessions[state] = &oauthSession{verifier: verifier, state: state, cfg: cfg, id: id, created: time.Now()}
 	for k, s := range w.sessions {
 		if time.Since(s.created) > 10*time.Minute {
 			delete(w.sessions, k)
 		}
 	}
 	w.mu.Unlock()
-	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state, "owner": ownerLabel})
+	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state})
 }
 
 func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
@@ -639,17 +617,17 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "token exchange: "+err.Error(), 400)
 		return
 	}
-	if err := w.g.oauth.Set(sess.id, sess.owner, tok); err != nil {
+	if err := w.g.oauth.Set(sess.id, tok); err != nil {
 		http.Error(rw, err.Error(), 500)
 		return
 	}
-	writeJSON(rw, map[string]any{"connected": true, "owner": sess.owner, "expires": tok.Expiry.Unix()})
+	writeJSON(rw, map[string]any{"connected": true, "expires": tok.Expiry.Unix()})
 }
 
 // startDeviceFlow kicks off OAuth device flow (RFC 8628). Returns
 // {user_code, verification_uri, device_code, interval} so the dashboard
 // can prompt the user to enter the code at the verification URI.
-func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthIntegration, owner, ownerLabel string) {
+func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthIntegration) {
 	form := url.Values{}
 	form.Set("client_id", resolveTemplate(it.OAuth.ClientID))
 	if len(it.OAuth.Scopes) > 0 {
@@ -685,7 +663,6 @@ func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthInt
 	w.sessions[state] = &oauthSession{
 		state:    state,
 		id:       id,
-		owner:    owner,
 		created:  time.Now(),
 		verifier: dr.DeviceCode, // reuse field for device_code
 		cfg: &oauth2.Config{
@@ -701,7 +678,6 @@ func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthInt
 		"verification_uri": dr.VerificationURI,
 		"interval":         dr.Interval,
 		"expires_in":       dr.ExpiresIn,
-		"owner":            ownerLabel,
 	})
 }
 
@@ -712,7 +688,7 @@ func (w *webMux) startDeviceFlow(rw http.ResponseWriter, id string, it *OAuthInt
 // session and fed to the poll handler. Verification URL is hardcoded
 // to https://auth.openai.com/codex/device since OpenAI's response
 // doesn't include one.
-func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OAuthIntegration, owner, ownerLabel string) {
+func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OAuthIntegration) {
 	clientID := resolveTemplate(it.OAuth.ClientID)
 	body, _ := json.Marshal(map[string]string{"client_id": clientID})
 	req, _ := http.NewRequest("POST", it.OAuth.DeviceURL, bytes.NewReader(body))
@@ -746,7 +722,6 @@ func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OA
 	w.sessions[state] = &oauthSession{
 		state:   state,
 		id:      id,
-		owner:   owner,
 		created: time.Now(),
 		// Pack device_auth_id|user_code into verifier so pollDeviceFlow
 		// can split them; cfg.RedirectURL carries the codex-specific
@@ -776,7 +751,6 @@ func (w *webMux) startOpenAIDeviceFlow(rw http.ResponseWriter, id string, it *OA
 		"user_code":        dr.UserCode,
 		"verification_uri": "https://auth.openai.com/codex/device",
 		"interval":         interval,
-		"owner":            ownerLabel,
 	})
 }
 
@@ -862,11 +836,11 @@ func (w *webMux) pollOpenAIDeviceFlow(rw http.ResponseWriter, sess *oauthSession
 	w.mu.Lock()
 	delete(w.sessions, sess.state)
 	w.mu.Unlock()
-	if err := w.g.oauth.Set(sess.id, sess.owner, tok); err != nil {
+	if err := w.g.oauth.Set(sess.id, tok); err != nil {
 		http.Error(rw, err.Error(), 500)
 		return
 	}
-	writeJSON(rw, map[string]any{"connected": true, "owner": sess.owner})
+	writeJSON(rw, map[string]any{"connected": true})
 }
 
 // pollDeviceFlow exchanges device_code for a token. Called by the
@@ -928,11 +902,11 @@ func (w *webMux) pollDeviceFlow(rw http.ResponseWriter, sess *oauthSession) {
 	w.mu.Lock()
 	delete(w.sessions, sess.state)
 	w.mu.Unlock()
-	if err := w.g.oauth.Set(sess.id, sess.owner, tok); err != nil {
+	if err := w.g.oauth.Set(sess.id, tok); err != nil {
 		http.Error(rw, err.Error(), 500)
 		return
 	}
-	writeJSON(rw, map[string]any{"connected": true, "owner": sess.owner})
+	writeJSON(rw, map[string]any{"connected": true})
 }
 
 // exchangeOAuthCode finalizes an OAuth PKCE flow. Anthropic's token
@@ -1026,17 +1000,16 @@ func (w *webMux) apiOAuthRevoke(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		ID    string `json:"id"`
-		Owner string `json:"owner"`
+		ID string `json:"id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(rw, err.Error(), 400)
 		return
 	}
-	if body.ID == "" || body.Owner == "" {
-		http.Error(rw, "missing id or owner", 400)
+	if body.ID == "" {
+		http.Error(rw, "missing id", 400)
 		return
 	}
-	w.g.oauth.Revoke(body.ID, body.Owner)
+	w.g.oauth.Revoke(body.ID)
 	writeJSON(rw, map[string]bool{"ok": true})
 }

--- a/onboard.go
+++ b/onboard.go
@@ -576,7 +576,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "approval requires an authenticated operator", http.StatusForbidden)
 		return
 	}
-	owner, _ := w.credentialProfileKeyForRequest(r)
+	owner, _ := w.selectedProfileForRequest(r)
 	if owner == "" {
 		http.Error(rw, "approval requires a profile", http.StatusForbidden)
 		return

--- a/secrets.go
+++ b/secrets.go
@@ -12,7 +12,7 @@ import (
 )
 
 // gatewaySecretStore is the SecretStore the gateway hands to
-// credential plugins. Lookup order per (credential name, owner):
+// credential plugins. Lookup order per credential name:
 //
 //  1. credential_secrets table — slot bytes the operator pasted into
 //     the dashboard (single-slot fills Bytes; multi-slot fills Extras).
@@ -39,18 +39,16 @@ func newGatewaySecretStore(db *sql.DB, oauth *OAuthRegistry) runtime.SecretStore
 // satisfying tailscaleproto.SecretWriter. The tsnet ipn.StateStore
 // round-trips machine key, node key, and login profile through here
 // on first-time node auth and on every state mutation thereafter.
-// Owner is the empty string for tailscale (node identity is gateway-
-// wide, not per-owner).
-func (s *gatewaySecretStore) SetCredentialSlot(name, owner, slot, value string) error {
+func (s *gatewaySecretStore) SetCredentialSlot(name, slot, value string) error {
 	if s.db == nil {
 		return fmt.Errorf("gateway secret store: no db")
 	}
-	return setCredentialSlot(s.db, name, owner, slot, value)
+	return setCredentialSlot(s.db, name, slot, value)
 }
 
-func (s *gatewaySecretStore) Get(name, owner string) (runtime.Secret, error) {
+func (s *gatewaySecretStore) Get(name string) (runtime.Secret, error) {
 	if s.db != nil {
-		sec, ok, err := readCredentialSecrets(s.db, name, owner)
+		sec, ok, err := readCredentialSecrets(s.db, name)
 		if err != nil {
 			return runtime.Secret{}, err
 		}
@@ -59,22 +57,22 @@ func (s *gatewaySecretStore) Get(name, owner string) (runtime.Secret, error) {
 		}
 	}
 	if s.oauth != nil {
-		if tok, err := s.oauth.Token(name, owner); err != nil {
+		if tok, err := s.oauth.Token(name); err != nil {
 			return runtime.Secret{}, err
 		} else if tok != "" {
 			return runtime.Secret{Kind: "oauth_bearer", Bytes: []byte(tok)}, nil
 		}
 	}
-	return s.env.Get(name, owner)
+	return s.env.Get(name)
 }
 
-// readCredentialSecrets fetches every slot persisted for (credential,
-// profile). Returns (Secret, true) when at least one slot exists. The
-// unnamed slot (slot = ”) fills Bytes; named slots fill Extras.
-func readCredentialSecrets(db *sql.DB, credential, profile string) (runtime.Secret, bool, error) {
+// readCredentialSecrets fetches every slot persisted for the named
+// credential. Returns (Secret, true) when at least one slot exists.
+// The unnamed slot (slot = "") fills Bytes; named slots fill Extras.
+func readCredentialSecrets(db *sql.DB, credential string) (runtime.Secret, bool, error) {
 	rows, err := db.Query(
-		`SELECT slot, value FROM credential_secrets WHERE credential = ? AND profile = ?`,
-		credential, profile,
+		`SELECT slot, value FROM credential_secrets WHERE credential = ?`,
+		credential,
 	)
 	if err != nil {
 		return runtime.Secret{}, false, err
@@ -100,46 +98,46 @@ func readCredentialSecrets(db *sql.DB, credential, profile string) (runtime.Secr
 	return sec, found, rows.Err()
 }
 
-// setCredentialSlot upserts one (credential, profile, slot) row.
-// Used by the dashboard's connect-credential endpoint.
-func setCredentialSlot(db *sql.DB, credential, profile, slot, value string) error {
+// setCredentialSlot upserts one (credential, slot) row. Used by the
+// dashboard's connect-credential endpoint.
+func setCredentialSlot(db *sql.DB, credential, slot, value string) error {
 	if db == nil {
 		return fmt.Errorf("no db")
 	}
 	_, err := db.Exec(
-		`INSERT INTO credential_secrets (credential, profile, slot, value, updated_ns)
-		 VALUES (?, ?, ?, ?, ?)
-		 ON CONFLICT(credential, profile, slot) DO UPDATE SET
+		`INSERT INTO credential_secrets (credential, slot, value, updated_ns)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(credential, slot) DO UPDATE SET
 		   value = excluded.value, updated_ns = excluded.updated_ns`,
-		credential, profile, slot, value, time.Now().UnixNano(),
+		credential, slot, value, time.Now().UnixNano(),
 	)
 	return err
 }
 
-// clearCredentialSecrets drops every slot for (credential, profile).
+// clearCredentialSecrets drops every slot for the named credential.
 // The dashboard's disconnect button calls this.
-func clearCredentialSecrets(db *sql.DB, credential, profile string) error {
+func clearCredentialSecrets(db *sql.DB, credential string) error {
 	if db == nil {
 		return nil
 	}
 	_, err := db.Exec(
-		`DELETE FROM credential_secrets WHERE credential = ? AND profile = ?`,
-		credential, profile,
+		`DELETE FROM credential_secrets WHERE credential = ?`,
+		credential,
 	)
 	return err
 }
 
-// credentialSlotPresence returns the set of slots persisted for
-// (credential, profile). Used by the dashboard to render per-slot
+// credentialSlotPresence returns the set of slots persisted for the
+// named credential. Used by the dashboard to render per-slot
 // "filled / empty" status without leaking the secret bytes.
-func credentialSlotPresence(db *sql.DB, credential, profile string) (map[string]bool, error) {
+func credentialSlotPresence(db *sql.DB, credential string) (map[string]bool, error) {
 	out := map[string]bool{}
 	if db == nil {
 		return out, nil
 	}
 	rows, err := db.Query(
-		`SELECT slot FROM credential_secrets WHERE credential = ? AND profile = ?`,
-		credential, profile,
+		`SELECT slot FROM credential_secrets WHERE credential = ?`,
+		credential,
 	)
 	if err != nil {
 		return out, err

--- a/tailscale_dashboard.go
+++ b/tailscale_dashboard.go
@@ -59,7 +59,7 @@ func (w *webMux) apiTailscaleConnect(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := tailscaleAuthResponse{ID: id}
-	present, _ := credentialSlotPresence(w.g.db, id, "")
+	present, _ := credentialSlotPresence(w.g.db, id)
 	switch {
 	case len(present) > 0:
 		resp.Connected = true
@@ -88,11 +88,10 @@ func (w *webMux) apiTailscaleStatus(rw http.ResponseWriter, r *http.Request) {
 	w.apiTailscaleConnect(rw, r)
 }
 
-// apiTailscaleDisconnect drops every stored slot for the credential
-// (owner = "" — tailscale node identity is gateway-wide). On the
-// next tunnel re-init, tsnet finds an empty StateStore and drives
-// the interactive login again. Hot-restart of the tunnel itself is
-// a follow-up; today the gateway-wide identity is reset and the next
+// apiTailscaleDisconnect drops every stored slot for the credential.
+// On the next tunnel re-init, tsnet finds an empty StateStore and
+// drives the interactive login again. Hot-restart of the tunnel
+// itself is a follow-up; today the identity is reset and the next
 // gateway boot picks it up.
 func (w *webMux) apiTailscaleDisconnect(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -116,7 +115,7 @@ func (w *webMux) apiTailscaleDisconnect(rw http.ResponseWriter, r *http.Request)
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := clearCredentialSecrets(w.g.db, body.ID, ""); err != nil {
+	if err := clearCredentialSecrets(w.g.db, body.ID); err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/web.go
+++ b/web.go
@@ -461,7 +461,6 @@ func (w *webMux) mountCredentialWebhooks(mux *http.ServeMux) {
 					Secrets:        w.g.secrets,
 					HITL:           w.g.hitl,
 					Policy:         w.g.Policy(),
-					Profiles:       orderedProfileNames(w.g.cfg.Policy),
 				}
 				handler(ctx, rw, r)
 			})
@@ -595,13 +594,13 @@ func (w *webMux) callerIdentity(r *http.Request) (user, device, displayHost stri
 	return who.UserProfile.LoginName, who.Node.StableID, who.Node.HostName
 }
 
-// credentialProfileKeyForRequest returns the credentials.profile key used when
-// dashboard requests read or write OAuth/secret rows. Prefer an explicit
-// profile selector, then the configured default policy profile. The remaining
-// fallbacks preserve legacy single-user/per-caller credential keys; they are
-// not necessarily declared policy profiles and must not be used as evidence
-// that the caller is authenticated.
-func (w *webMux) credentialProfileKeyForRequest(r *http.Request) (key, label string) {
+// selectedProfileForRequest returns the profile name a dashboard request
+// targets. Prefer an explicit profile selector, then the configured
+// default policy profile. The remaining fallbacks preserve legacy
+// single-user/per-caller keys; they are not necessarily declared policy
+// profiles and must not be used as evidence that the caller is
+// authenticated.
+func (w *webMux) selectedProfileForRequest(r *http.Request) (key, label string) {
 	if p := r.URL.Query().Get("profile"); p != "" {
 		return p, p
 	}
@@ -715,9 +714,9 @@ func serveState(rw http.ResponseWriter, r *http.Request, body []byte, tag string
 // declared credential ships (root view).
 
 // apiCredentialsSet persists one or more slot values for a non-OAuth
-// credential. Owner defaults to the caller's profile. Body shape:
+// credential. Body shape:
 //
-//	{ "id": "stripe-live", "owner": "default", "slots": { "": "sk_live_…" } }
+//	{ "id": "stripe-live", "slots": { "": "sk_live_…" } }
 //
 // Multi-slot credentials (mtls, slack tokens) pass multiple keys.
 // Empty values clear the slot.
@@ -728,7 +727,6 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 	}
 	var body struct {
 		ID    string            `json:"id"`
-		Owner string            `json:"owner"`
 		Slots map[string]string `json:"slots"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -737,13 +735,6 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 	}
 	if body.ID == "" {
 		http.Error(rw, "missing id", 400)
-		return
-	}
-	if body.Owner == "" {
-		body.Owner, _ = w.credentialProfileKeyForRequest(r)
-	}
-	if body.Owner == "" {
-		http.Error(rw, "missing owner", 400)
 		return
 	}
 	policy := w.g.policy.Load()
@@ -769,15 +760,15 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 		if v == "" {
 			// Empty value = clear that slot specifically.
 			if _, err := w.g.db.Exec(
-				`DELETE FROM credential_secrets WHERE credential = ? AND profile = ? AND slot = ?`,
-				body.ID, body.Owner, slot,
+				`DELETE FROM credential_secrets WHERE credential = ? AND slot = ?`,
+				body.ID, slot,
 			); err != nil {
 				http.Error(rw, err.Error(), 500)
 				return
 			}
 			continue
 		}
-		if err := setCredentialSlot(w.g.db, body.ID, body.Owner, slot, v); err != nil {
+		if err := setCredentialSlot(w.g.db, body.ID, slot, v); err != nil {
 			http.Error(rw, err.Error(), 500)
 			return
 		}
@@ -785,7 +776,7 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 	writeJSON(rw, map[string]any{"ok": true})
 }
 
-// apiCredentialsClear drops every slot for (id, owner). Disconnect
+// apiCredentialsClear drops every slot for the credential. Disconnect
 // button on the dashboard.
 func (w *webMux) apiCredentialsClear(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
@@ -793,8 +784,7 @@ func (w *webMux) apiCredentialsClear(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		ID    string `json:"id"`
-		Owner string `json:"owner"`
+		ID string `json:"id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(rw, err.Error(), 400)
@@ -804,10 +794,7 @@ func (w *webMux) apiCredentialsClear(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "missing id", 400)
 		return
 	}
-	if body.Owner == "" {
-		body.Owner, _ = w.credentialProfileKeyForRequest(r)
-	}
-	if err := clearCredentialSecrets(w.g.db, body.ID, body.Owner); err != nil {
+	if err := clearCredentialSecrets(w.g.db, body.ID); err != nil {
 		http.Error(rw, err.Error(), 500)
 		return
 	}
@@ -1232,12 +1219,7 @@ func (w *webMux) apiRulesAI(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "prompt required", 400)
 		return
 	}
-	owner, _ := w.credentialProfileKeyForRequest(r)
-	if owner == "" {
-		http.Error(rw, "profile required", http.StatusForbidden)
-		return
-	}
-	out, refused, err := generateRuleHCL(r.Context(), w.g, body.Agent, owner, body.Prompt, body.CurrentYAML, body.Scope)
+	out, refused, err := generateRuleHCL(r.Context(), w.g, body.Agent, body.Prompt, body.CurrentYAML, body.Scope)
 	if err != nil {
 		http.Error(rw, "ai: "+err.Error(), http.StatusBadGateway)
 		return

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -45,7 +45,6 @@ export default function App() {
   const [update, setUpdate] = useState<UpdateBanner | null>(null);
   const [readOnlyConfig, setReadOnlyConfig] = useState(false);
   const [connectId, setConnectId] = useState<string | null>(null);
-  const [connectProfile, setConnectProfile] = useState<string | undefined>(undefined);
   const [showAddDevice, setShowAddDevice] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [route, setRoute] = useState(parseRoute());
@@ -161,13 +160,9 @@ export default function App() {
           ip={route.ip}
           agents={agents}
           integrations={integrations}
-          whoami={whoami}
           readOnlyConfig={readOnlyConfig}
           onBack={() => navigate("")}
-          onConnect={(id, profile) => {
-            setConnectId(id);
-            setConnectProfile(profile);
-          }}
+          onConnect={(id) => setConnectId(id)}
           onRefresh={refresh}
         />
       )}
@@ -185,14 +180,9 @@ export default function App() {
         <ConnectModal
           id={connectId}
           oauth={integrations.find((i) => i.id === connectId)?.oauth}
-          profile={connectProfile}
-          onClose={() => {
-            setConnectId(null);
-            setConnectProfile(undefined);
-          }}
+          onClose={() => setConnectId(null)}
           onDone={() => {
             setConnectId(null);
-            setConnectProfile(undefined);
             refresh();
           }}
         />

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -99,14 +99,10 @@ export function AgentsTable({
                 <IntegrationStack
                   items={(a.integrations ?? []).map((id) => {
                     const it = byId.get(id);
-                    // Pick the owner row matching this device's profile
-                    // so two profiles connected to different GH accounts
-                    // surface distinct avatars in their respective rows.
-                    const owner = it?.owners?.find((o) => o.owner === a.profile) ?? it?.owners?.[0];
                     return {
                       id,
                       type: it?.type,
-                      avatar_url: owner?.avatar_url,
+                      avatar_url: it?.avatar_url,
                     };
                   })}
                 />

--- a/www/src/components/ConnectModal.tsx
+++ b/www/src/components/ConnectModal.tsx
@@ -10,13 +10,11 @@ import {
 export function ConnectModal({
   id,
   oauth,
-  profile,
   onClose,
   onDone,
 }: {
   id: string;
   oauth?: OAuthIntegrationUI | null;
-  profile?: string;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -38,7 +36,7 @@ export function ConnectModal({
   useEffect(() => {
     if (!started) return;
     const extraList = showsScopePicker ? Array.from(extras) : undefined;
-    oauthStart(id, profile, extraList)
+    oauthStart(id, extraList)
       .then((r) => {
         setStart(r);
         if (r.flow === "device") {
@@ -52,7 +50,7 @@ export function ConnectModal({
     // checklist is frozen once we kick off the OAuth flow, so don't
     // rerun this effect on later toggles.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, profile, started]);
+  }, [id, started]);
 
   // Stable ref to onDone — parent re-renders (App refreshes integrations
   // every 3s) reset the lambda otherwise, killing the polling interval
@@ -125,11 +123,6 @@ export function ConnectModal({
         <div className="text-[11px] uppercase tracking-[.12em] text-[#a3a3a3] mb-1">
           CONNECT {id}
         </div>
-        {start && "owner" in start && start.owner && (
-          <div className="text-[11px] text-[#737373] mb-3">
-            for <span className="text-[#171717] font-semibold">{start.owner}</span>
-          </div>
-        )}
         {done ? (
           <div className="py-6 text-center">
             <div className="text-[24px] mb-2">✓</div>

--- a/www/src/components/CredentialSecretsModal.tsx
+++ b/www/src/components/CredentialSecretsModal.tsx
@@ -13,12 +13,10 @@ import { setCredentialSlots } from "../lib/api";
 // re-pastes when rotating.
 export function CredentialSecretsModal({
   integration,
-  owner,
   onClose,
   onSaved,
 }: {
   integration: Integration;
-  owner: string;
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -35,7 +33,7 @@ export function CredentialSecretsModal({
     setSaving(true);
     setErr(null);
     try {
-      await setCredentialSlots(integration.id, owner, values);
+      await setCredentialSlots(integration.id, values);
       onSaved();
       onClose();
     } catch (e) {

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -6,7 +6,6 @@ import {
   setDeviceProfile,
   type Agent,
   type Integration,
-  type Whoami,
 } from "../lib/api";
 import { fmtBytes } from "../lib/format";
 import { DeviceIcon } from "./Logos";
@@ -20,7 +19,6 @@ export function DevicePage({
   ip,
   agents,
   integrations,
-  whoami,
   readOnlyConfig,
   onBack,
   onConnect,
@@ -29,10 +27,9 @@ export function DevicePage({
   ip: string;
   agents: Agent[];
   integrations: Integration[];
-  whoami: Whoami | null;
   readOnlyConfig?: boolean;
   onBack: () => void;
-  onConnect: (id: string, profile?: string) => void;
+  onConnect: (id: string) => void;
   onRefresh: () => void;
 }) {
   const a = useMemo(() => agents.find((x) => x.ip === ip) ?? null, [agents, ip]);
@@ -221,13 +218,7 @@ export function DevicePage({
       <LiveRequests agentIP={a.ip} height="360px" />
 
       {/* integrations management for this user */}
-      <IntegrationsCards
-        list={allForUser}
-        whoami={whoami}
-        profile={a.profile}
-        onConnect={onConnect}
-        onRefresh={onRefresh}
-      />
+      <IntegrationsCards list={allForUser} onConnect={onConnect} onRefresh={onRefresh} />
 
       {/* rules — per-device scope (with global rules layered in) */}
       <RulesPanel deviceIP={a.ip} profile={a.profile} readOnly={readOnlyConfig} />

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useState } from "react";
-import type { Integration, Whoami } from "../lib/api";
+import type { Integration } from "../lib/api";
 import { fmtExpiry } from "../lib/format";
 import { IntegrationIcon } from "./Logos";
 import { clearCredential, oauthRevoke, tailscaleConnect, tailscaleDisconnect } from "../lib/api";
@@ -36,31 +36,21 @@ const VISIBLE_CAP = 4;
 
 export function IntegrationsCards({
   list,
-  whoami,
-  profile,
   onConnect,
   onRefresh,
 }: {
   list: Integration[];
-  whoami: Whoami | null;
-  profile?: string;
-  onConnect: (id: string, profile?: string) => void;
+  onConnect: (id: string) => void;
   onRefresh: () => void;
 }) {
-  const youKey = profile || whoami?.user || whoami?.host || "";
   const [editing, setEditing] = useState<Integration | null>(null);
   const [allOpen, setAllOpen] = useState(false);
 
-  // Sort: connected first (most relevant), then unconnected, then
-  // already-disabled ones (no auth path) — preserves declaration
-  // order within each bucket. Tailscale credentials carry their
-  // connect state on the row itself (gateway-wide, no per-owner
-  // entry) so the score falls through to that flag when owners[]
-  // doesn't have a matching row.
+  // Sort: connected first, then unconnected, then disabled (no auth
+  // path) — preserves declaration order within each bucket.
   const sorted = [...list].sort((a, b) => {
     const score = (i: Integration) => {
-      const me = (i.owners ?? []).find((o) => o.owner === youKey);
-      if (me?.connected || i.tailscale_auth?.connected) return 0;
+      if (i.connected || i.tailscale_auth?.connected) return 0;
       if (i.has_oauth || i.has_tailscale_auth || (i.slots && i.slots.length > 0)) return 1;
       return 2;
     };
@@ -95,7 +85,7 @@ export function IntegrationsCards({
       return;
     }
     if (i.has_oauth) {
-      onConnect(i.id, profile);
+      onConnect(i.id);
       return;
     }
     if (i.slots && i.slots.length > 0) {
@@ -109,9 +99,9 @@ export function IntegrationsCards({
       return;
     }
     if (i.has_oauth) {
-      oauthRevoke(i.id, youKey).then(onRefresh);
+      oauthRevoke(i.id).then(onRefresh);
     } else {
-      clearCredential(i.id, youKey).then(onRefresh);
+      clearCredential(i.id).then(onRefresh);
     }
   }
 
@@ -122,7 +112,6 @@ export function IntegrationsCards({
           <Card
             key={i.id}
             integration={i}
-            youKey={youKey}
             onConnect={() => handleConnect(i)}
             onDisconnect={() => disconnect(i)}
           />
@@ -140,7 +129,6 @@ export function IntegrationsCards({
       {allOpen && (
         <AllIntegrationsModal
           list={sorted}
-          youKey={youKey}
           onClose={() => setAllOpen(false)}
           onConnect={(i) => {
             setAllOpen(false);
@@ -153,7 +141,6 @@ export function IntegrationsCards({
       {editing && (
         <CredentialSecretsModal
           integration={editing}
-          owner={youKey}
           onClose={() => setEditing(null)}
           onSaved={onRefresh}
         />
@@ -197,24 +184,19 @@ function OwnerAvatar({
 
 function Card({
   integration: i,
-  youKey,
   onConnect,
   onDisconnect,
 }: {
   integration: Integration;
-  youKey: string;
   onConnect: () => void;
   onDisconnect: () => void;
 }) {
-  const me = (i.owners ?? []).find((o) => o.owner === youKey);
-  // Tailscale credentials don't have per-owner rows — the connect
-  // status hangs off i.tailscale_auth and applies gateway-wide.
-  const connected = (me?.connected ?? false) || (i.tailscale_auth?.connected ?? false);
+  const connected = i.connected || (i.tailscale_auth?.connected ?? false);
   const hasSlots = (i.slots?.length ?? 0) > 0;
   const clickable = (i.has_oauth || i.has_tailscale_auth || hasSlots) && !connected;
   const subtitle = connected
-    ? me?.expires_at
-      ? "expires " + fmtExpiry(me.expires_at)
+    ? i.expires_at
+      ? "expires " + fmtExpiry(i.expires_at)
       : "connected"
     : i.has_oauth || i.has_tailscale_auth
       ? "click to connect"
@@ -235,18 +217,18 @@ function Card({
       }
     >
       <div className="flex items-center gap-2 w-full">
-        {connected && me?.avatar_url ? (
-          <OwnerAvatar src={me.avatar_url} fallbackId={i.id} fallbackType={i.type} />
+        {connected && i.avatar_url ? (
+          <OwnerAvatar src={i.avatar_url} fallbackId={i.id} fallbackType={i.type} />
         ) : (
           <IntegrationIcon id={i.id} type={i.type} className="w-[16px] h-[16px] flex-shrink-0" />
         )}
         <span
           className="text-[12px] font-semibold text-[#171717] truncate"
-          title={me?.display_name ?? i.id}
+          title={i.display_name ?? i.id}
         >
           {(() => {
             const label = TYPE_LABEL[i.type] ?? i.name;
-            return me?.display_name ? `${label} (${me.display_name})` : label;
+            return i.display_name ? `${label} (${i.display_name})` : label;
           })()}
         </span>
         <span className="ml-auto flex items-center gap-1.5 flex-shrink-0">
@@ -286,13 +268,11 @@ function Card({
 
 function AllIntegrationsModal({
   list,
-  youKey,
   onClose,
   onConnect,
   onDisconnect,
 }: {
   list: Integration[];
-  youKey: string;
   onClose: () => void;
   onConnect: (i: Integration) => void;
   onDisconnect: (i: Integration) => void;
@@ -322,7 +302,6 @@ function AllIntegrationsModal({
             <Card
               key={i.id}
               integration={i}
-              youKey={youKey}
               onConnect={() => onConnect(i)}
               onDisconnect={() => onDisconnect(i)}
             />

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -1,15 +1,4 @@
-// Profile is per-device, not per-dashboard. The OAuth connect flow
-// picks which profile a credential lands under via an explicit query
-// param on /api/oauth/start; everything else is single-tenant.
 const api = fetch;
-
-export type Owner = {
-  owner: string;
-  connected: boolean;
-  expires_at?: number;
-  display_name?: string;
-  avatar_url?: string;
-};
 
 export type SecretSlot = {
   name: string;
@@ -39,6 +28,8 @@ export type TailscaleAuthStatusUI = {
   disconnect_url: string;
 };
 
+// Each credential carries one secret. The connection state lives
+// directly on the row; multi-tenant per-owner fan-out was removed.
 export type Integration = {
   id: string;
   name: string;
@@ -46,10 +37,10 @@ export type Integration = {
   has_oauth: boolean;
   oauth?: OAuthIntegrationUI | null;
   slots?: SecretSlot[] | null;
-  owners: Owner[] | null;
-  // Tailscale node-auth credentials surface their live state and the
-  // dashboard-relative endpoints the Connect button drives through.
-  // Node identity is gateway-wide, so owners is empty for these rows.
+  connected: boolean;
+  expires_at?: number;
+  display_name?: string;
+  avatar_url?: string;
   has_tailscale_auth?: boolean;
   tailscale_auth?: TailscaleAuthStatusUI | null;
 };
@@ -78,24 +69,20 @@ export async function tailscaleDisconnect(disconnectURL: string): Promise<void> 
   if (!r.ok) throw new Error(await r.text());
 }
 
-export async function setCredentialSlots(
-  id: string,
-  owner: string,
-  slots: Record<string, string>,
-): Promise<void> {
+export async function setCredentialSlots(id: string, slots: Record<string, string>): Promise<void> {
   const r = await fetch("/api/credentials/set", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id, owner, slots }),
+    body: JSON.stringify({ id, slots }),
   });
   if (!r.ok) throw new Error(await r.text());
 }
 
-export async function clearCredential(id: string, owner: string): Promise<void> {
+export async function clearCredential(id: string): Promise<void> {
   const r = await fetch("/api/credentials/clear", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id, owner }),
+    body: JSON.stringify({ id }),
   });
   if (!r.ok) throw new Error(await r.text());
 }
@@ -386,24 +373,18 @@ export async function getState(): Promise<StateResp> {
 }
 
 export type OAuthStartResp =
-  | { flow?: "auth_code"; auth_url: string; state: string; owner: string }
+  | { flow?: "auth_code"; auth_url: string; state: string }
   | {
       flow: "device";
       user_code: string;
       verification_uri: string;
       state: string;
-      owner: string;
       interval: number;
       expires_in: number;
     };
 
-export async function oauthStart(
-  id: string,
-  profile?: string,
-  extraScopes?: string[],
-): Promise<OAuthStartResp> {
+export async function oauthStart(id: string, extraScopes?: string[]): Promise<OAuthStartResp> {
   let qs = `id=${encodeURIComponent(id)}`;
-  if (profile) qs += `&profile=${encodeURIComponent(profile)}`;
   if (extraScopes && extraScopes.length > 0) {
     qs += `&extra_scopes=${encodeURIComponent(extraScopes.join(","))}`;
   }
@@ -414,7 +395,6 @@ export async function oauthStart(
 
 export async function oauthDevicePoll(state: string): Promise<{
   connected?: boolean;
-  owner?: string;
   error?: string;
   detail?: string;
   interval?: number;
@@ -426,11 +406,11 @@ export async function oauthDevicePoll(state: string): Promise<{
   return r.json();
 }
 
-export async function oauthRevoke(id: string, owner: string): Promise<void> {
+export async function oauthRevoke(id: string): Promise<void> {
   const r = await api("/api/oauth/revoke", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id, owner }),
+    body: JSON.stringify({ id }),
   });
   if (!r.ok) throw new Error(await r.text());
 }
@@ -527,7 +507,7 @@ export async function getAnalytics(params: {
 export async function oauthExchange(
   state: string,
   code: string,
-): Promise<{ connected: boolean; owner: string; expires: number }> {
+): Promise<{ connected: boolean; expires: number }> {
   const r = await api("/api/oauth/exchange", {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Each credential declared in HCL now maps to exactly one secret.
Operators who want distinct material for different callers declare
two credentials and bind each to its own endpoint, rather than
silently fanning one credential out into N secret rows.

* `migrations/sqlite/0011_credentials_global.sql`: collapse
  `credential_secrets` and `credentials` to one row per credential
  (resp. per credential+slot for the slotted table), keeping the
  most-recently-updated value when multiple profiles existed.
* `runtime.SecretStore.Get(name)`: drop the `owner` arg.
  `EnvSecretStore`, `gatewaySecretStore`, and every plugin call site
  (ssh / postgres / clickhouse / slack / llm-approver / tailscale /
  extplugin adapter) updated. This is a breaking change for external
  plugins built against the old signature.
* `ApproveRequest.Profile` removed; `AgentIP` added in its place for
  HITL display. Slack approval cards and `HITLPending` now key off
  `AgentIP` directly instead of overloading the profile string as
  the agent label.
* `/api/credentials/{set,clear}` and `/api/oauth/{start,exchange,
  revoke,device-poll}` drop the `owner` field from request /
  response bodies.
* `Integration` JSON shape: `connected` / `expires_at` /
  `display_name` / `avatar_url` hoisted onto the row; the `Owners[]`
  fan-out is gone. Dashboard components (`IntegrationsCards`,
  `CredentialSecretsModal`, `ConnectModal`, `AgentsTable`,
  `DevicePage`) simplified accordingly.
* `credentialProfileKeyForRequest` renamed to
  `selectedProfileForRequest` -- its only remaining caller is the
  device-onboarding profile picker, unrelated to credential lookup.
* `doc/tailscale-oauth-credential.md` updated to drop the
  now-incorrect "OAuthRegistry stores per-owner tokens" framing
  that the design memo used to justify a separate
  `TailscaleAuthProvider` primitive; the remaining real differences
  (dynamic vs static URL, no clawpatrol-side token exchange,
  multi-slot ipn.StateStore bundle) carry the argument fine.

`devices.profile` and the rest of the profile concept (endpoint
visibility, rule scoping) are untouched -- only credential
ownership becomes global.

The migration was smoke-tested end-to-end: seeded multi-profile
rows for the same `(credential, slot)` collapse to the row with the
highest `updated_ns`.