### PR TITLE
dashboard: derive Tailscale 'Connected' from tsnet BackendState

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -584,17 +584,22 @@ type IntegrationRow struct {
 
 // TailscaleAuthStatusUI is the dashboard-facing slice of a
 // tailscale-node-auth credential's live state. Connected reflects
-// whether tsnet has persisted node identity for the credential.
-// PendingURL is the live Tailscale login URL emitted by tsnet when
-// no identity is stored yet — the dashboard's "Connect" button
-// redirects to it. Endpoint paths are surfaced so the dashboard
-// renders the connect flow without hard-coding the route layout.
+// whether tsnet's BackendState is Running — not merely whether
+// identity bytes have been persisted, which can happen mid-auth
+// before the tailnet join completes. State carries the underlying
+// label so the card can distinguish "awaiting authentication" from
+// "starting" from "stopped". PendingURL is the live Tailscale login
+// URL emitted by tsnet during NeedsLogin — the dashboard's "Connect"
+// button redirects to it. Endpoint paths are surfaced so the
+// dashboard renders the connect flow without hard-coding the route
+// layout.
 type TailscaleAuthStatusUI struct {
-	Connected     bool   `json:"connected"`
-	PendingURL    string `json:"pending_url,omitempty"`
-	ConnectURL    string `json:"connect_url"`
-	StatusURL     string `json:"status_url"`
-	DisconnectURL string `json:"disconnect_url"`
+	Connected     bool                          `json:"connected"`
+	State         tailscaleproto.NodeStateLabel `json:"state"`
+	PendingURL    string                        `json:"pending_url,omitempty"`
+	ConnectURL    string                        `json:"connect_url"`
+	StatusURL     string                        `json:"status_url"`
+	DisconnectURL string                        `json:"disconnect_url"`
 }
 
 // OAuthIntegrationUI is the dashboard-facing slice of an
@@ -658,8 +663,16 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 		if _, ok := ent.Body.(tailscaleproto.TailscaleAuthProvider); ok {
 			row.HasTailscaleAuth = true
 			present, _ := credentialSlotPresence(w.g.db, name)
+			label := tailscaleproto.DefaultStates.Get(name)
+			// Connected reads strictly from the live BackendState:
+			// persisted slots prove auth completed *at some point*, not
+			// that the node is currently joined. A gateway restart sees
+			// slots but Starting/NeedsLogin until tsnet finishes its
+			// boot — surfacing "connected" in that window misled the
+			// operator into thinking traffic could flow.
 			row.TailscaleAuth = &TailscaleAuthStatusUI{
-				Connected:     len(present) > 0,
+				Connected:     label == tailscaleproto.NodeStateRunning,
+				State:         dashboardTailscaleState(label, len(present) > 0),
 				PendingURL:    tailscaleproto.Default.Get(name),
 				ConnectURL:    "/api/tailscale/connect?id=" + name,
 				StatusURL:     "/api/tailscale/status?id=" + name,
@@ -669,6 +682,23 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 		out = append(out, row)
 	}
 	return out
+}
+
+// dashboardTailscaleState narrows the live BackendState for the
+// card's display. When the watcher has never observed a transition
+// (the tunnel may still be lazy and tsnet hasn't been brought up
+// yet), persisted slots flip the fallback from "unknown" to
+// "stopped" — the identity is on disk but nothing is running.
+// Without persisted slots and no observed state, "unknown" is
+// honest: the operator hasn't connected yet either.
+func dashboardTailscaleState(label tailscaleproto.NodeStateLabel, hasPersistedSlots bool) tailscaleproto.NodeStateLabel {
+	if label != tailscaleproto.NodeStateUnknown {
+		return label
+	}
+	if hasPersistedSlots {
+		return tailscaleproto.NodeStateStopped
+	}
+	return tailscaleproto.NodeStateUnknown
 }
 
 // credentialsInProfile returns the set of credential bare names that

--- a/config/plugins/tailscaleproto/tailscaleproto.go
+++ b/config/plugins/tailscaleproto/tailscaleproto.go
@@ -169,6 +169,98 @@ func (p *PendingNodeAuth) Wait(ctx context.Context, name string) string {
 // multiple gateway instances in one process can scope it.
 var Default = &PendingNodeAuth{}
 
+// NodeStateLabel is the dashboard-facing label for a tsnet node's
+// BackendState. Stable strings (not the numeric ipn.State constants)
+// so JSON consumers don't break if tailscale.com renumbers the enum.
+type NodeStateLabel string
+
+const (
+	NodeStateUnknown        NodeStateLabel = "unknown"
+	NodeStateNeedsLogin     NodeStateLabel = "needs_login"
+	NodeStateNeedsMachAuth  NodeStateLabel = "needs_machine_auth"
+	NodeStateStarting       NodeStateLabel = "starting"
+	NodeStateRunning        NodeStateLabel = "running"
+	NodeStateStopped        NodeStateLabel = "stopped"
+	NodeStateInUseOtherUser NodeStateLabel = "in_use_other_user"
+)
+
+// LabelFromIPNState projects an ipn.State onto the stable wire label.
+// NoState (the pre-init zero value) maps to "unknown" — the watcher
+// hasn't observed a state transition yet.
+func LabelFromIPNState(s ipn.State) NodeStateLabel {
+	switch s {
+	case ipn.NeedsLogin:
+		return NodeStateNeedsLogin
+	case ipn.NeedsMachineAuth:
+		return NodeStateNeedsMachAuth
+	case ipn.Starting:
+		return NodeStateStarting
+	case ipn.Running:
+		return NodeStateRunning
+	case ipn.Stopped:
+		return NodeStateStopped
+	case ipn.InUseOtherUser:
+		return NodeStateInUseOtherUser
+	default:
+		return NodeStateUnknown
+	}
+}
+
+// NodeStates tracks the latest observed tsnet BackendState per
+// credential bare name. The tunnel's IPN-bus watcher writes here on
+// every State transition; the dashboard reads here to render the
+// credential card's live status. Keyed on the credential rather than
+// the tunnel because tsnet node identity is gateway-wide (one node per
+// credential, shared by every tunnel referencing it).
+//
+// Distinct from PendingNodeAuth on purpose: the auth URL is a transient
+// side-effect of the NeedsLogin state, but transitions like
+// Starting → Running carry no URL. Storing them as a single sum type
+// would couple the two state machines awkwardly; two registries lets
+// each evolve independently.
+//
+// The zero value is usable. Safe for concurrent use.
+type NodeStates struct {
+	mu     sync.Mutex
+	states map[string]NodeStateLabel
+}
+
+// Set records the latest state label for credential `name`. The
+// tunnel calls this for every Notify.State transition observed on
+// the IPN bus. Passing NodeStateUnknown clears the entry (used when
+// the tunnel closes or the credential is disconnected).
+func (r *NodeStates) Set(name string, label NodeStateLabel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.states == nil {
+		r.states = map[string]NodeStateLabel{}
+	}
+	if label == NodeStateUnknown {
+		delete(r.states, name)
+		return
+	}
+	r.states[name] = label
+}
+
+// Get returns the latest state label for credential `name`, or
+// NodeStateUnknown when nothing has been recorded yet (typically:
+// the tunnel hasn't been acquired so tsnet hasn't started).
+func (r *NodeStates) Get(name string) NodeStateLabel {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.states == nil {
+		return NodeStateUnknown
+	}
+	if s, ok := r.states[name]; ok {
+		return s
+	}
+	return NodeStateUnknown
+}
+
+// DefaultStates is the process-wide NodeStates registry. Mirrors the
+// Default PendingNodeAuth pattern: tunnel writes, dashboard reads.
+var DefaultStates = &NodeStates{}
+
 // SecretWriter is the optional interface a runtime.SecretStore
 // implementation satisfies when it can persist slot bytes. The
 // tailscale credential's StateStore type-asserts to this; the gateway-

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -191,10 +191,11 @@ func (t *TailscaleTunnel) openWithCredential(_ context.Context, host runtime.Tun
 	tc.cancelUp = cancelUp
 
 	// IPN-bus watcher: surfaces tsnet's dynamic login URL into the
-	// PendingNodeAuth side-channel so the dashboard's Connect button
-	// can redirect the operator. Returns when ctx fires or the server
-	// closes.
-	go tc.watchLoginURL(upCtx)
+	// PendingNodeAuth side-channel and pushes BackendState transitions
+	// into DefaultStates so the dashboard renders "Running" only when
+	// tsnet has actually joined the tailnet (not just when Up() began).
+	// Returns when ctx fires or the server closes.
+	go tc.watchIPNBus(upCtx)
 	go tc.runUp(upCtx)
 
 	return tc, nil
@@ -263,6 +264,7 @@ func (t *tailscaleTunnelConn) Close() error {
 		}
 		if t.credential != "" {
 			tailscaleproto.Default.Set(t.credential, "")
+			tailscaleproto.DefaultStates.Set(t.credential, tailscaleproto.NodeStateUnknown)
 		}
 		if t.srv != nil {
 			err = t.srv.Close()
@@ -294,12 +296,15 @@ func (t *tailscaleTunnelConn) runUp(ctx context.Context) {
 	close(t.joined)
 }
 
-// watchLoginURL drains the IPN bus for BrowseToURL notifications and
-// parks them in the package-level PendingNodeAuth registry so the
-// dashboard's Connect button can redirect the operator. Multiple
-// watchers on the same bus are fine — Up() runs its own watcher in
-// parallel for the Running-state transition.
-func (t *tailscaleTunnelConn) watchLoginURL(ctx context.Context) {
+// watchIPNBus drains the IPN bus for BrowseToURL notifications and
+// State transitions. URLs go into the package-level PendingNodeAuth
+// registry (so the dashboard's Connect button can redirect the
+// operator); state labels go into DefaultStates (so the credential
+// card renders "Connected" only when tsnet has actually reached the
+// Running state, not just when Up() began). Multiple watchers on the
+// same bus are fine — Up() runs its own watcher in parallel for the
+// Running-state transition.
+func (t *tailscaleTunnelConn) watchIPNBus(ctx context.Context) {
 	if t.credential == "" {
 		return
 	}
@@ -326,6 +331,16 @@ func (t *tailscaleTunnelConn) watchLoginURL(ctx context.Context) {
 		if n.BrowseToURL != nil {
 			tailscaleproto.Default.Set(t.credential, *n.BrowseToURL)
 			t.logger.Printf("tailscale/%s: login URL pending — visit dashboard to Connect credential %q", t.name, t.credential)
+		}
+		if n.State != nil {
+			label := tailscaleproto.LabelFromIPNState(*n.State)
+			tailscaleproto.DefaultStates.Set(t.credential, label)
+			// Once the node is Running, no auth URL is in flight —
+			// drop any stale parked URL so the dashboard doesn't
+			// keep offering a click-through that's already complete.
+			if *n.State == ipn.Running {
+				tailscaleproto.Default.Set(t.credential, "")
+			}
 		}
 	}
 }

--- a/tailscale_dashboard.go
+++ b/tailscale_dashboard.go
@@ -43,11 +43,12 @@ const tailscaleConnectURLTimeout = 15 * time.Second
 const tailscaleConnectLoginWindow = 5 * time.Minute
 
 type tailscaleAuthResponse struct {
-	ID         string `json:"id"`
-	Connected  bool   `json:"connected"`
-	AuthURL    string `json:"auth_url,omitempty"`
-	PendingURL string `json:"pending_url,omitempty"`
-	Status     string `json:"status"` // "connected" | "pending" | "awaiting_url"
+	ID         string                        `json:"id"`
+	Connected  bool                          `json:"connected"`
+	State      tailscaleproto.NodeStateLabel `json:"state"`
+	AuthURL    string                        `json:"auth_url,omitempty"`
+	PendingURL string                        `json:"pending_url,omitempty"`
+	Status     string                        `json:"status"` // "connected" | "pending" | "awaiting_url"
 }
 
 // apiTailscaleConnect returns the live tsnet login URL for the
@@ -91,9 +92,14 @@ func (w *webMux) apiTailscaleConnect(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := tailscaleAuthResponse{ID: id}
-	present, _ := credentialSlotPresence(w.g.db, id)
+	label := tailscaleproto.DefaultStates.Get(id)
+	resp.State = label
 	switch {
-	case len(present) > 0:
+	case label == tailscaleproto.NodeStateRunning:
+		// Live tsnet has joined the tailnet — no operator click
+		// needed. Persisted slots alone (the previous "connected"
+		// gate) are not enough: they can exist while tsnet is still
+		// Starting or even in NeedsLogin after a state reset.
 		resp.Connected = true
 		resp.Status = "connected"
 	default:

--- a/tailscale_dashboard_test.go
+++ b/tailscale_dashboard_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"tailscale.com/ipn"
 
 	"github.com/denoland/clawpatrol/config"
 	"github.com/denoland/clawpatrol/config/plugins/tailscaleproto"
@@ -155,4 +158,115 @@ func TestPendingNodeAuthWaitCtxDone(t *testing.T) {
 	if got := p.Wait(ctx, "c"); got != "" {
 		t.Fatalf("Wait returned %q, want empty string when ctx expires before Set", got)
 	}
+}
+
+func TestDashboardTailscaleStateRespectsLive(t *testing.T) {
+	cases := []struct {
+		name      string
+		label     tailscaleproto.NodeStateLabel
+		slots     bool
+		want      tailscaleproto.NodeStateLabel
+		connected bool
+	}{
+		{"running with slots", tailscaleproto.NodeStateRunning, true, tailscaleproto.NodeStateRunning, true},
+		{"running no slots", tailscaleproto.NodeStateRunning, false, tailscaleproto.NodeStateRunning, true},
+		{"starting overrides slots", tailscaleproto.NodeStateStarting, true, tailscaleproto.NodeStateStarting, false},
+		{"needs login with slots", tailscaleproto.NodeStateNeedsLogin, true, tailscaleproto.NodeStateNeedsLogin, false},
+		{"unknown with slots maps to stopped", tailscaleproto.NodeStateUnknown, true, tailscaleproto.NodeStateStopped, false},
+		{"unknown no slots stays unknown", tailscaleproto.NodeStateUnknown, false, tailscaleproto.NodeStateUnknown, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dashboardTailscaleState(tc.label, tc.slots)
+			if got != tc.want {
+				t.Fatalf("dashboardTailscaleState(%q, slots=%v) = %q, want %q", tc.label, tc.slots, got, tc.want)
+			}
+			if connected := tc.label == tailscaleproto.NodeStateRunning; connected != tc.connected {
+				t.Fatalf("connected = %v, want %v", connected, tc.connected)
+			}
+		})
+	}
+}
+
+func TestLabelFromIPNStateMapping(t *testing.T) {
+	cases := []struct {
+		in   ipn.State
+		want tailscaleproto.NodeStateLabel
+	}{
+		{ipn.NoState, tailscaleproto.NodeStateUnknown},
+		{ipn.InUseOtherUser, tailscaleproto.NodeStateInUseOtherUser},
+		{ipn.NeedsLogin, tailscaleproto.NodeStateNeedsLogin},
+		{ipn.NeedsMachineAuth, tailscaleproto.NodeStateNeedsMachAuth},
+		{ipn.Stopped, tailscaleproto.NodeStateStopped},
+		{ipn.Starting, tailscaleproto.NodeStateStarting},
+		{ipn.Running, tailscaleproto.NodeStateRunning},
+	}
+	for _, tc := range cases {
+		if got := tailscaleproto.LabelFromIPNState(tc.in); got != tc.want {
+			t.Fatalf("LabelFromIPNState(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNodeStatesSetGet(t *testing.T) {
+	r := &tailscaleproto.NodeStates{}
+	if got := r.Get("c"); got != tailscaleproto.NodeStateUnknown {
+		t.Fatalf("Get before Set = %q, want unknown", got)
+	}
+	r.Set("c", tailscaleproto.NodeStateStarting)
+	if got := r.Get("c"); got != tailscaleproto.NodeStateStarting {
+		t.Fatalf("Get after Set = %q, want starting", got)
+	}
+	r.Set("c", tailscaleproto.NodeStateRunning)
+	if got := r.Get("c"); got != tailscaleproto.NodeStateRunning {
+		t.Fatalf("Get after second Set = %q, want running", got)
+	}
+	r.Set("c", tailscaleproto.NodeStateUnknown)
+	if got := r.Get("c"); got != tailscaleproto.NodeStateUnknown {
+		t.Fatalf("Get after clearing = %q, want unknown", got)
+	}
+}
+
+func TestApiTailscaleConnectRunningStateMarksConnected(t *testing.T) {
+	// A credential whose live tsnet state is Running should drive the
+	// connect endpoint into the "connected" branch — no auth URL fetch
+	// is attempted, the operator doesn't have anything to click.
+	defer tailscaleproto.DefaultStates.Set("live-cred", tailscaleproto.NodeStateUnknown)
+	tailscaleproto.DefaultStates.Set("live-cred", tailscaleproto.NodeStateRunning)
+
+	g := &Gateway{}
+	credEnt := &config.Entity{
+		Plugin: &config.Plugin{Type: "tailscale_credential"},
+		Body:   stubTailscaleCred{},
+	}
+	g.policy.Store(&config.CompiledPolicy{
+		Credentials: map[string]*config.Entity{"live-cred": credEnt},
+	})
+	w := &webMux{g: g}
+	r := httptest.NewRequest(http.MethodPost, "/api/tailscale/connect?id=live-cred", nil)
+	rw := httptest.NewRecorder()
+	w.apiTailscaleConnect(rw, r)
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %q, want 200", rw.Code, rw.Body.String())
+	}
+	var resp tailscaleAuthResponse
+	if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Connected || resp.Status != "connected" {
+		t.Fatalf("response = %+v, want Connected=true Status=connected", resp)
+	}
+	if resp.State != tailscaleproto.NodeStateRunning {
+		t.Fatalf("response.State = %q, want running", resp.State)
+	}
+}
+
+// stubTailscaleCred satisfies tailscaleproto.TailscaleAuthProvider so
+// lookupTailscaleAuth's type assertion succeeds without dragging in the
+// real credential plugin (which would pull the gateway's full secret-
+// store wiring).
+type stubTailscaleCred struct{}
+
+func (stubTailscaleCred) TailscaleAuth() *tailscaleproto.TailscaleAuthIntegration {
+	return &tailscaleproto.TailscaleAuthIntegration{}
 }

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
-import type { Integration } from "../lib/api";
+import type { Integration, TailscaleNodeState } from "../lib/api";
 import { clearCredential, oauthRevoke, tailscaleConnect, tailscaleDisconnect } from "../lib/api";
 import { credentialTypeLabel } from "../lib/credentialLabels";
 import { fmtExpiry } from "../lib/format";
@@ -184,6 +184,32 @@ function isConnected(i: Integration) {
   return i.connected || (i.tailscale_auth?.connected ?? false);
 }
 
+// tailscaleStatusLabel renders the credential card's bottom-row hint
+// when the credential is *not* connected — the connected branch is
+// handled directly by Card. Maps each NodeStateLabel onto the operator-
+// facing phrasing the bead specified: NeedsLogin / NeedsMachineAuth
+// surfaces the auth URL via the existing card-click handler, so the
+// label says "awaiting authentication" to make the action obvious.
+function tailscaleStatusLabel(state: TailscaleNodeState | undefined): string {
+  switch (state) {
+    case "needs_login":
+    case "needs_machine_auth":
+      return "awaiting authentication";
+    case "starting":
+      return "starting";
+    case "stopped":
+      return "stopped";
+    case "in_use_other_user":
+      return "error: in use by another user";
+    case "running":
+      // Defensive fallback; `connected` short-circuits the running
+      // branch in Card before this helper runs.
+      return "connected";
+    default:
+      return "click to connect";
+  }
+}
+
 // OwnerAvatar renders the OAuth user's PFP (e.g. github avatar) with
 // the provider icon as fallback when the image 404s or the host
 // blocks hotlinking. Failure flips to icon via state, not just an
@@ -229,11 +255,13 @@ function Card({
     ? i.expires_at
       ? "expires " + fmtExpiry(i.expires_at)
       : "connected"
-    : i.has_oauth || i.has_tailscale_auth
-      ? "click to connect"
-      : hasSlots
-        ? "paste secret"
-        : "api key only";
+    : i.has_tailscale_auth
+      ? tailscaleStatusLabel(i.tailscale_auth?.state)
+      : i.has_oauth
+        ? "click to connect"
+        : hasSlots
+          ? "paste secret"
+          : "api key only";
   // Plugin display name (e.g. "GitHub", "Postgres"). Falls back to the
   // raw HCL type key for unrecognised plugins rather than the bare
   // credential name, which would produce `<name> · <name>` titles.
@@ -313,9 +341,19 @@ function contextualSubtitle(i: Integration, connected: boolean, hasSlots: boolea
     if (hasSlots || i.has_tailscale_auth) return "Saved";
     return "";
   }
-  // Not connected: OAuth and Tailscale both await an explicit user
-  // action; manual creds with slots are simply unconfigured.
-  if (i.has_oauth || i.has_tailscale_auth) return "Not connected";
+  // Not connected: OAuth awaits an explicit user action. Tailscale's
+  // hint depends on whether tsnet is mid-auth — "Awaiting
+  // authentication" makes the click-to-open-URL flow legible to the
+  // operator, whereas "Not connected" reads as a dead-end.
+  if (i.has_tailscale_auth) {
+    const s = i.tailscale_auth?.state;
+    if (s === "needs_login" || s === "needs_machine_auth") return "Awaiting authentication";
+    if (s === "starting") return "Starting";
+    if (s === "stopped") return "Stopped";
+    if (s === "in_use_other_user") return "In use by another user";
+    return "Not connected";
+  }
+  if (i.has_oauth) return "Not connected";
   if (hasSlots) return "Not configured";
   return "";
 }

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -14,6 +14,20 @@ export type OAuthIntegrationUI = {
   optional_scopes?: OptionalScopeGroup[];
 };
 
+// TailscaleNodeState mirrors the stable wire labels emitted by the
+// backend's tailscaleproto.NodeStateLabel. `connected` is the boolean
+// shortcut (true iff state === "running"); the raw label lets the
+// card distinguish "awaiting authentication" from "starting" or
+// "stopped" without re-encoding the bool back into a state machine.
+export type TailscaleNodeState =
+  | "unknown"
+  | "needs_login"
+  | "needs_machine_auth"
+  | "starting"
+  | "running"
+  | "stopped"
+  | "in_use_other_user";
+
 // TailscaleAuthStatusUI matches IntegrationRow.TailscaleAuth on the
 // server. The dashboard reads connect/disconnect endpoint paths off
 // the row instead of hardcoding /api/tailscale/* so backend route
@@ -22,6 +36,7 @@ export type OAuthIntegrationUI = {
 // completes the join.
 export type TailscaleAuthStatusUI = {
   connected: boolean;
+  state: TailscaleNodeState;
   pending_url?: string;
   connect_url: string;
   status_url: string;


### PR DESCRIPTION
## Summary

The Tailscale credential card flipped to **Connected** as soon as any identity bytes hit `credential_secrets`, which happens before tsnet has joined the tailnet. Operators saw a green dot while traffic still errored with `node not connected`.

The card now derives its state from the live `tsnet` `BackendState`. A new `tailscaleproto.NodeStates` registry sits beside `PendingNodeAuth`; the tunnel's IPN-bus watcher records every State transition (and clears the parked auth URL once Running).

## BackendState → display mapping

| `ipn.State` | wire label | card status |
|---|---|---|
| `Running` | `running` | Connected |
| `NeedsLogin` | `needs_login` | Awaiting authentication (click opens auth URL) |
| `NeedsMachineAuth` | `needs_machine_auth` | Awaiting authentication |
| `Starting` | `starting` | Starting |
| `Stopped` | `stopped` | Stopped |
| `InUseOtherUser` | `in_use_other_user` | In use by another user |
| `NoState` / unobserved | `unknown` (falls back to `stopped` if slots are persisted) | Not connected / Stopped |

`apiTailscaleConnect` no longer treats slot presence as proof of connectivity — only the live `Running` label drives the `connected` branch.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .`
- [x] `npm run build`, `npm run lint`, `npm run format:check` in `www/`
- [x] Unit tests cover the `ipn.State → NodeStateLabel` mapping, registry semantics, the dashboard fallback when no state has been observed, and the `apiTailscaleConnect` Running-state shortcut
- [ ] Manual: reset the Tailscale state dir, boot the gateway, confirm the card reads "Awaiting authentication" with a clickable URL; complete auth; confirm it flips to "Connected"