### PR TITLE
rules: add CEL template for human-approval messages

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -187,7 +187,17 @@ type CompiledRule struct {
 	Condition  string
 	Credential string
 	Matcher    match.Matcher
-	Outcome    Outcome
+	// Template is the original CEL source for the optional rule
+	// `template = "..."` attribute; kept alongside TemplateRenderer
+	// for dashboard / diagnostic consumers that want to inspect the
+	// expression. Empty when the rule has no template.
+	Template string
+	// TemplateRenderer is the compiled CEL program. nil when Template
+	// is empty (or when the facet doesn't support templates). The
+	// approval flow renders it once per request and falls back to the
+	// approver's default message on eval error.
+	TemplateRenderer match.Renderer
+	Outcome          Outcome
 }
 
 // Outcome captures a rule's verdict + (when applicable) approve chain.

--- a/config/extplugin/adapter.go
+++ b/config/extplugin/adapter.go
@@ -431,6 +431,7 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 			Verb:    stringField(action, "verb"),
 			Summary: ev.Summary,
 			Rule:    rule,
+			Request: req,
 		})
 		verdict.Rule = rule.Name
 		verdict.Reason = v.Reason

--- a/config/extplugin/celenv.go
+++ b/config/extplugin/celenv.go
@@ -98,6 +98,31 @@ func (m *pluginMatcher) References() map[string]bool {
 
 func (m *pluginMatcher) SubFieldRefs() map[string]bool { return m.subFieldRefs }
 
+// newPluginFacetTemplate compiles expression as a CEL string template
+// against the same dyn-typed env newPluginFacetMatcher builds. Used by
+// rules with a `template = "..."` attribute attached to a plugin
+// facet; the renderer evaluates against the same Meta map the matcher
+// reads, so templates can interpolate any sub-field the plugin emits.
+func newPluginFacetTemplate(facetName, expression string) (match.Renderer, error) {
+	if facetName == "" {
+		return nil, fmt.Errorf("plugin facet template: empty facet name")
+	}
+	env, err := cel.NewEnv(
+		cel.Variable(facetName, cel.MapType(cel.StringType, cel.DynType)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("plugin facet %q: cel env: %w", facetName, err)
+	}
+	buildAct := func(req *match.Request) map[string]any {
+		m, ok := req.Meta.(map[string]any)
+		if !ok {
+			return nil
+		}
+		return map[string]any{facetName: m}
+	}
+	return match.CompileTemplate(env, expression, buildAct)
+}
+
 // parseSubFieldRefs walks condition's AST and returns the set of
 // `<facet>.<field>` selector chains. Used to decide which stream
 // fields a rule will read at evaluation time. Best-effort — when

--- a/config/extplugin/facet.go
+++ b/config/extplugin/facet.go
@@ -59,6 +59,14 @@ func (p *pluginFacet) NewMatcher(condition string) (match.Matcher, error) {
 	return newPluginFacetMatcher(p.name, condition, p.streamFields)
 }
 
+// NewTemplate compiles a CEL string expression against the same
+// dyn-typed plugin facet env the matcher uses. Plugin-facet rules can
+// therefore set `template = '"saw " + <facet>.<field>'` and have it
+// render at HITL time with the same bindings the condition read.
+func (p *pluginFacet) NewTemplate(expression string) (match.Renderer, error) {
+	return newPluginFacetTemplate(p.name, expression)
+}
+
 // registerFacet synthesizes a pluginFacet from a FacetDecl and
 // installs it under the bare name from the decl. Returns a
 // diagnostic when the name collides with another already-registered

--- a/config/facet/facet.go
+++ b/config/facet/facet.go
@@ -68,6 +68,13 @@ type Runtime interface {
 	// passthrough matcher.
 	NewMatcher(condition string) (match.Matcher, error)
 
+	// NewTemplate compiles a CEL string expression into a Renderer
+	// used by rules with an optional `template = "..."` attribute.
+	// The expression evaluates against the same activation as the
+	// matcher and must yield a string; any other output type is
+	// rejected at compile time.
+	NewTemplate(expression string) (match.Renderer, error)
+
 	// PrepareRequest is called by the gateway after building the
 	// request snapshot and before any matcher runs. The facet
 	// derives its Meta value from the request's existing fields
@@ -187,4 +194,14 @@ func NewMatcher(family, condition string) (match.Matcher, error) {
 		return nil, fmt.Errorf("unknown family %q (known: %v)", family, Names())
 	}
 	return r.NewMatcher(condition)
+}
+
+// NewTemplate dispatches to the named facet's NewTemplate. Mirrors
+// NewMatcher for the optional `template = "..."` rule attribute.
+func NewTemplate(family, expression string) (match.Renderer, error) {
+	r := Lookup(family)
+	if r == nil {
+		return nil, fmt.Errorf("unknown family %q (known: %v)", family, Names())
+	}
+	return r.NewTemplate(expression)
 }

--- a/config/match/cel.go
+++ b/config/match/cel.go
@@ -91,6 +91,72 @@ func (m *celMatcher) References() map[string]bool { return m.refs }
 // dispatcher's fail-closed check is O(1) per match.
 func (m *celMatcher) InspectsTruncatableFacet() bool { return m.inspectsTruncatable }
 
+// Renderer evaluates a CEL string expression against a Request and
+// returns the rendered text. Facets compile templates (the optional
+// `template = "..."` attribute on a `rule` block) through this
+// interface; the human-approval flow then renders the matched rule's
+// template to produce the message body sent to the operator.
+//
+// Render returns the empty string and an error when the CEL program
+// fails at evaluation time (despite passing load-time type-checks).
+// Callers fall back to the default approval message and log the error.
+type Renderer interface {
+	Render(req *Request) (string, error)
+}
+
+// CompileTemplate compiles a CEL expression source into a Renderer
+// that evaluates against the activation built by buildAct on each
+// call. The compiled expression must produce a string — any other
+// output type is rejected at compile time so a misconfigured rule
+// fails policy load rather than rendering garbage at approval time.
+//
+// Templates intentionally don't carry the lowercasedPaths /
+// truncatablePaths handling that matchers do: those are about
+// boolean-predicate semantics. A template renders text, and the
+// matcher-level truncation gate has already fail-closed any rule
+// whose match read truncated bytes before the approve chain runs.
+func CompileTemplate(env *cel.Env, expression string, buildAct ActivationBuilder) (Renderer, error) {
+	ast, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("cel compile: %w", issues.Err())
+	}
+	if ast.OutputType() != cel.StringType {
+		return nil, fmt.Errorf("cel template must yield string, got %s", ast.OutputType())
+	}
+	prog, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("cel program: %w", err)
+	}
+	return &celRenderer{
+		prog:     prog,
+		buildAct: buildAct,
+	}, nil
+}
+
+type celRenderer struct {
+	prog     cel.Program
+	buildAct ActivationBuilder
+}
+
+func (r *celRenderer) Render(req *Request) (string, error) {
+	if r == nil || r.prog == nil {
+		return "", fmt.Errorf("nil template renderer")
+	}
+	act := r.buildAct(req)
+	if act == nil {
+		return "", fmt.Errorf("no activation for request")
+	}
+	out, _, err := r.prog.Eval(act)
+	if err != nil {
+		return "", err
+	}
+	s, ok := out.(types.String)
+	if !ok {
+		return "", fmt.Errorf("template eval returned %T, want string", out)
+	}
+	return string(s), nil
+}
+
 // PassThrough is a Matcher that always returns true. Facets use it
 // for empty conditions (catch-all rules).
 type PassThrough struct{}

