### PR TITLE
drop dashboard_secret requirement on private bind

### DIFF
--- a/config/bind.go
+++ b/config/bind.go
@@ -1,0 +1,46 @@
+package config
+
+import "net"
+
+// BindIsPublic reports whether a listen-address host portion would
+// expose the listener to the public internet. Returns true for:
+//
+//   - empty host or "0.0.0.0" or "::" — bind on all interfaces
+//   - any IP literal that isn't loopback / RFC1918 / RFC4193 ULA /
+//     link-local / CGNAT (100.64.0.0/10, where Tailscale lives)
+//
+// Hostnames are treated conservatively as public — operators who
+// want to bind a tailnet hostname should resolve it themselves and
+// use the IP literal, or accept the warning.
+func BindIsPublic(host string) bool {
+	if host == "" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true // hostname — can't tell, assume public
+	}
+	if ip.IsUnspecified() {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return false
+	}
+	// CGNAT 100.64.0.0/10 — Tailscale's range, not covered by
+	// IsPrivate but private in practice.
+	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+		return false
+	}
+	return true
+}
+
+// BindStringIsPublic parses a "host:port" listen string and reports
+// whether the host portion would expose the listener publicly.
+// Returns true on parse error (conservative).
+func BindStringIsPublic(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return true
+	}
+	return BindIsPublic(host)
+}

--- a/config/bind_test.go
+++ b/config/bind_test.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import "testing"
 
@@ -48,8 +48,8 @@ func TestBindIsPublic(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.host, func(t *testing.T) {
-			if got := bindIsPublic(tc.host); got != tc.want {
-				t.Errorf("bindIsPublic(%q) = %v, want %v", tc.host, got, tc.want)
+			if got := BindIsPublic(tc.host); got != tc.want {
+				t.Errorf("BindIsPublic(%q) = %v, want %v", tc.host, got, tc.want)
 			}
 		})
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -418,12 +418,17 @@ func validateOperational(gw *Gateway) hcl.Diagnostics {
 		}
 	}
 
+	// Public dashboard bind without auth = open admin console. Private
+	// bind (loopback / tailnet / VPN) is OK without an app-layer
+	// secret — the network is the trust boundary.
 	if gw.InfoListen != "" && gw.DashboardSecret == "" && !gw.InsecureNoDashboardSecret {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Dashboard auth not configured",
-			Detail:   "info_listen is set but the dashboard has no auth: set dashboard_secret = \"<long random string>\", or set insecure_no_dashboard_secret = true to explicitly opt out.",
-		})
+		if BindStringIsPublic(gw.InfoListen) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Dashboard auth not configured",
+				Detail:   "info_listen is publicly bound but the dashboard has no auth: set dashboard_secret = \"<long random string>\", bind info_listen to a private interface (loopback / tailnet / VPN), or set insecure_no_dashboard_secret = true to explicitly opt out.",
+			})
+		}
 	}
 
 	return diags

--- a/config/testdata/error_dashboard_no_auth.errors.txt
+++ b/config/testdata/error_dashboard_no_auth.errors.txt
@@ -1,1 +1,1 @@
-error: Dashboard auth not configured — info_listen is set but the dashboard has no auth: set dashboard_secret = "<long random string>", or set insecure_no_dashboard_secret = true to explicitly opt out.
+error: Dashboard auth not configured — info_listen is publicly bound but the dashboard has no auth: set dashboard_secret = "<long random string>", bind info_listen to a private interface (loopback / tailnet / VPN), or set insecure_no_dashboard_secret = true to explicitly opt out.

--- a/gateway.example.hcl
+++ b/gateway.example.hcl
@@ -38,15 +38,16 @@ state_dir   = "/opt/clawpatrol"
 # socket. Set it only in Tailscale mode (where it's the tsnet
 # listener on the tailnet IP).
 
-# Dashboard auth — pick exactly one. The gateway refuses to serve the
-# dashboard / APIs until one of these is set, to avoid silently
-# exposing it on a public network.
+# Dashboard auth — required only when info_listen is publicly bound.
+# With info_listen on a private interface (loopback / tailnet / VPN /
+# RFC1918 / ULA — the example above uses 127.0.0.1) the network IS
+# the trust boundary; no app-layer secret needed. Uncomment one of
+# these only if you change info_listen to a public address:
 #
 #   dashboard_secret = "<long random string>"   # production
 #   insecure_no_dashboard_secret = true         # testing only — anyone
 #                                               # who can reach the
 #                                               # dashboard URL gets in
-dashboard_secret = "change-me-to-a-long-random-string"
 
 control        = "wireguard"
 wg_subnet_cidr = "10.55.0.0/24"

--- a/main.go
+++ b/main.go
@@ -453,40 +453,11 @@ func logDashboardSecretState(cfg *config.Gateway) {
 		log.Printf("dashboard auth: enabled (dashboard_secret set)")
 	case cfg.InsecureNoDashboardSecret:
 		log.Printf("dashboard auth: DISABLED via insecure_no_dashboard_secret — anyone who reaches the dashboard URL gets in")
+	case cfg.InfoListen != "" && !config.BindStringIsPublic(cfg.InfoListen):
+		log.Printf("dashboard auth: network-only (info_listen %q is privately bound; no app-layer secret required)", cfg.InfoListen)
 	default:
 		log.Printf("dashboard auth: MISCONFIGURED — gateway.hcl is missing both dashboard_secret and insecure_no_dashboard_secret; dashboard will refuse to serve until one is set")
 	}
