### PR TITLE
wg: drop default tunnel MTU 1420 → 1220 (over-Tailscale fix)

### DIFF
--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -93,10 +93,10 @@ func (n *epNotify) WriteNotify() {
 // whole-machine bursts; 16384 absorbs realistic spikes.
 const netstackQueueSize = 16384
 
-// wgTunMTU matches wireguard.go's constant. 1280 (IPv6 minimum MTU)
-// is the safest universal default — see the comment over there for
-// why we can't go lower.
-const wgTunMTU = 1280
+// wgTunMTU matches wireguard.go's constant. 1220 fits Tailscale's
+// 1280-byte underlay without IP fragmentation. v6 unavailable inside
+// the tunnel; see the comment over there.
+const wgTunMTU = 1220
 
 func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	t := &netTun{

--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -93,6 +93,11 @@ func (n *epNotify) WriteNotify() {
 // whole-machine bursts; 16384 absorbs realistic spikes.
 const netstackQueueSize = 16384
 
+// wgTunMTU matches wireguard.go's constant. 1280 (IPv6 minimum MTU)
+// is the safest universal default — see the comment over there for
+// why we can't go lower.
+const wgTunMTU = 1280
+
 func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	t := &netTun{
 		ep: channel.New(netstackQueueSize, uint32(mtu), ""),
@@ -310,7 +315,7 @@ func wg_netstack_init(confC *C.char, errBuf *C.char, errLen C.int) C.int {
 		setErr(errBuf, errLen, "parse client IP: no IPv4 in Address")
 		return -1
 	}
-	t, err := newNetTUN(clientIP, clientIP6, 1420)
+	t, err := newNetTUN(clientIP, clientIP6, wgTunMTU)
 	if err != nil {
 		setErr(errBuf, errLen, "newNetTUN: "+err.Error())
 		return -1

--- a/run_linux.go
+++ b/run_linux.go
@@ -50,8 +50,9 @@ import (
 const (
 	runChildEnv        = "CLAWPATROL_RUN_CHILD"
 	runNoAutoExposeEnv = "CLAWPATROL_RUN_NO_AUTO_EXPOSE"
-	tunIfName          = "wg0"
-	tunMTU             = 1420
+	tunIfName = "wg0"
+	// IPv6 minimum MTU (RFC 8200). See wgTunMTU comment in wireguard.go.
+	tunMTU = 1280
 )
 
 // runRun is `clawpatrol run`. Re-execs self in new user+net+mnt namespaces

--- a/run_linux.go
+++ b/run_linux.go
@@ -51,8 +51,10 @@ const (
 	runChildEnv        = "CLAWPATROL_RUN_CHILD"
 	runNoAutoExposeEnv = "CLAWPATROL_RUN_NO_AUTO_EXPOSE"
 	tunIfName = "wg0"
-	// IPv6 minimum MTU (RFC 8200). See wgTunMTU comment in wireguard.go.
-	tunMTU = 1280
+	// Match wgTunMTU in wireguard.go (1220 — fits Tailscale's
+	// 1280-byte underlay after WG/UDP/IP encap). v6 unavailable; see
+	// the comment over there.
+	tunMTU = 1220
 )
 
 // runRun is `clawpatrol run`. Re-execs self in new user+net+mnt namespaces
@@ -711,7 +713,7 @@ func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
 	}
 
 	cfg.PrivateKey = privB64
-	cfg.Address = result.IP + "/32, " + result.IP6 + "/128"
+	cfg.Address = result.IP + "/32"
 	_ = os.Setenv("CLAWPATROL_EPHEMERAL_ADDR", cfg.Address)
 
 	return func() {

--- a/run_linux.go
+++ b/run_linux.go
@@ -50,7 +50,7 @@ import (
 const (
 	runChildEnv        = "CLAWPATROL_RUN_CHILD"
 	runNoAutoExposeEnv = "CLAWPATROL_RUN_NO_AUTO_EXPOSE"
-	tunIfName = "wg0"
+	tunIfName          = "wg0"
 	// Match wgTunMTU in wireguard.go (1220 — fits Tailscale's
 	// 1280-byte underlay after WG/UDP/IP encap). v6 unavailable; see
 	// the comment over there.

--- a/wireguard.go
+++ b/wireguard.go
@@ -55,15 +55,18 @@ import (
 
 // wgTunMTU is the IP MTU of every clawpatrol-WG tunnel — server-side
 // netstack, issued wg.conf, Linux per-process TUN, macOS netstack
-// client. 1280 is the IPv6 minimum MTU (RFC 8200) — Linux refuses
-// `ip addr add <v6>/128 dev wg0` if MTU is lower, so 1220 (the
-// "fits-in-Tailscale's-underlay-without-fragmentation" sweet spot)
-// is unreachable while we still issue Address = .../128 in wg.conf.
-// 1280 instead: full IPv6 support, slight IP-layer fragmentation
-// when running over Tailscale (outer encap = 1340 > 1280), but
-// fragmenting on a local TUN is cheap. Empirically 1280 keeps bulk
-// throughput acceptable where 1420 collapses to <2 KB/s.
-const wgTunMTU = 1280
+// client. 1220 = 1280 (Tailscale's tailscale0 MTU) - 60 (IPv4 + UDP
+// + WG header). At 1420 (wireguard-go's bare-metal default) the
+// outer-encap packet is 1480 bytes which fragments on tailscale0
+// and TCP collapses to <2 KB/s. At 1220 inner-encap is exactly 1280
+// outer and fragmentation goes away (688 KB/s sustained in tests).
+//
+// 1220 is < 1280 (RFC 8200 IPv6 minimum), so Linux refuses
+// `ip addr add <v6>/128 dev wg0`. The wg.conf issued below omits
+// the v6 client address and uses AllowedIPs = 0.0.0.0/0 only;
+// inside-tunnel IPv6 is unavailable. Acceptable for the agent
+// use case (api.github.com, openai.com, claude.ai are all IPv4).
+const wgTunMTU = 1220
 
 // netTun is our own wireguard-go tun.Device backed by a gVisor stack +
 // channel.Endpoint. Can't use golang.zx2c4.com/wireguard/tun/netstack
@@ -860,10 +863,9 @@ func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string) (string,
 	// Avoiding `DNS =` because wg-quick needs resolvconf/openresolv
 	// for that, which many minimal images lack. Backup-then-restore
 	// keeps system DNS sane after `wg-quick down`.
-	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
 	conf := fmt.Sprintf(`[Interface]
 PrivateKey = %s
-Address = %s/32, %s/128
+Address = %s/32
 MTU = %d
 PostUp = cp /etc/resolv.conf /etc/resolv.conf.clawpatrol.bak 2>/dev/null; printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
 PostDown = mv /etc/resolv.conf.clawpatrol.bak /etc/resolv.conf 2>/dev/null || true
@@ -871,9 +873,9 @@ PostDown = mv /etc/resolv.conf.clawpatrol.bak /etc/resolv.conf 2>/dev/null || tr
 [Peer]
 PublicKey = %s
 Endpoint = %s
-AllowedIPs = 0.0.0.0/0, ::/0
+AllowedIPs = 0.0.0.0/0
 PersistentKeepalive = 25
-`, clientPrivB64, ip, ip6, wgTunMTU, serverPubB64, clientEndpoint)
+`, clientPrivB64, ip, wgTunMTU, serverPubB64, clientEndpoint)
 	return conf, "wireguard://" + w.iface(), ip, nil
 }
 

--- a/wireguard.go
+++ b/wireguard.go
@@ -53,6 +53,18 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
+// wgTunMTU is the IP MTU of every clawpatrol-WG tunnel — server-side
+// netstack, issued wg.conf, Linux per-process TUN, macOS netstack
+// client. 1280 is the IPv6 minimum MTU (RFC 8200) — Linux refuses
+// `ip addr add <v6>/128 dev wg0` if MTU is lower, so 1220 (the
+// "fits-in-Tailscale's-underlay-without-fragmentation" sweet spot)
+// is unreachable while we still issue Address = .../128 in wg.conf.
+// 1280 instead: full IPv6 support, slight IP-layer fragmentation
+// when running over Tailscale (outer encap = 1340 > 1280), but
+// fragmenting on a local TUN is cheap. Empirically 1280 keeps bulk
+// throughput acceptable where 1420 collapses to <2 KB/s.
+const wgTunMTU = 1280
+
 // netTun is our own wireguard-go tun.Device backed by a gVisor stack +
 // channel.Endpoint. Can't use golang.zx2c4.com/wireguard/tun/netstack
 // because it builds the stack with HandleLocal=true; combined with
@@ -320,7 +332,7 @@ func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	serverIP := prefix.Addr().Next() // x.x.x.1
 	serverIP6 := wg6FromV4(serverIP) // fd77::<last-octet>
 
-	tun, err := newNetTUN(serverIP, serverIP6, 1420)
+	tun, err := newNetTUN(serverIP, serverIP6, wgTunMTU)
 	if err != nil {
 		return nil, err
 	}
@@ -852,6 +864,7 @@ func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string) (string,
 	conf := fmt.Sprintf(`[Interface]
 PrivateKey = %s
 Address = %s/32, %s/128
+MTU = %d
 PostUp = cp /etc/resolv.conf /etc/resolv.conf.clawpatrol.bak 2>/dev/null; printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
 PostDown = mv /etc/resolv.conf.clawpatrol.bak /etc/resolv.conf 2>/dev/null || true
 
@@ -860,7 +873,7 @@ PublicKey = %s
 Endpoint = %s
 AllowedIPs = 0.0.0.0/0, ::/0
 PersistentKeepalive = 25
-`, clientPrivB64, ip, ip6, serverPubB64, clientEndpoint)
+`, clientPrivB64, ip, ip6, wgTunMTU, serverPubB64, clientEndpoint)
 	return conf, "wireguard://" + w.iface(), ip, nil
 }
 


### PR DESCRIPTION
Default WG tunnel MTU was 1420 (wireguard-go's bare-metal default,
sized for direct Ethernet). When the underlay is Tailscale
(`tailscale0` MTU 1280), the clawpatrol-WG outer-encap of 60 bytes
puts the underlay packet at 1480, fragments on tailscale0, UDP
reassembly fails under load, TCP retransmits, throughput collapses
to <2 KB/s.

The PR lowers the default to **1220** so the outer-encap is
exactly 1280 bytes — fits Tailscale's underlay without
fragmentation. Linux refuses to assign IPv6 to a link with
MTU < 1280 (RFC 8200), so the issued `wg.conf` also drops the v6
address line and the `::/0` from AllowedIPs. **Inside-tunnel IPv6
is no longer supported.** Outside-tunnel IPv6 (the destinations
the gateway dials on behalf of clients) is unaffected.

### Empirical throughput

931 KB tarball, lima VM on tailnet → cp-001 gateway, MITM TLS, →
github.com:

| Setup | Throughput |
|---|---|
| MTU 1420 link (status quo) | 1.6 KB/s |
| MTU 1280 link | 1.3 KB/s |
| MTU 1280 link + route MTU 1220 | 119 KB/s |
| **MTU 1220 link, no v6 (this PR)** | **649 KB/s** |

### Migration

Existing devices need to re-onboard to pick up the new wg.conf
(`clawpatrol join http://<gateway>:8080`). Or hand-strip the v6
portion of the Address line and lower MTU to 1220 in their existing
`~/.config/clawpatrol/wg.conf`.

Cost on direct-WG deployments (no Tailscale underlay): ~14%
throughput overhead vs 1420 because the wire-format payload is
smaller. Acceptable given the catastrophic Tailscale case it fixes.
