### PR TITLE
sqlite: force clawpatrol.db + WAL/SHM to mode 0600

### DIFF
--- a/db.go
+++ b/db.go
@@ -16,9 +16,11 @@ package main
 import (
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,11 +46,34 @@ func OpenDB(path string) (*sql.DB, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite ping: %w", err)
 	}
+	// Tighten file modes after the sqlite driver creates them. The
+	// driver creates files at process-umask (commonly 0644), but the
+	// DB holds the CA private key, OAuth tokens, and audit log —
+	// owner-only is the only correct mode. Idempotent: catches both
+	// fresh creates and existing files inherited from older installs.
+	// Mitigates security-review F-24.
+	tightenDBPerms(path)
 	if err := migrate(db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return db, nil
+}
+
+// tightenDBPerms chmods the sqlite db file plus its WAL/SHM
+// sidecars to 0600. Called after sql.Open + db.Ping. Missing files
+// are skipped (the WAL/SHM may not exist yet on fresh boots). Any
+// chmod failure is logged but doesn't block startup — the
+// warnIfStateLooselyPermissioned tripwire in main.go logs a follow-
+// up warning if the mode doesn't stick.
+func tightenDBPerms(dbPath string) {
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		err := os.Chmod(p, 0o600)
+		if err == nil || errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		log.Printf("warning: chmod %s 0600: %v", p, err)
+	}
 }
 
 // migrate applies any unapplied .sql files from migrations/sqlite/.

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenDB_FreshCreateIs0600 covers the common case: state_dir is
+// fresh, sqlite creates clawpatrol.db with its default mode (0644 on
+// systems with umask 022), OpenDB should tighten it.
+func TestOpenDB_FreshCreateIs0600(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "clawpatrol.db")
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, name := range []string{"clawpatrol.db", "clawpatrol.db-wal", "clawpatrol.db-shm"} {
+		p := filepath.Join(dir, name)
+		st, err := os.Stat(p)
+		if err != nil {
+			// WAL/SHM are created on first write; tolerate absence.
+			continue
+		}
+		if mode := st.Mode().Perm(); mode != 0o600 {
+			t.Errorf("%s mode = %#o, want 0600", name, mode)
+		}
+	}
+}
+
+// TestOpenDB_TightensExisting0644 covers the upgrade path: a DB file
+// inherited from an older clawpatrol that wrote 0644 should get
+// tightened on the next OpenDB.
+func TestOpenDB_TightensExisting0644(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "clawpatrol.db")
+
+	// Pre-create with the bad mode, simulating an old install.
+	f, err := os.OpenFile(dbPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+	_ = f.Close()
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	st, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("%s mode = %#o, want 0600 after OpenDB tightens it", dbPath, mode)
+	}
+}


### PR DESCRIPTION
## Summary

Closes **F-24** in `security-review.md`. `clawpatrol.db`, plus its WAL/SHM sidecars, end up at mode 0644 on creation because the modernc.org/sqlite driver uses process umask. The DB holds the CA private key, OAuth tokens, and audit log — owner-only is the only correct mode.

Caught it on the new GCP gateway during smoke-test: the existing `warnIfStateLooselyPermissioned` tripwire fired with `warning: /var/lib/clawpatrol/clawpatrol.db has mode 0644 (want 0600)`.

## Fix

`OpenDB` (`db.go`) now chmods the DB + WAL + SHM to 0600 after `sql.Open` + `db.Ping`. Single function `tightenDBPerms`:

- Idempotent — runs every boot, catches both fresh creates and existing 0644 files inherited from older installs.
- Missing WAL/SHM (not yet created on a fresh boot) are skipped via `errors.Is(err, fs.ErrNotExist)`.
- Chmod failure logs a warning but doesn't block startup — the `warnIfStateLooselyPermissioned` tripwire in `main.go` stays in place as a defense-in-depth check for mode drift between boots.

## Tests

Two new tests in `db_test.go`:

- `TestOpenDB_FreshCreateIs0600`: fresh `state_dir`, `OpenDB` creates DB, mode checks at 0600 afterwards (WAL/SHM tolerated as absent on a fresh open with no writes).
- `TestOpenDB_TightensExisting0644`: pre-creates the file at 0644 (simulating an upgrade from an older clawpatrol), `OpenDB` tightens it to 0600.

Both pass; full suite still green.

## Defense-in-depth

This PR fixes the **file** layer. The **directory** layer was already 0700 via `StateDirectory=clawpatrol` in the recommended systemd unit, so a non-clawpatrol UID on the box couldn't traverse into the state dir anyway. After this PR, even if the directory mode drifts, the file mode keeps secrets owner-only. Both layers stay together: belt + suspenders.
