### PR TITLE
regenerate config-reference.md for google_gke_credential

### DIFF
--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -144,7 +144,7 @@ approver "llm_approver" "example" {
 
 Block syntax: `credential "<type>" "<name>" { ... }`
 
-Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`tailscale`](#credential-tailscale), [`telegram_bot_token`](#credential-telegrambottoken).
+Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`tailscale`](#credential-tailscale), [`telegram_bot_token`](#credential-telegrambottoken).
 
 ### `credential "anthropic_manual_key" "<name>"`
 
@@ -232,6 +232,23 @@ _No configurable attributes._
 
 ```hcl
 credential "github_oauth" "example" {}
+```
+
+### `credential "google_gke_credential" "<name>"`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `cluster` | `string` | yes |  |
+| `location` | `string` | yes |  |
+| `project` | `string` | yes |  |
+| `impersonate_service_account` | `string` | no |  |
+
+```hcl
+credential "google_gke_credential" "example" {
+  cluster = "example"
+  location = "example"
+  project = "example"
+}
 ```
 
 ### `credential "header_token" "<name>"`


### PR DESCRIPTION
## Summary

Regenerate `site/doc/config-reference.md` so it picks up `google_gke_credential`. The plugin landed on main in `4e80f8d` (Add google_gke_credential plugin) but the docgen drift test caught that the reference doc wasn't regenerated — CI on main has been failing since.

`go run ./tools/docgen` from the repo root, single-file diff.

## Test plan

- [x] `go test ./tools/docgen/...` — drift test now passes
