### PR TITLE
clickhouse: per-database endpoint routing

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -248,6 +248,13 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		cp.Endpoints[name] = ce
 	}
 
+	// Cross-endpoint invariants. Per-endpoint Validate runs during
+	// Load (block-local); this pass enforces the rules that need to
+	// see two endpoint records side-by-side.
+	if err := validateDatabaseRouting(cp); err != nil {
+		return nil, err
+	}
+
 	// Compile rules and attach to each endpoint they target. The
 	// rule plugin owns the lowering (its CompileRule callback) so
 	// match.Matcher construction lives next to the rule's schema,
@@ -624,6 +631,98 @@ func pluginType(p *Plugin) string {
 		return ""
 	}
 	return p.Type
+}
+
+// DatabaseRouter is the optional interface an endpoint body
+// implements to opt into per-database dispatch routing. The
+// dispatcher uses DispatchDatabase to decide which endpoint claims
+// a connection when several endpoints of the same plugin type bind
+// to the same host. Implementers return their configured Database
+// string (empty == catch-all). The compile pass enforces uniqueness
+// across endpoints — see validateDatabaseRouting.
+type DatabaseRouter interface {
+	DispatchDatabase() string
+}
+
+// validateDatabaseRouting enforces uniqueness for endpoint bodies
+// that satisfy DatabaseRouter. When two endpoints of the same plugin
+// type bind to the same host, the dispatcher reads the agent-declared
+// database off the wire and picks the endpoint whose Database equals
+// it; a Database-less endpoint is the catch-all for that host.
+// Ambiguous shapes the dispatcher couldn't resolve without
+// coin-flipping are rejected here so the operator finds out at
+// policy load instead of from a connection that silently routed
+// through the wrong credential:
+//
+//   - two specifics with identical (plugin, host, Database): which
+//     credential should claim a connection to that database?
+//   - two catch-alls on the same (plugin, host): which credential
+//     should claim a connection whose database didn't match any
+//     specific?
+//
+// A specific + a catch-all on the same host is allowed — specific
+// wins.
+func validateDatabaseRouting(cp *CompiledPolicy) error {
+	if cp == nil {
+		return nil
+	}
+	// Key: pluginType + "\x00" + host + "\x00" + database. Value:
+	// the endpoint name that already claimed it. Empty Database is
+	// the catch-all slot; the same key shape catches catch-all dupes
+	// because the database segment is empty for both.
+	seen := make(map[string]string)
+	// Stable iteration so the error message is deterministic when
+	// multiple conflicts could fire — important for test goldens.
+	names := make([]string, 0, len(cp.Endpoints))
+	for n := range cp.Endpoints {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		ce := cp.Endpoints[name]
+		if ce == nil || ce.Plugin == nil {
+			continue
+		}
+		dr, ok := ce.Body.(DatabaseRouter)
+		if !ok {
+			continue
+		}
+		db := dr.DispatchDatabase()
+		for _, hp := range ce.Hosts {
+			host := normalizeRoutingHost(hp)
+			if host == "" {
+				continue
+			}
+			key := ce.Plugin.Type + "\x00" + host + "\x00" + db
+			if prior, dup := seen[key]; dup {
+				if db == "" {
+					return fmt.Errorf(
+						"endpoint %q (%s): host %q is already claimed by catch-all endpoint %q; two %s endpoints on the same host without a database field are ambiguous — give one of them `database = \"...\"`",
+						name, ce.Plugin.Type, host, prior, ce.Plugin.Type)
+				}
+				return fmt.Errorf(
+					"endpoint %q (%s): database %q on host %q is already claimed by endpoint %q; two %s endpoints can't share the same (host, database) pair",
+					name, ce.Plugin.Type, db, host, prior, ce.Plugin.Type)
+			}
+			seen[key] = name
+		}
+	}
+	return nil
+}
+
+// normalizeRoutingHost strips an optional :port suffix so the
+// dispatch-time host comparison treats `clickhouse.example:9000` and
+// `clickhouse.example` as the same host. Database routing is
+// host-scoped; the port disambiguates which protocol claims the
+// listener, not which database the connection is for.
+func normalizeRoutingHost(hp string) string {
+	if hp == "" {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(hp); err == nil {
+		return strings.ToLower(h)
+	}
+	return strings.ToLower(hp)
 }
 
 // parseKeepalive turns the HCL keepalive string into (duration,

--- a/config/compile_database_routing_test.go
+++ b/config/compile_database_routing_test.go
@@ -1,0 +1,207 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+// TestCompileClickhouseNativeDatabaseRoutingSpecific+CatchAllOK covers
+// the valid shape: one specific endpoint and one catch-all on the
+// same host. The dispatcher resolves a connection to the specific
+// when Hello.Database matches and to the catch-all otherwise.
+func TestCompileClickhouseNativeSpecificPlusCatchAllOK(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "ch-prod" {}
+credential "clickhouse_credential" "ch-default" {}
+
+endpoint "clickhouse_native" "prod" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_prod"
+  credential = ch-prod
+}
+endpoint "clickhouse_native" "any" {
+  hosts      = ["clickhouse.example.com"]
+  credential = ch-default
+}
+`)
+	gw, diags := config.LoadBytes(src, "specific_plus_catchall.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if _, err := config.Compile(gw); err != nil {
+		t.Fatalf("specific + catch-all on same host should compile, got: %v", err)
+	}
+}
+
+// TestCompileClickhouseNativeTwoSpecificsDifferentDBsOK exercises the
+// dual-database shape from the bead: two endpoints, same host, two
+// different specific databases. Both compile and the dispatcher can
+// route a connection to whichever one Hello.Database picks.
+func TestCompileClickhouseNativeTwoSpecificsDifferentDBsOK(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "ch-prod" {}
+credential "clickhouse_credential" "ch-dev" {}
+
+endpoint "clickhouse_native" "prod" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_prod"
+  credential = ch-prod
+}
+endpoint "clickhouse_native" "dev" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_dev"
+  credential = ch-dev
+}
+`)
+	gw, diags := config.LoadBytes(src, "two_specifics.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if _, err := config.Compile(gw); err != nil {
+		t.Fatalf("two different specifics on same host should compile, got: %v", err)
+	}
+}
+
+func TestCompileClickhouseNativeDuplicateSpecificFails(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "a" {}
+credential "clickhouse_credential" "b" {}
+
+endpoint "clickhouse_native" "alpha" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_prod"
+  credential = a
+}
+endpoint "clickhouse_native" "beta" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_prod"
+  credential = b
+}
+`)
+	gw, diags := config.LoadBytes(src, "dup_specific.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	_, err := config.Compile(gw)
+	if err == nil {
+		t.Fatal("two endpoints on same (host, database) should fail compile")
+	}
+	if !strings.Contains(err.Error(), "analytics_prod") {
+		t.Errorf("error %q does not mention the offending database", err)
+	}
+	if !strings.Contains(err.Error(), "clickhouse.example.com") {
+		t.Errorf("error %q does not mention the offending host", err)
+	}
+}
+
+func TestCompileClickhouseNativeDuplicateCatchAllFails(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "a" {}
+credential "clickhouse_credential" "b" {}
+
+endpoint "clickhouse_native" "alpha" {
+  hosts      = ["clickhouse.example.com"]
+  credential = a
+}
+endpoint "clickhouse_native" "beta" {
+  hosts      = ["clickhouse.example.com"]
+  credential = b
+}
+`)
+	gw, diags := config.LoadBytes(src, "dup_catchall.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	_, err := config.Compile(gw)
+	if err == nil {
+		t.Fatal("two catch-all endpoints on same host should fail compile")
+	}
+	if !strings.Contains(err.Error(), "catch-all") {
+		t.Errorf("error %q does not mention catch-all", err)
+	}
+}
+
+func TestCompileClickhouseHTTPSDuplicateSpecificFails(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "a" {}
+credential "clickhouse_credential" "b" {}
+
+endpoint "clickhouse_https" "alpha" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "prod"
+  credential = a
+}
+endpoint "clickhouse_https" "beta" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "prod"
+  credential = b
+}
+`)
+	gw, diags := config.LoadBytes(src, "https_dup.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if _, err := config.Compile(gw); err == nil {
+		t.Fatal("two clickhouse_https endpoints on same (host, database) should fail compile")
+	}
+}
+
+// TestCompileClickhouseDifferentPluginsDontConflict ensures the
+// (plugin, host, database) key keeps native and https from colliding
+// on shared infra — a clickhouse cluster typically exposes both
+// protocols on the same hostname.
+func TestCompileClickhouseDifferentPluginsDontConflict(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "a" {}
+
+endpoint "clickhouse_native" "native-prod" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_prod"
+  credential = a
+}
+endpoint "clickhouse_https" "https-prod" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "analytics_prod"
+  credential = a
+}
+`)
+	gw, diags := config.LoadBytes(src, "different_plugins.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if _, err := config.Compile(gw); err != nil {
+		t.Fatalf("native + https on same (host, database) should compile, got: %v", err)
+	}
+}
+
+// TestCompileClickhouseHostPortNormalization makes the routing check
+// host-only — `clickhouse.example.com:9000` and
+// `clickhouse.example.com` are the same host. Two specifics with the
+// same database on these two host strings must still fail compile.
+func TestCompileClickhouseHostPortNormalization(t *testing.T) {
+	src := []byte(`
+credential "clickhouse_credential" "a" {}
+credential "clickhouse_credential" "b" {}
+
+endpoint "clickhouse_native" "alpha" {
+  hosts      = ["clickhouse.example.com"]
+  database   = "prod"
+  credential = a
+}
+endpoint "clickhouse_native" "beta" {
+  hosts      = ["clickhouse.example.com:9000"]
+  database   = "prod"
+  credential = b
+}
+`)
+	gw, diags := config.LoadBytes(src, "port_normalization.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if _, err := config.Compile(gw); err == nil {
+		t.Fatal("host:port and bare host should normalize to the same routing key")
+	}
+}

