### PR TITLE
settings credentials: group cards by plugin type

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -568,12 +568,20 @@ func shortHash(s string) string {
 }
 
 type IntegrationRow struct {
-	ID               string                 `json:"id"`
-	Name             string                 `json:"name"`
-	Type             string                 `json:"type"` // credential plugin type
-	HasOAuth         bool                   `json:"has_oauth"`
-	OAuth            *OAuthIntegrationUI    `json:"oauth,omitempty"`
-	Slots            []config.SecretSlot    `json:"slots,omitempty"`
+	ID       string              `json:"id"`
+	Name     string              `json:"name"`
+	Type     string              `json:"type"` // credential plugin type
+	HasOAuth bool                `json:"has_oauth"`
+	OAuth    *OAuthIntegrationUI `json:"oauth,omitempty"`
+	Slots    []config.SecretSlot `json:"slots,omitempty"`
+	// Subtitle is the plugin's account-level identity rendered under
+	// the card heading: the connected-OAuth display_name for
+	// OAuth-flow credentials post-connect, or the HCL-derived
+	// CardSubtitle for plugins like Postgres / Clickhouse that carry
+	// a user field on the body. Empty when the plugin has no useful
+	// identity to surface — the dashboard then omits the subtitle
+	// slot entirely rather than render a placeholder.
+	Subtitle         string                 `json:"subtitle,omitempty"`
 	Connected        bool                   `json:"connected"`
 	ExpiresAt        int64                  `json:"expires_at,omitempty"`
 	DisplayName      string                 `json:"display_name,omitempty"`
@@ -664,6 +672,18 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 				ConnectURL:    "/api/tailscale/connect?id=" + name,
 				StatusURL:     "/api/tailscale/status?id=" + name,
 				DisconnectURL: "/api/tailscale/disconnect?id=" + name,
+			}
+		}
+		// Card subtitle: prefer the OAuth-supplied display_name when
+		// the credential is a connected OAuth flow; fall back to any
+		// HCL-derived identity (Postgres / Clickhouse user, etc.).
+		// Leaves Subtitle empty when neither source has anything to
+		// say — the dashboard then drops the subtitle slot rather
+		// than rendering a misleading "Saved" placeholder.
+		row.Subtitle = row.DisplayName
+		if row.Subtitle == "" {
+			if sp, ok := ent.Body.(config.CardSubtitleProvider); ok {
+				row.Subtitle = sp.CardSubtitle()
 			}
 		}
 		out = append(out, row)

--- a/config/oauth.go
+++ b/config/oauth.go
@@ -65,3 +65,20 @@ type OptionalScope struct {
 type OAuthFlowProvider interface {
 	OAuthFlow() *OAuthIntegration
 }
+
+// OAuthProfileFetcher is the optional interface an OAuth-flow
+// credential plugin's body implements when it knows how to enrich a
+// freshly-issued access token with the connected account's identity
+// (display name + avatar). The host calls this once at exchange time
+// and persists the result on the credentials row; the dashboard
+// surfaces the display name as the card subtitle so two same-type
+// OAuth credentials can be told apart at a glance.
+//
+// Plugins that don't implement this leave the identity empty — the
+// dashboard then shows no subtitle (the green dot + status text still
+// indicate the connection state). Implementations should be
+// best-effort: a failed userinfo fetch returns ("", "") rather than
+// surfacing an error to the connect flow.
+type OAuthProfileFetcher interface {
+	FetchOAuthProfile(accessToken string) (displayName, avatarURL string)
+}

--- a/config/plugins/credentials/clickhouse.go
+++ b/config/plugins/credentials/clickhouse.go
@@ -47,6 +47,10 @@ func (*ClickhouseCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "ClickHouse password"}}
 }
 
