### PR TITLE
fix: update SecretStore.Get signature and req.AgentIP after runtime refactor

### DIFF
--- a/config/plugins/approvers/template.go
+++ b/config/plugins/approvers/template.go
@@ -37,7 +37,7 @@ func expandMessage(tmpl string, req runtime.ApproveRequest) string {
 
 func buildTemplateVars(req runtime.ApproveRequest) map[string]string {
 	vars := map[string]string{
-		"profile":  req.Profile,
+		"profile":  req.AgentIP,
 		"host":     req.Host,
 		"endpoint": runtime.HITLEndpointLabel(req),
 		"reason":   req.Reason,

--- a/telegram_request_body_redaction_test.go
+++ b/telegram_request_body_redaction_test.go
@@ -22,7 +22,7 @@ var fakeTelegramRequestBodyToken = []byte("999999999:FAKE_REDACTED_TELEGRAM_TOKE
 
 type telegramRequestBodySecretStore struct{}
 
-func (telegramRequestBodySecretStore) Get(string, string) (runtime.Secret, error) {
+func (telegramRequestBodySecretStore) Get(string) (runtime.Secret, error) {
 	return runtime.Secret{Bytes: fakeTelegramRequestBodyToken}, nil
 }
 


### PR DESCRIPTION
Fixes two compile/test breakages on main after the runtime refactor landed:

- `template.go`: `req.Profile` → `req.AgentIP` (field renamed in `ApproveRequest`)
- `telegram_request_body_redaction_test.go`: `Get(string, string)` → `Get(string)` (SecretStore interface dropped the profile param)

Note: once #349 merges and reinstates `ApproveRequest.Profile` as a human-readable field, `template.go`'s `{{profile}}` var should be updated to use `req.Profile` instead of `req.AgentIP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)