### PR TITLE
refuse public info_listen bind without dashboard_secret

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+func TestBindIsPublic(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		// Public (or unable-to-classify-as-private).
+		{"", true},               // ":port" — all interfaces
+		{"0.0.0.0", true},        // explicit IPv4 wildcard
+		{"::", true},             // IPv6 wildcard
+		{"1.2.3.4", true},        // public v4
+		{"8.8.8.8", true},        // public v4
+		{"2001:db8::1", true},    // public v6 (documentation prefix, but globally routable in classifier terms)
+		{"gw.example.com", true}, // hostname — assumed public
+		{"deno.clawpatrol.dev", true},
+
+		// Private — loopback.
+		{"127.0.0.1", false},
+		{"127.0.0.42", false},
+		{"::1", false},
+
+		// Private — RFC1918.
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+		{"172.31.255.254", false},
+		{"192.168.1.1", false},
+
+		// Not private — gap between 172.16/12 and 172.32.
+		{"172.32.0.1", true},
+
+		// IPv6 ULA (RFC 4193).
+		{"fd00::1", false},
+		{"fd12:3456:789a::1", false},
+
+		// Link-local.
+		{"169.254.1.1", false},
+		{"fe80::1", false},
+
+		// CGNAT (Tailscale's range).
+		{"100.64.0.1", false},
+		{"100.100.100.100", false},
+		{"100.127.255.254", false},
+		// 100.128.0.0 is OUTSIDE CGNAT — public.
+		{"100.128.0.1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			if got := bindIsPublic(tc.host); got != tc.want {
+				t.Errorf("bindIsPublic(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -68,7 +68,7 @@ curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
 
 cat > /opt/clawpatrol/gateway.hcl <<'EOF'
 listen       = "0.0.0.0:8443"
-info_listen  = "0.0.0.0:8080"
+info_listen  = "127.0.0.1:8080"
 public_url   = "http://clawpatrol-gateway"    # tailnet hostname suffices
 admin_email  = "you@example.com"
 state_dir    = "/opt/clawpatrol"

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -75,7 +75,7 @@ curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
 
 cat > /opt/clawpatrol/gateway.hcl <<'EOF'
 listen       = "0.0.0.0:8443"
-info_listen  = "0.0.0.0:8080"
+info_listen  = "127.0.0.1:8080"
 public_url   = "http://your-gw.example.com:8080"
 admin_email  = "you@example.com"
 log_path     = "/opt/clawpatrol/gateway.log"

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -29,7 +29,7 @@
 # ── operational --------------------------------------------------------
 
 listen      = "0.0.0.0:8443"
-info_listen = "0.0.0.0:8080"
+info_listen = "127.0.0.1:8080"
 public_url  = "https://gw.example.com"
 admin_email = "you@example.com"
 state_dir   = "/opt/clawpatrol"

--- a/main.go
+++ b/main.go
@@ -449,6 +449,71 @@ func logDashboardSecretState(cfg *config.Gateway) {
 	}
 }
 
+// bindIsPublic reports whether a listen-address host portion would
+// expose the listener to the public internet. Returns true for:
+//   - empty host or "0.0.0.0" or "::" — bind on all interfaces
+//   - any IP literal that isn't loopback / RFC1918 / RFC4193 ULA /
+//     link-local / CGNAT (100.64.0.0/10, where Tailscale lives)
+//
+// Hostnames are treated conservatively as public — operators who
+// want to bind a tailnet hostname should resolve it themselves and
+// use the IP literal, or accept the warning.
+func bindIsPublic(host string) bool {
+	if host == "" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true // hostname — can't tell, assume public
+	}
+	if ip.IsUnspecified() {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return false
+	}
+	// CGNAT 100.64.0.0/10 — Tailscale's range, not covered by
+	// IsPrivate but private in practice.
+	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+		return false
+	}
+	return true
+}
+
+// validateDashboardBindOrFatal refuses to boot if info_listen would
+// expose the dashboard publicly with no authentication. The escape
+// hatch is the --insecure-public-dashboard CLI flag — verbose by
+// design so it can't be set by accident.
+func validateDashboardBindOrFatal(cfg *config.Gateway, insecurePublic bool) {
+	if cfg.InfoListen == "" {
+		return
+	}
+	host, _, err := net.SplitHostPort(cfg.InfoListen)
+	if err != nil {
+		log.Fatalf("info_listen %q: %v", cfg.InfoListen, err)
+	}
+	public := bindIsPublic(host)
+	if !public {
+		return
+	}
+	if insecurePublic {
+		log.Printf("WARNING: info_listen %q is publicly bound (--insecure-public-dashboard acknowledged)", cfg.InfoListen)
+		return
+	}
+	if cfg.DashboardSecret != "" {
+		log.Printf("WARNING: info_listen %q is publicly bound — dashboard is reachable from the internet. Use a private bind (loopback / tailnet / VPN) or front it with an auth proxy on the host.", cfg.InfoListen)
+		return
+	}
+	log.Fatalf(
+		"refusing to start: info_listen %q binds to a public interface and dashboard_secret is unset.\n"+
+			"  The dashboard would be reachable from anywhere without authentication.\n"+
+			"  Fix one of:\n"+
+			"    - bind info_listen to a private interface (loopback, RFC1918, ULA, tailnet/CGNAT)\n"+
+			"    - set dashboard_secret in gateway.hcl\n"+
+			"    - pass --insecure-public-dashboard if you really mean it (testing only)",
+		cfg.InfoListen)
+}
+
 // trackCodexWSUsage parses a single WebSocket text-frame payload from
 // chatgpt.com/codex traffic. Codex sends JSON envelopes containing the
 // user prompt (client→server) and usage info (server→client). Sessions
