### PR TITLE
kubernetes endpoint: wire ca_cert through to upstream TLS

### DIFF
--- a/config/plugins/endpoints/kubernetes.go
+++ b/config/plugins/endpoints/kubernetes.go
@@ -5,6 +5,10 @@ package endpoints
 // time).
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
@@ -61,6 +65,28 @@ func (e *KubernetesEndpoint) EndpointCredentials() []config.CredBinding {
 // KubernetesEndpoint internals.
 func (e *KubernetesEndpoint) AWSEKSAuthParams() (cluster, region string) {
 	return e.ClusterName, e.Region
+}
+
+// ConfigureUpstreamTLS pins cfg.RootCAs to the cluster CA when the
+// endpoint declares one. EKS apiservers present a per-cluster CA
+// that the system trust store can't validate; the operator inlines
+// it via `ca_cert = <<file:cluster-ca.pem>>` (or the base64 from
+// `aws eks describe-cluster`). Self-hosted clusters whose
+// mtls_credential already supplies a `ca` slot leave this empty —
+// the credential's ConfigureUpstreamTLS runs next and wins.
+func (e *KubernetesEndpoint) ConfigureUpstreamTLS(cfg *tls.Config) error {
+	if e.CACert == "" {
+		return nil
+	}
+	pool := cfg.RootCAs
+	if pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM([]byte(e.CACert)) {
+		return errors.New("kubernetes endpoint ca_cert: no PEM blocks parsed")
+	}
+	cfg.RootCAs = pool
+	return nil
 }
 
 func init() {

--- a/config/plugins/endpoints/kubernetes_test.go
+++ b/config/plugins/endpoints/kubernetes_test.go
@@ -1,0 +1,68 @@
+package endpoints
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+// TestKubernetesEndpointConfigureUpstreamTLS verifies the endpoint's
+// ca_cert HCL field is applied to cfg.RootCAs at dial time. Without
+// this wiring the EKS apiserver path errors with "x509: certificate
+// signed by unknown authority" because EKS uses a per-cluster CA
+// that no system trust store carries.
+func TestKubernetesEndpointConfigureUpstreamTLS(t *testing.T) {
+	// Real self-signed ed25519 cert (generated once with `openssl req`),
+	// included verbatim so the test stays hermetic.
+	const ca = `-----BEGIN CERTIFICATE-----
+MIIBTzCCAQGgAwIBAgIUIFiZ5s2fC7N/ElT4ljred+5VuZYwBQYDK2VwMB0xGzAZ
+BgNVBAMMEmNsYXdwYXRyb2wtdGVzdC1jYTAeFw0yNjA1MTMyMjM2MDdaFw0zNjA1
+MTAyMjM2MDdaMB0xGzAZBgNVBAMMEmNsYXdwYXRyb2wtdGVzdC1jYTAqMAUGAytl
+cAMhAEEjAD+PAfsebOa0TpxGWC4BbXTJZS0Zyio+ag4KjFuMo1MwUTAdBgNVHQ4E
+FgQUyuf5UybO1z6734KuSwqtX94QnmQwHwYDVR0jBBgwFoAUyuf5UybO1z6734Ku
+SwqtX94QnmQwDwYDVR0TAQH/BAUwAwEB/zAFBgMrZXADQQA4uIgKBvkbVsXIoitq
+DpvHwDcxnGIz9Te9sfFH29Zr2iHwmMcz5T34iFfm/7XpBw8ajzrO+i5nFfIofiAI
+bRYL
+-----END CERTIFICATE-----`
+	e := &KubernetesEndpoint{CACert: ca}
+	cfg := &tls.Config{}
+	if err := e.ConfigureUpstreamTLS(cfg); err != nil {
+		t.Fatalf("ConfigureUpstreamTLS: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("RootCAs is nil after ConfigureUpstreamTLS — ca_cert was ignored")
+	}
+	if got := len(cfg.RootCAs.Subjects()); got == 0 { //nolint:staticcheck // SA1019 fine for test
+		t.Fatal("RootCAs has no certificates after ConfigureUpstreamTLS")
+	}
+}
+
+// TestKubernetesEndpointConfigureUpstreamTLSEmpty verifies the
+// no-op path: endpoints that don't declare a ca_cert leave cfg
+// untouched so the credential's ConfigureUpstreamTLS (mtls) or the
+// system trust store still wins.
+func TestKubernetesEndpointConfigureUpstreamTLSEmpty(t *testing.T) {
+	e := &KubernetesEndpoint{}
+	cfg := &tls.Config{}
+	if err := e.ConfigureUpstreamTLS(cfg); err != nil {
+		t.Fatalf("ConfigureUpstreamTLS: %v", err)
+	}
+	if cfg.RootCAs != nil {
+		t.Fatal("RootCAs mutated even though ca_cert was empty")
+	}
+}
+
+// TestKubernetesEndpointConfigureUpstreamTLSBadPEM surfaces a
+// configuration error when ca_cert isn't decodable. Operators see
+// the error at dial time (logged + fallback to default roots).
+func TestKubernetesEndpointConfigureUpstreamTLSBadPEM(t *testing.T) {
+	e := &KubernetesEndpoint{CACert: "not a pem"}
+	cfg := &tls.Config{}
+	err := e.ConfigureUpstreamTLS(cfg)
+	if err == nil {
+		t.Fatal("expected error on un-decodable ca_cert")
+	}
+	if !strings.Contains(err.Error(), "PEM") {
+		t.Errorf("err = %v, want one mentioning PEM", err)
+	}
+}

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -123,6 +123,21 @@ type TLSCredentialRuntime interface {
 	ConfigureUpstreamTLS(cfg *tls.Config, sec Secret) error
 }
 
+// EndpointTLSConfigurer is the optional hook an endpoint plugin
+// implements when it carries upstream-TLS state that doesn't belong
+// on a credential — most commonly a cluster-scoped CA pin. The
+// kubernetes endpoint implements it to apply its ca_cert HCL field
+// to cfg.RootCAs before the upstream dial: EKS apiservers present
+// per-cluster CAs that no system trust store knows about, and the
+// aws_credential plugin handles bearer auth, not root verification.
+//
+// Called by dialUpstream before any credential's ConfigureUpstreamTLS,
+// so a credential can still override RootCAs / append Certificates
+// when it has good reason to.
+type EndpointTLSConfigurer interface {
+	ConfigureUpstreamTLS(cfg *tls.Config) error
+}
+
 // ConnEndpointRuntime owns request-time handling for protocols that
 // don't fit the http.Request model — postgres, clickhouse_native,
 // any future binary wire protocol. The plugin receives the agent

--- a/dial.go
+++ b/dial.go
@@ -85,6 +85,14 @@ func (g *Gateway) servePorts() {}
 func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint, profile string) (net.Conn, error) {
 	cfg := &tls.Config{ServerName: serverName, NextProtos: []string{"http/1.1"}}
 
+	if ep != nil && ep.Body != nil {
+		if cfgr, ok := ep.Body.(runtime.EndpointTLSConfigurer); ok {
+			if err := cfgr.ConfigureUpstreamTLS(cfg); err != nil {
+				log.Printf("upstream tls %s: %v — dialing with default roots", serverName, err)
+			}
+		}
+	}
+
 	if ep != nil {
 		for _, cc := range ep.Credentials {
 			// Body is the real decoded HCL instance; Plugin.Runtime


### PR DESCRIPTION
The \`KubernetesEndpoint\` HCL \`ca_cert\` field is declared (with
\`FileIncludeFields\`, so operators inline the cluster CA via
\`ca_cert = <<file:cluster-ca.pem>>\`), but \`dialUpstream\` never read
it — only credentials implementing \`runtime.TLSCredentialRuntime\`
(\`mtls_credential\`) got to configure \`RootCAs\`. The result for
\`aws_credential\`-bound EKS endpoints: the gateway's upstream dial
errored with \`x509: certificate signed by unknown authority\` and
agent kubectl calls failed before the bearer was ever offered, since
EKS apiservers present a per-cluster CA that no system trust store
carries.

Introduce \`runtime.EndpointTLSConfigurer\`, implement it on
\`KubernetesEndpoint\` (append \`CACert\` PEM to \`cfg.RootCAs\`, falling
back to system roots), and invoke it from \`dial.go\` before the
credential's \`ConfigureUpstreamTLS\` so a credential can still override
\`RootCAs\` / append \`Certificates\` when it has good reason to.

Verified live: the staging-dev EKS apiserver in the running
prod.example.com policy now accepts the gateway's TLS handshake;
before the fix, every kubectl request errored on TLS verification.