### PR TITLE
fix: retain HITL terminal states for stale prompts

### DIFF
--- a/config/plugins/approvers/dashboard.go
+++ b/config/plugins/approvers/dashboard.go
@@ -31,6 +31,8 @@ func (DashboardApprover) Approve(ctx context.Context, req runtime.ApproveRequest
 			By:       d.By,
 		}, nil
 	case <-ctx.Done():
+		state, reason := hitlCancelStateForContext(ctx.Err())
+		cancelPending(req.Pool, id, state, reason)
 		return runtime.ApproveVerdict{}, ctx.Err()
 	}
 }

--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -133,10 +133,14 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 			By:       d.By,
 		}, nil
 	case <-timer.C:
+		reason := fmt.Sprintf("approver %q timed out after %s; upstream request was not sent", req.ApproverName, timeout)
+		cancelPending(req.Pool, id, runtime.HITLStateTimedOut, reason)
 		return runtime.ApproveVerdict{
-			Reason: fmt.Sprintf("approver %q timed out after %s", req.ApproverName, timeout),
+			Reason: reason,
 		}, nil
 	case <-ctx.Done():
+		state, reason := hitlCancelStateForContext(ctx.Err())
+		cancelPending(req.Pool, id, state, reason)
 		return runtime.ApproveVerdict{}, ctx.Err()
 	}
 }

