### PR TITLE
dashboard: surface tailscale disconnect ✕ when state persists

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -594,12 +594,19 @@ type IntegrationRow struct {
 // dashboard renders the connect flow without hard-coding the route
 // layout.
 type TailscaleAuthStatusUI struct {
-	Connected     bool                          `json:"connected"`
-	State         tailscaleproto.NodeStateLabel `json:"state"`
-	PendingURL    string                        `json:"pending_url,omitempty"`
-	ConnectURL    string                        `json:"connect_url"`
-	StatusURL     string                        `json:"status_url"`
-	DisconnectURL string                        `json:"disconnect_url"`
+	Connected bool                          `json:"connected"`
+	State     tailscaleproto.NodeStateLabel `json:"state"`
+	// HasState is true when credential_secrets carries any rows for
+	// this credential — i.e. there's a persisted tsnet identity (or a
+	// fragment of one) that could be cleared by Disconnect. The
+	// dashboard renders the disconnect ✕ off this field rather than
+	// gating it on Connected, so an operator can reset a stuck
+	// identity even when tsnet has dropped out of Running.
+	HasState      bool   `json:"has_state,omitempty"`
+	PendingURL    string `json:"pending_url,omitempty"`
+	ConnectURL    string `json:"connect_url"`
+	StatusURL     string `json:"status_url"`
+	DisconnectURL string `json:"disconnect_url"`
 }
 
 // OAuthIntegrationUI is the dashboard-facing slice of an
@@ -673,6 +680,7 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 			row.TailscaleAuth = &TailscaleAuthStatusUI{
 				Connected:     label == tailscaleproto.NodeStateRunning,
 				State:         dashboardTailscaleState(label, len(present) > 0),
+				HasState:      len(present) > 0,
 				PendingURL:    tailscaleproto.Default.Get(name),
 				ConnectURL:    "/api/tailscale/connect?id=" + name,
 				StatusURL:     "/api/tailscale/status?id=" + name,

--- a/www/src/components/IntegrationsCards.tsx
+++ b/www/src/components/IntegrationsCards.tsx
@@ -264,6 +264,13 @@ function Card({
   const connected = isConnected(i);
   const hasSlots = (i.slots?.length ?? 0) > 0;
   const clickable = i.has_oauth || hasSlots || (i.has_tailscale_auth && !connected);
+  // Tailscale identities can persist while the live node is *not*
+  // running (rejected machine key, expired auth, etc.) — the gateway
+  // exposes has_state in that window so the card can offer a Reset
+  // path. Without this the operator had to bounce the gateway to
+  // recover from a stuck registration.
+  const canReset = i.has_tailscale_auth && (i.tailscale_auth?.has_state ?? false);
+  const showDisconnect = connected || canReset;
   const status = connected
     ? i.expires_at
       ? "expires " + fmtExpiry(i.expires_at)
@@ -304,14 +311,14 @@ function Card({
           {heading}
         </span>
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
-          {connected && (
+          {showDisconnect && (
             <span
               onClick={(e) => {
                 e.stopPropagation();
                 onDisconnect();
               }}
               className="opacity-0 group-hover:opacity-100 text-xs leading-none text-text-subtle hover:text-danger-500 transition-opacity cursor-pointer"
-              title="disconnect"
+              title={connected ? "disconnect" : "reset stored identity"}
             >
               ✕
             </span>

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -37,6 +37,11 @@ export type TailscaleNodeState =
 export type TailscaleAuthStatusUI = {
   connected: boolean;
   state: TailscaleNodeState;
+  // has_state is true when credential_secrets carries persisted
+  // identity bytes — even when `connected` is false. The card uses
+  // this to render the disconnect ✕ for stuck-but-not-running nodes
+  // so the operator can reset without bouncing the gateway.
+  has_state?: boolean;
   pending_url?: string;
   connect_url: string;
   status_url: string;


### PR DESCRIPTION
The Card gated the disconnect ✕ on `connected`, so once tsnet
dropped out of Running (rejected machine key, expired auth, network
glitch) the operator had no UI affordance to trigger the disconnect
handler that #399 just made effective — they had to either hand-edit
`credential_secrets` or bounce the gateway. This is the missing UI
half of that fix.

* `TailscaleAuthStatusUI` gains `HasState`, populated from
  `credentialSlotPresence`. True whenever there's a persisted
  identity (or fragment of one) regardless of live BackendState.
* `Card` renders the ✕ when `connected || (has_tailscale_auth &&
  has_state)`; title text flips to "reset stored identity" for the
  not-connected case so the action reads correctly.