### PR TITLE
force loopback for cfg.Listen in WireGuard mode (closes open TLS proxy)

### DIFF
--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -74,7 +74,6 @@ in promiscuous mode — same shape as unclaw's `boringtun` + `smoltcp`
 curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
 
 cat > /opt/clawpatrol/gateway.hcl <<'EOF'
-listen       = "0.0.0.0:8443"
 info_listen  = "127.0.0.1:8080"
 public_url   = "http://your-gw.example.com:8080"
 admin_email  = "you@example.com"

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -28,11 +28,15 @@
 
 # ── operational --------------------------------------------------------
 
-listen      = "0.0.0.0:8443"
 info_listen = "127.0.0.1:8080"
 public_url  = "https://gw.example.com"
 admin_email = "you@example.com"
 state_dir   = "/opt/clawpatrol"
+
+# `listen` (TLS MITM listener) is omitted: in WireGuard mode the
+# gateway routes agent TLS through the WG netstack, not through this
+# socket. Set it only in Tailscale mode (where it's the tsnet
+# listener on the tailnet IP).
 
 # Dashboard auth — pick exactly one. The gateway refuses to serve the
 # dashboard / APIs until one of these is set, to avoid silently

--- a/main.go
+++ b/main.go
@@ -135,7 +135,16 @@ func loadConfig(path string) (*config.Gateway, *config.CompiledPolicy, error) {
 		return nil, nil, fmt.Errorf("%s", diags.Error())
 	}
 	if gw.Listen == "" {
-		gw.Listen = ":443"
+		if isTailscaleControlMode(gw.Control) {
+			// tsnet listener on the tailnet IP; 443 is the historical
+			// default and is unprivileged inside the tsnet stack.
+			gw.Listen = ":443"
+		} else {
+			// WireGuard mode: socket is loopback-only anyway (see
+			// tailscale.go's openListener). Use 8443 so the gateway can
+			// run rootless.
+			gw.Listen = "127.0.0.1:8443"
+		}
 	}
 	cp, err := config.Compile(gw)
 	if err != nil {

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -30,7 +30,6 @@ On the server, pick a data directory (anywhere — `/opt/clawpatrol`,
 into it, and edit the operational fields:
 
 ```hcl
-listen           = "0.0.0.0:8443"
 info_listen      = "127.0.0.1:9080"   # bind the dashboard private — see below
 public_url       = "https://gw.example.com"
 admin_email      = "you@example.com"

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -96,7 +96,7 @@ profile "default" { endpoints = [github] }
 | Field | Notes |
 |---|---|
 | `admin_email` | Required. |
-| `listen` | TLS gateway bind. Default `:443`. |
+| `listen` | TLS gateway bind. Meaningful only in Tailscale mode (tsnet listener); in WireGuard mode the agent path uses the WG tunnel and this socket is forced to loopback. |
 | `info_listen` | Dashboard + API bind. |
 | `public_url` | Dashboard URL handed out at join time. |
 | `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |

--- a/tailscale.go
+++ b/tailscale.go
@@ -1,8 +1,18 @@
 // Gateway control-plane listener. When the operator's HCL sets the
 // top-level `authkey = "..."` (or TS_AUTHKEY is in the env), the
 // gateway joins a tailnet via an embedded tsnet.Server and accepts
-// agent traffic on its tailnet IP. Otherwise a plain TCP listener
-// on cfg.Listen is used.
+// agent traffic on its tailnet IP — this is the meaningful Listener
+// for tsnet-mode deployments.
+//
+// In WireGuard mode the listener is vestigial: agent TLS flows
+// through the WG netstack's promiscuous forwarder inside the tunnel
+// (main.go's tcpDispatch handles dst port 443), not through this
+// socket. We still open a loopback listener so g.handle is reachable
+// for in-process local debugging, but force the bind to 127.0.0.1
+// regardless of cfg.Listen — historically operators set this to
+// 0.0.0.0:8443, which combined with g.handle's "unknown SNI →
+// splice" fall-through turned the socket into an open TLS proxy
+// (security-review F-19).
 //
 // tsnet's dep tree is unconditionally compiled in — the tunnel
 // package's tailscale plugin already pulls it, so there's no
@@ -12,6 +22,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -44,7 +55,16 @@ func openListener(cfg *config.Gateway, stateDir string) (net.Listener, error) {
 		authKey = os.Getenv("TS_AUTHKEY")
 	}
 	if authKey == "" {
-		return net.Listen("tcp", cfg.Listen)
+		// WireGuard mode: bind loopback regardless of cfg.Listen's
+		// host portion. See the file-level comment.
+		host, port, err := net.SplitHostPort(cfg.Listen)
+		if err != nil || port == "" {
+			port = "8443"
+		}
+		if host != "" && host != "127.0.0.1" && host != "::1" {
+			log.Printf("WARNING: listen %q overridden to loopback in WireGuard mode; agent traffic flows through the WG tunnel, this socket is for local debugging only.", cfg.Listen)
+		}
+		return net.Listen("tcp", net.JoinHostPort("127.0.0.1", port))
 	}
 	hn := cfg.Hostname
 	if hn == "" {

--- a/tailscale_test.go
+++ b/tailscale_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,11 +40,10 @@ func TestGatewayTsnetDir_EmptyStateDir(t *testing.T) {
 	}
 }
 
-// TestOpenListener_NoAuthKey covers the plain-TCP fallback: when neither
-// authkey nor TS_AUTHKEY is set, openListener never touches tsnet, so it
-// should bind a plain TCP listener even with HOME and XDG_CONFIG_HOME
-// unset. This guards the env-independence guarantee for the most common
-// (non-Tailscale) deployment.
+// TestOpenListener_NoAuthKey covers the WireGuard-mode path: when
+// neither authkey nor TS_AUTHKEY is set, openListener binds loopback
+// regardless of cfg.Listen's host portion, and is unaffected by
+// HOME / XDG_CONFIG_HOME being unset (no tsnet path is reached).
 func TestOpenListener_NoAuthKey(t *testing.T) {
 	t.Setenv("HOME", "")
 	t.Setenv("XDG_CONFIG_HOME", "")
@@ -54,6 +54,33 @@ func TestOpenListener_NoAuthKey(t *testing.T) {
 		t.Fatalf("openListener: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
+	host, _, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	if host != "127.0.0.1" && host != "::1" {
+		t.Errorf("expected loopback bind in WG mode, got %s", host)
+	}
+}
+
+// TestOpenListener_NoAuthKey_PublicListenIsOverridden verifies that
+// an operator-set "0.0.0.0:0" still results in a loopback bind in
+// WireGuard mode — the F-19 open-proxy fix.
+func TestOpenListener_NoAuthKey_PublicListenIsOverridden(t *testing.T) {
+	t.Setenv("TS_AUTHKEY", "")
+	cfg := &config.Gateway{Listen: "0.0.0.0:0"}
+	ln, err := openListener(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("openListener: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	host, _, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	if host != "127.0.0.1" && host != "::1" {
+		t.Fatalf("expected loopback bind, got %s", host)
+	}
 }
 
 // TestOpenListener_EnvIndependent verifies that with an authkey set but


### PR DESCRIPTION
## Summary

Phase 1c. Closes **F-19** (open TLS proxy via `cfg.Listen` in WireGuard mode) and **F-17** (`listen = "0.0.0.0:*"` was wrong for WG mode).

In WG mode the listener is **vestigial** — agent TLS flows through the WG netstack's promiscuous forwarder inside the tunnel (`tcpDispatch`'s dst-port 443 branch), not through this TCP socket. Historically operators set `listen = "0.0.0.0:8443"` anyway, which combined with `g.handle`'s "unknown SNI → splice" fall-through turned the socket into an open TLS proxy on the public internet.

After this PR:

- WG-mode bind is **always loopback** regardless of `cfg.Listen`. Operator-set host portions are overridden (with a `WARNING` log line in journalctl so it's visible). Port portion is preserved.
- Default in WG mode (no operator override): `127.0.0.1:8443` — unprivileged port, rootless-friendly.
- Tsnet-mode bind is unchanged. `listen` keeps its historical role there (tsnet listener on the tailnet IP, default `:443`).

The behavior I verified live on `prod.example.com` last week (curl + SNI=example.com against `:8443` returning real example.com HTML) is no longer reachable after this lands.

## Code changes

- `tailscale.go` — `openListener` WG-mode path forces 127.0.0.1, warns when overriding non-loopback.
- `main.go` — `loadConfig` picks a mode-aware default: `:443` for tsnet (privileged but tsnet doesn't care), `127.0.0.1:8443` for WG.
- `tailscale_test.go` — updated `TestOpenListener_NoAuthKey` to assert loopback bind; added `TestOpenListener_NoAuthKey_PublicListenIsOverridden` (`0.0.0.0:0` → loopback).

## Doc + example changes

- `gateway.example.hcl`, `getting-started.md`, `doc/wireguard.md` — drop the `listen = "0.0.0.0:8443"` line from WG-mode examples with a comment noting it's tsnet-only.
- `skill.md` — clarify that `listen` is meaningful only in Tailscale mode.

## gateway.hcl (sibling repo)

`../prod-deploy/gateway.hcl` updated locally to drop `listen = "0.0.0.0:8443"`. No urgency on pushing — under the new binary the field is silently overridden to loopback either way; dropping it just avoids the WARNING line in journalctl.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test -count=1 ./...` — all packages green
- [x] `clawpatrol validate gateway.example.hcl` — passes
- [x] `TestOpenListener_*` — three subtests pass, including the new override-public test
- [ ] Manual on prod: after deploy, `curl -sk --resolve example.com:8443:66.42.120.196 https://example.com:8443/` should NOT return example.com — connection RST or empty response