--- a/config/plugins/approvers/human_test.go
+++ b/config/plugins/approvers/human_test.go
@@ -16,8 +16,9 @@ type captureHITLPool struct {
 	id       string
 	decision chan runtime.HITLDecision
 
-	mu      sync.Mutex
-	pending runtime.HITLPending
+	mu           sync.Mutex
+	pending      runtime.HITLPending
+	cancelResult runtime.HITLResolveResult
 }
 
 func newCaptureHITLPool() *captureHITLPool {
@@ -40,10 +41,23 @@ func (p *captureHITLPool) Discard(string) {}
 
 func (p *captureHITLPool) Decide(string, runtime.HITLDecision) bool { return false }
 
+func (p *captureHITLPool) Cancel(_ string, state runtime.HITLState, reason string) runtime.HITLResolveResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancelResult = runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
+	return p.cancelResult
+}
+
 func (p *captureHITLPool) capturedPending() runtime.HITLPending {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.pending
+}
+
+func (p *captureHITLPool) capturedCancel() runtime.HITLResolveResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cancelResult
 }
 
 func TestHumanApproverPendingExpirationUsesApproverTimeout(t *testing.T) {
@@ -59,6 +73,92 @@ func TestHumanApproverPendingExpirationUsesPolicyTimeoutFallback(t *testing.T) {
 func TestHumanApproverPendingExpirationUsesDefaultTimeoutFallback(t *testing.T) {
 	pending := captureHumanPending(t, &HumanApprover{}, nil)
 	assertPendingLifetime(t, pending, 10*time.Minute)
+}
+
+func TestHumanApproverTimeoutRecordsTimedOutTerminalState(t *testing.T) {
+	pool := newCaptureHITLPool()
+	done := make(chan struct {
+		verdict runtime.ApproveVerdict
+		err     error
+	}, 1)
+	go func() {
+		verdict, err := (&HumanApprover{Timeout: 1}).Approve(context.Background(), runtime.ApproveRequest{
+			Pool:         pool,
+			ApproverName: "ops",
+			Method:       "POST",
+			Host:         "api.example.test",
+			Path:         "/v1/write",
+		})
+		done <- struct {
+			verdict runtime.ApproveVerdict
+			err     error
+		}{verdict: verdict, err: err}
+	}()
+
+	select {
+	case <-pool.added:
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not publish pending entry")
+	}
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Approve error = %v, want nil", got.err)
+		}
+		if got.verdict.Decision != "" {
+			t.Fatalf("verdict Decision = %q, want deny/empty timeout verdict", got.verdict.Decision)
+		}
+		if got.verdict.Reason == "" {
+			t.Fatal("timeout verdict Reason is empty")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("human approver did not time out")
+	}
+
+	cancelResult := pool.capturedCancel()
+	if cancelResult.State != runtime.HITLStateTimedOut {
+		t.Fatalf("Cancel state = %q, want %q", cancelResult.State, runtime.HITLStateTimedOut)
+	}
+}
+
+func TestHumanApproverContextCancelRecordsClientDisconnected(t *testing.T) {
+	pool := newCaptureHITLPool()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := (&HumanApprover{Timeout: 60}).Approve(ctx, runtime.ApproveRequest{
+			Pool:         pool,
+			ApproverName: "ops",
+			Method:       "POST",
+			Host:         "api.example.test",
+			Path:         "/v1/write",
+		})
+		done <- err
+	}()
+
+	select {
+	case <-pool.added:
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not publish pending entry")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Approve error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not return after context cancellation")
+	}
+	cancelResult := pool.capturedCancel()
+	if cancelResult.State != runtime.HITLStateClientDisconnected {
+		t.Fatalf("Cancel state = %q, want %q", cancelResult.State, runtime.HITLStateClientDisconnected)
+	}
+	if cancelResult.Reason == "" {
+		t.Fatal("Cancel reason is empty")
+	}
 }
 
 func captureHumanPending(t *testing.T, approver *HumanApprover, policy *config.CompiledPolicy) runtime.HITLPending {

--- a/config/plugins/approvers/util.go
+++ b/config/plugins/approvers/util.go
@@ -5,6 +5,8 @@
 package approvers
 
 import (
+	"context"
+	"errors"
 	"time"
 
 	"github.com/denoland/clawpatrol/config/runtime"
@@ -39,4 +41,22 @@ func decision(allow bool) string {
 		return "allow"
 	}
 	return "deny"
+}
+
+func cancelPending(pool runtime.HITLPool, id string, state runtime.HITLState, reason string) runtime.HITLResolveResult {
+	if canceler, ok := pool.(runtime.HITLPoolCanceler); ok {
+		return canceler.Cancel(id, state, reason)
+	}
+	pool.Discard(id)
+	return runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
+}
+
+func hitlCancelStateForContext(err error) (runtime.HITLState, string) {
+	if errors.Is(err, context.Canceled) {
+		return runtime.HITLStateClientDisconnected, "original client connection closed before approval; upstream request was not sent"
+	}
+	if err != nil {
+		return runtime.HITLStateCanceled, err.Error()
+	}
+	return runtime.HITLStateCanceled, "approval canceled before a decision; upstream request was not sent"
 }

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -369,26 +369,64 @@ func applySlackInteractivePayload(ctx runtime.WebhookCtx, payload []byte) map[st
 		return map[string]any{"text": "missing pending id"}
 	}
 	allow := act.ActionID == "approve"
-	ok := ctx.HITL.Decide(act.Value, runtime.HITLDecision{Allow: allow, By: "slack:" + p.User.Name})
+	decision := runtime.HITLDecision{Allow: allow, By: "slack:" + p.User.Name}
+	result := runtime.HITLResolveResult{State: runtime.HITLStateUnknown, Reason: "unknown or expired HITL request"}
+	if decider, ok := ctx.HITL.(runtime.HITLPoolDecider); ok {
+		result = decider.DecideWithResult(act.Value, decision)
+	} else if ctx.HITL != nil {
+		result.OK = ctx.HITL.Decide(act.Value, decision)
+		if result.OK {
+			if allow {
+				result.State = runtime.HITLStateApproved
+			} else {
+				result.State = runtime.HITLStateDenied
+			}
+		}
+	}
 
-	var status string
-	if !ok {
-		status = "Already resolved or expired."
-	} else {
+	status := slackHITLStatus(result, allow, p.User.Name)
+	if result.OK {
 		verb := "approved"
-		emoji := ":white_check_mark:"
 		if !allow {
 			verb = "denied"
-			emoji = ":no_entry:"
 		}
 		log.Printf("slack-interactive: %s %s by %s", act.Value, verb, p.User.Name)
-		status = fmt.Sprintf("%s %s by <@%s>", emoji, verb, p.User.Name)
 	}
 
 	if p.ResponseURL != "" {
 		go postSlackResponseURL(p.ResponseURL, status, withStatusBlock(p.Message.Blocks, status))
 	}
 	return map[string]any{} // empty ack — real update flows via response_url
+}
+
+func slackHITLStatus(result runtime.HITLResolveResult, allow bool, user string) string {
+	if result.OK {
+		verb := "approved"
+		emoji := ":white_check_mark:"
+		if !allow {
+			verb = "denied"
+			emoji = ":no_entry:"
+		}
+		return fmt.Sprintf("%s %s by <@%s>", emoji, verb, user)
+	}
+
+	switch result.State {
+	case runtime.HITLStateClientDisconnected:
+		return ":warning: Request is no longer active. The original client connection closed before approval, so the upstream request was not sent."
+	case runtime.HITLStateTimedOut:
+		return ":hourglass_flowing_sand: Approval expired. The upstream request was not sent."
+	case runtime.HITLStateApproved:
+		return ":white_check_mark: This request was already approved."
+	case runtime.HITLStateDenied:
+		return ":no_entry: This request was already denied."
+	case runtime.HITLStateCanceled:
+		if result.Reason != "" {
+			return ":warning: Approval canceled. " + result.Reason
+		}
+		return ":warning: Approval canceled. The upstream request was not sent."
+	default:
+		return "Already resolved or expired."
+	}
 }
 
 // postSlackResponseURL fires the message-replace POST. Slack accepts

--- a/config/plugins/credentials/slack_test.go
+++ b/config/plugins/credentials/slack_test.go
@@ -1,0 +1,162 @@
+package credentials
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+type fakeInteractiveHITL struct {
+	result runtime.HITLResolveResult
+
+	mu       sync.Mutex
+	id       string
+	decision runtime.HITLDecision
+}
+
+func (f *fakeInteractiveHITL) Add(runtime.HITLPending) (string, <-chan runtime.HITLDecision) {
+	return "", make(chan runtime.HITLDecision)
+}
+
+func (f *fakeInteractiveHITL) Discard(string) {}
+
+func (f *fakeInteractiveHITL) Decide(id string, decision runtime.HITLDecision) bool {
+	return f.DecideWithResult(id, decision).OK
+}
+
+func (f *fakeInteractiveHITL) DecideWithResult(id string, decision runtime.HITLDecision) runtime.HITLResolveResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.id = id
+	f.decision = decision
+	return f.result
+}
+
+func TestApplySlackInteractivePayloadReportsClientDisconnected(t *testing.T) {
+	posted := make(chan slackResponseURLRequest, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		var req slackResponseURLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode response_url body: %v", err)
+			rw.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		posted <- req
+		_, _ = rw.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	pool := &fakeInteractiveHITL{result: runtime.HITLResolveResult{
+		OK:     false,
+		State:  runtime.HITLStateClientDisconnected,
+		Reason: "original client connection closed before approval; upstream request was not sent",
+	}}
+	ack := applySlackInteractivePayload(runtime.WebhookCtx{HITL: pool}, slackInteractivePayload(t, srv.URL, "approve", "pending-1"))
+	if len(ack) != 0 {
+		t.Fatalf("ack = %#v, want empty map", ack)
+	}
+
+	select {
+	case req := <-posted:
+		if !req.ReplaceOriginal {
+			t.Fatal("response_url payload did not request replace_original")
+		}
+		if !strings.Contains(req.Text, "Request is no longer active") {
+			t.Fatalf("response_url text = %q, want client disconnect explanation", req.Text)
+		}
+		if !strings.Contains(req.Text, "upstream request was not sent") {
+			t.Fatalf("response_url text = %q, want upstream not sent explanation", req.Text)
+		}
+		for _, block := range req.Blocks {
+			if block["type"] == "actions" {
+				t.Fatalf("response_url blocks still contain actions block: %#v", req.Blocks)
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Slack response_url update was not posted")
+	}
+
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+	if pool.id != "pending-1" {
+		t.Fatalf("decided id = %q, want pending-1", pool.id)
+	}
+	if !pool.decision.Allow {
+		t.Fatal("decision Allow = false, want true")
+	}
+	if pool.decision.By != "slack:U123" {
+		t.Fatalf("decision By = %q, want slack:U123", pool.decision.By)
+	}
+}
+
+func TestSlackHITLStatusExplainsTerminalStates(t *testing.T) {
+	tests := []struct {
+		name   string
+		result runtime.HITLResolveResult
+		want   string
+	}{
+		{
+			name:   "timed out",
+			result: runtime.HITLResolveResult{State: runtime.HITLStateTimedOut},
+			want:   "Approval expired",
+		},
+		{
+			name:   "already approved",
+			result: runtime.HITLResolveResult{State: runtime.HITLStateApproved},
+			want:   "already approved",
+		},
+		{
+			name:   "already denied",
+			result: runtime.HITLResolveResult{State: runtime.HITLStateDenied},
+			want:   "already denied",
+		},
+		{
+			name:   "unknown",
+			result: runtime.HITLResolveResult{State: runtime.HITLStateUnknown},
+			want:   "Already resolved or expired",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slackHITLStatus(tt.result, true, "U123")
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("status = %q, want substring %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type slackResponseURLRequest struct {
+	ReplaceOriginal bool             `json:"replace_original"`
+	Text            string           `json:"text"`
+	Blocks          []map[string]any `json:"blocks"`
+}
+
+func slackInteractivePayload(t *testing.T, responseURL, actionID, pendingID string) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"user":         map[string]any{"name": "U123"},
+		"response_url": responseURL,
+		"actions": []map[string]any{
+			{"action_id": actionID, "value": pendingID},
+		},
+		"message": map[string]any{
+			"blocks": []map[string]any{
+				{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": "pending"}},
+				{"type": "actions"},
+			},
+		},
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return buf
+}

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -424,10 +424,11 @@ type HITLPool interface {
 	// Add publishes a pending entry. Returns the assigned id (used
 	// by Decide) and a channel that fires exactly once when the
 	// pool gets a verdict. Caller must select on ctx.Done() too;
-	// if ctx fires first, call Discard(id) to clean up.
+	// when ctx fires first, prefer HITLPoolCanceler.Cancel so stale
+	// prompts can explain why the upstream request was not sent.
 	Add(p HITLPending) (id string, decision <-chan HITLDecision)
-	// Discard drops a pending entry without a decision. Use when
-	// the caller's context expires before the channel fires.
+	// Discard drops a pending entry without recording terminal state.
+	// Use only for compatibility or best-effort cleanup after resolve.
 	Discard(id string)
 	// Decide resolves a pending entry — used by webhook handlers
 	// (Slack interactive callback, future Discord etc.) to forward
@@ -435,6 +436,45 @@ type HITLPool interface {
 	// /api/hitl/decide writes to. Returns false when the id is
 	// unknown (already resolved or expired).
 	Decide(id string, d HITLDecision) bool
+}
+
+// HITLPoolDecider is implemented by pools that can explain why a
+// decision was accepted or rejected. Callers should prefer this over
+// Decide when rendering operator-facing stale-click messages.
+type HITLPoolDecider interface {
+	DecideWithResult(id string, d HITLDecision) HITLResolveResult
+}
+
+// HITLPoolCanceler is implemented by pools that preserve a short-lived
+// terminal state when a synchronous HITL request ends without a human
+// decision (timeout, client disconnect, gateway cancellation).
+type HITLPoolCanceler interface {
+	Cancel(id string, state HITLState, reason string) HITLResolveResult
+}
+
+// HITLState names the lifecycle state of a human approval prompt.
+type HITLState string
+
+// HITL terminal states exposed to dashboard and Slack stale-click handlers.
+const (
+	HITLStatePending            HITLState = "pending"
+	HITLStateApproved           HITLState = "approved"
+	HITLStateDenied             HITLState = "denied"
+	HITLStateTimedOut           HITLState = "timed_out"
+	HITLStateClientDisconnected HITLState = "client_disconnected"
+	HITLStateCanceled           HITLState = "canceled"
+	HITLStateUnknown            HITLState = "unknown"
+)
+
+// HITLResolveResult is returned by structured HITL resolution APIs.
+// OK means this call transitioned an active pending request. State and
+// Reason are still populated for stale/duplicate decisions so Slack and
+// the dashboard can distinguish timed-out, disconnected, and already
+// decided prompts instead of showing a generic expired message.
+type HITLResolveResult struct {
+	OK     bool      `json:"ok"`
+	State  HITLState `json:"state"`
+	Reason string    `json:"reason,omitempty"`
 }
 
 // HITLPending mirrors the dashboard's pending-approval shape. Stays

--- a/hitl_registry_test.go
+++ b/hitl_registry_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestHITLRegistryDecideWithResultRecordsTerminalState(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	id, ch := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+
+	result := registry.DecideWithResult(id, runtime.HITLDecision{Allow: true, By: "dashboard"})
+	if !result.OK {
+		t.Fatalf("DecideWithResult OK = false, want true: %#v", result)
+	}
+	if result.State != runtime.HITLStateApproved {
+		t.Fatalf("DecideWithResult State = %q, want %q", result.State, runtime.HITLStateApproved)
+	}
+	select {
+	case decision := <-ch:
+		if !decision.Allow || decision.By != "dashboard" {
+			t.Fatalf("decision = %#v, want approved by dashboard", decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("decision channel did not receive approval")
+	}
+
+	stale := registry.DecideWithResult(id, runtime.HITLDecision{Allow: false, By: "slack:U123"})
+	if stale.OK {
+		t.Fatalf("stale DecideWithResult OK = true, want false")
+	}
+	if stale.State != runtime.HITLStateApproved {
+		t.Fatalf("stale State = %q, want %q", stale.State, runtime.HITLStateApproved)
+	}
+	if !strings.Contains(stale.Reason, "dashboard") {
+		t.Fatalf("stale Reason = %q, want original decision maker", stale.Reason)
+	}
+}
+
+func TestHITLRegistryCancelRecordsClientDisconnected(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	id, ch := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+
+	reason := "original client connection closed before approval; upstream request was not sent"
+	result := registry.Cancel(id, runtime.HITLStateClientDisconnected, reason)
+	if !result.OK {
+		t.Fatalf("Cancel OK = false, want true: %#v", result)
+	}
+	if result.State != runtime.HITLStateClientDisconnected {
+		t.Fatalf("Cancel State = %q, want %q", result.State, runtime.HITLStateClientDisconnected)
+	}
+	select {
+	case decision := <-ch:
+		t.Fatalf("Cancel delivered decision %#v, want no human decision", decision)
+	default:
+	}
+
+	stale := registry.DecideWithResult(id, runtime.HITLDecision{Allow: true, By: "slack:U123"})
+	if stale.OK {
+		t.Fatal("stale approve after client disconnect OK = true, want false")
+	}
+	if stale.State != runtime.HITLStateClientDisconnected {
+		t.Fatalf("stale State = %q, want %q", stale.State, runtime.HITLStateClientDisconnected)
+	}
+	if !strings.Contains(stale.Reason, "upstream request was not sent") {
+		t.Fatalf("stale Reason = %q, want upstream-not-sent explanation", stale.Reason)
+	}
+}
+
+func TestAPIHITLDecideReturnsStructuredTerminalState(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	id, _ := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+	reason := "original client connection closed before approval; upstream request was not sent"
+	registry.Cancel(id, runtime.HITLStateClientDisconnected, reason)
+
+	w := &webMux{g: &Gateway{hitl: registry}}
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/hitl/decide", strings.NewReader(fmt.Sprintf(`{"id":%q,"allow":true}`, id)))
+	req = req.WithContext(contextWithPrincipal(req.Context(), principal{Kind: principalDashboardSecret, Owner: "operator"}))
+	w.apiHITLDecide(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rw.Code, http.StatusOK, rw.Body.String())
+	}
+	var result runtime.HITLResolveResult
+	if err := json.NewDecoder(rw.Body).Decode(&result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result.OK {
+		t.Fatal("api result OK = true, want false for stale terminal state")
+	}
+	if result.State != runtime.HITLStateClientDisconnected {
+		t.Fatalf("api result State = %q, want %q", result.State, runtime.HITLStateClientDisconnected)
+	}
+	if !strings.Contains(result.Reason, "upstream request was not sent") {
+		t.Fatalf("api result Reason = %q, want upstream-not-sent explanation", result.Reason)
+	}
+}

--- a/web.go
+++ b/web.go
@@ -1261,8 +1261,21 @@ func (w *webMux) apiHITLDecide(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "decision requires an authenticated operator", http.StatusForbidden)
 		return
 	}
-	ok = w.g.hitl.Decide(body.ID, runtime.HITLDecision{Allow: body.Allow, By: principal.Owner})
-	writeJSON(rw, map[string]bool{"ok": ok})
+	result := runtime.HITLResolveResult{State: runtime.HITLStateUnknown, Reason: "unknown or expired HITL request"}
+	decision := runtime.HITLDecision{Allow: body.Allow, By: principal.Owner}
+	if decider, ok := interface{}(w.g.hitl).(runtime.HITLPoolDecider); ok {
+		result = decider.DecideWithResult(body.ID, decision)
+	} else {
+		result.OK = w.g.hitl.Decide(body.ID, decision)
+		if result.OK {
+			if body.Allow {
+				result.State = runtime.HITLStateApproved
+			} else {
+				result.State = runtime.HITLStateDenied
+			}
+		}
+	}
+	writeJSON(rw, result)
 }
 
 func isLoopback(host string) bool {
@@ -2340,11 +2353,11 @@ func wrapBodySampler(rc io.ReadCloser, s *sampler) io.ReadCloser {
 	return teeReadCloser{r: io.TeeReader(rc, s), c: rc}
 }
 
-// HITL — human-in-the-loop request approval. Rules with `action: hitl`
-// pause the upstream call until an operator approves on the dashboard.
-// Decisions arrive over a per-request channel; the gateway times out
-// after Rule.HITLTimeout (default 60s). Notifier plugins (Slack,
-// web-push, etc.) are fired when an approval becomes pending.
+// HITL — human-in-the-loop request approval. Rules with `approve = [...]`
+// pause the upstream call until an operator approves on the dashboard,
+// Slack, or another notifier. Decisions arrive over a per-request
+// channel; the active request only remains resumable while the original
+// client connection/context is alive.
 
 // HITLPending and HITLDecision moved to config/runtime — declared
 // there so approver plugins can produce them without importing main.
@@ -2352,13 +2365,19 @@ func wrapBodySampler(rc io.ReadCloser, s *sampler) io.ReadCloser {
 // HITLRegistry is the pool of pending approvals + per-pending decision
 // channel. Approver runtimes (config/plugins/approvers) call Add to
 // publish a pending entry and select on the returned channel.
-// Dashboard's PUT /api/hitl/decide calls Decide(id, allow) to resolve.
+// Dashboard's POST /api/hitl/decide calls DecideWithResult(id, decision)
+// to resolve and receive operator-facing terminal-state details.
 //
-// Implements runtime.HITLPool via Add / Discard.
+// Implements runtime.HITLPool via Add / Discard and preserves recent
+// terminal states so stale Slack/dashboard prompts can explain whether
+// a request was already decided, timed out, or lost its client.
+const hitlTerminalTTL = 30 * time.Minute
+
 type HITLRegistry struct {
-	mu      sync.Mutex
-	pending map[string]*pendingEntry
-	sink    *Sink // SSE fan-out for the dashboard
+	mu       sync.Mutex
+	pending  map[string]*pendingEntry
+	terminal map[string]terminalHITLEntry
+	sink     *Sink // SSE fan-out for the dashboard
 }
 
 type pendingEntry struct {
@@ -2366,8 +2385,17 @@ type pendingEntry struct {
 	decision chan runtime.HITLDecision
 }
 
+type terminalHITLEntry struct {
+	result    runtime.HITLResolveResult
+	expiresAt time.Time
+}
+
 func newHITLRegistry(sink *Sink) *HITLRegistry {
-	return &HITLRegistry{pending: map[string]*pendingEntry{}, sink: sink}
+	return &HITLRegistry{
+		pending:  map[string]*pendingEntry{},
+		terminal: map[string]terminalHITLEntry{},
+		sink:     sink,
+	}
 }
 
 // Add publishes a pending entry and returns its assigned id + a
@@ -2383,7 +2411,9 @@ func (r *HITLRegistry) Add(p runtime.HITLPending) (string, <-chan runtime.HITLDe
 	}
 	ch := make(chan runtime.HITLDecision, 1)
 	r.mu.Lock()
+	r.pruneTerminalLocked(time.Now())
 	r.pending[p.ID] = &pendingEntry{p: p, decision: ch}
+	delete(r.terminal, p.ID)
 	r.mu.Unlock()
 	if r.sink != nil {
 		r.sink.Emit(Event{
@@ -2403,6 +2433,7 @@ func (r *HITLRegistry) Discard(id string) {
 func (r *HITLRegistry) List() []runtime.HITLPending {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.pruneTerminalLocked(time.Now())
 	out := make([]runtime.HITLPending, 0, len(r.pending))
 	for _, e := range r.pending {
 		out = append(out, e.p)
@@ -2413,16 +2444,73 @@ func (r *HITLRegistry) List() []runtime.HITLPending {
 // Decide fires the pending entry's channel. Returns false when the
 // id is unknown (already discarded / never existed).
 func (r *HITLRegistry) Decide(id string, d runtime.HITLDecision) bool {
-	r.mu.Lock()
-	e := r.pending[id]
-	r.mu.Unlock()
-	if e == nil {
-		return false
+	return r.DecideWithResult(id, d).OK
+}
+
+// DecideWithResult resolves a pending entry and records the terminal
+// state. Duplicate/stale clicks get the stored state back with OK=false.
+func (r *HITLRegistry) DecideWithResult(id string, d runtime.HITLDecision) runtime.HITLResolveResult {
+	state := runtime.HITLStateDenied
+	if d.Allow {
+		state = runtime.HITLStateApproved
+	}
+	reason := strings.TrimSpace(d.Reason)
+	if reason == "" {
+		verb := string(state)
+		if d.By != "" {
+			reason = fmt.Sprintf("%s by %s", verb, d.By)
+		} else {
+			reason = verb
+		}
+	}
+	e, result := r.resolve(id, state, reason)
+	if !result.OK {
+		return result
 	}
 	select {
 	case e.decision <- d:
-		return true
+		return result
 	default:
-		return false
+		return runtime.HITLResolveResult{OK: false, State: state, Reason: "pending request was already resolved"}
+	}
+}
+
+// Cancel resolves a pending entry without delivering a human decision.
+// It is used when the original synchronous request times out or the
+// client connection disappears before approval.
+func (r *HITLRegistry) Cancel(id string, state runtime.HITLState, reason string) runtime.HITLResolveResult {
+	if state == "" || state == runtime.HITLStatePending || state == runtime.HITLStateUnknown {
+		state = runtime.HITLStateCanceled
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = string(state)
+	}
+	_, result := r.resolve(id, state, reason)
+	return result
+}
+
+func (r *HITLRegistry) resolve(id string, state runtime.HITLState, reason string) (*pendingEntry, runtime.HITLResolveResult) {
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneTerminalLocked(now)
+	e := r.pending[id]
+	if e == nil {
+		if terminal, ok := r.terminal[id]; ok {
+			return nil, terminal.result
+		}
+		return nil, runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "unknown or expired HITL request"}
+	}
+	delete(r.pending, id)
+	terminal := runtime.HITLResolveResult{OK: false, State: state, Reason: reason}
+	r.terminal[id] = terminalHITLEntry{result: terminal, expiresAt: now.Add(hitlTerminalTTL)}
+	return e, runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
+}
+
+func (r *HITLRegistry) pruneTerminalLocked(now time.Time) {
+	for id, entry := range r.terminal {
+		if !entry.expiresAt.After(now) {
+			delete(r.terminal, id)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add structured HITL resolve results and terminal states for stale dashboard/Slack decisions.
- Retain short-lived terminal reasons for approved, denied, timed out, client-disconnected, and canceled requests.
- Mark timeout/client disconnect paths with explicit upstream-not-sent reasons, then surface reason-specific Slack stale-click messages.
- Add registry/API, Slack interactive, and human approver regression coverage.

Originally opened as a stacked follow-up to #374. After #374 merged, this PR was rebased onto `main` and reopened with `main` as the base.

## Test plan
- `git diff --check`
- `test -z "$(gofmt -l config/runtime/runtime.go web.go config/plugins/approvers/dashboard.go config/plugins/approvers/human.go config/plugins/approvers/util.go config/plugins/approvers/human_test.go config/plugins/credentials/slack.go config/plugins/credentials/slack_test.go hitl_registry_test.go)"`
- `go test ./...`
- `(cd www && npm ci && npm run build)`
