### PR TITLE
postgres + clickhouse_native: honor agent cancel during approval

### DIFF
--- a/config/plugins/endpoints/clickhouse_native_cancel_test.go
+++ b/config/plugins/endpoints/clickhouse_native_cancel_test.go
@@ -1,0 +1,195 @@
+package endpoints
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	chgoproto "github.com/ClickHouse/ch-go/proto"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/facet"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+// chCancelPeekFixture pairs a test-controlled agent connection with a
+// chApproveCancelState wired into the runtime side. The Approve
+// callback blocks on releaseApprove until the test signals it to
+// return, so we can exercise the "byte arrives mid-approval" path
+// deterministically.
+type chCancelPeekFixture struct {
+	agent      net.Conn
+	runtime    net.Conn
+	state      *chApproveCancelState
+	released   chan struct{}
+	approveRet runtime.ApproveVerdict
+}
+
+func newChCancelPeekFixture(t *testing.T, verdict runtime.ApproveVerdict) *chCancelPeekFixture {
+	t.Helper()
+	agentSide, runtimeSide := net.Pipe()
+	released := make(chan struct{})
+	mock := &runtime.ConnHandle{
+		Conn:     runtimeSide,
+		Endpoint: &config.CompiledEndpoint{Name: "fixture", Family: "sql"},
+		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
+			// Block until released — the test writes its peek byte
+			// in between so chApproveCancelState's goroutine has time
+			// to consume it.
+			select {
+			case <-released:
+			case <-req.Cancel:
+			}
+			return verdict
+		},
+	}
+	state := &chApproveCancelState{
+		agentReader: chgoproto.NewReader(runtimeSide),
+		ch:          mock,
+	}
+	return &chCancelPeekFixture{
+		agent:      agentSide,
+		runtime:    runtimeSide,
+		state:      state,
+		released:   released,
+		approveRet: verdict,
+	}
+}
+
+func (f *chCancelPeekFixture) close() {
+	_ = f.agent.Close()
+	_ = f.runtime.Close()
+}
+
+func TestChApproveCancelStateClientCancelClosesCancelChan(t *testing.T) {
+	f := newChCancelPeekFixture(t, runtime.ApproveVerdict{Decision: "allow"})
+	defer f.close()
+
+	// Run state.run in a goroutine. The approver inside is parked on
+	// req.Cancel | f.released; we expect the peek to fire close on
+	// req.Cancel after seeing the cancel byte.
+	done := make(chan runtime.ApproveVerdict, 1)
+	go func() {
+		done <- f.state.run(runtime.ApproveCallRequest{})
+	}()
+
+	if _, err := f.agent.Write([]byte{byte(chgoproto.ClientCodeCancel)}); err != nil {
+		t.Fatalf("write cancel byte: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("state.run did not return after cancel byte arrival")
+	}
+
+	if !f.state.canceled {
+		t.Errorf("state.canceled = false, want true")
+	}
+	if f.state.rewound != nil {
+		t.Errorf("state.rewound = non-nil for cancel byte; should be swallowed")
+	}
+}
+
+func TestChApproveCancelStateNonCancelByteRewinds(t *testing.T) {
+	f := newChCancelPeekFixture(t, runtime.ApproveVerdict{Decision: "allow"})
+	defer f.close()
+
+	done := make(chan runtime.ApproveVerdict, 1)
+	go func() {
+		done <- f.state.run(runtime.ApproveCallRequest{})
+	}()
+
+	// Agent sends a ClientCodeData byte mid-approval (INSERT's
+	// trailing data block). chApproveCancelState must NOT treat it
+	// as a cancel; instead it should leave canceled=false and
+	// surface a rewound reader holding that byte.
+	if _, err := f.agent.Write([]byte{byte(chgoproto.ClientCodeData)}); err != nil {
+		t.Fatalf("write data byte: %v", err)
+	}
+	// Give the peek goroutine a moment to consume the byte before we
+	// release the approver — otherwise the SetReadDeadline kick fires
+	// before the byte lands and we test the wrong path.
+	time.Sleep(20 * time.Millisecond)
+	close(f.released)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("state.run did not return")
+	}
+
+	if f.state.canceled {
+		t.Errorf("state.canceled = true; want false for non-cancel byte")
+	}
+	if f.state.rewound == nil {
+		t.Fatal("state.rewound = nil; want chRewindReader with the buffered byte")
+	}
+	b, err := f.state.rewound.UInt8()
+	if err != nil {
+		t.Fatalf("read rewound byte: %v", err)
+	}
+	if chgoproto.ClientCode(b) != chgoproto.ClientCodeData {
+		t.Errorf("rewound byte = %d, want ClientCodeData (%d)", b, chgoproto.ClientCodeData)
+	}
+}
+
+func TestChApproveCancelStateNoByteCleanReturn(t *testing.T) {
+	f := newChCancelPeekFixture(t, runtime.ApproveVerdict{Decision: "allow"})
+	defer f.close()
+
+	done := make(chan runtime.ApproveVerdict, 1)
+	go func() {
+		done <- f.state.run(runtime.ApproveCallRequest{})
+	}()
+
+	// Release approver immediately; the agent sends nothing. The peek
+	// goroutine should be interrupted by SetReadDeadline once Approve
+	// returns, and state.run should exit cleanly with no cancel and
+	// no rewound reader.
+	close(f.released)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("state.run did not return without a byte")
+	}
+
+	if f.state.canceled {
+		t.Errorf("state.canceled = true; want false")
+	}
+	if f.state.rewound != nil {
+		t.Errorf("state.rewound = non-nil; want nil when no byte arrived")
+	}
+}
+
+// TestChEvaluateSQLCancelDuringApprovalReturnsAllowVerdict pins the
+// fact that chEvaluateSQL still returns the approver's verdict — the
+// "canceled by agent" reason is overlaid by chHandleQuery once it
+// inspects approveSt.canceled. Keeping chEvaluateSQL's contract
+// minimal here prevents surprising the existing non-cancel tests.
+func TestChEvaluateSQLCancelDuringApprovalReturnsAllowVerdict(t *testing.T) {
+	approveCondition := "sql.verb == 'drop'"
+	approveRule := &config.CompiledRule{
+		Name:      "approve-drops",
+		Condition: approveCondition,
+		Outcome: config.Outcome{
+			Approve: []config.ApproveStage{{Name: "human"}},
+		},
+	}
+	m, err := facet.NewMatcher("sql", approveCondition)
+	if err != nil {
+		t.Fatalf("matcher: %v", err)
+	}
+	approveRule.Matcher = m
+	ep := chBuildEndpoint(t, approveRule)
+
+	mock, _ := chNewMockHandle(t, ep)
+	mock.Approve = chMockApprove("allow", "ok")
+
+	verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false, nil)
+	if verdict != "" {
+		t.Errorf("approver allow → verdict %q, want empty (chEvaluateSQL no longer overlays cancel reason)", verdict)
+	}
+}

--- a/config/plugins/endpoints/clickhouse_native_cancel_test.go
+++ b/config/plugins/endpoints/clickhouse_native_cancel_test.go
@@ -165,10 +165,11 @@ func TestChApproveCancelStateNoByteCleanReturn(t *testing.T) {
 }
 
 // TestChEvaluateSQLCancelDuringApprovalReturnsAllowVerdict pins the