--- a/config/plugins/endpoints/clickhouse_database_routing_test.go
+++ b/config/plugins/endpoints/clickhouse_database_routing_test.go
@@ -1,0 +1,166 @@
+package endpoints
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// compiledNative wraps a ClickhouseNativeEndpoint into a
+// *config.CompiledEndpoint shaped just enough for the routing
+// helper. Only Body, Name, and Plugin.Type are read.
+func compiledNative(name string, body *ClickhouseNativeEndpoint) *config.CompiledEndpoint {
+	return &config.CompiledEndpoint{
+		Name:   name,
+		Plugin: &config.Plugin{Type: "clickhouse_native"},
+		Body:   body,
+	}
+}
+
+func TestPickClickhouseNativeByDatabaseSpecificWins(t *testing.T) {
+	prod := compiledNative("prod", &ClickhouseNativeEndpoint{Database: "analytics_prod"})
+	dev := compiledNative("dev", &ClickhouseNativeEndpoint{Database: "analytics_dev"})
+	catchAll := compiledNative("all", &ClickhouseNativeEndpoint{})
+	cands := []*config.CompiledEndpoint{catchAll, prod, dev}
+
+	if got := pickClickhouseNativeByDatabase(cands, "analytics_prod"); got != prod {
+		t.Fatalf("want prod, got %v", got)
+	}
+	if got := pickClickhouseNativeByDatabase(cands, "analytics_dev"); got != dev {
+		t.Fatalf("want dev, got %v", got)
+	}
+}
+
+func TestPickClickhouseNativeByDatabaseFallsBackToCatchAll(t *testing.T) {
+	prod := compiledNative("prod", &ClickhouseNativeEndpoint{Database: "analytics_prod"})
+	catchAll := compiledNative("all", &ClickhouseNativeEndpoint{})
+	cands := []*config.CompiledEndpoint{prod, catchAll}
+
+	if got := pickClickhouseNativeByDatabase(cands, "analytics_dev"); got != catchAll {
+		t.Fatalf("unmatched database should fall through to catch-all; got %v", got)
+	}
+	// Empty Hello.Database matches catch-all the same way.
+	if got := pickClickhouseNativeByDatabase(cands, ""); got != catchAll {
+		t.Fatalf("empty database should pick catch-all; got %v", got)
+	}
+}
+
+func TestPickClickhouseNativeByDatabaseNoCatchAllNoMatchReturnsNil(t *testing.T) {
+	prod := compiledNative("prod", &ClickhouseNativeEndpoint{Database: "analytics_prod"})
+	dev := compiledNative("dev", &ClickhouseNativeEndpoint{Database: "analytics_dev"})
+	cands := []*config.CompiledEndpoint{prod, dev}
+
+	if got := pickClickhouseNativeByDatabase(cands, "other"); got != nil {
+		t.Fatalf("no specific match and no catch-all should return nil; got %v", got)
+	}
+}
+
+func TestPickClickhouseNativeByDatabaseEmptyInput(t *testing.T) {
+	if got := pickClickhouseNativeByDatabase(nil, "x"); got != nil {
+		t.Fatalf("empty candidates should return nil; got %v", got)
+	}
+}
+
+func TestPickClickhouseNativeByDatabaseIgnoresWrongBody(t *testing.T) {
+	// Defensive: a candidate whose Body isn't *ClickhouseNativeEndpoint
+	// (e.g. accidental cross-plugin reuse) is skipped, not crashed on.
+	bogus := &config.CompiledEndpoint{
+		Name:   "bogus",
+		Plugin: &config.Plugin{Type: "clickhouse_native"},
+		Body:   struct{}{},
+	}
+	prod := compiledNative("prod", &ClickhouseNativeEndpoint{Database: "p"})
+	if got := pickClickhouseNativeByDatabase([]*config.CompiledEndpoint{bogus, prod}, "p"); got != prod {
+		t.Fatalf("non-native body should be skipped; got %v", got)
+	}
+}
+
+func TestClickhouseHTTPSDatabaseFromRequest(t *testing.T) {
+	mustURL := func(raw string) *url.URL {
+		t.Helper()
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", raw, err)
+		}
+		return u
+	}
+	cases := []struct {
+		name string
+		req  *http.Request
+		want string
+	}{
+		{
+			name: "query parameter",
+			req:  &http.Request{URL: mustURL("https://ch/?database=foo")},
+			want: "foo",
+		},
+		{
+			name: "header",
+			req: &http.Request{
+				URL:    mustURL("https://ch/"),
+				Header: http.Header{"X-Clickhouse-Database": []string{"bar"}},
+			},
+			want: "bar",
+		},
+		{
+			name: "query wins over header",
+			req: &http.Request{
+				URL:    mustURL("https://ch/?database=fromquery"),
+				Header: http.Header{"X-Clickhouse-Database": []string{"fromheader"}},
+			},
+			want: "fromquery",
+		},
+		{
+			name: "neither set",
+			req:  &http.Request{URL: mustURL("https://ch/?other=1")},
+			want: "",
+		},
+		{
+			name: "case preserved",
+			req:  &http.Request{URL: mustURL("https://ch/?database=Prod")},
+			want: "Prod",
+		},
+		{
+			name: "nil request",
+			req:  nil,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClickhouseHTTPSDatabaseFromRequest(tc.req); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPickClickhouseHTTPSEndpointByDatabase(t *testing.T) {
+	prod := &ClickhouseHTTPSEndpoint{Database: "analytics_prod"}
+	dev := &ClickhouseHTTPSEndpoint{Database: "analytics_dev"}
+	catchAll := &ClickhouseHTTPSEndpoint{}
+	cands := []*ClickhouseHTTPSEndpoint{catchAll, prod, dev}
+
+	if got := PickClickhouseHTTPSEndpointByDatabase(cands, "analytics_prod"); got != prod {
+		t.Fatalf("want prod, got %v", got)
+	}
+	if got := PickClickhouseHTTPSEndpointByDatabase(cands, "analytics_dev"); got != dev {
+		t.Fatalf("want dev, got %v", got)
+	}
+	if got := PickClickhouseHTTPSEndpointByDatabase(cands, "other"); got != catchAll {
+		t.Fatalf("unmatched should fall through to catch-all, got %v", got)
+	}
+	if got := PickClickhouseHTTPSEndpointByDatabase(cands, ""); got != catchAll {
+		t.Fatalf("empty database should pick catch-all, got %v", got)
+	}
+	if got := PickClickhouseHTTPSEndpointByDatabase(nil, "x"); got != nil {
+		t.Fatalf("nil candidates should return nil, got %v", got)
+	}
+	// No catch-all, no match: nil.
+	noCatch := []*ClickhouseHTTPSEndpoint{prod, dev}
+	if got := PickClickhouseHTTPSEndpointByDatabase(noCatch, "other"); got != nil {
+		t.Fatalf("no catch-all, no match should return nil, got %v", got)
+	}
+}

--- a/config/plugins/endpoints/clickhouse_https.go
+++ b/config/plugins/endpoints/clickhouse_https.go
@@ -5,14 +5,25 @@ package endpoints
 // so rules can target both via `endpoints = [ch-https, ch-native]`.
 
 import (
+	"net/http"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/config"
 )
 
 // ClickhouseHTTPSEndpoint is part of the clawpatrol plugin API.
+//
+// Database, when set, restricts this endpoint to requests whose
+// agent-declared database (the `database` URL query parameter or
+// `X-ClickHouse-Database` header, query wins when both are set)
+// equals the configured value. Unset = catch-all: the endpoint claims
+// every request to its host regardless of database. Specific beats
+// catch-all when both are bound to the same host.
 type ClickhouseHTTPSEndpoint struct {
 	Hosts      []string `hcl:"hosts"`
+	Database   string   `hcl:"database,optional"`
 	Credential string   `hcl:"credential,optional"`
 }
 
@@ -22,6 +33,67 @@ func (e *ClickhouseHTTPSEndpoint) EndpointHosts() []string { return e.Hosts }
 // EndpointCredentials is part of the clawpatrol plugin API.
 func (e *ClickhouseHTTPSEndpoint) EndpointCredentials() []config.CredBinding {
 	return singleBinding(e.Credential)
+}
+
+// DispatchDatabase opts the endpoint into the compile-time
+// database-routing uniqueness check (config.DatabaseRouter).
+func (e *ClickhouseHTTPSEndpoint) DispatchDatabase() string { return e.Database }
+
+// ClickhouseHTTPSDatabaseFromRequest extracts the agent-declared
+// database from a ClickHouse HTTPS request. ClickHouse accepts the
+// target database two ways: the `database` URL query parameter or
+// the `X-ClickHouse-Database` header; the query parameter takes
+// precedence when both are set, mirroring clickhouse-server's own
+// resolution order. Returns "" when neither is set.
+func ClickhouseHTTPSDatabaseFromRequest(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+	if req.URL != nil {
+		if v := req.URL.Query().Get("database"); v != "" {
+			return v
+		}
+	}
+	if req.Header != nil {
+		if v := req.Header.Get("X-ClickHouse-Database"); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// PickClickhouseHTTPSEndpointByDatabase chooses an endpoint from a
+// set of clickhouse_https candidates whose Database fields disagree.
+// Precedence: a candidate whose Database matches db exactly wins
+// over a catch-all (Database == ""). When no specific candidate
+// matches, the catch-all is returned. Returns nil only when the
+// input is empty.
+//
+// Callers — once the HTTPS MITM request loop wires
+// clickhouse_https endpoints — pass every endpoint that claims the
+// SNI'd host (typically from a per-host candidate list built at
+// policy compile time) and the request's database, computed via
+// ClickhouseHTTPSDatabaseFromRequest.
+func PickClickhouseHTTPSEndpointByDatabase(candidates []*ClickhouseHTTPSEndpoint, db string) *ClickhouseHTTPSEndpoint {
+	if len(candidates) == 0 {
+		return nil
+	}
+	var catchAll *ClickhouseHTTPSEndpoint
+	for _, c := range candidates {
+		if c == nil {
+			continue
+		}
+		if c.Database == "" {
+			if catchAll == nil {
+				catchAll = c
+			}
+			continue
+		}
+		if c.Database == db {
+			return c
+		}
+	}
+	return catchAll
 }
 
 func init() {
@@ -35,6 +107,9 @@ func init() {
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
+			if e.Database != "" {
+				b.SetAttributeValue("database", cty.StringVal(e.Database))
+			}
 			if e.Credential != "" {
 				config.SetIdent(b, "credential", e.Credential)
 			}

--- a/config/plugins/endpoints/clickhouse_native.go
+++ b/config/plugins/endpoints/clickhouse_native.go
@@ -44,11 +44,18 @@ import (
 // same name: when true and tls is on, the gateway skips upstream cert
 // validation. Use for self-hosted ClickHouse fronted by a private CA.
 // Default false keeps full validation against system roots.
+// Database, when set, restricts this endpoint to connections whose
+// agent-declared database (Hello.Database) equals the configured
+// value. Unset = catch-all: the endpoint claims connections to its
+// host regardless of database, which preserves the v1 single-endpoint
+// behavior. Specific beats catch-all when both are bound to the same
+// host (the dispatcher reads Hello before picking).
 type ClickhouseNativeEndpoint struct {
 	Hosts                    []string `hcl:"hosts"`
 	Port                     int      `hcl:"port,optional"`
 	TLS                      bool     `hcl:"tls,optional"`
 	AcceptInvalidCertificate bool     `hcl:"accept_invalid_certificate,optional"`
+	Database                 string   `hcl:"database,optional"`
 	Credential               string   `hcl:"credential,optional"`
 }
 
@@ -75,6 +82,12 @@ func (e *ClickhouseNativeEndpoint) EndpointHosts() []string {
 func (e *ClickhouseNativeEndpoint) EndpointCredentials() []config.CredBinding {
 	return singleBinding(e.Credential)
 }
+
+// DispatchDatabase opts the endpoint into the compile-time
+// database-routing uniqueness check (config.DatabaseRouter). The
+// runtime reads the value via the same accessor when picking among
+// candidate endpoints that share a host.
+func (e *ClickhouseNativeEndpoint) DispatchDatabase() string { return e.Database }
 
 // RequiresVIP opts the endpoint into DNS-VIP interception. The wire
 // protocol carries no SNI / Host header, so the gateway can't
@@ -146,11 +159,51 @@ func init() {
 			if e.AcceptInvalidCertificate {
 				b.SetAttributeValue("accept_invalid_certificate", cty.BoolVal(true))
 			}
+			if e.Database != "" {
+				b.SetAttributeValue("database", cty.StringVal(e.Database))
+			}
 			if e.Credential != "" {
 				config.SetIdent(b, "credential", e.Credential)
 			}
 		},
 	})
+}
+
+// pickClickhouseNativeByDatabase chooses an endpoint from a set of
+// clickhouse_native candidates whose Database fields disagree.
+// Candidates are the same-host siblings the dispatcher saw at
+// dispatch time; database is Hello.Database read from the agent's
+// session-startup packet. Precedence: a candidate whose Database
+// equals database wins; otherwise the catch-all (Database == "")
+// wins. Returns nil when the input is empty OR when there is no
+// catch-all and no specific match — the dispatcher then refuses the
+// connection rather than silently routing through an unrelated
+// endpoint. The compile pass already rejected duplicate (host,
+// Database) pairs, so the picked endpoint is unambiguous.
+func pickClickhouseNativeByDatabase(candidates []*config.CompiledEndpoint, database string) *config.CompiledEndpoint {
+	if len(candidates) == 0 {
+		return nil
+	}
+	var catchAll *config.CompiledEndpoint
+	for _, c := range candidates {
+		if c == nil {
+			continue
+		}
+		body, ok := c.Body.(*ClickhouseNativeEndpoint)
+		if !ok {
+			continue
+		}
+		if body.Database == "" {
+			if catchAll == nil {
+				catchAll = c
+			}
+			continue
+		}
+		if body.Database == database {
+			return c
+		}
+	}
+	return catchAll
 }
 
 // validateClickhouseNativeEndpoint rejects accept_invalid_certificate

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -172,6 +172,41 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 		return fmt.Errorf("read hello: %w", err)
 	}
 
+	// Step 1.5: when more than one clickhouse_native endpoint claims
+	// this host (per-database routing), pick the endpoint whose
+	// `database` field matches Hello.Database. Specific beats
+	// catch-all (Database == ""); the compile pass already rejected
+	// two specifics on the same database or two catch-alls on the
+	// same host, so the choice is unambiguous. The dispatcher set
+	// ch.Endpoint to one of the candidates as an initial guess; we
+	// overwrite with the protocol-correct pick so downstream wiring
+	// (credential, rules, event Endpoint name) reflects the actual
+	// claim.
+	if len(ch.Candidates) > 1 {
+		picked := pickClickhouseNativeByDatabase(ch.Candidates, hello.Database)
+		if picked == nil {
+			chEmitError(ch, "no-endpoint-for-database", hello.Database)
+			return fmt.Errorf("clickhouse_native: no endpoint on host %q claims database %q", ch.UpstreamHost, hello.Database)
+		}
+		if picked != ch.Endpoint {
+			ch.Endpoint = picked
+			pickedEp, pickedOk := picked.Body.(*ClickhouseNativeEndpoint)
+			if !pickedOk {
+				err := fmt.Errorf("clickhouse_native runtime invoked on non-native endpoint %v", picked)
+				chEmitError(ch, "wrong-endpoint-type", picked.Name)
+				return err
+			}
+			chEp = pickedEp
+			// chPickUpstream depends on the picked endpoint's Hosts
+			// (and its default port); rebuild the upstream addr.
+			upstreamAddr = chPickUpstream(ch.Endpoint.Hosts, ch.UpstreamHost, ch.DstPort, chEp.port())
+			if upstreamAddr == "" {
+				chEmitError(ch, "no-host", ch.Endpoint.Name)
+				return fmt.Errorf("clickhouse_native endpoint %q has no host", ch.Endpoint.Name)
+			}
+		}
+	}
+
 	// Step 2: resolve credential and inject. Single-credential native
 	// endpoints today; multi-credential dispatch via placeholder lands
 	// when SQL parsing does in iter 2.

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -233,6 +233,15 @@ type ConnHandle struct {
 	// SNI the client sent. nil when the dispatcher can't mint
 	// (gateway has no CA).
 	MintCert func(host string) (*tls.Certificate, error)
+	// Candidates is the full set of endpoints (same plugin type) the
+	// dispatcher saw as eligible for this connection's dst — populated
+	// only when more than one endpoint matched the host. Plugins that
+	// route by an in-band field (clickhouse_native picks among multiple
+	// endpoints on the same host by Hello.Database) use it to re-pick
+	// the right endpoint after reading the protocol's intro packet.
+	// Empty / nil means the dispatcher already settled on Endpoint and
+	// the plugin should service the connection through it directly.
+	Candidates []*config.CompiledEndpoint
 }
 
 // ApproveCallRequest is what a ConnEndpointRuntime hands to

--- a/config/testdata/full.want.json
+++ b/config/testdata/full.want.json
@@ -351,6 +351,7 @@
             "clickhouse-o11y.example",
             "ch-o11y.internal.example"
           ],
+          "Database": "",
           "Credential": "ch-o11y"
         },
         "family": "sql",
@@ -364,6 +365,7 @@
           "Port": 0,
           "TLS": false,
           "AcceptInvalidCertificate": false,
+          "Database": "",
           "Credential": "ch-o11y"
         },
         "family": "sql",

--- a/main.go
+++ b/main.go
@@ -1426,7 +1426,35 @@ func (g *Gateway) handleVIPConn(c net.Conn, dstIP string, dstPort uint16) {
 		_ = c.Close()
 		return
 	}
-	g.dispatchConnEndpoint(c, dstIP, matchedPort, ep, hostname)
+	// Sibling candidates with the same plugin type — populated when the
+	// dispatcher sees more than one endpoint claiming this VIP and the
+	// plugin can re-pick after reading the protocol intro. Profile +
+	// port filter is applied here for the same reason it was for the
+	// primary pick above.
+	var candidates []*config.CompiledEndpoint
+	for _, h := range hits {
+		if h.Endpoint == nil || h.Endpoint.Plugin == nil {
+			continue
+		}
+		if h.Endpoint.Plugin.Type != ep.Plugin.Type {
+			continue
+		}
+		if profile != "" {
+			if prof, ok := policy.Profiles[profile]; ok {
+				if _, in := prof.Endpoints[h.Endpoint.Name]; !in {
+					continue
+				}
+			}
+		}
+		if dstPort != 0 && h.Port != 0 && dstPort != h.Port {
+			continue
+		}
+		candidates = append(candidates, h.Endpoint)
+	}
+	if len(candidates) <= 1 {
+		candidates = nil // single-endpoint host — plugin uses Endpoint directly
+	}
+	g.dispatchConnEndpoint(c, dstIP, matchedPort, ep, hostname, candidates)
 }
 
 // tryDirectIPConn is the post-VIP fallback that dispatches inbound
