### PR TITLE
golangci-lint: fix latest main findings

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -150,18 +150,3 @@ func mintAndStoreCA(db *sql.DB) (*CertCache, error) {
 	}
 	return parseCertCache(certPEM, keyPEM)
 }
-
-// importCAFromPEM inserts pre-existing PEM material into ca_material.
-// Used by the legacy-state importer to move on-disk ca.crt + ca.key
-// into sqlite on first boot of a migrated gateway. Caller should
-// guard against double-insert by checking the row first.
-func importCAFromPEM(db *sql.DB, certPEM, keyPEM []byte) error {
-	if _, err := parseCertCache(certPEM, keyPEM); err != nil {
-		return fmt.Errorf("validate legacy ca: %w", err)
-	}
-	_, err := db.Exec(
-		`INSERT INTO ca_material (id, cert_pem, key_pem, created_ns) VALUES (1, ?, ?, ?)`,
-		certPEM, keyPEM, time.Now().UnixNano(),
-	)
-	return err
-}

--- a/config/extplugin/adapter.go
+++ b/config/extplugin/adapter.go
@@ -32,7 +32,6 @@ import (
 type endpointAdapter struct {
 	client      *Client
 	typeName    string
-	hosts       []string
 	tlsMode     pb.TLSMode
 	requiresVIP bool
 }
@@ -98,7 +97,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 		}
 		conn = tc
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Resolve credential secret.
 	var (
@@ -135,7 +134,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 	if err != nil {
 		return fmt.Errorf("extplugin: open HandleConn stream: %w", err)
 	}
-	defer stream.CloseSend()
+	defer func() { _ = stream.CloseSend() }()
 
 	// Send ConnInit.
 	init := &pb.ConnInit{
@@ -363,11 +362,11 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 			if pf != nil && pf.kindByField[fieldName] != pb.FacetKind_FACET_STREAM {
 				continue
 			}
-			cap := streamCapBytesForRule
+			limit := streamCapBytesForRule
 			if pf != nil && !needed[fieldName] {
-				cap = streamCapBytesForLog
+				limit = streamCapBytesForLog
 			}
-			data, hit := pullStream(ctx, doSend, streamReply, handle, cap)
+			data, hit := pullStream(ctx, doSend, streamReply, handle, limit)
 			if hit {
 				truncated = true
 			}
@@ -564,7 +563,7 @@ func facetFor(family string) *pluginFacet {
 // by newPluginFacetMatcher implement SubFieldReferencer; matchers
 // from other origins (an unlikely mix) are treated as referencing
 // every field, since we have no visibility into their AST.
-func streamFieldsNeeded(rules []*config.CompiledRule, facetShortName string) map[string]bool {
+func streamFieldsNeeded(rules []*config.CompiledRule, _ string) map[string]bool {
 	out := map[string]bool{}
 	for _, r := range rules {
 		ref, ok := r.Matcher.(SubFieldReferencer)
@@ -586,13 +585,13 @@ func streamFieldsNeeded(rules []*config.CompiledRule, facetShortName string) map
 // cap (and not because the stream eof'd). Errors and read failures
 // land here as eof, not truncation — we have no way to tell from
 // outside whether the plugin had more bytes to give.
-func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, handle string, cap int) (data []byte, truncated bool) {
-	if cap <= 0 {
+func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, handle string, limit int) (data []byte, truncated bool) {
+	if limit <= 0 {
 		return nil, false
 	}
-	out := make([]byte, 0, cap)
-	for len(out) < cap {
-		want := cap - len(out)
+	out := make([]byte, 0, limit)
+	for len(out) < limit {
+		want := limit - len(out)
 		if want > 32*1024 {
 			want = 32 * 1024
 		}
@@ -610,7 +609,7 @@ func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamR
 			if !ok || chunk == nil {
 				return out, false
 			}
-			if n := cap - len(out); n < len(chunk.Payload) {
+			if n := limit - len(out); n < len(chunk.Payload) {
 				out = append(out, chunk.Payload[:n]...)
 				// We stopped because cap was reached; the plugin
 				// might still have had more (`!chunk.Eof`) or

--- a/config/extplugin/register.go
+++ b/config/extplugin/register.go
@@ -345,10 +345,6 @@ func (b *dynamicEndpointBody) EndpointCredentials() []config.CredBinding {
 	return []config.CredBinding{{Credential: b.credentialName}}
 }
 
-// credentialName is the resolved credential bare-name, populated by
-// the synthesized DecodeBody.
-type endpointDecodeExtras struct{ credentialName string }
-
 func init() {
 	// Compile-time sanity: dynamicEndpointBody satisfies the
 	// reflective interface compile.go expects.

--- a/config/plugins/facets/https/https.go
+++ b/config/plugins/facets/https/https.go
@@ -24,24 +24,24 @@ import (
 	"github.com/denoland/clawpatrol/config/match"
 )
 
-// HttpsFields is the CEL-facing view of an HTTPS request. Exposed
+// Fields is the CEL-facing view of an HTTPS request. Exposed
 // as the `http` variable in rule conditions (`http.method`,
 // `http.path`, `http.body_json`, etc.). The facet name matches the
 // CEL variable (`http`); the endpoint plugin keeps the HCL label
 // `https` since that names the wire (TLS).
 //
-// BodyJson is *structpb.Value rather than `any` because cel-go's
+// BodyJSON is *structpb.Value rather than `any` because cel-go's
 // NativeTypes converter drops interface-typed struct fields silently;
 // google.protobuf.Value gives the field the dyn-shape the operator
 // expects when writing `http.body_json.archived == true` style
 // predicates.
-type HttpsFields struct {
+type Fields struct {
 	Method   string              `cel:"method"`
 	Path     string              `cel:"path"`
 	Query    map[string][]string `cel:"query"`
 	Headers  map[string][]string `cel:"headers"`
 	Body     string              `cel:"body"`
-	BodyJson *structpb.Value     `cel:"body_json"`
+	BodyJSON *structpb.Value     `cel:"body_json"`
 }
 
 // Facet is the HTTPS facet Runtime. Singleton; held by the registry
@@ -99,10 +99,10 @@ func init() {
 	env, err := cel.NewEnv(
 		ext.Sets(),
 		ext.NativeTypes(
-			reflect.TypeFor[HttpsFields](),
+			reflect.TypeFor[Fields](),
 			ext.ParseStructTags(true),
 		),
-		cel.Variable("http", cel.ObjectType("https.HttpsFields")),
+		cel.Variable("http", cel.ObjectType("https.Fields")),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("https facet: cel env: %v", err))
@@ -148,7 +148,7 @@ func buildActivation(req *match.Request) map[string]any {
 	// HTTP method is lowercased here (and declared in lowercasedPaths)
 	// so rules can write either "POST" or "post" — CompileCondition
 	// normalizes the want-side literals to lowercase at rule-load time.
-	f := &HttpsFields{
+	f := &Fields{
 		Method:  strings.ToLower(req.Method),
 		Path:    match.PathOf(req.URL),
 		Headers: mapToCEL(req.Headers),
@@ -164,7 +164,7 @@ func buildActivation(req *match.Request) map[string]any {
 	// limits. Empty body / parse error → an empty struct value, so
 	// `http.body_json.<field>` evaluates to null rather than blowing
 	// up at request time.
-	f.BodyJson = parseBodyJSON(req.Body)
+	f.BodyJSON = parseBodyJSON(req.Body)
 	return map[string]any{"http": f}
 }
 

--- a/config/plugins/facets/k8s/k8s.go
+++ b/config/plugins/facets/k8s/k8s.go
@@ -25,11 +25,11 @@ import (
 	"github.com/denoland/clawpatrol/config/match"
 )
 
-// K8sFields is the CEL-facing view of a kubernetes request. Exposed
+// Fields is the CEL-facing view of a kubernetes request. Exposed
 // as the `k8s` variable in rule conditions (`k8s.verb`,
 // `k8s.namespace`, etc.). Tag-driven field naming keeps the Go field
 // names idiomatic while preserving the on-the-wire CEL names.
-type K8sFields struct {
+type Fields struct {
 	Verb      string            `cel:"verb"`
 	Resource  string            `cel:"resource"`
 	Namespace string            `cel:"namespace"`
@@ -118,10 +118,10 @@ func init() {
 	env, err := cel.NewEnv(
 		ext.Sets(),
 		ext.NativeTypes(
-			reflect.TypeFor[K8sFields](),
+			reflect.TypeFor[Fields](),
 			ext.ParseStructTags(true),
 		),
-		cel.Variable("k8s", cel.ObjectType("k8s.K8sFields")),
+		cel.Variable("k8s", cel.ObjectType("k8s.Fields")),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("k8s facet: cel env: %v", err))
@@ -166,7 +166,7 @@ func buildActivation(req *match.Request) map[string]any {
 		params = map[string]string{}
 	}
 	return map[string]any{
-		"k8s": &K8sFields{
+		"k8s": &Fields{
 			Verb:      strings.ToLower(meta.Verb),
 			Resource:  meta.Resource,
 			Namespace: meta.Namespace,

--- a/config/plugins/facets/sql/sql.go
+++ b/config/plugins/facets/sql/sql.go
@@ -25,12 +25,12 @@ import (
 	"github.com/denoland/clawpatrol/config/match"
 )
 
-// SqlFields is the CEL-facing view of a SQL statement. Exposed as
+// Fields is the CEL-facing view of a SQL statement. Exposed as
 // the `sql` variable in rule conditions (`sql.verb`, `sql.tables`,
 // `sql.functions`, `sql.statement`). The plural `functions` matches
 // the multi-valued shape (a statement can reference multiple
 // functions) and parallels `tables`.
-type SqlFields struct {
+type Fields struct {
 	Verb      string   `cel:"verb"`
 	Tables    []string `cel:"tables"`
 	Functions []string `cel:"functions"`
@@ -109,10 +109,10 @@ func init() {
 	env, err := cel.NewEnv(
 		ext.Sets(),
 		ext.NativeTypes(
-			reflect.TypeFor[SqlFields](),
+			reflect.TypeFor[Fields](),
 			ext.ParseStructTags(true),
 		),
-		cel.Variable("sql", cel.ObjectType("sql.SqlFields")),
+		cel.Variable("sql", cel.ObjectType("sql.Fields")),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("sql facet: cel env: %v", err))
@@ -164,7 +164,7 @@ func buildActivation(req *match.Request) map[string]any {
 		return nil
 	}
 	return map[string]any{
-		"sql": &SqlFields{
+		"sql": &Fields{
 			Verb:      strings.ToLower(meta.Verb),
 			Tables:    coalesceList(meta.Tables),
 			Functions: coalesceList(meta.Functions),

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -164,7 +164,7 @@ func (t *TailscaleTunnel) Open(ctx context.Context, host runtime.TunnelHost, _ r
 // tailscaleproto.Default so the dashboard's Connect button can surface
 // it. On subsequent boots (state already in sqlite) tsnet joins in
 // seconds and the pending window is invisible to dependent endpoints.
-func (t *TailscaleTunnel) openWithCredential(ctx context.Context, host runtime.TunnelHost, hostname string, logger *log.Logger) (runtime.Tunnel, error) {
+func (t *TailscaleTunnel) openWithCredential(_ context.Context, host runtime.TunnelHost, hostname string, logger *log.Logger) (runtime.Tunnel, error) {
 	ni, ok := host.Credential.Body.(tailscaleproto.NodeIdentity)
 	if !ok {
 		return nil, fmt.Errorf("tailscale tunnel %q: credential %q is not a tailscale node identity (got %T)", host.Name, host.Credential.Name, host.Credential.Body)
@@ -317,7 +317,7 @@ func (t *tailscaleTunnelConn) watchLoginURL(ctx context.Context) {
 		}
 		return
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 	for {
 		n, err := watcher.Next()
 		if err != nil {

--- a/dial.go
+++ b/dial.go
@@ -82,7 +82,7 @@ func (g *Gateway) servePorts() {}
 // falls back to plain TLS — the request still flows but the
 // upstream rejects it on cert-required endpoints. Operators see
 // the misconfiguration in the dashboard event log.
-func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint, profile string) (net.Conn, error) {
+func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint, _ string) (net.Conn, error) {
 	cfg := &tls.Config{ServerName: serverName, NextProtos: []string{"http/1.1"}}
 
 	if ep != nil && ep.Body != nil {

--- a/plugin-example/demo_echo.go
+++ b/plugin-example/demo_echo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -35,7 +36,7 @@ func handleDemoEcho(ctx context.Context, conn *pluginsdk.Conn) error {
 	for {
 		line, err := br.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err

--- a/plugin-example/demo_https.go
+++ b/plugin-example/demo_https.go
@@ -151,7 +151,11 @@ func handleDemoHTTPS(ctx context.Context, conn *pluginsdk.Conn) error {
 		}
 
 		if err := writeMutatedResponse(conn, resp); err != nil {
+			_ = resp.Body.Close()
 			return fmt.Errorf("write response: %w", err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			return fmt.Errorf("close response body: %w", err)
 		}
 		if req.Close || resp.Close {
 			return nil
@@ -229,11 +233,15 @@ func forwardOneHTTPS(ctx context.Context, req *http.Request, upstream *url.URL, 
 // transfer encoding because the appended bytes invalidate any
 // upstream Content-Length.
 func writeMutatedResponse(w io.Writer, resp *http.Response) error {
-	resp.Body = io.NopCloser(io.MultiReader(resp.Body, strings.NewReader("\nbye!\n")))
-	resp.ContentLength = -1
-	resp.Header.Del("Content-Length")
-	resp.TransferEncoding = []string{"chunked"}
-	return resp.Write(w)
+	body := resp.Body
+	out := new(http.Response)
+	*out = *resp
+	out.Body = io.NopCloser(io.MultiReader(body, strings.NewReader("\nbye!\n")))
+	out.ContentLength = -1
+	out.Header = resp.Header.Clone()
+	out.Header.Del("Content-Length")
+	out.TransferEncoding = []string{"chunked"}
+	return out.Write(w)
 }
 
 type closingBody struct {

--- a/plugin-example/demo_smtp.go
+++ b/plugin-example/demo_smtp.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -56,7 +57,7 @@ func handleDemoSMTP(ctx context.Context, conn *pluginsdk.Conn) error {
 	for {
 		line, err := br.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err
@@ -158,9 +159,7 @@ func readSMTPData(br *bufio.Reader) ([]byte, error) {
 		}
 		// RFC 5321: leading "." on a line is an escape for a line
 		// that actually starts with a dot.
-		if strings.HasPrefix(stripped, ".") {
-			stripped = stripped[1:]
-		}
+		stripped = strings.TrimPrefix(stripped, ".")
 		buf.WriteString(stripped)
 		buf.WriteString("\r\n")
 	}

--- a/plugin-example/passthrough.go
+++ b/plugin-example/passthrough.go
@@ -17,16 +17,16 @@ func passthroughDef() pluginsdk.TunnelDef {
 	return pluginsdk.TunnelDef{
 		TypeName: "example_passthrough",
 		Schema:   pluginsdk.Schema{},
-		Open: func(ctx context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+		Open: func(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
 			// No state to keep; the tunnel name itself is enough.
 			return req.TunnelInstance, nil
 		},
-		Dial: func(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+		Dial: func(_ context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
 			c, err := net.Dial(req.Network, req.Addr)
 			if err != nil {
 				return err
 			}
-			defer c.Close()
+			defer func() { _ = c.Close() }()
 			done := make(chan struct{}, 2)
 			go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
 			go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()

--- a/pluginsdk/conn.go
+++ b/pluginsdk/conn.go
@@ -1,8 +1,6 @@
 package pluginsdk
 
 import (
-	"context"
-	"errors"
 	"io"
 	"net"
 	"sync"
@@ -28,10 +26,9 @@ type streamConn struct {
 	// closeFn tears down both directions. Idempotent.
 	closeFn func()
 
-	mu       sync.Mutex
-	closed   bool
-	readBuf  []byte
-	readDone <-chan struct{}
+	mu      sync.Mutex
+	closed  bool
+	readBuf []byte
 
 	rdMu       sync.Mutex
 	rdDeadline time.Time
@@ -104,10 +101,8 @@ func (c *streamConn) Write(p []byte) (int, error) {
 	c.mu.Unlock()
 	// Copy because the gRPC layer holds the slice asynchronously.
 	buf := append([]byte(nil), p...)
-	select {
-	case c.send <- buf:
-		return len(p), nil
-	}
+	c.send <- buf
+	return len(p), nil
 }
 
 // Close tears down both directions. Safe to call multiple times.
@@ -161,61 +156,3 @@ type errReadDeadline struct{}
 func (errReadDeadline) Error() string   { return "read deadline exceeded" }
 func (errReadDeadline) Timeout() bool   { return true }
 func (errReadDeadline) Temporary() bool { return true }
-
-// pumpFrames runs two goroutines that move bytes between an arbitrary
-// duplex byte source/sink and a streamConn. Returns when ctx is
-// cancelled, the conn is closed, or sink yields an error.
-func pumpFrames(ctx context.Context, conn net.Conn, recvFromPeer <-chan []byte, sendToPeer func([]byte) error, peerClosed <-chan struct{}) error {
-	errCh := make(chan error, 2)
-
-	// peer -> conn
-	go func() {
-		for {
-			select {
-			case b, ok := <-recvFromPeer:
-				if !ok {
-					errCh <- nil
-					return
-				}
-				if _, err := conn.Write(b); err != nil {
-					errCh <- err
-					return
-				}
-			case <-ctx.Done():
-				errCh <- ctx.Err()
-				return
-			case <-peerClosed:
-				errCh <- nil
-				return
-			}
-		}
-	}()
-
-	// conn -> peer
-	go func() {
-		buf := make([]byte, 32*1024)
-		for {
-			n, err := conn.Read(buf)
-			if n > 0 {
-				if perr := sendToPeer(append([]byte(nil), buf[:n]...)); perr != nil {
-					errCh <- perr
-					return
-				}
-			}
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					errCh <- nil
-				} else {
-					errCh <- err
-				}
-				return
-			}
-		}
-	}()
-
-	// Wait for either side to finish. The first non-nil error wins.
-	first := <-errCh
-	_ = conn.Close()
-	<-errCh
-	return first
-}

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -74,10 +74,14 @@ type FacetField struct {
 type FacetKind int
 
 const (
-	FacetString     FacetKind = 0
+	// FacetString is a scalar string facet field.
+	FacetString FacetKind = 0
+	// FacetStringList is a repeated string facet field.
 	FacetStringList FacetKind = 1
-	FacetStringMap  FacetKind = 2
-	FacetInt        FacetKind = 3
+	// FacetStringMap is a string-to-string map facet field.
+	FacetStringMap FacetKind = 2
+	// FacetInt is an integer facet field.
+	FacetInt FacetKind = 3
 	// FacetStream is a lazy bytes value the plugin offers via
 	// pluginsdk.Stream(io.Reader) in the action map. The gateway
 	// pulls chunks on demand — the full payload (up to a cap) when

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -198,7 +198,7 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 			Summary:  fmt.Sprintf("plugin build failed for %s.%s %q", req.Kind, req.TypeName, req.InstanceName),
 			Detail:   err.Error(),
 		}}
-		return resp, nil
+		return resp, nil //nolint:nilerr // Build errors are returned as diagnostics in the successful gRPC response.
 	}
 
 	if built != nil {
@@ -209,7 +209,7 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 				Summary:  "plugin returned non-JSON-serializable canonical body",
 				Detail:   jerr.Error(),
 			}}
-			return resp, nil
+			return resp, nil //nolint:nilerr // JSON serialization errors are returned as diagnostics in the successful gRPC response.
 		}
 		resp.CanonicalJson = j
 	} else {
@@ -537,11 +537,11 @@ func serveStreamRead(req *pb.StreamRead, mu *sync.Mutex, streams map[string]*str
 	}
 	reg.mu.Unlock()
 
-	max := int(req.MaxBytes)
-	if max <= 0 || max > 64*1024 {
-		max = 64 * 1024
+	limit := int(req.MaxBytes)
+	if limit <= 0 || limit > 64*1024 {
+		limit = 64 * 1024
 	}
-	buf := make([]byte, max)
+	buf := make([]byte, limit)
 	n, err := reg.r.Read(buf)
 	chunk := &pb.StreamChunk{Handle: req.Handle, Payload: buf[:n]}
 	if err != nil {

--- a/telemetry.go
+++ b/telemetry.go
@@ -298,20 +298,6 @@ func loadOrCreateInstanceID(db *sql.DB) (string, error) {
 	return id, nil
 }
 
-// importTelemetryInstanceID writes a pre-existing UUIDv7 into
-// telemetry_state. Used by the legacy-state importer.
-func importTelemetryInstanceID(db *sql.DB, id string) error {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return fmt.Errorf("instance_id empty")
-	}
-	_, err := db.Exec(
-		`INSERT INTO telemetry_state (id, instance_id, created_ns) VALUES (1, ?, ?)`,
-		id, time.Now().UnixNano(),
-	)
-	return err
-}
-
 func shortID(s string) string {
 	if len(s) > 8 {
 		return s[:8]

--- a/tools/docgen/internal/render/godoc.go
+++ b/tools/docgen/internal/render/godoc.go
@@ -49,56 +49,65 @@ func loadGoDocs() (*goDocs, error) {
 
 	fset := token.NewFileSet()
 	for _, dir := range dirs {
-		pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
-			n := fi.Name()
-			return strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go")
-		}, parser.ParseComments)
-		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", dir, err)
-		}
-		for _, pkg := range pkgs {
-			extractPkg(pkg, docs)
+		if err := filepath.WalkDir(dir, func(path string, de fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if de.IsDir() {
+				return nil
+			}
+			n := de.Name()
+			if !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+				return nil
+			}
+			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				return fmt.Errorf("parse %s: %w", path, err)
+			}
+			extractFile(file, docs)
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("walk %s: %w", dir, err)
 		}
 	}
 	return docs, nil
 }
 
-func extractPkg(pkg *ast.Package, out *goDocs) {
-	for _, file := range pkg.Files {
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok || gd.Tok != token.TYPE {
+func extractFile(file *ast.File, out *goDocs) {
+	pkgName := file.Name.Name
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
 				continue
 			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok {
-					continue
-				}
-				st, ok := ts.Type.(*ast.StructType)
-				if !ok {
-					continue
-				}
-				typeKey := pkg.Name + "." + ts.Name.Name
-				doc := commentText(ts.Doc)
-				if doc == "" {
-					// Type doc may be on the GenDecl rather than
-					// the TypeSpec when the type is the only spec
-					// in the decl.
-					doc = commentText(gd.Doc)
-				}
-				if doc != "" {
-					out.types[typeKey] = doc
-				}
-				if st.Fields != nil {
-					for _, f := range st.Fields.List {
-						fieldDoc := commentText(f.Doc)
-						if fieldDoc == "" {
-							fieldDoc = commentText(f.Comment)
-						}
-						for _, name := range f.Names {
-							out.fields[typeKey+"."+name.Name] = fieldDoc
-						}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			typeKey := pkgName + "." + ts.Name.Name
+			doc := commentText(ts.Doc)
+			if doc == "" {
+				// Type doc may be on the GenDecl rather than
+				// the TypeSpec when the type is the only spec
+				// in the decl.
+				doc = commentText(gd.Doc)
+			}
+			if doc != "" {
+				out.types[typeKey] = doc
+			}
+			if st.Fields != nil {
+				for _, f := range st.Fields.List {
+					fieldDoc := commentText(f.Doc)
+					if fieldDoc == "" {
+						fieldDoc = commentText(f.Comment)
+					}
+					for _, name := range f.Names {
+						out.fields[typeKey+"."+name.Name] = fieldDoc
 					}
 				}
 			}

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -187,7 +187,7 @@ func (r *renderer) writeKind(kind config.Kind) {
 	fmt.Fprintf(&r.out, "Block syntax: `%s`\n\n", syntax)
 	// Single-label kinds with one registered plugin (rule today) have
 	// no type discriminator — skip the type-link line entirely.
-	if !(len(plugins) == 1 && plugins[0].Type == "") {
+	if len(plugins) != 1 || plugins[0].Type != "" {
 		fmt.Fprintf(&r.out, "Registered types: ")
 		for i, p := range plugins {
 			if i > 0 {
@@ -237,7 +237,7 @@ func (r *renderer) writePlugin(kind config.Kind, p *config.Plugin) {
 // struct reflect.Type. New() returns a pointer to the body struct.
 func pluginStructType(p *config.Plugin) reflect.Type {
 	v := reflect.ValueOf(p.New())
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	return v.Type()
@@ -392,7 +392,7 @@ func blockElemType(rt reflect.Type, fieldName string) reflect.Type {
 		return nil
 	}
 	t := f.Type
-	for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice {
+	for t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {
@@ -555,7 +555,7 @@ func formatGoType(t reflect.Type) string {
 		return "object"
 	}
 	switch t.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return formatGoType(t.Elem())
 	case reflect.Slice:
 		return "[]" + formatGoType(t.Elem())

--- a/web.go
+++ b/web.go
@@ -1439,7 +1439,7 @@ func (w *webMux) apiActionByID(
 func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
 	policy := w.g.Policy()
 	if policy == nil {
-		http.Error(rw, "policy not loaded", 503)
+		http.Error(rw, "policy not loaded", http.StatusServiceUnavailable)
 		return
 	}
 	if ev.Endpoint == "" {
@@ -1481,7 +1481,7 @@ func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
 		}
 		fx.Action.SQL = sql
 	default:
-		http.Error(rw, fmt.Sprintf("endpoint family %q is not yet exportable", ep.Family), 501)
+		http.Error(rw, fmt.Sprintf("endpoint family %q is not yet exportable", ep.Family), http.StatusNotImplemented)
 		return
 	}
 

--- a/wg_watchdog.go
+++ b/wg_watchdog.go
@@ -142,8 +142,7 @@ func runWGWatchdogLoop(ctx context.Context, c wgWatchdogConfig) {
 			continue
 		}
 
-		stuck := forced
-		if !stuck {
+		if !forced {
 			age := c.now().Sub(s.lastHandshake)
 			if age <= c.stuckTimeout {
 				lastTx = s.txBytes
@@ -156,7 +155,6 @@ func runWGWatchdogLoop(ctx context.Context, c wgWatchdogConfig) {
 				lastTx = s.txBytes
 				continue
 			}
-			stuck = true
 		}
 
 		age := "n/a"

--- a/wg_watchdog_test.go
+++ b/wg_watchdog_test.go
@@ -61,7 +61,7 @@ func loggerWithLines() (*device.Logger, *[]string) {
 	var lines []string
 	l := &device.Logger{
 		Verbosef: device.DiscardLogf,
-		Errorf: func(format string, args ...any) {
+		Errorf: func(format string, _ ...any) {
 			lines = append(lines, format)
 		},
 	}

--- a/wireguard.go
+++ b/wireguard.go
@@ -696,21 +696,6 @@ func loadOrGenWGServerKey(db *sql.DB) (string, error) {
 	return priv, nil
 }
 
-// importWGServerKey writes a pre-existing hex key into wg_server_key.
-// Used by the legacy-state importer to move the on-disk
-// wg-server.key into sqlite. Caller guards against double-insert.
-func importWGServerKey(db *sql.DB, privHex string) error {
-	privHex = strings.TrimSpace(privHex)
-	if _, err := wgPubFromPrivHex(privHex); err != nil {
-		return fmt.Errorf("validate legacy wg key: %w", err)
-	}
-	_, err := db.Exec(
-		`INSERT INTO wg_server_key (id, priv_hex, created_ns) VALUES (1, ?, ?)`,
-		privHex, time.Now().UnixNano(),
-	)
-	return err
-}
-
 func wgPubFromPrivHex(privHex string) (string, error) {
 	priv, err := hex.DecodeString(strings.TrimSpace(privHex))
 	if err != nil || len(priv) != 32 {


### PR DESCRIPTION
## Summary
- Fix the current `golangci-lint` findings on latest `main` without changing the lint config.
- Close response bodies / cleanup handles explicitly, avoid builtin shadowing, and replace raw HTTP status literals with `http.Status*` constants.
- Remove dead code caught by `unused`/`staticcheck`, and update docgen comment extraction away from deprecated `parser.ParseDir` / `ast.Package` usage.

## Test Plan
- `cd www && npm run build`
- `test -z "$(gofmt -l .)"`
- `GOWORK=off golangci-lint config verify`
- `GOWORK=off golangci-lint run ./...`
- `GOWORK=off go test ./...`
- `git diff --check`

## Notes
- `golangci-lint` is currently not run by CI; this PR makes the checked-in config pass locally on latest `main`.
- An independent pre-commit review found and then re-checked a response-body close issue in `plugin-example/demo_https.go`; the follow-up review approved the fix.