### PR TITLE
Show credential identifiers in dashboard metadata

### DIFF
--- a/www/src/components/CredentialSecretsModal.tsx
+++ b/www/src/components/CredentialSecretsModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Integration } from "../lib/api";
 import { setCredentialSlots } from "../lib/api";
+import { credentialTypeLabel } from "../lib/credentialLabels";
 
 // Modal that renders one input per declared SecretSlot for a non-OAuth
 // credential. Single-slot credentials (bearer / header / cookie / api
@@ -22,6 +23,7 @@ export function CredentialSecretsModal({
   onSaved: () => void;
 }) {
   const slots = integration.slots ?? [];
+  const label = credentialTypeLabel(integration.type, integration.name);
   const [values, setValues] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -54,8 +56,13 @@ export function CredentialSecretsModal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
-          <div className="text-[14px] font-semibold text-[#171717]">
-            {mode === "update" ? "Update" : "Connect"} {integration.name}
+          <div>
+            <div className="text-[14px] font-semibold text-[#171717]">
+              {mode === "update" ? "Update" : "Connect"} {label}
+            </div>
+            <div className="text-[11px] text-[#737373]">
+              <span className="font-mono">{integration.id}</span>
+            </div>
           </div>
           <button
             onClick={onClose}
@@ -71,6 +78,16 @@ export function CredentialSecretsModal({
               untouched slots blank to keep them unchanged.
             </p>
           )}
+          <dl className="grid grid-cols-[auto,minmax(0,1fr)] gap-x-3 gap-y-1 rounded border border-[#e5e5e5] bg-[#fafafa] px-3 py-2 text-[11px]">
+            <dt className="text-[#737373]">Credential</dt>
+            <dd className="min-w-0 truncate font-mono text-[#171717]" title={integration.id}>
+              {integration.id}
+            </dd>
+            <dt className="text-[#737373]">Type</dt>
+            <dd className="min-w-0 truncate text-[#171717]" title={integration.type}>
+              {label} <span className="font-mono text-[#737373]">({integration.type})</span>
+            </dd>
+          </dl>
           {slots.map((s) => (
             <label key={s.name} className="flex flex-col gap-1">
               <span className="text-[11px] uppercase tracking-[.08em] text-[#737373]">

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -1,33 +1,16 @@
 import * as React from "react";
 import { useState } from "react";
 import type { Integration } from "../lib/api";
-import { fmtExpiry } from "../lib/format";
-import { IntegrationIcon } from "./Logos";
 import { clearCredential, oauthRevoke, tailscaleConnect, tailscaleDisconnect } from "../lib/api";
+import { credentialTypeLabel } from "../lib/credentialLabels";
+import { fmtExpiry } from "../lib/format";
 import { CredentialSecretsModal } from "./CredentialSecretsModal";
+import { IntegrationIcon } from "./Logos";
 
-// Display name by credential plugin type. Bare credential names
-// often look like "pg-writer-cred" — useful as identifier, not as a
-// label. The type maps to the recognizable brand / protocol; the
-// bare name shows up as a subtitle so operators can still tell two
-// "Postgres" cards apart.
-const TYPE_LABEL: Record<string, string> = {
-  anthropic_oauth_subscription: "Claude",
-  anthropic_manual_key: "Claude (API key)",
-  openai_codex_oauth: "Codex",
-  github_oauth: "GitHub",
-  notion_oauth: "Notion",
-  postgres_credential: "Postgres",
-  clickhouse_credential: "ClickHouse",
-  mtls_credential: "mTLS",
-  slack_tokens: "Slack",
-  telegram_bot_token: "Telegram",
-  gemini_api_key: "Gemini",
-  aws_eks_credential: "AWS EKS",
-  bearer_token: "Bearer token",
-  header_token: "Header token",
-  cookie_token: "Cookie token",
-};
+// Bare credential names often look like "pg-writer-cred" — useful as
+// identifiers, not as labels. The type maps to the recognizable brand /
+// protocol; the bare name is always rendered as metadata so operators
+// can still tell two same-type cards apart.
 
 // Cap on visible cards before the overflow button appears. The N-th
 // slot is replaced by "+ K more" so the row width stays predictable
@@ -199,7 +182,7 @@ function Card({
   const connected = isConnected(i);
   const hasSlots = (i.slots?.length ?? 0) > 0;
   const clickable = i.has_oauth || hasSlots || (i.has_tailscale_auth && !connected);
-  const subtitle = connected
+  const status = connected
     ? i.expires_at
       ? "expires " + fmtExpiry(i.expires_at)
       : "connected"
@@ -208,6 +191,8 @@ function Card({
       : hasSlots
         ? "paste secret"
         : "api key only";
+  const label = credentialTypeLabel(i.type, i.name);
+  const title = [label, `credential: ${i.id}`, `type: ${i.type}`, status].join("\n");
   return (
     <button
       disabled={!clickable && !connected}
@@ -228,14 +213,8 @@ function Card({
         ) : (
           <IntegrationIcon id={i.id} type={i.type} className="w-[16px] h-[16px] flex-shrink-0" />
         )}
-        <span
-          className="text-[12px] font-semibold text-[#171717] truncate"
-          title={i.display_name ?? i.id}
-        >
-          {(() => {
-            const label = TYPE_LABEL[i.type] ?? i.name;
-            return i.display_name ? `${label} (${i.display_name})` : label;
-          })()}
+        <span className="text-[12px] font-semibold text-[#171717] truncate" title={title}>
+          {i.display_name ? `${label} (${i.display_name})` : label}
         </span>
         <span className="ml-auto flex items-center gap-1.5 flex-shrink-0">
           {connected && (
@@ -257,16 +236,13 @@ function Card({
           />
         </span>
       </div>
-      <div className="text-[10px] text-[#737373] tabular-nums w-full truncate" title={i.id}>
-        {/* Connected → show expiry / "connected". Otherwise show the
-            bare credential name so two same-type cards (pg-writer +
-            pg-readonly) are distinguishable; falls back to the status
-            text when type and name match (claude / codex / github). */}
-        {connected
-          ? subtitle
-          : TYPE_LABEL[i.type] && i.id !== (TYPE_LABEL[i.type] ?? "").toLowerCase()
-            ? i.id
-            : subtitle}
+      <div className="w-full min-w-0 space-y-0.5">
+        <div className="text-[10px] text-[#737373] tabular-nums truncate" title={i.id}>
+          <span className="font-mono">{i.id}</span>
+        </div>
+        <div className="text-[10px] text-[#a3a3a3] tabular-nums truncate" title={status}>
+          {status}
+        </div>
       </div>
     </button>
   );

--- a/www/src/lib/credentialLabels.ts
+++ b/www/src/lib/credentialLabels.ts
@@ -1,0 +1,21 @@
+export const CREDENTIAL_TYPE_LABEL: Record<string, string> = {
+  anthropic_oauth_subscription: "Claude",
+  anthropic_manual_key: "Claude (API key)",
+  openai_codex_oauth: "Codex",
+  github_oauth: "GitHub",
+  notion_oauth: "Notion",
+  postgres_credential: "Postgres",
+  clickhouse_credential: "ClickHouse",
+  mtls_credential: "mTLS",
+  slack_tokens: "Slack",
+  telegram_bot_token: "Telegram",
+  gemini_api_key: "Gemini",
+  aws_eks_credential: "AWS EKS",
+  bearer_token: "Bearer token",
+  header_token: "Header token",
+  cookie_token: "Cookie token",
+};
+
+export function credentialTypeLabel(type: string, fallback: string): string {
+  return CREDENTIAL_TYPE_LABEL[type] ?? fallback;
+}


### PR DESCRIPTION
## Summary
- Always render the bare credential ID on integration cards so same-type credentials are distinguishable
- Show credential metadata in the secret modal: credential ID, plugin type, and profile
- Share credential type labels between cards and the modal

Stacked on #336, which makes non-OAuth credentials updateable after they are set.

## Test plan
- `cd www && npm ci`
- `cd www && npm run format:check`
- `cd www && npm run lint:github`
- `cd www && npm run build`