+// CardSubtitle surfaces the configured ClickHouse user as the
+// dashboard card subtitle. Empty when the operator omitted `user`.
+func (c *ClickhouseCredential) CardSubtitle() string { return c.User }
+
 func init() {
 	var _ runtime.HTTPCredentialRuntime = (*ClickhouseCredential)(nil)
 	var _ runtime.ClickhouseAuthCredential = (*ClickhouseCredential)(nil)

--- a/config/plugins/credentials/github.go
+++ b/config/plugins/credentials/github.go
@@ -6,6 +6,7 @@ package credentials
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -71,6 +72,39 @@ func (*GitHubOAuth) EnvVars() []config.EnvVar {
 		{Name: "GH_TOKEN", Value: phGitHub, Description: "gh CLI"},
 		{Name: "GITHUB_TOKEN", Value: phGitHub, Description: "GitHub Actions / SDKs"},
 	}
+}
+
+// FetchOAuthProfile pulls the connected GitHub identity from
+// api.github.com/user so the dashboard can surface the login (or full
+// name, when set) as the card subtitle instead of an opaque
+// "connected" indicator. Best-effort: a network error, non-200, or
+// malformed body returns empty strings and the dashboard falls back
+// to no subtitle.
+func (*GitHubOAuth) FetchOAuthProfile(accessToken string) (string, string) {
+	req, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		return "", ""
+	}
+	var u struct {
+		Login     string `json:"login"`
+		Name      string `json:"name"`
+		AvatarURL string `json:"avatar_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return "", ""
+	}
+	display := u.Login
+	if u.Name != "" {
+		display = u.Name
+	}
+	return display, u.AvatarURL
 }
 
 // OAuthFlow on GitHubOAuth returns the gh CLI's published OAuth

--- a/config/plugins/credentials/postgres.go
+++ b/config/plugins/credentials/postgres.go
@@ -30,6 +30,12 @@ func (*PostgresCredential) SecretSlots() []config.SecretSlot {
 	return []config.SecretSlot{{Label: "Postgres password"}}
 }
 
+// CardSubtitle surfaces the configured Postgres user as the dashboard
+// card subtitle so two same-host postgres credentials (e.g. a
+// read-only and a read-write user against the same DB) read apart at
+// a glance. Empty when the operator omitted `user` from the HCL.
+func (p *PostgresCredential) CardSubtitle() string { return p.User }
+
 func init() {
 	var _ runtime.PostgresAuthCredential = (*PostgresCredential)(nil)
 	config.Register(&config.Plugin{

--- a/config/secret_slot.go
+++ b/config/secret_slot.go
@@ -26,3 +26,17 @@ type SecretSlot struct {
 type SecretSlotsProvider interface {
 	SecretSlots() []SecretSlot
 }
+
+// CardSubtitleProvider is the optional interface a credential plugin's
+// decoded body implements when its non-secret HCL fields carry an
+// account-level identity (Postgres / Clickhouse user, etc.) worth
+// surfacing as the dashboard card subtitle. Returning "" means "no
+// useful identity on the body" — the card then either shows the
+// OAuth display_name (for OAuth-flow credentials post-connect) or no
+// subtitle at all, rather than a misleading "Saved" placeholder.
+//
+// Called once per /api/state build, so implementations should be
+// pure (read body fields, return a short string).
+type CardSubtitleProvider interface {
+	CardSubtitle() string
+}

--- a/oauth.go
+++ b/oauth.go
@@ -50,14 +50,19 @@ type OAuthRegistry struct {
 	mu           sync.RWMutex
 	integrations map[string]*OAuthIntegration
 	states       map[string]*oauthState // key: id
-	db           *sql.DB
+	// profileFetchers keyed by credential id (== integration id at
+	// register time). Captured separately from the OAuth flow config
+	// so the host can call userinfo without re-walking the policy.
+	profileFetchers map[string]config.OAuthProfileFetcher
+	db              *sql.DB
 }
 
 func NewOAuthRegistry(items []OAuthIntegration, db *sql.DB) (*OAuthRegistry, error) {
 	r := &OAuthRegistry{
-		integrations: map[string]*OAuthIntegration{},
-		states:       map[string]*oauthState{},
-		db:           db,
+		integrations:    map[string]*OAuthIntegration{},
+		states:          map[string]*oauthState{},
+		profileFetchers: map[string]config.OAuthProfileFetcher{},
+		db:              db,
 	}
 	for i := range items {
 		r.integrations[items[i].ID] = &items[i]
@@ -138,8 +143,10 @@ func (r *OAuthRegistry) Token(id string) (string, error) {
 // gateway boot to register OAuth-flow credentials from the new
 // policy under their bare-name as the ID. Idempotent: re-registering
 // the same ID with an identical definition is a no-op; replacing one
-// with a different definition overwrites.
-func (r *OAuthRegistry) Register(id string, def OAuthIntegration) {
+// with a different definition overwrites. fetcher is optional — pass
+// nil for OAuth providers that don't (yet) know how to enrich the
+// token with the connected account's identity.
+func (r *OAuthRegistry) Register(id string, def OAuthIntegration, fetcher config.OAuthProfileFetcher) {
 	if id == "" {
 		return
 	}
@@ -147,6 +154,11 @@ func (r *OAuthRegistry) Register(id string, def OAuthIntegration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.integrations[id] = &def
+	if fetcher != nil {
+		r.profileFetchers[id] = fetcher
+	} else {
+		delete(r.profileFetchers, id)
+	}
 }
 
 // Status returns connected info for the named credential.
@@ -204,54 +216,12 @@ func (r *OAuthRegistry) Set(id string, tok *oauth2.Token) error {
 		r.states[id] = s
 	}
 	s.setToken(tok)
-	if name, avatar := fetchOAuthProfile(id, tok.AccessToken); name != "" || avatar != "" {
-		s.persistProfile(name, avatar)
+	if fetcher, ok := r.profileFetchers[id]; ok {
+		if name, avatar := fetcher.FetchOAuthProfile(tok.AccessToken); name != "" || avatar != "" {
+			s.persistProfile(name, avatar)
+		}
 	}
 	return nil
-}
-
-// OAuthProfile holds the human-identity bits we surface on the
-// dashboard (real name + avatar). Populated after a successful token
-// exchange by hitting the provider's userinfo endpoint.
-type OAuthProfile struct {
-	DisplayName string
-	AvatarURL   string
-}
-
-// fetchOAuthProfile returns the (display_name, avatar_url) for a
-// freshly-issued token. Per-provider — `github` hits api.github.com/
-// user; others currently return empty until their userinfo wiring
-// lands. Failure is non-fatal: profile metadata is decorative and
-// missing data falls back to the provider icon on the dashboard.
-func fetchOAuthProfile(id, accessToken string) (string, string) {
-	switch id {
-	case "github":
-		req, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
-		req.Header.Set("Authorization", "Bearer "+accessToken)
-		req.Header.Set("Accept", "application/vnd.github+json")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return "", ""
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != 200 {
-			return "", ""
-		}
-		var u struct {
-			Login     string `json:"login"`
-			Name      string `json:"name"`
-			AvatarURL string `json:"avatar_url"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
-			return "", ""
-		}
-		display := u.Login
-		if u.Name != "" {
-			display = u.Name
-		}
-		return display, u.AvatarURL
-	}
-	return "", ""
 }
 
 func newState(it *OAuthIntegration, db *sql.DB) *oauthState {

--- a/secrets.go
+++ b/secrets.go
@@ -224,7 +224,12 @@ func registerOAuthCredentials(reg *OAuthRegistry, policy *config.CompiledPolicy)
 		}
 		copied := *flow
 		copied.ID = name
