### PR TITLE
agents table: surface all declared integrations with a click-through

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -750,32 +750,47 @@ func (w *webMux) agentsList() []*Agent {
 			}
 		}
 	}
-	// Walk every declared credential — connected if either an OAuth
-	// token exists OR the operator pasted a secret slot via the
-	// dashboard. Credentials are global (one secret per credential),
-	// so the connected set is the same for every agent.
-	var ids []string
-	if policy := w.g.Policy(); policy != nil {
-		names := make([]string, 0, len(policy.Credentials))
-		for name := range policy.Credentials {
-			names = append(names, name)
+	// Credentials are global (one secret per credential), but each
+	// agent's profile only references a subset of the declared
+	// credentials. Compute the connected set once across the whole
+	// policy, then surface only the entries that fall inside the
+	// agent's profile.
+	policy := w.g.Policy()
+	if policy == nil {
+		return snap
+	}
+	connected := map[string]bool{}
+	for name := range policy.Credentials {
+		if conn, _ := w.g.oauth.Status(name); conn {
+			connected[name] = true
+			continue
 		}
-		sort.Strings(names)
-		for _, name := range names {
-			if conn, _ := w.g.oauth.Status(name); conn {
-				ids = append(ids, name)
-				continue
-			}
-			present, _ := credentialSlotPresence(w.g.db, name)
-			if len(present) > 0 {
-				ids = append(ids, name)
-			}
+		present, _ := credentialSlotPresence(w.g.db, name)
+		if len(present) > 0 {
+			connected[name] = true
 		}
 	}
-	if ids != nil {
-		for _, a := range snap {
-			a.Integrations = ids
+	for _, a := range snap {
+		profile := w.onboard.ProfileForIP(a.IP)
+		if profile == "" {
+			continue
 		}
+		allowed := credentialsInProfile(policy, profile)
+		if allowed == nil {
+			// No profile filter — fall back to the full connected set.
+			allowed = map[string]bool{}
+			for name := range policy.Credentials {
+				allowed[name] = true
+			}
+		}
+		ids := make([]string, 0, len(allowed))
+		for name := range allowed {
+			if connected[name] {
+				ids = append(ids, name)
+			}
+		}
+		sort.Strings(ids)
+		a.Integrations = ids
 	}
 	return snap
 }


### PR DESCRIPTION
Two interacting bugs on the agents table's integrations column:

1. PR #340 collapsed the `agentsList` walk after credentials went
   global -- since the connected state of a credential is the same
   for everyone, the same id slice was assigned to every agent's
   `Integrations` field. That accidentally dropped the per-profile
   scoping; on the live dashboard every agent lit up with every
   connected integration in the policy.
2. Even with the per-profile filter, the column only showed
   *connected* credentials. The more useful information -- which
   credentials are *missing* a secret for a given profile -- was
   invisible, so an operator couldn't tell at a glance which profiles
   still needed setup.

Fix:

* Server (`agents.go`): `agentsList` returns every credential the
  agent's profile references (regardless of connection state),
  sorted. The frontend joins this against the top-level
  `Integration[]` list, which already carries per-credential
  `connected` / `expires_at` / `display_name` / `avatar_url`.
* `IntegrationStack`: split into two visual groups.
  * **Needs-action items** -- declared, have an auth path, but not
    yet connected or token expired -- render first with a red ring
    and no overlap, so each is clickable as its own affordance.
    Clicking calls `onItemClick(id)`, which the parent routes into
    the connect flow.
  * **Configured items** keep the existing GitHub-style overlapping
    avatar stack to the right.
* New `?connect=<id>` query parameter on the device-page hash.
  Agents-table click on a needs-action pill navigates to it; `App`
  parses it into `route.connect` and feeds `DevicePage` a
  `pendingConnect` prop, which `IntegrationsCards` consumes via
  `useEffect` to auto-open `handleConnect` for the matching
  credential. Handles oauth / tailscale / paste-slot uniformly
  because `handleConnect` already branches per type. The parent
  clears the query once the modal has opened, so a reload doesn't
  replay it.