### PR TITLE
fix(site): exempt /install.sh from pre-launch basic auth gate

### DIFF
--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -35,6 +35,9 @@ export default {
     if (url.pathname === "/api/telemetry/v1/check") {
       return handleCheck(req, env);
     }
+    if (url.pathname === "/install.sh") {
+      return env.ASSETS.fetch(req);
+    }
     if (!authorized(req)) {
       return new Response("Authentication required", {
         status: 401,


### PR DESCRIPTION
`clawpatrol.dev/install.sh` returns 401 because the Workers site has a pre-launch basic auth gate on all routes. The comment even says "Remove once the site is public."

Exempts `/install.sh` so `curl -fsSL https://clawpatrol.dev/install.sh | sh` works without credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)