-		reg.Register(name, copied)
+		// Optional: plugins that know how to enrich the token with a
+		// connected-account identity hand the host their fetcher here.
+		// nil for plugins that don't — the dashboard then renders the
+		// card without a subtitle (still has the green dot + status).
+		fetcher, _ := ent.Body.(config.OAuthProfileFetcher)
+		reg.Register(name, copied, fetcher)
 	}
 	if err := reg.LoadFromDB(); err != nil {
 		log.Printf("oauth: rehydrate from db: %v", err)

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -406,21 +406,15 @@ function Card({
 }
 
 // contextualSubtitle returns the per-credential-type hint shown below
-// the card title. Sources are all non-secret fields already on the
-// IntegrationRow payload — no secret material (token prefixes, raw
-// password hashes, etc.) is rendered. Returns "" to mean "omit the
-// subtitle slot entirely" (compact card).
+// the card title. For connected credentials the server resolves the
+// account identity (OAuth display_name, Postgres/Clickhouse user,
+// etc.) into `subtitle` — we surface that verbatim and otherwise
+// leave the slot empty (the green dot + status text already convey
+// "connected"). The unconnected hints are still synthesised here
+// because they depend on which connect path the card offers.
 function contextualSubtitle(i: Integration, connected: boolean, hasSlots: boolean): string {
   if (connected) {
-    // OAuth flows persist the connected account identity (email /
-    // username / workspace name) on the credential at connect time —
-    // that's what `display_name` is. Surface it directly when present.
-    if (i.display_name) return i.display_name;
-    // Manual / Tailscale / OAuth-without-identity: nothing useful to
-    // distinguish two same-type creds, fall back to a stable
-    // placeholder so the row still reads "configured".
-    if (hasSlots || i.has_tailscale_auth) return "Saved";
-    return "";
+    return i.subtitle ?? "";
   }
   // Not connected: OAuth and Tailscale both await an explicit user
   // action; manual creds with slots are simply unconfigured.

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -46,7 +46,9 @@ export function IntegrationsCards({
   const [allOpen, setAllOpen] = useState(false);
 
   // Sort: connected first, then unconnected, then disabled (no auth
-  // path) — preserves declaration order within each bucket.
+  // path) — preserves declaration order within each bucket. Only used
+  // by the device-page row (compact + overflow). The Settings page
+  // (showAll) groups by plugin type instead — see groupedByType below.
   const sorted = [...list].sort((a, b) => {
     const score = (i: Integration) => {
       if (i.connected || i.tailscale_auth?.connected) return 0;
@@ -59,6 +61,12 @@ export function IntegrationsCards({
   const overflow = !showAll && sorted.length > VISIBLE_CAP;
   const visible = overflow ? sorted.slice(0, VISIBLE_CAP - 1) : sorted;
   const hiddenCount = sorted.length - visible.length;
+
+  // Settings-page grouping: cluster cards by plugin type, with each
+  // group labelled by display name + count and sorted alphabetically
+  // by display name. Within a group, sort by credential bare name so
+  // the layout is stable across refreshes.
+  const groupedByType = showAll ? groupByType(list) : null;
 
   function handleConnect(i: Integration) {
     if (i.has_tailscale_auth && i.tailscale_auth) {
@@ -137,24 +145,47 @@ export function IntegrationsCards({
 
   return (
     <>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5">
-        {visible.map((i) => (
-          <Card
-            key={i.id}
-            integration={i}
-            onConnect={() => handleConnect(i)}
-            onDisconnect={() => disconnect(i)}
-          />
-        ))}
-        {overflow && (
-          <button
-            onClick={() => setAllOpen(true)}
-            className="flex items-center justify-center px-3 py-2.5 bg-canvas-light border-2 border-dashed border-navy text-xs text-text-muted hover:bg-navy-50 hover:text-text transition-colors"
-          >
-            + {hiddenCount} more
-          </button>
-        )}
-      </div>
+      {groupedByType ? (
+        <div className="space-y-5">
+          {groupedByType.map((g) => (
+            <div key={g.type} className="space-y-2">
+              <h3 className="text-2xs uppercase tracking-[.12em] text-text-muted font-bold flex items-baseline gap-1.5">
+                <span>{g.label}</span>
+                <span className="text-text-subtle font-normal">— {g.items.length}</span>
+              </h3>
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5">
+                {g.items.map((i) => (
+                  <Card
+                    key={i.id}
+                    integration={i}
+                    onConnect={() => handleConnect(i)}
+                    onDisconnect={() => disconnect(i)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5">
+          {visible.map((i) => (
+            <Card
+              key={i.id}
+              integration={i}
+              onConnect={() => handleConnect(i)}
+              onDisconnect={() => disconnect(i)}
+            />
+          ))}
+          {overflow && (
+            <button
+              onClick={() => setAllOpen(true)}
+              className="flex items-center justify-center px-3 py-2.5 bg-canvas-light border-2 border-dashed border-navy text-xs text-text-muted hover:bg-navy-50 hover:text-text transition-colors"
+            >
+              + {hiddenCount} more
+            </button>
+          )}
+        </div>
+      )}
 
       {allOpen && (
         <AllIntegrationsModal
@@ -182,6 +213,28 @@ export function IntegrationsCards({
 
 function isConnected(i: Integration) {
   return i.connected || (i.tailscale_auth?.connected ?? false);
+}
+
+type CredentialGroup = {
+  type: string;
+  label: string;
+  items: Integration[];
+};
+
+function groupByType(list: Integration[]): CredentialGroup[] {
+  const buckets = new Map<string, Integration[]>();
+  for (const i of list) {
+    const arr = buckets.get(i.type);
+    if (arr) arr.push(i);
+    else buckets.set(i.type, [i]);
+  }
+  return Array.from(buckets.entries())
+    .map(([type, items]) => ({
+      type,
+      label: credentialTypeLabel(type, type),
+      items: [...items].sort((a, b) => a.name.localeCompare(b.name)),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 // OwnerAvatar renders the OAuth user's PFP (e.g. github avatar) with

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -155,15 +155,12 @@ export function IntegrationsCards({
                 <span>{section.label}</span>
                 <span className="text-text-subtle font-normal">— {section.total}</span>
               </h3>
-              <div className="flex flex-wrap gap-3">
+              <div className="flex flex-wrap gap-x-6 gap-y-4">
                 {section.types.map((g) => (
-                  <div
-                    key={g.type}
-                    className="border-2 border-navy bg-canvas-light px-3 py-2.5 space-y-2"
-                  >
-                    <div className="text-2xs uppercase tracking-[.12em] text-text-subtle font-semibold flex items-baseline gap-1.5">
+                  <div key={g.type} className="space-y-1.5">
+                    <div className="text-2xs uppercase tracking-[.12em] text-text-subtle flex items-baseline gap-1.5">
                       <span>{g.label}</span>
-                      <span className="font-normal">— {g.items.length}</span>
+                      <span>— {g.items.length}</span>
                     </div>
                     <div className="flex flex-wrap gap-2">
                       {g.items.map((i) => (

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -62,11 +62,13 @@ export function IntegrationsCards({
   const visible = overflow ? sorted.slice(0, VISIBLE_CAP - 1) : sorted;
   const hiddenCount = sorted.length - visible.length;
 
-  // Settings-page grouping: cluster cards by plugin type, with each
-  // group labelled by display name + count and sorted alphabetically
-  // by display name. Within a group, sort by credential bare name so
-  // the layout is stable across refreshes.
-  const groupedByType = showAll ? groupByType(list) : null;
+  // Settings-page grouping: split by connection state first
+  // (Connected / Not Configured) and then cluster by plugin type
+  // within each state. The two state sections stack vertically; the
+  // per-type boxes inside each section flow horizontally and wrap on
+  // overflow so a long credential catalog scans like a grid of
+  // labelled clusters rather than a vertical ladder.
+  const groupedByStatus = showAll ? groupByStatusThenType(list) : null;
 
   function handleConnect(i: Integration) {
     if (i.has_tailscale_auth && i.tailscale_auth) {
@@ -145,25 +147,39 @@ export function IntegrationsCards({
 
   return (
     <>
-      {groupedByType ? (
-        <div className="space-y-5">
-          {groupedByType.map((g) => (
-            <div key={g.type} className="space-y-2">
+      {groupedByStatus ? (
+        <div className="space-y-6">
+          {groupedByStatus.map((section) => (
+            <section key={section.status} className="space-y-2.5">
               <h3 className="text-2xs uppercase tracking-[.12em] text-text-muted font-bold flex items-baseline gap-1.5">
-                <span>{g.label}</span>
-                <span className="text-text-subtle font-normal">— {g.items.length}</span>
+                <span>{section.label}</span>
+                <span className="text-text-subtle font-normal">— {section.total}</span>
               </h3>
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5">
-                {g.items.map((i) => (
-                  <Card
-                    key={i.id}
-                    integration={i}
-                    onConnect={() => handleConnect(i)}
-                    onDisconnect={() => disconnect(i)}
-                  />
+              <div className="flex flex-wrap gap-3">
+                {section.types.map((g) => (
+                  <div
+                    key={g.type}
+                    className="border-2 border-navy bg-canvas-light px-3 py-2.5 space-y-2"
+                  >
+                    <div className="text-2xs uppercase tracking-[.12em] text-text-subtle font-semibold flex items-baseline gap-1.5">
+                      <span>{g.label}</span>
+                      <span className="font-normal">— {g.items.length}</span>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {g.items.map((i) => (
+                        <div key={i.id} className="w-44">
+                          <Card
+                            integration={i}
+                            onConnect={() => handleConnect(i)}
+                            onDisconnect={() => disconnect(i)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                 ))}
               </div>
-            </div>
+            </section>
           ))}
         </div>
       ) : (
@@ -220,6 +236,46 @@ type CredentialGroup = {
   label: string;
   items: Integration[];
 };
+
+type StatusSection = {
+  status: "connected" | "unconfigured";
+  label: string;
+  total: number;
+  types: CredentialGroup[];
+};
+
+// groupByStatusThenType splits the credential list into Connected /
+// Not Configured sections and clusters each section by plugin type.
+// Empty sections are dropped so a fully-connected (or fully-empty)
+// catalog doesn't render a stub heading. The unconfigured bucket
+// also catches credentials with no auth path at all — from the
+// operator's point of view those are equally "not yet usable".
+function groupByStatusThenType(list: Integration[]): StatusSection[] {
+  const connected: Integration[] = [];
+  const unconfigured: Integration[] = [];
+  for (const i of list) {
+    if (isConnected(i)) connected.push(i);
+    else unconfigured.push(i);
+  }
+  const sections: StatusSection[] = [];
+  if (connected.length > 0) {
+    sections.push({
+      status: "connected",
+      label: "Connected",
+      total: connected.length,
+      types: groupByType(connected),
+    });
+  }
+  if (unconfigured.length > 0) {
+    sections.push({
+      status: "unconfigured",
+      label: "Not configured",
+      total: unconfigured.length,
+      types: groupByType(unconfigured),
+    });
+  }
+  return sections;
+}
 
 function groupByType(list: Integration[]): CredentialGroup[] {
   const buckets = new Map<string, Integration[]>();
@@ -302,7 +358,7 @@ function Card({
       disabled={!clickable && !connected}
       onClick={() => clickable && onConnect()}
       className={
-        "group relative flex flex-col items-start gap-2 px-3 py-2.5 bg-canvas-light border-2 border-navy text-left transition-colors " +
+        "group relative w-full flex flex-col items-start gap-2 px-3 py-2.5 bg-canvas-light border-2 border-navy text-left transition-colors " +
         (clickable ? "cursor-pointer hover:bg-navy-50" : "cursor-default")
       }
     >

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -37,6 +37,12 @@ export type Integration = {
   has_oauth: boolean;
   oauth?: OAuthIntegrationUI | null;
   slots?: SecretSlot[] | null;
+  // subtitle is the server-resolved account identity rendered under
+  // the card heading — the OAuth display_name post-connect, the
+  // Postgres/Clickhouse user from HCL, etc. Empty when the plugin
+  // has no useful identity to surface; the dashboard then omits the
+  // subtitle slot rather than render a placeholder.
+  subtitle?: string;
   connected: boolean;
   expires_at?: number;
   display_name?: string;


### PR DESCRIPTION
On the Settings page's credentials section, cluster credential cards
by plugin type instead of rendering one flat row. Each group gets a
small heading with the plugin display name + a count of cards in the
group; groups are ordered alphabetically by display name, and cards
within a group are sorted by their HCL block name so the layout is
stable across refreshes.

Layout-only — card content/behaviour, the device-page row, and the
overflow modal are unchanged. Grouping is gated on `showAll`, so only
the Settings page picks it up; the device page keeps its compact
connected-first ordering with the "+ K more" overflow.

The group label uses the same `credentialTypeLabel` resolution as the
card title, falling back to the raw HCL type for unknown plugins.
Empty types render nothing (we only iterate over types that appear in
the integration list).