@@ -1459,16 +1487,46 @@ func (g *Gateway) tryDirectIPConn(c net.Conn, dstIP string, dstPort uint16) bool
 	if _, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime); !ok {
 		return false
 	}
-	g.dispatchConnEndpoint(c, dstIP, dstPort, ep, "")
+	// Sibling candidates: all endpoints the conn-index returned for
+	// this dst IP that share ep's plugin type and the device's
+	// profile. Same-IP siblings of a different plugin type can't
+	// co-claim this conn (the protocol-dispatch port already
+	// disambiguated them); endpoints outside the profile aren't
+	// reachable from this device.
+	var siblings []*config.CompiledEndpoint
+	prof, hasProf := policy.Profiles[profile]
+	for _, cnd := range candidates {
+		if cnd == nil || cnd.Plugin == nil {
+			continue
+		}
+		if cnd.Plugin.Type != ep.Plugin.Type {
+			continue
+		}
+		if profile != "" && hasProf {
+			if _, in := prof.Endpoints[cnd.Name]; !in {
+				continue
+			}
+		}
+		siblings = append(siblings, cnd)
+	}
+	if len(siblings) <= 1 {
+		siblings = nil
+	}
+	g.dispatchConnEndpoint(c, dstIP, dstPort, ep, "", siblings)
 	return true
 }
 
 // dispatchConnEndpoint hands one accepted conn to the endpoint's
 // ConnEndpointRuntime. Shared between handleVIPConn and
 // tryDirectIPConn; hostname is the agent-dialed name (set by the VIP
