### PR TITLE
Design pass; add remove confirmation

### DIFF
--- a/dev_seed.go
+++ b/dev_seed.go
@@ -209,7 +209,13 @@ var devSeedHostnames = []string{
 	"build-host-east", "build-host-west", "scratch-vm",
 }
 
-var devSeedProfiles = []string{"default", "default", "default", "ops-team", "ci-bot"}
+var devSeedProfiles = []string{
+	"default", "default", "default",
+	"ops-team", "ops-team",
+	"data-team",
+	"support",
+	"ci-bot",
+}
 
 func devSeedDevices(g *Gateway, r *rand.Rand, n int) ([]devSeedDevice, error) {
 	out := make([]devSeedDevice, 0, n)
@@ -254,15 +260,30 @@ func devSeedDevices(g *Gateway, r *rand.Rand, n int) ([]devSeedDevice, error) {
 
 func devSeedCredentials(db *sql.DB) error {
 	now := time.Now().UnixNano()
+	// Credentials are global (one row per id, no per-profile fan-out).
+	// The display_name + avatar attached to a credential is the
+	// connected-as identity surfaced anywhere that credential is
+	// referenced.
 	creds := []struct {
-		id, profile, display, avatar string
+		id, display, avatar string
 	}{
-		{"anthropic-tok", "default", "Jane Doe", "https://i.pravatar.cc/64?img=12"},
-		{"github-tok", "default", "octo-engineering", "https://avatars.githubusercontent.com/u/9919?s=64"},
-		{"openai-tok", "default", "", ""},
-		{"slack-tok", "default", "agent-ops", "https://i.pravatar.cc/64?img=33"},
-		{"github-tok", "ops-team", "ops-bot", "https://i.pravatar.cc/64?img=7"},
-		{"github-tok", "ci-bot", "ci-runner", "https://i.pravatar.cc/64?img=5"},
+		// Original bearer-token quartet
+		{"anthropic-tok", "Jane Doe", "https://i.pravatar.cc/64?img=12"},
+		{"github-tok", "octo-engineering", "https://avatars.githubusercontent.com/u/9919?s=64"},
+		{"openai-tok", "", ""},
+		{"slack-tok", "agent-ops", "https://i.pravatar.cc/64?img=33"},
+
+		// Brand-typed credentials so the dashboard renders proper logos
+		{"claude", "jane@example.com", "https://i.pravatar.cc/64?img=15"},
+		{"codex", "alex@example.com", "https://i.pravatar.cc/64?img=18"},
+		{"github", "octocat", "https://avatars.githubusercontent.com/u/583231?s=64"},
+		{"notion", "Engineering", ""},
+		{"gemini", "data@example.com", "https://i.pravatar.cc/64?img=27"},
+		{"slack-bot", "claw-patrol-bot", ""},
+		{"pg-writer", "writer", ""},
+		{"pg-readonly", "readonly", ""},
+		{"ch-analytics", "analytics", ""},
+		{"alerts-tg", "alerts-bot", ""},
 	}
 	tx, err := db.Begin()
 	if err != nil {
@@ -271,28 +292,30 @@ func devSeedCredentials(db *sql.DB) error {
 	for _, c := range creds {
 		if _, err := tx.Exec(`
 			INSERT INTO credentials
-			  (id, profile, access_token, token_type, refresh_token,
+			  (id, access_token, token_type, refresh_token,
 			   expiry_ns, updated_ns, display_name, avatar_url)
-			VALUES (?, ?, 'redacted-fake-token', 'Bearer', '', 0, ?, ?, ?)`,
-			c.id, c.profile, now,
+			VALUES (?, 'redacted-fake-token', 'Bearer', '', 0, ?, ?, ?)`,
+			c.id, now,
 			nullIfEmpty(c.display), nullIfEmpty(c.avatar)); err != nil {
 			_ = tx.Rollback()
 			return err
 		}
 	}
 	bearers := []struct {
-		credential, profile, slot, value string
+		credential, slot, value string
 	}{
-		{"anthropic-tok", "default", "", "sk-ant-fake-redacted"},
-		{"github-tok", "ci-bot", "", "ghp_fake_redacted"},
-		{"slack-tok", "default", "bot", "xoxb-fake-redacted"},
-		{"slack-tok", "default", "signing", "fake-signing-secret"},
+		{"anthropic-tok", "", "sk-ant-fake-redacted"},
+		{"github-tok", "", "ghp_fake_redacted"},
+		{"slack-tok", "bot", "xoxb-fake-redacted"},
+		{"slack-tok", "signing", "fake-signing-secret"},
+		{"gemini", "", "AIza-fake-redacted"},
+		{"alerts-tg", "", "1234567890:fake-tg-redacted"},
 	}
 	for _, b := range bearers {
 		if _, err := tx.Exec(`
-			INSERT INTO credential_secrets (credential, profile, slot, value, updated_ns)
-			VALUES (?, ?, ?, ?, ?)`,
-			b.credential, b.profile, b.slot, b.value, now); err != nil {
+			INSERT INTO credential_secrets (credential, slot, value, updated_ns)
+			VALUES (?, ?, ?, ?)`,
+			b.credential, b.slot, b.value, now); err != nil {
 			_ = tx.Rollback()
 			return err
 		}

--- a/www/login.html
+++ b/www/login.html
@@ -3,88 +3,154 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>clawpatrol</title>
+    <title>Log in — Claw Patrol</title>
     <style>
+      /* ── Minimal subset of the dashboard's design tokens ─────────
+         Only the values used on this page; mirrors www/src/index.css.
+         Source Sans 3 regular + bold is the only family loaded here —
+         no display serif, no mono — keeping the login bundle small. */
+      @font-face {
+        font-family: "Source Sans 3";
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url("/fonts/source-sans-3/SourceSans3-Regular--latin_basic.woff2")
+          format("woff2");
+      }
+      @font-face {
+        font-family: "Source Sans 3";
+        font-style: normal;
+        font-weight: 700;
+        font-display: swap;
+        src: url("/fonts/source-sans-3/SourceSans3-Bold--latin_basic.woff2")
+          format("woff2");
+      }
+
+      :root {
+        --color-canvas: #fcfaf5;
+        --color-canvas-light: #ffffff;
+        --color-navy: #1f2a44;
+        --color-navy-100: #d6dde9;
+        --color-navy-900: #0a0f1c;
+        --color-rust: #e87632;
+        --color-rust-300: #f29e5a;
+        --color-text: #2c2e35;
+        --color-text-muted: #62656d;
+        --color-text-subtle: #82838c;
+        --color-danger: #a83232;
+        --font-sans:
+          "Source Sans 3", "Public Sans", system-ui, -apple-system, sans-serif;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
       body {
-        font:
-          14px -apple-system,
-          BlinkMacSystemFont,
-          sans-serif;
-        background: #fafafa;
-        color: #171717;
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        background: var(--color-canvas);
+        color: var(--color-text);
+        font: 14px/1.5 var(--font-sans);
+        -webkit-font-smoothing: antialiased;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
-        min-height: 100vh;
-        margin: 0;
-      }
-      form {
-        background: #fff;
-        border: 1px solid #e5e5e5;
-        border-radius: 6px;
+        gap: 20px;
         padding: 24px;
-        width: 320px;
       }
+
+      .logo {
+        height: 56px;
+        width: auto;
+      }
+
+      form {
+        background: var(--color-canvas-light);
+        border: 2px solid var(--color-navy);
+        padding: 24px;
+        width: 100%;
+        max-width: 360px;
+      }
+
       h1 {
-        font-family: Georgia, serif;
-        font-size: 28px;
-        font-weight: 400;
+        font-family: var(--font-sans);
+        font-size: 24px;
+        font-weight: 700;
         margin: 0 0 16px;
         letter-spacing: -0.01em;
+        color: var(--color-text);
       }
+
       label {
         display: block;
-        font-size: 11px;
+        font-size: 12px;
+        font-weight: 700;
         text-transform: uppercase;
-        letter-spacing: 0.09em;
-        color: #a3a3a3;
+        letter-spacing: 0.05em;
+        color: var(--color-navy);
         margin: 0 0 6px;
       }
+
       input {
         width: 100%;
         box-sizing: border-box;
         padding: 8px 10px;
-        border: 1px solid #e5e5e5;
-        border-radius: 4px;
-        font:
-          13px ui-monospace,
-          SFMono-Regular,
-          monospace;
+        border: 2px solid var(--color-navy);
+        background: var(--color-canvas-light);
+        color: var(--color-text);
+        font: 14px/1.5 var(--font-sans);
         outline: none;
       }
       input:focus {
-        border-color: #171717;
+        outline: 2px solid var(--color-rust);
+        outline-offset: 2px;
       }
+
       button {
-        margin-top: 12px;
+        margin-top: 16px;
         width: 100%;
-        padding: 8px;
-        background: #171717;
-        color: #fff;
-        border: 0;
-        border-radius: 4px;
-        font-size: 12px;
+        padding: 8px 16px;
+        background: var(--color-rust);
+        color: var(--color-navy-900);
+        border: 2px solid var(--color-navy);
+        font: 14px/1.5 var(--font-sans);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
         cursor: pointer;
+        transition: background-color 0.15s ease;
       }
       button:hover {
-        background: #000;
+        background: var(--color-rust-300);
       }
+      button:focus-visible {
+        outline: 2px solid var(--color-rust);
+        outline-offset: 2px;
+      }
+
       .err {
-        color: #dc2626;
+        color: var(--color-danger);
         font-size: 12px;
         margin: 0 0 12px;
       }
     </style>
   </head>
   <body>
+    <img src="/claw-patrol-logo.svg" alt="Claw Patrol" class="logo" />
     <form method="POST" action="/__login?next={{.Next}}">
-      <h1>clawpatrol</h1>
+      <h1>Log in</h1>
       {{if .Error}}
       <p class="err">{{.Error}}</p>
       {{end}}
-      <label>secret</label>
-      <input type="password" name="secret" autofocus required />
-      <button type="submit">unlock</button>
+      <label for="secret">Secret</label>
+      <input id="secret" type="password" name="secret" autofocus required />
+      <button type="submit">Unlock</button>
     </form>
   </body>
 </html>

--- a/www/login.html
+++ b/www/login.html
@@ -14,16 +14,14 @@
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url("/fonts/source-sans-3/SourceSans3-Regular--latin_basic.woff2")
-          format("woff2");
+        src: url("/fonts/source-sans-3/SourceSans3-Regular--latin_basic.woff2") format("woff2");
       }
       @font-face {
         font-family: "Source Sans 3";
         font-style: normal;
         font-weight: 700;
         font-display: swap;
-        src: url("/fonts/source-sans-3/SourceSans3-Bold--latin_basic.woff2")
-          format("woff2");
+        src: url("/fonts/source-sans-3/SourceSans3-Bold--latin_basic.woff2") format("woff2");
       }
 
       :root {
@@ -38,8 +36,7 @@
         --color-text-muted: #62656d;
         --color-text-subtle: #82838c;
         --color-danger: #a83232;
-        --font-sans:
-          "Source Sans 3", "Public Sans", system-ui, -apple-system, sans-serif;
+        --font-sans: "Source Sans 3", "Public Sans", system-ui, -apple-system, sans-serif;
       }
 
       *,

--- a/www/src/components/AddDeviceModal.tsx
+++ b/www/src/components/AddDeviceModal.tsx
@@ -14,31 +14,13 @@ export function AddDeviceModal({
   const joinCmd = `clawpatrol join ${url}`;
 
   return (
-    <Modal onClose={onClose} labelledBy="add-device-title">
-      <div className="bg-canvas-light border-2 border-navy rounded-md shadow-2xl overflow-hidden w-[600px]">
-        <div className="flex items-center px-4 py-3 bg-navy-100">
-          <h2
-            id="add-device-title"
-            className="text-xs uppercase tracking-[.12em] text-navy font-bold"
-          >
-            ADD DEVICE
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="ml-auto text-xl leading-none px-2 py-1 text-navy hover:text-text"
-          >
-            ✕
-          </button>
-        </div>
-        <div className="p-4 space-y-6">
-          <h3 className="font-serif text-2xl leading-none tracking-tight text-text">
-            run on the new machine
-          </h3>
-          <Step n={1} label="install" cmd={installCmd} />
-          <Step n={2} label="join" cmd={joinCmd} />
-        </div>
+    <Modal title="Add device" onClose={onClose}>
+      <div className="p-4 space-y-6">
+        <h3 className="text-lg leading-none tracking-tight text-text font-sans">
+          Run the following on the new machine:
+        </h3>
+        <Step n={1} label="Install" cmd={installCmd} />
+        <Step n={2} label="Join" cmd={joinCmd} />
       </div>
     </Modal>
   );
@@ -58,13 +40,13 @@ function Step({ n, label, cmd }: { n: number; label: string; cmd: string }) {
         <span className="w-[16px] h-[16px] rounded-full bg-navy text-canvas text-2xs font-semibold flex items-center justify-center shrink-0">
           {n}
         </span>
-        <span className="text-xs text-text-muted">{label}</span>
+        <span className="text-sm text-text-muted font-sans">{label}</span>
       </div>
       <div className="relative">
-        <pre className="bg-navy rounded px-4 py-3 text-xs font-mono text-canvas overflow-x-auto whitespace-pre">
+        <pre className="bg-navy rounded px-4 py-4 text-xs font-mono text-canvas overflow-x-auto whitespace-pre">
           {cmd}
         </pre>
-        <Button variant="outline" onClick={copy} className="absolute top-1 right-1">
+        <Button variant="outline" onClick={copy} className="absolute top-2.5 right-1">
           {copied ? "copied" : "copy"}
         </Button>
       </div>

--- a/www/src/components/AgentsTable.tsx
+++ b/www/src/components/AgentsTable.tsx
@@ -36,14 +36,14 @@ export function AgentsTable({
         <col />
         <col style={{ width: 110 }} />
       </colgroup>
-      <thead className="bg-navy-100">
+      <thead className="bg-navy-100 border-b border-navy">
         <tr>
-          <Th>DEVICE</Th>
-          <Th className="hidden md:table-cell">PROFILE</Th>
-          <Th>ACTIVITY</Th>
-          <Th className="text-right">REQS</Th>
+          <Th>Device</Th>
+          <Th className="hidden md:table-cell">Profile</Th>
+          <Th>Activity</Th>
+          <Th className="text-right">Reqs</Th>
           <Th className="hidden lg:table-cell">IP</Th>
-          <Th>INTEGRATIONS</Th>
+          <Th>Integrations</Th>
         </tr>
       </thead>
       <tbody>
@@ -146,7 +146,7 @@ function Th({ children, className = "" }: { children: React.ReactNode; className
   return (
     <th
       className={
-        "px-3 sm:px-[14px] py-[9px] text-left text-2xs uppercase tracking-[.12em] text-navy font-bold " +
+        "px-3 sm:px-[14px] py-[9px] text-left text-xs font-sans uppercase tracking-wider text-navy font-bold " +
         className
       }
     >

--- a/www/src/components/AnalyticsPage.tsx
+++ b/www/src/components/AnalyticsPage.tsx
@@ -1,6 +1,7 @@
 import * as Plot from "@observablehq/plot";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getAnalytics, type Agent, type EventRecord } from "../lib/api";
+import { Tag } from "./Tag";
 
 const RANGES = ["1m", "5m", "15m", "30m", "1h", "6h", "24h"] as const;
 type Range = (typeof RANGES)[number];
@@ -174,16 +175,17 @@ export function AnalyticsPage({ ip, agents }: { ip?: string; agents: Agent[] }) 
             <span className="text-sm text-text-muted">analytics</span>
           )}
           {hasFilter && (
-            <button
+            <Tag
+              tone="info"
+              dismissible
               onClick={() => {
                 setFilterDevice(null);
                 setFilterHost(null);
               }}
-              className="ml-3 px-2 py-0.5 rounded text-sm border border-navy bg-navy text-canvas flex items-center gap-1.5 self-center"
+              className="ml-3 self-center normal-case"
             >
               {filterLabel}
-              <span className="text-2xs">&times;</span>
-            </button>
+            </Tag>
           )}
         </div>
         <Toggle options={[...RANGES]} value={range} onChange={setRange} />
@@ -247,7 +249,7 @@ function fmtMs(ms: number): string {
 function Stat({ label, value, tone }: { label: string; value: string; tone?: "warn" }) {
   return (
     <div className="flex flex-col gap-1.5 px-5 py-4">
-      <span className="text-2xs uppercase tracking-[.12em] text-text-subtle">{label}</span>
+      <span className="text-2xs uppercase tracking-wider text-text-subtle">{label}</span>
       <span
         className={
           "text-2xl font-semibold leading-none tabular-nums tracking-tight " +
@@ -500,8 +502,10 @@ function LatencyChart({
 
   return (
     <section className="bg-canvas-light border-2 border-navy overflow-hidden">
-      <header className="flex items-center justify-between px-4 py-2.5 bg-navy-100">
-        <span className="text-2xs uppercase tracking-[.12em] font-bold text-navy">Latency</span>
+      <header className="flex items-center justify-between px-4 py-2.5 bg-navy-100 border-b border-navy">
+        <span className="text-xs font-sans uppercase tracking-wider font-bold text-navy">
+          Latency
+        </span>
         <div className="flex items-center gap-3">
           <Toggle options={colorOptions} value={colorBy} onChange={setColorBy} />
           <Toggle options={["log", "linear"] as Scale[]} value={scale} onChange={setScale} />
@@ -584,7 +588,7 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
 
   const hdr = (label: string, field: "count" | "p99Ms") => (
     <th
-      className="px-3 sm:px-[14px] py-[9px] text-right text-2xs font-bold uppercase tracking-[.12em] text-navy cursor-pointer hover:text-navy-700 select-none"
+      className="px-3 sm:px-[14px] py-[9px] text-right text-xs font-sans font-bold uppercase tracking-wider text-navy cursor-pointer hover:text-navy-700 select-none"
       onClick={() => setSortBy(field)}
     >
       {label}
@@ -600,9 +604,9 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
           <col className="w-[120px]" />
           <col className="w-[80px]" />
         </colgroup>
-        <thead className="bg-navy-100">
+        <thead className="bg-navy-100 border-b border-navy">
           <tr>
-            <th className="px-3 sm:px-[14px] py-[9px] text-left text-2xs uppercase tracking-[.12em] text-navy font-bold">
+            <th className="px-3 sm:px-[14px] py-[9px] text-left text-xs font-sans uppercase tracking-wider text-navy font-bold">
               Top routes
             </th>
             {hdr("Reqs", "count")}
@@ -680,8 +684,10 @@ function BarList({
 
   return (
     <section className="bg-canvas-light border-2 border-navy overflow-hidden">
-      <header className="px-4 py-2.5 bg-navy-100">
-        <span className="text-2xs uppercase tracking-[.12em] font-bold text-navy">{title}</span>
+      <header className="px-4 py-2.5 bg-navy-100 border-b border-navy">
+        <span className="text-xs font-sans uppercase tracking-wider font-bold text-navy">
+          {title}
+        </span>
       </header>
       <div className="p-3 space-y-0.5">
         {items.slice(0, 10).map((item) => {

--- a/www/src/components/ConfigSaveReview.tsx
+++ b/www/src/components/ConfigSaveReview.tsx
@@ -21,52 +21,32 @@ export function ConfigSaveReview({
   );
 
   return (
-    <Modal onClose={onCancel} labelledBy="config-save-review-title">
-      <div className="bg-canvas-light border-2 border-navy rounded-md shadow-2xl overflow-hidden flex flex-col w-[920px] max-w-[96vw] max-h-[88vh]">
-        <div className="flex items-center px-4 py-3 bg-navy-100">
-          <div>
-            <h2
-              id="config-save-review-title"
-              className="text-xs uppercase tracking-[.12em] text-navy font-bold"
-            >
-              REVIEW GATEWAY.HCL CHANGES
-            </h2>
-            <div className="text-xs text-navy/70 mt-1">
-              HCL parsed successfully · formatting applied · {preview.bytes} bytes will be saved
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={busy}
-            aria-label="Close"
-            className="ml-auto text-xl leading-none px-2 py-1 text-navy hover:text-text disabled:opacity-40"
-          >
-            ✕
-          </button>
-        </div>
+    <Modal
+      size="lg"
+      title="Review gateway.hcl changes"
+      subtitle={`HCL parsed successfully · formatting applied · ${preview.bytes} bytes will be saved`}
+      onClose={onCancel}
+    >
+      <div className="px-4 py-3 border-b border-canvas-dark bg-canvas-muted text-xs text-text">
+        Confirming writes the <span className="font-mono">formatted</span> draft below to disk. If{" "}
+        <span className="font-mono">gateway.hcl</span> changed since this preview, the save is
+        rejected.
+      </div>
 
-        <div className="px-4 py-3 border-b border-canvas-dark bg-canvas-muted text-xs text-text">
-          Confirming writes the <span className="font-mono">formatted</span> draft below to disk. If{" "}
-          <span className="font-mono">gateway.hcl</span> changed since this preview, the save is
-          rejected.
-        </div>
+      <pre className="config-diff-view flex-1 overflow-auto m-0 p-4 text-xs leading-5 font-mono whitespace-pre-wrap language-diff diff-highlight">
+        <code
+          className="config-diff-view language-diff diff-highlight"
+          dangerouslySetInnerHTML={{ __html: diffHtml }}
+        />
+      </pre>
 
-        <pre className="config-diff-view flex-1 overflow-auto m-0 p-4 text-xs leading-5 font-mono whitespace-pre-wrap language-diff diff-highlight">
-          <code
-            className="config-diff-view language-diff diff-highlight"
-            dangerouslySetInnerHTML={{ __html: diffHtml }}
-          />
-        </pre>
-
-        <div className="flex items-center gap-2 px-4 py-3 border-t border-canvas-dark">
-          <Button variant="outline" onClick={onCancel} disabled={busy} className="ml-auto">
-            back to editor
-          </Button>
-          <Button onClick={onConfirm} disabled={busy || !preview.changed}>
-            {busy ? "saving…" : "save changes"}
-          </Button>
-        </div>
+      <div className="flex items-center gap-2 px-4 py-3 border-t border-navy">
+        <Button variant="outline" onClick={onCancel} disabled={busy} className="ml-auto">
+          back to editor
+        </Button>
+        <Button onClick={onConfirm} disabled={busy || !preview.changed}>
+          {busy ? "saving…" : "save changes"}
+        </Button>
       </div>
     </Modal>
   );

--- a/www/src/components/ConnectModal.tsx
+++ b/www/src/components/ConnectModal.tsx
@@ -114,156 +114,138 @@ export function ConnectModal({
   }
 
   return (
-    <Modal onClose={onClose} labelledBy="connect-modal-title">
-      <div className="bg-canvas-light border-2 border-navy rounded-md shadow-2xl overflow-hidden w-[520px]">
-        <div className="flex items-center px-5 py-3 bg-navy-100">
-          <h2
-            id="connect-modal-title"
-            className="text-xs uppercase tracking-[.12em] text-navy font-bold"
-          >
-            CONNECT {id}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="ml-auto text-xl leading-none px-2 py-1 text-navy hover:text-text"
-          >
-            ✕
-          </button>
-        </div>
-        <div className="p-5">
-          {done ? (
-            <div className="py-6 text-center">
-              <div className="text-2xl mb-2">✓</div>
-              <div className="text-xs text-text">connected</div>
+    <Modal title={`Connect ${id}`} onClose={onClose}>
+      <div className="p-5">
+        {done ? (
+          <div className="py-6 text-center">
+            <div className="text-2xl mb-2">✓</div>
+            <div className="text-xs text-text">connected</div>
+          </div>
+        ) : showsScopePicker && !started ? (
+          <div className="space-y-3">
+            <div className="text-xs text-text-muted leading-relaxed">
+              {baseScopes.length > 0 ? (
+                <>
+                  defaults (<code className="text-text">{baseScopes.join(", ")}</code>) are always
+                  requested.
+                </>
+              ) : (
+                <>no scopes are requested by default.</>
+              )}
             </div>
-          ) : showsScopePicker && !started ? (
-            <div className="space-y-3">
-              <div className="text-xs text-text-muted leading-relaxed">
-                {baseScopes.length > 0 ? (
-                  <>
-                    defaults (<code className="text-text">{baseScopes.join(", ")}</code>) are always
-                    requested.
-                  </>
-                ) : (
-                  <>no scopes are requested by default.</>
-                )}
-              </div>
-              <details className="border border-canvas-dark rounded bg-canvas-muted group">
-                <summary className="cursor-pointer list-none flex items-center gap-2 px-2 py-1.5 text-xs text-text hover:bg-canvas rounded">
-                  <span className="inline-block w-3 text-text-subtle transition-transform group-open:rotate-90">
-                    ›
-                  </span>
-                  <span>advanced permissions</span>
-                  <span className="ml-auto text-2xs text-text-muted tabular-nums">
-                    {extras.size > 0 ? `${extras.size} selected` : "optional"}
-                  </span>
-                </summary>
-                <div className="max-h-[300px] overflow-y-auto p-2 space-y-3 border-t border-canvas-dark">
-                  {optionalGroups.map((g) => (
-                    <div key={g.title}>
-                      <div className="text-2xs uppercase tracking-[.1em] text-text-subtle mb-1">
-                        {g.title}
-                      </div>
-                      <div className="grid grid-cols-1 gap-y-0.5">
-                        {g.scopes.map((s) => {
-                          const isBase = baseSet.has(s.id);
-                          const checked = isBase || extras.has(s.id);
-                          return (
-                            <label
-                              key={s.id}
-                              className={
-                                "flex items-center gap-2 text-xs py-0.5 px-1 rounded " +
-                                (isBase
-                                  ? "text-text-subtle"
-                                  : "text-text cursor-pointer hover:bg-canvas")
-                              }
-                            >
-                              <input
-                                type="checkbox"
-                                checked={checked}
-                                disabled={isBase}
-                                onChange={(e) => {
-                                  setExtras((prev) => {
-                                    const next = new Set(prev);
-                                    if (e.target.checked) next.add(s.id);
-                                    else next.delete(s.id);
-                                    return next;
-                                  });
-                                }}
-                                className="accent-text"
-                              />
-                              <code className="text-xs">{s.id}</code>
-                              <span className="text-text-muted">— {s.label}</span>
-                              {isBase && (
-                                <span className="ml-auto text-2xs text-text-subtle">default</span>
-                              )}
-                            </label>
-                          );
-                        })}
-                      </div>
+            <details className="border border-canvas-dark rounded bg-canvas-muted group">
+              <summary className="cursor-pointer list-none flex items-center gap-2 px-2 py-1.5 text-xs text-text hover:bg-canvas rounded">
+                <span className="inline-block w-3 text-text-subtle transition-transform group-open:rotate-90">
+                  ›
+                </span>
+                <span>advanced permissions</span>
+                <span className="ml-auto text-2xs text-text-muted tabular-nums">
+                  {extras.size > 0 ? `${extras.size} selected` : "optional"}
+                </span>
+              </summary>
+              <div className="max-h-[300px] overflow-y-auto p-2 space-y-3 border-t border-navy">
+                {optionalGroups.map((g) => (
+                  <div key={g.title}>
+                    <div className="text-2xs uppercase tracking-wider text-text-subtle mb-1">
+                      {g.title}
                     </div>
-                  ))}
-                </div>
-              </details>
-              {err && <div className="text-xs text-rust-700 break-all">{err}</div>}
-              <div className="flex gap-2 justify-end">
+                    <div className="grid grid-cols-1 gap-y-0.5">
+                      {g.scopes.map((s) => {
+                        const isBase = baseSet.has(s.id);
+                        const checked = isBase || extras.has(s.id);
+                        return (
+                          <label
+                            key={s.id}
+                            className={
+                              "flex items-center gap-2 text-xs py-0.5 px-1 rounded " +
+                              (isBase
+                                ? "text-text-subtle"
+                                : "text-text cursor-pointer hover:bg-canvas")
+                            }
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              disabled={isBase}
+                              onChange={(e) => {
+                                setExtras((prev) => {
+                                  const next = new Set(prev);
+                                  if (e.target.checked) next.add(s.id);
+                                  else next.delete(s.id);
+                                  return next;
+                                });
+                              }}
+                              className="accent-text"
+                            />
+                            <code className="text-xs">{s.id}</code>
+                            <span className="text-text-muted">— {s.label}</span>
+                            {isBase && (
+                              <span className="ml-auto text-2xs text-text-subtle">default</span>
+                            )}
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </details>
+            {err && <div className="text-xs text-rust-700 break-all">{err}</div>}
+            <div className="flex gap-2 justify-end">
+              <Button variant="outline" onClick={onClose}>
+                cancel
+              </Button>
+              <Button onClick={() => setStarted(true)}>
+                continue ({baseScopes.length + extras.size} scopes)
+              </Button>
+            </div>
+          </div>
+        ) : !start ? (
+          <div className="text-xs text-text-muted">opening browser…</div>
+        ) : start.flow === "device" ? (
+          <div className="space-y-3">
+            <div className="text-xs text-text-muted leading-relaxed">
+              browser opened to <code className="text-text">{start.verification_uri}</code>. enter
+              this code:
+            </div>
+            <div className="font-mono text-3xl tracking-[.18em] text-text text-center py-3 bg-canvas-muted border border-canvas-dark rounded select-all">
+              {start.user_code}
+            </div>
+            <div className="text-xs text-text-subtle text-center">waiting for approval…</div>
+            {err && <div className="text-xs text-rust-700 break-all">{err}</div>}
+            <div className="flex justify-end">
+              <Button variant="outline" onClick={onClose}>
+                cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="text-sm text-text-muted font-sans leading-relaxed">
+              Browser opened. Log in, then paste the code from the redirect URL bar (after{" "}
+              <code className="text-text">?code=</code>) here:
+            </div>
+            <form onSubmit={submit}>
+              <input
+                type="text"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="paste code here"
+                className="w-full text-xs border border-canvas-dark rounded px-2 py-2 focus:outline-none focus:border-text font-mono transition-colors"
+                autoFocus
+              />
+              {err && <div className="text-xs text-rust-700 mt-2 break-all">{err}</div>}
+              <div className="flex gap-2 mt-3 justify-end">
                 <Button variant="outline" onClick={onClose}>
                   cancel
                 </Button>
-                <Button onClick={() => setStarted(true)}>
-                  continue ({baseScopes.length + extras.size} scopes)
+                <Button type="submit" disabled={busy || !code}>
+                  {busy ? "exchanging…" : "connect"}
                 </Button>
               </div>
-            </div>
-          ) : !start ? (
-            <div className="text-xs text-text-muted">opening browser…</div>
-          ) : start.flow === "device" ? (
-            <div className="space-y-3">
-              <div className="text-xs text-text-muted leading-relaxed">
-                browser opened to <code className="text-text">{start.verification_uri}</code>. enter
-                this code:
-              </div>
-              <div className="font-mono text-3xl tracking-[.18em] text-text text-center py-3 bg-canvas-muted border border-canvas-dark rounded select-all">
-                {start.user_code}
-              </div>
-              <div className="text-xs text-text-subtle text-center">waiting for approval…</div>
-              {err && <div className="text-xs text-rust-700 break-all">{err}</div>}
-              <div className="flex justify-end">
-                <Button variant="outline" onClick={onClose}>
-                  cancel
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              <div className="text-xs text-text-muted leading-relaxed">
-                browser opened. log in, then paste the code from the redirect URL bar (after{" "}
-                <code className="text-text">?code=</code>) here:
-              </div>
-              <form onSubmit={submit}>
-                <input
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  placeholder="paste code here"
-                  className="w-full text-xs border border-canvas-dark rounded px-2 py-2 focus:outline-none focus:border-text font-mono transition-colors"
-                  autoFocus
-                />
-                {err && <div className="text-xs text-rust-700 mt-2 break-all">{err}</div>}
-                <div className="flex gap-2 mt-3 justify-end">
-                  <Button variant="outline" onClick={onClose}>
-                    cancel
-                  </Button>
-                  <Button type="submit" disabled={busy || !code}>
-                    {busy ? "exchanging…" : "connect"}
-                  </Button>
-                </div>
-              </form>
-            </div>
-          )}
-        </div>
+            </form>
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/www/src/components/CredentialSecretsModal.tsx
+++ b/www/src/components/CredentialSecretsModal.tsx
@@ -49,76 +49,62 @@ export function CredentialSecretsModal({
   }
 
   return (
-    <Modal onClose={onClose} labelledBy="credential-modal-title">
-      <div className="bg-canvas-light border-2 border-navy rounded shadow-lg overflow-hidden w-full max-w-md">
-        <div className="flex items-center px-5 py-3 bg-navy-100">
-          <h2
-            id="credential-modal-title"
-            className="text-xs uppercase tracking-[.12em] text-navy font-bold"
-          >
-            {mode === "update" ? "Update" : "Connect"} {label}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="ml-auto text-xl leading-none px-2 py-1 text-navy hover:text-text"
-          >
-            ✕
-          </button>
-        </div>
-        <div className="flex flex-col gap-3 p-5">
-          {mode === "update" && (
-            <p className="text-xs leading-relaxed text-text-muted">
-              Existing secret values are not shown. Paste a new value to replace a slot; leave
-              untouched slots blank to keep them unchanged.
-            </p>
-          )}
-          <dl className="grid grid-cols-[auto,minmax(0,1fr)] gap-x-3 gap-y-1 rounded border border-canvas-dark bg-canvas-muted px-3 py-2 text-xs">
-            <dt className="text-text-muted">Credential</dt>
-            <dd className="min-w-0 truncate font-mono text-text" title={integration.id}>
-              {integration.id}
-            </dd>
-            <dt className="text-text-muted">Type</dt>
-            <dd className="min-w-0 truncate text-text" title={integration.type}>
-              {label} <span className="font-mono text-text-muted">({integration.type})</span>
-            </dd>
-          </dl>
-          {slots.map((s) => (
-            <label key={s.name} className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-[.08em] text-text-muted">{s.label}</span>
-              {s.multiline ? (
-                <textarea
-                  rows={5}
-                  value={values[s.name] ?? ""}
-                  onChange={(e) => update(s.name, e.target.value)}
-                  placeholder={s.description ?? ""}
-                  className="border border-canvas-dark rounded px-2 py-1.5 text-xs font-mono focus:outline-none focus:border-text"
-                />
-              ) : (
-                <input
-                  type="password"
-                  value={values[s.name] ?? ""}
-                  onChange={(e) => update(s.name, e.target.value)}
-                  placeholder={s.description ?? ""}
-                  className="border border-canvas-dark rounded px-2 py-1.5 text-xs focus:outline-none focus:border-text"
-                />
-              )}
-              {s.description && !s.multiline && (
-                <span className="text-2xs text-text-subtle">{s.description}</span>
-              )}
-            </label>
-          ))}
-          {err && <div className="text-xs text-danger-500">{err}</div>}
-          <div className="flex justify-end gap-2 mt-2">
-            <Button variant="outline" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button onClick={save} disabled={saving}>
-              {saving ? "Saving…" : mode === "update" ? "Update" : "Save"}
-            </Button>
-          </div>
-        </div>
+    <Modal
+      size="sm"
+      title={`${mode === "update" ? "Update" : "Connect"} ${label}`}
+      onClose={onClose}
+    >
+      <div className="flex flex-col gap-3 p-5">
+        {mode === "update" && (
+          <p className="text-sm font-sans leading-relaxed text-text-muted">
+            Existing secret values are not shown. Paste a new value to replace a slot; leave
+            untouched slots blank to keep them unchanged.
+          </p>
+        )}
+        <dl className="grid grid-cols-[auto,minmax(0,1fr)] gap-x-3 gap-y-1 rounded border border-canvas-dark bg-canvas-muted px-3 py-2 text-xs">
+          <dt className="text-text-muted font-bold font-sans">Credential</dt>
+          <dd className="min-w-0 truncate font-mono text-text" title={integration.id}>
+            {integration.id}
+          </dd>
+          <dt className="text-text-muted font-bold font-sans">Type</dt>
+          <dd className="min-w-0 truncate text-text" title={integration.type}>
+            {label} <span className="font-mono text-text-muted">({integration.type})</span>
+          </dd>
+        </dl>
+        {slots.map((s) => (
+          <label key={s.name} className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wider text-text-muted">{s.label}</span>
+            {s.multiline ? (
+              <textarea
+                rows={5}
+                value={values[s.name] ?? ""}
+                onChange={(e) => update(s.name, e.target.value)}
+                placeholder={s.description ?? ""}
+                className="border border-canvas-dark rounded px-2 py-1.5 text-xs font-mono focus:outline-none focus:border-text"
+              />
+            ) : (
+              <input
+                type="password"
+                value={values[s.name] ?? ""}
+                onChange={(e) => update(s.name, e.target.value)}
+                placeholder={s.description ?? ""}
+                className="border border-canvas-dark rounded px-2 py-1.5 text-xs focus:outline-none focus:border-text"
+              />
+            )}
+            {s.description && !s.multiline && (
+              <span className="text-2xs text-text-subtle">{s.description}</span>
+            )}
+          </label>
+        ))}
+        {err && <div className="text-xs text-danger-500">{err}</div>}
+      </div>
+      <div className="flex justify-end gap-2 px-4 py-3 border-t border-navy">
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={save} disabled={saving}>
+          {saving ? "Saving…" : mode === "update" ? "Update" : "Save"}
+        </Button>
       </div>
     </Modal>
   );

--- a/www/src/components/DevicePage.tsx
+++ b/www/src/components/DevicePage.tsx
@@ -198,7 +198,7 @@ export function DevicePage({
               {a.os && (
                 <>
                   {" "}
-                  · <span className="uppercase tracking-[.08em]">{a.os}</span>
+                  · <span className="uppercase tracking-wider">{a.os}</span>
                 </>
               )}
             </div>
@@ -206,11 +206,11 @@ export function DevicePage({
           <div className="ml-auto flex items-center gap-3">
             <Sparkline data={a.activity} width={160} height={26} />
             <div className="text-right">
-              <div className="text-2xs uppercase tracking-[.09em] text-text-subtle">TRAFFIC</div>
+              <div className="text-2xs uppercase tracking-wider text-text-subtle">Traffic</div>
               <div className="text-xs tabular-nums">{fmtBytes(total)}</div>
             </div>
             <div className="text-right">
-              <div className="text-2xs uppercase tracking-[.09em] text-text-subtle">REQS</div>
+              <div className="text-2xs uppercase tracking-wider text-text-subtle">Reqs</div>
               <div className="text-xs tabular-nums">{a.reqs}</div>
             </div>
           </div>
@@ -288,7 +288,7 @@ function ProfilePicker({
       </button>
       {open && (
         <div className="absolute right-0 top-[calc(100%+6px)] z-20 min-w-[200px] bg-canvas-light border-2 border-navy rounded shadow-lg py-1">
-          <div className="px-3 py-1.5 text-2xs uppercase tracking-[.12em] text-text-subtle border-b border-canvas-muted">
+          <div className="px-3 py-1.5 text-2xs uppercase tracking-wider text-text-subtle border-b border-canvas-muted">
             choose profile
           </div>
           {profiles.length === 0 ? (

--- a/www/src/components/HITLBar.tsx
+++ b/www/src/components/HITLBar.tsx
@@ -41,8 +41,8 @@ export function HITLBar() {
 
   return (
     <div className="bg-canvas-light border-2 border-navy overflow-hidden">
-      <div className="px-4 py-2.5 text-2xs uppercase tracking-[.12em] text-navy font-bold flex items-center bg-navy-100">
-        <span>PENDING APPROVALS</span>
+      <div className="px-4 py-2.5 text-xs font-sans uppercase tracking-wider text-navy font-bold flex items-center bg-navy-100 border-b border-navy">
+        <span>Pending approvals</span>
         <span className="ml-2 text-rust-500 tabular-nums">● {pending.length}</span>
       </div>
       {notice && (

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -130,7 +130,11 @@ export function IntegrationsCards({
       : i.has_tailscale_auth
         ? "disconnect the Tailscale node"
         : "clear the stored secrets";
-    if (!confirm(`Disconnect ${label} (${i.id})?\n\nThis will ${what}. You'll need to reconnect to use it again.`)) {
+    if (
+      !confirm(
+        `Disconnect ${label} (${i.id})?\n\nThis will ${what}. You'll need to reconnect to use it again.`,
+      )
+    ) {
       return;
     }
     if (i.has_tailscale_auth && i.tailscale_auth) {

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -124,6 +124,15 @@ export function IntegrationsCards({
   }, [pendingConnect]);
 
   function disconnect(i: Integration) {
+    const label = credentialTypeLabel(i.type, i.name);
+    const what = i.has_oauth
+      ? "revoke the OAuth token"
+      : i.has_tailscale_auth
+        ? "disconnect the Tailscale node"
+        : "clear the stored secrets";
+    if (!confirm(`Disconnect ${label} (${i.id})?\n\nThis will ${what}. You'll need to reconnect to use it again.`)) {
+      return;
+    }
     if (i.has_tailscale_auth && i.tailscale_auth) {
       tailscaleDisconnect(i.tailscale_auth.disconnect_url).then(onRefresh);
       return;
@@ -332,34 +341,16 @@ function AllIntegrationsModal({
   onDisconnect: (i: Integration) => void;
 }) {
   return (
-    <Modal onClose={onClose} labelledBy="all-integrations-title">
-      <div className="bg-canvas-light border-2 border-navy rounded shadow-lg overflow-hidden w-full max-w-3xl max-h-[80vh] flex flex-col">
-        <div className="flex items-center px-5 py-3 bg-navy-100">
-          <h2
-            id="all-integrations-title"
-            className="text-xs uppercase tracking-[.12em] text-navy font-bold"
-          >
-            All integrations ({list.length})
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="ml-auto text-xl leading-none px-2 py-1 text-navy hover:text-text"
-          >
-            ✕
-          </button>
-        </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5 p-5 overflow-y-auto">
-          {list.map((i) => (
-            <Card
-              key={i.id}
-              integration={i}
-              onConnect={() => onConnect(i)}
-              onDisconnect={() => onDisconnect(i)}
-            />
-          ))}
-        </div>
+    <Modal size="lg" title={`All integrations (${list.length})`} onClose={onClose}>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2.5 p-5 overflow-y-auto">
+        {list.map((i) => (
+          <Card
+            key={i.id}
+            integration={i}
+            onConnect={() => onConnect(i)}
+            onDisconnect={() => onDisconnect(i)}
+          />
+        ))}
       </div>
     </Modal>
   );

--- a/www/src/components/LiveRequests.tsx
+++ b/www/src/components/LiveRequests.tsx
@@ -75,8 +75,8 @@ export function LiveRequests({
       className="flex flex-col bg-canvas-light border-2 border-navy overflow-hidden"
       style={{ height: height ?? "420px" }}
     >
-      <div className="flex items-center px-4 py-2.5 text-2xs uppercase tracking-[.12em] text-navy font-bold bg-navy-100 shrink-0">
-        <span>LIVE REQUESTS</span>
+      <div className="flex items-center px-4 py-2.5 text-xs font-sans uppercase tracking-wider text-navy font-bold bg-navy-100 border-b border-navy shrink-0">
+        <span>Live requests</span>
         <span className="ml-2 text-success-500 tabular-nums flex items-center gap-1">
           <span className="w-1.5 h-1.5 rounded-full bg-success-500 animate-pulse" />
           {events.length}

--- a/www/src/components/Modal.tsx
+++ b/www/src/components/Modal.tsx
@@ -1,30 +1,47 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useId, useRef, type ReactNode } from "react";
 
 // Thin wrapper around the native <dialog> element. Opening with
 // `.showModal()` gives us role="dialog" + aria-modal="true",
 // trapped focus, ESC-to-close, body scroll lock, and a real
 // backdrop — for free, no library.
 //
-// Caller responsibility:
-//  - pass `onClose` to unmount the modal when the dialog closes
-//    (fires on ESC, .close(), or click outside the inner box).
-//  - pass `labelledBy` matching an id on the header title for
-//    screen readers to announce the modal name.
-//  - bring the visual chrome (bg, border, padding, sizing) on the
-//    child element — this wrapper resets the UA <dialog> styles to
-//    transparent so it doesn't paint twice.
+// Visual chrome (bg-canvas-light, navy border, rounded corners,
+// shadow, overflow-clip for the rounded edges), the navy-100 header
+// strip with title + close ✕, and the size scale all live on this
+// component so every modal looks the same. Callers only supply:
+//   - title    — the uppercase-navy header label (required)
+//   - subtitle — optional secondary line under the title
+//   - size     — sm | md | lg (defaults to md)
+//   - children — the modal body (header + footer strips are owned here)
+type Size = "sm" | "md" | "lg";
+
+const sizes: Record<Size, string> = {
+  // sm — narrow forms: connect/credential secret entry.
+  sm: "w-full max-w-md",
+  // md — single-purpose action modals: scope picker, add-device steps.
+  md: "w-full max-w-xl",
+  // lg — editor/diff/scrollable-list modals; flex column so an inner
+  // body can flex-1 and a header/footer pin top/bottom.
+  lg: "w-full max-w-4xl max-h-[85vh] flex flex-col",
+};
+
 export function Modal({
+  title,
+  subtitle,
+  size = "md",
   onClose,
-  labelledBy,
   className,
   children,
 }: {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  size?: Size;
   onClose: () => void;
-  labelledBy?: string;
   className?: string;
   children: ReactNode;
 }) {
   const ref = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
 
   useEffect(() => {
     const dlg = ref.current;
@@ -39,7 +56,7 @@ export function Modal({
   return (
     <dialog
       ref={ref}
-      aria-labelledby={labelledBy}
+      aria-labelledby={titleId}
       onClose={onClose}
       onClick={(e) => {
         // The dialog element itself is only the event target when the
@@ -47,8 +64,38 @@ export function Modal({
         // a child, so this only fires for "outside the box" clicks.
         if (e.target === ref.current) ref.current?.close();
       }}
-      className={`m-auto p-0 bg-transparent text-text backdrop:bg-navy/40 ${className ?? ""}`}
+      className={
+        "m-auto p-0 text-text bg-canvas-light border-2 border-navy  " +
+        "shadow-2xl overflow-hidden backdrop:bg-navy/40 backdrop:backdrop-blur-xs " +
+        sizes[size] +
+        " " +
+        (className ?? "")
+      }
     >
+      <div className="flex items-center px-4 py-3 bg-navy-100 border-b border-navy">
+        <div>
+          <h2
+            id={titleId}
+            className="text-sm uppercase tracking-wider text-navy font-bold font-sans"
+          >
+            {title}
+          </h2>
+          {subtitle && (
+            <div className="text-xs text-navy/70 mt-1 normal-case tracking-normal font-normal">
+              {subtitle}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="ml-auto text-2xl leading-none px-2 aspect-square py-1 pt-0.5 text-navy hover:text-text cursor-pointer"
+        >
+          <span aria-hidden="true">✕</span>
+          <span className="sr-only">Close modal</span>
+        </button>
+      </div>
       {children}
     </dialog>
   );

--- a/www/src/components/OnboardPage.tsx
+++ b/www/src/components/OnboardPage.tsx
@@ -40,7 +40,7 @@ export function OnboardPage({ code, onBack }: { code: string; onBack: () => void
       <button onClick={onBack} className="text-xs text-text-muted hover:text-text">
         ← back
       </button>
-      <h1 className="font-serif text-4xl leading-none tracking-tight text-text">add device</h1>
+      <h1 className="text-4xl leading-none tracking-tight text-text">add device</h1>
 
       {!info && !err && <div className="text-xs text-text-muted">loading…</div>}
       {err && <div className="text-xs text-danger-500">{err}</div>}
@@ -48,9 +48,7 @@ export function OnboardPage({ code, onBack }: { code: string; onBack: () => void
       {info && (
         <div className="bg-canvas-light border-2 border-navy p-6 space-y-4">
           <div>
-            <div className="text-2xs uppercase tracking-[.12em] text-text-subtle">
-              code from CLI
-            </div>
+            <div className="text-2xs uppercase tracking-wider text-text-subtle">code from CLI</div>
             <div className="font-mono text-3xl tracking-[.18em] text-text mt-1">
               {info.user_code || code}
             </div>

--- a/www/src/components/RequestDetailPage.tsx
+++ b/www/src/components/RequestDetailPage.tsx
@@ -406,7 +406,7 @@ function Facets({ rows }: { rows: Array<{ name: string; label: string; value: st
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <details open>
-      <summary className="cursor-pointer px-4 py-2.5 text-2xs uppercase tracking-wider font-bold text-navy bg-navy-100 hover:text-text select-none">
+      <summary className="cursor-pointer px-4 py-2.5 text-xs font-sans uppercase tracking-wider font-bold text-navy bg-navy-100 border-b border-navy hover:text-text select-none">
         {title}
       </summary>
       <div>{children}</div>
@@ -572,7 +572,7 @@ function HttpBody({ text }: { text: string }) {
           return (
             <div key={i}>
               {e.type && (
-                <div className="text-2xs uppercase tracking-[.12em] text-text-subtle mb-1">
+                <div className="text-2xs uppercase tracking-wider text-text-subtle mb-1">
                   event:{" "}
                   <span className="normal-case tracking-normal text-text-muted">{e.type}</span>
                 </div>

--- a/www/src/components/RulesEditor.tsx
+++ b/www/src/components/RulesEditor.tsx
@@ -90,61 +90,42 @@ export function RulesEditor({ onClose, onSaved }: { onClose: () => void; onSaved
 
   return (
     <>
-      <Modal onClose={onClose} labelledBy="rules-editor-title">
-        <div className="bg-canvas-light border-2 border-navy rounded-md shadow-2xl overflow-hidden flex flex-col w-[820px] max-w-full max-h-[85vh]">
-          <div className="flex items-center px-4 py-3 bg-navy-100">
-            <h2
-              id="rules-editor-title"
-              className="text-xs uppercase tracking-[.12em] text-navy font-bold"
-            >
-              EDIT GATEWAY.HCL
-            </h2>
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close"
-              className="ml-auto text-xl leading-none px-2 py-1 text-navy hover:text-text"
-            >
-              ✕
-            </button>
-          </div>
+      <Modal size="lg" title="Edit gateway.hcl" onClose={onClose}>
+        <div className="flex-1 overflow-auto">
+          <HCLEditor value={text} onChange={setText} minHeight={320} />
+        </div>
 
-          <div className="flex-1 overflow-auto">
-            <HCLEditor value={text} onChange={setText} minHeight={320} />
-          </div>
+        <form
+          onSubmit={runAI}
+          className="flex items-center gap-2 px-4 py-2.5 border-t border-navy bg-canvas"
+        >
+          <span className="text-2xs uppercase tracking-wider text-text-subtle">AI</span>
+          <input
+            type="text"
+            value={aiPrompt}
+            onChange={(e) => setAIPrompt(e.target.value)}
+            placeholder='e.g. "deny POSTs to api.github.com" — uses connected Claude/Codex'
+            className="flex-1 text-xs border border-canvas-dark rounded px-2 py-1.5 focus:outline-none focus:border-text transition-colors"
+          />
+          <Button type="submit" variant="outline" disabled={aiBusy || !aiPrompt.trim()}>
+            {aiBusy ? "thinking…" : "apply"}
+          </Button>
+        </form>
 
-          <form
-            onSubmit={runAI}
-            className="flex items-center gap-2 px-4 py-2.5 border-t border-canvas-dark bg-canvas"
-          >
-            <span className="text-2xs uppercase tracking-[.09em] text-text-subtle">AI</span>
-            <input
-              type="text"
-              value={aiPrompt}
-              onChange={(e) => setAIPrompt(e.target.value)}
-              placeholder='e.g. "deny POSTs to api.github.com" — uses connected Claude/Codex'
-              className="flex-1 text-xs border border-canvas-dark rounded px-2 py-1.5 focus:outline-none focus:border-text transition-colors"
-            />
-            <Button type="submit" variant="outline" disabled={aiBusy || !aiPrompt.trim()}>
-              {aiBusy ? "thinking…" : "apply"}
-            </Button>
-          </form>
-
-          <div className="flex items-center px-4 py-3 border-t border-canvas-dark gap-3">
-            {err && <span className="text-xs text-rust-700 break-all flex-1">{err}</span>}
-            {okMsg && <span className="text-xs text-success-600 flex-1">{okMsg}</span>}
-            {!err && !okMsg && (
-              <span className="text-xs text-text-subtle flex-1">
-                {dirty ? "unsaved changes" : "no changes"}
-              </span>
-            )}
-            <Button variant="outline" onClick={onClose}>
-              close
-            </Button>
-            <Button onClick={save} disabled={!dirty || busy}>
-              {busy ? "saving…" : "save"}
-            </Button>
-          </div>
+        <div className="flex items-center px-4 py-3 border-t border-navy gap-3">
+          {err && <span className="text-xs text-rust-700 break-all flex-1">{err}</span>}
+          {okMsg && <span className="text-xs text-success-600 flex-1">{okMsg}</span>}
+          {!err && !okMsg && (
+            <span className="text-xs text-text-subtle flex-1">
+              {dirty ? "unsaved changes" : "no changes"}
+            </span>
+          )}
+          <Button variant="outline" onClick={onClose}>
+            close
+          </Button>
+          <Button onClick={save} disabled={!dirty || busy}>
+            {busy ? "saving…" : "save"}
+          </Button>
         </div>
       </Modal>
       {preview && (

--- a/www/src/components/RulesPanel.tsx
+++ b/www/src/components/RulesPanel.tsx
@@ -86,8 +86,8 @@ function Section({
 
   return (
     <div className="last:border-b-0">
-      <div className="flex items-center px-4 py-2.5 bg-navy-100">
-        <div className="text-xs uppercase tracking-[.09em] text-navy font-bold">{title}</div>
+      <div className="flex items-center px-4 py-2.5 bg-navy-100 border-b border-navy">
+        <div className="text-xs uppercase tracking-wider text-navy font-bold">{title}</div>
         <span className="ml-2 text-2xs text-navy/70 tabular-nums">
           {rows.length} rule{rows.length === 1 ? "" : "s"}
         </span>

--- a/www/src/components/SessionsTable.tsx
+++ b/www/src/components/SessionsTable.tsx
@@ -20,13 +20,13 @@ export function SessionsTable({ sessions: all }: { sessions: Session[] }) {
             <col style={{ width: 60 }} />
             <col style={{ width: 200 }} />
           </colgroup>
-          <thead className="bg-navy-100">
+          <thead className="bg-navy-100 border-b border-navy">
             <tr>
-              <Th>SESSION</Th>
-              <Th>ACTIVITY</Th>
-              <Th className="text-right">AGE</Th>
-              <Th className="text-right">REQS</Th>
-              <Th>MODEL/CTX</Th>
+              <Th>Session</Th>
+              <Th>Activity</Th>
+              <Th className="text-right">Age</Th>
+              <Th className="text-right">Reqs</Th>
+              <Th>Model/Ctx</Th>
             </tr>
           </thead>
           <tbody>
@@ -121,7 +121,7 @@ function Th({ children, className = "" }: { children: React.ReactNode; className
   return (
     <th
       className={
-        "px-3 sm:px-[14px] py-[9px] text-left text-2xs uppercase tracking-[.09em] text-navy font-bold " +
+        "px-3 sm:px-[14px] py-[9px] text-left text-xs font-sans uppercase tracking-wider text-navy font-bold " +
         className
       }
     >

--- a/www/src/components/SettingsPage.tsx
+++ b/www/src/components/SettingsPage.tsx
@@ -39,7 +39,7 @@ export function SettingsPage({
       </nav>
 
       <section className="space-y-3">
-        <h2 className="text-xs uppercase tracking-[.12em] text-navy font-bold">CREDENTIALS</h2>
+        <h2 className="text-xs uppercase tracking-wider text-navy font-bold">Credentials</h2>
         {integrations.length === 0 ? (
           <div className="bg-canvas-light border-2 border-navy px-4 py-6 text-xs text-text-subtle">
             No credentials declared in gateway.hcl yet. Add a credential block to connect Anthropic
@@ -116,9 +116,9 @@ function ConfigSection({ readOnly, onSaved }: { readOnly?: boolean; onSaved: () 
   return (
     <section className="space-y-3">
       <div className="bg-canvas-light border-2 border-navy overflow-hidden">
-        <div className="flex items-center px-4 py-3 bg-navy-100">
-          <h2 className="text-xs uppercase tracking-[.12em] text-navy font-bold">
-            CONFIGURATION · gateway.hcl
+        <div className="flex items-center px-4 py-3 bg-navy-100 border-b border-navy">
+          <h2 className="text-xs uppercase tracking-wider text-navy font-bold">
+            Configuration · gateway.hcl
             {readOnly && (
               <span className="ml-2 normal-case tracking-normal font-normal text-navy/70">
                 · read-only (--read-only-config)
@@ -129,15 +129,17 @@ function ConfigSection({ readOnly, onSaved }: { readOnly?: boolean; onSaved: () 
         <div className="overflow-auto">
           <HCLEditor value={text} onChange={setText} minHeight={420} readOnly={readOnly} />
         </div>
-        <div className="flex items-center gap-2 px-4 py-3 border-t border-canvas-dark">
-          {err && <div className="text-xs text-danger-500 truncate">{err}</div>}
-          {okMsg && <div className="text-xs text-success-600 truncate">{okMsg}</div>}
-          {!readOnly && (
-            <Button onClick={save} disabled={!dirty || busy} className="ml-auto">
-              {busy ? "saving…" : "save"}
-            </Button>
-          )}
-        </div>
+        {(err || okMsg || !readOnly) && (
+          <div className="flex items-center gap-2 px-4 py-3 border-t border-navy">
+            {err && <div className="text-xs text-danger-500 truncate">{err}</div>}
+            {okMsg && <div className="text-xs text-success-600 truncate">{okMsg}</div>}
+            {!readOnly && (
+              <Button onClick={save} disabled={!dirty || busy} className="ml-auto">
+                {busy ? "saving…" : "save"}
+              </Button>
+            )}
+          </div>
+        )}
       </div>
       {preview && (
         <ConfigSaveReview

--- a/www/src/components/Tag.tsx
+++ b/www/src/components/Tag.tsx
@@ -11,23 +11,51 @@ const tones: Record<Tone, string> = {
 };
 
 const base =
-  "inline-block text-2xs uppercase tracking-[.05em] font-semibold " +
+  "inline-flex items-center gap-1 text-2xs uppercase tracking-wider font-semibold " +
   "px-1.5 py-0.5 squircle-md border";
 
+// Tag renders as a <span> by default; pass `onClick` to render as a
+// <button> instead (e.g. for active-filter chips that dismiss on
+// click). Pass `dismissible` to append a × glyph after the label.
 export function Tag({
   tone = "neutral",
   className,
+  onClick,
+  dismissible,
   children,
   ...rest
 }: {
   tone?: Tone;
   className?: string;
+  onClick?: () => void;
+  dismissible?: boolean;
   children: ReactNode;
   title?: string;
 }) {
-  return (
-    <span className={`${base} ${tones[tone]} ${className ?? ""}`} {...rest}>
+  const cls =
+    `${base} ${tones[tone]} ` +
+    (onClick ? "cursor-pointer hover:opacity-80 transition-opacity " : "") +
+    (className ?? "");
+  const body = (
+    <>
       {children}
+      {dismissible && (
+        <span aria-hidden="true" className="text-2xs">
+          ✕
+        </span>
+      )}
+    </>
+  );
+  if (onClick) {
+    return (
+      <button type="button" onClick={onClick} className={cls} {...rest}>
+        {body}
+      </button>
+    );
+  }
+  return (
+    <span className={cls} {...rest}>
+      {body}
     </span>
   );
 }

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -259,6 +259,14 @@
     font: 14px/1.5 var(--font-sans);
     -webkit-font-smoothing: antialiased;
   }
+
+  /* Brand-colored focus ring. Overrides the browser default (blue
+     solid) with a 2px solid rust ring at 2px offset — visible
+     against the cream canvas and the navy-bordered cards. */
+  *:focus-visible {
+    outline: 2px solid var(--color-rust);
+    outline-offset: 2px;
+  }
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
Brings the dashboard onto the brand: shared Modal, Button, and Tag
components; unified card/table chrome; brand-token-only colors and
type scale; native <dialog>-based modals with proper a11y; logo
replaces the wordmark; login page redesigned to match.

Adds a confirmation prompt before disconnecting a credential.