### PR TITLE
endpoint dispatch: match host case-insensitively

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/denoland/clawpatrol/config/match"
@@ -294,8 +295,12 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				continue
 			}
 			profile.Endpoints[epName] = ce
+			// DNS hostnames are case-insensitive; index lowercase
+			// so a SNI-peek lookup (TLS clients usually lowercase
+			// SNI on the wire) matches a config-declared host
+			// regardless of its casing.
 			for _, h := range ce.Hosts {
-				profile.HostIndex[h] = ce
+				profile.HostIndex[strings.ToLower(h)] = ce
 			}
 		}
 		// Add default-port TLS aliases only after every exact host is
@@ -310,6 +315,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			}
 			for _, h := range ce.Hosts {
 				if bare, ok := bareHostAlias(ce, h); ok {
+					bare = strings.ToLower(bare)
 					if _, exists := profile.HostIndex[bare]; !exists {
 						profile.HostIndex[bare] = ce
 					}

--- a/config/runtime/dispatch.go
+++ b/config/runtime/dispatch.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"strings"
+
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/match"
 )
@@ -9,13 +11,16 @@ import (
 // that owns it. Compile populates HostIndex with exact declared hosts
 // plus bare-host aliases for HTTPS-family default-port declarations,
 // so a TLS SNI value like "api.example.com" can match an endpoint
-// declared as "api.example.com:443" without a runtime scan. Returns nil
-// when the profile doesn't bind any matching endpoint — the caller then
+// declared as "api.example.com:443" without a runtime scan. DNS
+// hostnames are case-insensitive; the lookup key is lowercased to
+// match the lowercase keys Compile inserts. Returns nil when the
+// profile doesn't bind any matching endpoint — the caller then
 // applies the defaults.unknown_host policy.
 func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.CompiledEndpoint {
 	if policy == nil {
 		return nil
 	}
+	host = strings.ToLower(host)
 	prof, ok := policy.Profiles[profile]
 	if !ok {
 		// Single-tenant fallback: if no peer-to-profile mapping is

--- a/config/runtime/dispatch_test.go
+++ b/config/runtime/dispatch_test.go
@@ -80,6 +80,27 @@ func TestHostEndpoint(t *testing.T) {
 	}
 }
 
+// TestHostEndpointIsCaseInsensitive guards against a regression where a
+// config-declared uppercase host (common with EKS cluster apiservers,
+// e.g. "3F6827…GR7.us-east-2.eks.amazonaws.com") failed to match a
+// lowercase SNI value sent by TLS clients like curl. DNS hostnames are
+// case-insensitive; the lookup must be too.
+func TestHostEndpointIsCaseInsensitive(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "eks" {
+  hosts = ["AB123.gr7.us-east-2.eks.amazonaws.com"]
+}
+profile "default" { endpoints = [eks] }
+`)
+
+	if got := runtime.HostEndpoint(cp, "default", "ab123.gr7.us-east-2.eks.amazonaws.com"); got == nil || got.Name != "eks" {
+		t.Fatalf("lowercase SNI against uppercase config: got %+v, want eks", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "AB123.GR7.US-EAST-2.EKS.AMAZONAWS.COM"); got == nil || got.Name != "eks" {
+		t.Fatalf("uppercase lookup: got %+v, want eks", got)
+	}
+}
+
 func TestHostEndpointMatchesBareSNIForPortQualifiedHost(t *testing.T) {
 	cp := compileFixture(t, `
 endpoint "https" "api" {


### PR DESCRIPTION
SNI dispatch built HostIndex from the raw config-declared host and
compared against the raw SNI value. TLS clients lowercase SNI on the
wire (per RFC 6066), so an endpoint declared with uppercase letters —
e.g. an EKS apiserver hostname like
`3F6827434FE1BF291BDCBC1E756EE7E3.gr7.us-east-2.eks.amazonaws.com` —
never matched a lowercase SNI value from curl, and the gateway
spliced the connection through to the real upstream instead of
running its MITM auth-injection pipeline. The agent then hit the
apiserver with no bearer and saw a 401.

DNS hostnames are case-insensitive. Lowercase both sides: index
under `strings.ToLower(host)` at compile, and lowercase the lookup
key in HostEndpoint.

Fixes example/prod-deploy#23.