### PR TITLE
feat(hitl): message field on human_approver for Slack card templating

### DIFF
--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -46,6 +46,14 @@ type HumanApprover struct {
 	// metadata. Classifier failures are non-fatal — the generic card is
 	// used as fallback.
 	Classifier string `hcl:"classifier,optional"`
+	// Message is an optional Go-template-style string with {{var}}
+	// placeholders. When set, the expanded text replaces the default
+	// section body in the Slack (or other notifier) card. Supported
+	// vars mirror the CEL facet namespace: {{http.method}},
+	// {{http.path}}, {{k8s.verb}}, {{sql.tables}}, {{body_json.ticket}},
+	// {{profile}}, {{endpoint}}, {{reason}}, etc.
+	// Classifier (if also set) still runs; Message takes display precedence.
+	Message string `hcl:"message,optional"`
 }
 
 // HumanApproverChannel + HumanApproverCredential expose the fields
@@ -85,6 +93,10 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 		ent, ok := req.Policy.Credentials[h.Credential]
 		if ok {
 			if notifier, ok := ent.Body.(runtime.HITLNotifier); ok {
+				var msg string
+				if h.Message != "" {
+					msg = expandMessage(h.Message, req)
+				}
 				target := runtime.HITLTarget{
 					CredentialName: h.Credential,
 					Channel:        h.Channel,
@@ -93,6 +105,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					DashboardURL:   req.DashboardURL,
 					ThreadTS:       req.ThreadTS,
 					Summary:        summary,
+					Message:        msg,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {
@@ -161,6 +174,9 @@ func init() {
 			}
 			if a.Classifier != "" {
 				config.SetIdent(b, "classifier", a.Classifier)
+			}
+			if a.Message != "" {
+				b.SetAttributeValue("message", cty.StringVal(a.Message))
 			}
 		},
 	})

--- a/config/plugins/approvers/template.go
+++ b/config/plugins/approvers/template.go
@@ -1,0 +1,114 @@
+package approvers
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/denoland/clawpatrol/config/facet"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// templateVarRe matches {{var}} placeholders, capturing the var name.
+var templateVarRe = regexp.MustCompile(`\{\{([^{}]+)\}\}`)
+
+// expandMessage substitutes {{var}} placeholders in tmpl using fields
+// from req. Supported vars:
+//
+//   - Common (no prefix): profile, host, endpoint, reason, body, method, path
+//   - Facet-prefixed (mirror CEL namespace):
+//     http.method, http.path
+//     k8s.verb, k8s.resource, k8s.namespace, k8s.name
+//     sql.verb, sql.tables, sql.functions, sql.statement
+//   - JSON body access: body_json.<field> or body_json.<a>.<b>...
+//
+// Unknown vars are left as-is. Expansions are not recursed.
+func expandMessage(tmpl string, req runtime.ApproveRequest) string {
+	vars := buildTemplateVars(req)
+	return templateVarRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		key := strings.TrimSpace(m[2 : len(m)-2])
+		if v, ok := vars[key]; ok {
+			return v
+		}
+		return m
+	})
+}
+
+func buildTemplateVars(req runtime.ApproveRequest) map[string]string {
+	vars := map[string]string{
+		"profile":  req.Profile,
+		"host":     req.Host,
+		"endpoint": runtime.HITLEndpointLabel(req),
+		"reason":   req.Reason,
+		"body":     req.BodySample,
+		"method":   req.Method,
+		"path":     req.Path,
+	}
+
+	// Facet-specific fields under the facet's own namespace prefix.
+	if req.Endpoint != nil && req.Request != nil {
+		if f := facet.Lookup(req.Endpoint.Family); f != nil {
+			prefix := f.Name() + "."
+			for k, v := range f.Report(req.Request) {
+				vars[prefix+k] = stringify(v)
+				// Also expose without prefix when it doesn't collide.
+				if _, exists := vars[k]; !exists {
+					vars[k] = stringify(v)
+				}
+			}
+		}
+	}
+
+	// JSON body fields under body_json.<path>.
+	var bodyRaw []byte
+	if req.Request != nil {
+		bodyRaw = req.Request.Body
+	}
+	if len(bodyRaw) > 0 {
+		var bodyMap map[string]any
+		if json.Unmarshal(bodyRaw, &bodyMap) == nil {
+			addJSONVars(vars, "body_json", bodyMap, 3)
+		}
+	}
+
+	return vars
+}
+
+// addJSONVars flattens a JSON object into dot-path vars under prefix,
+// up to maxDepth levels deep to avoid infinite recursion on cycles.
+func addJSONVars(vars map[string]string, prefix string, m map[string]any, maxDepth int) {
+	if maxDepth == 0 {
+		return
+	}
+	for k, v := range m {
+		key := prefix + "." + k
+		switch val := v.(type) {
+		case map[string]any:
+			vars[key] = "" // intermediate node — empty string
+			addJSONVars(vars, key, val, maxDepth-1)
+		default:
+			vars[key] = stringify(v)
+		}
+	}
+}
+
+func stringify(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case []string:
+		return strings.Join(val, ", ")
+	case []any:
+		parts := make([]string, 0, len(val))
+		for _, item := range val {
+			parts = append(parts, fmt.Sprintf("%v", item))
+		}
+		return strings.Join(parts, ", ")
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -125,7 +125,14 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 
 	title := slackTrunc(runtime.HITLTitle(req.Method, endpoint), 140)
 	var blocks []map[string]any
-	if s := target.Summary; s != nil {
+	switch {
+	case target.Message != "":
+		blocks = []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
+			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": slackTrunc(target.Message, 3000)}},
+		}
+	case target.Summary != nil:
+		s := target.Summary
 		headerText := s.TicketID
 		if headerText == "" {
 			headerText = title
@@ -140,7 +147,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 			{"type": "header", "text": map[string]any{"type": "plain_text", "text": slackTrunc(headerText, 140)}},
 			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": sectionText}},
 		}
-	} else {
+	default:
 		blocks = []map[string]any{
 			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
 			{"type": "section", "text": map[string]any{

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -264,6 +264,10 @@ type HITLTarget struct {
 	// Summary is an optional pre-computed classification. When non-nil,
 	// notifiers render a richer card instead of the generic method/path display.
 	Summary *HITLSummary
+	// Message is an optional pre-expanded template string. When non-empty,
+	// notifiers use it as the section text, overriding the default path
+	// display and the Summary card.
+	Message string
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.

--- a/config/testdata/feature_example.want.json
+++ b/config/testdata/feature_example.want.json
@@ -17,7 +17,8 @@
           "Timeout": 600,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       }

--- a/config/testdata/feature_minimal.want.json
+++ b/config/testdata/feature_minimal.want.json
@@ -10,7 +10,8 @@
           "Timeout": 600,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       }

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -12,7 +12,8 @@
           "Timeout": 0,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       },
@@ -23,7 +24,8 @@
           "Timeout": 0,
           "RequireApprovers": 2,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       },
@@ -34,7 +36,8 @@
           "Timeout": 0,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       },
@@ -53,7 +56,8 @@
           "Timeout": 0,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       },
