### PR TITLE
fix(hitl): pass request body sample to approvers

### DIFF
--- a/hitl_body_sample_test.go
+++ b/hitl_body_sample_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+type captureBodySampleApprover struct {
+	seen chan string
+}
+
+func (a captureBodySampleApprover) Approve(_ context.Context, req runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
+	a.seen <- req.BodySample
+	return runtime.ApproveVerdict{Decision: "deny", Reason: "captured body sample", By: "test"}, nil
+}
+
+func TestHTTPSApproveChainReceivesBufferedRequestBodySample(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(`
+credential "bearer_token" "pat" {}
+endpoint "https" "api" {
+  hosts      = ["api.example.test"]
+  credential = pat
+}
+approver "human_approver" "capture" {
+  channel = "#ops"
+}
+rule "approved-post" {
+  endpoint  = api
+  condition = "http.method == 'POST' && http.path == '/v1/resources/update'"
+  approve   = [capture]
+}
+profile "default" { endpoints = [api] }
+`), "hitl-body-sample-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load config: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile config: %v", err)
+	}
+	ep := policy.Endpoints["api"]
+	if ep == nil {
+		t.Fatal("missing compiled api endpoint")
+	}
+
+	seenBodySamples := make(chan string, 1)
+	policy.Approvers["capture"] = &config.Entity{
+		Symbol: &config.Symbol{Name: "capture"},
+		Body:   captureBodySampleApprover{seen: seenBodySamples},
+	}
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	defer close(sink.ch)
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{cfg: gw, certs: certs, sink: sink}
+	g.policy.Store(policy)
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.mitmHTTPS(serverConn, "api.example.test", ep)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: "api.example.test"})
+	defer func() { _ = clientTLS.Close() }()
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+
+	requestBody := `{"resource":"example","message":"Please apply this update."}`
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.test/v1/resources/update", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if err := req.Write(clientTLS); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientTLS), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	select {
+	case got := <-seenBodySamples:
+		if got != requestBody {
+			t.Fatalf("BodySample = %q, want request body %q", got, requestBody)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for approver body sample")
+	}
+
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1739,9 +1739,9 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		if cr != nil && len(cr.Outcome.Approve) > 0 {
 			v := g.runApproveChain(req.Context(), cr.Outcome.Approve, runApproveCtx{
 				AgentIP: agentAddr, Host: host, Method: req.Method, Path: req.URL.RequestURI(),
-				UA: req.Header.Get("User-Agent"), Reason: cr.Outcome.Reason,
+				UA: req.Header.Get("User-Agent"), BodySample: string(matchBody), Reason: cr.Outcome.Reason,
 				ThreadTS: req.Header.Get("X-HITL-Thread-TS"),
-				Endpoint: ep, Rule: cr, Profile: profile,
+				Endpoint: ep, Rule: cr, Profile: profile, Request: mreq,
 			})
 			if v.Decision != "allow" {
 				reason := v.Reason
@@ -2065,6 +2065,7 @@ type runApproveCtx struct {
 	Endpoint   *config.CompiledEndpoint
 	Rule       *config.CompiledRule
 	Profile    string
+	Request    *match.Request
 }
 
 // runApproveChain dispatches each stage of an approve = [...] list to
@@ -2091,6 +2092,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			Stage:        st,
 			Endpoint:     c.Endpoint,
 			Rule:         c.Rule,
+			Request:      c.Request,
 			ApproverName: st.Name,
 			AgentIP:      c.AgentIP,
 			Profile:      c.Profile,


### PR DESCRIPTION
## Summary
- Pass the HTTPS MITM buffered request body sample into the HITL approval chain.
- Add a generic regression test that exercises an approved HTTPS POST through TLS MITM and asserts approvers receive the actual JSON body.
- Preserve request/profile metadata when building the runtime approver request.

## Test plan
- `go test -run TestHTTPSApproveChainReceivesBufferedRequestBodySample -count=1 ./`
- `go test ./...`
- `git diff --check`
- `gofmt -l main.go hitl_body_sample_test.go config/runtime/runtime.go`
