### PR TITLE
postgres dispatch: consult dnsvip before conn-index

### DIFF
--- a/main.go
+++ b/main.go
@@ -1247,16 +1247,36 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 	agentPip := g.agentIPFor(c)
 
 	policy := g.Policy()
-	// Try the DNS-resolved IP index first — multi-postgres profiles
-	// dispatch correctly when each endpoint's hostname resolves to
-	// distinct IPs. When multiple endpoints share an IP (writer +
-	// readonly pointing at the same RDS), filter by the device's
-	// profile so the right one wins. Fall back to first-postgres-in-
-	// profile so single-database profiles work without DNS at all.
+	// Dispatch order:
+	//
+	//   1. dnsvip.LookupVIP — tunneled endpoints reach upstream via
+	//      a synthetic hostname routed through a VIP, and conn-index
+	//      intentionally skips them (would double-route past the
+	//      tunnel). Without this lookup, a tunneled postgres endpoint
+	//      lands in the firstPostgresEndpoint fallback below and the
+	//      gateway dials the wrong RDS / cloud-sql-proxy.
+	//   2. ConnIndex — non-tunneled endpoints indexed by DNS-resolved
+	//      upstream IP. Filtered by profile so writer / readonly
+	//      pointing at one RDS still picks the right one.
+	//   3. firstPostgresEndpoint — last-resort fallback so a
+	//      single-postgres profile works without DNS interception.
 	var ep *config.CompiledEndpoint
-	if idx := g.connIdx.Load(); idx != nil {
-		candidates := idx.Lookup(dstIP)
-		ep = pickEndpointForProfile(candidates, policy, profile)
+	if g.dnsvip != nil {
+		if _, hits := g.dnsvip.LookupVIP(dstIP); len(hits) > 0 {
+			cand := make([]*config.CompiledEndpoint, 0, len(hits))
+			for _, h := range hits {
+				if h.Endpoint != nil {
+					cand = append(cand, h.Endpoint)
+				}
+			}
+			ep = pickEndpointForProfile(cand, policy, profile)
+		}
+	}
+	if ep == nil {
+		if idx := g.connIdx.Load(); idx != nil {
+			candidates := idx.Lookup(dstIP)
+			ep = pickEndpointForProfile(candidates, policy, profile)
+		}
 	}
 	if ep == nil {
 		ep = firstPostgresEndpoint(policy, profile)


### PR DESCRIPTION
\`handlePostgresConn\` looked up an endpoint by dstIP via ConnIndex
only. But ConnIndex intentionally skips tunneled endpoints (so the WG
forwarder doesn't double-route past the tunnel — see
\`BuildConnIndex\`'s comment), so a tunneled postgres endpoint's VIP
never resolved here. The fallback was \`firstPostgresEndpoint\`, which
returns whichever postgres endpoint sits first in the profile.

Reproducer: an \`dev2\` profile with two postgres endpoints —
\`pg-deploy-classic-staging\` (cloud-sql-proxy tunnel) and
\`pg-staging-dev\` (kubernetes_port_forward tunnel to a transient
socat pod in EKS). A psql connection to the staging-dev synthetic
hostname got VIP-allocated, hit \`handlePostgresConn\` with that VIP,
then dispatched through the cloud-sql-proxy tunnel and onto
denosr-staging's main-pg14 database — same wire format, very wrong
upstream.

Fix: try \`dnsvip.LookupVIP(dstIP)\` first. When the dst IP belongs to
a VIP, the allocator's EndpointHits are the authoritative answer for
which tunneled endpoint owns the connection; the existing
\`pickEndpointForProfile\` then filters by the device's profile so
VIPs shared by multiple profiles still route to the right one.
Falls through to ConnIndex / firstPostgresEndpoint when the dst IP
isn't a VIP (direct-IP postgres endpoints, the pre-existing path).

Verified live on prod.example.com with the dev2 profile.