### PR TITLE
clawpatrol run: tsnet path + gateway advertise-exit-node

### DIFF
--- a/main.go
+++ b/main.go
@@ -2395,10 +2395,10 @@ usage:
                   --hostname NAME        device name to register (default: os.Hostname)
                   --profile NAME         suggest a profile for the approver
                   --whole-machine        bring up wg-quick (route all traffic)
+                  --tsnet-authkey KEY    onboard via embedded tsnet client (skips wg/host-tailscale)
+                  --tsnet-exit-node NAME gateway tailnet hostname or IP (required with --tsnet-authkey)
   clawpatrol login                       onboard this machine (tailscale path)
-  clawpatrol run -- <cmd> [args...]      route one process tree through gateway (WG via wg.conf)
-                  --tsnet-authkey KEY    use embedded tsnet client instead of WG
-                  --tsnet-exit-node NAME tailscale exit-node hostname or IP (required with --tsnet-authkey)
+  clawpatrol run -- <cmd> [args...]      route one process tree through gateway
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing

--- a/main.go
+++ b/main.go
@@ -2396,7 +2396,9 @@ usage:
                   --profile NAME         suggest a profile for the approver
                   --whole-machine        bring up wg-quick (route all traffic)
   clawpatrol login                       onboard this machine (tailscale path)
-  clawpatrol run -- <cmd> [args...]      route one process tree through gateway
+  clawpatrol run -- <cmd> [args...]      route one process tree through gateway (WG via wg.conf)
+                  --tsnet-authkey KEY    use embedded tsnet client instead of WG
+                  --tsnet-exit-node NAME tailscale exit-node hostname or IP (required with --tsnet-authkey)
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing

