### PR TITLE
aws_credential: set X-Amz-Expires=60 on EKS presigned URL

### DIFF
--- a/config/plugins/credentials/aws.go
+++ b/config/plugins/credentials/aws.go
@@ -94,7 +94,7 @@ func mintEKSBearerToken(ctx context.Context, akid, secret, sessionToken, region,
 	}
 	presigner := sts.NewPresignClient(sts.NewFromConfig(cfg), func(o *sts.PresignOptions) {
 		o.ClientOptions = append(o.ClientOptions, func(co *sts.Options) {
-			co.APIOptions = append(co.APIOptions, eksClusterHeaderMiddleware(cluster))
+			co.APIOptions = append(co.APIOptions, eksPresignMiddleware(cluster))
 		})
 	})
 	out, err := presigner.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
@@ -104,20 +104,32 @@ func mintEKSBearerToken(ctx context.Context, akid, secret, sessionToken, region,
 	return "k8s-aws-v1." + base64.RawURLEncoding.EncodeToString([]byte(out.URL)), nil
 }
 
-// eksClusterHeaderMiddleware stamps the `x-k8s-aws-id` header on the
-// outbound STS request before the SigV4 signer reads headers to build
-// the canonical request. The signer runs in the Finalize phase, so
-// adding the header in Build (After) guarantees it's signed.
-func eksClusterHeaderMiddleware(cluster string) func(*smithymiddleware.Stack) error {
+// eksPresignMiddleware stamps both the `x-k8s-aws-id` header (so the
+// canonical request includes the cluster scope EKS pins) and the
+// `X-Amz-Expires=60` query parameter required by aws-iam-authenticator
+// before the SigV4 signer reads headers / query to build the canonical
+// request. The SDK's PresignHTTP intentionally omits X-Amz-Expires;
+// aws-iam-authenticator (and EKS's webhook frontend) reject any
+// presigned URL whose query string has no expiration — the request
+// then comes back as 401 Unauthorized from the apiserver.
+//
+// The signer runs in Finalize, so mutating the request in Build
+// (After) guarantees both pieces are part of the signature.
+func eksPresignMiddleware(cluster string) func(*smithymiddleware.Stack) error {
 	return func(stack *smithymiddleware.Stack) error {
 		return stack.Build.Add(smithymiddleware.BuildMiddlewareFunc(
-			"clawpatrolEKSClusterHeader",
+			"clawpatrolEKSPresign",
 			func(ctx context.Context, in smithymiddleware.BuildInput, next smithymiddleware.BuildHandler) (smithymiddleware.BuildOutput, smithymiddleware.Metadata, error) {
 				r, ok := in.Request.(*smithyhttp.Request)
 				if !ok {
 					return smithymiddleware.BuildOutput{}, smithymiddleware.Metadata{}, fmt.Errorf("aws_credential: unexpected smithy request type %T", in.Request)
 				}
 				r.Header.Set("X-K8s-Aws-Id", cluster)
+				// aws-iam-authenticator caps presigned URL age at
+				// 60s; matching aws-cli's `eks get-token` shape.
+				q := r.URL.Query()
+				q.Set("X-Amz-Expires", "60")
+				r.URL.RawQuery = q.Encode()
 				return next.HandleBuild(ctx, in)
 			},
 		), smithymiddleware.After)

--- a/config/plugins/credentials/aws_test.go
+++ b/config/plugins/credentials/aws_test.go
@@ -71,6 +71,9 @@ func TestAWSCredentialSignHTTPRequestEmitsEKSBearer(t *testing.T) {
 	if got := q.Get("X-Amz-Credential"); !strings.HasPrefix(got, "AKIDEXAMPLE/") {
 		t.Errorf("X-Amz-Credential = %q, want prefix AKIDEXAMPLE/", got)
 	}
+	if got := q.Get("X-Amz-Expires"); got != "60" {
+		t.Errorf("X-Amz-Expires = %q, want 60 (aws-iam-authenticator rejects presigned URLs without an expiration)", got)
+	}
 }
 
 func TestAWSCredentialSignHTTPRequestRejectsNonEKSEndpoint(t *testing.T) {


### PR DESCRIPTION
The SDK's PresignHTTP intentionally omits X-Amz-Expires (see v4.go:332
in aws-sdk-go-v2). aws-iam-authenticator (and EKS's webhook frontend)
treat a presigned URL with no expiration as invalid and return 401
Unauthorized, so kubectl-via-clawpatrol against EKS gets "the server
has asked for the client to provide credentials" even though the
SigV4 signature itself verifies.

aws-cli's \`aws eks get-token\` sets X-Amz-Expires=60 explicitly; do
the same here in eksPresignMiddleware (renamed from
eksClusterHeaderMiddleware since it now does two things). Setting it
in Build (After) — alongside the X-K8s-Aws-Id header — guarantees the
parameter is part of the canonical request the signer hashes.

Verified live against the staging-dev EKS cluster from
prod.example.com: before the fix, every kubectl call returned 401;
after, the upstream returns the expected payload.