### PR TITLE
kubernetes_port_forward: self-contained EKS auth via aws_credential

### DIFF
--- a/config/file_include.go
+++ b/config/file_include.go
@@ -25,7 +25,7 @@ import (
 // have field-precise positions at this layer.
 func expandFileIncludes(p *Policy, configDir string) hcl.Diagnostics {
 	var diags hcl.Diagnostics
-	for _, group := range []map[string]*Entity{p.Endpoints, p.Credentials, p.Approvers, p.Rules} {
+	for _, group := range []map[string]*Entity{p.Endpoints, p.Credentials, p.Approvers, p.Rules, p.Tunnels} {
 		for name, ent := range group {
 			fi, ok := ent.Body.(FileIncludable)
 			if !ok {

--- a/config/plugins/credentials/aws.go
+++ b/config/plugins/credentials/aws.go
@@ -46,7 +46,7 @@ type awsEKSParams interface {
 }
 
 // SignHTTPRequest is part of the clawpatrol plugin API.
-func (*AWSCredential) SignHTTPRequest(ctx context.Context, req *http.Request, sec runtime.Secret, endpoint any) error {
+func (c *AWSCredential) SignHTTPRequest(ctx context.Context, req *http.Request, sec runtime.Secret, endpoint any) error {
 	params, ok := endpoint.(awsEKSParams)
 	if !ok {
 		return errors.New("aws_credential: endpoint does not declare EKS auth params (use `endpoint \"kubernetes\"` with cluster_name + region)")
@@ -55,16 +55,27 @@ func (*AWSCredential) SignHTTPRequest(ctx context.Context, req *http.Request, se
 	if cluster == "" || region == "" {
 		return errors.New("aws_credential: kubernetes endpoint missing cluster_name / region")
 	}
-	akid, secret, token, err := awsCredentialMaterial(sec)
-	if err != nil {
-		return err
-	}
-	bearer, err := mintEKSBearerToken(ctx, akid, secret, token, region, cluster)
+	bearer, err := c.MintEKSBearer(ctx, sec, region, cluster)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+bearer)
 	return nil
+}
+
+// MintEKSBearer implements runtime.EKSBearerMinter — same code path
+// SignHTTPRequest uses, exported so the kubernetes_port_forward
+// tunnel can build a self-contained kubeconfig without a parallel
+// STS presign.
+func (*AWSCredential) MintEKSBearer(ctx context.Context, sec runtime.Secret, region, cluster string) (string, error) {
+	if cluster == "" || region == "" {
+		return "", errors.New("aws_credential: cluster + region are required to mint an EKS bearer")
+	}
+	akid, secret, token, err := awsCredentialMaterial(sec)
+	if err != nil {
+		return "", err
+	}
+	return mintEKSBearerToken(ctx, akid, secret, token, region, cluster)
 }
 
 // awsCredentialMaterial reads the three secret slots. access_key_id
@@ -150,6 +161,7 @@ func (*AWSCredential) SecretSlots() []config.SecretSlot {
 
 func init() {
 	var _ runtime.HTTPRequestSigner = (*AWSCredential)(nil)
+	var _ runtime.EKSBearerMinter = (*AWSCredential)(nil)
 	config.Register(&config.Plugin{
 		Kind:    config.KindCredential,
 		Type:    "aws_credential",

--- a/config/plugins/tunnels/kubernetes_port_forward.go
+++ b/config/plugins/tunnels/kubernetes_port_forward.go
@@ -54,12 +54,15 @@ package tunnels
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -77,7 +80,9 @@ import (
 
 // KubernetesPortForwardTunnel configures the tunnel runtime.
 type KubernetesPortForwardTunnel struct {
-	// Context selects a kubeconfig context; empty uses the current context.
+	// Context selects a kubeconfig context; empty uses the current
+	// context. Ignored when Server is set (the plugin builds its own
+	// per-tunnel kubeconfig).
 	Context string `hcl:"context,optional"`
 	// Namespace selects the Kubernetes namespace for kubectl commands.
 	Namespace string `hcl:"namespace,optional"`
@@ -102,6 +107,25 @@ type KubernetesPortForwardTunnel struct {
 	// case; "keep" disables deletion.
 	Cleanup string `hcl:"cleanup,optional"`
 
+	// Server is the Kubernetes apiserver URL. When set the plugin
+	// writes a per-tunnel kubeconfig (server + ca_cert + bearer minted
+	// from the bound credential) and invokes kubectl with --kubeconfig
+	// pointing at it; no external kubeconfig or KUBECONFIG env is
+	// needed. The Context field is then ignored.
+	Server string `hcl:"server,optional"`
+	// CACert is the cluster CA PEM. Supports `<<file:path.pem>>` for
+	// out-of-line storage; the loader inlines the file contents.
+	// Required when Server is set against EKS (the apiserver presents
+	// a per-cluster CA that no system trust store carries).
+	CACert string `hcl:"ca_cert,optional"`
+	// ClusterName is the EKS cluster name, used by an aws_credential
+	// to scope the STS presign (sets the X-K8s-Aws-Id header). Only
+	// meaningful alongside Server + an aws_credential.
+	ClusterName string `hcl:"cluster_name,optional"`
+	// Region is the AWS region the EKS cluster lives in; SigV4 needs
+	// it. Only meaningful alongside Server + an aws_credential.
+	Region string `hcl:"region,optional"`
+
 	// Share controls whether runtime instances are singleton, per-endpoint, or per-request.
 	Share string `hcl:"share,optional"`
 	// Keepalive keeps an idle tunnel runtime warm for the given duration.
@@ -110,6 +134,15 @@ type KubernetesPortForwardTunnel struct {
 	Via string `hcl:"via,optional"`
 	// Credential references an optional credential block for Kubernetes access.
 	Credential string `hcl:"credential,optional"`
+}
+
+// FileIncludeFields tells the loader to inline `<<file:NAME>>` markers
+// in ca_cert. Operators reference the cluster CA by filename so the
+// PEM stays out of the policy file.
+func (t *KubernetesPortForwardTunnel) FileIncludeFields() []config.FileIncludeField {
+	return []config.FileIncludeField{
+		{Get: func() string { return t.CACert }, Set: func(v string) { t.CACert = v }},
+	}
 }
 
 // TunnelCommon returns shared tunnel settings.
@@ -157,18 +190,109 @@ func (t *KubernetesPortForwardTunnel) Open(ctx context.Context, host runtime.Tun
 		ns:      ns,
 		cleanup: t.Cleanup != "keep",
 	}
+	if t.Server != "" {
+		path, err := t.writeKubeconfig(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("kubernetes_port_forward/%s: %w", host.Name, err)
+		}
+		rt.kubeconfig = path
+		// Context (kubeconfig context name) is meaningless once we own
+		// the kubeconfig — clear it so kctlArgs doesn't double up with
+		// a --context flag.
+		rt.ctx = ""
+	}
 	target, err := t.resolveTarget(ctx, rt)
 	if err != nil {
 		rt.cleanupCreatedPod(context.Background())
+		rt.removeKubeconfig()
 		return nil, fmt.Errorf("kubernetes_port_forward/%s: %w", host.Name, err)
 	}
 	if err := rt.startPortForward(ctx, target, t.Port); err != nil {
 		rt.cleanupCreatedPod(context.Background())
+		rt.removeKubeconfig()
 		return nil, fmt.Errorf("kubernetes_port_forward/%s: %w", host.Name, err)
 	}
 	logger.Printf("kubernetes_port_forward/%s: forwarding %s/%s → %s",
 		host.Name, ns, target, rt.localAddr)
 	return rt, nil
+}
+
+// writeKubeconfig materialises a self-contained kubeconfig (server +
+// ca + bearer) backed by the bound credential, and returns the temp
+// file path. EKS bearer tokens have a 15-minute TTL (60s when minted
+// the way aws-cli does it), but kubectl's port-forward holds open one
+// authenticated session for its whole lifetime — the bearer's only
+// consumed at handshake, so a single mint per Open() is fine.
+func (t *KubernetesPortForwardTunnel) writeKubeconfig(ctx context.Context, host runtime.TunnelHost) (string, error) {
+	if t.CACert == "" {
+		return "", errors.New("`server` set without `ca_cert`; inline the cluster CA (or `<<file:cluster-ca.pem>>`) so kubectl can verify the apiserver")
+	}
+	if host.Credential == nil {
+		return "", errors.New("`server` is set but no `credential` is bound; kubectl can't authenticate")
+	}
+	minter, ok := host.Credential.Body.(runtime.EKSBearerMinter)
+	if !ok {
+		return "", fmt.Errorf("credential %q (%s) does not implement EKSBearerMinter — bind an `aws_credential`",
+			host.Credential.Name, host.Credential.Type)
+	}
+	if t.ClusterName == "" || t.Region == "" {
+		return "", errors.New("`server` is set against an EKS-auth credential, so `cluster_name` + `region` are required")
+	}
+	sec, err := host.SecretStore.Get(host.Credential.Name)
+	if err != nil {
+		return "", fmt.Errorf("fetch credential secret %q: %w", host.Credential.Name, err)
+	}
+	bearer, err := minter.MintEKSBearer(ctx, sec, t.Region, t.ClusterName)
+	if err != nil {
+		return "", fmt.Errorf("mint EKS bearer: %w", err)
+	}
+	yaml := buildEKSKubeconfig(t.Server, t.CACert, bearer)
+	dir := filepath.Join(host.StateDir, "tunnels", "kubernetes_port_forward")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	f, err := os.CreateTemp(dir, host.Name+"-kubeconfig-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("create kubeconfig temp: %w", err)
+	}
+	if _, err := f.Write([]byte(yaml)); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("write kubeconfig: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("close kubeconfig: %w", err)
+	}
+	_ = os.Chmod(f.Name(), 0o600)
+	return f.Name(), nil
+}
+
+// buildEKSKubeconfig produces a minimal v1 kubeconfig with cluster
+// (server + inline CA) + user (static bearer) + matching context.
+// Cleartext bearer in a 0600 temp file is fine because the gateway
+// itself is the only consumer; nothing else on the host runs as the
+// same uid by design.
+func buildEKSKubeconfig(server, caPEM, bearer string) string {
+	enc := base64.StdEncoding.EncodeToString([]byte(caPEM))
+	return strings.Join([]string{
+		"apiVersion: v1",
+		"kind: Config",
+		"clusters:",
+		"- name: cluster",
+		"  cluster:",
+		"    server: " + server,
+		"    certificate-authority-data: " + enc,
+		"users:",
+		"- name: user",
+		"  user:",
+		"    token: " + bearer,
+		"contexts:",
+		"- name: ctx",
+		"  context: { cluster: cluster, user: user }",
+		"current-context: ctx",
+		"",
+	}, "\n")
 }
 
 // validateModes enforces exactly-one-of pod / service / selector /
@@ -204,7 +328,7 @@ func (t *KubernetesPortForwardTunnel) resolveTarget(ctx context.Context, rt *kub
 	case t.Service != "":
 		return "svc/" + t.Service, nil
 	case len(t.Selector) > 0:
-		name, err := pickReadyPod(ctx, rt.ctx, rt.ns, t.Selector)
+		name, err := pickReadyPod(ctx, rt.kubeconfig, rt.ctx, rt.ns, t.Selector)
 		if err != nil {
 			return "", err
 		}
@@ -227,8 +351,8 @@ func (t *KubernetesPortForwardTunnel) resolveTarget(ctx context.Context, rt *kub
 // --field-selector=status.phase=Running` and returns the first
 // match. Ready is approximated by Running; kubectl's port-forward
 // will fail loudly if the pod isn't actually accepting connections.
-func pickReadyPod(ctx context.Context, kctx, ns string, selector map[string]string) (string, error) {
-	args := kctlArgs(kctx, ns,
+func pickReadyPod(ctx context.Context, kubeconfig, kctx, ns string, selector map[string]string) (string, error) {
+	args := kctlArgs(kubeconfig, kctx, ns,
 		"get", "pods",
 		"-l", labelSelector(selector),
 		"--field-selector=status.phase=Running",
@@ -296,11 +420,15 @@ func labelSelector(m map[string]string) string {
 	return out
 }
 
-// kctlArgs prepends --context and --namespace flags (when set) to
-// the given kubectl arg vector.
-func kctlArgs(kctx, ns string, args ...string) []string {
+// kctlArgs prepends --kubeconfig / --context and --namespace flags
+// (when set) to the given kubectl arg vector. When kubeconfig is set
+// the plugin owns a per-tunnel config file, so --context isn't
+// emitted (the file's current-context is correct by construction).
+func kctlArgs(kubeconfig, kctx, ns string, args ...string) []string {
 	out := []string{}
-	if kctx != "" {
+	if kubeconfig != "" {
+		out = append(out, "--kubeconfig", kubeconfig)
+	} else if kctx != "" {
 		out = append(out, "--context", kctx)
 	}
 	if ns != "" {
@@ -330,8 +458,9 @@ type kubernetesPortForwardTunnel struct {
 	name   string
 	logger *log.Logger
 
-	ctx string // kubectl --context
-	ns  string
+	ctx        string // kubectl --context (skipped when kubeconfig is set)
+	kubeconfig string // kubectl --kubeconfig path, or "" to fall back to KUBECONFIG / ~/.kube/config
+	ns         string
 
 	// createdPod, if non-empty, is the name of a pod the plugin
 	// applied at Open and should delete on Close (when cleanup=true).
@@ -343,12 +472,26 @@ type kubernetesPortForwardTunnel struct {
 	once      sync.Once
 }
 
+// removeKubeconfig deletes the temp kubeconfig the plugin minted at
+// Open time, if any. No-op when the plugin used an external
+// kubeconfig (KUBECONFIG / ~/.kube/config / explicit context).
+func (t *kubernetesPortForwardTunnel) removeKubeconfig() {
+	if t.kubeconfig == "" {
+		return
+	}
+	path := t.kubeconfig
+	t.kubeconfig = ""
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.logger.Printf("kubernetes_port_forward/%s: remove kubeconfig %s: %v", t.name, path, err)
+	}
+}
+
 // applyAndWait shells out to `kubectl create -f -` + `kubectl wait
 // --for=condition=Ready`. Returns the resolved pod name (which may
 // differ from doc.name when `generateName` is used).
 func (t *kubernetesPortForwardTunnel) applyAndWait(ctx context.Context, doc *podDoc) (string, error) {
 	cmd := exec.CommandContext(ctx, "kubectl",
-		kctlArgs(t.ctx, t.ns, "create", "-f", "-", "-o", "name")...)
+		kctlArgs(t.kubeconfig, t.ctx, t.ns, "create", "-f", "-", "-o", "name")...)
 	cmd.Stdin = strings.NewReader(doc.raw)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -365,7 +508,7 @@ func (t *kubernetesPortForwardTunnel) applyAndWait(ctx context.Context, doc *pod
 	}
 	t.logger.Printf("kubernetes_port_forward/%s: created pod %s/%s", t.name, t.ns, name)
 
-	waitArgs := kctlArgs(t.ctx, t.ns,
+	waitArgs := kctlArgs(t.kubeconfig, t.ctx, t.ns,
 		"wait", "--for=condition=Ready", "pod/"+name, "--timeout=2m")
 	if _, err := runKubectl(ctx, waitArgs); err != nil {
 		return name, fmt.Errorf("pod %s/%s never became ready: %w", t.ns, name, err)
@@ -382,7 +525,7 @@ var portForwardReady = regexp.MustCompile(`Forwarding from 127\.0\.0\.1:(\d+) ->
 // on Close. We isolate the child in its own process group so we can
 // signal it (and any subprocesses) reliably.
 func (t *kubernetesPortForwardTunnel) startPortForward(ctx context.Context, target string, podPort int) error {
-	args := kctlArgs(t.ctx, t.ns,
+	args := kctlArgs(t.kubeconfig, t.ctx, t.ns,
 		"port-forward", target, fmt.Sprintf(":%d", podPort),
 		"--address=127.0.0.1")
 	cmd := exec.Command("kubectl", args...)
@@ -451,6 +594,7 @@ func (t *kubernetesPortForwardTunnel) Close() error {
 	t.once.Do(func() {
 		t.killPF()
 		t.cleanupCreatedPod(context.Background())
+		t.removeKubeconfig()
 	})
 	return nil
 }
@@ -464,7 +608,7 @@ func (t *kubernetesPortForwardTunnel) cleanupCreatedPod(ctx context.Context) {
 	t.logger.Printf("kubernetes_port_forward/%s: deleting pod %s/%s", t.name, t.ns, name)
 	delCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	args := kctlArgs(t.ctx, t.ns, "delete", "pod/"+name, "--wait=false")
+	args := kctlArgs(t.kubeconfig, t.ctx, t.ns, "delete", "pod/"+name, "--wait=false")
 	if _, err := runKubectl(delCtx, args); err != nil {
 		t.logger.Printf("kubernetes_port_forward/%s: delete pod failed: %v", t.name, err)
 	}
@@ -507,6 +651,18 @@ func init() {
 			}
 			if t.Port != 0 {
 				b.SetAttributeValue("port", cty.NumberIntVal(int64(t.Port)))
+			}
+			if t.Server != "" {
+				b.SetAttributeValue("server", cty.StringVal(t.Server))
+			}
+			if t.CACert != "" {
+				b.SetAttributeValue("ca_cert", cty.StringVal(t.CACert))
+			}
+			if t.ClusterName != "" {
+				b.SetAttributeValue("cluster_name", cty.StringVal(t.ClusterName))
+			}
+			if t.Region != "" {
+				b.SetAttributeValue("region", cty.StringVal(t.Region))
 			}
 			emitCommon(b, t.TunnelCommon())
 		},

--- a/config/plugins/tunnels/kubernetes_port_forward_test.go
+++ b/config/plugins/tunnels/kubernetes_port_forward_test.go
@@ -1,6 +1,7 @@
 package tunnels
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 )
@@ -100,6 +101,44 @@ spec:
 `)
 	if err == nil {
 		t.Fatal("expected error for missing name")
+	}
+}
+
+// TestKctlArgsKubeconfigBeatsContext verifies that when a per-tunnel
+// kubeconfig is set, --context is suppressed: kubectl reads
+// `current-context` from the file we just wrote, so passing both
+// would either confuse it (--context unknown) or, worse, silently
+// flip back to a wrong context that happens to exist by name.
+func TestKctlArgsKubeconfigBeatsContext(t *testing.T) {
+	got := kctlArgs("/tmp/k.yaml", "ignored-context", "default", "get", "pods")
+	if got[0] != "--kubeconfig" || got[1] != "/tmp/k.yaml" {
+		t.Fatalf("args = %v, want --kubeconfig /tmp/k.yaml first", got)
+	}
+	for _, a := range got {
+		if a == "--context" {
+			t.Fatalf("args = %v, must not include --context when --kubeconfig is set", got)
+		}
+	}
+}
+
+// TestBuildEKSKubeconfig pins the shape kubectl will see when the
+// tunnel mints its own kubeconfig: cluster.server + base64'd
+// certificate-authority-data, user.token, single matching context,
+// current-context set.
+func TestBuildEKSKubeconfig(t *testing.T) {
+	out := buildEKSKubeconfig("https://eks.example", "ca-pem-bytes", "k8s-aws-v1.xxxx")
+	wantCA := "certificate-authority-data: " + base64.StdEncoding.EncodeToString([]byte("ca-pem-bytes"))
+	for _, want := range []string{
+		"apiVersion: v1",
+		"kind: Config",
+		"server: https://eks.example",
+		wantCA,
+		"token: k8s-aws-v1.xxxx",
+		"current-context: ctx",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("buildEKSKubeconfig missing %q\nfull output:\n%s", want, out)
+		}
 	}
 }
 

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -138,6 +138,22 @@ type EndpointTLSConfigurer interface {
 	ConfigureUpstreamTLS(cfg *tls.Config) error
 }
 
+// EKSBearerMinter is the credential-plugin contract for minting a
+// k8s-aws-v1.<…> bearer scoped to one (region, cluster) pair. The
+// kubernetes_port_forward tunnel uses this to materialise a temp
+// kubeconfig at Open time, so operators can drop the external
+// awscli + kubeconfig + KUBECONFIG-in-systemd glue: HCL declares the
+// cluster shape (server + ca_cert + cluster_name + region) and binds
+// an aws_credential that satisfies this interface; the tunnel mints,
+// writes, and cleans up the per-tunnel kubeconfig itself.
+//
+// The HTTPRequestSigner path (kubernetes endpoint, per-request HTTP
+// auth) calls the same underlying STS presigner — both shapes route
+// through one mint helper so signature semantics stay in sync.
+type EKSBearerMinter interface {
+	MintEKSBearer(ctx context.Context, sec Secret, region, cluster string) (string, error)
+}
+
 // ConnEndpointRuntime owns request-time handling for protocols that
 // don't fit the http.Request model — postgres, clickhouse_native,
 // any future binary wire protocol. The plugin receives the agent

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -553,7 +553,7 @@ Configures the tunnel runtime.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `context` | `string` | no | Selects a kubeconfig context; empty uses the current context. |
+| `context` | `string` | no | Selects a kubeconfig context; empty uses the current context. Ignored when Server is set (the plugin builds its own per-tunnel kubeconfig). |
 | `namespace` | `string` | no | Selects the Kubernetes namespace for kubectl commands. |
 | `pod` | `string` | no | Names an existing pod to port-forward to. Exactly one of pod, service, selector, or template must be set. |
 | `service` | `string` | no | Names a service to port-forward to. |
@@ -561,6 +561,10 @@ Configures the tunnel runtime.
 | `template` | `string` | no | A pod manifest to apply and port-forward to. |
 | `port` | `int` | yes | The pod-side port the forwarder targets. For service mode it's the *service* port; kubectl resolves the matching targetPort. |
 | `cleanup` | `string` | no | Controls whether a template-created pod is deleted on tunnel teardown. "delete" (default) is right for the common create-on-demand case; "keep" disables deletion. |
+| `server` | `string` | no | The Kubernetes apiserver URL. When set the plugin writes a per-tunnel kubeconfig (server + ca_cert + bearer minted from the bound credential) and invokes kubectl with --kubeconfig pointing at it; no external kubeconfig or KUBECONFIG env is needed. The Context field is then ignored. |
+| `ca_cert` | `string` | no | The cluster CA PEM. Supports `<<file:path.pem>>` for out-of-line storage; the loader inlines the file contents. Required when Server is set against EKS (the apiserver presents a per-cluster CA that no system trust store carries). |
+| `cluster_name` | `string` | no | The EKS cluster name, used by an aws_credential to scope the STS presign (sets the X-K8s-Aws-Id header). Only meaningful alongside Server + an aws_credential. |
+| `region` | `string` | no | The AWS region the EKS cluster lives in; SigV4 needs it. Only meaningful alongside Server + an aws_credential. |
 | `share` | `string` | no | Controls whether runtime instances are singleton, per-endpoint, or per-request. |
 | `keepalive` | `string` | no | Keeps an idle tunnel runtime warm for the given duration. |
 | `via` | `ref(tunnel)` | no | Chains kubectl access through another tunnel. |


### PR DESCRIPTION
Operators wiring a \`kubernetes_port_forward\` tunnel against an EKS
cluster had to install awscli + a kubeconfig on the gateway host and
export \`KUBECONFIG\` in the systemd unit. Everything outside the HCL
— implicit dependencies that no \`clawpatrol validate\` could catch,
and that get blown away on a rebuild.

Add four optional HCL fields to the tunnel: \`server\`, \`ca_cert\`
(with \`FileIncludable\` support), \`cluster_name\`, \`region\`. When
\`server\` is set, Open():

* Type-asserts the bound credential to \`runtime.EKSBearerMinter\`
  (extracted out of \`aws_credential.SignHTTPRequest\` so the same STS
  presign path serves both the kubernetes endpoint and the tunnel).
* Fetches the secret, mints a fresh \`k8s-aws-v1.<…>\` bearer.
* Writes a per-tunnel kubeconfig (server + inline CA + bearer) into
  \`<state_dir>/tunnels/kubernetes_port_forward/\`, chmod 0600.
* Threads \`--kubeconfig=<path>\` through every kubectl invocation
  (\`kctlArgs\` grew a new first arg; \`--context\` is suppressed when
  \`--kubeconfig\` is set so kubectl doesn't get conflicting hints).

\`Close()\` removes the temp kubeconfig. The single-mint-per-Open
matches the lifetime semantics of kubectl port-forward: the bearer
is only consumed during the initial handshake, the SPDY tunnel
takes over from there.

Side-effect: \`expandFileIncludes\` now walks \`p.Tunnels\` too, so
the tunnel's \`ca_cert = <<file:cluster-ca.pem>>\` works the same
way the kubernetes endpoint's already did.

Verified live: prod.example.com runs psql through this tunnel
against staging-dev's RDS with no awscli on the host, no
kubeconfig in /root, no \`KUBECONFIG\` env. Cold-start (gateway
restart) reproduces successfully.