--- a/run_linux.go
+++ b/run_linux.go
@@ -79,15 +79,10 @@ func runRun(args []string) {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	confPath := fs.String("conf", defaultRunConf(), "path to wg conf written by `clawpatrol join`")
 	noAutoExpose := fs.Bool("no-auto-expose", false, "disable the seccomp relay that mirrors TCP listeners inside the netns back to the host")
-	tsnetAuthKey := fs.String("tsnet-authkey", os.Getenv("CLAWPATROL_RUN_TSNET_AUTHKEY"), "tailscale authkey for the embedded tsnet client (selects tsnet path; otherwise the WG `wg.conf` path is used)")
-	tsnetExitNode := fs.String("tsnet-exit-node", os.Getenv("CLAWPATROL_RUN_TSNET_EXIT_NODE"), "tailscale exit-node hostname or IP — required with --tsnet-authkey")
-	tsnetControlURL := fs.String("tsnet-control-url", os.Getenv("CLAWPATROL_RUN_TSNET_CONTROL_URL"), "override tailscale control-plane URL")
-	tsnetHostname := fs.String("tsnet-hostname", os.Getenv("CLAWPATROL_RUN_TSNET_HOSTNAME"), "tailscale hostname for the embedded tsnet client (default: clawpatrol-run-<pid>)")
-	tsnetStateDir := fs.String("tsnet-state-dir", os.Getenv("CLAWPATROL_RUN_TSNET_STATE_DIR"), "tsnet state dir (default: <clawpatrol-dir>/run-tsnet)")
 	_ = fs.Parse(args)
 	cmd := fs.Args()
 	if len(cmd) == 0 {
-		fail("usage: clawpatrol run [--conf <path>] [--no-auto-expose] [--tsnet-authkey KEY --tsnet-exit-node NAME-OR-IP] -- <cmd> [args...]")
+		fail("usage: clawpatrol run [--conf <path>] [--no-auto-expose] -- <cmd> [args...]")
 	}
 	// Honour both the flag and the env var so children re-execed by this
 	// process see the same setting without round-tripping the flag.
@@ -96,23 +91,17 @@ func runRun(args []string) {
 	}
 	autoExpose := os.Getenv(runNoAutoExposeEnv) != "1"
 
-	useTsnet := *tsnetAuthKey != ""
+	// `clawpatrol join --tsnet-authkey ...` persists node identity
+	// + exit-node config under defaultClawpatrolDir; presence of
+	// that bundle picks the tsnet path automatically. Operators
+	// that joined via the WG device-flow stay on the wg.conf path.
+	tsOpts, useTsnet := loadTsnetJoinConfig(defaultClawpatrolDir())
 	var cfg *runConf
-	if useTsnet {
-		if *tsnetExitNode == "" {
-			fail("tsnet path: --tsnet-exit-node (or CLAWPATROL_RUN_TSNET_EXIT_NODE) is required when --tsnet-authkey is set")
-		}
-		if *tsnetHostname == "" {
-			*tsnetHostname = fmt.Sprintf("clawpatrol-run-%d", os.Getpid())
-		}
-		if *tsnetStateDir == "" {
-			*tsnetStateDir = defaultTsnetStateDir()
-		}
-	} else {
+	if !useTsnet {
 		var err error
 		cfg, err = parseRunConf(*confPath)
 		if err != nil {
-			fail("conf %s: %v\n  hint: run `clawpatrol join <gw>` first, or use the tsnet path via --tsnet-authkey", *confPath, err)
+			fail("conf %s: %v\n  hint: run `clawpatrol join <gw>` first (or `clawpatrol join --tsnet-authkey KEY --tsnet-exit-node NAME <gw>` for the tsnet path)", *confPath, err)
 		}
 	}
 
@@ -124,7 +113,8 @@ func runRun(args []string) {
 	// Allocate a per-run ephemeral WireGuard identity so concurrent
 	// `clawpatrol run` invocations on the same machine don't share a
 	// keypair and fight over the gateway's WG session. Only meaningful
-	// for the WG path — tsnet does its own per-node identity via Dir.
+	// for the WG path — tsnet reuses the join-time node identity via
+	// the persisted state dir.
 	if !useTsnet {
 		cleanupEphemeral, _ := ephemeralPeer(cfg)
 		defer cleanupEphemeral()
@@ -199,11 +189,10 @@ func runRun(args []string) {
 		tsCtx, tsCancel := context.WithCancel(context.Background())
 		defer tsCancel()
 		al, cleanup, err := runTsnetParent(tsCtx, tunFd, tsnetRunOpts{
-			authKey:    *tsnetAuthKey,
-			controlURL: *tsnetControlURL,
-			hostname:   *tsnetHostname,
-			exitNode:   *tsnetExitNode,
-			stateDir:   *tsnetStateDir,
+			controlURL: tsOpts.controlURL,
+			hostname:   tsOpts.hostname,
+			exitNode:   tsOpts.exitNode,
+			stateDir:   tsOpts.clientDir,
 		}, stdLogger)
 		if err != nil {
 			_ = child.Process.Kill()

--- a/run_linux.go
+++ b/run_linux.go
@@ -31,6 +31,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -78,10 +79,15 @@ func runRun(args []string) {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	confPath := fs.String("conf", defaultRunConf(), "path to wg conf written by `clawpatrol join`")
 	noAutoExpose := fs.Bool("no-auto-expose", false, "disable the seccomp relay that mirrors TCP listeners inside the netns back to the host")
+	tsnetAuthKey := fs.String("tsnet-authkey", os.Getenv("CLAWPATROL_RUN_TSNET_AUTHKEY"), "tailscale authkey for the embedded tsnet client (selects tsnet path; otherwise the WG `wg.conf` path is used)")
+	tsnetExitNode := fs.String("tsnet-exit-node", os.Getenv("CLAWPATROL_RUN_TSNET_EXIT_NODE"), "tailscale exit-node hostname or IP — required with --tsnet-authkey")
+	tsnetControlURL := fs.String("tsnet-control-url", os.Getenv("CLAWPATROL_RUN_TSNET_CONTROL_URL"), "override tailscale control-plane URL")
+	tsnetHostname := fs.String("tsnet-hostname", os.Getenv("CLAWPATROL_RUN_TSNET_HOSTNAME"), "tailscale hostname for the embedded tsnet client (default: clawpatrol-run-<pid>)")
+	tsnetStateDir := fs.String("tsnet-state-dir", os.Getenv("CLAWPATROL_RUN_TSNET_STATE_DIR"), "tsnet state dir (default: <clawpatrol-dir>/run-tsnet)")
 	_ = fs.Parse(args)
 	cmd := fs.Args()
 	if len(cmd) == 0 {
-		fail("usage: clawpatrol run [--conf <path>] [--no-auto-expose] -- <cmd> [args...]")
+		fail("usage: clawpatrol run [--conf <path>] [--no-auto-expose] [--tsnet-authkey KEY --tsnet-exit-node NAME-OR-IP] -- <cmd> [args...]")
 	}
 	// Honour both the flag and the env var so children re-execed by this
 	// process see the same setting without round-tripping the flag.
@@ -90,9 +96,24 @@ func runRun(args []string) {
 	}
 	autoExpose := os.Getenv(runNoAutoExposeEnv) != "1"
 
-	cfg, err := parseRunConf(*confPath)
-	if err != nil {
-		fail("conf %s: %v\n  hint: run `clawpatrol join <gw>` first", *confPath, err)
+	useTsnet := *tsnetAuthKey != ""
+	var cfg *runConf
+	if useTsnet {
+		if *tsnetExitNode == "" {
+			fail("tsnet path: --tsnet-exit-node (or CLAWPATROL_RUN_TSNET_EXIT_NODE) is required when --tsnet-authkey is set")
+		}
+		if *tsnetHostname == "" {
+			*tsnetHostname = fmt.Sprintf("clawpatrol-run-%d", os.Getpid())
+		}
+		if *tsnetStateDir == "" {
+			*tsnetStateDir = defaultTsnetStateDir()
+		}
+	} else {
+		var err error
+		cfg, err = parseRunConf(*confPath)
+		if err != nil {
+			fail("conf %s: %v\n  hint: run `clawpatrol join <gw>` first, or use the tsnet path via --tsnet-authkey", *confPath, err)
+		}
 	}
 
 	checkUserNS()
@@ -102,9 +123,12 @@ func runRun(args []string) {
 
 	// Allocate a per-run ephemeral WireGuard identity so concurrent
 	// `clawpatrol run` invocations on the same machine don't share a
-	// keypair and fight over the gateway's WG session.
-	cleanupEphemeral, _ := ephemeralPeer(cfg)
-	defer cleanupEphemeral()
+	// keypair and fight over the gateway's WG session. Only meaningful
+	// for the WG path — tsnet does its own per-node identity via Dir.
+	if !useTsnet {
+		cleanupEphemeral, _ := ephemeralPeer(cfg)
+		defer cleanupEphemeral()
+	}
 
 	// socketpair: TUN fd handoff (child→parent) via SCM_RIGHTS.
 	// pipe: parent signals child "WG is up, finish setup".
@@ -165,32 +189,69 @@ func runRun(args []string) {
 		fail("recv tun fd: %v", err)
 	}
 
-	tunDev := newRawFDTun(tunFd)
-	baseLogger := device.NewLogger(device.LogLevelError, "[clawpatrol run] ")
-	// Wrap the wireguard-go logger so the keypair-derivation failure
-	// short-circuits the watchdog poll loop — see denoland/orchid#45.
-	forceReset := make(chan struct{}, 1)
-	logger := wrapWGLogger(baseLogger, forceReset)
-	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
-	if err := dev.IpcSet(buildWGIpc(cfg)); err != nil {
-		_ = child.Process.Kill()
-		fail("wg ipc: %v", err)
-	}
-	if err := dev.Up(); err != nil {
-		_ = child.Process.Kill()
-		fail("wg up: %v", err)
-	}
-	defer dev.Close()
+	// Bring the parent-side stack up around tunFd. Both branches end
+	// up writing the netns-side address line ("v4/32, v6/128") to the
+	// child via wgUpW, then closing the pipe to release the child's
+	// blocking read.
+	var addrLine string
+	if useTsnet {
+		stdLogger := log.New(os.Stderr, "[clawpatrol run tsnet] ", log.LstdFlags)
+		tsCtx, tsCancel := context.WithCancel(context.Background())
+		defer tsCancel()
+		al, cleanup, err := runTsnetParent(tsCtx, tunFd, tsnetRunOpts{
+			authKey:    *tsnetAuthKey,
+			controlURL: *tsnetControlURL,
+			hostname:   *tsnetHostname,
+			exitNode:   *tsnetExitNode,
+			stateDir:   *tsnetStateDir,
+		}, stdLogger)
+		if err != nil {
+			_ = child.Process.Kill()
+			fail("tsnet: %v", err)
+		}
+		defer cleanup()
+		addrLine = al
+	} else {
+		tunDev := newRawFDTun(tunFd)
+		baseLogger := device.NewLogger(device.LogLevelError, "[clawpatrol run] ")
+		// Wrap the wireguard-go logger so the keypair-derivation failure
+		// short-circuits the watchdog poll loop — see denoland/orchid#45.
+		forceReset := make(chan struct{}, 1)
+		logger := wrapWGLogger(baseLogger, forceReset)
+		dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
+		if err := dev.IpcSet(buildWGIpc(cfg)); err != nil {
+			_ = child.Process.Kill()
+			fail("wg ipc: %v", err)
+		}
+		if err := dev.Up(); err != nil {
+			_ = child.Process.Kill()
+			fail("wg up: %v", err)
+		}
+		defer dev.Close()
 
-	// Watchdog reruns the original IpcSet on a stuck handshake; that
-	// wipes the wireguard-go peer trie and triggers a fresh initiation.
-	wdCtx, wdCancel := context.WithCancel(context.Background())
-	defer wdCancel()
-	go runWGWatchdog(wdCtx, dev, baseLogger, forceReset, func() error {
-		return dev.IpcSet(buildWGIpc(cfg))
-	})
+		// Watchdog reruns the original IpcSet on a stuck handshake; that
+		// wipes the wireguard-go peer trie and triggers a fresh initiation.
+		wdCtx, wdCancel := context.WithCancel(context.Background())
+		defer wdCancel()
+		go runWGWatchdog(wdCtx, dev, baseLogger, forceReset, func() error {
+			return dev.IpcSet(buildWGIpc(cfg))
+		})
 
-	_, _ = wgUpW.Write([]byte{1})
+		addrLine = cfg.Address
+	}
+
+	// Length-prefixed payload (1 length byte + N address bytes). Empty
+	// payload means "child should fall back to env-derived addresses"
+	// — current callers always send something, but the byte stays cheap
+	// and keeps the framing simple.
+	if len(addrLine) > 255 {
+		_ = child.Process.Kill()
+		fail("addr line too long (%d bytes)", len(addrLine))
+	}
+	if _, err := wgUpW.Write(append([]byte{byte(len(addrLine))}, []byte(addrLine)...)); err != nil {
+		_ = child.Process.Kill()
+		fail("write addr to child: %v", err)
+	}
 	_ = wgUpW.Close()
 
 	// Second SCM_RIGHTS message from the child: [notify_fd, sup_sock] for
@@ -269,22 +330,35 @@ func runRunChild() {
 	// auto-expose relay fds once the netns is fully plumbed.
 	_ = unix.Close(tunFd)
 
-	one := make([]byte, 1)
-	if _, err := io.ReadFull(wgUpR, one); err != nil {
+	// Parent sends a 1-byte length followed by the address line. The
+	// fallback to wg.conf / CLAWPATROL_EPHEMERAL_ADDR only fires when
+	// the parent explicitly leaves the payload empty.
+	lenBuf := make([]byte, 1)
+	if _, err := io.ReadFull(wgUpR, lenBuf); err != nil {
 		fail("wait wg-up: %v", err)
+	}
+	var addrSource string
+	if n := int(lenBuf[0]); n > 0 {
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(wgUpR, buf); err != nil {
+			fail("read addr from parent: %v", err)
+		}
+		addrSource = string(buf)
 	}
 	_ = wgUpR.Close()
 
-	cfg := mustParseRunConf(os.Getenv("CLAWPATROL_RUN_CONF"))
-	// CLAWPATROL_EPHEMERAL_ADDR overrides cfg.Address when the parent
-	// successfully registered an ephemeral WG identity for this run.
-	addrSource := cfg.Address
-	if ea := os.Getenv("CLAWPATROL_EPHEMERAL_ADDR"); ea != "" {
-		addrSource = ea
+	if addrSource == "" {
+		cfg := mustParseRunConf(os.Getenv("CLAWPATROL_RUN_CONF"))
+		// CLAWPATROL_EPHEMERAL_ADDR overrides cfg.Address when the parent
+		// successfully registered an ephemeral WG identity for this run.
+		addrSource = cfg.Address
+		if ea := os.Getenv("CLAWPATROL_EPHEMERAL_ADDR"); ea != "" {
+			addrSource = ea
+		}
 	}
 	addrs := splitWGAddresses(addrSource)
 	if len(addrs) == 0 {
-		fail("wg conf: empty Address")
+		fail("empty netns address")
 	}
 	steps := [][]string{
 		{"ip", "link", "set", "lo", "up"},

--- a/run_tsnet.go
+++ b/run_tsnet.go
@@ -1,0 +1,79 @@
+package main
+
+// Cross-platform tsnet helpers shared by `clawpatrol join` (CA fetch
+// + node-state seeding) and `clawpatrol run` (per-namespace
+// bring-up). The Linux-specific TUN handoff lives in
+// run_tsnet_linux.go; everything that can be expressed without a
+// tun.Device sits here so the same tsnet glue compiles on both
+// linux and darwin.
+
+import (
+	"fmt"
+	"net/netip"
+	"path/filepath"
+	"strings"
+
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+)
+
+// exitNodePrefs resolves the operator's exit-node value to an IP and
+// packages it as a MaskedPrefs. IP literals go straight in;
+// anything else is matched (case-insensitively) against peer Hostname
+// / DNSName. We surface a clear error when the gateway isn't visible
+// yet so the operator hits a real failure ("no peer matched") rather
+// than silently routing in the clear.
+func exitNodePrefs(status *ipnstate.Status, exitNode string) (*ipn.MaskedPrefs, error) {
+	if ip, err := netip.ParseAddr(exitNode); err == nil {
+		return &ipn.MaskedPrefs{
+			ExitNodeIPSet: true,
+			Prefs:         ipn.Prefs{ExitNodeIP: ip},
+		}, nil
+	}
+	want := strings.ToLower(strings.TrimSuffix(exitNode, "."))
+	for _, p := range status.Peer {
+		if p == nil {
+			continue
+		}
+		dns := strings.ToLower(strings.TrimSuffix(p.DNSName, "."))
+		host := strings.ToLower(p.HostName)
+		// MagicDNS DNSNames look like "host.tail-xxxx.ts.net"; an
+		// operator supplying just "host" should still match.
+		if want == host || want == dns || strings.HasPrefix(dns, want+".") {
+			if len(p.TailscaleIPs) == 0 {
+				return nil, fmt.Errorf("tsnet exit-node %q matched peer but it has no tailnet IP yet", exitNode)
+			}
+			return &ipn.MaskedPrefs{
+				ExitNodeIPSet: true,
+				Prefs:         ipn.Prefs{ExitNodeIP: p.TailscaleIPs[0]},
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("tsnet exit-node %q: no peer matched (peer must be online and visible to this tailnet)", exitNode)
+}
+
+// joinAddrs renders a slice of "ip/prefix" strings into the wg-quick
+// `Address =` style ("v4/32, v6/128") that the netns-side child
+// passes to `ip addr add`.
+func joinAddrs(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	default:
+		out := parts[0]
+		for _, p := range parts[1:] {
+			out += ", " + p
+		}
+		return out
+	}
+}
+
+// defaultTsnetClientDir is the on-disk path holding the tsnet client
+// node identity persisted by `clawpatrol join` and reused by
+// `clawpatrol run`. Living under defaultClawpatrolDir keeps it next
+// to ca.crt / api-token / wg.conf — the join's other side-effects.
+func defaultTsnetClientDir() string {
+	return filepath.Join(defaultClawpatrolDir(), tsnetClientDir)
+}

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -21,48 +21,40 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/netip"
 	"os"
-	"path/filepath"
-	"strings"
 
 	tstun "github.com/tailscale/wireguard-go/tun"
-	"tailscale.com/ipn"
-	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tsnet"
 )
 
 type tsnetRunOpts struct {
-	authKey    string
 	controlURL string
 	hostname   string
 	exitNode   string // hostname or IP of the gateway exit node
-	stateDir   string
+	stateDir   string // populated by `clawpatrol join`; carries node identity
 }
 
 // runTsnetParent brings up the embedded tsnet node bound to tunFd
 // (handed up from the namespaced child), points it at the operator's
 // gateway as an exit node, and returns the netns-side address line
 // (`v4/32, v6/128`) the child must `ip addr add` plus a cleanup that
-// tears tsnet down.
+// tears tsnet down. Node identity comes from opts.stateDir, which
+// `clawpatrol join` seeded with the one-shot authkey — no authkey is
+// needed at run time.
 func runTsnetParent(ctx context.Context, tunFd int, opts tsnetRunOpts, logger *log.Logger) (addrLine string, cleanup func(), err error) {
-	if opts.authKey == "" {
-		return "", nil, errors.New("tsnet: empty authkey")
-	}
 	if opts.exitNode == "" {
-		return "", nil, errors.New("tsnet: --tsnet-exit-node is required (gateway hostname or tailnet IP)")
+		return "", nil, errors.New("tsnet: empty exit-node (run `clawpatrol join --tsnet-authkey ... --tsnet-exit-node ...`)")
 	}
 	if opts.stateDir == "" {
 		return "", nil, errors.New("tsnet: empty state dir")
 	}
-	if err := os.MkdirAll(opts.stateDir, 0o700); err != nil {
-		return "", nil, fmt.Errorf("tsnet state dir: %w", err)
+	if _, err := os.Stat(opts.stateDir); err != nil {
+		return "", nil, fmt.Errorf("tsnet state dir %s: %w (run `clawpatrol join --tsnet-authkey ... --tsnet-exit-node ...` first)", opts.stateDir, err)
 	}
 
 	tunDev := newTsnetFDTun(tunFd)
 	srv := &tsnet.Server{
 		Hostname:   opts.hostname,
-		AuthKey:    opts.authKey,
 		ControlURL: opts.controlURL,
 		Dir:        opts.stateDir,
 		Tun:        tunDev,
@@ -109,63 +101,6 @@ func runTsnetParent(ctx context.Context, tunFd int, opts tsnetRunOpts, logger *l
 	addrLine = joinAddrs(parts)
 	logger.Printf("tsnet: joined as %q (%s); exit-node=%s", srv.Hostname, addrLine, opts.exitNode)
 	return addrLine, closer, nil
-}
-
-// exitNodePrefs resolves the operator's --tsnet-exit-node value to an
-// IP and packages it as a MaskedPrefs. IP literals go straight in;
-// anything else is matched (case-insensitively) against peer Hostname
-// / DNSName. We surface a clear error when the gateway isn't visible
-// yet so the operator hits a real failure ("no peer matched") rather
-// than silently routing in the clear.
-func exitNodePrefs(status *ipnstate.Status, exitNode string) (*ipn.MaskedPrefs, error) {
-	if ip, err := netip.ParseAddr(exitNode); err == nil {
-		return &ipn.MaskedPrefs{
-			ExitNodeIPSet: true,
-			Prefs:         ipn.Prefs{ExitNodeIP: ip},
-		}, nil
-	}
-	want := strings.ToLower(strings.TrimSuffix(exitNode, "."))
-	for _, p := range status.Peer {
-		if p == nil {
-			continue
-		}
-		dns := strings.ToLower(strings.TrimSuffix(p.DNSName, "."))
-		host := strings.ToLower(p.HostName)
-		// MagicDNS DNSNames look like "host.tail-xxxx.ts.net"; an
-		// operator supplying just "host" should still match.
-		if want == host || want == dns || strings.HasPrefix(dns, want+".") {
-			if len(p.TailscaleIPs) == 0 {
-				return nil, fmt.Errorf("tsnet exit-node %q matched peer but it has no tailnet IP yet", exitNode)
-			}
-			return &ipn.MaskedPrefs{
-				ExitNodeIPSet: true,
-				Prefs:         ipn.Prefs{ExitNodeIP: p.TailscaleIPs[0]},
-			}, nil
-		}
-	}
-	return nil, fmt.Errorf("tsnet exit-node %q: no peer matched (peer must be online and visible to this tailnet)", exitNode)
-}
-
-func joinAddrs(parts []string) string {
-	switch len(parts) {
-	case 0:
-		return ""
-	case 1:
-		return parts[0]
-	default:
-		out := parts[0]
-		for _, p := range parts[1:] {
-			out += ", " + p
-		}
-		return out
-	}
-}
-
-// defaultTsnetStateDir places per-run tsnet state under the user's
-// clawpatrol dir so credentials persist across `clawpatrol run`
-// invocations and the second run is a fast warm-cache join.
-func defaultTsnetStateDir() string {
-	return filepath.Join(defaultClawpatrolDir(), "run-tsnet")
 }
 
 // --- TUN adapter for tailscale's wireguard-go fork ----------------

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -1,0 +1,216 @@
+//go:build linux
+
+package main
+
+// tsnet path for `clawpatrol run`. Mirrors the WG path's plumbing —
+// child opens TUN inside an unprivileged netns, parent owns the TUN
+// fd and drives the network stack — but swaps wireguard-go for an
+// embedded `tsnet.Server` that joins a tailnet via a literal authkey
+// and uses the operator-supplied gateway as its `ExitNodeIP` /
+// `ExitNodeID`. The tsnet stack writes inbound packets to the TUN
+// (visible inside the netns) and reads outbound packets from it,
+// encrypts them with wgengine, and ships them out over the parent's
+// host-netns UDP socket.
+//
+// Selection: `--tsnet-authkey` (or `CLAWPATROL_RUN_TSNET_AUTHKEY`) is
+// the trigger. When set, the WG `wg.conf` / ephemeral-peer code path
+// is skipped entirely; otherwise behaviour is unchanged.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tstun "github.com/tailscale/wireguard-go/tun"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tsnet"
+)
+
+type tsnetRunOpts struct {
+	authKey    string
+	controlURL string
+	hostname   string
+	exitNode   string // hostname or IP of the gateway exit node
+	stateDir   string
+}
+
+// runTsnetParent brings up the embedded tsnet node bound to tunFd
+// (handed up from the namespaced child), points it at the operator's
+// gateway as an exit node, and returns the netns-side address line
+// (`v4/32, v6/128`) the child must `ip addr add` plus a cleanup that
+// tears tsnet down.
+func runTsnetParent(ctx context.Context, tunFd int, opts tsnetRunOpts, logger *log.Logger) (addrLine string, cleanup func(), err error) {
+	if opts.authKey == "" {
+		return "", nil, errors.New("tsnet: empty authkey")
+	}
+	if opts.exitNode == "" {
+		return "", nil, errors.New("tsnet: --tsnet-exit-node is required (gateway hostname or tailnet IP)")
+	}
+	if opts.stateDir == "" {
+		return "", nil, errors.New("tsnet: empty state dir")
+	}
+	if err := os.MkdirAll(opts.stateDir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("tsnet state dir: %w", err)
+	}
+
+	tunDev := newTsnetFDTun(tunFd)
+	srv := &tsnet.Server{
+		Hostname:   opts.hostname,
+		AuthKey:    opts.authKey,
+		ControlURL: opts.controlURL,
+		Dir:        opts.stateDir,
+		Tun:        tunDev,
+		Logf:       func(f string, args ...any) { logger.Printf(f, args...) },
+	}
+
+	closer := func() {
+		_ = srv.Close()
+	}
+
+	status, err := srv.Up(ctx)
+	if err != nil {
+		closer()
+		return "", nil, fmt.Errorf("tsnet up: %w", err)
+	}
+	if len(status.TailscaleIPs) == 0 {
+		closer()
+		return "", nil, errors.New("tsnet: no tailnet IP after Up")
+	}
+
+	mp, err := exitNodePrefs(status, opts.exitNode)
+	if err != nil {
+		closer()
+		return "", nil, err
+	}
+	lc, err := srv.LocalClient()
+	if err != nil {
+		closer()
+		return "", nil, fmt.Errorf("tsnet local client: %w", err)
+	}
+	if _, err := lc.EditPrefs(ctx, mp); err != nil {
+		closer()
+		return "", nil, fmt.Errorf("tsnet edit prefs (exit node): %w", err)
+	}
+
+	var parts []string
+	for _, ip := range status.TailscaleIPs {
+		if ip.Is4() {
+			parts = append(parts, ip.String()+"/32")
+		} else {
+			parts = append(parts, ip.String()+"/128")
+		}
+	}
+	addrLine = joinAddrs(parts)
+	logger.Printf("tsnet: joined as %q (%s); exit-node=%s", srv.Hostname, addrLine, opts.exitNode)
+	return addrLine, closer, nil
+}
+
+// exitNodePrefs resolves the operator's --tsnet-exit-node value to an
+// IP and packages it as a MaskedPrefs. IP literals go straight in;
+// anything else is matched (case-insensitively) against peer Hostname
+// / DNSName. We surface a clear error when the gateway isn't visible
+// yet so the operator hits a real failure ("no peer matched") rather
+// than silently routing in the clear.
+func exitNodePrefs(status *ipnstate.Status, exitNode string) (*ipn.MaskedPrefs, error) {
+	if ip, err := netip.ParseAddr(exitNode); err == nil {
+		return &ipn.MaskedPrefs{
+			ExitNodeIPSet: true,
+			Prefs:         ipn.Prefs{ExitNodeIP: ip},
+		}, nil
+	}
+	want := strings.ToLower(strings.TrimSuffix(exitNode, "."))
+	for _, p := range status.Peer {
+		if p == nil {
+			continue
+		}
+		dns := strings.ToLower(strings.TrimSuffix(p.DNSName, "."))
+		host := strings.ToLower(p.HostName)
+		// MagicDNS DNSNames look like "host.tail-xxxx.ts.net"; an
+		// operator supplying just "host" should still match.
+		if want == host || want == dns || strings.HasPrefix(dns, want+".") {
+			if len(p.TailscaleIPs) == 0 {
+				return nil, fmt.Errorf("tsnet exit-node %q matched peer but it has no tailnet IP yet", exitNode)
+			}
+			return &ipn.MaskedPrefs{
+				ExitNodeIPSet: true,
+				Prefs:         ipn.Prefs{ExitNodeIP: p.TailscaleIPs[0]},
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("tsnet exit-node %q: no peer matched (peer must be online and visible to this tailnet)", exitNode)
+}
+
+func joinAddrs(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	default:
+		out := parts[0]
+		for _, p := range parts[1:] {
+			out += ", " + p
+		}
+		return out
+	}
+}
+
+// defaultTsnetStateDir places per-run tsnet state under the user's
+// clawpatrol dir so credentials persist across `clawpatrol run`
+// invocations and the second run is a fast warm-cache join.
+func defaultTsnetStateDir() string {
+	return filepath.Join(defaultClawpatrolDir(), "run-tsnet")
+}
+
+// --- TUN adapter for tailscale's wireguard-go fork ----------------
+
+// tsnetFDTun mirrors rawFDTun (zx2c4 fork) but satisfies the tailscale
+// fork's tun.Device interface. tsnet imports
+// github.com/tailscale/wireguard-go/tun, whose Event type is distinct
+// from zx2c4's despite being structurally identical, so the adapter
+// has to be duplicated even though the read/write halves are byte-
+// identical.
+type tsnetFDTun struct {
+	f      *os.File
+	events chan tstun.Event
+}
+
+func newTsnetFDTun(fd int) *tsnetFDTun {
+	t := &tsnetFDTun{
+		f:      os.NewFile(uintptr(fd), tunIfName),
+		events: make(chan tstun.Event, 1),
+	}
+	t.events <- tstun.EventUp
+	return t
+}
+
+func (t *tsnetFDTun) File() *os.File             { return t.f }
+func (t *tsnetFDTun) Name() (string, error)      { return tunIfName, nil }
+func (t *tsnetFDTun) MTU() (int, error)          { return tunMTU, nil }
+func (t *tsnetFDTun) Events() <-chan tstun.Event { return t.events }
+func (t *tsnetFDTun) BatchSize() int             { return 1 }
+func (t *tsnetFDTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	n, err := t.f.Read(bufs[0][offset:])
+	if n > 0 {
+		sizes[0] = n
+	}
+	return 1, err
+}
+func (t *tsnetFDTun) Write(bufs [][]byte, offset int) (int, error) {
+	for _, b := range bufs {
+		if _, err := t.f.Write(b[offset:]); err != nil {
+			return 0, err
+		}
+	}
+	return len(bufs), nil
+}
+func (t *tsnetFDTun) Close() error {
+	close(t.events)
+	return t.f.Close()
+}

--- a/run_tsnet_linux_test.go
+++ b/run_tsnet_linux_test.go
@@ -1,0 +1,115 @@
+//go:build linux
+
+package main
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/key"
+)
+
+func TestExitNodePrefsByIP(t *testing.T) {
+	mp, err := exitNodePrefs(&ipnstate.Status{}, "100.64.0.7")
+	if err != nil {
+		t.Fatalf("exitNodePrefs by IP: %v", err)
+	}
+	if !mp.ExitNodeIPSet {
+		t.Fatalf("ExitNodeIPSet not set")
+	}
+	if got := mp.Prefs.ExitNodeIP; got != netip.MustParseAddr("100.64.0.7") {
+		t.Fatalf("ExitNodeIP = %v, want 100.64.0.7", got)
+	}
+}
+
+func newPeerKey() key.NodePublic { return key.NewNode().Public() }
+
+func TestExitNodePrefsByHostname(t *testing.T) {
+	st := &ipnstate.Status{
+		Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+			newPeerKey(): {
+				HostName:     "clawpatrol-gateway",
+				DNSName:      "clawpatrol-gateway.tail-abc.ts.net.",
+				TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.7")},
+			},
+			newPeerKey(): {
+				HostName:     "other-node",
+				DNSName:      "other-node.tail-abc.ts.net.",
+				TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")},
+			},
+		},
+	}
+
+	cases := []string{
+		"clawpatrol-gateway",                  // bare hostname
+		"CLAWPATROL-GATEWAY",                  // case-insensitive
+		"clawpatrol-gateway.tail-abc.ts.net",  // FQDN sans dot
+		"clawpatrol-gateway.tail-abc.ts.net.", // FQDN with trailing dot
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			mp, err := exitNodePrefs(st, name)
+			if err != nil {
+				t.Fatalf("exitNodePrefs(%q): %v", name, err)
+			}
+			if got := mp.Prefs.ExitNodeIP; got != netip.MustParseAddr("100.64.0.7") {
+				t.Fatalf("got %v, want 100.64.0.7", got)
+			}
+		})
+	}
+}
+
+func TestExitNodePrefsNoMatch(t *testing.T) {
+	st := &ipnstate.Status{
+		Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+			newPeerKey(): {
+				HostName:     "other-node",
+				DNSName:      "other-node.tail-abc.ts.net.",
+				TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")},
+			},
+		},
+	}
+	_, err := exitNodePrefs(st, "missing-host")
+	if err == nil {
+		t.Fatalf("expected error for missing peer")
+	}
+	if !strings.Contains(err.Error(), "no peer matched") {
+		t.Fatalf("error %q does not mention `no peer matched`", err)
+	}
+}
+
+func TestExitNodePrefsPeerWithoutIP(t *testing.T) {
+	st := &ipnstate.Status{
+		Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+			newPeerKey(): {
+				HostName: "pending-node",
+				DNSName:  "pending-node.tail-abc.ts.net.",
+			},
+		},
+	}
+	_, err := exitNodePrefs(st, "pending-node")
+	if err == nil || !strings.Contains(err.Error(), "no tailnet IP") {
+		t.Fatalf("expected `no tailnet IP` error, got %v", err)
+	}
+}
+
+func TestJoinAddrs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"100.64.0.5/32"}, "100.64.0.5/32"},
+		{"dual", []string{"100.64.0.5/32", "fd7a::5/128"}, "100.64.0.5/32, fd7a::5/128"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinAddrs(tc.in); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/setup.go
+++ b/setup.go
@@ -94,12 +94,32 @@ func runJoin(args []string) {
 	wholeMachine := fs.Bool("whole-machine", false, "bring up wg-quick to route ALL host traffic through the gateway (default: persist conf only, use `clawpatrol run` for per-process routing)")
 	profile := fs.String("profile", "", "profile to assign at approval time (defaults to the gateway's default profile if the approver doesn't pick one)")
 	hostname := fs.String("hostname", "", "device name to register with the gateway (defaults to os.Hostname)")
+	tsnetAuthKey := fs.String("tsnet-authkey", "", "tailscale authkey for the embedded tsnet client (selects tsnet onboarding; one-shot, not persisted to disk)")
+	tsnetExitNode := fs.String("tsnet-exit-node", "", "tailscale exit-node hostname or IP for the embedded tsnet client (required with --tsnet-authkey)")
+	tsnetControlURL := fs.String("tsnet-control-url", "", "override tailscale control-plane URL (Headscale etc.)")
+	tsnetHostname := fs.String("tsnet-hostname", "", "tailscale hostname for the embedded tsnet client (default: clawpatrol-<os.Hostname>)")
 	_ = fs.Parse(reorderJoinArgsForFlagParse(args))
 	rest := fs.Args()
 	if len(rest) != 1 || rest[0] == "" {
-		fail("usage: clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] <gateway-url>")
+		fail("usage: clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] [--tsnet-authkey KEY --tsnet-exit-node NAME-OR-IP] <gateway-url>")
 	}
 	gatewayURL := rest[0]
+	if *tsnetAuthKey != "" {
+		if *wholeMachine {
+			fail("--tsnet-authkey is incompatible with --whole-machine (tsnet-mode clients reach the gateway via tailnet, not wg-quick)")
+		}
+		if *tsnetExitNode == "" {
+			fail("--tsnet-exit-node is required with --tsnet-authkey (gateway's tailnet hostname or IP)")
+		}
+		runJoinTsnet(gatewayURL, *caOut, *skipTrust, tsnetJoinOpts{
+			authKey:    *tsnetAuthKey,
+			exitNode:   *tsnetExitNode,
+			controlURL: *tsnetControlURL,
+			hostname:   *tsnetHostname,
+			clientDir:  filepath.Join(*caOut, tsnetClientDir),
+		})
+		return
+	}
 	if *wholeMachine {
 		if local, reason := isLocalGateway(gatewayURL); local {
 			fail("refusing --whole-machine join: gateway URL points at this host (%s).\n"+
@@ -141,6 +161,34 @@ func runJoin(args []string) {
 		loginArgs = append(loginArgs, "-no-trust")
 	}
 	runLogin(loginArgs)
+}
+
+// runJoinTsnet handles the tsnet branch of `clawpatrol join`. The
+// flow skips the gateway-side device-flow / WG onboard entirely —
+// tsnet clients are recognised by the gateway via tailnet identity,
+// not a registered WG peer — so this is just CA fetch + tsnet
+// validate + persist.
+func runJoinTsnet(gatewayURL, caDir string, skipTrust bool, opts tsnetJoinOpts) {
+	setup, err := preJoinFetchCA(gatewayURL, caDir)
+	if err != nil {
+		fail("ca fetch: %v", err)
+	}
+	if err := runTsnetJoin(opts); err != nil {
+		fail("tsnet join: %v", err)
+	}
+	if err := persistTsnetJoinConfig(caDir, opts); err != nil {
+		fail("persist tsnet config: %v", err)
+	}
+	finishJoinSetup(&setup, skipTrust)
+	fmt.Println("Joined tailnet via embedded tsnet client.")
+	fmt.Printf("  exit-node: %s\n", opts.exitNode)
+	fmt.Printf("  state dir: %s\n", opts.clientDir)
+	if setup.caInstalled {
+		fmt.Println("  CA installed into system trust store.")
+	} else if setup.caHint != "" {
+		fmt.Println(setup.caHint)
+	}
+	fmt.Println("Run agents via `clawpatrol run -- <cmd> [args...]`.")
 }
 
 // joinSetup carries the post-join side-effect status so the caller

--- a/setup_tsnet.go
+++ b/setup_tsnet.go
@@ -1,0 +1,149 @@
+package main
+
+// tsnet onboarding for `clawpatrol join`. Walks an authkey-supplied
+// embedded tsnet bring-up, validates the operator's named gateway is
+// visible as a peer (so a typo isn't deferred to the next
+// `clawpatrol run`), then tears the node down — the persistent
+// node-state lives in `<dir>/tsnet-client/` so subsequent
+// `clawpatrol run` invocations resume the identity without ever
+// touching the (one-shot) authkey again.
+//
+// Joining this way is mutually exclusive with the WG / host-tailscale
+// paths: tsnet-mode clients reach the gateway via tailnet IP and
+// don't need a gateway-side WG peer registration, so the device-flow
+// onboard is skipped entirely. The CA fetch is shared.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"tailscale.com/tsnet"
+)
+
+const (
+	tsnetClientDir      = "tsnet-client"    // tsnet state dir under defaultClawpatrolDir
+	tsnetExitNodeFile   = "tsnet-exit-node" // hostname or IP of the gateway exit node
+	tsnetControlURLFile = "tsnet-control-url"
+	tsnetHostnameFile   = "tsnet-hostname"
+)
+
+type tsnetJoinOpts struct {
+	authKey    string
+	exitNode   string
+	controlURL string
+	hostname   string
+	clientDir  string // <ca-dir>/tsnet-client; tsnet.Server.Dir
+}
+
+// runTsnetJoin executes the tsnet branch of `clawpatrol join`. The
+// caller has already fetched the CA and is responsible for printing
+// the success banner.
+func runTsnetJoin(opts tsnetJoinOpts) error {
+	if opts.authKey == "" {
+		return errors.New("--tsnet-authkey is required")
+	}
+	if opts.exitNode == "" {
+		return errors.New("--tsnet-exit-node is required (gateway tailnet hostname or IP)")
+	}
+	if opts.clientDir == "" {
+		return errors.New("client state dir is required")
+	}
+	if err := os.MkdirAll(opts.clientDir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", opts.clientDir, err)
+	}
+
+	hn := opts.hostname
+	if hn == "" {
+		if h, err := os.Hostname(); err == nil {
+			hn = "clawpatrol-" + h
+		} else {
+			hn = "clawpatrol-client"
+		}
+	}
+
+	logger := log.New(os.Stderr, "[clawpatrol join tsnet] ", log.LstdFlags)
+	srv := &tsnet.Server{
+		Hostname:   hn,
+		AuthKey:    opts.authKey,
+		ControlURL: opts.controlURL,
+		Dir:        opts.clientDir,
+		Logf:       func(f string, args ...any) { logger.Printf(f, args...) },
+	}
+	defer func() { _ = srv.Close() }()
+
+	stop := startSpinner("Joining tailnet")
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	status, err := srv.Up(ctx)
+	stop()
+	if err != nil {
+		return fmt.Errorf("tsnet up: %w", err)
+	}
+	if len(status.TailscaleIPs) == 0 {
+		return errors.New("tsnet: joined but no tailnet IP")
+	}
+
+	if _, err := exitNodePrefs(status, opts.exitNode); err != nil {
+		return fmt.Errorf("validate exit-node: %w", err)
+	}
+
+	return nil
+}
+
+// persistTsnetJoinConfig writes the operator-supplied tsnet config
+// alongside ca.crt so `clawpatrol run` can find it without flags. The
+// authkey is intentionally not persisted — node identity lives in
+// the tsnet state dir, the authkey is one-shot.
+func persistTsnetJoinConfig(caDir string, opts tsnetJoinOpts) error {
+	type entry struct {
+		name string
+		val  string
+	}
+	files := []entry{
+		{tsnetExitNodeFile, opts.exitNode},
+		{tsnetControlURLFile, opts.controlURL},
+		{tsnetHostnameFile, opts.hostname},
+	}
+	for _, e := range files {
+		path := filepath.Join(caDir, e.name)
+		if e.val == "" {
+			_ = os.Remove(path)
+			continue
+		}
+		if err := os.WriteFile(path, []byte(strings.TrimSpace(e.val)+"\n"), 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", e.name, err)
+		}
+	}
+	return nil
+}
+
+// loadTsnetJoinConfig reads what persistTsnetJoinConfig wrote.
+// Returns ok=false when the join wasn't done in tsnet mode (no exit
+// node persisted) so callers can fall back to the WG path.
+func loadTsnetJoinConfig(caDir string) (opts tsnetJoinOpts, ok bool) {
+	opts.clientDir = filepath.Join(caDir, tsnetClientDir)
+	opts.exitNode = strings.TrimSpace(readFileSilentDir(caDir, tsnetExitNodeFile))
+	opts.controlURL = strings.TrimSpace(readFileSilentDir(caDir, tsnetControlURLFile))
+	opts.hostname = strings.TrimSpace(readFileSilentDir(caDir, tsnetHostnameFile))
+	if opts.exitNode == "" {
+		return opts, false
+	}
+	if _, err := os.Stat(opts.clientDir); err != nil {
+		return opts, false
+	}
+	return opts, true
+}
+
+func readFileSilentDir(dir, name string) string {
+	b, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/setup_tsnet_test.go
+++ b/setup_tsnet_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Round-trip: persistTsnetJoinConfig writes operator-supplied flags
+// alongside the CA, and loadTsnetJoinConfig only declares ok once
+// the tsnet state dir is also present (so a stale exit-node file
+// from a previous join doesn't switch `clawpatrol run` to a path
+// whose state dir was wiped).
+func TestTsnetJoinConfigRoundTrip(t *testing.T) {
+	caDir := t.TempDir()
+
+	opts := tsnetJoinOpts{
+		exitNode:   "clawpatrol-gateway",
+		controlURL: "https://controlplane.example.com",
+		hostname:   "laptop-alice",
+		clientDir:  filepath.Join(caDir, tsnetClientDir),
+	}
+	if err := persistTsnetJoinConfig(caDir, opts); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	if _, ok := loadTsnetJoinConfig(caDir); ok {
+		t.Fatalf("load returned ok=true with no state dir on disk")
+	}
+
+	if err := os.MkdirAll(opts.clientDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	got, ok := loadTsnetJoinConfig(caDir)
+	if !ok {
+		t.Fatalf("load ok=false after persist + state dir created")
+	}
+	if got.exitNode != opts.exitNode {
+		t.Fatalf("exitNode = %q, want %q", got.exitNode, opts.exitNode)
+	}
+	if got.controlURL != opts.controlURL {
+		t.Fatalf("controlURL = %q, want %q", got.controlURL, opts.controlURL)
+	}
+	if got.hostname != opts.hostname {
+		t.Fatalf("hostname = %q, want %q", got.hostname, opts.hostname)
+	}
+	if got.clientDir != opts.clientDir {
+		t.Fatalf("clientDir = %q, want %q", got.clientDir, opts.clientDir)
+	}
+
+	// Persisted exit-node file must not be world-readable; it's not a
+	// secret today but the join helpers also write secret-adjacent
+	// material with these helpers, so we want 0600 baseline.
+	st, err := os.Stat(filepath.Join(caDir, tsnetExitNodeFile))
+	if err != nil {
+		t.Fatalf("stat exit-node file: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("exit-node mode = %#o, want 0600", mode)
+	}
+}
+
+func TestTsnetJoinConfigOmittedFieldsAreCleaned(t *testing.T) {
+	caDir := t.TempDir()
+	if err := persistTsnetJoinConfig(caDir, tsnetJoinOpts{
+		exitNode:   "gw",
+		controlURL: "https://controlplane.example.com",
+	}); err != nil {
+		t.Fatalf("persist 1: %v", err)
+	}
+	// Subsequent join with empty controlURL should remove the prior file.
+	if err := persistTsnetJoinConfig(caDir, tsnetJoinOpts{
+		exitNode: "gw2",
+	}); err != nil {
+		t.Fatalf("persist 2: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(caDir, tsnetControlURLFile)); !os.IsNotExist(err) {
+		t.Fatalf("controlURL file should be gone after empty rewrite, stat err = %v", err)
+	}
+}

--- a/tailscale.go
+++ b/tailscale.go
@@ -21,12 +21,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 
+	"tailscale.com/ipn"
 	"tailscale.com/tsnet"
 
 	"github.com/denoland/clawpatrol/config"
@@ -80,9 +83,46 @@ func openListener(cfg *config.Gateway, stateDir string) (net.Listener, error) {
 		ControlURL: cfg.ControlURL,
 		Dir:        dir,
 	}
+	if err := advertiseGatewayExitNode(s); err != nil {
+		log.Printf("tsnet: advertise exit node: %v (gateway will not appear in `tailscale exit-node list` until this is resolved; tailnet admin still has to approve the routes)", err)
+	}
 	port := cfg.Listen
 	if port == "" {
 		port = ":443"
 	}
 	return s.Listen("tcp", port)
+}
+
+// advertiseGatewayExitNode tells the embedded tsnet node to advertise
+// itself as an exit node (`0.0.0.0/0` and `::/0` subnet routes), the
+// in-process equivalent of `tailscale set --advertise-exit-node`. The
+// tailnet admin still has to approve the advertised routes in the
+// admin console before peers can select this node — advertising just
+// registers the intent.
+//
+// Wiring this here keeps `clawpatrol run` (which targets the gateway
+// via `ExitNodeIP`) symmetric with `clawpatrol gateway`: both sides
+// of the tsnet path are configured by the gateway operator's HCL,
+// no out-of-band `tailscale` CLI call needed.
+func advertiseGatewayExitNode(s *tsnet.Server) error {
+	if err := s.Start(); err != nil {
+		return fmt.Errorf("tsnet start: %w", err)
+	}
+	lc, err := s.LocalClient()
+	if err != nil {
+		return fmt.Errorf("tsnet local client: %w", err)
+	}
+	_, err = lc.EditPrefs(context.Background(), &ipn.MaskedPrefs{
+		AdvertiseRoutesSet: true,
+		Prefs: ipn.Prefs{
+			AdvertiseRoutes: []netip.Prefix{
+				netip.MustParsePrefix("0.0.0.0/0"),
+				netip.MustParsePrefix("::/0"),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("edit prefs: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
* `gateway`: when tsnet comes up (HCL `authkey` or `TS_AUTHKEY`),
  EditPrefs to advertise both `0.0.0.0/0` and `::/0` so the
  gateway appears as a usable exit node. Failures are logged but
  don't gate the listener (the tailnet admin still has to approve
  the routes).
* `clawpatrol join --tsnet-authkey KEY --tsnet-exit-node NAME`
  brings up an embedded tsnet node, validates the named gateway
  is visible as a peer, tears down, and persists the node
  identity under `<ca-dir>/tsnet-client/` plus the operator's
  exit-node / control-url / hostname next to ca.crt. The
  device-flow / WG onboard is skipped — tsnet clients reach the
  gateway via tailnet identity, not a registered WG peer. The
  authkey is one-shot and never written to disk.
* `clawpatrol run` auto-detects the persisted tsnet bundle and
  selects the tsnet path (no flags needed); otherwise it stays
  on the wg.conf flow. The wg-up signal pipe carries a 1-byte
  length plus the netns-side address line so the parent can hand
  the tsnet-discovered tailnet IPs to the namespaced child (the
  WG path also routes its address through this pipe; the
  env-based fallback in the child is preserved for compatibility).

Tests cover exit-node prefs resolution by IP / hostname (case +
FQDN with/without trailing dot) / no-match / peer-without-IP, and
the join-config persist / load round-trip.