### PR TITLE
tsnet: set Server.Dir explicitly so gateway boots with HOME/XDG unset

### DIFF
--- a/main.go
+++ b/main.go
@@ -2482,7 +2482,7 @@ func runGateway(args []string) {
 		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, :5432=pg, :53=dns-vip, VIP=ssh|ch_native, :%d=dash, plugins=conn-index, else=relay)", dashPort)
 	}
 
-	ln, err := openListener(cfg)
+	ln, err := openListener(cfg, stateDir)
 	if err != nil {
 		log.Fatalf("listen: %v", err)
 	}

--- a/tailscale.go
+++ b/tailscale.go
@@ -11,15 +11,34 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 
 	"tailscale.com/tsnet"
 
 	"github.com/denoland/clawpatrol/config"
 )
 
-func openListener(cfg *config.Gateway) (net.Listener, error) {
+// gatewayTsnetDir is the per-gateway tsnet state directory, carved out
+// of the resolved state_dir. Setting tsnet.Server.Dir explicitly keeps
+// tsnet from consulting $XDG_CONFIG_HOME / $HOME — those may be unset
+// under systemd-hardened units, container runtimes, and similar
+// minimal environments. Mode 0700 because tsnet stores private node
+// keys here.
+func gatewayTsnetDir(stateDir string) (string, error) {
+	if stateDir == "" {
+		return "", fmt.Errorf("tsnet: state_dir is empty (resolved gateway state_dir required)")
+	}
+	dir := filepath.Join(stateDir, "tsnet")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("tsnet state dir: %w", err)
+	}
+	return dir, nil
+}
+
+func openListener(cfg *config.Gateway, stateDir string) (net.Listener, error) {
 	authKey := cfg.AuthKey
 	if authKey == "" {
 		authKey = os.Getenv("TS_AUTHKEY")
@@ -31,11 +50,15 @@ func openListener(cfg *config.Gateway) (net.Listener, error) {
 	if hn == "" {
 		hn = "clawpatrol-gateway"
 	}
+	dir, err := gatewayTsnetDir(stateDir)
+	if err != nil {
+		return nil, err
+	}
 	s := &tsnet.Server{
 		Hostname:   hn,
 		AuthKey:    authKey,
 		ControlURL: cfg.ControlURL,
-		Dir:        cfg.StateDir,
+		Dir:        dir,
 	}
 	port := cfg.Listen
 	if port == "" {

--- a/tailscale_test.go
+++ b/tailscale_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestGatewayTsnetDir_CreatesPath(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	root := t.TempDir()
+	dir, err := gatewayTsnetDir(root)
+	if err != nil {
+		t.Fatalf("gatewayTsnetDir: %v", err)
+	}
+	want := filepath.Join(root, "tsnet")
+	if dir != want {
+		t.Fatalf("dir = %q, want %q", dir, want)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if !st.IsDir() {
+		t.Fatalf("%s is not a directory", dir)
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("mode = %#o, want %#o", mode, 0o700)
+	}
+}
+
+func TestGatewayTsnetDir_EmptyStateDir(t *testing.T) {
+	if _, err := gatewayTsnetDir(""); err == nil {
+		t.Fatal("expected error for empty state_dir")
+	}
+}
+
+// TestOpenListener_NoAuthKey covers the plain-TCP fallback: when neither
+// authkey nor TS_AUTHKEY is set, openListener never touches tsnet, so it
+// should bind a plain TCP listener even with HOME and XDG_CONFIG_HOME
+// unset. This guards the env-independence guarantee for the most common
+// (non-Tailscale) deployment.
+func TestOpenListener_NoAuthKey(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("TS_AUTHKEY", "")
+	cfg := &config.Gateway{Listen: "127.0.0.1:0"}
+	ln, err := openListener(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("openListener: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+}
+
+// TestOpenListener_EnvIndependent verifies that with an authkey set but
+// HOME and XDG_CONFIG_HOME unset, openListener does not fail with the
+// "neither $XDG_CONFIG_HOME nor $HOME are defined" error from tsnet's
+// default-dir resolver. The tsnet.Listen call itself may still error
+// (no real control plane in tests), but the failure must not be the
+// env-var fallback path.
+func TestOpenListener_EnvIndependent(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	cfg := &config.Gateway{
+		Listen:  "127.0.0.1:0",
+		AuthKey: "tskey-test-invalid",
+	}
+	// Direct tsnet.Listen against an unreachable control URL avoids the
+	// blocking join; we only care that Server construction picked up an
+	// explicit Dir rather than consulting env vars.
+	cfg.ControlURL = "https://127.0.0.1:1"
+	_, err := openListener(cfg, t.TempDir())
+	if err == nil {
+		// A test environment that happens to bring tsnet up against a
+		// reachable control plane is fine — just close and return.
+		return
+	}
+	if strings.Contains(err.Error(), "$XDG_CONFIG_HOME") || strings.Contains(err.Error(), "$HOME") {
+		t.Fatalf("openListener leaked env-var dependency: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`tsnet.Server` defaults its state directory from `$XDG_CONFIG_HOME` /
`$HOME` when `Server.Dir` is unset. Under systemd-hardened units and
minimal container runtimes neither is defined, and the gateway crashes:

```
tsnet.Up: tsnet: neither $XDG_CONFIG_HOME nor $HOME are defined
```

Set `Server.Dir` explicitly to `<state_dir>/tsnet` (mode 0700, matching
the tunnel-plugin pattern in `config/plugins/tunnels/tailscale.go`).
Listener bootstrap no longer consults the environment for state
location.

## Migration

Existing deployments that relied on tsnet's env-derived default (e.g.
`$HOME/.config/tsnet-clawpatrol-gateway`) will now use
`<state_dir>/tsnet` instead. tsnet rejoins fresh on first boot (the
control plane re-issues a node key from the configured `authkey`); to
preserve the existing node identity, copy the old state directory's
contents into `<state_dir>/tsnet` before upgrading.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] New tests cover the empty-env case and the plain-TCP fallback