### PR TITLE
security hints + drop state/ subdir convention

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Gateway struct {
 	AdminEmail string `hcl:"admin_email,optional"`
 	// StateDir is the directory holding clawpatrol.db (and anything
 	// else a plugin persists to disk under it). Defaults to
-	// ${HOME}/.clawpatrol/state when unset.
+	// ${HOME}/.clawpatrol when unset.
 	StateDir        string `hcl:"state_dir,optional"`
 	Resolver        string `hcl:"resolver,optional"`
 	LogPath         string `hcl:"log_path,optional"`

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -71,7 +71,7 @@ listen       = "0.0.0.0:8443"
 info_listen  = "0.0.0.0:8080"
 public_url   = "http://clawpatrol-gateway"    # tailnet hostname suffices
 admin_email  = "you@example.com"
-state_dir    = "/opt/clawpatrol/state"
+state_dir    = "/opt/clawpatrol"
 integrations = ["claude", "codex", "github"]
 
 control             = "tailscale"

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -79,7 +79,7 @@ info_listen  = "0.0.0.0:8080"
 public_url   = "http://your-gw.example.com:8080"
 admin_email  = "you@example.com"
 log_path     = "/opt/clawpatrol/gateway.log"
-state_dir    = "/opt/clawpatrol/state"
+state_dir    = "/opt/clawpatrol"
 integrations = ["claude", "codex", "github"]
 
 tailscale {

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -32,7 +32,7 @@ listen      = "0.0.0.0:8443"
 info_listen = "0.0.0.0:8080"
 public_url  = "https://gw.example.com"
 admin_email = "you@example.com"
-state_dir   = "/opt/clawpatrol/state"
+state_dir   = "/opt/clawpatrol"
 
 # Dashboard auth — pick exactly one. The gateway refuses to serve the
 # dashboard / APIs until one of these is set, to avoid silently

--- a/main.go
+++ b/main.go
@@ -44,7 +44,9 @@ type JoinConfig = config.JoinConfig
 
 // resolveStateDir picks the directory where the gateway keeps its
 // sqlite DB. The HCL `state_dir` attribute is the only knob;
-// defaults to ${HOME}/.clawpatrol/state when unset.
+// defaults to ${HOME}/.clawpatrol when unset. The DB filename
+// (clawpatrol.db) coexists with the client-side ca.crt that lives
+// in the same dir on dev machines.
 func resolveStateDir(cfg *config.Gateway) string {
 	if cfg.StateDir != "" {
 		return cfg.StateDir
@@ -53,7 +55,7 @@ func resolveStateDir(cfg *config.Gateway) string {
 	if err != nil || home == "" {
 		log.Fatalf("state_dir unset and $HOME unavailable")
 	}
-	return filepath.Join(home, ".clawpatrol", "state")
+	return filepath.Join(home, ".clawpatrol")
 }
 
 // warnIfStateLooselyPermissioned logs a warning when state_dir or

--- a/main.go
+++ b/main.go
@@ -56,6 +56,27 @@ func resolveStateDir(cfg *config.Gateway) string {
 	return filepath.Join(home, ".clawpatrol", "state")
 }
 
+// warnIfStateLooselyPermissioned logs a warning when state_dir or
+// clawpatrol.db is readable by group / others. The sqlite db holds
+// the CA private key, OAuth tokens, and audit log — anything not
+// owned and 0700/0600 is a credential-leak path. Non-fatal so a
+// fresh-from-mkdir setup that hasn't yet been tightened can still
+// boot.
+func warnIfStateLooselyPermissioned(stateDir string) {
+	check := func(path string, want os.FileMode) {
+		st, err := os.Stat(path)
+		if err != nil {
+			return
+		}
+		mode := st.Mode().Perm()
+		if mode&0o077 != 0 {
+			log.Printf("warning: %s has mode %#o (want %#o); CA key + OAuth tokens are readable beyond owner. Tighten with: chmod %#o %s", path, mode, want, want, path)
+		}
+	}
+	check(stateDir, 0o700)
+	check(filepath.Join(stateDir, "clawpatrol.db"), 0o600)
+}
+
 // emit a terminal request event to both the SSE sink and OTel.
 // ev.Action and ev.Ms must be populated. Non-request events (e.g.
 // hitl_pending) call g.sink.Emit directly to stay out of the
@@ -2272,6 +2293,7 @@ func runGateway(args []string) {
 	if err != nil {
 		log.Fatalf("db: %v", err)
 	}
+	warnIfStateLooselyPermissioned(stateDir)
 	setDB(db)
 	blobs := newGatewayBlobStore(db)
 	endpoints.SetBlobStore(blobs)

--- a/run_darwin.go
+++ b/run_darwin.go
@@ -78,6 +78,8 @@ func sessionIPC(msg string) error {
 }
 
 func runRun(args []string) {
+	warnIfOnGatewayHost()
+
 	if _, err := os.Stat(macHelperPath); err != nil {
 		fail("Clawpatrol.app not installed. Build + install from macos/:\n" +
 			"  cd macos && ./install.sh\n" +

--- a/run_linux.go
+++ b/run_linux.go
@@ -62,6 +62,8 @@ func runRun(args []string) {
 		return
 	}
 
+	warnIfOnGatewayHost()
+
 	// `sudo clawpatrol run` is doomed on this distro: the UidMappings
 	// below collapse to `0 → 0`, and most distros refuse to put pid 0
 	// into a new user namespace at all (apparmor restrict-unpriv-userns

--- a/run_safety.go
+++ b/run_safety.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// findGatewayStateLeak returns the path of a gateway sqlite db that
+// is readable from the current process, or "" if none is found.
+// Almost always means `clawpatrol run` is being invoked on the
+// gateway host itself — the intended workflow runs on a client
+// device that joined over WireGuard. The wrapped agent inherits the
+// calling user's filesystem access, so the gateway's sqlite db
+// (CA private key, OAuth tokens, audit log) would be reachable to it.
+//
+// This is a UX hint, not a security boundary: even if `clawpatrol
+// run` refuses, the same exposure exists for any agent the operator
+// launches directly. The actual fix is locking down state_dir's
+// permissions and running the gateway under a dedicated service
+// user — see site/doc/getting-started.md.
+func findGatewayStateLeak() string {
+	candidates := []string{
+		"/opt/clawpatrol/state/clawpatrol.db",
+		"/opt/clawpatrol/oauth/clawpatrol.db",
+		"/srv/clawpatrol/state/clawpatrol.db",
+		"/var/lib/clawpatrol/state/clawpatrol.db",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".clawpatrol/state/clawpatrol.db"),
+			filepath.Join(home, ".clawpatrol/clawpatrol.db"),
+			filepath.Join(home, ".clawpatrol/oauth/clawpatrol.db"),
+		)
+	}
+	for _, p := range candidates {
+		f, err := os.Open(p)
+		if err != nil {
+			continue
+		}
+		_ = f.Close()
+		return p
+	}
+	return ""
+}
+
+// warnIfOnGatewayHost prints a stderr hint when a gateway state db
+// is readable from the current process. Non-fatal — `clawpatrol run`
+// continues either way.
+func warnIfOnGatewayHost() {
+	p := findGatewayStateLeak()
+	if p == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"clawpatrol: heads up — gateway state db %q is readable from this process.\n"+
+			"  `clawpatrol run` is meant for client devices that joined the gateway over\n"+
+			"  WireGuard, not the gateway host itself. The wrapped agent will have direct\n"+
+			"  filesystem access to the CA private key, OAuth tokens, and audit log.\n",
+		p)
+}

--- a/run_safety.go
+++ b/run_safety.go
@@ -22,8 +22,8 @@ import (
 func findGatewayStateLeak() string {
 	candidates := []string{
 		"/opt/clawpatrol/clawpatrol.db",
-		"/opt/clawpatrol/state/clawpatrol.db",   // legacy
-		"/opt/clawpatrol/oauth/clawpatrol.db",   // legacy
+		"/opt/clawpatrol/state/clawpatrol.db", // legacy
+		"/opt/clawpatrol/oauth/clawpatrol.db", // legacy
 		"/srv/clawpatrol/clawpatrol.db",
 		"/var/lib/clawpatrol/clawpatrol.db",
 	}

--- a/run_safety.go
+++ b/run_safety.go
@@ -21,16 +21,17 @@ import (
 // user — see site/doc/getting-started.md.
 func findGatewayStateLeak() string {
 	candidates := []string{
-		"/opt/clawpatrol/state/clawpatrol.db",
-		"/opt/clawpatrol/oauth/clawpatrol.db",
-		"/srv/clawpatrol/state/clawpatrol.db",
-		"/var/lib/clawpatrol/state/clawpatrol.db",
+		"/opt/clawpatrol/clawpatrol.db",
+		"/opt/clawpatrol/state/clawpatrol.db",   // legacy
+		"/opt/clawpatrol/oauth/clawpatrol.db",   // legacy
+		"/srv/clawpatrol/clawpatrol.db",
+		"/var/lib/clawpatrol/clawpatrol.db",
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append(candidates,
-			filepath.Join(home, ".clawpatrol/state/clawpatrol.db"),
 			filepath.Join(home, ".clawpatrol/clawpatrol.db"),
-			filepath.Join(home, ".clawpatrol/oauth/clawpatrol.db"),
+			filepath.Join(home, ".clawpatrol/state/clawpatrol.db"), // legacy
+			filepath.Join(home, ".clawpatrol/oauth/clawpatrol.db"), // legacy
 		)
 	}
 	for _, p := range candidates {

--- a/run_safety_test.go
+++ b/run_safety_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFindGatewayStateLeakHomeDB drops a fake gateway sqlite db into
+// $HOME/.clawpatrol/state and checks that findGatewayStateLeak picks
+// it up. HOME is rewritten for the duration of the test.
+func TestFindGatewayStateLeakHomeDB(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".clawpatrol/state"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, ".clawpatrol/state/clawpatrol.db")
+	if err := os.WriteFile(dbPath, []byte("fake sqlite\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", dir)
+	got := findGatewayStateLeak()
+	if got != dbPath {
+		t.Errorf("got %q, want %q", got, dbPath)
+	}
+}
+
+// TestFindGatewayStateLeakNone confirms that an isolated HOME with
+// no clawpatrol artifacts returns "". (The well-known absolute paths
+// like /opt/clawpatrol/... are unlikely to exist on a CI runner, but
+// we don't assert that — the test would be flaky on a developer
+// machine that does run a local gateway.)
+func TestFindGatewayStateLeakNone(t *testing.T) {
+	if findGatewayStateLeak() != "" {
+		t.Skip("a gateway state db exists in one of the candidate paths on this host; skipping the negative case")
+	}
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	if got := findGatewayStateLeak(); got != "" {
+		t.Errorf("expected no leak with empty HOME; got %q", got)
+	}
+}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -30,7 +30,7 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 | `info_listen` | `string` | no |  |
 | `public_url` | `string` | no |  |
 | `admin_email` | `string` | no |  |
-| `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything else a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol/state when unset. |
+| `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything else a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol when unset. |
 | `resolver` | `string` | no |  |
 | `log_path` | `string` | no |  |
 | `dashboard_secret` | `string` | no |  |

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -60,6 +60,16 @@ The dashboard is at `http://<gateway-host>:9080`.
 
 ### Under systemd
 
+Create a dedicated service user so the gateway's state directory
+(CA private key, OAuth tokens, audit log) isn't readable by any
+human or agent on the box:
+
+```bash
+useradd --system --home /opt/clawpatrol --shell /usr/sbin/nologin clawpatrol
+chown -R clawpatrol:clawpatrol /opt/clawpatrol
+chmod 700 /opt/clawpatrol /opt/clawpatrol/state
+```
+
 Drop the following at `/etc/systemd/system/clawpatrol-gateway.service`,
 adjusting the three paths to wherever you put the binary and config:
 
@@ -71,6 +81,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+User=clawpatrol
+Group=clawpatrol
 WorkingDirectory=/opt/clawpatrol
 ExecStart=/usr/local/bin/clawpatrol gateway /opt/clawpatrol/gateway.hcl
 Restart=on-failure
@@ -88,6 +100,9 @@ systemctl daemon-reload
 systemctl enable --now clawpatrol-gateway
 journalctl -u clawpatrol-gateway -f       # tail the gateway log
 ```
+
+If you skip the dedicated-user step, the gateway logs a warning at
+startup when `state_dir` or `clawpatrol.db` is readable beyond owner.
 
 ## Join a device
 
@@ -123,6 +138,35 @@ The gateway intercepts the wrapped process's HTTPS traffic, matches each
 request against the rules in `gateway.hcl`, injects the configured
 credential, and forwards the request upstream. The agent never sees the
 real key.
+
+## Security notes
+
+A few footguns worth knowing about before you point an agent at a
+Claw Patrol gateway:
+
+- **Don't run agents on the gateway host.** `clawpatrol run` is for
+  client devices — the gateway's `state_dir` holds the CA private
+  key, OAuth tokens, and audit log. An agent running on the gateway
+  host can read those directly, with or without `clawpatrol run` in
+  front. The correct shape is: gateway on one box (small VPS, no
+  human logins, no developer tools); your laptop / CI runner joins
+  it over WireGuard. `clawpatrol run` prints a heads-up if it
+  detects a gateway state db in a common location.
+
+- **Lock down `state_dir`.** The gateway warns at startup when
+  `state_dir` or `clawpatrol.db` is readable beyond owner. The
+  systemd snippet above creates a dedicated `clawpatrol` service
+  user with mode-700 ownership; if you skip that, anyone with
+  shell access to the gateway host can read every credential.
+
+- **`clawpatrol join --whole-machine` is for client devices only.**
+  Running it on (or pointed at) the gateway host itself routes the
+  host's own traffic through its own WireGuard endpoint — a loop
+  that breaks DNS, outbound traffic from the gateway daemon, and
+  the dashboard's reachability. Per-process routing (the default
+  `clawpatrol join` + `clawpatrol run` shape) is also what most
+  people actually want on a multi-purpose laptop, so they don't
+  accidentally route every browser tab through the gateway.
 
 ## What's next
 

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -35,7 +35,7 @@ info_listen      = "0.0.0.0:9080"
 public_url       = "http://gw.example.com:9080"
 admin_email      = "you@example.com"
 dashboard_secret = "<long random string>"
-state_dir        = "/opt/clawpatrol/state"
+state_dir        = "/opt/clawpatrol"
 
 control        = "wireguard"
 wg_subnet_cidr = "10.55.0.0/24"
@@ -67,7 +67,7 @@ human or agent on the box:
 ```bash
 useradd --system --home /opt/clawpatrol --shell /usr/sbin/nologin clawpatrol
 chown -R clawpatrol:clawpatrol /opt/clawpatrol
-chmod 700 /opt/clawpatrol /opt/clawpatrol/state
+chmod 700 /opt/clawpatrol
 ```
 
 Drop the following at `/etc/systemd/system/clawpatrol-gateway.service`,

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -100,7 +100,7 @@ profile "default" { endpoints = [github] }
 | `info_listen` | Dashboard + API bind. |
 | `public_url` | Dashboard URL handed out at join time. |
 | `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |
-| `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol/state`. |
+| `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol`. |
 | `control` | `"wireguard"` or `"tailscale"`. |
 | `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet. |
 | `unknown_host` | `"passthrough"` (default) or `"deny"` for traffic no endpoint claims. |


### PR DESCRIPTION
## Summary

Two threads woven into one PR:

**Security UX hardening:**
- `clawpatrol run` prints a stderr heads-up when it detects a gateway sqlite db readable from the current process. Non-fatal — the wrapped agent has the same exposure with or without `clawpatrol run`, so blocking would be theater; the hint just redirects the operator to the right shape (run from a client device).
- Gateway logs a warning at startup when `state_dir` or `clawpatrol.db` is readable beyond owner. This is the actual security boundary — under a dedicated service user with mode-700 ownership, no agent on the box can read credentials regardless of how it was invoked.
- `site/doc/getting-started.md` gains a **Security notes** section covering (a) don't run agents on the gateway host, (b) lock down `state_dir`, (c) don't `clawpatrol join --whole-machine` from the gateway host (loop). The systemd snippet now creates a `clawpatrol` service user and uses `User=clawpatrol`.

**`state/` subdir cleanup:**
- `state_dir` used to be a directory the gateway stuffed multiple files into; everything has been in `clawpatrol.db` for a while. Dropping the `/state/` subdir convention — `resolveStateDir` default goes from `~/.clawpatrol/state` → `~/.clawpatrol`. Examples + docs follow: `state_dir = "/opt/clawpatrol"` instead of `/opt/clawpatrol/state`. Existing deployments are unaffected (they have `state_dir` set explicitly). `findGatewayStateLeak` still scans the legacy `/state/` and `/oauth/` subpaths so the heads-up fires on hosts running the old layout.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./...` passes
- [x] New `TestFindGatewayStateLeak*` tests cover both the positive (HOME with db) and negative (HOME without db) paths
- [x] `clawpatrol validate gateway.example.hcl` still validates
- [x] `go run ./tools/docgen` rerun — config-reference.md picks up the updated `state_dir` doc comment
- [ ] Manual: start the gateway with `state_dir` owned by my user and 0700 — no warning. Loosen to 0755 — warning fires.
- [ ] Manual: `clawpatrol run` on the gateway host — heads-up appears, the wrapped command still runs.