-// fact that chEvaluateSQL still returns the approver's verdict — the
-// "canceled by agent" reason is overlaid by chHandleQuery once it
-// inspects approveSt.canceled. Keeping chEvaluateSQL's contract
-// minimal here prevents surprising the existing non-cancel tests.
+// fact that chEvaluateSQL passes through the approver's verdict on
+// the happy path. The cancel-during-approval path lives in
+// approveSt.run, which substitutes Decision="canceled" and lets
+// chEvaluateSQL emit a distinct "canceled" Action — covered
+// separately so the non-cancel tests stay simple.
 func TestChEvaluateSQLCancelDuringApprovalReturnsAllowVerdict(t *testing.T) {
 	approveCondition := "sql.verb == 'drop'"
 	approveRule := &config.CompiledRule{

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	chgoproto "github.com/ClickHouse/ch-go/proto"
@@ -394,7 +395,7 @@ func chAgentToServer(ctx context.Context, ch *runtime.ConnHandle, agentReader *c
 		}
 		switch chgoproto.ClientCode(code) {
 		case chgoproto.ClientCodeQuery:
-			next, fatal := chHandleQuery(ctx, ch, agentReader, upstream, revision, credName, &sessionDB)
+			next, rewound, fatal := chHandleQuery(ctx, ch, agentReader, upstream, revision, credName, &sessionDB)
 			if fatal {
 				return
 			}
@@ -405,6 +406,13 @@ func chAgentToServer(ctx context.Context, ch *runtime.ConnHandle, agentReader *c
 			// us reading a compressed frame as an uncompressed Block,
 			// which surfaces as a "data-block-decode" boolean error.
 			compression = next
+			if rewound != nil {
+				// The approval-cancel peek consumed a byte that
+				// turned out NOT to be a ClientCancel; prepend it
+				// back onto the agent stream so the next code-loop
+				// iteration sees the start of the next packet.
+				agentReader = rewound
+			}
 		case chgoproto.ClientCodeData:
 			rewound, ok := chHandleData(ch, agentReader, upstream, revision, compression)
 			if !ok {
@@ -459,7 +467,7 @@ func chAgentToServer(ctx context.Context, ch *runtime.ConnHandle, agentReader *c
 // nil pointer disables the tracking (used by tests that don't care
 // about session state and the truncated-frame path that has no SQL
 // to inspect).
-func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chgoproto.Reader, upstream io.Writer, revision int, credName string, sessionDB *string) (chgoproto.Compression, bool) {
+func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chgoproto.Reader, upstream io.Writer, revision int, credName string, sessionDB *string) (chgoproto.Compression, *chgoproto.Reader, bool) {
 	// Build the forward-bound preamble (everything up to the body
 	// length prefix) as we decode each field. Re-encoding these small
 	// fields is cheap; the body is the only field whose size warrants
@@ -470,7 +478,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	id, err := agentReader.Str()
 	if err != nil {
 		chEmitError(ch, "query-decode", "id: "+err.Error())
-		return chgoproto.CompressionDisabled, true
+		return chgoproto.CompressionDisabled, nil, true
 	}
 	preamble.PutString(id)
 
@@ -478,20 +486,20 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 		var info chgoproto.ClientInfo
 		if err := info.DecodeAware(agentReader, revision); err != nil {
 			chEmitError(ch, "query-decode", "client info: "+err.Error())
-			return chgoproto.CompressionDisabled, true
+			return chgoproto.CompressionDisabled, nil, true
 		}
 		info.EncodeAware(&preamble, revision)
 	}
 
 	if !chgoproto.FeatureSettingsSerializedAsStrings.In(revision) {
 		chEmitError(ch, "query-decode", "unsupported settings format")
-		return chgoproto.CompressionDisabled, true
+		return chgoproto.CompressionDisabled, nil, true
 	}
 	for {
 		var s chgoproto.Setting
 		if err := s.Decode(agentReader); err != nil {
 			chEmitError(ch, "query-decode", "setting: "+err.Error())
-			return chgoproto.CompressionDisabled, true
+			return chgoproto.CompressionDisabled, nil, true
 		}
 		if s.Key == "" {
 			preamble.PutString("") // end-of-settings sentinel
@@ -504,14 +512,14 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 		secret, err := agentReader.Str()
 		if err != nil {
 			chEmitError(ch, "query-decode", "inter-server secret: "+err.Error())
-			return chgoproto.CompressionDisabled, true
+			return chgoproto.CompressionDisabled, nil, true
 		}
 		preamble.PutString(secret)
 	}
 
 	if _, err := agentReader.UVarInt(); err != nil {
 		chEmitError(ch, "query-decode", "stage: "+err.Error())
-		return chgoproto.CompressionDisabled, true
+		return chgoproto.CompressionDisabled, nil, true
 	}
 	// chgoproto.Query.EncodeAware hard-codes StageComplete on the wire
 	// regardless of what the agent sent; mirror that here so the
@@ -522,12 +530,12 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	compU, err := agentReader.UVarInt()
 	if err != nil {
 		chEmitError(ch, "query-decode", "compression: "+err.Error())
-		return chgoproto.CompressionDisabled, true
+		return chgoproto.CompressionDisabled, nil, true
 	}
 	compression := chgoproto.Compression(compU)
 	if !compression.IsACompression() {
 		chEmitError(ch, "query-decode", fmt.Sprintf("unknown compression %d", compU))
-		return chgoproto.CompressionDisabled, true
+		return chgoproto.CompressionDisabled, nil, true
 	}
 	compression.Encode(&preamble)
 
@@ -537,7 +545,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	bodyLen, err := agentReader.StrLen()
 	if err != nil {
 		chEmitError(ch, "query-decode", "body length: "+err.Error())
-		return compression, true
+		return compression, nil, true
 	}
 	truncated := bodyLen > chMaxQueryBody
 	headLen := bodyLen
@@ -547,14 +555,30 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	head := make([]byte, headLen)
 	if err := agentReader.ReadFull(head); err != nil {
 		chEmitError(ch, "query-decode", "body head: "+err.Error())
-		return compression, true
+		return compression, nil, true
 	}
 
 	database := ""
 	if sessionDB != nil {
 		database = *sessionDB
 	}
-	verdict, reason, nextDB := chEvaluateSQL(ctx, ch, string(head), credName, database, truncated)
+	// Wrap ch.Approve with a peek loop that watches the agent
+	// connection for an in-band ClientCancel while the approver chain
+	// blocks. Any non-cancel byte the peek consumes survives via the
+	// rewound reader the state struct carries; chAgentToServer swaps
+	// it in place of agentReader so the next packet sees the byte we
+	// read.
+	approveSt := &chApproveCancelState{agentReader: agentReader, ch: ch}
+	verdict, reason, nextDB := chEvaluateSQL(ctx, ch, string(head), credName, database, truncated, approveSt.run)
+	rewound := approveSt.rewound
+	if approveSt.canceled {
+		// The agent issued a ClientCancel while we were parked. Force
+		// the verdict to deny so the agent sees a terminating
+		// Exception (and the pump doesn't try to ship Data blocks
+		// that follow the canceled Query to upstream).
+		verdict, reason = "deny", "canceled by agent"
+		rewound = nil
+	}
 	if verdict == "deny" {
 		// Drain the rest of this Query off the wire so the pump can
 		// keep reading subsequent packets — same shape as the previous
@@ -562,7 +586,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 		if truncated {
 			if _, derr := io.CopyN(io.Discard, agentReader, int64(bodyLen-headLen)); derr != nil {
 				chEmitError(ch, "query-drain", "body tail: "+derr.Error())
-				return compression, true
+				return compression, nil, true
 			}
 		}
 		if chgoproto.FeatureParameters.In(revision) {
@@ -570,7 +594,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 				var p chgoproto.Parameter
 				if perr := p.Decode(agentReader); perr != nil {
 					chEmitError(ch, "query-drain", "parameter: "+perr.Error())
-					return compression, true
+					return compression, nil, true
 				}
 				if p.Key == "" {
 					break
@@ -579,11 +603,11 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 		}
 		if _, werr := ch.Conn.Write(chEncodeException(reason)); werr != nil {
 			// Agent gone — there's nothing left to keep alive.
-			return compression, true
+			return compression, nil, true
 		}
 		log.Printf("clickhouse_native %s deny %s: %s",
 			ch.Endpoint.Name, ch.PeerIP, reason)
-		return compression, false
+		return compression, rewound, false
 	}
 
 	// Allow. Flush preamble + body-length + head, then splice the
@@ -593,11 +617,11 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	preamble.PutInt(bodyLen)
 	preamble.Buf = append(preamble.Buf, head...)
 	if _, werr := upstream.Write(preamble.Buf); werr != nil {
-		return compression, true
+		return compression, nil, true
 	}
 	if truncated {
 		if _, werr := io.CopyN(upstream, agentReader, int64(bodyLen-headLen)); werr != nil {
-			return compression, true
+			return compression, nil, true
 		}
 	}
 
@@ -607,7 +631,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 			var p chgoproto.Parameter
 			if perr := p.Decode(agentReader); perr != nil {
 				chEmitError(ch, "query-decode", "parameter: "+perr.Error())
-				return compression, true
+				return compression, nil, true
 			}
 			if p.Key == "" {
 				paramBuf.PutString("") // end-of-parameters sentinel
@@ -616,7 +640,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 			p.Encode(&paramBuf)
 		}
 		if _, werr := upstream.Write(paramBuf.Buf); werr != nil {
-			return compression, true
+			return compression, nil, true
 		}
 	}
 
@@ -633,7 +657,7 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	if sessionDB != nil && nextDB != "" {
 		*sessionDB = nextDB
 	}
-	return compression, false
+	return compression, rewound, false
 }
 
 // chHandleData decodes one client Data packet (table-name header +
@@ -916,7 +940,10 @@ func chRewindReader(head []byte, tail *chgoproto.Reader) *chgoproto.Reader {
 // based on the database the agent is leaving, not the one it's
 // entering. The new value only enters circulation on the next
 // statement.
-func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, database string, truncated bool) (verdict, reason, nextDB string) {
+func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, database string, truncated bool, approveFn func(runtime.ApproveCallRequest) runtime.ApproveVerdict) (verdict, reason, nextDB string) {
+	if approveFn == nil && ch != nil {
+		approveFn = ch.Approve
+	}
 	info := parseChSQL(sql)
 	defer func() {
 		// Allow paths surface the USE target; deny paths leave nextDB
@@ -955,7 +982,7 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, d
 	rule := cr.Name
 
 	if len(cr.Outcome.Approve) > 0 {
-		if ch.Approve == nil {
+		if ch.Approve == nil || approveFn == nil {
 			chEmit(ch, runtime.ConnEvent{
 				Action: "deny", Reason: "HITL not configured",
 				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
@@ -963,7 +990,7 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, d
 			verdict, reason = "deny", "approval required but HITL is not configured"
 			return
 		}
-		v := ch.Approve(runtime.ApproveCallRequest{
+		v := approveFn(runtime.ApproveCallRequest{
 			Stages: cr.Outcome.Approve, Verb: info.Verb,
 			Summary: summary, Rule: cr,
 		})
@@ -1008,6 +1035,105 @@ func chEmit(ch *runtime.ConnHandle, ev runtime.ConnEvent) {
 	if ch != nil && ch.Emit != nil {
 		ch.Emit(ev)
 	}
+}
+
+// chApproveCancelState owns the in-band ClientCancel watcher for a
+// single Query packet's parked-approval window. While ch.Approve
+// blocks, a goroutine reads one byte from the agent reader: if it's
+// ClientCodeCancel, the watcher fires ApproveCallRequest.Cancel so
+// the approver chain returns immediately; otherwise the byte was the
+// start of the next packet (a Data block following INSERT, typically)
+// and the state struct surfaces a rewound reader so chAgentToServer
+// can prepend the byte back onto the stream after Query handling
+// finishes. SetReadDeadline interrupts a blocked peek read once the
+// approver chain has returned, so we never wait indefinitely on a
+// session whose user never pressed Ctrl+C.
+type chApproveCancelState struct {
+	agentReader *chgoproto.Reader
+	ch          *runtime.ConnHandle
+	rewound     *chgoproto.Reader
+	canceled    bool
+}
+
+// chPeekDeadlineEpsilon is how far into the past SetReadDeadline is
+// nudged when we want to immediately interrupt any blocked peek read
+// without race-windowing a subsequent legitimate read.
+var chPeekDeadlineEpsilon = -time.Second
+
+// run wraps ch.Approve. It spawns a goroutine that reads one byte
+// off agentReader and, depending on the byte, closes a cancel
+// channel handed to the approver or marks the byte for rewind.
+// Returns the approver's verdict.
+func (s *chApproveCancelState) run(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
+	if s.ch == nil || s.ch.Approve == nil || s.agentReader == nil {
+		// Defensive — chEvaluateSQL already requires ch.Approve non-nil
+		// before constructing an ApproveCallRequest, but a nil
+		// agentReader would deadlock the peek goroutine. Fall back to
+		// the plain approve path so tests that don't wire the watcher
+		// keep working.
+		if s.ch != nil && s.ch.Approve != nil {
+			return s.ch.Approve(req)
+		}
+		return runtime.ApproveVerdict{Decision: "deny", Reason: "approve unwired"}
+	}
+	cancelCh := make(chan struct{})
+	var cancelOnce sync.Once
+	fireCancel := func() {
+		cancelOnce.Do(func() {
+			close(cancelCh)
+		})
+	}
+	req.Cancel = cancelCh
+
+	type peekResult struct {
+		b   byte
+		err error
+	}
+	peekDone := make(chan peekResult, 1)
+	go func() {
+		b, err := s.agentReader.UInt8()
+		if err == nil && chgoproto.ClientCode(b) == chgoproto.ClientCodeCancel {
+			// Trip the approver immediately so it returns without
+			// waiting for the test / operator to act on the (now
+			// stale) HITL prompt.
+			s.canceled = true
+			fireCancel()
+		}
+		peekDone <- peekResult{b, err}
+	}()
+
+	verdict := s.ch.Approve(req)
+
+	// Unblock the peek goroutine if it's still waiting on the wire.
+	// SetReadDeadline on a chgoproto.Reader's underlying net.Conn
+	// kicks any pending Read out with ErrDeadlineExceeded; we then
+	// restore the zero deadline so subsequent packets read normally.
+	conn, ok := s.ch.Conn.(net.Conn)
+	if ok {
+		_ = conn.SetReadDeadline(time.Now().Add(chPeekDeadlineEpsilon))
+	}
+	result := <-peekDone
+	if ok {
+		_ = conn.SetReadDeadline(time.Time{})
+	}
+
+	if result.err != nil {
+		// Make sure we don't leak the cancel chan in the closed-but-
+		// uncanceled state; the approver already returned.
+		return verdict
+	}
+	if chgoproto.ClientCode(result.b) == chgoproto.ClientCodeCancel {
+		s.canceled = true
+		fireCancel()
+		return verdict
+	}
+	// Non-cancel byte → prepend it back onto the reader so
+	// chAgentToServer's next iteration treats it as the leading byte
+	// of the next packet. The most common case is ClientCodeData
+	// following an INSERT Query: the agent emits Data blocks
+	// optimistically while we're parked.
+	s.rewound = chRewindReader([]byte{result.b}, s.agentReader)
+	return verdict
 }
 
 // chEmitError emits a structured error ConnEvent if the host wired

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -572,14 +572,14 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	verdict, reason, nextDB := chEvaluateSQL(ctx, ch, string(head), credName, database, truncated, approveSt.run)
 	rewound := approveSt.rewound
 	if approveSt.canceled {
-		// The agent issued a ClientCancel while we were parked. Force
-		// the verdict to deny so the agent sees a terminating
-		// Exception (and the pump doesn't try to ship Data blocks
-		// that follow the canceled Query to upstream).
-		verdict, reason = "deny", "canceled by agent"
+		// The agent issued a ClientCancel while we were parked.
+		// chEvaluateSQL already surfaced verdict="canceled" + a
+		// "canceled" ConnEvent via approveSt.run. Drop any rewound
+		// byte: the pump must not ship Data blocks the agent queued
+		// behind the now-canceled Query to upstream.
 		rewound = nil
 	}
-	if verdict == "deny" {
+	if verdict == "deny" || verdict == "canceled" {
 		// Drain the rest of this Query off the wire so the pump can
 		// keep reading subsequent packets — same shape as the previous
 		// implementation (deny → write Exception → continue).
@@ -605,8 +605,8 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 			// Agent gone — there's nothing left to keep alive.
 			return compression, nil, true
 		}
-		log.Printf("clickhouse_native %s deny %s: %s",
-			ch.Endpoint.Name, ch.PeerIP, reason)
+		log.Printf("clickhouse_native %s %s %s: %s",
+			ch.Endpoint.Name, verdict, ch.PeerIP, reason)
 		return compression, rewound, false
 	}
 
@@ -994,6 +994,22 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, d
 			Stages: cr.Outcome.Approve, Verb: info.Verb,
 			Summary: summary, Rule: cr,
 		})
+		if v.Decision == "canceled" {
+			// Agent canceled mid-approval — distinct Action so the
+			// dashboard's deny-reason filter doesn't conflate agent
+			// Ctrl+C with operator HITL denies. No approver fields:
+			// no human / LLM produced this outcome.
+			r := v.Reason
+			if r == "" {
+				r = "canceled by agent"
+			}
+			chEmit(ch, runtime.ConnEvent{
+				Action: "canceled", Reason: r,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
+			})
+			verdict, reason = "canceled", r
+			return
+		}
 		if v.Decision != "allow" {
 			r := v.Reason
 			if r == "" {
@@ -1063,7 +1079,10 @@ var chPeekDeadlineEpsilon = -time.Second
 // run wraps ch.Approve. It spawns a goroutine that reads one byte
 // off agentReader and, depending on the byte, closes a cancel
 // channel handed to the approver or marks the byte for rewind.
-// Returns the approver's verdict.
+// Returns the approver's verdict, except on agent cancel where it
+// substitutes Decision="canceled" so chEvaluateSQL can emit a
+// distinct Action and the dashboard can tell an agent Ctrl+C apart
+// from an operator HITL deny.
 func (s *chApproveCancelState) run(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
 	if s.ch == nil || s.ch.Approve == nil || s.agentReader == nil {
 		// Defensive — chEvaluateSQL already requires ch.Approve non-nil
@@ -1125,7 +1144,7 @@ func (s *chApproveCancelState) run(req runtime.ApproveCallRequest) runtime.Appro
 	if chgoproto.ClientCode(result.b) == chgoproto.ClientCodeCancel {
 		s.canceled = true
 		fireCancel()
-		return verdict
+		return runtime.ApproveVerdict{Decision: "canceled", Reason: "canceled by agent"}
 	}
 	// Non-cancel byte → prepend it back onto the reader so
 	// chAgentToServer's next iteration treats it as the leading byte

--- a/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -562,13 +562,53 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	if sessionDB != nil {
 		database = *sessionDB
 	}
+
+	// Drain the Parameters block off the wire BEFORE invoking
+	// approval so the peek goroutine in chApproveCancelState.run sees
+	// a true packet boundary. If we left it for the post-approval
+	// re-encode, the peek's UInt8() would consume the leading byte of
+	// the Parameters block — corrupting both the deny drain and the
+	// allow re-encode, AND risking a false ClientCancel detection
+	// when that byte happens to equal 0x03 (e.g. the UVarInt key
+	// length of a 3-character parameter name).
+	//
+	// Truncated queries are excepted: the body tail still sits ahead
+	// of Parameters on the wire and buffering a multi-MiB tail isn't
+	// safe. For those we disable the peek entirely (see the approveSt
+	// wiring below) and decode Parameters inline on the allow path —
+	// the cancel-during-approval loss for queries with > chMaxQueryBody
+	// SQL bodies is acceptable, and matches the pre-existing
+	// behaviour on that path (the old peek was off-by-one there too).
+	var paramBuf chgoproto.Buffer
+	paramsPreEncoded := false
+	if !truncated && chgoproto.FeatureParameters.In(revision) {
+		for {
+			var p chgoproto.Parameter
+			if perr := p.Decode(agentReader); perr != nil {
+				chEmitError(ch, "query-decode", "parameter: "+perr.Error())
+				return compression, nil, true
+			}
+			if p.Key == "" {
+				paramBuf.PutString("") // end-of-parameters sentinel
+				break
+			}
+			p.Encode(&paramBuf)
+		}
+		paramsPreEncoded = true
+	}
+
 	// Wrap ch.Approve with a peek loop that watches the agent
 	// connection for an in-band ClientCancel while the approver chain
 	// blocks. Any non-cancel byte the peek consumes survives via the
 	// rewound reader the state struct carries; chAgentToServer swaps
 	// it in place of agentReader so the next packet sees the byte we
-	// read.
-	approveSt := &chApproveCancelState{agentReader: agentReader, ch: ch}
+	// read. For truncated queries we leave agentReader unset so
+	// state.run falls through to plain ch.Approve (the body tail
+	// would otherwise feed the peek a mid-packet byte).
+	approveSt := &chApproveCancelState{ch: ch}
+	if !truncated {
+		approveSt.agentReader = agentReader
+	}
 	verdict, reason, nextDB := chEvaluateSQL(ctx, ch, string(head), credName, database, truncated, approveSt.run)
 	rewound := approveSt.rewound
 	if approveSt.canceled {
@@ -582,22 +622,24 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	if verdict == "deny" || verdict == "canceled" {
 		// Drain the rest of this Query off the wire so the pump can
 		// keep reading subsequent packets — same shape as the previous
-		// implementation (deny → write Exception → continue).
+		// implementation (deny → write Exception → continue). For
+		// !truncated, Parameters were already drained pre-approval
+		// and the buffered paramBuf is simply dropped.
 		if truncated {
 			if _, derr := io.CopyN(io.Discard, agentReader, int64(bodyLen-headLen)); derr != nil {
 				chEmitError(ch, "query-drain", "body tail: "+derr.Error())
 				return compression, nil, true
 			}
-		}
-		if chgoproto.FeatureParameters.In(revision) {
-			for {
-				var p chgoproto.Parameter
-				if perr := p.Decode(agentReader); perr != nil {
-					chEmitError(ch, "query-drain", "parameter: "+perr.Error())
-					return compression, nil, true
-				}
-				if p.Key == "" {
-					break
+			if chgoproto.FeatureParameters.In(revision) {
+				for {
+					var p chgoproto.Parameter
+					if perr := p.Decode(agentReader); perr != nil {
+						chEmitError(ch, "query-drain", "parameter: "+perr.Error())
+						return compression, nil, true
+					}
+					if p.Key == "" {
+						break
+					}
 				}
 			}
 		}
@@ -626,18 +668,21 @@ func chHandleQuery(ctx context.Context, ch *runtime.ConnHandle, agentReader *chg
 	}
 
 	if chgoproto.FeatureParameters.In(revision) {
-		var paramBuf chgoproto.Buffer
-		for {
-			var p chgoproto.Parameter
-			if perr := p.Decode(agentReader); perr != nil {
-				chEmitError(ch, "query-decode", "parameter: "+perr.Error())
-				return compression, nil, true
+		if !paramsPreEncoded {
+			// Truncated path: Parameters still on the wire after the
+			// body tail. Decode + re-encode inline.
+			for {
+				var p chgoproto.Parameter
+				if perr := p.Decode(agentReader); perr != nil {
+					chEmitError(ch, "query-decode", "parameter: "+perr.Error())
+					return compression, nil, true
+				}
+				if p.Key == "" {
+					paramBuf.PutString("") // end-of-parameters sentinel
+					break
+				}
+				p.Encode(&paramBuf)
 			}
-			if p.Key == "" {
-				paramBuf.PutString("") // end-of-parameters sentinel
-				break
-			}
-			p.Encode(&paramBuf)
 		}
 		if _, werr := upstream.Write(paramBuf.Buf); werr != nil {
 			return compression, nil, true

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -443,7 +443,7 @@ func TestChEvaluateSQLThreadsDatabaseIntoMeta(t *testing.T) {
 
 	t.Run("matches when database equal", func(t *testing.T) {
 		mock, _ := chNewMockHandle(t, ep)
-		verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "metrics", false)
+		verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "metrics", false, nil)
 		if verdict != "deny" {
 			t.Errorf("DROP on metrics verdict = %q, want deny", verdict)
 		}
@@ -454,7 +454,7 @@ func TestChEvaluateSQLThreadsDatabaseIntoMeta(t *testing.T) {
 
 	t.Run("different case does not match", func(t *testing.T) {
 		mock, _ := chNewMockHandle(t, ep)
-		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "Metrics", false)
+		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "Metrics", false, nil)
 		if verdict != "" {
 			t.Errorf("DROP on Metrics (mixed case) verdict = %q, want allow", verdict)
 		}
@@ -462,7 +462,7 @@ func TestChEvaluateSQLThreadsDatabaseIntoMeta(t *testing.T) {
 
 	t.Run("empty database does not match", func(t *testing.T) {
 		mock, _ := chNewMockHandle(t, ep)
-		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false)
+		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false, nil)
 		if verdict != "" {
 			t.Errorf("DROP with empty database verdict = %q, want allow", verdict)
 		}
@@ -486,7 +486,7 @@ func TestChEvaluateSQLTruncated(t *testing.T) {
 
 		mock, _ := chNewMockHandle(t, ep)
 
-		verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "SELECT 1", "ch-cred", "", true)
+		verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "SELECT 1", "ch-cred", "", true, nil)
 		if verdict != "deny" {
 			t.Errorf("truncated SELECT verdict = %q, want deny (synth)", verdict)
 		}
@@ -505,7 +505,7 @@ func TestChEvaluateSQLTruncated(t *testing.T) {
 
 		mock, _ := chNewMockHandle(t, ep)
 
-		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "anything", "ch-cred", "", true)
+		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "anything", "ch-cred", "", true, nil)
 		if verdict != "" {
 			t.Errorf("truncated passthrough verdict = %q, want allow (empty)", verdict)
 		}
@@ -524,7 +524,7 @@ func TestChEvaluateSQLAllowsSelectDeniesInsert(t *testing.T) {
 
 	mock, _ := chNewMockHandle(t, ep)
 
-	verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "INSERT INTO events VALUES (1)", "ch-cred", "", false)
+	verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "INSERT INTO events VALUES (1)", "ch-cred", "", false, nil)
 	if verdict != "deny" {
 		t.Errorf("INSERT verdict = %q, want deny", verdict)
 	}
@@ -532,7 +532,7 @@ func TestChEvaluateSQLAllowsSelectDeniesInsert(t *testing.T) {
 		t.Errorf("INSERT reason = %q, want %q", reason, "writes blocked")
 	}
 
-	verdict, _, _ = chEvaluateSQL(context.Background(), mock.ConnHandle, "SELECT 1", "ch-cred", "", false)
+	verdict, _, _ = chEvaluateSQL(context.Background(), mock.ConnHandle, "SELECT 1", "ch-cred", "", false, nil)
 	if verdict != "" {
 		t.Errorf("SELECT verdict = %q, want allow (empty)", verdict)
 	}
@@ -580,7 +580,7 @@ func TestChEvaluateSQLApproveChain(t *testing.T) {
 	t.Run("approver allows", func(t *testing.T) {
 		mock, _ := chNewMockHandle(t, ep)
 		mock.Approve = chMockApprove("allow", "ok")
-		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false)
+		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false, nil)
 		if verdict != "" {
 			t.Errorf("approver allow → verdict %q, want empty", verdict)
 		}
@@ -591,7 +591,7 @@ func TestChEvaluateSQLApproveChain(t *testing.T) {
 	t.Run("approver denies", func(t *testing.T) {
 		mock, _ := chNewMockHandle(t, ep)
 		mock.Approve = chMockApprove("deny", "operator rejected")
-		verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false)
+		verdict, reason, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false, nil)
 		if verdict != "deny" || reason != "operator rejected" {
 			t.Errorf("verdict=%q reason=%q, want deny/operator rejected", verdict, reason)
 		}
@@ -602,7 +602,7 @@ func TestChEvaluateSQLApproveChain(t *testing.T) {
 	t.Run("missing Approve callback default-denies", func(t *testing.T) {
 		mock, _ := chNewMockHandle(t, ep)
 		mock.Approve = nil
-		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false)
+		verdict, _, _ := chEvaluateSQL(context.Background(), mock.ConnHandle, "DROP TABLE events", "ch-cred", "", false, nil)
 		if verdict != "deny" {
 			t.Errorf("no Approve → verdict %q, want deny", verdict)
 		}

--- a/config/plugins/endpoints/clickhouse_native_test.go
+++ b/config/plugins/endpoints/clickhouse_native_test.go
@@ -1518,3 +1518,211 @@ func TestClickhousePickUpstream(t *testing.T) {
 		}
 	}
 }
+
+// TestChAgentToServerForwardsQueryWithParameters pins the modern-
+// protocol Query + Parameters round-trip. The Parameters block sits
+// after the body on the wire when revision >= FeatureParameters
+// (54459); chHandleQuery must drain it pre-approval so the
+// approval-cancel peek doesn't consume the leading byte. The first
+// parameter key is deliberately 3 chars long — its UVarInt key
+// length is 0x03, identical to ClientCodeCancel: with the older
+// post-approval peek the byte would corrupt the re-encoded Parameters
+// block AND risk a spurious cancel.
+func TestChAgentToServerForwardsQueryWithParameters(t *testing.T) {
+	const revision = chMaxProtocolRev
+
+	rule := &config.CompiledRule{
+		Name: "allow-all", Matcher: match.PassThrough{},
+		Outcome: config.Outcome{Verdict: "allow"},
+	}
+	ep := chBuildEndpoint(t, rule)
+	mock, _ := chNewMockHandle(t, ep)
+	defer func() { _ = mock.Conn.Close() }()
+
+	q := chgoproto.Query{
+		ID:    "qid-params",
+		Body:  "SELECT {p:String}",
+		Stage: chgoproto.StageComplete,
+		Info: chgoproto.ClientInfo{
+			ProtocolVersion: revision, Major: 24, Minor: 8,
+			Interface:   chgoproto.InterfaceTCP,
+			Query:       chgoproto.ClientQueryInitial,
+			InitialUser: "alice",
+		},
+		Parameters: []chgoproto.Parameter{
+			// 3-character key → UVarInt leading byte = 0x03,
+			// which collides with ClientCodeCancel.
+			{Key: "abc", Value: "hello"},
+			{Key: "second", Value: "world"},
+		},
+	}
+	var agentBuf chgoproto.Buffer
+	q.EncodeAware(&agentBuf, revision)
+
+	reader := chgoproto.NewReader(bytes.NewReader(agentBuf.Buf))
+	var upstream bytes.Buffer
+	chAgentToServer(context.Background(), mock.ConnHandle, reader, &upstream, revision, "ch-cred", "")
+
+	out := upstream.Bytes()
+	if len(out) == 0 || chgoproto.ClientCode(out[0]) != chgoproto.ClientCodeQuery {
+		t.Fatalf("upstream first byte = %d, want ClientCodeQuery", out[0])
+	}
+	r := chgoproto.NewReader(bytes.NewReader(out[1:]))
+	var got chgoproto.Query
+	if err := got.DecodeAware(r, revision); err != nil {
+		t.Fatalf("decode upstream Query: %v", err)
+	}
+	if got.Body != q.Body {
+		t.Errorf("Body = %q, want %q", got.Body, q.Body)
+	}
+	if diff := cmp.Diff(q.Parameters, got.Parameters); diff != "" {
+		t.Errorf("Parameters round-trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestChAgentToServerDeniesQueryWithParameters pins the deny-path
+// drain when Parameters follow the body on a modern-protocol Query.
+// A denied Query must consume Parameters off the wire so the pump
+// sees the next packet's leading byte cleanly on the next iteration.
+// The stream is q1 (denied DROP with Parameters) → q2 (allowed
+// SELECT); the pump must surface q2 to upstream and write exactly
+// one Exception to the agent.
+func TestChAgentToServerDeniesQueryWithParameters(t *testing.T) {
+	const revision = chMaxProtocolRev
+
+	rule := chRuleSQL(t, "deny-drop",
+		"sql.verb == 'drop'", "deny", "drops blocked", 100)
+	ep := chBuildEndpoint(t, rule)
+	mock, agentSide := chNewMockHandle(t, ep)
+	defer func() { _ = agentSide.Close() }()
+	defer func() { _ = mock.Conn.Close() }()
+
+	mkQuery := func(id, body string, params []chgoproto.Parameter) []byte {
+		q := chgoproto.Query{
+			ID: id, Body: body,
+			Stage: chgoproto.StageComplete,
+			Info: chgoproto.ClientInfo{
+				ProtocolVersion: revision, Major: 24, Minor: 8,
+				Interface:   chgoproto.InterfaceTCP,
+				Query:       chgoproto.ClientQueryInitial,
+				InitialUser: "alice",
+			},
+			Parameters: params,
+		}
+		var b chgoproto.Buffer
+		q.EncodeAware(&b, revision)
+		return b.Buf
+	}
+
+	var stream bytes.Buffer
+	stream.Write(mkQuery("q1", "DROP TABLE events", []chgoproto.Parameter{
+		{Key: "abc", Value: "ignored"}, // 3-char key → 0x03 lead byte
+	}))
+	stream.Write(mkQuery("q2", "SELECT 1", nil))
+
+	agentBytes := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 4096)
+		n, _ := agentSide.Read(buf)
+		agentBytes <- append([]byte(nil), buf[:n]...)
+	}()
+
+	reader := chgoproto.NewReader(bytes.NewReader(stream.Bytes()))
+	var upstream bytes.Buffer
+	chAgentToServer(context.Background(), mock.ConnHandle, reader, &upstream, revision, "ch-cred", "")
+
+	r := chgoproto.NewReader(bytes.NewReader(upstream.Bytes()))
+	var bodies []string
+	for {
+		code, err := r.UInt8()
+		if err != nil {
+			break
+		}
+		if chgoproto.ClientCode(code) != chgoproto.ClientCodeQuery {
+			t.Fatalf("upstream packet code = %d, want ClientCodeQuery (wire alignment lost)", code)
+		}
+		var q chgoproto.Query
+		if err := q.DecodeAware(r, revision); err != nil {
+			t.Fatalf("decode upstream Query: %v", err)
+		}
+		bodies = append(bodies, q.Body)
+	}
+	wantBodies := []string{"SELECT 1"}
+	if diff := cmp.Diff(wantBodies, bodies); diff != "" {
+		t.Errorf("upstream Query bodies (-want +got):\n%s", diff)
+	}
+
+	exc := <-agentBytes
+	if len(exc) == 0 || chgoproto.ServerCode(exc[0]) != chgoproto.ServerCodeException {
+		t.Errorf("agent did not receive Exception; first byte = %d", exc[0])
+	}
+}
+
+// TestChApproveCancelStateHITLAllowWithParameters verifies that an
+// HITL approval that allows a Query whose body is followed by a
+// Parameters block does NOT mis-fire as canceled, even when a
+// parameter key's UVarInt length byte equals ClientCodeCancel (0x03).
+// chHandleQuery now drains Parameters before invoking approval, so
+// the peek goroutine sees a true packet boundary (nothing more on
+// the wire until the next packet) — not the Parameters lead byte.
+func TestChApproveCancelStateHITLAllowWithParameters(t *testing.T) {
+	const revision = chMaxProtocolRev
+
+	approveCondition := "sql.verb == 'drop'"
+	approveRule := &config.CompiledRule{
+		Name:      "approve-drops",
+		Condition: approveCondition,
+		Outcome: config.Outcome{
+			Approve: []config.ApproveStage{{Name: "human"}},
+		},
+	}
+	m, err := facet.NewMatcher("sql", approveCondition)
+	if err != nil {
+		t.Fatalf("matcher: %v", err)
+	}
+	approveRule.Matcher = m
+	ep := chBuildEndpoint(t, approveRule)
+	mock, _ := chNewMockHandle(t, ep)
+	defer func() { _ = mock.Conn.Close() }()
+	mock.Approve = chMockApprove("allow", "ok")
+
+	q := chgoproto.Query{
+		ID: "qid-hitl", Body: "DROP TABLE events",
+		Stage: chgoproto.StageComplete,
+		Info: chgoproto.ClientInfo{
+			ProtocolVersion: revision, Major: 24, Minor: 8,
+			Interface:   chgoproto.InterfaceTCP,
+			Query:       chgoproto.ClientQueryInitial,
+			InitialUser: "alice",
+		},
+		Parameters: []chgoproto.Parameter{
+			{Key: "abc", Value: "v"}, // 0x03 leading byte — would have been a false cancel.
+		},
+	}
+	var agentBuf chgoproto.Buffer
+	q.EncodeAware(&agentBuf, revision)
+
+	reader := chgoproto.NewReader(bytes.NewReader(agentBuf.Buf))
+	var upstream bytes.Buffer
+	chAgentToServer(context.Background(), mock.ConnHandle, reader, &upstream, revision, "ch-cred", "")
+
+	out := upstream.Bytes()
+	if len(out) == 0 || chgoproto.ClientCode(out[0]) != chgoproto.ClientCodeQuery {
+		t.Fatalf("upstream first byte = %d, want ClientCodeQuery — HITL allow forwarded nothing", out[0])
+	}
+	r := chgoproto.NewReader(bytes.NewReader(out[1:]))
+	var got chgoproto.Query
+	if err := got.DecodeAware(r, revision); err != nil {
+		t.Fatalf("decode upstream Query: %v", err)
+	}
+	if diff := cmp.Diff(q.Parameters, got.Parameters); diff != "" {
+		t.Errorf("Parameters mismatch after HITL allow (-want +got):\n%s", diff)
+	}
+	// hitl_allow event proves the approver ran; if the peek had
+	// mis-fired as canceled, chEvaluateSQL would have emitted a
+	// "canceled" event and chHandleQuery would have skipped the
+	// upstream write.
+	if len(mock.events) == 0 || mock.events[0].Action != "hitl_allow" {
+		t.Errorf("expected hitl_allow event, got: %+v", mock.events)
+	}
+}

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -190,7 +190,11 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 		return fmt.Errorf("postgres endpoint %q has no host", ch.Endpoint.Name)
 	}
 
-	// Step 1: agent's first 8 bytes — SSLRequest or StartupMessage.
+	// Step 1: agent's first 8 bytes — SSLRequest, StartupMessage, or
+	// CancelRequest. CancelRequest arrives on a brand-new TCP
+	// connection (postgres does not multiplex cancel onto the existing
+	// session); we route it to the cancel registry instead of trying
+	// to perform a startup.
 	hdr := make([]byte, 8)
 	if _, err := io.ReadFull(ch.Conn, hdr); err != nil {
 		return nil
@@ -198,12 +202,19 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 	length := binary.BigEndian.Uint32(hdr[:4])
 	code := binary.BigEndian.Uint32(hdr[4:8])
 	var startupHead []byte
-	if length == 8 && code == sslRequestCode {
+	switch {
+	case length == pgCancelRequestLen && code == pgCancelRequestCode:
+		dial := func(network, addr string) (net.Conn, error) {
+			return ch.DialUpstream(ctx, network, addr)
+		}
+		_ = pgHandleCancelRequest(ch.Conn, pgCancelReg, dial)
+		return nil
+	case length == 8 && code == sslRequestCode:
 		if _, err := ch.Conn.Write([]byte{'N'}); err != nil {
 			return nil
 		}
 		startupHead = nil
-	} else {
+	default:
 		startupHead = hdr // actually the start of the StartupMessage
 	}
 
@@ -287,6 +298,29 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 		pgWriteError(ch.Conn, "upstream auth: "+err.Error())
 		return err
 	}
+
+	// Mint a synthetic BackendKeyData for the agent. The upstream's
+	// real (pid, key) stays on the cancel-registry entry; the agent
+	// only ever sees the synth pair. A subsequent CancelRequest using
+	// the synth (pid, key) routes back to *this* session via the
+	// registry (parked → abort approval; not parked → forward upstream
+	// using the real key).
+	synthPID, synthKey, keyErr := pgGenerateBackendKey()
+	var entry *pgCancelEntry
+	if keyErr == nil {
+		swapped, upstreamPID, upstreamKey, ok := pgSwapBackendKeyData(postAuth, synthPID, synthKey)
+		if ok {
+			postAuth = swapped
+			entry = &pgCancelEntry{
+				upstreamAddr: upstreamAddr,
+				upstreamPID:  upstreamPID,
+				upstreamKey:  upstreamKey,
+			}
+			pgCancelReg.register(synthPID, synthKey, entry)
+			defer pgCancelReg.unregister(synthPID, synthKey)
+		}
+	}
+
 	if err := pgWriteAuthOK(ch.Conn, postAuth); err != nil {
 		return nil
 	}
@@ -303,7 +337,7 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 	}()
 	go func() {
 		defer func() { done <- struct{}{} }()
-		pgClientToServer(ctx, ch, upstream, credName, database)
+		pgClientToServer(ctx, ch, upstream, credName, database, entry)
 	}()
 	<-done
 	return nil
@@ -393,7 +427,7 @@ const maxPgMessage = 1 << 20
 // the new database. From this gateway's vantage that arrives as a
 // new ConnHandle, so the session-start value remains authoritative
 // for every Query / Parse frame on this connection.
-func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.Conn, credName, database string) {
+func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.Conn, credName, database string, cancelEntry *pgCancelEntry) {
 	done := make(chan struct{})
 	defer close(done)
 	go func() {
@@ -447,7 +481,7 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 				if msg.typ == 'Q' || msg.typ == 'P' {
 					sql := pgExtractSQL(msg.typ, msg.payload)
 					if sql != "" {
-						verdict, reason := pgEvaluate(ch, sql, credName, database)
+						verdict, reason := pgEvaluate(ch, sql, credName, database, cancelEntry)
 						if verdict == "deny" {
 							pgWriteDeny(ch.Conn, reason)
 							log.Printf("pg-deny %s: %s", ch.PeerIP, reason)
@@ -596,14 +630,14 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName, 
 //
 //	("deny", reason) — first sub-statement to deny short-circuits.
 //	("", "")         — every sub-statement allowed or had no match.
-func pgEvaluate(ch *runtime.ConnHandle, sql, credName, database string) (string, string) {
+func pgEvaluate(ch *runtime.ConnHandle, sql, credName, database string, cancelEntry *pgCancelEntry) (string, string) {
 	for _, stmt := range analyseAll(sql) {
-		v, reason := pgEvaluateInfo(ch, stmt.Outer, credName, database, false)
+		v, reason := pgEvaluateInfo(ch, stmt.Outer, credName, database, false, cancelEntry)
 		if v == "deny" {
 			return v, reason
 		}
 		for _, inner := range stmt.Inner {
-			v, reason := pgEvaluateInfo(ch, inner, credName, database, true)
+			v, reason := pgEvaluateInfo(ch, inner, credName, database, true, cancelEntry)
 			if v == "deny" {
 				return v, reason
 			}
@@ -616,7 +650,7 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName, database string) (string,
 // suppresses emission on allow / hitl_allow so synthesised
 // sub-statements don't pollute the dashboard; deny emissions still
 // fire either way (operators need to see *why* a batch was denied).
-func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database string, shadow bool) (string, string) {
+func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database string, shadow bool, cancelEntry *pgCancelEntry) (string, string) {
 	summary := pgSummary(info)
 	mreq := &match.Request{
 		Family:     "sql",
@@ -668,13 +702,30 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 			})
 			return "deny", "approval required but HITL is not configured"
 		}
+		var parkCancel chan struct{}
+		if cancelEntry != nil {
+			parkCancel = make(chan struct{})
+			cancelEntry.markParked(parkCancel)
+		}
 		v := ch.Approve(runtime.ApproveCallRequest{
 			Stages: cr.Outcome.Approve, Verb: info.Verb,
 			Summary: summary, Rule: cr,
+			Cancel: parkCancel,
 		})
-		if v.Decision != "allow" {
+		canceled := false
+		if cancelEntry != nil {
+			cancelEntry.markUnparked()
+			select {
+			case <-parkCancel:
+				canceled = true
+			default:
+			}
+		}
+		if canceled || v.Decision != "allow" {
 			reason := v.Reason
-			if reason == "" {
+			if canceled {
+				reason = "canceled by agent"
+			} else if reason == "" {
 				reason = "denied by approver"
 			}
 			emit(ch, runtime.ConnEvent{

--- a/config/plugins/endpoints/postgres.go
+++ b/config/plugins/endpoints/postgres.go
@@ -482,9 +482,9 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 					sql := pgExtractSQL(msg.typ, msg.payload)
 					if sql != "" {
 						verdict, reason := pgEvaluate(ch, sql, credName, database, cancelEntry)
-						if verdict == "deny" {
+						if verdict == "deny" || verdict == "canceled" {
 							pgWriteDeny(ch.Conn, reason)
-							log.Printf("pg-deny %s: %s", ch.PeerIP, reason)
+							log.Printf("pg-%s %s: %s", verdict, ch.PeerIP, reason)
 							continue
 						}
 					}
@@ -628,17 +628,20 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName, 
 //
 // Returns:
 //
-//	("deny", reason) — first sub-statement to deny short-circuits.
-//	("", "")         — every sub-statement allowed or had no match.
+//	("deny", reason)     — first sub-statement to deny short-circuits.
+//	("canceled", reason) — agent canceled mid-approval; treated as a
+//	                       wire-deny by the caller but reported to the
+//	                       dashboard with a distinct Action.
+//	("", "")             — every sub-statement allowed or had no match.
 func pgEvaluate(ch *runtime.ConnHandle, sql, credName, database string, cancelEntry *pgCancelEntry) (string, string) {
 	for _, stmt := range analyseAll(sql) {
 		v, reason := pgEvaluateInfo(ch, stmt.Outer, credName, database, false, cancelEntry)
-		if v == "deny" {
+		if v == "deny" || v == "canceled" {
 			return v, reason
 		}
 		for _, inner := range stmt.Inner {
 			v, reason := pgEvaluateInfo(ch, inner, credName, database, true, cancelEntry)
-			if v == "deny" {
+			if v == "deny" || v == "canceled" {
 				return v, reason
 			}
 		}
@@ -721,11 +724,22 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 			default:
 			}
 		}
-		if canceled || v.Decision != "allow" {
+		if canceled {
+			// Agent canceled mid-approval. Emit a distinct "canceled"
+			// action — and return a "canceled" verdict — so the
+			// dashboard's deny-rate / SLO metrics don't conflate an
+			// agent Ctrl+C with an operator HITL deny. The approver
+			// fields stay empty: no human / LLM rendered a decision.
+			reason := "canceled by agent"
+			emit(ch, runtime.ConnEvent{
+				Action: "canceled", Reason: reason,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
+			})
+			return "canceled", reason
+		}
+		if v.Decision != "allow" {
 			reason := v.Reason
-			if canceled {
-				reason = "canceled by agent"
-			} else if reason == "" {
+			if reason == "" {
 				reason = "denied by approver"
 			}
 			emit(ch, runtime.ConnEvent{

--- a/config/plugins/endpoints/postgres_cancel.go
+++ b/config/plugins/endpoints/postgres_cancel.go
@@ -1,0 +1,313 @@
+package endpoints
+
+// Postgres CancelRequest handling.
+//
+// A postgres `Ctrl+C` does not travel down the existing session's
+// connection. The client opens a fresh TCP connection to the gateway
+// and sends a CancelRequest message — [int32 length=16][int32
+// code=80877102][int32 backend_pid][int32 secret_key]. The gateway
+// must:
+//
+//  1. Recognize the CancelRequest at the same entry point that
+//     handles StartupMessage / SSLRequest (HandleConn's first 8 bytes).
+//  2. Map (pid, key) to a live session via a process-global registry.
+//  3. If the session is parked waiting for HITL approval, abort the
+//     approval (so the agent's psql sees the cancel as an error +
+//     ReadyForQuery instead of waiting indefinitely).
+//  4. Otherwise, forward the cancel to the upstream postgres using the
+//     real (pid, key) we captured when relaying the upstream's
+//     BackendKeyData. Postgres servers expect this pattern — the
+//     CancelRequest connection is one-shot, gets no response, and the
+//     server drops it after acting (or ignoring an unknown key).
+//
+// The session-side (pid, key) we publish to the agent is gateway-
+// minted: the gateway picks two random uint32s, rewrites the
+// BackendKeyData (the `'K'` post-auth frame) before forwarding it,
+// and registers them here keyed on the synth pair. This is also a
+// security improvement — the agent never learns the upstream's real
+// PID, so an agent that knows another tenant's BackendKeyData can't
+// cancel queries it didn't issue.
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	// pgStartupCodeV3 is the wire protocol version sent by every modern
+	// libpq StartupMessage.
+	pgStartupCodeV3 uint32 = 196608
+	// pgCancelRequestCode is the magic int32 a postgres CancelRequest
+	// puts in its protocol-version slot. Sent on a fresh TCP connection
+	// to the same TCP port that accepts StartupMessages.
+	pgCancelRequestCode uint32 = 80877102
+	// pgCancelRequestLen is the fixed total length of a CancelRequest.
+	// 4 (length) + 4 (code) + 4 (pid) + 4 (secret_key).
+	pgCancelRequestLen uint32 = 16
+)
+
+// pgCancelEntry tracks one live postgres session's cancel state.
+// Each pgClientToServer pump owns exactly one entry from the moment
+// it relays the synthesized BackendKeyData to the agent until
+// HandleConn returns.
+type pgCancelEntry struct {
+	// upstreamAddr is the host:port that upstream was dialed on; the
+	// fallback path (session not parked) opens a fresh TCP connection
+	// there to forward the CancelRequest.
+	upstreamAddr string
+	// upstreamPID / upstreamKey are the real BackendKeyData the
+	// upstream postgres assigned to this session. Cancel forwarding
+	// uses them in the CancelRequest body.
+	upstreamPID uint32
+	upstreamKey uint32
+
+	mu sync.Mutex
+	// parked is true between pgMarkParked and pgMarkUnparked. While
+	// parked, an inbound CancelRequest closes parkCancel; otherwise the
+	// CancelRequest forwards to upstream.
+	parked bool
+	// parkCancel is the channel the parking pgEvaluate hands to
+	// ch.Approve via ApproveCallRequest.Cancel. Closed at most once;
+	// pgEvaluate re-creates it on each park.
+	parkCancel chan struct{}
+	// closed prevents a double-close of parkCancel when two cancel
+	// requests race or when the session itself transitions out of park
+	// at the same instant.
+	closed bool
+}
+
+// markParked records that the session is waiting on HITL. The plugin
+// passes parkCancel to the approver chain via ApproveCallRequest.Cancel
+// so a subsequent CancelRequest can abort the chain.
+func (e *pgCancelEntry) markParked(parkCancel chan struct{}) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.parked = true
+	e.parkCancel = parkCancel
+	e.closed = false
+}
+
+// markUnparked records that the approval call has returned. After
+// this, an inbound CancelRequest skips the parkCancel close and falls
+// through to the upstream-forward path.
+func (e *pgCancelEntry) markUnparked() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.parked = false
+	e.parkCancel = nil
+}
+
+// cancelParked closes parkCancel if the session is currently parked.
+// Returns whether the close happened — callers (the CancelRequest
+// handler) use the result to decide between "agent saw a cancel
+// already wired through approval" and "forward to upstream as a
+// fallback".
+func (e *pgCancelEntry) cancelParked() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.parked || e.closed || e.parkCancel == nil {
+		return false
+	}
+	close(e.parkCancel)
+	e.closed = true
+	return true
+}
+
+// pgCancelRegistry holds the (synth pid, synth key) → entry mapping
+// for every postgres session in the process. Cancel requests look up
+// here from a brand-new TCP connection; sessions register on auth
+// completion and deregister on HandleConn exit.
+type pgCancelRegistry struct {
+	mu sync.Mutex
+	m  map[uint64]*pgCancelEntry
+}
+
+func newPgCancelRegistry() *pgCancelRegistry {
+	return &pgCancelRegistry{m: make(map[uint64]*pgCancelEntry)}
+}
+
+func pgRegistryKey(pid, key uint32) uint64 {
+	return uint64(pid)<<32 | uint64(key)
+}
+
+func (r *pgCancelRegistry) register(pid, key uint32, e *pgCancelEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[pgRegistryKey(pid, key)] = e
+}
+
+func (r *pgCancelRegistry) unregister(pid, key uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.m, pgRegistryKey(pid, key))
+}
+
+func (r *pgCancelRegistry) lookup(pid, key uint32) *pgCancelEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.m[pgRegistryKey(pid, key)]
+}
+
+// pgCancelReg is the process-global registry the HandleConn entry
+// reads and writes. Tests that need isolation can swap this through
+// the test hooks below.
+var pgCancelReg = newPgCancelRegistry()
+
+// pgGenerateBackendKey mints a fresh (pid, key) pair the gateway
+// publishes to the agent as a synthetic BackendKeyData. Each field is
+// 4 random bytes — a 64-bit collision space across concurrent
+// sessions, which is comfortably larger than any realistic
+// connection-count target. crypto/rand is used because the value is
+// also the secret that authorizes a cancel, and a predictable PRNG
+// would let one agent guess another's key.
+func pgGenerateBackendKey() (pid, key uint32, err error) {
+	var b [8]byte
+	if _, err = rand.Read(b[:]); err != nil {
+		return 0, 0, err
+	}
+	pid = binary.BigEndian.Uint32(b[0:4])
+	key = binary.BigEndian.Uint32(b[4:8])
+	return pid, key, nil
+}
+
+// pgEncodeBackendKeyData builds a wire `K` frame carrying (pid, key).
+// Body layout matches the postgres v3 protocol: int32 pid, int32 key.
+func pgEncodeBackendKeyData(pid, key uint32) []byte {
+	out := make([]byte, 0, 13)
+	out = append(out, 'K')
+	out = append(out, encUint32(12)...) // 4 (length) + 4 (pid) + 4 (key)
+	out = append(out, encUint32(pid)...)
+	out = append(out, encUint32(key)...)
+	return out
+}
+
+// pgSwapBackendKeyData walks the postAuth byte slice the upstream
+// auth handshake collected, finds the upstream's BackendKeyData
+// frame, and rewrites it in place with the gateway's synthetic
+// (newPID, newKey). Returns the rewritten buffer and the upstream's
+// original (pid, key) so the caller can stash them on a pgCancelEntry
+// for the forwarding path.
+//
+// If postAuth does not contain a BackendKeyData (some servers send it
+// out of order, future protocol revisions might drop it), returns
+// (postAuth, 0, 0, false). The agent then sees no key and cannot
+// trigger a cancel — postgres treats missing BackendKeyData as
+// "cancellation unavailable", which is the safe fallback.
+func pgSwapBackendKeyData(postAuth []byte, newPID, newKey uint32) (out []byte, upstreamPID, upstreamKey uint32, ok bool) {
+	// Walk type-prefixed frames: 1B type + 4B length (length includes
+	// itself; payload follows). Looking for type 'K' with length=12.
+	i := 0
+	for i+5 <= len(postAuth) {
+		typ := postAuth[i]
+		length := binary.BigEndian.Uint32(postAuth[i+1 : i+5])
+		if length < 4 || int(length)+1 > len(postAuth)-i {
+			return postAuth, 0, 0, false
+		}
+		frameEnd := i + 1 + int(length)
+		if typ == 'K' && length == 12 {
+			upstreamPID = binary.BigEndian.Uint32(postAuth[i+5 : i+9])
+			upstreamKey = binary.BigEndian.Uint32(postAuth[i+9 : i+13])
+			rewritten := make([]byte, 0, len(postAuth))
+			rewritten = append(rewritten, postAuth[:i]...)
+			rewritten = append(rewritten, pgEncodeBackendKeyData(newPID, newKey)...)
+			rewritten = append(rewritten, postAuth[frameEnd:]...)
+			return rewritten, upstreamPID, upstreamKey, true
+		}
+		i = frameEnd
+	}
+	return postAuth, 0, 0, false
+}
+
+// pgReadCancelRequestBody pulls the [pid:4][secret_key:4] payload of
+// a CancelRequest message off `r`. The 8-byte head (length + code)
+// was already consumed by the HandleConn entry; this is the
+// remainder. Returns (0,0,err) on short read.
+func pgReadCancelRequestBody(r io.Reader) (pid, key uint32, err error) {
+	body := make([]byte, 8)
+	if _, err = io.ReadFull(r, body); err != nil {
+		return 0, 0, err
+	}
+	pid = binary.BigEndian.Uint32(body[0:4])
+	key = binary.BigEndian.Uint32(body[4:8])
+	return pid, key, nil
+}
+
+// pgHandleCancelRequest dispatches an inbound CancelRequest. The
+// caller has already read the 8-byte head; this function reads the
+// remaining 8-byte body off `conn`, looks up the (pid, key) in the
+// registry, and either aborts the parked approval or forwards the
+// cancel upstream. Always returns nil — the only side effects are
+// closing the parkCancel chan or dialing upstream; the caller closes
+// conn afterwards (CancelRequest has no protocol response).
+func pgHandleCancelRequest(conn net.Conn, reg *pgCancelRegistry, dial pgUpstreamDialer) error {
+	pid, key, err := pgReadCancelRequestBody(conn)
+	if err != nil {
+		return fmt.Errorf("read CancelRequest body: %w", err)
+	}
+	entry := reg.lookup(pid, key)
+	if entry == nil {
+		// Unknown (pid, key) — silent drop matches postgres-server
+		// behavior. An agent that guessed wrong sees the same
+		// nothing-happened that a real postgres server would emit.
+		return nil
+	}
+	if entry.cancelParked() {
+		// Parked approval aborted; the live session's pgEvaluate
+		// turns the resulting non-allow verdict into a pgWriteDeny
+		// on the agent's original connection.
+		return nil
+	}
+	// Not parked → the upstream is either running a query the gateway
+	// already approved or sitting idle. Forward the cancel so upstream
+	// can abort or no-op. pgForwardCancel makes a best-effort attempt
+	// on a short deadline; the cancel path stays unobservable to the
+	// agent regardless of outcome.
+	pgForwardCancel(entry.upstreamAddr, entry.upstreamPID, entry.upstreamKey, dial)
+	return nil
+}
+
+// pgUpstreamDialer is the dialer signature pgForwardCancel uses to
+// open a one-shot TCP connection to the upstream postgres for the
+// purpose of sending a CancelRequest. ConnHandle's DialUpstream
+// signature matches; tests pass a synthetic dialer to assert
+// forwarding without hitting the network.
+type pgUpstreamDialer func(network, addr string) (net.Conn, error)
+
+const pgForwardCancelTimeout = 5 * time.Second
+
+// pgForwardCancel opens a fresh TCP connection to upstreamAddr and
+// sends one CancelRequest with the real (pid, key) the gateway saw in
+// the upstream's BackendKeyData. The connection is closed
+// immediately afterwards — CancelRequest is one-shot and gets no
+// response per the postgres protocol.
+//
+// Best-effort: dial / write errors are swallowed (logging is the
+// caller's concern). The gateway can't promise the upstream honored
+// the cancel; what it promises is that it relayed the request.
+func pgForwardCancel(upstreamAddr string, pid, key uint32, dial pgUpstreamDialer) {
+	if upstreamAddr == "" {
+		return
+	}
+	if dial == nil {
+		dial = func(network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, pgForwardCancelTimeout)
+		}
+	}
+	conn, err := dial("tcp", upstreamAddr)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetWriteDeadline(time.Now().Add(pgForwardCancelTimeout))
+	body := make([]byte, 0, 16)
+	body = append(body, encUint32(pgCancelRequestLen)...)
+	body = append(body, encUint32(pgCancelRequestCode)...)
+	body = append(body, encUint32(pid)...)
+	body = append(body, encUint32(key)...)
+	_, _ = conn.Write(body)
+}

--- a/config/plugins/endpoints/postgres_cancel_test.go
+++ b/config/plugins/endpoints/postgres_cancel_test.go
@@ -1,0 +1,265 @@
+package endpoints
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPgSwapBackendKeyDataReplacesPidAndKey(t *testing.T) {
+	// Build a postAuth buffer that mirrors what pgPerformAuth would
+	// have collected: AuthenticationOk ('R' + len=8 + code=0) followed
+	// by BackendKeyData ('K' + len=12 + pid + key), then
+	// ReadyForQuery ('Z' + len=5 + 'I').
+	const upstreamPID uint32 = 0x11223344
+	const upstreamKey uint32 = 0x55667788
+
+	var postAuth []byte
+	postAuth = append(postAuth, 'R')
+	postAuth = append(postAuth, encUint32(8)...)
+	postAuth = append(postAuth, encUint32(0)...)
+	postAuth = append(postAuth, 'K')
+	postAuth = append(postAuth, encUint32(12)...)
+	postAuth = append(postAuth, encUint32(upstreamPID)...)
+	postAuth = append(postAuth, encUint32(upstreamKey)...)
+	postAuth = append(postAuth, 'Z', 0, 0, 0, 5, 'I')
+
+	swapped, gotUpstreamPID, gotUpstreamKey, ok := pgSwapBackendKeyData(postAuth, 0xAAAABBBB, 0xCCCCDDDD)
+	if !ok {
+		t.Fatalf("expected ok, got false")
+	}
+	if gotUpstreamPID != upstreamPID || gotUpstreamKey != upstreamKey {
+		t.Fatalf("captured upstream key (%x,%x), want (%x,%x)",
+			gotUpstreamPID, gotUpstreamKey, upstreamPID, upstreamKey)
+	}
+	if len(swapped) != len(postAuth) {
+		t.Fatalf("swapped length %d != original %d", len(swapped), len(postAuth))
+	}
+	// AuthenticationOk preserved.
+	if swapped[0] != 'R' || binary.BigEndian.Uint32(swapped[1:5]) != 8 {
+		t.Errorf("AuthenticationOk corrupted: %v", swapped[:9])
+	}
+	// BackendKeyData rewritten.
+	if swapped[9] != 'K' {
+		t.Fatalf("K frame moved or removed: %v", swapped[9:22])
+	}
+	gotPID := binary.BigEndian.Uint32(swapped[14:18])
+	gotKey := binary.BigEndian.Uint32(swapped[18:22])
+	if gotPID != 0xAAAABBBB || gotKey != 0xCCCCDDDD {
+		t.Errorf("synth (pid,key) = (%x,%x), want (AAAABBBB,CCCCDDDD)", gotPID, gotKey)
+	}
+	// ReadyForQuery preserved.
+	if swapped[22] != 'Z' || swapped[27] != 'I' {
+		t.Errorf("ReadyForQuery corrupted: %v", swapped[22:])
+	}
+}
+
+func TestPgSwapBackendKeyDataMissingReturnsFalse(t *testing.T) {
+	postAuth := []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0, 'Z', 0, 0, 0, 5, 'I'}
+	swapped, _, _, ok := pgSwapBackendKeyData(postAuth, 1, 2)
+	if ok {
+		t.Fatalf("expected ok=false for postAuth without K frame, got swapped=%v", swapped)
+	}
+}
+
+func TestPgCancelRegistryRegistersAndLookups(t *testing.T) {
+	reg := newPgCancelRegistry()
+	e := &pgCancelEntry{upstreamAddr: "example.test:5432"}
+	reg.register(42, 99, e)
+	if got := reg.lookup(42, 99); got != e {
+		t.Errorf("lookup hit returned %v, want %v", got, e)
+	}
+	if got := reg.lookup(99, 42); got != nil {
+		t.Errorf("lookup miss returned %v, want nil", got)
+	}
+	reg.unregister(42, 99)
+	if got := reg.lookup(42, 99); got != nil {
+		t.Errorf("post-unregister lookup returned %v, want nil", got)
+	}
+}
+
+func TestPgCancelEntryParkAndCancel(t *testing.T) {
+	e := &pgCancelEntry{}
+	// Not parked → cancelParked is a no-op and reports false.
+	if e.cancelParked() {
+		t.Fatal("cancelParked on unparked entry returned true")
+	}
+	parkCh := make(chan struct{})
+	e.markParked(parkCh)
+	if !e.cancelParked() {
+		t.Fatal("cancelParked on parked entry returned false")
+	}
+	select {
+	case <-parkCh:
+	default:
+		t.Fatal("parkCh not closed after cancelParked")
+	}
+	// Double cancel doesn't panic or double-close.
+	if e.cancelParked() {
+		t.Fatal("second cancelParked returned true")
+	}
+	e.markUnparked()
+	if e.cancelParked() {
+		t.Fatal("cancelParked after unpark returned true")
+	}
+}
+
+func TestPgHandleCancelRequestUnknownDropsSilently(t *testing.T) {
+	reg := newPgCancelRegistry()
+	clientConn, gwConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = gwConn.Close() }()
+
+	go func() {
+		// Write the 8-byte body (pid + key) the handler is about to read.
+		body := append(encUint32(1234), encUint32(5678)...)
+		_, _ = clientConn.Write(body)
+		_ = clientConn.Close()
+	}()
+
+	dialed := int32(0)
+	dial := func(_, _ string) (net.Conn, error) {
+		atomic.StoreInt32(&dialed, 1)
+		return nil, errors.New("should not dial")
+	}
+	if err := pgHandleCancelRequest(gwConn, reg, dial); err != nil {
+		t.Fatalf("handle cancel: %v", err)
+	}
+	if atomic.LoadInt32(&dialed) != 0 {
+		t.Errorf("unknown (pid, key) triggered dial; expected silent drop")
+	}
+}
+
+func TestPgHandleCancelRequestParkedFiresCancelChannel(t *testing.T) {
+	reg := newPgCancelRegistry()
+	entry := &pgCancelEntry{upstreamAddr: "example.test:5432"}
+	parkCh := make(chan struct{})
+	entry.markParked(parkCh)
+	reg.register(7, 8, entry)
+
+	clientConn, gwConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = gwConn.Close() }()
+
+	go func() {
+		body := append(encUint32(7), encUint32(8)...)
+		_, _ = clientConn.Write(body)
+	}()
+
+	dialed := int32(0)
+	dial := func(_, _ string) (net.Conn, error) {
+		atomic.StoreInt32(&dialed, 1)
+		return nil, errors.New("should not dial when parked")
+	}
+	if err := pgHandleCancelRequest(gwConn, reg, dial); err != nil {
+		t.Fatalf("handle cancel: %v", err)
+	}
+	select {
+	case <-parkCh:
+	case <-time.After(time.Second):
+		t.Fatal("parkCh not closed after cancel request")
+	}
+	if atomic.LoadInt32(&dialed) != 0 {
+		t.Errorf("parked cancel triggered upstream dial; should abort approval instead")
+	}
+}
+
+func TestPgHandleCancelRequestNotParkedForwardsUpstream(t *testing.T) {
+	reg := newPgCancelRegistry()
+	entry := &pgCancelEntry{
+		upstreamAddr: "example.test:5432",
+		upstreamPID:  0xDEADBEEF,
+		upstreamKey:  0xCAFEF00D,
+	}
+	reg.register(11, 22, entry)
+
+	clientConn, gwConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = gwConn.Close() }()
+
+	go func() {
+		body := append(encUint32(11), encUint32(22)...)
+		_, _ = clientConn.Write(body)
+	}()
+
+	// dial returns a synthetic upstream conn we can inspect for the
+	// CancelRequest bytes the handler is supposed to forward.
+	upstreamRead, upstreamWrite := net.Pipe()
+	defer func() { _ = upstreamRead.Close() }()
+	defer func() { _ = upstreamWrite.Close() }()
+	dial := func(network, addr string) (net.Conn, error) {
+		if network != "tcp" || addr != "example.test:5432" {
+			t.Errorf("dial(%q,%q), want tcp/example.test:5432", network, addr)
+		}
+		return upstreamWrite, nil
+	}
+
+	got := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 16)
+		_ = upstreamRead.SetReadDeadline(time.Now().Add(time.Second))
+		n, _ := upstreamRead.Read(buf)
+		got <- buf[:n]
+	}()
+
+	if err := pgHandleCancelRequest(gwConn, reg, dial); err != nil {
+		t.Fatalf("handle cancel: %v", err)
+	}
+
+	select {
+	case forwarded := <-got:
+		if len(forwarded) != 16 {
+			t.Fatalf("forwarded %d bytes, want 16: %v", len(forwarded), forwarded)
+		}
+		if binary.BigEndian.Uint32(forwarded[0:4]) != pgCancelRequestLen {
+			t.Errorf("forwarded length = %d, want %d",
+				binary.BigEndian.Uint32(forwarded[0:4]), pgCancelRequestLen)
+		}
+		if binary.BigEndian.Uint32(forwarded[4:8]) != pgCancelRequestCode {
+			t.Errorf("forwarded code = %d, want %d",
+				binary.BigEndian.Uint32(forwarded[4:8]), pgCancelRequestCode)
+		}
+		if binary.BigEndian.Uint32(forwarded[8:12]) != 0xDEADBEEF {
+			t.Errorf("forwarded pid = %x, want DEADBEEF",
+				binary.BigEndian.Uint32(forwarded[8:12]))
+		}
+		if binary.BigEndian.Uint32(forwarded[12:16]) != 0xCAFEF00D {
+			t.Errorf("forwarded key = %x, want CAFEF00D",
+				binary.BigEndian.Uint32(forwarded[12:16]))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no bytes forwarded to upstream")
+	}
+}
+
+// TestPgCancelBeatsConcurrentAllow exercises the precedence the task
+// calls out: a CancelRequest racing with an approver's "allow"
+// verdict on the same session must still result in cancellation. The
+// pgEvaluate side detects the close-of-parkCh by re-checking the
+// channel after Approve returns; the test simulates the race by
+// closing the channel before the Approve callback returns its
+// verdict.
+func TestPgCancelBeatsConcurrentAllow(t *testing.T) {
+	entry := &pgCancelEntry{}
+	parkCh := make(chan struct{})
+	entry.markParked(parkCh)
+
+	// Simulate the cancel-handler closing the channel mid-approval.
+	if !entry.cancelParked() {
+		t.Fatal("cancelParked returned false despite parked state")
+	}
+
+	// pgEvaluateInfo's logic: after Approve returns, check parkCh.
+	canceled := false
+	select {
+	case <-parkCh:
+		canceled = true
+	default:
+	}
+	if !canceled {
+		t.Fatal("parkCh select missed close; cancel-beats-allow precedence broken")
+	}
+}

--- a/config/plugins/endpoints/postgres_runtime_test.go
+++ b/config/plugins/endpoints/postgres_runtime_test.go
@@ -208,7 +208,7 @@ func TestPgClientToServerForwardsQueryMessage(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "")
+	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "", nil)
 
 	wire := serializePgMessage(pgMessage{typ: 'Q', payload: []byte("SELECT 1\x00")})
 	go func() { _, _ = agent.Write(wire) }()
@@ -231,7 +231,7 @@ func TestPgClientToServerDeniesQueryMessage(t *testing.T) {
 			Outcome: config.Outcome{Verdict: "deny", Reason: "blocked"},
 		}}},
 	}
-	go pgClientToServer(ctx, ch, upstream, "", "")
+	go pgClientToServer(ctx, ch, upstream, "", "", nil)
 
 	wire := serializePgMessage(pgMessage{typ: 'Q', payload: []byte("DROP TABLE users\x00")})
 	go func() { _, _ = agent.Write(wire) }()
@@ -250,7 +250,7 @@ func TestPgClientToServerForwardsNonInspectedMessage(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "")
+	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "", nil)
 
 	wire := serializePgMessage(pgMessage{typ: 'B', payload: []byte("portal\x00stmt\x00\x00\x00")})
 	go func() { _, _ = agent.Write(wire) }()
@@ -267,7 +267,7 @@ func TestPgClientToServerForwardsPartialFrame(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "")
+	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "", nil)
 
 	wire := serializePgMessage(pgMessage{typ: 'Q', payload: []byte("SELECT 1\x00")})
 	go func() {
@@ -288,7 +288,7 @@ func TestPgClientToServerForwardsMultipleFramesFromOneRead(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "")
+	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "", nil)
 
 	q := serializePgMessage(pgMessage{typ: 'Q', payload: []byte("SELECT 1\x00")})
 	syncMsg := serializePgMessage(pgMessage{typ: 'S'})
@@ -335,7 +335,7 @@ func TestPgClientToServerReturnsOnContextCancel(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "")
+		pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "", nil)
 	}()
 
 	cancel()
@@ -402,7 +402,7 @@ rule "default-deny" {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ch := &runtime.ConnHandle{Conn: gateway, Endpoint: ep}
-	go pgClientToServer(ctx, ch, upstream, "", "")
+	go pgClientToServer(ctx, ch, upstream, "", "", nil)
 
 	// Declare a Q frame whose length exceeds maxPgMessage. We send
 	// the header followed by a small "body" that exercises the
@@ -463,7 +463,7 @@ rule "by-credential" {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ch := &runtime.ConnHandle{Conn: gateway, Endpoint: ep}
-	go pgClientToServer(ctx, ch, upstream, "cred", "")
+	go pgClientToServer(ctx, ch, upstream, "cred", "", nil)
 
 	oversize := uint32(maxPgMessage + 8)
 	header := []byte{'Q', 0, 0, 0, 0}
@@ -645,7 +645,7 @@ func TestPgEvaluate_Audit143(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ch := denyAll(denyRule("blocked"))
-			v, _ := pgEvaluate(ch, tc.sql, "", "")
+			v, _ := pgEvaluate(ch, tc.sql, "", "", nil)
 			if v != "deny" {
 				t.Errorf("pgEvaluate(%q) verdict = %q, want deny", tc.sql, v)
 			}
@@ -670,7 +670,7 @@ func TestPgClientToServerDeniesFunctionCall(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "")
+	go pgClientToServer(ctx, &runtime.ConnHandle{Conn: gateway}, upstream, "", "", nil)
 
 	wire := serializePgMessage(pgMessage{typ: 'F', payload: []byte{0, 0, 0, 1, 0, 0}})
 	go func() { _, _ = agent.Write(wire) }()
@@ -699,7 +699,7 @@ func TestPgEvaluateEmitsAllowOnNoMatch(t *testing.T) {
 		},
 		Emit: func(ev runtime.ConnEvent) { events = append(events, ev) },
 	}
-	if v, _ := pgEvaluate(ch, "SELECT 1", "", ""); v != "" {
+	if v, _ := pgEvaluate(ch, "SELECT 1", "", "", nil); v != "" {
 		t.Errorf("verdict %q, want empty (allow)", v)
 	}
 	if len(events) != 1 {
@@ -774,16 +774,16 @@ func TestPgEvaluateThreadsDatabaseIntoMeta(t *testing.T) {
 	}
 	ch := &runtime.ConnHandle{Endpoint: ep, Emit: func(runtime.ConnEvent) {}}
 
-	if v, _ := pgEvaluate(ch, "DELETE FROM users", "", "Prod"); v != "deny" {
+	if v, _ := pgEvaluate(ch, "DELETE FROM users", "", "Prod", nil); v != "deny" {
 		t.Errorf("DELETE on Prod verdict = %q, want deny", v)
 	}
-	if v, _ := pgEvaluate(ch, "DELETE FROM users", "", "prod"); v != "" {
+	if v, _ := pgEvaluate(ch, "DELETE FROM users", "", "prod", nil); v != "" {
 		t.Errorf("DELETE on prod (lowercase) verdict = %q, want allow", v)
 	}
-	if v, _ := pgEvaluate(ch, "DELETE FROM users", "", ""); v != "" {
+	if v, _ := pgEvaluate(ch, "DELETE FROM users", "", "", nil); v != "" {
 		t.Errorf("DELETE with empty database verdict = %q, want allow", v)
 	}
-	if v, _ := pgEvaluate(ch, "SELECT 1", "", "Prod"); v != "" {
+	if v, _ := pgEvaluate(ch, "SELECT 1", "", "Prod", nil); v != "" {
 		t.Errorf("SELECT on Prod verdict = %q, want allow (verb mismatch)", v)
 	}
 }

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -279,7 +279,7 @@ type ApproveCallRequest struct {
 // dashboard doesn't have to round-trip through the legacy
 // Verb / Summary squashing.
 type ConnEvent struct {
-	Action  string // "allow" | "deny" | "approved" | "denied" | "error"
+	Action  string // "allow" | "deny" | "approved" | "denied" | "canceled" | "error"
 	Reason  string
 	Verb    string // SQL verb / k8s verb / etc.
 	Summary string // human-readable one-liner for the event log

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -255,6 +255,17 @@ type ApproveCallRequest struct {
 	// Rule is the matched compiled rule (carries Reason for the
 	// dashboard's "why is this gated" line).
 	Rule *config.CompiledRule
+	// Cancel, when non-nil, lets the endpoint plugin abort a parked
+	// approval from outside the synchronous call. The host derives a
+	// cancellable context from this channel and propagates ctx.Done()
+	// to every approver in the chain. Closing the channel makes the
+	// in-flight approver return early; the chain then yields a non-
+	// allow verdict (typically Decision=="deny", Reason carries the
+	// cancel cause). Postgres uses this to honor an agent-issued
+	// CancelRequest on a separate connection; clickhouse_native uses
+	// it to honor a ClientCancel packet read off the agent socket
+	// while the inspector is parked waiting for approval.
+	Cancel <-chan struct{}
 }
 
 // ConnEvent is the wire-protocol-agnostic event shape conn-family

--- a/main.go
+++ b/main.go
@@ -1367,7 +1367,9 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 			})
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
-			return g.runApproveChain(context.Background(), req.Stages, runApproveCtx{
+			ctx, cancel := approveCancelCtx(req.Cancel)
+			defer cancel()
+			return g.runApproveChain(ctx, req.Stages, runApproveCtx{
 				AgentIP: agentPip, Host: dstIP, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
 				Endpoint: ep, Rule: req.Rule, Profile: profile,
@@ -1603,7 +1605,9 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
 			cep := currentEP()
-			return g.runApproveChain(context.Background(), req.Stages, runApproveCtx{
+			ctx, cancel := approveCancelCtx(req.Cancel)
+			defer cancel()
+			return g.runApproveChain(ctx, req.Stages, runApproveCtx{
 				AgentIP: agentPip, Host: eventHost, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
 				Endpoint: cep, Rule: req.Rule, Profile: profile,
@@ -2277,6 +2281,28 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 		}
 	}
 	return runtime.ApproveVerdict{Decision: "allow"}
+}
+
+// approveCancelCtx derives an approval-chain context that fires when
+// the endpoint plugin closes its Cancel channel. Plugins use it to
+// abort a parked approval in response to an agent-issued cancel (a
+// postgres CancelRequest on a separate connection, a clickhouse_native
+// ClientCancel packet read off the agent socket). cancel must be
+// invoked when the chain returns so the watcher goroutine exits even
+// when the channel is never closed.
+func approveCancelCtx(cancelCh <-chan struct{}) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	if cancelCh == nil {
+		return ctx, cancel
+	}
+	go func() {
+		select {
+		case <-cancelCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
 }
 
 // ifNotEmpty returns f(v) when v != nil, else "".


### PR DESCRIPTION
## Summary

When a SQL query is parked waiting for HITL approval, an agent-side
`Ctrl+C` (psql, clickhouse-client) printed "Cancel request sent" but
the cancel didn't take effect — the query kept waiting on the
approver. This change wires both protocols' cancel paths through to
the approval flow.

### postgres

Cancel arrives on a **separate** TCP connection to port 5432, not on
the existing session. The dispatcher entry now distinguishes
StartupMessage (`196608`), SSLRequest (`80877103`), and CancelRequest
(`80877102`) at the first-8-bytes check. CancelRequest reads
`[pid:4][secret_key:4]` and looks up the live session in a
process-wide registry.

To make the registry safe, the gateway now mints its own
BackendKeyData (the `'K'` post-auth frame) before relaying it to the
agent: a random `(pid, key)` pair the agent uses for cancel, with the
upstream's real `(pid, key)` retained on the registry entry for the
forwarding path.

Dispatch on cancel:

- session parked for approval → abort the approval chain via the new
  `ApproveCallRequest.Cancel` channel → `pgWriteDeny` on the
  original agent connection (`E` + `Z`);
- session running upstream → open a one-shot TCP connection to the
  upstream postgres and forward the CancelRequest with the real
  `(pid, key)`;
- unknown `(pid, key)` → silent drop (mirrors what real postgres
  does).

Precedence: a cancel concurrent with an `allow` verdict still
denies — `pgEvaluateInfo` re-checks the channel after `Approve`
returns and overrides the verdict.

### clickhouse_native

Verification confirmed the bug: the inspector loop synchronously
calls `ch.Approve` from inside `chHandleQuery`, so an inbound
`ClientCancel` byte sits in the kernel socket buffer until approval
resolves. Fixed by spawning a one-shot peek goroutine while the
approver is parked:

- if the byte is `ClientCodeCancel`, close
  `ApproveCallRequest.Cancel` so the approver returns immediately
  and `chHandleQuery` overlays a "canceled by agent" deny that the
  agent sees as a `ServerException`;
- otherwise (typical case: `ClientCodeData` from an INSERT's
  trailing block), the byte is rewound onto a fresh
  `chgoproto.Reader` via the existing `chRewindReader` helper so the
  main pump keeps streaming;
- if no byte arrives by the time the approver resolves,
  `SetReadDeadline` unblocks the peek with no side effects.

### Shared plumbing

- `runtime.ApproveCallRequest` gains a `Cancel <-chan struct{}`
  channel.
- `main.go` derives a cancellable context for `runApproveChain` from
  that channel so existing approvers' `<-ctx.Done()` paths fire
  unchanged.

### Out of scope

clickhouse_https cancellation (HTTP queries aren't cancellable
client-side); operator-driven cancel from the dashboard; idle-timeout
cancel of long-parked approvals.

## Test plan

- [x] `go test ./...` and `go test -race ./...` green
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] new unit tests cover: `(pid, key)` registry register / lookup /
      unregister, park / cancel-parked / unpark transitions, unknown
      cancel silently dropped, parked cancel fires the close, not-
      parked cancel forwards upstream with the real key, cancel-
      beats-allow precedence, ClickhouseClientCancel mid-approval
      aborts and is swallowed, non-cancel byte rewinds, no-byte case
      cleans up via SetReadDeadline
- [ ] manual end-to-end with psql against a gateway-fronted postgres
      (out of scope for this PR — requires test infrastructure)