### PR TITLE
Add notion_mcp_oauth credential for mcp.notion.com

### DIFF
--- a/config/oauth.go
+++ b/config/oauth.go
@@ -11,6 +11,7 @@ type OAuthConfig struct {
 	AuthURL      string
 	TokenURL     string
 	DeviceURL    string // used by Flow="device"
+	RegisterURL  string // RFC 7591 dynamic client registration (used by Flow="notion_mcp")
 	RedirectURI  string
 	Scopes       []string
 	RefreshToken string // bootstrap; per-owner tokens override

--- a/config/plugins/credentials/notion_mcp_oauth.go
+++ b/config/plugins/credentials/notion_mcp_oauth.go
@@ -1,0 +1,64 @@
+package credentials
+
+// notion_mcp_oauth: OAuth flow against mcp.notion.com (Notion's hosted
+// MCP server). Uses RFC 7591 dynamic client registration so no Notion-
+// side integration setup is required — the dashboard registers a client
+// on the fly when the user clicks "Connect", and persists the per-
+// credential client_id alongside the tokens (see migration 0013).
+//
+// The resulting bearer is scoped to mcp.notion.com only. For
+// api.notion.com (the regular Notion REST API), use notion_oauth and
+// paste a manual integration token.
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// NotionMCPOAuth is part of the clawpatrol plugin API.
+type NotionMCPOAuth struct{}
+
+// InjectHTTP is part of the clawpatrol plugin API.
+func (n *NotionMCPOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
+	if len(sec.Bytes) == 0 {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+string(sec.Bytes))
+	return nil
+}
+
+// SecretSlots intentionally returns nothing: the token is captured
+// through the OAuth flow, never pasted by the operator.
+func (*NotionMCPOAuth) SecretSlots() []config.SecretSlot { return nil }
+
+// OAuthFlow returns Notion's MCP OAuth flow. ClientID is intentionally
+// empty — the dashboard registers one at connect time (Flow="notion_mcp"
+// branch in oauth.go) and persists it per-credential.
+func (n *NotionMCPOAuth) OAuthFlow() *config.OAuthIntegration {
+	return &config.OAuthIntegration{
+		Type:   "oauth2",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+		Flow:   "notion_mcp",
+		OAuth: config.OAuthConfig{
+			AuthURL:     "https://mcp.notion.com/authorize",
+			TokenURL:    "https://mcp.notion.com/token",
+			RegisterURL: "https://mcp.notion.com/register",
+		},
+	}
+}
+
+func init() {
+	var _ runtime.HTTPCredentialRuntime = (*NotionMCPOAuth)(nil)
+	config.Register(&config.Plugin{
+		Kind:    config.KindCredential,
+		Type:    "notion_mcp_oauth",
+		New:     newer[NotionMCPOAuth](),
+		Runtime: (*NotionMCPOAuth)(nil),
+		Build:   passthrough,
+		Emit:    emptyEmit,
+	})
+}

--- a/migrations/sqlite/0013_credential_client_id.sql
+++ b/migrations/sqlite/0013_credential_client_id.sql
@@ -1,0 +1,11 @@
+-- 0013_credential_client_id — carry the dynamically registered OAuth
+-- client_id on each credential row. RFC 7591 dynamic client registration
+-- (used by mcp.notion.com / Notion MCP) produces a unique client_id at
+-- connect time; without it, refresh would have to fall back to the
+-- integration's static ClientID, which dynamic-registration flows do not
+-- ship. Static-ClientID flows (github, anthropic, codex) leave this NULL
+-- and continue to refresh against their plugin-declared client_id.
+
+ALTER TABLE credentials ADD COLUMN client_id TEXT;
+
+INSERT INTO _schema (version) VALUES (13);

--- a/oauth.go
+++ b/oauth.go
@@ -40,8 +40,14 @@ type oauthState struct {
 	id          string
 	displayName string // human-readable name (e.g. github login)
 	avatarURL   string // dashboard pfp
-	db          *sql.DB
-	mu          sync.Mutex
+	// clientID is the dynamically-registered OAuth client_id for flows
+	// that use RFC 7591 (notion_mcp). Static-ClientID flows (github,
+	// anthropic, codex) leave this empty and use cfg.ClientID. Persisted
+	// in the credentials table alongside the tokens so refresh works
+	// across gateway restarts.
+	clientID string
+	db       *sql.DB
+	mu       sync.Mutex
 }
 
 // OAuthRegistry holds all configured OAuth integrations and one token
@@ -192,6 +198,15 @@ func (r *OAuthRegistry) Revoke(id string) {
 
 // Set stores tokens captured externally (browser auth flow callback).
 func (r *OAuthRegistry) Set(id string, tok *oauth2.Token) error {
+	return r.SetWithClient(id, tok, "")
+}
+
+// SetWithClient is Set + a dynamically registered client_id. Pass empty
+// clientID for static-ClientID flows; pass the per-credential client_id
+// for RFC 7591 dynamic registration flows (notion_mcp). The clientID is
+// stamped onto the in-memory state and persisted alongside the tokens so
+// refresh continues to work after restart.
+func (r *OAuthRegistry) SetWithClient(id string, tok *oauth2.Token, clientID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	it, ok := r.integrations[id]
@@ -202,6 +217,10 @@ func (r *OAuthRegistry) Set(id string, tok *oauth2.Token) error {
 	if s == nil {
 		s = newState(it, r.db)
 		r.states[id] = s
+	}
+	if clientID != "" {
+		s.clientID = clientID
+		s.cfg.ClientID = clientID
 	}
 	s.setToken(tok)
 	if name, avatar := fetchOAuthProfile(id, tok.AccessToken); name != "" || avatar != "" {
@@ -287,6 +306,11 @@ func (s *oauthState) setToken(tok *oauth2.Token) {
 		// (returns "Invalid request format" otherwise). Stdlib oauth2
 		// only sends form-urlencoded.
 		base = &anthropicRefreshSource{cfg: s.cfg, current: tok}
+	case isNotionMCPTokenURL(s.cfg.Endpoint.TokenURL):
+		// Notion's MCP token endpoint refreshes via form-urlencoded body
+		// and expects the dynamically registered client_id (no static
+		// ClientSecret — PKCE-only public client).
+		base = &notionMCPRefreshSource{cfg: s.cfg, current: tok}
 	default:
 		base = s.cfg.TokenSource(context.Background(), tok)
 	}
@@ -404,15 +428,26 @@ func (s *oauthState) persist(t *oauth2.Token) {
 		expiryNs = t.Expiry.UnixNano()
 	}
 	_, _ = s.db.Exec(`
-		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns, client_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			access_token  = excluded.access_token,
 			token_type    = excluded.token_type,
 			refresh_token = excluded.refresh_token,
 			expiry_ns     = excluded.expiry_ns,
-			updated_ns    = excluded.updated_ns
-	`, s.id, t.AccessToken, t.TokenType, t.RefreshToken, expiryNs, time.Now().UnixNano())
+			updated_ns    = excluded.updated_ns,
+			client_id     = excluded.client_id
+	`, s.id, t.AccessToken, t.TokenType, t.RefreshToken, expiryNs, time.Now().UnixNano(), nullableString(s.clientID))
+}
+
+// nullableString returns sql.NullString so that the empty-string case is
+// persisted as SQL NULL — static-ClientID flows leave client_id NULL
+// rather than "" so a future schema-shape check can distinguish them.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }
 
 // LoadFromDB rehydrates every credential row whose integration is
@@ -431,7 +466,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 	if r.db == nil {
 		return nil
 	}
-	rows, err := r.db.Query("SELECT id, access_token, token_type, refresh_token, expiry_ns, display_name, avatar_url FROM credentials")
+	rows, err := r.db.Query("SELECT id, access_token, token_type, refresh_token, expiry_ns, display_name, avatar_url, client_id FROM credentials")
 	if err != nil {
 		return err
 	}
@@ -442,8 +477,9 @@ func (r *OAuthRegistry) loadFromDB() error {
 			access, typ, refr   sql.NullString
 			expiryNs            sql.NullInt64
 			displayName, avatar sql.NullString
+			clientID            sql.NullString
 		)
-		if err := rows.Scan(&id, &access, &typ, &refr, &expiryNs, &displayName, &avatar); err != nil {
+		if err := rows.Scan(&id, &access, &typ, &refr, &expiryNs, &displayName, &avatar, &clientID); err != nil {
 			return err
 		}
 		it, ok := r.integrations[id]
@@ -451,6 +487,12 @@ func (r *OAuthRegistry) loadFromDB() error {
 			continue
 		}
 		s := newState(it, r.db)
+		// Restore the dynamically-registered client_id BEFORE setToken
+		// so the refresh source (notion_mcp) picks it up via s.cfg.
+		if clientID.Valid && clientID.String != "" {
+			s.clientID = clientID.String
+			s.cfg.ClientID = clientID.String
+		}
 		tok := &oauth2.Token{
 			AccessToken:  access.String,
 			TokenType:    typ.String,
@@ -473,6 +515,10 @@ type oauthSession struct {
 	cfg      *oauth2.Config
 	id       string
 	created  time.Time
+	// dynClientID is the RFC 7591 client_id this session registered at
+	// start time (notion_mcp). Empty for static-ClientID flows. Stamped
+	// onto the credential row at exchange time so refresh can replay it.
+	dynClientID string
 }
 
 // mergeExtraScopes appends user-selected scopes from the connect-time
@@ -550,6 +596,10 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		w.startOpenAIDeviceFlow(rw, id, flow)
 		return
 	}
+	if flow.Flow == "notion_mcp" {
+		w.startNotionMCPFlow(rw, r, id, flow)
+		return
+	}
 
 	verifier := randomString(64)
 	sum := sha256.Sum256([]byte(verifier))
@@ -575,6 +625,104 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 	}
 	w.mu.Unlock()
 	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state})
+}
+
+// startNotionMCPFlow drives the mcp.notion.com auth-code flow with RFC
+// 7591 dynamic client registration. Notion accepts arbitrary redirect
+// URIs at registration, so we register the dashboard's own
+// /oauth/callback page — the page auto-exchanges via /api/oauth/exchange
+// when it loads, with copy-paste from the URL bar as a fallback.
+func (w *webMux) startNotionMCPFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
+	redirectURI := w.dashboardRedirectURI(r, "/oauth/callback")
+	clientID, err := registerOAuthClient(r.Context(), flow.OAuth.RegisterURL, redirectURI)
+	if err != nil {
+		http.Error(rw, "dynamic client registration: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	verifier := randomString(64)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	state := randomString(32)
+	cfg := &oauth2.Config{
+		ClientID:    clientID,
+		Scopes:      flow.OAuth.Scopes,
+		RedirectURL: redirectURI,
+		Endpoint:    oauth2.Endpoint{AuthURL: flow.OAuth.AuthURL, TokenURL: flow.OAuth.TokenURL},
+	}
+	authURL := cfg.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("code_challenge", challenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+	w.mu.Lock()
+	w.sessions[state] = &oauthSession{
+		verifier:    verifier,
+		state:       state,
+		cfg:         cfg,
+		id:          id,
+		created:     time.Now(),
+		dynClientID: clientID,
+	}
+	for k, s := range w.sessions {
+		if time.Since(s.created) > 10*time.Minute {
+			delete(w.sessions, k)
+		}
+	}
+	w.mu.Unlock()
+	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state})
+}
+
+// dashboardRedirectURI builds a same-origin URL on the dashboard host
+// the browser used to hit /api/oauth/start. Used as the registered
+// redirect_uri for dynamic-registration flows so the OAuth callback
+// lands back on the dashboard the user is already authenticated to.
+func (w *webMux) dashboardRedirectURI(r *http.Request, path string) string {
+	scheme := "http"
+	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	host := r.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return scheme + "://" + host + path
+}
+
+// registerOAuthClient performs RFC 7591 dynamic client registration
+// against `registerURL`, asking for a public PKCE client bound to the
+// given redirect URI. Returns the issued client_id.
+func registerOAuthClient(ctx context.Context, registerURL, redirectURI string) (string, error) {
+	body, _ := json.Marshal(map[string]any{
+		"client_name":                "clawpatrol",
+		"redirect_uris":              []string{redirectURI},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	})
+	req, err := http.NewRequestWithContext(ctx, "POST", registerURL, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("register %d: %s", resp.StatusCode, string(respBytes))
+	}
+	var rr struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.Unmarshal(respBytes, &rr); err != nil {
+		return "", err
+	}
+	if rr.ClientID == "" {
+		return "", fmt.Errorf("register: empty client_id in response: %s", string(respBytes))
+	}
+	return rr.ClientID, nil
 }
 
 func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
@@ -617,7 +765,7 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "token exchange: "+err.Error(), 400)
 		return
 	}
-	if err := w.g.oauth.Set(sess.id, tok); err != nil {
+	if err := w.g.oauth.SetWithClient(sess.id, tok, sess.dynClientID); err != nil {
 		http.Error(rw, err.Error(), 500)
 		return
 	}
@@ -927,6 +1075,76 @@ func isAnthropicTokenURL(u string) bool {
 	return strings.Contains(u, "anthropic.com/")
 }
 
+func isNotionMCPTokenURL(u string) bool {
+	return strings.Contains(u, "mcp.notion.com/")
+}
+
+// notionMCPRefreshSource refreshes Notion MCP OAuth tokens via the
+// form-urlencoded body the spec mandates. The client_id is read from
+// cfg.ClientID, which the registry restores from the persisted
+// credentials.client_id column on boot. Stateful: holds the current
+// token (with refresh_token) and rotates it on each refresh.
+type notionMCPRefreshSource struct {
+	mu      sync.Mutex
+	cfg     *oauth2.Config
+	current *oauth2.Token
+}
+
+func (n *notionMCPRefreshSource) Token() (*oauth2.Token, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.current.Valid() {
+		return n.current, nil
+	}
+	if n.current.RefreshToken == "" {
+		return nil, fmt.Errorf("notion_mcp refresh: no refresh_token")
+	}
+	if n.cfg.ClientID == "" {
+		return nil, fmt.Errorf("notion_mcp refresh: no client_id (dynamic registration was never persisted)")
+	}
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", n.current.RefreshToken)
+	form.Set("client_id", n.cfg.ClientID)
+	req, err := http.NewRequest("POST", n.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("notion_mcp refresh %d: %s", resp.StatusCode, string(respBytes))
+	}
+	var tr struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(respBytes, &tr); err != nil {
+		return nil, err
+	}
+	t := &oauth2.Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		TokenType:    tr.TokenType,
+	}
+	if t.RefreshToken == "" {
+		t.RefreshToken = n.current.RefreshToken
+	}
+	if tr.ExpiresIn > 0 {
+		t.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	n.current = t
+	return t, nil
+}
+
 func exchangeAnthropicCode(ctx context.Context, sess *oauthSession, code, state string) (*oauth2.Token, error) {
 	body, _ := json.Marshal(map[string]string{
 		"grant_type":    "authorization_code",
@@ -1012,4 +1230,124 @@ func (w *webMux) apiOAuthRevoke(rw http.ResponseWriter, r *http.Request) {
 	}
 	w.g.oauth.Revoke(body.ID)
 	writeJSON(rw, map[string]bool{"ok": true})
+}
+
+// oauthCallbackHTML is served at GET /oauth/callback for
+// dynamic-registration flows that redirect back to the dashboard
+// (notion_mcp). The inline JS extracts ?code & ?state, POSTs them to
+// /api/oauth/exchange so the original ConnectModal sees the credential
+// connect itself, and shows the code prominently as a copy-paste
+// fallback if the auto-exchange fails (e.g. dashboard secret expired,
+// state already consumed, etc.).
+const oauthCallbackHTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>OAuth callback — clawpatrol</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; min-height: 100vh;
+         display: flex; align-items: center; justify-content: center;
+         background: #f7f5f0; color: #1a1a1a; }
+  .box { max-width: 480px; padding: 2rem; background: white;
+         border: 2px solid #1a1a1a; border-radius: 6px;
+         box-shadow: 4px 4px 0 #1a1a1a; }
+  h1 { font-size: 1rem; text-transform: uppercase; letter-spacing: .1em;
+       margin: 0 0 1rem; }
+  .status { font-size: .85rem; margin-bottom: 1rem; line-height: 1.5; }
+  .code { font-family: ui-monospace, monospace; font-size: .8rem;
+          word-break: break-all; padding: .75rem; background: #f0ebe0;
+          border: 1px solid #1a1a1a; border-radius: 3px; user-select: all; }
+  .err { color: #a8482e; }
+  .ok { color: #2b6630; }
+  button { font-family: inherit; font-size: .8rem; padding: .4rem .8rem;
+           background: #1a1a1a; color: white; border: none; cursor: pointer;
+           border-radius: 3px; margin-top: .75rem; }
+  button:hover { background: #333; }
+  details { margin-top: 1rem; font-size: .8rem; }
+  details summary { cursor: pointer; color: #666; }
+  details p { margin: .5rem 0 0; line-height: 1.5; color: #444; }
+</style>
+</head>
+<body>
+<div class="box">
+  <h1 id="title">Completing sign-in…</h1>
+  <div id="status" class="status">Exchanging authorization code.</div>
+  <div id="fallback" style="display:none">
+    <p class="status">Auto-exchange failed. Copy this code and paste it
+    into the dashboard's connect dialog:</p>
+    <div id="code" class="code"></div>
+    <button onclick="navigator.clipboard.writeText(document.getElementById('code').textContent)">copy code</button>
+  </div>
+  <details id="details" style="display:none">
+    <summary>error detail</summary>
+    <p id="detail"></p>
+  </details>
+</div>
+<script>
+(async () => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  const state = params.get('state');
+  const err = params.get('error');
+  const errDesc = params.get('error_description');
+  const $ = (id) => document.getElementById(id);
+
+  if (err) {
+    $('title').textContent = 'Authorization denied';
+    $('title').classList.add('err');
+    $('status').textContent = errDesc || err;
+    return;
+  }
+  if (!code || !state) {
+    $('title').textContent = 'Missing code or state';
+    $('title').classList.add('err');
+    $('status').textContent = 'This page expects ?code= and ?state= query parameters.';
+    return;
+  }
+
+  try {
+    const resp = await fetch('/api/oauth/exchange', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      credentials: 'same-origin',
+      body: JSON.stringify({code, state}),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error('HTTP ' + resp.status + ': ' + text);
+    }
+    $('title').textContent = 'Connected';
+    $('title').classList.add('ok');
+    $('status').textContent = 'You can close this tab.';
+    // Nudge any open dashboard tab to refresh — same-origin BroadcastChannel.
+    try { new BroadcastChannel('oauth').postMessage({type: 'connected', state}); } catch (_) {}
+    setTimeout(() => window.close(), 1500);
+  } catch (e) {
+    $('title').textContent = 'Auto-exchange failed';
+    $('title').classList.add('err');
+    $('status').style.display = 'none';
+    $('fallback').style.display = 'block';
+    $('code').textContent = code;
+    $('details').style.display = 'block';
+    $('detail').textContent = String(e && e.message ? e.message : e);
+  }
+})();
+</script>
+</body>
+</html>
+`
+
+// serveOAuthCallback renders the dynamic-registration redirect-uri page
+// (see oauthCallbackHTML). Same dashboard-secret gating as everything
+// else — the user is already authenticated to the dashboard when the
+// browser follows the OAuth redirect here (SameSite=Lax cookie rides
+// along), so no special handling is needed.
+func (w *webMux) serveOAuthCallback(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		http.Error(rw, "GET", http.StatusMethodNotAllowed)
+		return
+	}
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	rw.Header().Set("Cache-Control", "no-store")
+	_, _ = rw.Write([]byte(oauthCallbackHTML))
 }

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -144,7 +144,7 @@ approver "llm_approver" "example" {
 
 Block syntax: `credential "<type>" "<name>" { ... }`
 
-Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`tailscale`](#credential-tailscale), [`telegram_bot_token`](#credential-telegrambottoken).
+Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh`](#credential-ssh), [`tailscale`](#credential-tailscale), [`telegram_bot_token`](#credential-telegrambottoken).
 
 ### `credential "anthropic_manual_key" "<name>"`
 
@@ -270,6 +270,14 @@ _No configurable attributes._
 
 ```hcl
 credential "mtls_credential" "example" {}
+```
+
+### `credential "notion_mcp_oauth" "<name>"`
+
+_No configurable attributes._
+
+```hcl
+credential "notion_mcp_oauth" "example" {}
 ```
 
 ### `credential "notion_oauth" "<name>"`

--- a/web.go
+++ b/web.go
@@ -232,6 +232,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/oauth/exchange", Auth: authDashboard, Handler: w.apiOAuthExchange},
 		{Method: http.MethodPost, Path: "/api/oauth/device-poll", Auth: authDashboard, Handler: w.apiOAuthDevicePoll},
 		{Method: http.MethodPost, Path: "/api/oauth/revoke", Auth: authDashboard, Handler: w.apiOAuthRevoke},
+		{Method: http.MethodGet, Path: "/oauth/callback", Auth: authDashboard, Handler: w.serveOAuthCallback},
 		{Method: http.MethodPost, Path: "/api/tailscale/connect", Auth: authDashboard, Handler: w.apiTailscaleConnect},
 		{Method: http.MethodGet, Path: "/api/tailscale/status", Auth: authDashboard, Handler: w.apiTailscaleStatus},
 		{Method: http.MethodPost, Path: "/api/tailscale/disconnect", Auth: authDashboard, Handler: w.apiTailscaleDisconnect},

--- a/www/src/components/ConnectModal.tsx
+++ b/www/src/components/ConnectModal.tsx
@@ -60,6 +60,34 @@ export function ConnectModal({
   const onDoneRef = useRef(onDone);
   onDoneRef.current = onDone;
 
+  // Auto-complete path: when the OAuth callback page in another tab
+  // POSTs /api/oauth/exchange successfully, it pings the BroadcastChannel
+  // so this modal can close itself instead of asking the user to copy
+  // the code into the input field below. Lazy `try` so older browsers
+  // without BroadcastChannel just fall back to the copy-paste UX.
+  useEffect(() => {
+    if (!start || start.flow === "device" || done) return;
+    let ch: BroadcastChannel | null = null;
+    try {
+      ch = new BroadcastChannel("oauth");
+      ch.onmessage = (e) => {
+        if (e.data?.type === "connected" && e.data?.state === start.state) {
+          setDone(true);
+          setTimeout(() => onDoneRef.current(), 800);
+        }
+      };
+    } catch {
+      /* no BroadcastChannel — copy-paste fallback still works */
+    }
+    return () => {
+      try {
+        ch?.close();
+      } catch {
+        /* no-op */
+      }
+    };
+  }, [start, done]);
+
   useEffect(() => {
     if (!start || start.flow !== "device") return;
     let cancelled = false;

--- a/www/src/components/Logos.tsx
+++ b/www/src/components/Logos.tsx
@@ -76,7 +76,8 @@ export function IntegrationIcon({
     return <BrandIcon name="telegram" color="%2326a5e4" className={className} />;
   if (t === "gemini_api_key")
     return <BrandIcon name="googlegemini" color="%238e75b2" className={className} />;
-  if (t === "notion_oauth") return <BrandIcon name="notion" className={className} />;
+  if (t === "notion_oauth" || t === "notion_mcp_oauth")
+    return <BrandIcon name="notion" className={className} />;
   if (t === "aws_credential")
     return <BrandIcon name="amazoneks" color="%23ff9900" className={className} />;
   if (t === "mtls_credential") return <KeyGlyph className={className} />;

--- a/www/src/lib/credentialLabels.ts
+++ b/www/src/lib/credentialLabels.ts
@@ -4,6 +4,7 @@ export const CREDENTIAL_TYPE_LABEL: Record<string, string> = {
   openai_codex_oauth: "Codex",
   github_oauth: "GitHub",
   notion_oauth: "Notion",
+  notion_mcp_oauth: "Notion (MCP)",
   postgres_credential: "Postgres",
   clickhouse_credential: "ClickHouse",
   mtls_credential: "mTLS",


### PR DESCRIPTION
New credential type that drives the OAuth flow against
mcp.notion.com (Notion's hosted MCP server) via RFC 7591 dynamic
client registration, so operators don't have to register a Notion
integration first. The resulting bearer is scoped to mcp.notion.com
only; api.notion.com keeps notion_oauth (manual integration token).

* config/plugins/credentials/notion_mcp_oauth.go: new plugin.
  Stamps Authorization: Bearer (no Notion-Version, MCP doesn't use
  it). OAuthFlow() returns Flow="notion_mcp" with register/auth/
  token URLs pointing at mcp.notion.com — no static ClientID
  (registered on the fly per credential).
* config/oauth.go: add RegisterURL field to OAuthConfig.
* oauth.go: Flow="notion_mcp" branch in apiOAuthStart does RFC 7591
  registration at RegisterURL with redirect_uri derived from
  r.Host, generates PKCE, stores the dynamic client_id in the
  session. notionMCPRefreshSource refreshes via form-urlencoded
  body using the persisted client_id. Threaded client_id through
  oauthState/persist/loadFromDB so refresh works after restart.
* migrations/sqlite/0013_credential_client_id.sql: ALTER TABLE
  credentials ADD COLUMN client_id TEXT. Static-ClientID flows
  (github / anthropic / codex) leave this NULL.
* GET /oauth/callback: dashboard page the dynamic-registration
  flow redirects to. Auto-POSTs ?code&state to /api/oauth/exchange
  and BroadcastChannel-pings the original ConnectModal so it
  closes itself. Copy-paste from the URL bar still works as a
  fallback (existing UX, unchanged).
* ConnectModal: listens on BroadcastChannel("oauth") so the
  auto-exchange completion closes the modal without the user
  pasting anything.
* UI labels: notion_mcp_oauth renders as "Notion (MCP)" with the
  Notion brand icon.