-}
-
-// bindIsPublic reports whether a listen-address host portion would
-// expose the listener to the public internet. Returns true for:
-//   - empty host or "0.0.0.0" or "::" — bind on all interfaces
-//   - any IP literal that isn't loopback / RFC1918 / RFC4193 ULA /
-//     link-local / CGNAT (100.64.0.0/10, where Tailscale lives)
-//
-// Hostnames are treated conservatively as public — operators who
-// want to bind a tailnet hostname should resolve it themselves and
-// use the IP literal, or accept the warning.
-func bindIsPublic(host string) bool {
-	if host == "" {
-		return true
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return true // hostname — can't tell, assume public
-	}
-	if ip.IsUnspecified() {
-		return true
-	}
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
-		return false
-	}
-	// CGNAT 100.64.0.0/10 — Tailscale's range, not covered by
-	// IsPrivate but private in practice.
-	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
-		return false
-	}
-	return true
 }
 
 // validateDashboardBindOrFatal refuses to boot if info_listen would
@@ -501,7 +472,7 @@ func validateDashboardBindOrFatal(cfg *config.Gateway, insecurePublic bool) {
 	if err != nil {
 		log.Fatalf("info_listen %q: %v", cfg.InfoListen, err)
 	}
-	public := bindIsPublic(host)
+	public := config.BindIsPublic(host)
 	if !public {
 		return
 	}

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -30,11 +30,10 @@ On the server, pick a data directory (anywhere — `/opt/clawpatrol`,
 into it, and edit the operational fields:
 
 ```hcl
-info_listen      = "127.0.0.1:9080"   # bind the dashboard private — see below
-public_url       = "https://gw.example.com"
-admin_email      = "you@example.com"
-dashboard_secret = "<long random string>"
-state_dir        = "/opt/clawpatrol"
+info_listen = "127.0.0.1:9080"   # bind the dashboard private — see below
+public_url  = "https://gw.example.com"
+admin_email = "you@example.com"
+state_dir   = "/opt/clawpatrol"
 
 control        = "wireguard"
 wg_subnet_cidr = "10.55.0.0/24"
@@ -42,14 +41,18 @@ wg_subnet_cidr = "10.55.0.0/24"
 
 **`info_listen` should bind privately.** The dashboard holds the
 credential vault — the gateway refuses to boot when `info_listen`
-is on a public interface (`0.0.0.0`, `::`, or a routable IP) without
-`dashboard_secret`. Recommended shapes:
+is publicly bound (`0.0.0.0`, `::`, or a routable IP) without
+`dashboard_secret`. When `info_listen` is on a private interface
+(loopback / RFC1918 / RFC4193 ULA / link-local / CGNAT including
+Tailscale's 100.64.0.0/10) the network IS the trust boundary —
+no `dashboard_secret` needed. Recommended shapes, ranked:
 
-- **`127.0.0.1:9080`** — loopback. Reach the dashboard via SSH
-  tunnel (`ssh -L 9080:127.0.0.1:9080 gateway-host`) or front it
-  with a local reverse proxy.
-- **A tailnet / VPN IP** — e.g. `100.x.x.x:9080`. Anyone on the
-  tailnet reaches it directly; nothing public.
+- **`127.0.0.1:9080`** — loopback. No `dashboard_secret` required.
+  Reach the dashboard via SSH tunnel (`ssh -L 9080:127.0.0.1:9080
+  gateway-host`) or front it with a local reverse proxy.
+- **A tailnet / VPN IP** — e.g. `100.x.x.x:9080`. No
+  `dashboard_secret` required. Tailscale whois attributes audit
+  events to each operator (see [Architecture](/docs/architecture/)).
 - **Public + `dashboard_secret`** — works if you really need it,
   but logs a warning. Pair with an auth proxy
   (Cloudflare Access, oauth2-proxy) before pointing real users

--- a/web.go
+++ b/web.go
@@ -238,19 +238,35 @@ func (w *webMux) routes() []webRoute {
 }
 
 // dashboardSecretGate requires every non-public request to carry the
-// configured dashboard_secret (cookie / header). Onboarding
-// + health endpoints stay open so brand-new clients can still join.
+// configured dashboard_secret (cookie / header). Onboarding +
+// health endpoints stay open so brand-new clients can still join.
 //
 // When dashboard_secret is empty, the gate's behavior depends on
-// insecure_no_dashboard_secret: if that's true, the gate is a no-op
-// (testing escape hatch); otherwise the gate refuses to serve and
-// every gated route returns a misconfiguration error so an open
-// dashboard isn't published by accident.
+// the listen address and explicit opt-outs:
+//   - info_listen bound private (loopback / RFC1918 / ULA / CGNAT /
+//     link-local): pass through. The network is the trust boundary;
+//     anyone who can reach the socket is implicitly trusted. In
+//     Tailscale control mode the tailnetGate downstream still picks
+//     up per-operator identity from whois.
+//   - insecure_no_dashboard_secret = true: pass through. Testing
+//     escape hatch — anyone on the network gets in.
+//   - otherwise: refuse to serve. validateDashboardBindOrFatal at
+//     boot keeps the gateway from getting here for public binds,
+//     so this branch fires only on misconfigured stacks (e.g.
+//     hostname-bound listener that resolves dynamically).
+//
 // credentialWebhookPrefix is the path prefix every plugin webhook
 // route mounts under. Public — credential plugins authenticate
 // callbacks via their own signature header (Slack signing secret,
 // etc.) so the dashboard secret gate skips the prefix.
 const credentialWebhookPrefix = "/api/cred/"
+
+// infoListenIsPrivate reports whether the dashboard is bound on a
+// private interface. When true, the network is the trust boundary
+// and the dashboard_secret app-layer check is redundant.
+func (w *webMux) infoListenIsPrivate() bool {
+	return !config.BindStringIsPublic(w.g.cfg.InfoListen)
+}
 
 func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -260,7 +276,7 @@ func (w *webMux) dashboardSecretGate(next http.Handler) http.Handler {
 				next.ServeHTTP(rw, r)
 				return
 			}
-			if w.g.cfg.InsecureNoDashboardSecret {
+			if w.g.cfg.InsecureNoDashboardSecret || w.infoListenIsPrivate() {
 				next.ServeHTTP(rw, r.WithContext(contextWithPrincipal(r.Context(), w.dashboardSecretPrincipal())))
 				return
 			}


### PR DESCRIPTION
## Summary

Phase 2a in `security-refactoring.md`. With `info_listen` bound to a private interface (loopback / RFC1918 / RFC4193 ULA / link-local / CGNAT including Tailscale's 100.64.0.0/10), the network IS the trust boundary — anyone who reaches the socket is implicitly trusted. App-layer `dashboard_secret` on top is redundant. Drop the requirement.

For Deno's deployment shape (gateway on tailnet, dashboard bound to the tailnet IP), this lands the VPN-only path: no shared secret to rotate / forget / leak, and the existing `tailnetGate` downstream already attributes per-operator identity from tsnet whois.

## Behavior matrix (after this PR)

| info_listen | dashboard_secret | result |
|---|---|---|
| **private** | unset | **boots silently, dashboard serves without auth** (network = trust boundary) |
| **private** | set | boots, dashboard requires secret (operator's choice) |
| public | set | boots with `WARNING` (from 1b) |
| public | unset | refuses to boot (from 1b) |

The `private` row's "unset" case is the new path enabled by this PR.

## Code changes

- `config/bind.go` — exports `BindIsPublic` + `BindStringIsPublic`. Migrated from `main.go`'s `bindIsPublic` helper (added in 1b) so the same classification logic is reusable across config-load-time validation and web-handler request-time gating.
- `bind_test.go` moved into `config/bind_test.go` package — 24 host cases still pass.
- `config/config.go` `validateOperational` — the "Dashboard auth not configured" diagnostic now only fires when `info_listen` is publicly bound. Private bind + no secret loads clean.
- `web.go` `dashboardSecretGate` — when `dashboard_secret` is empty, allow through if `info_listen` is privately bound (mirrors the load-time check), attributing the principal via the existing `dashboardSecretPrincipal()`. In tailscale control mode the `tailnetGate` downstream still resolves per-operator whois on top.
- `main.go` `logDashboardSecretState` — new `network-only` log line for the private-bind path so the auth posture is auditable in `journalctl` regardless of whether anyone touches the dashboard.

## Doc changes

- `getting-started.md` — clarify which `info_listen` shapes need `dashboard_secret` and which don't. Example HCL drops the `dashboard_secret` line (loopback bind doesn't need it).
- `gateway.example.hcl` — `dashboard_secret` commented out; the comment explains it's only required for public binds.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test -count=1 ./...` — all packages green
- [x] `TestBindIsPublic` (24 cases) — passes in its new `config` package home
- [x] `config/testdata/error_dashboard_no_auth` — still fires (its fixture has `info_listen = "0.0.0.0:8080"` which stays public + no auth = error)
- [x] Manual: private bind (`info_listen = "127.0.0.1:9080"`) + no `dashboard_secret` → gateway boots with "network-only" log line; `curl /info` and `curl /api/state` both return 200 without any cookie
- [ ] Manual on Deno's gateway after deploy: confirm dashboard still loads from the tailnet without requiring a cookie

## Operator note

`prod.example.com` currently has `dashboard_secret = "notpawpatrol"` set. After this PR, with `info_listen = "127.0.0.1:8080"` (already updated locally in the sibling repo), the secret becomes optional. **Recommend dropping `dashboard_secret` from `gateway.hcl` once both this PR + the gateway.hcl edit are deployed** — eliminates one shared credential. The tailnet whois path keeps attributing audit events to each operator.