@@ -64,7 +68,8 @@
           "Timeout": 0,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       },
@@ -99,7 +104,8 @@
           "Timeout": 0,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       },
@@ -118,7 +124,8 @@
           "Timeout": 86400,
           "RequireApprovers": 0,
           "Interactive": false,
-          "Classifier": ""
+          "Classifier": "",
+          "Message": ""
         },
         "type": "human_approver"
       }

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -111,6 +111,7 @@ operator clicks approve/deny on the dashboard).
 | `require_approvers` | `int` | no |  |
 | `interactive` | `bool` | no | Toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
 | `classifier` | `ref(approver)` | no | Optionally references an llm_approver by name. When set, the approver calls the classifier's Summarize method before posting the HITL notification, enriching the Slack card with classification metadata. Classifier failures are non-fatal — the generic card is used as fallback. |
+| `message` | `string` | no | An optional Go-template-style string with {{var}} placeholders. When set, the expanded text replaces the default section body in the Slack (or other notifier) card. Supported vars mirror the CEL facet namespace: {{http.method}}, {{http.path}}, {{k8s.verb}}, {{sql.tables}}, {{body_json.ticket}}, {{profile}}, {{endpoint}}, {{reason}}, etc. Classifier (if also set) still runs; Message takes display precedence. |
 
 ```hcl
 approver "human_approver" "example" {


### PR DESCRIPTION
## Summary

- Add `message string` (HCL `message,optional`) to `HumanApprover`
- New `config/plugins/approvers/template.go`: regexp-based `{{var}}` expansion engine
- Add `Message string` to `HITLTarget` in `config/runtime/runtime.go`
- `slack.go` `NotifyHITL`: when `target.Message != ""` use it as section text (highest priority, overrides `Summary` card and default path display)

## Template var namespace (mirrors CEL)

| Var | Value |
|---|---|
| `{{profile}}` | agent profile name |
| `{{host}}` | destination host |
| `{{endpoint}}` | endpoint label |
| `{{reason}}` | rule reason string |
| `{{body}}` | body sample (truncated) |
| `{{method}}` / `{{http.method}}` | HTTP method |
| `{{path}}` / `{{http.path}}` | HTTP path |
| `{{k8s.verb}}` | k8s verb |
| `{{k8s.resource}}` | k8s resource |
| `{{k8s.namespace}}` | k8s namespace |
| `{{k8s.name}}` | k8s object name |
| `{{sql.verb}}` | SQL verb |
| `{{sql.tables}}` | SQL tables (comma-separated) |
| `{{sql.statement}}` | full SQL statement |
| `{{body_json.<field>}}` | JSON body field (dot-path, up to 3 levels) |

## Example

```hcl
approver "human_approver" "support-ops" {
  channel     = "#agent-support"
  credential  = slack
  interactive = true
  message     = ":ticket: *{{body_json.ticket}}* — `{{http.method}} {{http.path}}`\nAgent: {{profile}}"
}
```

## Notes

- Unknown `{{vars}}` are left as-is (no silent empty expansion)
- `classifier` still runs when both are set; `message` only overrides the Slack section text
- Facet fields added via `facet.Report()` so new facets get template support automatically

## Test plan

- [x] `go build ./...` passes
- [x] `gofmt -l` → empty
- [ ] Gateway starts with `message` field in HCL
- [ ] Slack card shows expanded message text as section body
- [ ] Unknown `{{vars}}` preserved in output
- [ ] `body_json.nested.field` resolves correctly for multi-level JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)