### PR TITLE
Reinstate ApproveRequest.Profile as a display-only field

### DIFF
--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -157,10 +157,10 @@ func (s *SlackTokens) NotifyHITL(_ context.Context, req runtime.ApproveRequest, 
 		}
 	}
 	ctx := []map[string]any{}
-	if req.AgentIP != "" {
+	if req.Profile != "" {
 		ctx = append(ctx, map[string]any{
 			"type": "mrkdwn",
-			"text": "agent `" + req.AgentIP + "`",
+			"text": "agent `" + req.Profile + "`",
 		})
 	}
 	if r := strings.TrimSpace(req.Reason); r != "" {

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -297,9 +297,13 @@ type ApproveRequest struct {
 	// disambiguate per-approver state.
 	ApproverName string
 	// AgentIP is the WireGuard source IP of the originating peer.
-	// Approvers use it as a display label / log key; it carries no
-	// credential-lookup meaning.
+	// Used as the HITLPending.AgentIP key and as a log identifier.
 	AgentIP string
+	// Profile is the tenant profile the originating peer is bound to
+	// (e.g. "avocet2"). Informational — approvers use it as a
+	// human-readable label in slack cards / log lines / message
+	// templates; it carries no credential-lookup meaning.
+	Profile string
 	// Method / Host / Path / UA / BodySample carry the request shape
 	// for HITL prompts. Endpoint plugins fill these so approvers
 	// don't have to know the family-specific Request internals.

--- a/main.go
+++ b/main.go
@@ -2080,6 +2080,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			Rule:         c.Rule,
 			ApproverName: st.Name,
 			AgentIP:      c.AgentIP,
+			Profile:      c.Profile,
 			Method:       c.Method,
 			Host:         c.Host,
 			Path:         c.Path,

--- a/telegram_request_body_redaction_test.go
+++ b/telegram_request_body_redaction_test.go
@@ -22,7 +22,7 @@ var fakeTelegramRequestBodyToken = []byte("999999999:FAKE_REDACTED_TELEGRAM_TOKE
 
 type telegramRequestBodySecretStore struct{}
 
-func (telegramRequestBodySecretStore) Get(string, string) (runtime.Secret, error) {
+func (telegramRequestBodySecretStore) Get(string) (runtime.Secret, error) {
 	return runtime.Secret{Bytes: fakeTelegramRequestBodyToken}, nil
 }
 


### PR DESCRIPTION
PR #340 dropped `Profile` from `ApproveRequest` because it was
documented as "SecretStore lookup key for per-profile credentials".
With per-profile credential keying gone, the lookup role no longer
applies -- but the field had a second, legitimate purpose that #340
overlooked: it was the tenant identifier the slack approver stamped
into the card (`` agent `<profile>` ``) and that #338's templated
message feature exposed as `{{profile}}`.

Replacing those with `AgentIP` (the raw WireGuard peer IP) is a
regression -- the profile name is the meaningful tenant label;
the IP is a routing artifact. And #338's `template.go` didn't
compile against `main` at all after the field went away.

Reinstate `Profile` as a contextual display field:

* `runtime.ApproveRequest`: re-add `Profile` alongside `AgentIP`,
  doc comment makes the display-only role explicit
  ("informational -- no credential-lookup meaning").
* `main.runApproveChain`: populate `Profile` from
  `runApproveCtx.Profile` (alongside `AgentIP`, which keeps its
  log-key role).
* slack `NotifyHITL`: restore the `` agent `<profile>` `` context
  line.
* `approvers/template.go`: `{{profile}}` resolves again (no source
  change needed -- `req.Profile` is back).

Fixes the `req.Profile undefined` build break that landed when
#338 was merged after #340.