--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -93,6 +93,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					DashboardURL:   req.DashboardURL,
 					ThreadTS:       req.ThreadTS,
 					Summary:        summary,
+					Message:        req.Message,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -118,14 +118,78 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 	if bot == "" {
 		return fmt.Errorf("credential %s has no bot token (paste via dashboard)", target.CredentialName)
 	}
-	link := strings.TrimRight(target.DashboardURL, "/") + "/#hitl/" + target.PendingID
+	title, blocks := buildSlackHITLBlocks(req, target)
+	body := map[string]any{
+		"channel": target.Channel,
+		"text":    "clawpatrol: " + title,
+		"blocks":  blocks,
+	}
+	if target.ThreadTS != "" {
+		body["thread_ts"] = target.ThreadTS
+	}
+	buf, _ := json.Marshal(body)
+	hreq, err := http.NewRequest("POST", "https://slack.com/api/chat.postMessage", bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	hreq.Header.Set("Authorization", "Bearer "+bot)
+	hreq.Header.Set("Content-Type", "application/json; charset=utf-8")
 
+	c := &http.Client{Timeout: 5 * time.Second}
+	resp, err := c.Do(hreq)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(respBody, &result)
+	if resp.StatusCode >= 400 || !result.OK {
+		log.Printf("slack notify %s: chat.postMessage failed: status=%d ok=%v error=%q",
+			req.ApproverName, resp.StatusCode, result.OK, result.Error)
+		return fmt.Errorf("slack chat.postMessage error: %s", result.Error)
+	}
+	return nil
+}
+
+// buildSlackHITLBlocks composes the Block Kit message for an
+// approval prompt. Returns the title (also used in the message's
+// fallback `text` field) and the block list. Three body-block
+// modes, picked in this order:
+//
+//  1. target.Message non-empty — rule-author rendered a `template`
+//     CEL expression. The result is sent verbatim as a single
+//     mrkdwn section; operator includes whatever Slack markup they
+//     want. Default header is kept so the prompt still announces
+//     "Approve <method> · <endpoint>".
+//  2. target.Summary set — classifier LLM produced a richer card;
+//     header text falls back to the ticket id when present.
+//  3. otherwise — default method/path body.
+//
+// Context (agent ip, reason), optional body sample, and the
+// approve/deny vs. dashboard-link action row are appended in every
+// mode.
+func buildSlackHITLBlocks(req runtime.ApproveRequest, target runtime.HITLTarget) (string, []map[string]any) {
+	link := strings.TrimRight(target.DashboardURL, "/") + "/#hitl/" + target.PendingID
 	endpoint := runtime.HITLEndpointLabel(req)
 	queryLabel := runtime.HITLQueryLabel(req.Endpoint)
-
 	title := slackTrunc(runtime.HITLTitle(req.Method, endpoint), 140)
+
 	var blocks []map[string]any
-	if s := target.Summary; s != nil {
+	switch {
+	case target.Message != "":
+		blocks = []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
+			{"type": "section", "text": map[string]any{
+				"type": "mrkdwn",
+				"text": slackTrunc(target.Message, 2900),
+			}},
+		}
+	case target.Summary != nil:
+		s := target.Summary
 		headerText := s.TicketID
 		if headerText == "" {
 			headerText = title
@@ -140,7 +204,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 			{"type": "header", "text": map[string]any{"type": "plain_text", "text": slackTrunc(headerText, 140)}},
 			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": sectionText}},
 		}
-	} else {
+	default:
 		blocks = []map[string]any{
 			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
 			{"type": "section", "text": map[string]any{
@@ -149,7 +213,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 			}},
 		}
 	}
-	ctx := []map[string]any{}
+	var ctx []map[string]any
 	if req.AgentIP != "" {
 		ctx = append(ctx, map[string]any{
 			"type": "mrkdwn",
@@ -207,41 +271,7 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 			},
 		})
 	}
