### PR TITLE
tailscale tunnel: fix credential branch Dir + clean disconnect

### DIFF
--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -283,6 +283,35 @@ func (t *tailscaleTunnelConn) Dial(ctx context.Context, network, addr string) (n
 	}
 }
 
+// CredentialName implements runtime.TunnelCredentialNamer so the
+// TunnelManager can route a credential-targeted disconnect to this
+// live runtime. Empty for the literal-authkey path — there's no
+// credential identity to sign out.
+func (t *tailscaleTunnelConn) CredentialName() string { return t.credential }
+
+// Disconnect implements runtime.TunnelDisconnector: signs the tsnet
+// node out of the control plane before the manager evicts the entry.
+//
+// Without this, the dashboard's Disconnect button only wipes the
+// secret store; the in-process tsnet keeps its (mkey, nkey) pair
+// resident and registered. tsnet's reconnect / key-rotation loop then
+// re-enters initMachineKeyLocked, finds the cleared store, mints a
+// fresh machine key, and tries to register the still-cached node key
+// under it — control answers 403 "bad machine key" in a tight backoff
+// loop. Logging out first deregisters the node upstream so the next
+// boot's fresh keys join a clean slate.
+func (t *tailscaleTunnelConn) Disconnect(ctx context.Context) error {
+	srv := t.srv
+	if srv == nil {
+		return nil
+	}
+	lc, err := srv.LocalClient()
+	if err != nil {
+		return fmt.Errorf("tailscale tunnel %q: local client: %w", t.name, err)
+	}
+	return lc.Logout(ctx)
+}
+
 func (t *tailscaleTunnelConn) Close() error {
 	var err error
 	t.once.Do(func() {

--- a/config/plugins/tunnels/tailscale.go
+++ b/config/plugins/tunnels/tailscale.go
@@ -86,6 +86,29 @@ func (t *TailscaleTunnel) TunnelCommon() config.TunnelCommon {
 // tunnel block, shared by every endpoint that references it.
 func (*TailscaleTunnel) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
 
+// tunnelStateDir resolves the on-disk path passed to tsnet.Server.Dir.
+// Honours `state_dir = ...` on the tunnel block; otherwise carves
+// tunnels/tailscale/<name> out of the gateway's state_dir. The dir is
+// created 0700 because tsnet writes private node-state material here
+// (literal-authkey branch) and derp / logtail caches (both branches).
+//
+// Setting Dir explicitly keeps tsnet from consulting
+// $XDG_CONFIG_HOME / $HOME, which may be unset under hardened systemd
+// units, minimal containers, etc.
+func tunnelStateDir(t *TailscaleTunnel, host runtime.TunnelHost) (string, error) {
+	dir := t.StateDir
+	if dir == "" && host.StateDir != "" {
+		dir = filepath.Join(host.StateDir, "tunnels", "tailscale", host.Name)
+	}
+	if dir == "" {
+		return "", errors.New("tailscale tunnel: state_dir is required (HCL `state_dir = ...` on the tunnel or the gateway)")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("tailscale tunnel %q: state dir: %w", host.Name, err)
+	}
+	return dir, nil
+}
+
 // Open brings up an embedded tsnet node and returns a Tunnel whose
 // Dial routes through it. Two paths:
 //
@@ -122,15 +145,9 @@ func (t *TailscaleTunnel) Open(ctx context.Context, host runtime.TunnelHost, _ r
 	if authKey == "" {
 		return nil, fmt.Errorf("tailscale tunnel %q: no authkey (set HCL `authkey = ...`, env %s, or wire a `credential = ...` reference)", host.Name, envAuthKey(host.Name))
 	}
-	stateDir := t.StateDir
-	if stateDir == "" && host.StateDir != "" {
-		stateDir = filepath.Join(host.StateDir, "tunnels", "tailscale", host.Name)
-	}
-	if stateDir == "" {
-		return nil, errors.New("tailscale tunnel: state_dir is required (HCL `state_dir = ...` on the tunnel or the gateway)")
-	}
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return nil, fmt.Errorf("tailscale tunnel %q: state dir: %w", host.Name, err)
+	stateDir, err := tunnelStateDir(t, host)
+	if err != nil {
+		return nil, err
 	}
 
 	srv := &tsnet.Server{
@@ -177,10 +194,21 @@ func (t *TailscaleTunnel) openWithCredential(ctx context.Context, host runtime.T
 		logger.Printf("tailscale/%s: literal authkey ignored — credential %q takes precedence", host.Name, host.Credential.Name)
 	}
 
+	// tsnet still wants a Dir even when Store carries the node
+	// identity — it caches derp maps, logtail buffers, etc. Leaving
+	// it unset makes tsnet fall back to $XDG_CONFIG_HOME / $HOME,
+	// which are absent under hardened systemd units and minimal
+	// container images.
+	dir, err := tunnelStateDir(t, host)
+	if err != nil {
+		return nil, err
+	}
+
 	srv := &tsnet.Server{
 		Hostname:   hostname,
 		ControlURL: t.ControlURL,
 		Store:      store,
+		Dir:        dir,
 		Logf:       func(f string, args ...any) { logger.Printf(f, args...) },
 	}
 

--- a/config/plugins/tunnels/tailscale_test.go
+++ b/config/plugins/tunnels/tailscale_test.go
@@ -1,0 +1,53 @@
+package tunnels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cruntime "github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestTunnelStateDir_HostStateDir(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	root := t.TempDir()
+	dir, err := tunnelStateDir(&TailscaleTunnel{}, cruntime.TunnelHost{Name: "ts1", StateDir: root})
+	if err != nil {
+		t.Fatalf("tunnelStateDir: %v", err)
+	}
+	want := filepath.Join(root, "tunnels", "tailscale", "ts1")
+	if dir != want {
+		t.Fatalf("dir = %q, want %q", dir, want)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if !st.IsDir() {
+		t.Fatalf("%s is not a directory", dir)
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("mode = %#o, want %#o", mode, 0o700)
+	}
+}
+
+func TestTunnelStateDir_TunnelOverride(t *testing.T) {
+	override := t.TempDir()
+	dir, err := tunnelStateDir(
+		&TailscaleTunnel{StateDir: override},
+		cruntime.TunnelHost{Name: "ts1", StateDir: t.TempDir()},
+	)
+	if err != nil {
+		t.Fatalf("tunnelStateDir: %v", err)
+	}
+	if dir != override {
+		t.Fatalf("dir = %q, want override %q", dir, override)
+	}
+}
+
+func TestTunnelStateDir_Empty(t *testing.T) {
+	if _, err := tunnelStateDir(&TailscaleTunnel{}, cruntime.TunnelHost{Name: "ts1"}); err == nil {
+		t.Fatal("expected error for empty state_dir")
+	}
+}

--- a/config/runtime/tunnel.go
+++ b/config/runtime/tunnel.go
@@ -81,6 +81,26 @@ type Tunnel interface {
 	Close() error
 }
 
+// TunnelCredentialNamer is an optional interface a Tunnel implements
+// when its identity is owned by a named credential. The TunnelManager
+// uses it to route DisconnectCredential to matching live instances.
+type TunnelCredentialNamer interface {
+	// CredentialName returns the bare credential name that owns this
+	// tunnel's identity, or "" if the tunnel wasn't credential-driven.
+	CredentialName() string
+}
+
+// TunnelDisconnector is an optional interface a Tunnel implements when
+// it can perform a clean upstream sign-off (e.g. tsnet's LocalClient
+// Logout deregisters the node from the control plane) before the
+// manager calls Close. The manager invokes Disconnect first, then
+// force-evicts the entry. A Disconnect error is non-fatal — the caller
+// proceeds with the eviction so a stuck upstream doesn't pin local
+// state.
+type TunnelDisconnector interface {
+	Disconnect(ctx context.Context) error
+}
+
 // TunnelHost bundles host-side dependencies a tunnel plugin's Open
 // callback may need. Kept narrow so plugin packages don't have to
 // import the gateway main package.

--- a/tailscale_dashboard.go
+++ b/tailscale_dashboard.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"sort"
 	"time"
@@ -195,11 +196,19 @@ func (w *webMux) apiTailscaleStatus(rw http.ResponseWriter, r *http.Request) {
 	w.apiTailscaleConnect(rw, r)
 }
 
-// apiTailscaleDisconnect drops every stored slot for the credential.
-// On the next tunnel re-init, tsnet finds an empty StateStore and
-// drives the interactive login again. Hot-restart of the tunnel
-// itself is a follow-up; today the identity is reset and the next
-// gateway boot picks it up.
+// apiTailscaleDisconnect drops every stored slot for the credential
+// AND signs the live tsnet node out of the control plane / evicts its
+// runtime from the tunnel manager. Order matters: Logout first (needs
+// a live tsnet), then close + evict, then wipe credential_secrets, then
+// clear the parked login URL. Wiping the store while tsnet is still
+// resident lets its in-memory (mkey, nkey) pair race the cleared
+// persistence layer — the reconnect loop then mints a fresh machine
+// key, re-presents the still-cached node key under it, and earns a
+// 403 "bad machine key" from control in a tight backoff loop.
+//
+// Logout is best-effort: a transient upstream failure still lets the
+// local wipe proceed, leaving at most a stale node entry on
+// tailscale.com that the operator can clean up out of band.
 func (w *webMux) apiTailscaleDisconnect(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)
@@ -221,6 +230,13 @@ func (w *webMux) apiTailscaleDisconnect(rw http.ResponseWriter, r *http.Request)
 	if _, err := lookupTailscaleAuth(w.g.policy.Load(), body.ID); err != nil {
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if w.g.tunnels != nil {
+		logoutCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		if err := w.g.tunnels.DisconnectCredential(logoutCtx, body.ID); err != nil {
+			log.Printf("tailscale credential %q: logout: %v (proceeding with local wipe)", body.ID, err)
+		}
+		cancel()
 	}
 	if err := clearCredentialSecrets(w.g.db, body.ID); err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)

--- a/tunnel.go
+++ b/tunnel.go
@@ -326,6 +326,78 @@ func (m *TunnelManager) SetPolicy(ctx context.Context, policy *config.CompiledPo
 	}
 }
 
+// DisconnectCredential force-evicts every live tunnel entry whose
+// runtime reports CredentialName() == credential. For each match, the
+// manager calls Disconnect (best-effort upstream sign-off — tsnet's
+// LocalClient Logout for the tailscale plugin) before Close, then
+// drops the entry from the in-flight map and any pinned slot. The
+// first Disconnect error is returned; eviction proceeds regardless so
+// the caller can follow up with a state wipe and the next Acquire
+// builds a fresh instance.
+//
+// Force-evicts in the sense that refcount is ignored: in-flight dials
+// holding a release closure will find the entry gone on next Release
+// (releaseEntry handles missing entries silently), and a subsequent
+// Acquire on the same (name, sharing-key) will re-Open from scratch.
+// Used by the dashboard's tailscale Disconnect handler so clearing
+// credential_secrets doesn't race a live tsnet that still holds the
+// node identity in memory.
+func (m *TunnelManager) DisconnectCredential(ctx context.Context, credential string) error {
+	if credential == "" {
+		return nil
+	}
+	type victim struct {
+		mk  mgrKey
+		ent *tunnelEntry
+	}
+	var matches []victim
+	m.mu.Lock()
+	for mk, e := range m.entries {
+		if e.tunnel == nil {
+			continue
+		}
+		cn, ok := e.tunnel.(runtime.TunnelCredentialNamer)
+		if !ok || cn.CredentialName() != credential {
+			continue
+		}
+		matches = append(matches, victim{mk: mk, ent: e})
+	}
+	m.mu.Unlock()
+
+	var firstErr error
+	for _, v := range matches {
+		if d, ok := v.ent.tunnel.(runtime.TunnelDisconnector); ok {
+			if err := d.Disconnect(ctx); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		m.mu.Lock()
+		cur, ok := m.entries[v.mk]
+		if !ok || cur != v.ent {
+			m.mu.Unlock()
+			continue
+		}
+		if cur.timer != nil {
+			cur.timer.Stop()
+			cur.timer = nil
+		}
+		delete(m.entries, v.mk)
+		// Drop the orphaned pin so the next SetPolicy reload (or any
+		// re-Acquire driven by the dashboard's Connect button) goes
+		// through a fresh Open against the now-empty StateStore.
+		delete(m.pinned, v.mk)
+		t, vr := cur.tunnel, cur.viaRelease
+		m.mu.Unlock()
+		if t != nil {
+			_ = t.Close()
+		}
+		if vr != nil {
+			vr()
+		}
+	}
+	return firstErr
+}
+
 // Close tears down every entry. Called at gateway shutdown.
 func (m *TunnelManager) Close() {
 	m.mu.Lock()

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -317,3 +317,143 @@ func TestManagerConcurrentAcquire(t *testing.T) {
 		}
 	}
 }
+
+// credTunnel is a fakeTunnel variant whose opened handle satisfies
+// runtime.TunnelCredentialNamer + runtime.TunnelDisconnector, so the
+// manager's DisconnectCredential path is exercised end-to-end.
+type credTunnel struct {
+	fakeTunnel
+	credential   string
+	disconnectCt atomic.Int32
+	disconnectEr error
+}
+
+func (c *credTunnel) Open(_ context.Context, _ runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
+	c.openCount.Add(1)
+	if c.openErr != nil {
+		return nil, c.openErr
+	}
+	return &credOpenedTunnel{parent: c, via: via}, nil
+}
+
+type credOpenedTunnel struct {
+	parent *credTunnel
+	via    runtime.Tunnel
+}
+
+func (t *credOpenedTunnel) Dial(_ context.Context, _, _ string) (net.Conn, error) {
+	t.parent.dialCount.Add(1)
+	_, b := net.Pipe()
+	return b, nil
+}
+
+func (t *credOpenedTunnel) Close() error {
+	t.parent.closeCount.Add(1)
+	return nil
+}
+
+func (t *credOpenedTunnel) CredentialName() string { return t.parent.credential }
+
+func (t *credOpenedTunnel) Disconnect(_ context.Context) error {
+	t.parent.disconnectCt.Add(1)
+	return t.parent.disconnectEr
+}
+
+func makeCredTunnel(name, credential string) (*config.CompiledTunnel, *credTunnel) {
+	body := &credTunnel{credential: credential}
+	return &config.CompiledTunnel{
+		Name:    name,
+		Plugin:  &config.Plugin{Kind: config.KindTunnel, Type: "fake_cred"},
+		Body:    body,
+		Sharing: runtime.TunnelShareSingleton,
+	}, body
+}
+
+// TestDisconnectCredential: matching entries get Disconnect-then-Close,
+// non-matching entries are untouched, and the next Acquire on the
+// evicted name builds a fresh runtime.
+func TestDisconnectCredential(t *testing.T) {
+	m := NewTunnelManager(runtime.EnvSecretStore{}, "")
+	ctA, fakeA := makeCredTunnel("tnA", "credX")
+	ctB, fakeB := makeCredTunnel("tnB", "credY")
+
+	_, relA, err := m.Acquire(context.Background(), ctA, "ep")
+	if err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	defer relA()
+	_, relB, err := m.Acquire(context.Background(), ctB, "ep")
+	if err != nil {
+		t.Fatalf("acquire B: %v", err)
+	}
+	defer relB()
+
+	if err := m.DisconnectCredential(context.Background(), "credX"); err != nil {
+		t.Fatalf("DisconnectCredential: %v", err)
+	}
+	if got := fakeA.disconnectCt.Load(); got != 1 {
+		t.Errorf("credX disconnect count = %d, want 1", got)
+	}
+	if got := fakeA.closeCount.Load(); got != 1 {
+		t.Errorf("credX close count = %d, want 1", got)
+	}
+	if got := fakeB.disconnectCt.Load(); got != 0 {
+		t.Errorf("credY disconnect count = %d, want 0 (non-matching)", got)
+	}
+	if got := fakeB.closeCount.Load(); got != 0 {
+		t.Errorf("credY close count = %d, want 0 (non-matching)", got)
+	}
+
+	// Re-Acquire on the evicted tunnel runs Open again — proves the
+	// entry was force-evicted regardless of the lingering release
+	// closure held by relA.
+	_, rel2, err := m.Acquire(context.Background(), ctA, "ep")
+	if err != nil {
+		t.Fatalf("re-acquire A: %v", err)
+	}
+	defer rel2()
+	if got := fakeA.openCount.Load(); got != 2 {
+		t.Errorf("credX openCount after evict+re-acquire = %d, want 2", got)
+	}
+}
+
+// TestDisconnectCredentialUnknown: a credential with no matching live
+// runtime is a silent no-op (no error, no Close calls).
+func TestDisconnectCredentialUnknown(t *testing.T) {
+	m := NewTunnelManager(runtime.EnvSecretStore{}, "")
+	ct, fake := makeCredTunnel("tn", "credX")
+	_, rel, err := m.Acquire(context.Background(), ct, "ep")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer rel()
+	if err := m.DisconnectCredential(context.Background(), "nope"); err != nil {
+		t.Fatalf("DisconnectCredential: %v", err)
+	}
+	if got := fake.disconnectCt.Load(); got != 0 {
+		t.Errorf("disconnect count = %d, want 0", got)
+	}
+	if got := fake.closeCount.Load(); got != 0 {
+		t.Errorf("close count = %d, want 0", got)
+	}
+}
+
+// TestDisconnectCredentialErrorIsNonFatal: a Disconnect error surfaces
+// from the manager but eviction still completes — Close still ran.
+func TestDisconnectCredentialErrorIsNonFatal(t *testing.T) {
+	m := NewTunnelManager(runtime.EnvSecretStore{}, "")
+	ct, fake := makeCredTunnel("tn", "credX")
+	fake.disconnectEr = errors.New("boom")
+	_, rel, err := m.Acquire(context.Background(), ct, "ep")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer rel()
+	err = m.DisconnectCredential(context.Background(), "credX")
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("DisconnectCredential err = %v, want boom", err)
+	}
+	if got := fake.closeCount.Load(); got != 1 {
+		t.Errorf("close count = %d, want 1 (evict proceeds past logout error)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two fixes to the credential-driven `tunnel "tailscale"` path:

- **`Server.Dir` on the credential branch (27e1b53).** #359 set `tsnet.Server.Dir` explicitly for the gateway's own tsnet server (control = "tailscale"), but `openWithCredential` still built `tsnet.Server` without a `Dir`, so under hardened systemd units (no `$HOME`, no `$XDG_CONFIG_HOME`) the tunnel died with *"neither \$XDG_CONFIG_HOME nor \$HOME are defined"*. Factored the existing literal-authkey path's stateDir derivation into a `tunnelStateDir` helper and called it from `openWithCredential` too.

- **Logout + force-evict on dashboard Disconnect (30b8fb7).** `apiTailscaleDisconnect` only wiped `credential_secrets`; the live `tsnet.Server` stayed resident with its `(mkey, nkey)` cached in `LocalBackend` memory. tsnet's reconnect / key-rotation loop then re-entered `initMachineKeyLocked`, found the cleared Store, minted a fresh machine key, and tried to register the still-cached node key under it — control answered `403 bad machine key` in a tight backoff loop. New surface:
  - `runtime.TunnelCredentialNamer` / `TunnelDisconnector`: optional interfaces a Tunnel implements when its identity is owned by a credential and it can perform an upstream sign-off before Close.
  - `tailscaleTunnelConn` satisfies both, calling `srv.LocalClient().Logout(ctx)` to deregister the node from the control plane.
  - `TunnelManager.DisconnectCredential` runs Disconnect best-effort, then force-evicts (refcount-ignoring) and drops any pinned slot so the next Acquire builds a fresh tsnet.
  - `apiTailscaleDisconnect` calls `DisconnectCredential` (10s ctx) before `clearCredentialSecrets` so Logout sees a live tsnet and the in-memory keys can't race the cleared persistence layer.

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] New unit tests cover match / non-match / Disconnect-error-is-non-fatal for `TunnelManager.DisconnectCredential`
- [ ] Manual: connect → click X → confirm tailscale.com no longer shows the node and the gateway logs do not loop on `403 bad machine key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)