### PR TITLE
agents table: surface all declared integrations with a click-through

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -750,25 +750,15 @@ func (w *webMux) agentsList() []*Agent {
 			}
 		}
 	}
-	// Credentials are global (one secret per credential), but each
-	// agent's profile only references a subset of the declared
-	// credentials. Compute the connected set once across the whole
-	// policy, then surface only the entries that fall inside the
-	// agent's profile.
+	// Every credential the agent's profile references — connected or
+	// not. The dashboard renders the unconfigured ones with a red ring
+	// so operators can see at a glance which credentials still need
+	// attention. Connection state is joined client-side from the
+	// top-level Integration[] list (which already carries per-credential
+	// connected / expires_at / display_name / avatar_url).
 	policy := w.g.Policy()
 	if policy == nil {
 		return snap
-	}
-	connected := map[string]bool{}
-	for name := range policy.Credentials {
-		if conn, _ := w.g.oauth.Status(name); conn {
-			connected[name] = true
-			continue
-		}
-		present, _ := credentialSlotPresence(w.g.db, name)
-		if len(present) > 0 {
-			connected[name] = true
-		}
 	}
 	for _, a := range snap {
 		profile := w.onboard.ProfileForIP(a.IP)
@@ -777,7 +767,7 @@ func (w *webMux) agentsList() []*Agent {
 		}
 		allowed := credentialsInProfile(policy, profile)
 		if allowed == nil {
-			// No profile filter — fall back to the full connected set.
+			// No profile filter — surface every declared credential.
 			allowed = map[string]bool{}
 			for name := range policy.Credentials {
 				allowed[name] = true
@@ -785,9 +775,7 @@ func (w *webMux) agentsList() []*Agent {
 		}
 		ids := make([]string, 0, len(allowed))
 		for name := range allowed {
-			if connected[name] {
-				ids = append(ids, name)
-			}
+			ids = append(ids, name)
 		}
 		sort.Strings(ids)
 		a.Integrations = ids

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -13,7 +13,7 @@ import { getState, type Agent, type Integration, type UpdateBanner, type Whoami 
 
 type Route =
   | { name: "main" }
-  | { name: "device"; ip: string }
+  | { name: "device"; ip: string; connect?: string }
   | { name: "analytics"; ip?: string }
   | { name: "onboard"; code: string }
   | { name: "request"; id: string }
@@ -24,6 +24,7 @@ function parseRoute(): Route {
   const raw = window.location.hash;
   const qi = raw.indexOf("?");
   const h = qi < 0 ? raw : raw.slice(0, qi);
+  const params = qi >= 0 ? new URLSearchParams(raw.slice(qi + 1)) : null;
   if (h.startsWith("#/onboard/"))
     return {
       name: "onboard",
@@ -39,7 +40,12 @@ function parseRoute(): Route {
   const da = h.match(/^#\/device\/([^/]+)\/analytics$/);
   if (da) return { name: "analytics", ip: decodeURIComponent(da[1]) };
   const m = h.match(/^#\/device\/([^/]+)$/);
-  if (m) return { name: "device", ip: decodeURIComponent(m[1]) };
+  if (m)
+    return {
+      name: "device",
+      ip: decodeURIComponent(m[1]),
+      connect: params?.get("connect") ?? undefined,
+    };
   return { name: "main" };
 }
 
@@ -161,6 +167,11 @@ export default function App() {
                 agents={agents}
                 integrations={integrations}
                 onSelect={(ip) => navigate("#/device/" + encodeURIComponent(ip))}
+                onConnectCredential={(ip, id) =>
+                  navigate(
+                    "#/device/" + encodeURIComponent(ip) + "?connect=" + encodeURIComponent(id),
+                  )
+                }
               />
             </div>
           </section>
@@ -189,6 +200,17 @@ export default function App() {
           onBack={() => navigate("")}
           onConnect={(id) => setConnectId(id)}
           onRefresh={refresh}
+          pendingConnect={route.connect}
+          onConsumePendingConnect={() => {
+            // Drop the ?connect= once the device page has acted on it
+            // so a reload doesn't reopen the modal.
+            window.history.replaceState(
+              null,
+              "",
+              "#/device/" + encodeURIComponent(route.ip),
+            );
+            setRoute(parseRoute());
+          }}
         />
       )}
       {showAddDevice && (

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -10,10 +10,15 @@ export function AgentsTable({
   agents,
   integrations,
   onSelect,
+  onConnectCredential,
 }: {
   agents: Agent[];
   integrations?: Integration[];
   onSelect?: (ip: string) => void;
+  // Called when the operator clicks an unconfigured credential pill on
+  // an agent's row. The parent navigates to the device page with the
+  // connect flow pre-armed for that credential.
+  onConnectCredential?: (ip: string, id: string) => void;
 }) {
   // id → Integration lookup so the icon stack can pick the right
   // logo per credential type (postgres/slack/etc, not just the
@@ -102,8 +107,12 @@ export function AgentsTable({
                       id,
                       type: it?.type,
                       avatar_url: it?.avatar_url,
+                      needsAction: needsAction(it),
                     };
                   })}
+                  onItemClick={
+                    onConnectCredential ? (id) => onConnectCredential(a.ip, id) : undefined
+                  }
                 />
               </Td>
             </tr>
@@ -112,6 +121,21 @@ export function AgentsTable({
       </tbody>
     </table>
   );
+}
+
+// needsAction returns true when a declared credential is missing its
+// secret (not connected) or its OAuth token has already expired. The
+// dashboard flags these with a red ring + click-to-configure handler.
+// Credentials with no auth path (the rare "api key only" inert case)
+// don't qualify — there's nothing actionable to do.
+function needsAction(it: Integration | undefined): boolean {
+  if (!it) return false;
+  const hasAuthPath = !!(it.has_oauth || it.has_tailscale_auth || (it.slots && it.slots.length > 0));
+  if (!hasAuthPath) return false;
+  const connected = it.connected || (it.tailscale_auth?.connected ?? false);
+  if (!connected) return true;
+  if (it.expires_at && it.expires_at * 1000 < Date.now()) return true;
+  return false;
 }
 
 function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -23,6 +23,8 @@ export function DevicePage({
   onBack,
   onConnect,
   onRefresh,
+  pendingConnect,
+  onConsumePendingConnect,
 }: {
   ip: string;
   agents: Agent[];
@@ -31,6 +33,12 @@ export function DevicePage({
   onBack: () => void;
   onConnect: (id: string) => void;
   onRefresh: () => void;
+  // When set, a credential id the page should auto-open the connect
+  // flow for on mount. Used by the agents-table click-through.
+  pendingConnect?: string;
+  // Called once the page has acted on pendingConnect, so the parent can
+  // clean the ?connect= out of the URL.
+  onConsumePendingConnect?: () => void;
 }) {
   const a = useMemo(() => agents.find((x) => x.ip === ip) ?? null, [agents, ip]);
   const [profiles, setProfiles] = useState<string[]>([]);
@@ -216,7 +224,13 @@ export function DevicePage({
       <LiveRequests agentIP={a.ip} height="360px" />
 
       {/* integrations management for this user */}
-      <IntegrationsCards list={allForUser} onConnect={onConnect} onRefresh={onRefresh} />
+      <IntegrationsCards
+        list={allForUser}
+        onConnect={onConnect}
+        onRefresh={onRefresh}
+        pendingConnect={pendingConnect}
+        onConsumePendingConnect={onConsumePendingConnect}
+      />
 
       {/* rules — per-device scope (with global rules layered in) */}
       <RulesPanel deviceIP={a.ip} profile={a.profile} readOnly={readOnlyConfig} />

--- a/www/src/components/IntegrationStack.tsx
+++ b/www/src/components/IntegrationStack.tsx
@@ -1,59 +1,115 @@
 import * as React from "react";
 import { IntegrationIcon } from "./Logos";
 
-// Overlapping circles a la GitHub avatar stack. Items carry both the
-// credential bare-name (id) and the plugin type — IntegrationIcon uses
-// the type to pick a brand logo, falling back to the id for the
-// claude/codex/github built-ins where the bare name happens to match
-// the brand. avatar_url, when present, replaces the brand logo with
-// the connected user's PFP (e.g. github avatar) so two devices in
-// different profiles connected to different accounts are
-// visually distinguishable in the agents table.
+// Compact integration display for the agents table.
+//
+// Items split into two visual groups:
+//
+//   1. Needs-action items (unconfigured / expired credentials) — shown
+//      first, with a red ring, side-by-side (no overlap). These are
+//      what operators must act on, so they get the visual priority and
+//      are clickable: clicking calls onItemClick(id), which the parent
+//      routes into the connect flow.
+//   2. Configured items — stacked à la GitHub avatar group, overlapping
+//      so a long list stays compact.
+//
+// avatar_url, when present, replaces the brand logo with the connected
+// account's PFP (e.g. github avatar) so two devices connected to
+// different accounts are visually distinguishable.
+export type StackItem = {
+  id: string;
+  type?: string;
+  avatar_url?: string;
+  needsAction?: boolean;
+};
+
 export function IntegrationStack({
   items,
   size = 20,
+  onItemClick,
 }: {
-  items: { id: string; type?: string; avatar_url?: string }[];
+  items: StackItem[];
   size?: number;
+  onItemClick?: (id: string) => void;
 }) {
   if (!items?.length) return <span className="text-2xs text-text-subtle">—</span>;
   const inner = Math.round(size * 0.6);
+  // Stable sort: needs-action first, original order otherwise. The
+  // server already returns the per-profile credential list in
+  // alphabetical order, so we preserve that within each bucket.
+  const sorted = items
+    .map((it, i) => ({ it, i }))
+    .sort((a, b) => {
+      const an = a.it.needsAction ? 0 : 1;
+      const bn = b.it.needsAction ? 0 : 1;
+      if (an !== bn) return an - bn;
+      return a.i - b.i;
+    })
+    .map((x) => x.it);
   return (
     <div className="flex items-center">
-      {items.map((it, i) => (
-        <span
-          key={it.id}
-          title={it.id}
-          className="rounded-full bg-canvas border border-canvas-dark flex items-center justify-center overflow-hidden"
-          style={{
-            width: size,
-            height: size,
-            marginLeft: i === 0 ? 0 : -size * 0.35,
-            zIndex: items.length - i,
-          }}
-        >
-          {it.avatar_url ? (
-            <StackAvatar
-              src={it.avatar_url}
-              fallbackId={it.id}
-              fallbackType={it.type}
-              size={size}
-              inner={inner}
-            />
-          ) : (
-            <span
-              style={{
-                width: inner,
-                height: inner,
-                display: "inline-flex",
-                color: "var(--color-text)",
-              }}
-            >
-              <IntegrationIcon id={it.id} type={it.type} className="w-full h-full" />
-            </span>
-          )}
-        </span>
-      ))}
+      {sorted.map((it, i) => {
+        const prev = i > 0 ? sorted[i - 1] : undefined;
+        // Needs-action items: small positive gap so the red rings stay
+        // legible. Configured items: stacked with a negative margin,
+        // except the first one after a needs-action group, which
+        // anchors at zero so the two groups don't visually fuse.
+        const margin =
+          i === 0
+            ? 0
+            : it.needsAction
+              ? 4
+              : prev?.needsAction
+                ? 6
+                : Math.round(-size * 0.35);
+        const clickable = it.needsAction && onItemClick;
+        return (
+          <span
+            key={it.id}
+            title={it.needsAction ? `${it.id} — click to configure` : it.id}
+            onClick={
+              clickable
+                ? (e) => {
+                    e.stopPropagation();
+                    onItemClick(it.id);
+                  }
+                : undefined
+            }
+            className={
+              "rounded-full bg-canvas flex items-center justify-center overflow-hidden " +
+              (it.needsAction ? "border-2 border-danger " : "border border-canvas-dark ") +
+              (clickable ? "cursor-pointer hover:border-text" : "")
+            }
+            style={{
+              width: size,
+              height: size,
+              marginLeft: margin,
+              zIndex: sorted.length - i,
+            }}
+          >
+            {it.avatar_url ? (
+              <StackAvatar
+                src={it.avatar_url}
+                fallbackId={it.id}
+                fallbackType={it.type}
+                size={size}
+                inner={inner}
+              />
+            ) : (
+              <span
+                style={{
+                  width: inner,
+                  height: inner,
+                  display: "inline-flex",
+                  color: "var(--color-text)",
+                }}
+              >
+                <IntegrationIcon id={it.id} type={it.type} className="w-full h-full" />
+              </span>
+            )}
+          </span>
+        );
+      })}
     </div>
   );
 }

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Integration } from "../lib/api";
 import { clearCredential, oauthRevoke, tailscaleConnect, tailscaleDisconnect } from "../lib/api";
 import { credentialTypeLabel } from "../lib/credentialLabels";
@@ -23,6 +23,8 @@ export function IntegrationsCards({
   showAll,
   onConnect,
   onRefresh,
+  pendingConnect,
+  onConsumePendingConnect,
 }: {
   list: Integration[];
   // When true, render every card in the grid (no overflow button,
@@ -31,6 +33,12 @@ export function IntegrationsCards({
   showAll?: boolean;
   onConnect: (id: string) => void;
   onRefresh: () => void;
+  // A credential id the parent wants the connect flow auto-opened for.
+  // Set by the agents-table click-through (?connect=<id> on the
+  // device-page URL); cleared via onConsumePendingConnect once we've
+  // acted on it so a reload doesn't reopen the modal.
+  pendingConnect?: string;
+  onConsumePendingConnect?: () => void;
 }) {
   const [editing, setEditing] = useState<Integration | null>(null);
   const [allOpen, setAllOpen] = useState(false);
@@ -107,6 +115,21 @@ export function IntegrationsCards({
       setEditing(i);
     }
   }
+
+  // Auto-open the connect flow when navigated to via ?connect=<id>.
+  // Runs once per pendingConnect value; consuming the prop signals the
+  // parent to drop the query param from the URL so a reload doesn't
+  // reopen the same modal.
+  useEffect(() => {
+    if (!pendingConnect) return;
+    const target = list.find((i) => i.id === pendingConnect);
+    if (!target) return;
+    handleConnect(target);
+    onConsumePendingConnect?.();
+    // handleConnect / onConsume are stable per render; we deliberately
+    // re-run only when pendingConnect changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingConnect]);
 
   function disconnect(i: Integration) {
     if (i.has_tailscale_auth && i.tailscale_auth) {


### PR DESCRIPTION
The integrations column on the agents table currently shows only the
credentials a profile has connected. That hides the more useful
information -- which credentials in the profile are *missing* a
secret -- so an operator can't tell at a glance which profiles still
need setup.

Surface every credential the agent's profile references and split
the display into two visual groups:

* **Needs-action items** -- declared, have an auth path, but not yet
  connected or token expired -- render first with a red ring and no
  overlap, so each is clickable as its own affordance. Clicking
  calls `onItemClick(id)`, which the parent routes into the connect
  flow.
* **Configured items** keep the existing GitHub-style overlapping
  avatar stack to the right.

Click-through wiring:

* New `?connect=<id>` query parameter on the device-page hash.
* `AgentsTable` calls into a new `onConnectCredential(ip, id)` prop
  for the needs-action click; `App` navigates to the URL.
* `App.parseRoute` reads `?connect=` into `route.connect` and feeds
  `DevicePage` a `pendingConnect` prop.
* `IntegrationsCards` consumes it via `useEffect` and auto-runs
  `handleConnect` on the matching integration -- handles oauth,
  tailscale, and paste-slot uniformly because `handleConnect`
  already branches per type.
* Parent clears the query once the modal has opened, so a reload
  doesn't replay it.

Server side: `agentsList` drops the connection-state filter (added
in #354) and surfaces every credential the agent's profile
references. Per-credential connected / expires_at / display_name /
avatar_url are joined client-side from the top-level
`Integration[]` payload, which already carries them.