### PR TITLE
fix: align HITL pending expiry with human timeout

### DIFF
--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -72,7 +72,9 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 	if req.Pool == nil {
 		return runtime.ApproveVerdict{}, fmt.Errorf("human approver %q: no pool", req.ApproverName)
 	}
+	timeout := h.approvalTimeout(req.Policy)
 	pending := buildPending(req)
+	pending.ExpiresAt = pending.CreatedAt.Add(timeout)
 	id, ch := req.Pool.Add(pending)
 	defer req.Pool.Discard(id)
 
@@ -120,13 +122,6 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 		}
 	}
 
-	timeout := time.Duration(h.Timeout) * time.Second
-	if timeout <= 0 {
-		timeout = time.Duration(req.Policy.HumanTimeout) * time.Second
-	}
-	if timeout <= 0 {
-		timeout = 10 * time.Minute
-	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
@@ -144,6 +139,17 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 	case <-ctx.Done():
 		return runtime.ApproveVerdict{}, ctx.Err()
 	}
+}
+
+func (h *HumanApprover) approvalTimeout(policy *config.CompiledPolicy) time.Duration {
+	timeout := time.Duration(h.Timeout) * time.Second
+	if timeout <= 0 && policy != nil {
+		timeout = time.Duration(policy.HumanTimeout) * time.Second
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	return timeout
 }
 
 func init() {

--- a/config/plugins/approvers/human_test.go
+++ b/config/plugins/approvers/human_test.go
@@ -1,0 +1,112 @@
+package approvers
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+type captureHITLPool struct {
+	added    chan struct{}
+	id       string
+	decision chan runtime.HITLDecision
+
+	mu      sync.Mutex
+	pending runtime.HITLPending
+}
+
+func newCaptureHITLPool() *captureHITLPool {
+	return &captureHITLPool{
+		added:    make(chan struct{}),
+		id:       "pending-1",
+		decision: make(chan runtime.HITLDecision, 1),
+	}
+}
+
+func (p *captureHITLPool) Add(pending runtime.HITLPending) (string, <-chan runtime.HITLDecision) {
+	p.mu.Lock()
+	p.pending = pending
+	p.mu.Unlock()
+	close(p.added)
+	return p.id, p.decision
+}
+
+func (p *captureHITLPool) Discard(string) {}
+
+func (p *captureHITLPool) Decide(string, runtime.HITLDecision) bool { return false }
+
+func (p *captureHITLPool) capturedPending() runtime.HITLPending {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.pending
+}
+
+func TestHumanApproverPendingExpirationUsesApproverTimeout(t *testing.T) {
+	pending := captureHumanPending(t, &HumanApprover{Timeout: 17}, &config.CompiledPolicy{HumanTimeout: 600})
+	assertPendingLifetime(t, pending, 17*time.Second)
+}
+
+func TestHumanApproverPendingExpirationUsesPolicyTimeoutFallback(t *testing.T) {
+	pending := captureHumanPending(t, &HumanApprover{}, &config.CompiledPolicy{HumanTimeout: 23})
+	assertPendingLifetime(t, pending, 23*time.Second)
+}
+
+func TestHumanApproverPendingExpirationUsesDefaultTimeoutFallback(t *testing.T) {
+	pending := captureHumanPending(t, &HumanApprover{}, nil)
+	assertPendingLifetime(t, pending, 10*time.Minute)
+}
+
+func captureHumanPending(t *testing.T, approver *HumanApprover, policy *config.CompiledPolicy) runtime.HITLPending {
+	t.Helper()
+	pool := newCaptureHITLPool()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := approver.Approve(ctx, runtime.ApproveRequest{
+			Pool:         pool,
+			Policy:       policy,
+			ApproverName: "ops",
+			AgentIP:      "100.64.0.10",
+			Method:       "POST",
+			Host:         "api.example.test",
+			Path:         "/v1/write",
+			Reason:       "requires human approval",
+		})
+		done <- err
+	}()
+
+	select {
+	case <-pool.added:
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not publish pending entry")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Approve error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not return after context cancellation")
+	}
+	return pool.capturedPending()
+}
+
+func assertPendingLifetime(t *testing.T, pending runtime.HITLPending, want time.Duration) {
+	t.Helper()
+	if pending.CreatedAt.IsZero() {
+		t.Fatal("pending CreatedAt is zero")
+	}
+	if pending.ExpiresAt.IsZero() {
+		t.Fatal("pending ExpiresAt is zero")
+	}
+	if got := pending.ExpiresAt.Sub(pending.CreatedAt); got != want {
+		t.Fatalf("pending lifetime = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve the effective human approval timeout once and use it for both the pending prompt expiry and the wait timer.
- Keep `HITLPending.ExpiresAt` aligned with explicit `human_approver.timeout`, policy `human_timeout`, and the default timeout.
- Add regression coverage for the timeout selection cases.

## Test plan
- `(cd www && npm ci && npm run build)`
- `git diff --check`
- `go test ./...`