-
-	body := map[string]any{
-		"channel": target.Channel,
-		"text":    "clawpatrol: " + title,
-		"blocks":  blocks,
-	}
-	if target.ThreadTS != "" {
-		body["thread_ts"] = target.ThreadTS
-	}
-	buf, _ := json.Marshal(body)
-	hreq, err := http.NewRequest("POST", "https://slack.com/api/chat.postMessage", bytes.NewReader(buf))
-	if err != nil {
-		return err
-	}
-	hreq.Header.Set("Authorization", "Bearer "+bot)
-	hreq.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	c := &http.Client{Timeout: 5 * time.Second}
-	resp, err := c.Do(hreq)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	var result struct {
-		OK    bool   `json:"ok"`
-		Error string `json:"error"`
-	}
-	_ = json.Unmarshal(respBody, &result)
-	if resp.StatusCode >= 400 || !result.OK {
-		log.Printf("slack notify %s: chat.postMessage failed: status=%d ok=%v error=%q",
-			req.ApproverName, resp.StatusCode, result.OK, result.Error)
-		return fmt.Errorf("slack chat.postMessage error: %s", result.Error)
-	}
-	return nil
+	return title, blocks
 }
 
 func hitlClassificationEmoji(c string) string {

--- a/config/plugins/credentials/slack_test.go
+++ b/config/plugins/credentials/slack_test.go
@@ -1,0 +1,142 @@
+package credentials
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// findBlock returns the first block in blocks whose "type" matches.
+func findBlock(blocks []map[string]any, kind string) map[string]any {
+	for _, b := range blocks {
+		if b["type"] == kind {
+			return b
+		}
+	}
+	return nil
+}
+
+// findSectionContaining returns the first "section" block whose
+// mrkdwn text contains the given substring.
+func findSectionContaining(blocks []map[string]any, sub string) map[string]any {
+	for _, b := range blocks {
+		if b["type"] != "section" {
+			continue
+		}
+		txt, _ := b["text"].(map[string]any)
+		if txt == nil {
+			continue
+		}
+		s, _ := txt["text"].(string)
+		if strings.Contains(s, sub) {
+			return b
+		}
+	}
+	return nil
+}
+
+func sectionText(t *testing.T, b map[string]any) string {
+	t.Helper()
+	txt, ok := b["text"].(map[string]any)
+	if !ok {
+		t.Fatalf("section has no text block: %v", b)
+	}
+	s, _ := txt["text"].(string)
+	return s
+}
+
+func TestBuildSlackHITLBlocksDefaultBody(t *testing.T) {
+	req := runtime.ApproveRequest{
+		Method: "POST",
+		Host:   "api.example.com",
+		Path:   "/v1/repos",
+	}
+	target := runtime.HITLTarget{
+		PendingID:    "abc123",
+		DashboardURL: "https://dash.example.com",
+	}
+	title, blocks := buildSlackHITLBlocks(req, target)
+	if !strings.Contains(title, "POST") {
+		t.Errorf("title = %q, want POST", title)
+	}
+	body := findSectionContaining(blocks, "/v1/repos")
+	if body == nil {
+		t.Fatalf("default body missing path; blocks: %s", dumpJSON(blocks))
+	}
+	if strings.Contains(sectionText(t, body), "operator-authored") {
+		t.Errorf("default body should not contain template content")
+	}
+}
+
+func TestBuildSlackHITLBlocksUsesTemplateMessage(t *testing.T) {
+	req := runtime.ApproveRequest{
+		Method: "POST",
+		Host:   "api.example.com",
+		Path:   "/v1/repos",
+	}
+	target := runtime.HITLTarget{
+		PendingID:    "abc123",
+		DashboardURL: "https://dash.example.com",
+		Message:      "agent 10.0.0.1 wants to POST /v1/repos",
+	}
+	_, blocks := buildSlackHITLBlocks(req, target)
+	body := findSectionContaining(blocks, "agent 10.0.0.1 wants to POST")
+	if body == nil {
+		t.Fatalf("template message missing from blocks: %s", dumpJSON(blocks))
+	}
+	// Default Path-code-fence body should NOT appear when a template
+	// message is rendered — the template owns the prompt.
+	if findSectionContaining(blocks, "```/v1/repos```") != nil {
+		t.Errorf("default path-code-fence still rendered alongside template message")
+	}
+}
+
+func TestBuildSlackHITLBlocksTemplateBeatsSummary(t *testing.T) {
+	// When both Summary (classifier) and Message (template) are
+	// present, the operator's explicit template wins — they asked
+	// for that exact text.
+	req := runtime.ApproveRequest{Method: "POST", Path: "/x"}
+	target := runtime.HITLTarget{
+		Message: "explicit template body",
+		Summary: &runtime.HITLSummary{
+			TicketID:       "TKT-42",
+			Classification: "Legit",
+			Text:           "classifier summary text",
+		},
+	}
+	_, blocks := buildSlackHITLBlocks(req, target)
+	if findSectionContaining(blocks, "explicit template body") == nil {
+		t.Errorf("template message missing")
+	}
+	if findSectionContaining(blocks, "classifier summary text") != nil {
+		t.Errorf("classifier summary leaked into prompt despite template")
+	}
+}
+
+func TestBuildSlackHITLBlocksTemplateKeepsContextAndButtons(t *testing.T) {
+	req := runtime.ApproveRequest{
+		Method:  "POST",
+		AgentIP: "10.0.0.7",
+		Reason:  "writes go through ops",
+		Path:    "/x",
+	}
+	target := runtime.HITLTarget{
+		PendingID:   "abc",
+		Interactive: true,
+		Message:     "hello operator",
+	}
+	_, blocks := buildSlackHITLBlocks(req, target)
+	if findBlock(blocks, "context") == nil {
+		t.Errorf("context block missing")
+	}
+	if findBlock(blocks, "actions") == nil {
+		t.Errorf("actions block missing")
+	}
+}
+
+func dumpJSON(v any) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -621,7 +621,7 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName string) (string, string) {
 		}
 		v := ch.Approve(runtime.ApproveCallRequest{
 			Stages: cr.Outcome.Approve, Verb: info.Verb,
-			Summary: summary, Rule: cr,
+			Summary: summary, Rule: cr, Request: mreq,
 		})
 		if v.Decision != "allow" {
 			reason := v.Reason

--- a/config/plugins/facets/https/https.go
+++ b/config/plugins/facets/https/https.go
@@ -141,6 +141,13 @@ func (Facet) NewMatcher(condition string) (match.Matcher, error) {
 	return match.CompileCondition(celEnv, condition, buildActivation, lowercasedPaths, truncatablePaths)
 }
 
+// NewTemplate compiles a CEL string expression into a Renderer.
+// Reuses the HTTPS activation builder so templates can read every
+// field the matcher can (`http.method`, `http.path`, headers, etc.).
+func (Facet) NewTemplate(expression string) (match.Renderer, error) {
+	return match.CompileTemplate(celEnv, expression, buildActivation)
+}
+
 func buildActivation(req *match.Request) map[string]any {
 	if req == nil {
 		return nil

--- a/config/plugins/facets/https/https_template_test.go
+++ b/config/plugins/facets/https/https_template_test.go
@@ -1,0 +1,62 @@
+package https_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config/facet"
+
+	_ "github.com/denoland/clawpatrol/config/plugins/facets/https"
+)
+
+func TestHTTPTemplateRendersFromMatcherBindings(t *testing.T) {
+	r, err := facet.NewTemplate("http", `"agent wants " + http.method + " " + http.path`)
+	if err != nil {
+		t.Fatalf("NewTemplate: %v", err)
+	}
+	out, err := r.Render(httpReq("GET", "/v1/messages"))
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got, want := out, "agent wants get /v1/messages"; got != want {
+		t.Fatalf("Render = %q, want %q", got, want)
+	}
+}
+
+func TestHTTPTemplateRejectsNonStringOutput(t *testing.T) {
+	_, err := facet.NewTemplate("http", "http.method == 'GET'")
+	if err == nil {
+		t.Fatal("NewTemplate: expected error for bool output, got nil")
+	}
+	if !strings.Contains(err.Error(), "string") {
+		t.Fatalf("expected string-type error, got %v", err)
+	}
+}
+
+func TestHTTPTemplateRejectsUnknownBindings(t *testing.T) {
+	_, err := facet.NewTemplate("http", `"x" + http.no_such_field`)
+	if err == nil {
+		t.Fatal("NewTemplate: expected error for unknown sub-field, got nil")
+	}
+}
+
+func TestHTTPTemplateRejectsBadCEL(t *testing.T) {
+	_, err := facet.NewTemplate("http", "this is not cel")
+	if err == nil {
+		t.Fatal("NewTemplate: expected parse error, got nil")
+	}
+}
+
+func TestHTTPTemplateMultiLineConcat(t *testing.T) {
+	r, err := facet.NewTemplate("http", `"line 1\n" + http.method + "\nline 3"`)
+	if err != nil {
+		t.Fatalf("NewTemplate: %v", err)
+	}
+	out, err := r.Render(httpReq("POST", "/x"))
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if want := "line 1\npost\nline 3"; out != want {
+		t.Fatalf("Render = %q, want %q", out, want)
+	}
+}

--- a/config/plugins/facets/k8s/k8s.go
+++ b/config/plugins/facets/k8s/k8s.go
@@ -153,6 +153,13 @@ func (Facet) NewMatcher(condition string) (match.Matcher, error) {
 	return match.CompileCondition(celEnv, condition, buildActivation, lowercasedPaths, truncatablePaths)
 }
 
+// NewTemplate compiles a CEL string expression into a Renderer.
+// Reuses the k8s activation builder so templates can read every
+// `k8s.*` field the matcher can (`verb`, `resource`, `namespace`, etc.).
+func (Facet) NewTemplate(expression string) (match.Renderer, error) {
+	return match.CompileTemplate(celEnv, expression, buildActivation)
+}
+
 func buildActivation(req *match.Request) map[string]any {
 	if req == nil {
 		return nil

--- a/config/plugins/facets/sql/sql.go
+++ b/config/plugins/facets/sql/sql.go
@@ -155,6 +155,13 @@ func (Facet) NewMatcher(condition string) (match.Matcher, error) {
 	return match.CompileCondition(celEnv, condition, buildActivation, lowercasedPaths, truncatablePaths)
 }
 
+// NewTemplate compiles a CEL string expression into a Renderer.
+// Reuses the SQL activation builder so templates can read every
+// `sql.*` field the matcher can (`verb`, `tables`, `statement`, etc.).
+func (Facet) NewTemplate(expression string) (match.Renderer, error) {
+	return match.CompileTemplate(celEnv, expression, buildActivation)
+}
+
 func buildActivation(req *match.Request) map[string]any {
 	if req == nil {
 		return nil

--- a/config/plugins/rules/rules.go
+++ b/config/plugins/rules/rules.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/facet"
+	"github.com/denoland/clawpatrol/config/match"
 )
 
 // RuleBody is the gohcl-tagged decode target. The match predicate is
@@ -55,6 +56,14 @@ type RuleBody struct {
 	// approvers run in order; the request is allowed only if every
 	// stage approves. Set this *or* `verdict`, not both.
 	Approve cty.Value `hcl:"approve,optional"`
+
+	// Template, when set, is a CEL string expression evaluated at
+	// approval time to produce the message body sent to a
+	// human_approver (Slack today, other channels later). The
+	// expression reads the same per-facet bindings as the matcher
+	// and must yield a string. Empty → the approver's default
+	// message format applies, unchanged.
+	Template string `hcl:"template,optional"`
 }
 
 // Rule is the canonical, family-stamped record stored in
@@ -70,6 +79,7 @@ type Rule struct {
 	Verdict    string                `json:"verdict,omitempty"` // "allow" | "deny" | "" (when Approve is set)
 	Reason     string                `json:"reason,omitempty"`
 	Approve    []config.ApproveStage `json:"approve,omitempty"`
+	Template   string                `json:"template,omitempty"`
 }
 
 // Compile lowers a built rule into the runtime-friendly *CompiledRule
@@ -84,13 +94,22 @@ func (r *Rule) Compile() (*config.CompiledRule, []string, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("condition: %w", err)
 	}
+	var renderer match.Renderer
+	if r.Template != "" {
+		renderer, err = facet.NewTemplate(r.Family, r.Template)
+		if err != nil {
+			return nil, nil, fmt.Errorf("template: %w", err)
+		}
+	}
 	return &config.CompiledRule{
-		Name:       r.Name,
-		Priority:   r.Priority,
-		Disabled:   r.Disabled,
-		Condition:  r.Condition,
-		Credential: r.Credential,
-		Matcher:    matcher,
+		Name:             r.Name,
+		Priority:         r.Priority,
+		Disabled:         r.Disabled,
+		Condition:        r.Condition,
+		Credential:       r.Credential,
+		Matcher:          matcher,
+		Template:         r.Template,
+		TemplateRenderer: renderer,
 		Outcome: config.Outcome{
 			Verdict: r.Verdict,
 			Reason:  r.Reason,
@@ -192,6 +211,20 @@ func validate(body any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
 		}
 	}
 
+	// CEL template validation. Compiles against the same facet env
+	// as the matcher and must yield a string. Bad CEL, non-string
+	// output, and unknown bindings all surface here.
+	if rb.Template != "" && fam != "" {
+		if _, err := facet.NewTemplate(fam, rb.Template); err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid CEL template on rule %q", name),
+				Detail:   err.Error(),
+				Subject:  &ctx.Block.DefRange,
+			})
+		}
+	}
+
 	// Outcome: exactly one of verdict / approve.
 	hasVerdict := rb.Verdict != ""
 	hasApprove := !rb.Approve.IsNull() && rb.Approve.LengthInt() > 0
@@ -244,6 +277,7 @@ func build(body any, name string, ctx *config.BuildCtx) (any, hcl.Diagnostics) {
 		Credential: rb.Credential,
 		Verdict:    rb.Verdict,
 		Reason:     rb.Reason,
+		Template:   rb.Template,
 	}
 
 	// Approve chain.
@@ -347,6 +381,9 @@ func emitRule(body any, _ string, b *hclwrite.Body) {
 	}
 	if len(r.Approve) > 0 {
 		b.SetAttributeRaw("approve", approveToTokens(r.Approve))
+	}
+	if r.Template != "" {
+		b.SetAttributeValue("template", cty.StringVal(r.Template))
 	}
 }
 

--- a/config/runtime/dispatch.go
+++ b/config/runtime/dispatch.go
@@ -1,9 +1,29 @@
 package runtime
 
 import (
+	"log"
+
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/match"
 )
+
+// RenderTemplate evaluates rule.TemplateRenderer against req, returning
+// the rendered approval message. Empty rule / no template / nil
+// request return "" silently. Eval failures log and return "" so the
+// caller falls back to the approver's default message format —
+// preferred over denying the request or surfacing CEL stack traces to
+// the operator.
+func RenderTemplate(rule *config.CompiledRule, req *match.Request) string {
+	if rule == nil || rule.TemplateRenderer == nil || req == nil {
+		return ""
+	}
+	s, err := rule.TemplateRenderer.Render(req)
+	if err != nil {
+		log.Printf("rule %q: template render: %v", rule.Name, err)
+		return ""
+	}
+	return s
+}
 
 // HostEndpoint resolves a profile + SNI/authority host to the endpoint
 // that owns it. Compile populates HostIndex with exact declared hosts

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -194,6 +194,12 @@ type ApproveCallRequest struct {
 	// Rule is the matched compiled rule (carries Reason for the
 	// dashboard's "why is this gated" line).
 	Rule *config.CompiledRule
+	// Request is the per-family request snapshot the matcher saw.
+	// Conn-family plugins (postgres / clickhouse / external) pass it
+	// through so the host's Approve callback can evaluate the rule's
+	// optional `template = "..."` CEL expression against the same
+	// bindings. Nil disables template rendering for this call.
+	Request *match.Request
 }
 
 // ConnEvent is the wire-protocol-agnostic event shape conn-family
@@ -266,6 +272,12 @@ type HITLTarget struct {
 	// Summary is an optional pre-computed classification. When non-nil,
 	// notifiers render a richer card instead of the generic method/path display.
 	Summary *HITLSummary
+	// Message is the operator-authored approval message rendered
+	// from the matched rule's `template = "..."` CEL expression.
+	// Empty → the notifier uses its default message format. When
+	// non-empty, notifiers render the string verbatim as the prompt
+	// body (operator includes any channel-specific markup).
+	Message string
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.
@@ -309,6 +321,13 @@ type ApproveRequest struct {
 	// prompt as a reply in this Slack thread rather than top-level.
 	// Populated from the X-HITL-Thread-TS request header.
 	ThreadTS string
+
+	// Message is the rendered approval message — produced upstream
+	// by evaluating the matched rule's CEL template against the
+	// request snapshot. Empty when the rule has no template or
+	// rendering failed; the approver then falls back to its default
+	// message format and logs the failure (if any).
+	Message string
 
 	// Pool exposes the gateway's shared pending-approval list — the
 	// dashboard / Slack approvers use it to publish a pending entry

--- a/config/runtime/template_test.go
+++ b/config/runtime/template_test.go
@@ -1,0 +1,194 @@
+package runtime_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/facet"
+	"github.com/denoland/clawpatrol/config/match"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// TestTemplateRoundTrip loads a policy with a rule template,
+// matches against a synthetic request, and asserts the rendered
+// approval message reflects the matched request fields.
+func TestTemplateRoundTrip(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+
+approver "human_approver" "ops" { channel = "#ops" }
+
+rule "writes" {
+  endpoint = github
+  condition = "http.method == 'POST'"
+  approve  = [ops]
+  template = "'agent wants ' + http.method + ' ' + http.path"
+}
+
+profile "default" { endpoints = [github] }
+`)
+
+	ep := cp.Endpoints["github"]
+	if ep == nil {
+		t.Fatal("no github endpoint")
+	}
+	u, _ := url.Parse("https://api.github.com/v1/repos")
+	req := &match.Request{
+		Family:  "http",
+		Method:  "POST",
+		URL:     u,
+		Headers: http.Header{},
+	}
+	cr := runtime.MatchRequest(ep, req)
+	if cr == nil {
+		t.Fatal("MatchRequest: no rule matched")
+	}
+	if cr.Template == "" {
+		t.Fatal("CompiledRule.Template empty")
+	}
+	if cr.TemplateRenderer == nil {
+		t.Fatal("CompiledRule.TemplateRenderer nil")
+	}
+	got := runtime.RenderTemplate(cr, req)
+	if want := "agent wants post /v1/repos"; got != want {
+		t.Fatalf("RenderTemplate = %q, want %q", got, want)
+	}
+}
+
+// TestTemplateAbsentLeavesRendererNil ensures rules without a
+// template field don't carry a renderer, preserving the default
+// approval-message format.
+func TestTemplateAbsentLeavesRendererNil(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+
+approver "human_approver" "ops" { channel = "#ops" }
+
+rule "writes" {
+  endpoint = github
+  condition = "http.method == 'POST'"
+  approve  = [ops]
+}
+
+profile "default" { endpoints = [github] }
+`)
+	ep := cp.Endpoints["github"]
+	if len(ep.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(ep.Rules))
+	}
+	r := ep.Rules[0]
+	if r.Template != "" {
+		t.Errorf("Template = %q, want empty", r.Template)
+	}
+	if r.TemplateRenderer != nil {
+		t.Errorf("TemplateRenderer = %v, want nil", r.TemplateRenderer)
+	}
+	if got := runtime.RenderTemplate(r, &match.Request{Family: "http"}); got != "" {
+		t.Errorf("RenderTemplate with no template = %q, want \"\"", got)
+	}
+}
+
+// TestRenderTemplateFallsBackOnEvalError exercises the render-time
+// failure path: a template that compiles but errors at eval (here:
+// indexing into a string-valued field) renders to "" so the caller
+// falls back to the approver's default format.
+func TestRenderTemplateFallsBackOnEvalError(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+
+approver "human_approver" "ops" { channel = "#ops" }
+
+rule "writes" {
+  endpoint = github
+  approve  = [ops]
+  template = "http.headers['x-missing'][0]"
+}
+
+profile "default" { endpoints = [github] }
+`)
+	ep := cp.Endpoints["github"]
+	r := ep.Rules[0]
+	u, _ := url.Parse("https://api.github.com/")
+	req := &match.Request{
+		Family:  "http",
+		Method:  "POST",
+		URL:     u,
+		Headers: http.Header{},
+	}
+	if got := runtime.RenderTemplate(r, req); got != "" {
+		t.Errorf("RenderTemplate after eval error = %q, want \"\"", got)
+	}
+}
+
+func TestRenderTemplateNilRuleSafe(t *testing.T) {
+	if got := runtime.RenderTemplate(nil, &match.Request{}); got != "" {
+		t.Errorf("RenderTemplate(nil, ...) = %q, want \"\"", got)
+	}
+	if got := runtime.RenderTemplate(&config.CompiledRule{}, nil); got != "" {
+		t.Errorf("RenderTemplate(rule, nil) = %q, want \"\"", got)
+	}
+}
+
+// TestTemplateAcrossFacetsCompiles ensures every registered facet
+// exposes a working NewTemplate hook with the same compile-time
+// type checks the matcher enforces.
+func TestTemplateAcrossFacetsCompiles(t *testing.T) {
+	cases := []struct {
+		family string
+		expr   string
+	}{
+		{"http", "'method: ' + http.method"},
+		{"sql", "'verb: ' + sql.verb"},
+		{"k8s", "'verb: ' + k8s.verb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.family, func(t *testing.T) {
+			r, err := facet.NewTemplate(tc.family, tc.expr)
+			if err != nil {
+				t.Fatalf("NewTemplate(%s, %q): %v", tc.family, tc.expr, err)
+			}
+			if r == nil {
+				t.Fatalf("NewTemplate(%s) returned nil renderer", tc.family)
+			}
+		})
+	}
+}
+
+func TestNewTemplateRejectsNonStringOnEveryFacet(t *testing.T) {
+	cases := []struct {
+		family string
+		expr   string
+	}{
+		{"http", "http.method == 'GET'"},
+		{"sql", "sql.verb == 'select'"},
+		{"k8s", "k8s.verb == 'get'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.family, func(t *testing.T) {
+			if _, err := facet.NewTemplate(tc.family, tc.expr); err == nil {
+				t.Errorf("NewTemplate(%s, %q): want error, got nil", tc.family, tc.expr)
+			} else if !strings.Contains(err.Error(), "string") {
+				t.Errorf("NewTemplate(%s): unexpected error %v", tc.family, err)
+			}
+		})
+	}
+}

--- a/config/testdata/error_invalid_template.errors.txt
+++ b/config/testdata/error_invalid_template.errors.txt
@@ -1,0 +1,1 @@
+error: error_invalid_template.hcl:14:1: Invalid CEL template on rule "github-writes" — cel template must yield string, got bool

--- a/config/testdata/error_invalid_template.hcl
+++ b/config/testdata/error_invalid_template.hcl
@@ -1,0 +1,22 @@
+credential "bearer_token" "pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+
+approver "human_approver" "ops" {
+  channel = "#ops"
+}
+
+# Template must evaluate to a string. A bool expression must be
+# rejected at policy load with a clear diagnostic.
+rule "github-writes" {
+  endpoint = github
+  approve  = [ops]
+  template = "http.method == 'POST'"
+}
+
+profile "default" {
+  endpoints = [github]
+}

--- a/config/testdata/error_invalid_template_binding.errors.txt
+++ b/config/testdata/error_invalid_template_binding.errors.txt
@@ -1,0 +1,3 @@
+error: error_invalid_template_binding.hcl:14:1: Invalid CEL template on rule "github-writes" — cel compile: ERROR: <input>:1:14: undefined field 'no_such_field'
+ | 'msg ' + http.no_such_field
+ | .............^

--- a/config/testdata/error_invalid_template_binding.hcl
+++ b/config/testdata/error_invalid_template_binding.hcl
@@ -1,0 +1,22 @@
+credential "bearer_token" "pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+
+approver "human_approver" "ops" {
+  channel = "#ops"
+}
+
+# Template references an unknown CEL binding — must be rejected at
+# policy load via the facet env's type checker.
+rule "github-writes" {
+  endpoint = github
+  approve  = [ops]
+  template = "'msg ' + http.no_such_field"
+}
+
+profile "default" {
+  endpoints = [github]
+}

--- a/config/testdata/feature_rule_template.hcl
+++ b/config/testdata/feature_rule_template.hcl
@@ -1,0 +1,22 @@
+credential "bearer_token" "github-pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = github-pat
+}
+
+approver "human_approver" "ops" {
+  channel = "#ops"
+}
+
+# CEL template renders the approval message — same bindings as the
+# matcher; output must be a string.
+rule "github-writes" {
+  endpoint = github
+  approve  = [ops]
+  template = "'agent wants ' + http.method + ' ' + http.path"
+}
+
+profile "default" {
+  endpoints = [github]
+}

--- a/config/testdata/feature_rule_template.want.json
+++ b/config/testdata/feature_rule_template.want.json
@@ -1,0 +1,61 @@
+{
+  "policy": {
+    "approvers": {
+      "ops": {
+        "body": {
+          "Channel": "#ops",
+          "Credential": "",
+          "Timeout": 0,
+          "RequireApprovers": 0,
+          "Interactive": false,
+          "Classifier": ""
+        },
+        "type": "human_approver"
+      }
+    },
+    "credentials": {
+      "github-pat": {
+        "body": {
+          "IdempotencyKey": false
+        },
+        "type": "bearer_token"
+      }
+    },
+    "endpoints": {
+      "github": {
+        "body": {
+          "Hosts": [
+            "api.github.com"
+          ],
+          "Credential": "github-pat"
+        },
+        "family": "http",
+        "type": "https"
+      }
+    },
+    "profiles": {
+      "default": {
+        "endpoints": [
+          "github"
+        ]
+      }
+    },
+    "rules": {
+      "github-writes": {
+        "body": {
+          "name": "github-writes",
+          "family": "http",
+          "endpoints": [
+            "github"
+          ],
+          "approve": [
+            {
+              "name": "ops"
+            }
+          ],
+          "template": "'agent wants ' + http.method + ' ' + http.path"
+        }
+      }
+    }
+  }
+}

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -285,6 +285,12 @@ rule "github-writes" {
   endpoint  = github-api
   condition = "http.method in ['POST', 'PUT', 'PATCH', 'DELETE']"
   approve   = [ops]
+  # Optional `template` lets the operator override the default Slack
+  # approval-prompt body with a CEL string expression. It reads the
+  # same per-facet bindings as the matcher and must yield a string.
+  # Compile-time errors (bad CEL, non-string output, unknown
+  # bindings) surface at policy load.
+  template = "'agent wants to ' + http.method + ' ' + http.path"
 }
 
 # Postgres — layered defense.

--- a/main.go
+++ b/main.go
@@ -1288,6 +1288,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 				AgentIP: agentPip, Host: dstIP, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
 				Endpoint: ep, Rule: req.Rule, Profile: profile,
+				Message: runtime.RenderTemplate(req.Rule, req.Request),
 			})
 		},
 	}
@@ -1447,6 +1448,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 				AgentIP: agentPip, Host: eventHost, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
 				Endpoint: ep, Rule: req.Rule, Profile: profile,
+				Message: runtime.RenderTemplate(req.Rule, req.Request),
 			})
 		},
 	}
@@ -1742,6 +1744,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				UA: req.Header.Get("User-Agent"), Reason: cr.Outcome.Reason,
 				ThreadTS: req.Header.Get("X-HITL-Thread-TS"),
 				Endpoint: ep, Rule: cr, Profile: profile,
+				Message: runtime.RenderTemplate(cr, mreq),
 			})
 			if v.Decision != "allow" {
 				reason := v.Reason
@@ -2050,6 +2053,11 @@ type runApproveCtx struct {
 	Endpoint   *config.CompiledEndpoint
 	Rule       *config.CompiledRule
 	Profile    string
+	// Message is the pre-rendered approval text from the matched
+	// rule's CEL template (config/plugins/rules: `template = "..."`).
+	// Empty when the rule has no template or rendering failed —
+	// approvers then fall back to their default message.
+	Message string
 }
 
 // runApproveChain dispatches each stage of an approve = [...] list to
@@ -2085,6 +2093,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			BodySample:   c.BodySample,
 			Reason:       c.Reason,
 			ThreadTS:     c.ThreadTS,
+			Message:      c.Message,
 			Pool:         g.hitl,
 			Secrets:      g.secrets,
 			DashboardURL: g.cfg.PublicURL,

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -506,6 +506,7 @@ been inferred from the endpoint refs.
 | `verdict` | `string` | no | The outcome when the rule matches. Set exactly one of `verdict` (`"allow"` / `"deny"`) or `approve`. |
 | `reason` | `string` | no |  |
 | `approve` | `[]ref(approver)` | no | A list of bare-name approver references. The approvers run in order; the request is allowed only if every stage approves. Set this *or* `verdict`, not both. |
+| `template` | `string` | no | Template, when set, is a CEL string expression evaluated at approval time to produce the message body sent to a human_approver (Slack today, other channels later). The expression reads the same per-facet bindings as the matcher and must yield a string. Empty → the approver's default message format applies, unchanged. |
 
 ```hcl
 rule {}


### PR DESCRIPTION
## Summary

Adds an optional `template` attribute to `rule "..." { ... }` blocks. When the rule's verdict invokes a `human_approver` chain, the CEL expression is evaluated against the matcher's bindings to produce the message body sent to the operator (Slack today, other channels as they're added).

```hcl
rule "github-writes" {
  endpoint  = github-api
  condition = "http.method in ['POST', 'PUT', 'PATCH', 'DELETE']"
  approve   = [ops]
  template  = "'agent wants to ' + http.method + ' ' + http.path"
}
```

## Design notes

- **Bindings:** same per-facet env as the matcher (`http.*`, `sql.*`, `k8s.*`, plugin-facet maps). No new bindings in v1.
- **Output type:** CEL must yield `string`. Type-checked at policy load.
- **Validation:** bad CEL, non-string return, and unknown bindings all surface as `Invalid CEL template on rule "..."` diagnostics at load.
- **Render failure:** logs and falls back to the approver's default message; never denies the request.
- **Default preservation:** rules without `template` use the existing Slack format unchanged.
- **Markdown:** rendered string is sent verbatim — operator includes whatever Slack mrkdwn (bold, links, code fences) they want.

## Wire-up

- `match.CompileTemplate` mirrors `CompileCondition` but type-checks for string output.
- `facet.Runtime` gains `NewTemplate(expression)`; the three built-in facets plus the plugin-facet adapter implement it.
- `CompiledRule` carries the source string + compiled `match.Renderer`.
- The dispatcher renders once after matching and passes the result through `runtime.ApproveRequest.Message` → `runtime.HITLTarget.Message`. The Slack notifier swaps the default body section for the rendered text; classifier-summary blocks are dropped when a template is set (operator's explicit text wins).
- `ApproveCallRequest` gains `Request *match.Request` so conn-family plugins (postgres, clickhouse, external) get template rendering without each plugin re-evaluating CEL.

## Out of scope

- Approver-level templates (v2 if requested).
- Extra approval-context bindings (rule name, endpoint name, agent IP as CEL fields).
- Dashboard surface for the template field — operators inspect via `gateway.hcl`.

## Test plan

- [x] `go test ./...` (new tests for: template compile-time rejection of bad CEL / non-string / unknown bindings, render-error fallback, default-preservation, cross-facet `NewTemplate`, Slack block rendering with/without template).
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./tools/docgen` — config reference picks up the new field.
- [ ] Manual smoke: load `gateway.example.hcl` against a Slack workspace, trigger `github-writes`, confirm the custom message renders in the channel.