-// path, empty for direct-IP). Closes c on a runtime-mismatch fail
+// path, empty for direct-IP). When more than one endpoint of ep's
+// plugin type claims this dst, candidates is the full sibling set
+// (including ep) so a plugin that routes by an in-band field
+// (clickhouse_native's Hello.Database) can re-pick after reading the
+// protocol's intro packet. nil / single-entry candidates means the
+// dispatcher already settled. Closes c on a runtime-mismatch fail
 // path; otherwise the plugin owns the conn lifetime.
-func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16, ep *config.CompiledEndpoint, hostname string) {
+func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16, ep *config.CompiledEndpoint, hostname string, candidates []*config.CompiledEndpoint) {
 	connRT, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime)
 	if !ok {
 		log.Printf("conn dispatch: endpoint %q plugin lacks ConnEndpointRuntime", ep.Name)
@@ -1487,9 +1545,23 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 	if eventHost == "" {
 		eventHost = dstIP
 	}
-	ch := &runtime.ConnHandle{
+	// When the plugin can re-pick its endpoint from a candidate set
+	// (clickhouse_native by Hello.Database), the closures below must
+	// observe whatever ep the plugin landed on rather than the
+	// initial guess. Reading ch.Endpoint at call time covers both
+	// the no-re-pick case (single endpoint) and the post-intro
+	// switch. ch is wired in below.
+	var ch *runtime.ConnHandle
+	currentEP := func() *config.CompiledEndpoint {
+		if ch != nil && ch.Endpoint != nil {
+			return ch.Endpoint
+		}
+		return ep
+	}
+	ch = &runtime.ConnHandle{
 		Conn:         c,
 		Endpoint:     ep,
+		Candidates:   candidates,
 		Policy:       policy,
 		Profile:      profile,
 		PeerIP:       pip,
@@ -1511,28 +1583,30 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 			if addr == "" {
 				return nil, fmt.Errorf("conn dispatch: plugin gave empty upstream addr")
 			}
-			return g.dialThrough(ctx, ep, network, addr)
+			return g.dialThrough(ctx, currentEP(), network, addr)
 		},
 		Emit: func(ev runtime.ConnEvent) {
 			if g.sink == nil {
 				return
 			}
+			cep := currentEP()
 			g.sink.Emit(Event{
-				Mode: mode, Family: ep.Family, Host: eventHost, AgentIP: agentPip,
+				Mode: mode, Family: cep.Family, Host: eventHost, AgentIP: agentPip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,
-				Endpoint: ep.Name, Rule: ev.Rule,
+				Endpoint: cep.Name, Rule: ev.Rule,
 				Approver:     ev.Approver,
 				ApproverType: ev.ApproverType,
 				ApproverBy:   ev.ApproverBy,
 			})
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
+			cep := currentEP()
 			return g.runApproveChain(context.Background(), req.Stages, runApproveCtx{
 				AgentIP: agentPip, Host: eventHost, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
-				Endpoint: ep, Rule: req.Rule, Profile: profile,
+				Endpoint: cep, Rule: req.Rule, Profile: profile,
 			})
 		},
 	}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -341,11 +341,21 @@ Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_
 
 ### `endpoint "clickhouse_https" "<name>"`
 
+Is part of the clawpatrol plugin API.
+
+Database, when set, restricts this endpoint to requests whose
+agent-declared database (the `database` URL query parameter or
+`X-ClickHouse-Database` header, query wins when both are set)
+equals the configured value. Unset = catch-all: the endpoint claims
+every request to its host regardless of database. Specific beats
+catch-all when both are bound to the same host.
+
 Family: `sql`.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `hosts` | `[]string` | yes |  |
+| `database` | `string` | no |  |
 | `credential` | `ref(credential)` | no |  |
 
 ```hcl
@@ -375,6 +385,12 @@ AcceptInvalidCertificate mirrors clickhouse-client's flag of the
 same name: when true and tls is on, the gateway skips upstream cert
 validation. Use for self-hosted ClickHouse fronted by a private CA.
 Default false keeps full validation against system roots.
+Database, when set, restricts this endpoint to connections whose
+agent-declared database (Hello.Database) equals the configured
+value. Unset = catch-all: the endpoint claims connections to its
+host regardless of database, which preserves the v1 single-endpoint
+behavior. Specific beats catch-all when both are bound to the same
+host (the dispatcher reads Hello before picking).
 
 Family: `sql`.
 
@@ -384,6 +400,7 @@ Family: `sql`.
 | `port` | `int` | no |  |
 | `tls` | `bool` | no |  |
 | `accept_invalid_certificate` | `bool` | no |  |
+| `database` | `string` | no |  |
 | `credential` | `ref(credential)` | no |  |
 
 ```hcl


### PR DESCRIPTION
## Summary

- New optional `database` field on `clickhouse_native` and `clickhouse_https` endpoints. When set, only connections / requests whose agent-declared database matches are claimed; unset preserves today's catch-all behavior.
- Two endpoints can target the same host with different databases and different credentials — dispatch picks among them by the in-band database.

## Precedence rules

- A specific (`database = "X"`) beats a catch-all (no database) on the same host.
- Two specifics on the same `(host, database)` → compile error.
- Two catch-alls on the same host → compile error.
- Same `(host, database)` across different plugin types (native + https on shared infra) is fine.

## Dispatch indirection — clickhouse_native (Phase 2 option A)

The connection arrives at the WG forwarder before Hello is read, so the database isn't known at conn-accept time. Implemented as A) from the bead's options:

- `ConnIndex` / `dnsvip` already returns multiple endpoints when a host is multi-claimed; the gateway now threads the sibling set as `ConnHandle.Candidates`.
- `HandleConn` reads Hello, then re-picks the endpoint by `Hello.Database` and rebinds credential / upstream wiring before continuing into the existing per-session pump.
- Single-endpoint hosts skip the re-pick (`Candidates` nil) — zero overhead on the common shape.

## Dispatch — clickhouse_https

Per-request: `ClickhouseHTTPSDatabaseFromRequest` (query param wins over `X-ClickHouse-Database` header) + `PickClickhouseHTTPSEndpointByDatabase`. Hooked into the HTTPS MITM request loop when the loop grows clickhouse_https awareness; the schema + compile-time validation are in place today.

## Coordination with cl-cxre

cl-cxre adds a `sql.database` match facet (rule-level). This PR adds dispatch-time endpoint selection (endpoint-level). Both touch the same source data (`Hello.Database` / URL+header) but at different layers — once the endpoint is selected here, its rule's CEL condition can still read `sql.database` for additional filtering inside that endpoint's rule set. No code conflict.

## Out of scope

- Postgres equivalent (separate bead if wanted).
- Glob match on `database`.
- Mid-session database changes (USE / \\connect / SET database).
- Multi-database endpoints (one block claiming N specific databases).

## Test plan

- [x] Routing helpers: precedence + ambiguity + catch-all fallback (clickhouse_database_routing_test.go).
- [x] Compile-time validation: dup specifics, dup catch-alls, host:port normalization, cross-plugin no-conflict (compile_database_routing_test.go).
- [x] `go test ./...` passes.
- [x] `gofmt -l .`, `go vet ./...`, docgen regenerated.
- [ ] Manual: run gateway with two specifics + a catch-all and confirm dispatch lands on the right credential.