### PR TITLE
wireguard: ephemeral peers survive gateway restarts

### DIFF
--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -86,6 +86,21 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "missing pubkey", http.StatusBadRequest)
 		return
 	}
+	// Re-registration after gateway restart: pubkey already has an
+	// ephemeral row (kept across restarts so the WG trie survives).
+	// Skip IP allocation — restore the in-memory profile and return
+	// the existing IP so the client reconnects without re-joining.
+	var existingIP, existingParent string
+	if err := w.g.db.QueryRow(
+		"SELECT ip, parent_ip FROM wg_peers WHERE pubkey=? AND ephemeral=1",
+		pubkeyHex,
+	).Scan(&existingIP, &existingParent); err == nil && existingParent == parentIP {
+		profile := w.g.onboard.ProfileForIP(parentIP)
+		w.g.onboard.setEphemeralProfile(existingIP, parentIP, profile)
+		ip6 := wg6FromV4(netip.MustParseAddr(existingIP)).String()
+		writeJSON(rw, map[string]string{"ip": existingIP, "ip6": ip6})
+		return
+	}
 	ip, err := allocateEphemeralIP(w.ts.WGSubnetCIDR)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)

--- a/wireguard.go
+++ b/wireguard.go
@@ -604,11 +604,22 @@ func (s *WGServer) loadPeers() map[string]string {
 	if s.db == nil {
 		return out
 	}
-	// Ephemeral peers are owned by client processes that exit when the
-	// gateway restarts. Purge them so they don't accumulate in the WG
-	// trie or leak device rows via SetExternalIPs.
-	_, _ = s.db.Exec("DELETE FROM devices WHERE id IN (SELECT ip FROM wg_peers WHERE ephemeral=1)")
-	_, _ = s.db.Exec("DELETE FROM wg_peers WHERE ephemeral=1")
+	// Purge ephemeral peers whose parent device no longer exists — those
+	// are from crashed/killed `clawpatrol run` processes that never sent
+	// DELETE. Ephemeral peers with a live parent_ip survive so a gateway
+	// restart doesn't strand a still-running `clawpatrol run`.
+	_, _ = s.db.Exec(`
+		DELETE FROM devices WHERE id IN (
+			SELECT ip FROM wg_peers
+			WHERE ephemeral=1
+			AND parent_ip NOT IN (SELECT id FROM devices)
+		)
+	`)
+	_, _ = s.db.Exec(`
+		DELETE FROM wg_peers
+		WHERE ephemeral=1
+		AND parent_ip NOT IN (SELECT id FROM devices)
+	`)
 	rows, err := s.db.Query("SELECT pubkey, ip FROM wg_peers")
 	if err != nil {
 		return out


### PR DESCRIPTION
## Problem

`clawpatrol run` on Linux gets an ephemeral WireGuard IP. On gateway restart, `loadPeers()` was purging **all** ephemeral rows from `wg_peers` — stranding any `clawpatrol run` process that outlived the gateway (systemd restart, redeploy, etc.). The process kept running but lost its tunnel.

## Fix

**`wireguard.go`** — replace blanket ephemeral purge with targeted cleanup:
- Only purges ephemeral peers whose `parent_ip` is no longer in `devices` (crashed/killed runs that never sent `DELETE`)
- Live ephemeral peers load back into the WG trie on restart, same as persistent peers

**`ephemeral_peer.go`** — `POST /api/peer/ephemeral` handles re-registration:
- If pubkey already has an ephemeral row with matching `parent_ip`, skips IP allocation
- Restores in-memory profile, returns the same IP
- Client reconnects transparently — no re-join, no IP change

## Behavior after this change

| Scenario | Before | After |
|---|---|---|
| Gateway restart, `clawpatrol run` still alive | Tunnel dead, client stranded | Client re-registers, same IP, tunnel restored |
| `clawpatrol run` crashed without `DELETE` | Cleaned up on next restart | Cleaned up on next restart (orphan check) |
| `clawpatrol run` clean exit (`DELETE`) | Peer removed immediately | Peer removed immediately (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)