### PR TITLE
wg_endpoint: optional, derive client dial from public_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
 oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
 tailscale_tags      = ["tag:client"]
 
-# wireguard-only:
-wg_subnet_cidr = "10.55.0.0/24"
+# wireguard mode has no required fields beyond control = "wireguard";
+# wg_subnet_cidr (default 10.55.0.0/24) and wg_endpoint
+# (default 0.0.0.0:51820) are optional overrides.
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
 oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
 tailscale_tags      = ["tag:client"]
 
-# wireguard mode has no required fields beyond control = "wireguard";
-# wg_subnet_cidr (default 10.55.0.0/24) and wg_endpoint
-# (default 0.0.0.0:51820) are optional overrides.
+# wireguard-only:
+wg_subnet_cidr = "10.55.0.0/24"
 ```

--- a/README.md
+++ b/README.md
@@ -136,6 +136,5 @@ oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
 tailscale_tags      = ["tag:client"]
 
 # wireguard-only:
-wg_endpoint    = "gw.example.com:51820"
 wg_subnet_cidr = "10.55.0.0/24"
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -398,13 +398,6 @@ func validateOperational(gw *Gateway) hcl.Diagnostics {
 	}
 
 	if strings.EqualFold(gw.Control, "wireguard") {
-		if gw.WGSubnetCIDR == "" {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing wg_subnet_cidr",
-				Detail:   "control = \"wireguard\" requires wg_subnet_cidr (e.g. \"10.55.0.0/24\").",
-			})
-		}
 		// Clients dial host(public_url):port(wg_endpoint). Need a host
 		// from somewhere. wg_endpoint with a non-wildcard host is the
 		// escape hatch when public_url isn't reachable from clients

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,6 +110,10 @@ type JoinConfig struct {
 	WGEndpoint        string
 	WGServerPub       string
 	WGSubnetCIDR      string
+	// PublicURL is the operator-facing gateway URL. The WG onboarder
+	// uses its host as the default client dial target when
+	// WGEndpoint's host portion is wildcard / unset.
+	PublicURL string
 }
 
 // Join returns the join-related fields as a JoinConfig value bundle.
@@ -127,6 +132,7 @@ func (g *Gateway) Join() JoinConfig {
 		WGEndpoint:        g.WGEndpoint,
 		WGServerPub:       g.WGServerPub,
 		WGSubnetCIDR:      g.WGSubnetCIDR,
+		PublicURL:         g.PublicURL,
 	}
 }
 
@@ -399,11 +405,15 @@ func validateOperational(gw *Gateway) hcl.Diagnostics {
 				Detail:   "control = \"wireguard\" requires wg_subnet_cidr (e.g. \"10.55.0.0/24\").",
 			})
 		}
-		if gw.WGEndpoint == "" {
+		// Clients dial host(public_url):port(wg_endpoint). Need a host
+		// from somewhere. wg_endpoint with a non-wildcard host is the
+		// escape hatch when public_url isn't reachable from clients
+		// (split-host deployments).
+		if !hasWGDialTarget(gw.PublicURL, gw.WGEndpoint) {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Missing wg_endpoint",
-				Detail:   "control = \"wireguard\" requires wg_endpoint (e.g. \"gw.example.com:51820\") so onboarded clients know where to dial.",
+				Summary:  "WireGuard client dial target not configured",
+				Detail:   "set public_url, or set wg_endpoint to a non-wildcard host:port (e.g. \"gw.example.com:51820\") — onboarded clients need one of these to know where to dial.",
 			})
 		}
 	}
@@ -417,6 +427,24 @@ func validateOperational(gw *Gateway) hcl.Diagnostics {
 	}
 
 	return diags
+}
+
+// hasWGDialTarget reports whether the config provides a host clients
+// can dial for WireGuard. Either public_url is set (we use its host),
+// or wg_endpoint pins a non-wildcard host (the split-host escape
+// hatch).
+func hasWGDialTarget(publicURL, wgEndpoint string) bool {
+	if publicURL != "" {
+		return true
+	}
+	if wgEndpoint == "" {
+		return false
+	}
+	h, _, err := net.SplitHostPort(wgEndpoint)
+	if err != nil {
+		return false
+	}
+	return h != "" && h != "0.0.0.0" && h != "::"
 }
 
 // extractPolicyBlocks pulls every recognized top-level block out of

--- a/config/config.go
+++ b/config/config.go
@@ -398,6 +398,13 @@ func validateOperational(gw *Gateway) hcl.Diagnostics {
 	}
 
 	if strings.EqualFold(gw.Control, "wireguard") {
+		if gw.WGSubnetCIDR == "" {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing wg_subnet_cidr",
+				Detail:   "control = \"wireguard\" requires wg_subnet_cidr (e.g. \"10.55.0.0/24\").",
+			})
+		}
 		// Clients dial host(public_url):port(wg_endpoint). Need a host
 		// from somewhere. wg_endpoint with a non-wildcard host is the
 		// escape hatch when public_url isn't reachable from clients

--- a/config/testdata/error_wireguard_missing_fields.errors.txt
+++ b/config/testdata/error_wireguard_missing_fields.errors.txt
@@ -1,2 +1,1 @@
-error: Missing wg_subnet_cidr — control = "wireguard" requires wg_subnet_cidr (e.g. "10.55.0.0/24").
 error: WireGuard client dial target not configured — set public_url, or set wg_endpoint to a non-wildcard host:port (e.g. "gw.example.com:51820") — onboarded clients need one of these to know where to dial.

--- a/config/testdata/error_wireguard_missing_fields.errors.txt
+++ b/config/testdata/error_wireguard_missing_fields.errors.txt
@@ -1,2 +1,2 @@
 error: Missing wg_subnet_cidr — control = "wireguard" requires wg_subnet_cidr (e.g. "10.55.0.0/24").
-error: Missing wg_endpoint — control = "wireguard" requires wg_endpoint (e.g. "gw.example.com:51820") so onboarded clients know where to dial.
+error: WireGuard client dial target not configured — set public_url, or set wg_endpoint to a non-wildcard host:port (e.g. "gw.example.com:51820") — onboarded clients need one of these to know where to dial.

--- a/config/testdata/error_wireguard_missing_fields.errors.txt
+++ b/config/testdata/error_wireguard_missing_fields.errors.txt
@@ -1,1 +1,2 @@
+error: Missing wg_subnet_cidr — control = "wireguard" requires wg_subnet_cidr (e.g. "10.55.0.0/24").
 error: WireGuard client dial target not configured — set public_url, or set wg_endpoint to a non-wildcard host:port (e.g. "gw.example.com:51820") — onboarded clients need one of these to know where to dial.

--- a/config/testdata/error_wireguard_missing_fields.hcl
+++ b/config/testdata/error_wireguard_missing_fields.hcl
@@ -1,5 +1,6 @@
-# control = "wireguard" requires wg_subnet_cidr and wg_endpoint.
-# Without them StartWGServer log.Fatals at boot (subnet) or onboarding
+# control = "wireguard" requires wg_subnet_cidr, plus a client dial
+# target (either public_url or wg_endpoint with a non-wildcard host).
+# Without them StartWGServer fails at boot (subnet) or onboarding
 # clients dial an unknown endpoint.
 
 listen = "0.0.0.0:8443"

--- a/config/testdata/error_wireguard_missing_fields.hcl
+++ b/config/testdata/error_wireguard_missing_fields.hcl
@@ -1,7 +1,7 @@
-# control = "wireguard" requires a client dial target — either
-# public_url, or wg_endpoint with a non-wildcard host. wg_subnet_cidr
-# and wg_endpoint are otherwise optional (defaults 10.55.0.0/24 and
-# 0.0.0.0:51820).
+# control = "wireguard" requires wg_subnet_cidr, plus a client dial
+# target (either public_url or wg_endpoint with a non-wildcard host).
+# Without them StartWGServer fails at boot (subnet) or onboarding
+# clients dial an unknown endpoint.
 
 listen = "0.0.0.0:8443"
 

--- a/config/testdata/error_wireguard_missing_fields.hcl
+++ b/config/testdata/error_wireguard_missing_fields.hcl
@@ -1,7 +1,7 @@
-# control = "wireguard" requires wg_subnet_cidr, plus a client dial
-# target (either public_url or wg_endpoint with a non-wildcard host).
-# Without them StartWGServer fails at boot (subnet) or onboarding
-# clients dial an unknown endpoint.
+# control = "wireguard" requires a client dial target — either
+# public_url, or wg_endpoint with a non-wildcard host. wg_subnet_cidr
+# and wg_endpoint are otherwise optional (defaults 10.55.0.0/24 and
+# 0.0.0.0:51820).
 
 listen = "0.0.0.0:8443"
 

--- a/config/testdata/feature_example.hcl
+++ b/config/testdata/feature_example.hcl
@@ -37,7 +37,7 @@ state_dir        = "/opt/clawpatrol/oauth"
 dashboard_secret = "test-secret"
 
 control        = "wireguard"
-wg_endpoint    = "66.42.120.196:51820"
+wg_endpoint    = "0.0.0.0:51820"
 wg_subnet_cidr = "10.55.0.0/24"
 
 # ── policy --------------------------------------------------------------

--- a/config/testdata/feature_example.want.json
+++ b/config/testdata/feature_example.want.json
@@ -82,6 +82,6 @@
   "public_url": "http://66.42.120.196:8080",
   "state_dir": "/opt/clawpatrol/oauth",
   "unknown_host": "passthrough",
-  "wg_endpoint": "66.42.120.196:51820",
+  "wg_endpoint": "0.0.0.0:51820",
   "wg_subnet_cidr": "10.55.0.0/24"
 }

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -84,7 +84,6 @@ integrations = ["claude", "codex", "github"]
 
 tailscale {
   control        = "wireguard"
-  wg_endpoint    = "your-gw.example.com:51820"
   wg_subnet_cidr = "10.55.0.0/24"
 }
 EOF

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -83,8 +83,7 @@ state_dir    = "/opt/clawpatrol/state"
 integrations = ["claude", "codex", "github"]
 
 tailscale {
-  control        = "wireguard"
-  wg_subnet_cidr = "10.55.0.0/24"
+  control = "wireguard"
 }
 EOF
 

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -83,7 +83,8 @@ state_dir    = "/opt/clawpatrol/state"
 integrations = ["claude", "codex", "github"]
 
 tailscale {
-  control = "wireguard"
+  control        = "wireguard"
+  wg_subnet_cidr = "10.55.0.0/24"
 }
 EOF
 

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -44,18 +44,16 @@ state_dir   = "/opt/clawpatrol/state"
 #                                               # dashboard URL gets in
 dashboard_secret = "change-me-to-a-long-random-string"
 
-control = "wireguard"
+control        = "wireguard"
+wg_subnet_cidr = "10.55.0.0/24"
 
-# Optional WireGuard knobs (defaults shown):
-#
-#   wg_subnet_cidr = "10.55.0.0/24"  # /24 the gateway carves /32s
-#                                    # from for each onboarded peer
-#   wg_endpoint    = "0.0.0.0:51820" # listen address + port. Clients
-#                                    # dial host(public_url):port.
-#                                    # Pin a non-wildcard host for
-#                                    # split-host deployments
-#                                    # (wg.example.com:51820), or
-#                                    # change the port (":41820").
+# wg_endpoint is optional. Server-side it's listen address + port
+# (default 0.0.0.0:51820). Clients dial `host(public_url):port`, so
+# you only set wg_endpoint when you need a different host for WG
+# than for the dashboard (split-host deployments) or a non-default
+# port. Examples:
+#   wg_endpoint = ":41820"            # default host, custom port
+#   wg_endpoint = "wg.example.com:51820"   # WG host != dashboard host
 
 # ── policy defaults ---------------------------------------------------
 

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -44,16 +44,18 @@ state_dir   = "/opt/clawpatrol/state"
 #                                               # dashboard URL gets in
 dashboard_secret = "change-me-to-a-long-random-string"
 
-control        = "wireguard"
-wg_subnet_cidr = "10.55.0.0/24"
+control = "wireguard"
 
-# wg_endpoint is optional. Server-side it's listen address + port
-# (default 0.0.0.0:51820). Clients dial `host(public_url):port`, so
-# you only set wg_endpoint when you need a different host for WG
-# than for the dashboard (split-host deployments) or a non-default
-# port. Examples:
-#   wg_endpoint = ":41820"            # default host, custom port
-#   wg_endpoint = "wg.example.com:51820"   # WG host != dashboard host
+# Optional WireGuard knobs (defaults shown):
+#
+#   wg_subnet_cidr = "10.55.0.0/24"  # /24 the gateway carves /32s
+#                                    # from for each onboarded peer
+#   wg_endpoint    = "0.0.0.0:51820" # listen address + port. Clients
+#                                    # dial host(public_url):port.
+#                                    # Pin a non-wildcard host for
+#                                    # split-host deployments
+#                                    # (wg.example.com:51820), or
+#                                    # change the port (":41820").
 
 # ── policy defaults ---------------------------------------------------
 

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -45,8 +45,15 @@ state_dir   = "/opt/clawpatrol/state"
 dashboard_secret = "change-me-to-a-long-random-string"
 
 control        = "wireguard"
-wg_endpoint    = "gw.example.com:51820"
 wg_subnet_cidr = "10.55.0.0/24"
+
+# wg_endpoint is optional. Server-side it's listen address + port
+# (default 0.0.0.0:51820). Clients dial `host(public_url):port`, so
+# you only set wg_endpoint when you need a different host for WG
+# than for the dashboard (split-host deployments) or a non-default
+# port. Examples:
+#   wg_endpoint = ":41820"            # default host, custom port
+#   wg_endpoint = "wg.example.com:51820"   # WG host != dashboard host
 
 # ── policy defaults ---------------------------------------------------
 

--- a/main.go
+++ b/main.go
@@ -2193,9 +2193,11 @@ func canonicalPeerIP(ip string) string {
 	return v4.String()
 }
 
-// defaultWGV4Prefix matches the example config's wg_subnet_cidr
-// (10.55.0.0/24). Lets canonicalPeerIP work before the WGServer is
-// up.
+// defaultWGSubnetCIDR is the WireGuard peer subnet used when
+// wg_subnet_cidr is unset. defaultWGV4Prefix is the same /24
+// prefix in [3]byte form for canonicalPeerIP's early-boot path.
+const defaultWGSubnetCIDR = "10.55.0.0/24"
+
 var defaultWGV4Prefix = [3]byte{10, 55, 0}
 
 func printVersion() {

--- a/main.go
+++ b/main.go
@@ -2193,11 +2193,9 @@ func canonicalPeerIP(ip string) string {
 	return v4.String()
 }
 
-// defaultWGSubnetCIDR is the WireGuard peer subnet used when
-// wg_subnet_cidr is unset. defaultWGV4Prefix is the same /24
-// prefix in [3]byte form for canonicalPeerIP's early-boot path.
-const defaultWGSubnetCIDR = "10.55.0.0/24"
-
+// defaultWGV4Prefix matches the example config's wg_subnet_cidr
+// (10.55.0.0/24). Lets canonicalPeerIP work before the WGServer is
+// up.
 var defaultWGV4Prefix = [3]byte{10, 55, 0}
 
 func printVersion() {

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -37,8 +37,7 @@ admin_email      = "you@example.com"
 dashboard_secret = "<long random string>"
 state_dir        = "/opt/clawpatrol/state"
 
-control        = "wireguard"
-wg_subnet_cidr = "10.55.0.0/24"
+control = "wireguard"
 ```
 
 The CA is lazy-minted into sqlite under `state_dir` on first boot —

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -38,7 +38,6 @@ dashboard_secret = "<long random string>"
 state_dir        = "/opt/clawpatrol/state"
 
 control        = "wireguard"
