### PR TITLE
tsnet tunnel: set Server.Dir on the credential branch too

### DIFF
--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -86,6 +86,29 @@ func (t *TailscaleTunnel) TunnelCommon() config.TunnelCommon {
 // tunnel block, shared by every endpoint that references it.
 func (*TailscaleTunnel) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
 
+// tunnelStateDir resolves the on-disk path passed to tsnet.Server.Dir.
+// Honours `state_dir = ...` on the tunnel block; otherwise carves
+// tunnels/tailscale/<name> out of the gateway's state_dir. The dir is
+// created 0700 because tsnet writes private node-state material here
+// (literal-authkey branch) and derp / logtail caches (both branches).
+//
+// Setting Dir explicitly keeps tsnet from consulting
+// $XDG_CONFIG_HOME / $HOME, which may be unset under hardened systemd
+// units, minimal containers, etc.
+func tunnelStateDir(t *TailscaleTunnel, host runtime.TunnelHost) (string, error) {
+	dir := t.StateDir
+	if dir == "" && host.StateDir != "" {
+		dir = filepath.Join(host.StateDir, "tunnels", "tailscale", host.Name)
+	}
+	if dir == "" {
+		return "", errors.New("tailscale tunnel: state_dir is required (HCL `state_dir = ...` on the tunnel or the gateway)")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("tailscale tunnel %q: state dir: %w", host.Name, err)
+	}
+	return dir, nil
+}
+
 // Open brings up an embedded tsnet node and returns a Tunnel whose
 // Dial routes through it. Two paths:
 //
@@ -122,15 +145,9 @@ func (t *TailscaleTunnel) Open(ctx context.Context, host runtime.TunnelHost, _ r
 	if authKey == "" {
 		return nil, fmt.Errorf("tailscale tunnel %q: no authkey (set HCL `authkey = ...`, env %s, or wire a `credential = ...` reference)", host.Name, envAuthKey(host.Name))
 	}
-	stateDir := t.StateDir
-	if stateDir == "" && host.StateDir != "" {
-		stateDir = filepath.Join(host.StateDir, "tunnels", "tailscale", host.Name)
-	}
-	if stateDir == "" {
-		return nil, errors.New("tailscale tunnel: state_dir is required (HCL `state_dir = ...` on the tunnel or the gateway)")
-	}
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return nil, fmt.Errorf("tailscale tunnel %q: state dir: %w", host.Name, err)
+	stateDir, err := tunnelStateDir(t, host)
+	if err != nil {
+		return nil, err
 	}
 
 	srv := &tsnet.Server{
@@ -177,10 +194,21 @@ func (t *TailscaleTunnel) openWithCredential(ctx context.Context, host runtime.T
 		logger.Printf("tailscale/%s: literal authkey ignored — credential %q takes precedence", host.Name, host.Credential.Name)
 	}
 
+	// tsnet still wants a Dir even when Store carries the node
+	// identity — it caches derp maps, logtail buffers, etc. Leaving
+	// it unset makes tsnet fall back to $XDG_CONFIG_HOME / $HOME,
+	// which are absent under hardened systemd units and minimal
+	// container images.
+	dir, err := tunnelStateDir(t, host)
+	if err != nil {
+		return nil, err
+	}
+
 	srv := &tsnet.Server{
 		Hostname:   hostname,
 		ControlURL: t.ControlURL,
 		Store:      store,
+		Dir:        dir,
 		Logf:       func(f string, args ...any) { logger.Printf(f, args...) },
 	}
 

--- a/config/plugins/tunnels/tailscale_test.go
+++ b/config/plugins/tunnels/tailscale_test.go
@@ -1,0 +1,53 @@
+package tunnels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cruntime "github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestTunnelStateDir_HostStateDir(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	root := t.TempDir()
+	dir, err := tunnelStateDir(&TailscaleTunnel{}, cruntime.TunnelHost{Name: "ts1", StateDir: root})
+	if err != nil {
+		t.Fatalf("tunnelStateDir: %v", err)
+	}
+	want := filepath.Join(root, "tunnels", "tailscale", "ts1")
+	if dir != want {
+		t.Fatalf("dir = %q, want %q", dir, want)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if !st.IsDir() {
+		t.Fatalf("%s is not a directory", dir)
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("mode = %#o, want %#o", mode, 0o700)
+	}
+}
+
+func TestTunnelStateDir_TunnelOverride(t *testing.T) {
+	override := t.TempDir()
+	dir, err := tunnelStateDir(
+		&TailscaleTunnel{StateDir: override},
+		cruntime.TunnelHost{Name: "ts1", StateDir: t.TempDir()},
+	)
+	if err != nil {
+		t.Fatalf("tunnelStateDir: %v", err)
+	}
+	if dir != override {
+		t.Fatalf("dir = %q, want override %q", dir, override)
+	}
+}
+
+func TestTunnelStateDir_Empty(t *testing.T) {
+	if _, err := tunnelStateDir(&TailscaleTunnel{}, cruntime.TunnelHost{Name: "ts1"}); err == nil {
+		t.Fatal("expected error for empty state_dir")
+	}
+}


### PR DESCRIPTION
## Summary

- #359 set `tsnet.Server.Dir` explicitly for the gateway's own tsnet server (`control = "tailscale"`), but the tailscale **tunnel** plugin's credential-driven branch still built `tsnet.Server` without a `Dir`. tsnet then fell back to `$XDG_CONFIG_HOME` / `$HOME` at `LocalClient` / `Up` time and died with `tsnet: neither $XDG_CONFIG_HOME nor $HOME are defined` under hardened systemd units and minimal container images.
- Factor the literal-authkey path's `stateDir` derivation into `tunnelStateDir(t, host)` and call it from `openWithCredential` too, so both branches set `tsnet.Server.Dir` up front (under `<state_dir>/tunnels/tailscale/<name>`, 0700).

Reproduced locally by running the gateway under a systemd user unit with `UnsetEnvironment=HOME XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME`; the exact two log lines from the original report fire on the credential branch, and disappear with this patch (tsnet then logs `tsnet starting with hostname ..., varRoot ".../data/tunnels/tailscale/<name>"` and proceeds to its normal `NeedsLogin` flow).

## Test plan

- [x] `go test ./config/plugins/tunnels/` passes
- [x] Manual reproducer under a systemd user unit with `HOME` + `XDG_CONFIG_HOME` unset — pre-patch: env-leak error; post-patch: `varRoot` log + normal interactive-login flow
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)