### PR TITLE
hitl: add async grant config schema

### DIFF
--- a/config/compile.go
+++ b/config/compile.go
@@ -54,9 +54,10 @@ type CompiledPolicy struct {
 // lookup. CompiledEndpoint.Hosts keeps the operator-declared strings
 // unchanged.
 type CompiledProfile struct {
-	Name      string
-	Endpoints map[string]*CompiledEndpoint
-	HostIndex map[string]*CompiledEndpoint
+	Name            string
+	Endpoints       map[string]*CompiledEndpoint
+	HostIndex       map[string]*CompiledEndpoint
+	HITLAsyncGrants bool
 }
 
 // CompiledEndpoint flattens an endpoint plus the rules that target it.
@@ -292,9 +293,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	// don't fork per profile.
 	for name, pr := range p.Profiles {
 		profile := &CompiledProfile{
-			Name:      name,
-			Endpoints: map[string]*CompiledEndpoint{},
-			HostIndex: map[string]*CompiledEndpoint{},
+			Name:            name,
+			Endpoints:       map[string]*CompiledEndpoint{},
+			HostIndex:       map[string]*CompiledEndpoint{},
+			HITLAsyncGrants: pr.HITLAsyncGrants,
 		}
 		for _, epName := range pr.Endpoints {
 			ce, ok := cp.Endpoints[epName]

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,9 @@ import (
 type Gateway struct {
 	Listen     string `hcl:"listen,optional"`
 	InfoListen string `hcl:"info_listen,optional"`
+	// PublicURL is the canonical externally reachable gateway URL used
+	// for generated control-plane links such as WireGuard join targets and
+	// async HITL status URLs. Runtime code normalizes away trailing slashes.
 	PublicURL  string `hcl:"public_url,optional"`
 	AdminEmail string `hcl:"admin_email,optional"`
 	// StateDir is the directory holding clawpatrol.db (and anything
@@ -249,14 +252,16 @@ func (noopPluginLoader) LoadPlugins([]PluginSource) hcl.Diagnostics { return nil
 // only body attribute; rules ride along automatically because they're
 // attached to endpoints.
 type Profile struct {
-	Name      string   `json:"name"`
-	Endpoints []string `json:"endpoints"`
+	Name            string   `json:"name"`
+	Endpoints       []string `json:"endpoints"`
+	HITLAsyncGrants bool     `json:"hitl_async_grants,omitempty"`
 }
 
 // profileBody is the gohcl decode target for the profile body — the
 // label is read separately from the block.
 type profileBody struct {
-	Endpoints []string `hcl:"endpoints"`
+	Endpoints       []string `hcl:"endpoints"`
+	HITLAsyncGrants bool     `hcl:"hitl_async_grants,optional"`
 }
 
 // Load parses, validates, and resolves the gateway config at path.
@@ -298,6 +303,7 @@ func LoadBytes(src []byte, filename string) (*Gateway, hcl.Diagnostics) {
 		// blocks. For now, append and continue.
 		diags = append(diags, d...)
 	}
+	gw.PublicURL = normalizePublicURL(gw.PublicURL)
 
 	gw.Policy = &Policy{
 		Approvers:   make(map[string]*Entity),
@@ -335,6 +341,7 @@ func LoadBytes(src []byte, filename string) (*Gateway, hcl.Diagnostics) {
 	configDir := filepath.Dir(filename)
 	resolveDiags := decodePolicyBlocks(gw.Policy, table, evalCtx, configDir)
 	diags = append(diags, resolveDiags...)
+	diags = append(diags, validateHITLAsyncConfig(gw)...)
 
 	// Post-decode pass: substitute `<<file:NAME>>` markers in plugin
 	// body fields that opted in via FileIncludable. Runs after Build
@@ -522,7 +529,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 		if d := gohcl.DecodeBody(sym.Block.Body, evalCtx, &body); d.HasErrors() {
 			diags = append(diags, d...)
 		}
-		pr := &Profile{Name: sym.Name, Endpoints: body.Endpoints}
+		pr := &Profile{Name: sym.Name, Endpoints: body.Endpoints, HITLAsyncGrants: body.HITLAsyncGrants}
 		// Cross-check: each endpoint name resolves to an endpoint.
 		for _, ep := range pr.Endpoints {
 			if table.Get(KindEndpoint, ep) != nil {

--- a/config/dump.go
+++ b/config/dump.go
@@ -164,7 +164,11 @@ func dumpProfiles(m map[string]*Profile) map[string]any {
 	}
 	out := map[string]any{}
 	for name, p := range m {
-		out[name] = map[string]any{"endpoints": p.Endpoints}
+		row := map[string]any{"endpoints": p.Endpoints}
+		if p.HITLAsyncGrants {
+			row["hitl_async_grants"] = true
+		}
+		out[name] = row
 	}
 	return out
 }

--- a/config/emit.go
+++ b/config/emit.go
@@ -215,6 +215,9 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 		if len(pr.Endpoints) > 0 {
 			SetIdentList(b, "endpoints", pr.Endpoints)
 		}
+		if pr.HITLAsyncGrants {
+			b.SetAttributeValue("hitl_async_grants", cty.True)
+		}
 	default:
 		return false
 	}

--- a/config/hitl_async.go
+++ b/config/hitl_async.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+const (
+	// HITLAsyncDefaultApprovalTTL is the default lifetime for an async
+	// operation after the original synchronous wait returns 202.
+	HITLAsyncDefaultApprovalTTL = 15 * time.Minute
+	// HITLAsyncDefaultApprovedRetryTTL is the default lifetime of the
+	// one-shot retry grant after a human approval.
+	HITLAsyncDefaultApprovedRetryTTL = 5 * time.Minute
+	// HITLAsyncDefaultMaxBodyBytes is the default body size limit for
+	// raw-body request fingerprinting.
+	HITLAsyncDefaultMaxBodyBytes int64 = 1 << 20
+	// HITLAsyncHardMaxBodyBytes caps v1 raw-body fingerprinting so an
+	// approver config cannot make Claw Patrol buffer unbounded bodies.
+	HITLAsyncHardMaxBodyBytes int64 = 8 << 20
+	// HITLAsyncFingerprintRawBody is the only v1 fingerprint mode.
+	HITLAsyncFingerprintRawBody = "raw"
+)
+
+// HITLAsyncGrantConfig is the optional nested `async_grant { ... }`
+// block shared by async-capable HITL approvers. It is schema-only here;
+// runtime execution lives in the gateway and endpoint layers.
+type HITLAsyncGrantConfig struct {
+	// Enabled explicitly opts this approver into async retry-grant mode.
+	// The active profile must also set hitl_async_grants = true.
+	Enabled bool `hcl:"enabled,optional" json:"enabled,omitempty"`
+	// Human approval lifetime after the original sync wait falls back to a 202 response.
+	ApprovalTTL string `hcl:"approval_ttl,optional" json:"approval_ttl,omitempty"`
+	// Post-approval retry grant lifetime for the client to retry.
+	ApprovedRetryTTL string `hcl:"approved_retry_ttl,optional" json:"approved_retry_ttl,omitempty"`
+	// Request-body fingerprinting mode. V1 supports only "raw".
+	FingerprintBody string `hcl:"fingerprint_body,optional" json:"fingerprint_body,omitempty"`
+	// Maximum request body size eligible for async raw-body fingerprinting.
+	MaxBodyBytes *int `hcl:"max_body_bytes,optional" json:"max_body_bytes,omitempty"`
+}
+
+// HITLAsyncGrantEnabler is implemented by approver bodies that expose
+// whether their config enables async retry-grant behavior. Keeping this
+// small avoids a config -> approvers package import cycle.
+type HITLAsyncGrantEnabler interface {
+	HITLAsyncGrantEnabled() bool
+}
+
+func (g *HITLAsyncGrantConfig) ApprovalTTLDuration() (time.Duration, error) {
+	return parseOptionalPositiveDuration(g, g.approvalTTLRaw(), HITLAsyncDefaultApprovalTTL)
+}
+
+func (g *HITLAsyncGrantConfig) ApprovedRetryTTLDuration() (time.Duration, error) {
+	return parseOptionalPositiveDuration(g, g.approvedRetryTTLRaw(), HITLAsyncDefaultApprovedRetryTTL)
+}
+
+func (g *HITLAsyncGrantConfig) FingerprintBodyValue() string {
+	if g == nil || g.FingerprintBody == "" {
+		return HITLAsyncFingerprintRawBody
+	}
+	return g.FingerprintBody
+}
+
+func (g *HITLAsyncGrantConfig) MaxBodyBytesValue() int64 {
+	if g == nil || g.MaxBodyBytes == nil {
+		return HITLAsyncDefaultMaxBodyBytes
+	}
+	return int64(*g.MaxBodyBytes)
+}
+
+func (g *HITLAsyncGrantConfig) approvalTTLRaw() string {
+	if g == nil {
+		return ""
+	}
+	return g.ApprovalTTL
+}
+
+func (g *HITLAsyncGrantConfig) approvedRetryTTLRaw() string {
+	if g == nil {
+		return ""
+	}
+	return g.ApprovedRetryTTL
+}
+
+func parseOptionalPositiveDuration(_ *HITLAsyncGrantConfig, raw string, fallback time.Duration) (time.Duration, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	return time.ParseDuration(raw)
+}
+
+func normalizePublicURL(raw string) string {
+	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}
+
+func validateHITLAsyncConfig(gw *Gateway) hcl.Diagnostics {
+	if gw == nil || gw.Policy == nil {
+		return nil
+	}
+	if !policyHasAsyncProfileOptIn(gw.Policy) || !policyHasAsyncApprover(gw.Policy) {
+		return nil
+	}
+	if gw.PublicURL == "" {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Async HITL public_url not configured",
+			Detail:   "set top-level public_url when any profile has hitl_async_grants = true and any approver has async_grant.enabled = true; async status URLs must not be derived from request Host headers.",
+		}}
+	}
+	if err := validateHITLAsyncPublicURL(gw.PublicURL); err != nil {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid async HITL public_url",
+			Detail:   fmt.Sprintf("public_url must be an absolute http or https URL with a host when async HITL grants are enabled: %v", err),
+		}}
+	}
+	return nil
+}
+
+func validateHITLAsyncPublicURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" || u.Hostname() == "" {
+		return fmt.Errorf("host is empty")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("query strings and fragments are not allowed")
+	}
+	return nil
+}
+
+func policyHasAsyncProfileOptIn(p *Policy) bool {
+	for _, profile := range p.Profiles {
+		if profile != nil && profile.HITLAsyncGrants {
+			return true
+		}
+	}
+	return false
+}
+
+func policyHasAsyncApprover(p *Policy) bool {
+	for _, ent := range p.Approvers {
+		if ent == nil || ent.Body == nil {
+			continue
+		}
+		if reader, ok := ent.Body.(HITLAsyncGrantEnabler); ok && reader.HITLAsyncGrantEnabled() {
+			return true
+		}
+	}
+	return false
+}
+
+func ValidateHITLAsyncGrant(name string, syncWaitTimeout string, grant *HITLAsyncGrantConfig) hcl.Diagnostics {
+	if grant == nil || !grant.Enabled {
+		return nil
+	}
+	var diags hcl.Diagnostics
+	if syncWaitTimeout == "" {
+		diags = append(diags, hitlAsyncDiagnostic(name, "sync_wait_timeout is required", "set sync_wait_timeout to the synchronous HTTP hold budget, e.g. \"90s\"."))
+	} else if d, err := time.ParseDuration(syncWaitTimeout); err != nil {
+		diags = append(diags, hitlAsyncDiagnostic(name, "invalid sync_wait_timeout", err.Error()))
+	} else if d <= 0 {
+		diags = append(diags, hitlAsyncDiagnostic(name, "sync_wait_timeout must be positive", "sync_wait_timeout must be greater than zero."))
+	}
+
+	if grant.ApprovalTTL != "" {
+		if d, err := time.ParseDuration(grant.ApprovalTTL); err != nil {
+			diags = append(diags, hitlAsyncDiagnostic(name, "invalid async_grant.approval_ttl", err.Error()))
+		} else if d <= 0 {
+			diags = append(diags, hitlAsyncDiagnostic(name, "async_grant.approval_ttl must be positive", "approval_ttl must be greater than zero."))
+		}
+	}
+	if grant.ApprovedRetryTTL != "" {
+		if d, err := time.ParseDuration(grant.ApprovedRetryTTL); err != nil {
+			diags = append(diags, hitlAsyncDiagnostic(name, "invalid async_grant.approved_retry_ttl", err.Error()))
+		} else if d <= 0 {
+			diags = append(diags, hitlAsyncDiagnostic(name, "async_grant.approved_retry_ttl must be positive", "approved_retry_ttl must be greater than zero."))
+		}
+	}
+	if got := grant.FingerprintBodyValue(); got != HITLAsyncFingerprintRawBody {
+		diags = append(diags, hitlAsyncDiagnostic(name, "async_grant.fingerprint_body must be raw", fmt.Sprintf("v1 supports only fingerprint_body = %q, got %q.", HITLAsyncFingerprintRawBody, got)))
+	}
+	if grant.MaxBodyBytes != nil {
+		maxBody := int64(*grant.MaxBodyBytes)
+		if maxBody <= 0 {
+			diags = append(diags, hitlAsyncDiagnostic(name, "async_grant.max_body_bytes must be positive", "max_body_bytes must be greater than zero."))
+		} else if maxBody > HITLAsyncHardMaxBodyBytes {
+			diags = append(diags, hitlAsyncDiagnostic(name, "async_grant.max_body_bytes exceeds hard maximum", fmt.Sprintf("max_body_bytes must be <= %d in v1.", HITLAsyncHardMaxBodyBytes)))
+		}
+	}
+	return diags
+}
+
+func hitlAsyncDiagnostic(name, summary, detail string) *hcl.Diagnostic {
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  summary,
+		Detail:   fmt.Sprintf("approver %q: %s", name, detail),
+	}
+}

--- a/config/hitl_async_config_test.go
+++ b/config/hitl_async_config_test.go
@@ -1,0 +1,307 @@
+package config_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+func TestHITLAsyncConfigLoadsProfileApproverAndNormalizesPublicURL(t *testing.T) {
+	src := `
+public_url = "https://clawpatrol.example.test/"
+
+credential "bearer_token" "pat" {}
+endpoint "https" "api" {
+  hosts      = ["api.example.test"]
+  credential = pat
+}
+profile "agent" {
+  endpoints          = [api]
+  hitl_async_grants = true
+}
+approver "human_approver" "ops" {
+  channel           = "#ops"
+  sync_wait_timeout = "90s"
+  async_grant {
+    enabled            = true
+    approval_ttl       = "15m"
+    approved_retry_ttl = "5m"
+    fingerprint_body   = "raw"
+    max_body_bytes     = 1048576
+  }
+}
+rule "writes" {
+  endpoint = api
+  approve  = [ops]
+}
+`
+	gw, diags := config.LoadBytes([]byte(src), "hitl_async.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if gw.PublicURL != "https://clawpatrol.example.test" {
+		t.Fatalf("PublicURL = %q, want trailing slash stripped", gw.PublicURL)
+	}
+	if !gw.Policy.Profiles["agent"].HITLAsyncGrants {
+		t.Fatal("profile HITLAsyncGrants = false, want true")
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !cp.Profiles["agent"].HITLAsyncGrants {
+		t.Fatal("compiled profile HITLAsyncGrants = false, want true")
+	}
+
+	reader, ok := gw.Policy.Approvers["ops"].Body.(interface {
+		HITLAsyncGrantEnabled() bool
+		HITLSyncWaitTimeout() time.Duration
+		HITLAsyncApprovalTTL() time.Duration
+		HITLAsyncApprovedRetryTTL() time.Duration
+		HITLAsyncMaxBodyBytes() int64
+		HITLAsyncFingerprintBody() string
+	})
+	if !ok {
+		t.Fatalf("human approver body does not expose async HITL reader: %T", gw.Policy.Approvers["ops"].Body)
+	}
+	if !reader.HITLAsyncGrantEnabled() {
+		t.Fatal("async grant disabled, want enabled")
+	}
+	if got := reader.HITLSyncWaitTimeout(); got != 90*time.Second {
+		t.Fatalf("sync wait timeout = %v, want 90s", got)
+	}
+	if got := reader.HITLAsyncApprovalTTL(); got != 15*time.Minute {
+		t.Fatalf("approval ttl = %v, want 15m", got)
+	}
+	if got := reader.HITLAsyncApprovedRetryTTL(); got != 5*time.Minute {
+		t.Fatalf("approved retry ttl = %v, want 5m", got)
+	}
+	if got := reader.HITLAsyncMaxBodyBytes(); got != 1048576 {
+		t.Fatalf("max body bytes = %d, want 1048576", got)
+	}
+	if got := reader.HITLAsyncFingerprintBody(); got != "raw" {
+		t.Fatalf("fingerprint body = %q, want raw", got)
+	}
+}
+
+func TestHITLAsyncConfigRequiresValidPublicURLWhenEffective(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		publicURL string
+		want      string
+	}{
+		{name: "missing", publicURL: "", want: "Async HITL public_url not configured"},
+		{name: "relative", publicURL: "not-a-url", want: "Invalid async HITL public_url"},
+		{name: "hostless", publicURL: "https://", want: "Invalid async HITL public_url"},
+		{name: "unsupported scheme", publicURL: "ftp://clawpatrol.example.test", want: "Invalid async HITL public_url"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := hitlAsyncConfigSource(tc.publicURL, true, true, "90s", `enabled = true`)
+			_, diags := config.LoadBytes([]byte(src), tc.name+".hcl")
+			if !diags.HasErrors() {
+				t.Fatal("load succeeded, want public_url diagnostic")
+			}
+			if !diagnosticsContain(diags, tc.want) {
+				t.Fatalf("diagnostics did not mention %q:\n%v", tc.want, diags)
+			}
+		})
+	}
+}
+
+func TestHITLAsyncConfigDoesNotRequirePublicURLWithoutDualOptIn(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		profileOptIn   bool
+		approverOptIn  bool
+		syncWait       string
+		asyncGrantBody string
+	}{
+		{name: "profile only", profileOptIn: true},
+		{name: "approver block disabled", profileOptIn: true, approverOptIn: true, syncWait: "90s", asyncGrantBody: `enabled = false`},
+		{name: "approver only", approverOptIn: true, syncWait: "90s", asyncGrantBody: `enabled = true`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := hitlAsyncConfigSource("", tc.profileOptIn, tc.approverOptIn, tc.syncWait, tc.asyncGrantBody)
+			_, diags := config.LoadBytes([]byte(src), tc.name+".hcl")
+			if diags.HasErrors() {
+				t.Fatalf("load: %v", diags)
+			}
+		})
+	}
+}
+
+func TestHITLAsyncConfigReaderDefaultsWithoutAsyncGrant(t *testing.T) {
+	src := hitlAsyncConfigSource("", false, false, "", "")
+	gw, diags := config.LoadBytes([]byte(src), "sync_only.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	reader, ok := gw.Policy.Approvers["ops"].Body.(interface {
+		HITLAsyncGrantEnabled() bool
+		HITLSyncWaitTimeout() time.Duration
+		HITLAsyncApprovalTTL() time.Duration
+		HITLAsyncApprovedRetryTTL() time.Duration
+		HITLAsyncMaxBodyBytes() int64
+		HITLAsyncFingerprintBody() string
+	})
+	if !ok {
+		t.Fatalf("human approver body does not expose async HITL reader: %T", gw.Policy.Approvers["ops"].Body)
+	}
+	if reader.HITLAsyncGrantEnabled() {
+		t.Fatal("async grant enabled, want disabled")
+	}
+	if got := reader.HITLSyncWaitTimeout(); got != 0 {
+		t.Fatalf("sync wait timeout = %v, want 0", got)
+	}
+	if got := reader.HITLAsyncApprovalTTL(); got != config.HITLAsyncDefaultApprovalTTL {
+		t.Fatalf("approval ttl = %v, want default", got)
+	}
+	if got := reader.HITLAsyncApprovedRetryTTL(); got != config.HITLAsyncDefaultApprovedRetryTTL {
+		t.Fatalf("approved retry ttl = %v, want default", got)
+	}
+	if got := reader.HITLAsyncMaxBodyBytes(); got != config.HITLAsyncDefaultMaxBodyBytes {
+		t.Fatalf("max body bytes = %d, want default", got)
+	}
+	if got := reader.HITLAsyncFingerprintBody(); got != config.HITLAsyncFingerprintRawBody {
+		t.Fatalf("fingerprint body = %q, want raw", got)
+	}
+}
+
+func TestHITLAsyncConfigRequiresSyncWaitTimeoutWhenEnabled(t *testing.T) {
+	src := hitlAsyncConfigSource("https://clawpatrol.example.test", true, true, "", `enabled = true`)
+	_, diags := config.LoadBytes([]byte(src), "missing_sync_wait_timeout.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("load succeeded, want missing sync_wait_timeout diagnostic")
+	}
+	if !diagnosticsContain(diags, "sync_wait_timeout is required") {
+		t.Fatalf("diagnostics did not mention sync_wait_timeout requirement:\n%v", diags)
+	}
+}
+
+func TestHITLAsyncConfigRejectsInvalidApproverValues(t *testing.T) {
+	src := `
+public_url = "https://clawpatrol.example.test"
+
+credential "bearer_token" "pat" {}
+endpoint "https" "api" {
+  hosts      = ["api.example.test"]
+  credential = pat
+}
+profile "agent" {
+  endpoints          = [api]
+  hitl_async_grants = true
+}
+approver "human_approver" "ops" {
+  channel           = "#ops"
+  sync_wait_timeout = "0s"
+  async_grant {
+    enabled            = true
+    approval_ttl       = "nope"
+    approved_retry_ttl = "0s"
+    fingerprint_body   = "json"
+    max_body_bytes     = 0
+  }
+}
+rule "writes" {
+  endpoint = api
+  approve  = [ops]
+}
+`
+	_, diags := config.LoadBytes([]byte(src), "invalid_async.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("load succeeded, want invalid async HITL diagnostics")
+	}
+	for _, want := range []string{
+		"sync_wait_timeout must be positive",
+		"invalid async_grant.approval_ttl",
+		"async_grant.approved_retry_ttl must be positive",
+		"async_grant.fingerprint_body must be raw",
+		"async_grant.max_body_bytes must be positive",
+	} {
+		if !diagnosticsContain(diags, want) {
+			t.Fatalf("diagnostics missing %q:\n%v", want, diags)
+		}
+	}
+}
+
+func TestHITLAsyncConfigRejectsMaxBodyBytesAboveHardLimit(t *testing.T) {
+	src := hitlAsyncConfigSource(
+		"https://clawpatrol.example.test",
+		true,
+		true,
+		"90s",
+		fmt.Sprintf("enabled = true\n    max_body_bytes = %d", config.HITLAsyncHardMaxBodyBytes+1),
+	)
+	_, diags := config.LoadBytes([]byte(src), "oversize_body_limit.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("load succeeded, want max_body_bytes hard limit diagnostic")
+	}
+	if !diagnosticsContain(diags, "async_grant.max_body_bytes exceeds hard maximum") {
+		t.Fatalf("diagnostics did not mention max_body_bytes hard limit:\n%v", diags)
+	}
+}
+
+func hitlAsyncConfigSource(publicURL string, profileOptIn, includeAsyncGrant bool, syncWaitTimeout, asyncGrantBody string) string {
+	var b strings.Builder
+	if publicURL != "" {
+		fmt.Fprintf(&b, "public_url = %q\n\n", publicURL)
+	}
+	b.WriteString(`credential "bearer_token" "pat" {}
+endpoint "https" "api" {
+  hosts      = ["api.example.test"]
+  credential = pat
+}
+profile "agent" {
+  endpoints = [api]
+`)
+	if profileOptIn {
+		b.WriteString("  hitl_async_grants = true\n")
+	}
+	b.WriteString(`}
+approver "human_approver" "ops" {
+  channel = "#ops"
+`)
+	if syncWaitTimeout != "" {
+		fmt.Fprintf(&b, "  sync_wait_timeout = %q\n", syncWaitTimeout)
+	}
+	if includeAsyncGrant {
+		b.WriteString("  async_grant {\n")
+		if asyncGrantBody != "" {
+			for _, line := range strings.Split(asyncGrantBody, "\n") {
+				if line == "" {
+					b.WriteByte('\n')
+					continue
+				}
+				b.WriteString("    ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+		}
+		b.WriteString("  }\n")
+	}
+	b.WriteString(`}
+rule "writes" {
+  endpoint = api
+  approve  = [ops]
+}
+`)
+	return b.String()
+}
+
+func diagnosticsContain(diags hcl.Diagnostics, want string) bool {
+	for _, diag := range diags {
+		if diag == nil {
+			continue
+		}
+		if strings.Contains(diag.Summary, want) || strings.Contains(diag.Detail, want) {
+			return true
+		}
+	}
+	return strings.Contains(diags.Error(), want)
+}

--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -35,6 +35,13 @@ type HumanApprover struct {
 	Credential       string `hcl:"credential,optional"`
 	Timeout          int    `hcl:"timeout,optional"`
 	RequireApprovers int    `hcl:"require_approvers,optional"`
+	// SyncWaitTimeout is the HTTP hold budget before an async-capable
+	// HITL request returns 202 and moves to polling/retry-grant mode.
+	SyncWaitTimeout string `hcl:"sync_wait_timeout,optional" json:"sync_wait_timeout,omitempty"`
+	// AsyncGrant configures v1 HITL async retry grants for this approver.
+	// The nested block must set enabled = true, and the active profile must
+	// also set hitl_async_grants = true, before async behavior is effective.
+	AsyncGrant *config.HITLAsyncGrantConfig `hcl:"async_grant,block" json:"async_grant,omitempty"`
 	// Interactive toggles in-channel approve/deny buttons. Requires the
 	// referenced credential's signing_secret slot pasted via the
 	// dashboard AND Slack's Interactivity URL pointed at the gateway.
@@ -66,6 +73,42 @@ func (h *HumanApprover) HumanApproverCredential() string { return h.Credential }
 
 // HumanApproverInteractive is part of the clawpatrol plugin API.
 func (h *HumanApprover) HumanApproverInteractive() bool { return h.Interactive }
+
+// HITLAsyncGrantEnabled exposes the async opt-in to config-level cross validation.
+func (h *HumanApprover) HITLAsyncGrantEnabled() bool {
+	return h != nil && h.AsyncGrant != nil && h.AsyncGrant.Enabled
+}
+
+// HITLSyncWaitTimeout returns the parsed synchronous hold budget.
+func (h *HumanApprover) HITLSyncWaitTimeout() time.Duration {
+	if h == nil || h.SyncWaitTimeout == "" {
+		return 0
+	}
+	d, _ := time.ParseDuration(h.SyncWaitTimeout)
+	return d
+}
+
+// HITLAsyncApprovalTTL returns the async pending approval lifetime.
+func (h *HumanApprover) HITLAsyncApprovalTTL() time.Duration {
+	d, _ := h.AsyncGrant.ApprovalTTLDuration()
+	return d
+}
+
+// HITLAsyncApprovedRetryTTL returns the post-approval retry grant lifetime.
+func (h *HumanApprover) HITLAsyncApprovedRetryTTL() time.Duration {
+	d, _ := h.AsyncGrant.ApprovedRetryTTLDuration()
+	return d
+}
+
+// HITLAsyncMaxBodyBytes returns the raw-body fingerprinting size limit.
+func (h *HumanApprover) HITLAsyncMaxBodyBytes() int64 {
+	return h.AsyncGrant.MaxBodyBytesValue()
+}
+
+// HITLAsyncFingerprintBody returns the v1 request fingerprint mode.
+func (h *HumanApprover) HITLAsyncFingerprintBody() string {
+	return h.AsyncGrant.FingerprintBodyValue()
+}
 
 // Approve is part of the clawpatrol plugin API.
 func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
@@ -168,6 +211,10 @@ func init() {
 			{Path: "Credential", Kind: config.KindCredential, Optional: true},
 			{Path: "Classifier", Kind: config.KindApprover, Optional: true},
 		},
+		Validate: func(d any, name string, _ *config.BuildCtx) hcl.Diagnostics {
+			a := d.(*HumanApprover)
+			return config.ValidateHITLAsyncGrant(name, a.SyncWaitTimeout, a.AsyncGrant)
+		},
 		Build: func(d any, _ string, _ *config.BuildCtx) (any, hcl.Diagnostics) { return d, nil },
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			a := body.(*HumanApprover)
@@ -180,6 +227,27 @@ func init() {
 			}
 			if a.RequireApprovers != 0 {
 				b.SetAttributeValue("require_approvers", cty.NumberIntVal(int64(a.RequireApprovers)))
+			}
+			if a.SyncWaitTimeout != "" {
+				b.SetAttributeValue("sync_wait_timeout", cty.StringVal(a.SyncWaitTimeout))
+			}
+			if a.AsyncGrant != nil {
+				ag := b.AppendNewBlock("async_grant", nil).Body()
+				if a.AsyncGrant.Enabled {
+					ag.SetAttributeValue("enabled", cty.True)
+				}
+				if a.AsyncGrant.ApprovalTTL != "" {
+					ag.SetAttributeValue("approval_ttl", cty.StringVal(a.AsyncGrant.ApprovalTTL))
+				}
+				if a.AsyncGrant.ApprovedRetryTTL != "" {
+					ag.SetAttributeValue("approved_retry_ttl", cty.StringVal(a.AsyncGrant.ApprovedRetryTTL))
+				}
+				if a.AsyncGrant.FingerprintBody != "" {
+					ag.SetAttributeValue("fingerprint_body", cty.StringVal(a.AsyncGrant.FingerprintBody))
+				}
+				if a.AsyncGrant.MaxBodyBytes != nil {
+					ag.SetAttributeValue("max_body_bytes", cty.NumberIntVal(int64(*a.AsyncGrant.MaxBodyBytes)))
+				}
 			}
 			if a.Interactive {
 				b.SetAttributeValue("interactive", cty.True)

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -28,7 +28,7 @@ Every singleton gateway attribute — listen addresses, paths, control-plane joi
 |-----------|------|----------|-------------|
 | `listen` | `string` | no |  |
 | `info_listen` | `string` | no |  |
-| `public_url` | `string` | no |  |
+| `public_url` | `string` | no | The canonical externally reachable gateway URL used for generated control-plane links such as WireGuard join targets and async HITL status URLs. Runtime code normalizes away trailing slashes. |
 | `admin_email` | `string` | no |  |
 | `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything else a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol when unset. |
 | `resolver` | `string` | no |  |
@@ -80,10 +80,12 @@ Names a set of endpoints. Profiles bind to dashboard owners; an owner's profile 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `endpoints` | `[]ref(endpoint)` | yes | Bare-name endpoint references included in this profile. |
+| `hitl_async_grants` | `bool` | no | Explicit opt-in for agent-aware async HITL retry grants on this profile. Async behavior still also requires an approver with `async_grant.enabled = true`. |
 
 ```hcl
 profile "default" {
-  endpoints = [github, postgres-prod]
+  endpoints          = [github, postgres-prod]
+  hitl_async_grants = true
 }
 ```
 
@@ -109,9 +111,25 @@ operator clicks approve/deny on the dashboard).
 | `credential` | `ref(credential)` | no |  |
 | `timeout` | `int` | no |  |
 | `require_approvers` | `int` | no |  |
+| `sync_wait_timeout` | `string` | no | The HTTP hold budget before an async-capable HITL request returns 202 and moves to polling/retry-grant mode. |
+| `async_grant` | `block` | no | Configures v1 HITL async retry grants for this approver. The nested block must set enabled = true, and the active profile must also set hitl_async_grants = true, before async behavior is effective. |
 | `interactive` | `bool` | no | Toggles in-channel approve/deny buttons. Requires the referenced credential's signing_secret slot pasted via the dashboard AND Slack's Interactivity URL pointed at the gateway. Default false: message includes only an "Open dashboard" link. |
 | `classifier` | `ref(approver)` | no | Optionally references an llm_approver by name. When set, the approver calls the classifier's Summarize method before posting the HITL notification, enriching the Slack card with classification metadata. Classifier failures are non-fatal — the generic card is used as fallback. |
 | `message` | `string` | no | An optional Go-template-style string with {{var}} placeholders. When set, the expanded text replaces the default section body in the Slack (or other notifier) card. Supported vars mirror the CEL facet namespace: {{http.method}}, {{http.path}}, {{k8s.verb}}, {{sql.tables}}, {{body_json.ticket}}, {{profile}}, {{endpoint}}, {{reason}}, etc. Classifier (if also set) still runs; Message takes display precedence. |
+
+**Nested block `async_grant {}`:**
+
+The optional nested `async_grant { ... }`
+block shared by async-capable HITL approvers. It is schema-only here;
+runtime execution lives in the gateway and endpoint layers.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `enabled` | `bool` | no | Explicitly opts this approver into async retry-grant mode. The active profile must also set hitl_async_grants = true. |
+| `approval_ttl` | `string` | no | Human approval lifetime after the original sync wait falls back to a 202 response. |
+| `approved_retry_ttl` | `string` | no | Post-approval retry grant lifetime for the client to retry. |
+| `fingerprint_body` | `string` | no | Request-body fingerprinting mode. V1 supports only "raw". |
+| `max_body_bytes` | `int` | no | Maximum request body size eligible for async raw-body fingerprinting. |
 
 ```hcl
 approver "human_approver" "example" {

--- a/tools/docgen/internal/render/render.go
+++ b/tools/docgen/internal/render/render.go
@@ -172,8 +172,9 @@ func (r *renderer) writeProfile() {
 	r.out.WriteString("Names a set of endpoints. Profiles bind to dashboard owners; an owner's profile determines which endpoints their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.\n\n")
 	r.out.WriteString("| Attribute | Type | Required | Description |\n")
 	r.out.WriteString("|-----------|------|----------|-------------|\n")
-	r.out.WriteString("| `endpoints` | `[]ref(endpoint)` | yes | Bare-name endpoint references included in this profile. |\n\n")
-	r.out.WriteString("```hcl\nprofile \"default\" {\n  endpoints = [github, postgres-prod]\n}\n```\n\n")
+	r.out.WriteString("| `endpoints` | `[]ref(endpoint)` | yes | Bare-name endpoint references included in this profile. |\n")
+	r.out.WriteString("| `hitl_async_grants` | `bool` | no | Explicit opt-in for agent-aware async HITL retry grants on this profile. Async behavior still also requires an approver with `async_grant.enabled = true`. |\n\n")
+	r.out.WriteString("```hcl\nprofile \"default\" {\n  endpoints          = [github, postgres-prod]\n  hitl_async_grants = true\n}\n```\n\n")
 }
 
 // ── plugin-dispatched kinds ─────────────────────────────────────────
@@ -352,7 +353,7 @@ func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fi
 		row := fieldRow{
 			Name:        name,
 			Type:        typeStr,
-			Required:    !hasOpt(opts, "optional"),
+			Required:    fieldRequired(f.Type, opts),
 			Block:       hasOpt(opts, "block"),
 			GoFieldName: f.Name,
 			Doc:         stripIdentPrefix(r.docs.fieldDoc(pkgName, typeName, f.Name), f.Name),
@@ -381,6 +382,16 @@ func (r *renderer) fieldRefs(pkgName, typeName string) map[string]string {
 		}
 	}
 	return out
+}
+
+func fieldRequired(rt reflect.Type, opts []string) bool {
+	if hasOpt(opts, "optional") {
+		return false
+	}
+	if hasOpt(opts, "block") && rt.Kind() == reflect.Pointer {
+		return false
+	}
+	return true
 }
 
 // blockElemType returns the underlying struct type of a `hcl:"...,block"`


### PR DESCRIPTION
## Summary
- Add the first async HITL approval-grant config surface: `profile.hitl_async_grants`, `human_approver.sync_wait_timeout`, and `human_approver.async_grant { ... }`.
- Validate the v1 dual opt-in invariants, `public_url` requirements, positive async TTLs, raw-only body fingerprint mode, and bounded body size.
- Propagate the profile flag through compile/dump/emit and regenerate the config reference docs.

This is intentionally the first small slice from the implementation-ready design gist: https://gist.github.com/magurotuna/96a997753fb5adda4c2d303821790592. It does not add the durable operation store or async runtime yet.

## Test plan
- `go generate ./config/plugins/all`
- `git diff --check origin/main...HEAD`
- `go test ./config ./config/plugins/approvers ./tools/docgen ./tools/docgen/internal/render`
- `go test ./...`
- `npm --prefix site ci`
- `npm --prefix site run build`