-wg_endpoint    = "gw.example.com:51820"
 wg_subnet_cidr = "10.55.0.0/24"
 ```
 

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -37,7 +37,8 @@ admin_email      = "you@example.com"
 dashboard_secret = "<long random string>"
 state_dir        = "/opt/clawpatrol/state"
 
-control = "wireguard"
+control        = "wireguard"
+wg_subnet_cidr = "10.55.0.0/24"
 ```
 
 The CA is lazy-minted into sqlite under `state_dir` on first boot —

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -65,7 +65,8 @@ are bare (`credential = github-pat`, never `credential.github-pat`).
 admin_email      = "you@example.com"
 dashboard_secret = "change-me-long-random"
 
-control = "wireguard"
+control        = "wireguard"
+wg_subnet_cidr = "10.55.0.0/24"
 
 credential "bearer_token" "github-pat" {}
 
@@ -101,7 +102,7 @@ profile "default" { endpoints = [github] }
 | `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |
 | `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol/state`. |
 | `control` | `"wireguard"` or `"tailscale"`. |
-| `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet (both optional; defaults `0.0.0.0:51820` and `10.55.0.0/24`). |
+| `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet. |
 | `unknown_host` | `"passthrough"` (default) or `"deny"` for traffic no endpoint claims. |
 
 Full list: [Config reference](/docs/config-reference/#top-level-fields).

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -66,7 +66,6 @@ admin_email      = "you@example.com"
 dashboard_secret = "change-me-long-random"
 
 control        = "wireguard"
-wg_endpoint    = "1.2.3.4:51820"
 wg_subnet_cidr = "10.55.0.0/24"
 
 credential "bearer_token" "github-pat" {}

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -65,8 +65,7 @@ are bare (`credential = github-pat`, never `credential.github-pat`).
 admin_email      = "you@example.com"
 dashboard_secret = "change-me-long-random"
 
-control        = "wireguard"
-wg_subnet_cidr = "10.55.0.0/24"
+control = "wireguard"
 
 credential "bearer_token" "github-pat" {}
 
@@ -102,7 +101,7 @@ profile "default" { endpoints = [github] }
 | `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |
 | `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol/state`. |
 | `control` | `"wireguard"` or `"tailscale"`. |