@@ -2299,6 +2364,8 @@ Start from gateway.example.hcl in the repo, or see the HCL reference:
 
 func runGateway(args []string) {
 	fs := flag.NewFlagSet("gateway", flag.ExitOnError)
+	insecurePublicDashboard := fs.Bool("insecure-public-dashboard", false,
+		"allow info_listen to bind on a public interface without dashboard_secret (testing only)")
 	seedHook := devSeedAttach(fs)
 	fs.Usage = func() { fmt.Fprintln(os.Stderr, gatewayHelp) }
 	_ = fs.Parse(args)
@@ -2320,6 +2387,7 @@ func runGateway(args []string) {
 		log.Fatalf("config: %v", err)
 	}
 	logDashboardSecretState(cfg)
+	validateDashboardBindOrFatal(cfg, *insecurePublicDashboard)
 	stateDir := resolveStateDir(cfg)
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		log.Fatalf("state dir: %v", err)

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -31,8 +31,8 @@ into it, and edit the operational fields:
 
 ```hcl
 listen           = "0.0.0.0:8443"
-info_listen      = "0.0.0.0:9080"
-public_url       = "http://gw.example.com:9080"
+info_listen      = "127.0.0.1:9080"   # bind the dashboard private — see below
+public_url       = "https://gw.example.com"
 admin_email      = "you@example.com"
 dashboard_secret = "<long random string>"
 state_dir        = "/opt/clawpatrol"
@@ -41,6 +41,21 @@ control        = "wireguard"
 wg_subnet_cidr = "10.55.0.0/24"
 ```
 
+**`info_listen` should bind privately.** The dashboard holds the
+credential vault — the gateway refuses to boot when `info_listen`
+is on a public interface (`0.0.0.0`, `::`, or a routable IP) without
+`dashboard_secret`. Recommended shapes:
+
+- **`127.0.0.1:9080`** — loopback. Reach the dashboard via SSH
+  tunnel (`ssh -L 9080:127.0.0.1:9080 gateway-host`) or front it
+  with a local reverse proxy.
+- **A tailnet / VPN IP** — e.g. `100.x.x.x:9080`. Anyone on the
+  tailnet reaches it directly; nothing public.
+- **Public + `dashboard_secret`** — works if you really need it,
+  but logs a warning. Pair with an auth proxy
+  (Cloudflare Access, oauth2-proxy) before pointing real users
+  at it.
+
 The CA is lazy-minted into sqlite under `state_dir` on first boot —
 nothing to pre-create besides the directory itself. See
 [Config reference](/docs/config-reference/) for the full HCL grammar
@@ -48,15 +63,19 @@ and the rest of the credential / endpoint / rule blocks.
 
 ## Run the gateway
 
-Open the WireGuard UDP port and the dashboard TCP port on the host
-firewall (e.g. `iptables -I INPUT -p udp --dport 51820 -j ACCEPT`,
-same for `tcp/9080`), then:
+Open the WireGuard UDP port on the host firewall —
+`iptables -I INPUT -p udp --dport 51820 -j ACCEPT`. Leave the
+dashboard port closed to the public internet; reach it via the
+private bind you chose above.
 
 ```bash
 clawpatrol gateway /opt/clawpatrol/gateway.hcl
 ```
 
-The dashboard is at `http://<gateway-host>:9080`.
+For a loopback bind, reach the dashboard from your laptop with
+`ssh -L 9080:127.0.0.1:9080 gateway-host` and open
+`http://127.0.0.1:9080`. For a tailnet bind, just open the tailnet
+URL.
 
 ### Under systemd
 


### PR DESCRIPTION
## Summary

Phase 1b in `security-refactoring.md`. Addresses **F-21**: the dashboard would happily bind `0.0.0.0:8080` and the only thing preventing it from being a wide-open admin console on a fresh deploy was UFW on the host. One misconfigured firewall rule = full takeover.

The gateway now classifies `info_listen`'s host portion at startup:

| host shape | classified as |
|---|---|
| loopback (`127.x`, `::1`) | private |
| RFC1918 (`10/8`, `172.16/12`, `192.168/16`) | private |
| RFC4193 ULA (`fd00::/8`) | private |
| link-local (`169.254/16`, `fe80::/10`) | private |
| CGNAT `100.64.0.0/10` (Tailscale lives here) | private |
| `0.0.0.0`, `::`, empty host | public |
| any other IP literal | public |
| hostname (`gw.example.com`) | public (assumed, conservative) |

**Decision matrix:**

| info_listen | dashboard_secret | result |
|---|---|---|
| private | (anything) | boot silently |
| public | set | boot with WARNING |
| public | unset | **refuse to boot**, clear error |
| public | unset, `--insecure-public-dashboard` | boot with WARNING |

The refuse-to-boot message names the three fixes explicitly:

```
refusing to start: info_listen "0.0.0.0:9080" binds to a public interface and dashboard_secret is unset.
  The dashboard would be reachable from anywhere without authentication.
  Fix one of:
    - bind info_listen to a private interface (loopback, RFC1918, ULA, tailnet/CGNAT)
    - set dashboard_secret in gateway.hcl
    - pass --insecure-public-dashboard if you really mean it (testing only)
```

Existing deployments with `info_listen = "0.0.0.0:..."` + `dashboard_secret` set keep booting — they just see a startup WARNING (tripwire signal in `journalctl`). No forced operator action; the alarm lights up next time the unit restarts.

## Files

- `main.go` — `bindIsPublic()` classifier, `validateDashboardBindOrFatal()`, `--insecure-public-dashboard` CLI flag.
- `bind_test.go` — 24 host shapes, including wildcards, loopback, RFC1918, the gap between 172.16/12 and 172.32, ULA, link-local, the CGNAT boundary at 100.128.
- `gateway.example.hcl`, `getting-started.md`, `doc/wireguard.md`, `doc/tailscale.md` — example `info_listen` flips from `0.0.0.0` to `127.0.0.1`.
- `getting-started.md` gains an explicit paragraph on the three recommended `info_listen` shapes (loopback + SSH tunnel, tailnet/VPN, public + auth proxy).

## Operator note for the prod deploy

`prod.example.com` currently runs `info_listen = "0.0.0.0:8080"` + `dashboard_secret = "notpawpatrol"`. Under this change it keeps booting (the secret keeps it on the warning-not-fatal side). The gateway.hcl in the sibling repo has already been updated to `127.0.0.1:8080` — push that whenever convenient; no urgency.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test -count=1 ./...` — all packages green
- [x] `TestBindIsPublic` — 24/24 cases pass
- [x] Manual: built binary, ran four variants:
  - private bind, no secret, `insecure_no_dashboard_secret = true` → boots silently
  - public bind + secret → boots with WARNING
  - public bind, no secret → refuses with the clear error
  - public bind, no secret, `--insecure-public-dashboard` → boots with WARNING