-| `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet. |
+| `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet (both optional; defaults `0.0.0.0:51820` and `10.55.0.0/24`). |
 | `unknown_host` | `"passthrough"` (default) or `"deny"` for traffic no endpoint claims. |
 
 Full list: [Config reference](/docs/config-reference/#top-level-fields).

--- a/wireguard.go
+++ b/wireguard.go
@@ -299,7 +299,7 @@ func setDB(d *sql.DB)         { globalDB = d }
 // first boot. Stable across restarts so onboarded peers keep working.
 func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	if ts.WGSubnetCIDR == "" {
-		ts.WGSubnetCIDR = defaultWGSubnetCIDR
+		return nil, fmt.Errorf("wireguard: wg_subnet_cidr required")
 	}
 	listenPort := 51820
 	if ts.WGEndpoint != "" {

--- a/wireguard.go
+++ b/wireguard.go
@@ -299,7 +299,7 @@ func setDB(d *sql.DB)         { globalDB = d }
 // first boot. Stable across restarts so onboarded peers keep working.
 func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	if ts.WGSubnetCIDR == "" {
-		return nil, fmt.Errorf("wireguard: wg_subnet_cidr required")
+		ts.WGSubnetCIDR = defaultWGSubnetCIDR
 	}
 	listenPort := 51820
 	if ts.WGEndpoint != "" {

--- a/wireguard.go
+++ b/wireguard.go
@@ -27,7 +27,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -768,9 +770,62 @@ type wireguardOnboarder struct {
 	mu sync.Mutex
 }
 
+// wgClientEndpoint returns the host:port string clients should put in
+// their WireGuard `Endpoint =` line.
+//
+//   - port: parsed from wgEndpoint, falling back to 51820 when
+//     wgEndpoint is empty or omits a port.
+//   - host: if wgEndpoint specifies a non-wildcard host (anything
+//     other than empty / "0.0.0.0" / "::"), that host wins — the
+//     escape hatch for split-host deployments where the WG listener
+//     and the dashboard are on different IPs. Otherwise host is
+//     parsed from publicURL.
+//
+// Server-side, wgEndpoint's host is reserved for future
+// bind-to-interface support (wireguard-go's DefaultBind doesn't
+// support address-bound listening yet).
+func wgClientEndpoint(wgEndpoint, publicURL string) (string, error) {
+	port := 51820
+	var hostOverride string
+	if wgEndpoint != "" {
+		h, p, err := net.SplitHostPort(wgEndpoint)
+		if err != nil {
+			return "", fmt.Errorf("wg_endpoint %q: %w", wgEndpoint, err)
+		}
+		if p != "" {
+			n, err := strconv.Atoi(p)
+			if err != nil {
+				return "", fmt.Errorf("wg_endpoint port %q: %w", p, err)
+			}
+			port = n
+		}
+		if h != "" && h != "0.0.0.0" && h != "::" {
+			hostOverride = h
+		}
+	}
+	if hostOverride == "" {
+		if publicURL == "" {
+			return "", fmt.Errorf("cannot derive WG client endpoint: set public_url or pin a non-wildcard host in wg_endpoint")
+		}
+		u, err := url.Parse(publicURL)
+		if err != nil {
+			return "", fmt.Errorf("public_url %q: %w", publicURL, err)
+		}
+		hostOverride = u.Hostname()
+		if hostOverride == "" {
+			return "", fmt.Errorf("public_url %q has no host", publicURL)
+		}
+	}
+	return net.JoinHostPort(hostOverride, strconv.Itoa(port)), nil
+}
+
 func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string) (string, string, string, error) {
-	if w.ts.WGEndpoint == "" || w.ts.WGSubnetCIDR == "" {
-		return "", "", "", fmt.Errorf("wireguard not configured (set tailscale.wg_endpoint, wg_subnet_cidr)")
+	if w.ts.WGSubnetCIDR == "" {
+		return "", "", "", fmt.Errorf("wireguard not configured (set wg_subnet_cidr)")
+	}
+	clientEndpoint, err := wgClientEndpoint(w.ts.WGEndpoint, w.ts.PublicURL)
+	if err != nil {
+		return "", "", "", err
 	}
 	if globalWG == nil {
 		return "", "", "", fmt.Errorf("wireguard server not started")
@@ -820,7 +875,7 @@ PublicKey = %s
 Endpoint = %s
 AllowedIPs = 0.0.0.0/0, ::/0
 PersistentKeepalive = 25
-`, clientPrivB64, ip, ip6, serverPubB64, w.ts.WGEndpoint)
+`, clientPrivB64, ip, ip6, serverPubB64, clientEndpoint)
 	return conf, "wireguard://" + w.iface(), ip, nil
 }
 

--- a/wireguard_test.go
+++ b/wireguard_test.go
@@ -1,0 +1,91 @@
+package main
+
+import "testing"
+
+func TestWGClientEndpoint(t *testing.T) {
+	cases := []struct {
+		name      string
+		wgEnd     string
+		publicURL string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "empty wg_endpoint uses public_url host + default port",
+			wgEnd:     "",
+			publicURL: "https://gw.example.com:9080",
+			want:      "gw.example.com:51820",
+		},
+		{
+			name:      "wildcard host + port uses public_url",
+			wgEnd:     "0.0.0.0:51820",
+			publicURL: "https://gw.example.com",
+			want:      "gw.example.com:51820",
+		},
+		{
+			name:      "wildcard host + custom port",
+			wgEnd:     "0.0.0.0:41820",
+			publicURL: "https://gw.example.com",
+			want:      "gw.example.com:41820",
+		},
+		{
+			name:      "port-only form",
+			wgEnd:     ":41820",
+			publicURL: "https://gw.example.com",
+			want:      "gw.example.com:41820",
+		},
+		{
+			name:      "v6 wildcard uses public_url",
+			wgEnd:     "[::]:51820",
+			publicURL: "https://gw.example.com",
+			want:      "gw.example.com:51820",
+		},
+		{
+			name:      "non-wildcard host wins (escape hatch)",
+			wgEnd:     "1.2.3.4:51820",
+			publicURL: "https://dash.example.com",
+			want:      "1.2.3.4:51820",
+		},
+		{
+			name:      "hostname in wg_endpoint wins",
+			wgEnd:     "wg.example.com:51820",
+			publicURL: "https://dash.example.com",
+			want:      "wg.example.com:51820",
+		},
+		{
+			name:      "no public_url and wildcard wg_endpoint errors",
+			wgEnd:     "0.0.0.0:51820",
+			publicURL: "",
+			wantErr:   true,
+		},
+		{
+			name:      "neither set errors",
+			wgEnd:     "",
+			publicURL: "",
+			wantErr:   true,
+		},
+		{
+			name:      "malformed wg_endpoint errors",
+			wgEnd:     "no-port-here",
+			publicURL: "https://gw.example.com",
+			wantErr:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := wgClientEndpoint(tc.wgEnd, tc.publicURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `wg_endpoint` becomes optional (defaults to `0.0.0.0:51820`).
- Client WG conf's `Endpoint =` line now derives from `host(public_url):port` instead of being copied verbatim from `wg_endpoint`.
- Escape hatch: a non-wildcard host in `wg_endpoint` still wins, for split-host deployments where the WG listener and dashboard live on different IPs.
- Validation rewritten: "Missing wg_endpoint" gone; replaced with one check that a dial target exists somewhere (`public_url` set, or `wg_endpoint` has a non-wildcard host).
- Examples + docs drop `wg_endpoint` from the public-facing shapes; `gateway.example.hcl` keeps an inline comment showing the override forms.

## Why

`wg_endpoint` was doing two unrelated jobs in one string. Server-side, only the port portion was read (`wireguard.go:303-307`); the host was silently ignored, which made it look as if "where to listen" was a thing operators controlled when it really wasn't. Client-side, the full `host:port` was baked into per-device WG confs as `Endpoint =`. In every sane deployment the host portion duplicated `public_url`. Two fields, one of them redundant.

Server-side bind-to-interface support is a separate concern — wireguard-go's `DefaultBind` doesn't support address-bound listening out of the box. The host portion of `wg_endpoint` is reserved for that future work; today it's just the client-dial escape hatch.

## What's now in the example

```hcl
control        = "wireguard"
wg_subnet_cidr = "10.55.0.0/24"

# wg_endpoint is optional. Server-side: listen address + port
# (default 0.0.0.0:51820). Clients dial `host(public_url):port`,
# so you only set it for split-host deployments or a non-default
# port:
#   wg_endpoint = ":41820"                  # custom port
#   wg_endpoint = "wg.example.com:51820"    # WG host != dashboard host
```

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./...` passes
- [x] `clawpatrol validate gateway.example.hcl` — 14 endpoints across 4 profiles
- [x] New `TestWGClientEndpoint` covers 10 cases (default port / wildcard / port-only / v6 wildcard / escape hatch / hostname override / missing dial target / malformed)
- [ ] Manual: deploy a gateway with no `wg_endpoint`, join a device, confirm the per-device WG conf has `Endpoint = host(public_url):51820`
- [ ] Manual: deploy with `wg_endpoint = "1.2.3.4:51820"` + `public_url = "https://dash.example.com"`, confirm clients get `Endpoint = 1.2.3.4:51820`
