### PR TITLE
hitl: add async operation store

### DIFF
--- a/hitl_operation_store.go
+++ b/hitl_operation_store.go
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type HITLOperationState string
+
+const (
+	HITLOperationStateSyncWaiting             HITLOperationState = "sync_waiting"
+	HITLOperationStatePendingApproval         HITLOperationState = "pending_approval"
+	HITLOperationStateApprovedWaitingForRetry HITLOperationState = "approved_waiting_for_retry"
+	HITLOperationStateDenied                  HITLOperationState = "denied"
+	HITLOperationStateExpired                 HITLOperationState = "expired"
+	HITLOperationStateExecutingUpstream       HITLOperationState = "executing_upstream"
+	HITLOperationStateUpstreamSucceeded       HITLOperationState = "upstream_succeeded"
+	HITLOperationStateUpstreamFailed          HITLOperationState = "upstream_failed"
+	HITLOperationStateClientDisconnected      HITLOperationState = "client_disconnected"
+)
+
+var (
+	ErrHITLOperationNotFound     = errors.New("hitl operation not found")
+	ErrHITLOperationConflict     = errors.New("hitl operation state conflict")
+	ErrHITLRetryNotApproved      = errors.New("hitl retry not approved")
+	ErrHITLRetryExpired          = errors.New("hitl retry expired")
+	ErrHITLRetryMismatch         = errors.New("hitl retry mismatch")
+	ErrHITLGrantAlreadyConsumed  = errors.New("hitl retry grant already consumed")
+	ErrHITLOperationStoreInvalid = errors.New("invalid hitl operation")
+)
+
+type HITLOperationStore struct {
+	db *sql.DB
+}
+
+type HITLOperationCreate struct {
+	ID                  string
+	State               HITLOperationState
+	ProfileID           string
+	PrincipalID         string
+	EndpointID          string
+	ApprovalRuleID      string
+	ApproverID          string
+	Method              string
+	Scheme              string
+	Host                string
+	RedactedPath        string
+	RedactedQuery       string
+	RedactedHeadersJSON string
+	AuthBindingID       string
+	FingerprintVersion  string
+	HMACKeyID           string
+	RequestFingerprint  string
+	CreatedAt           time.Time
+	SyncWaitDeadline    time.Time
+	ApprovalExpiresAt   time.Time
+	RetryExpiresAt      time.Time
+}
+
+type HITLOperationTransition struct {
+	ID                         string
+	FromState                  HITLOperationState
+	ToState                    HITLOperationState
+	ExpectedVersion            int64
+	Now                        time.Time
+	RetryExpiresAt             time.Time
+	ExpiredReason              string
+	TerminalRetentionExpiresAt time.Time
+	UpstreamCalled             bool
+	LastError                  string
+}
+
+type HITLRetryGrantConsume struct {
+	ID                 string
+	ProfileID          string
+	PrincipalID        string
+	AuthBindingID      string
+	RequestFingerprint string
+	ConsumedBy         string
+	Now                time.Time
+}
+
+type HITLOperation struct {
+	ID                         string
+	State                      HITLOperationState
+	Version                    int64
+	ProfileID                  string
+	PrincipalID                string
+	EndpointID                 string
+	ApprovalRuleID             string
+	ApproverID                 string
+	Method                     string
+	Scheme                     string
+	Host                       string
+	RedactedPath               string
+	RedactedQuery              string
+	RedactedHeadersJSON        string
+	AuthBindingID              string
+	FingerprintVersion         string
+	HMACKeyID                  string
+	RequestFingerprint         string
+	CreatedAt                  time.Time
+	SyncWaitDeadline           time.Time
+	ApprovalExpiresAt          time.Time
+	RetryExpiresAt             *time.Time
+	ExpiredReason              string
+	TerminalAt                 *time.Time
+	TerminalRetentionExpiresAt *time.Time
+	UpstreamCalled             bool
+	GrantConsumedAt            *time.Time
+	GrantConsumedBy            string
+	SlackMessageRef            string
+	DashboardRef               string
+	LastError                  string
+}
+
+func NewHITLOperationStore(db *sql.DB) *HITLOperationStore {
+	return &HITLOperationStore{db: db}
+}
+
+func (s *HITLOperationStore) Create(ctx context.Context, in HITLOperationCreate) (HITLOperation, error) {
+	if s == nil || s.db == nil {
+		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if in.ID == "" {
+		in.ID = newReqID()
+	}
+	if in.State == "" {
+		in.State = HITLOperationStateSyncWaiting
+	}
+	if err := validateHITLOperationCreate(in); err != nil {
+		return HITLOperation{}, err
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO hitl_operations (
+  id, state, version,
+  profile_id, principal_id, endpoint_id, approval_rule_id, approver_id,
+  method, scheme, host, redacted_path, redacted_query, redacted_headers_json,
+  auth_binding_id, fingerprint_version, hmac_key_id, request_fingerprint,
+  created_ns, sync_wait_deadline_ns, approval_expires_ns, retry_expires_ns
+) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		in.ID, string(in.State),
+		in.ProfileID, in.PrincipalID, in.EndpointID, in.ApprovalRuleID, in.ApproverID,
+		in.Method, in.Scheme, in.Host, in.RedactedPath, nullString(in.RedactedQuery), nullString(in.RedactedHeadersJSON),
+		in.AuthBindingID, in.FingerprintVersion, in.HMACKeyID, in.RequestFingerprint,
+		timeNS(in.CreatedAt), timeNS(in.SyncWaitDeadline), timeNS(in.ApprovalExpiresAt), nullTimeNS(in.RetryExpiresAt),
+	)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	return s.get(ctx, in.ID)
+}
+
+func (s *HITLOperationStore) GetForPrincipal(ctx context.Context, id, profileID, principalID string) (HITLOperation, error) {
+	if s == nil || s.db == nil {
+		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	return s.scanOne(ctx, `SELECT `+hitlOperationColumns+` FROM hitl_operations WHERE id = ? AND profile_id = ? AND principal_id = ?`, id, profileID, principalID)
+}
+
+func (s *HITLOperationStore) Transition(ctx context.Context, tr HITLOperationTransition) (HITLOperation, error) {
+	if s == nil || s.db == nil {
+		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if tr.ID == "" || tr.FromState == "" || tr.ToState == "" || tr.ExpectedVersion <= 0 || tr.Now.IsZero() {
+		return HITLOperation{}, fmt.Errorf("%w: incomplete transition", ErrHITLOperationStoreInvalid)
+	}
+	if !isKnownHITLOperationState(tr.FromState) || !isKnownHITLOperationState(tr.ToState) {
+		return HITLOperation{}, fmt.Errorf("%w: unknown transition state", ErrHITLOperationStoreInvalid)
+	}
+	sets := []string{"state = ?", "version = version + 1"}
+	args := []any{string(tr.ToState)}
+	if !tr.RetryExpiresAt.IsZero() {
+		sets = append(sets, "retry_expires_ns = ?")
+		args = append(args, timeNS(tr.RetryExpiresAt))
+	}
+	if tr.ExpiredReason != "" {
+		sets = append(sets, "expired_reason = ?")
+		args = append(args, tr.ExpiredReason)
+	}
+	if isTerminalHITLOperationState(tr.ToState) {
+		sets = append(sets, "terminal_ns = ?")
+		args = append(args, timeNS(tr.Now))
+		if !tr.TerminalRetentionExpiresAt.IsZero() {
+			sets = append(sets, "terminal_retention_expires_ns = ?")
+			args = append(args, timeNS(tr.TerminalRetentionExpiresAt))
+		}
+	}
+	if tr.UpstreamCalled || tr.ToState == HITLOperationStateExecutingUpstream {
+		sets = append(sets, "upstream_called = 1")
+	}
+	if tr.LastError != "" {
+		sets = append(sets, "last_error = ?")
+		args = append(args, tr.LastError)
+	}
+	args = append(args, tr.ID, string(tr.FromState), tr.ExpectedVersion)
+	res, err := s.db.ExecContext(ctx, `UPDATE hitl_operations SET `+strings.Join(sets, ", ")+` WHERE id = ? AND state = ? AND version = ?`, args...)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	changed, err := res.RowsAffected()
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	if changed != 1 {
+		return HITLOperation{}, ErrHITLOperationConflict
+	}
+	return s.get(ctx, tr.ID)
+}
+
+func (s *HITLOperationStore) ConsumeRetryGrant(ctx context.Context, in HITLRetryGrantConsume) (HITLOperation, error) {
+	if s == nil || s.db == nil {
+		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if in.ID == "" || in.ProfileID == "" || in.PrincipalID == "" || in.Now.IsZero() {
+		return HITLOperation{}, fmt.Errorf("%w: incomplete retry consume", ErrHITLOperationStoreInvalid)
+	}
+	op, err := s.GetForPrincipal(ctx, in.ID, in.ProfileID, in.PrincipalID)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	if op.GrantConsumedAt != nil {
+		return HITLOperation{}, ErrHITLGrantAlreadyConsumed
+	}
+	if op.State != HITLOperationStateApprovedWaitingForRetry {
+		return HITLOperation{}, ErrHITLRetryNotApproved
+	}
+	if op.RetryExpiresAt == nil || !in.Now.Before(*op.RetryExpiresAt) {
+		return HITLOperation{}, ErrHITLRetryExpired
+	}
+	if op.AuthBindingID != in.AuthBindingID || op.RequestFingerprint != in.RequestFingerprint {
+		return HITLOperation{}, ErrHITLRetryMismatch
+	}
+	res, err := s.db.ExecContext(ctx, `
+UPDATE hitl_operations
+SET state = ?, version = version + 1, upstream_called = 1, grant_consumed_ns = ?, grant_consumed_by = ?
+WHERE id = ?
+  AND profile_id = ?
+  AND principal_id = ?
+  AND state = ?
+  AND version = ?
+  AND grant_consumed_ns IS NULL
+  AND retry_expires_ns > ?
+  AND auth_binding_id = ?
+  AND request_fingerprint = ?`,
+		string(HITLOperationStateExecutingUpstream), timeNS(in.Now), in.ConsumedBy,
+		in.ID, in.ProfileID, in.PrincipalID, string(HITLOperationStateApprovedWaitingForRetry), op.Version, timeNS(in.Now), in.AuthBindingID, in.RequestFingerprint,
+	)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	changed, err := res.RowsAffected()
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	if changed != 1 {
+		latest, latestErr := s.GetForPrincipal(ctx, in.ID, in.ProfileID, in.PrincipalID)
+		if latestErr != nil {
+			return HITLOperation{}, latestErr
+		}
+		if latest.GrantConsumedAt != nil {
+			return HITLOperation{}, ErrHITLGrantAlreadyConsumed
+		}
+		if latest.State != HITLOperationStateApprovedWaitingForRetry {
+			return HITLOperation{}, ErrHITLRetryNotApproved
+		}
+		if latest.RetryExpiresAt == nil || !in.Now.Before(*latest.RetryExpiresAt) {
+			return HITLOperation{}, ErrHITLRetryExpired
+		}
+		if latest.AuthBindingID != in.AuthBindingID || latest.RequestFingerprint != in.RequestFingerprint {
+			return HITLOperation{}, ErrHITLRetryMismatch
+		}
+		return HITLOperation{}, ErrHITLOperationConflict
+	}
+	return s.GetForPrincipal(ctx, in.ID, in.ProfileID, in.PrincipalID)
+}
+
+const hitlOperationColumns = `
+id, state, version,
+profile_id, principal_id, endpoint_id, approval_rule_id, approver_id,
+method, scheme, host, redacted_path, redacted_query, redacted_headers_json,
+auth_binding_id, fingerprint_version, hmac_key_id, request_fingerprint,
+created_ns, sync_wait_deadline_ns, approval_expires_ns, retry_expires_ns,
+expired_reason, terminal_ns, terminal_retention_expires_ns,
+upstream_called, grant_consumed_ns, grant_consumed_by, slack_message_ref, dashboard_ref, last_error`
+
+func (s *HITLOperationStore) get(ctx context.Context, id string) (HITLOperation, error) {
+	return s.scanOne(ctx, `SELECT `+hitlOperationColumns+` FROM hitl_operations WHERE id = ?`, id)
+}
+
+func (s *HITLOperationStore) scanOne(ctx context.Context, query string, args ...any) (HITLOperation, error) {
+	row := s.db.QueryRowContext(ctx, query, args...)
+	var op HITLOperation
+	var state string
+	var redactedQuery, redactedHeaders sql.NullString
+	var retryExpiresNS, terminalNS, terminalRetentionNS, grantConsumedNS sql.NullInt64
+	var expiredReason, grantConsumedBy, slackMessageRef, dashboardRef, lastError sql.NullString
+	var upstreamCalled int
+	var createdNS, syncWaitDeadlineNS, approvalExpiresNS int64
+	err := row.Scan(
+		&op.ID, &state, &op.Version,
+		&op.ProfileID, &op.PrincipalID, &op.EndpointID, &op.ApprovalRuleID, &op.ApproverID,
+		&op.Method, &op.Scheme, &op.Host, &op.RedactedPath, &redactedQuery, &redactedHeaders,
+		&op.AuthBindingID, &op.FingerprintVersion, &op.HMACKeyID, &op.RequestFingerprint,
+		&createdNS, &syncWaitDeadlineNS, &approvalExpiresNS, &retryExpiresNS,
+		&expiredReason, &terminalNS, &terminalRetentionNS,
+		&upstreamCalled, &grantConsumedNS, &grantConsumedBy, &slackMessageRef, &dashboardRef, &lastError,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return HITLOperation{}, ErrHITLOperationNotFound
+	}
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	op.State = HITLOperationState(state)
+	op.RedactedQuery = redactedQuery.String
+	op.RedactedHeadersJSON = redactedHeaders.String
+	op.CreatedAt = timeFromNS(createdNS)
+	op.SyncWaitDeadline = timeFromNS(syncWaitDeadlineNS)
+	op.ApprovalExpiresAt = timeFromNS(approvalExpiresNS)
+	op.RetryExpiresAt = nullTimeFromNS(retryExpiresNS)
+	op.ExpiredReason = expiredReason.String
+	op.TerminalAt = nullTimeFromNS(terminalNS)
+	op.TerminalRetentionExpiresAt = nullTimeFromNS(terminalRetentionNS)
+	op.UpstreamCalled = upstreamCalled != 0
+	op.GrantConsumedAt = nullTimeFromNS(grantConsumedNS)
+	op.GrantConsumedBy = grantConsumedBy.String
+	op.SlackMessageRef = slackMessageRef.String
+	op.DashboardRef = dashboardRef.String
+	op.LastError = lastError.String
+	return op, nil
+}
+
+func validateHITLOperationCreate(in HITLOperationCreate) error {
+	for name, value := range map[string]string{
+		"id":                  in.ID,
+		"profile_id":          in.ProfileID,
+		"principal_id":        in.PrincipalID,
+		"endpoint_id":         in.EndpointID,
+		"approval_rule_id":    in.ApprovalRuleID,
+		"approver_id":         in.ApproverID,
+		"method":              in.Method,
+		"scheme":              in.Scheme,
+		"host":                in.Host,
+		"redacted_path":       in.RedactedPath,
+		"auth_binding_id":     in.AuthBindingID,
+		"fingerprint_version": in.FingerprintVersion,
+		"hmac_key_id":         in.HMACKeyID,
+		"request_fingerprint": in.RequestFingerprint,
+	} {
+		if value == "" {
+			return fmt.Errorf("%w: missing %s", ErrHITLOperationStoreInvalid, name)
+		}
+	}
+	if !isKnownHITLOperationState(in.State) {
+		return fmt.Errorf("%w: unknown state %q", ErrHITLOperationStoreInvalid, in.State)
+	}
+	if in.CreatedAt.IsZero() || in.SyncWaitDeadline.IsZero() || in.ApprovalExpiresAt.IsZero() {
+		return fmt.Errorf("%w: missing operation timestamps", ErrHITLOperationStoreInvalid)
+	}
+	return nil
+}
+
+func isKnownHITLOperationState(state HITLOperationState) bool {
+	switch state {
+	case HITLOperationStateSyncWaiting,
+		HITLOperationStatePendingApproval,
+		HITLOperationStateApprovedWaitingForRetry,
+		HITLOperationStateDenied,
+		HITLOperationStateExpired,
+		HITLOperationStateExecutingUpstream,
+		HITLOperationStateUpstreamSucceeded,
+		HITLOperationStateUpstreamFailed,
+		HITLOperationStateClientDisconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+func isTerminalHITLOperationState(state HITLOperationState) bool {
+	switch state {
+	case HITLOperationStateDenied, HITLOperationStateExpired, HITLOperationStateUpstreamSucceeded, HITLOperationStateUpstreamFailed, HITLOperationStateClientDisconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+func timeNS(t time.Time) int64 {
+	return t.UTC().UnixNano()
+}
+
+func nullTimeNS(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return timeNS(t)
+}
+
+func timeFromNS(ns int64) time.Time {
+	return time.Unix(0, ns).UTC()
+}
+
+func nullTimeFromNS(ns sql.NullInt64) *time.Time {
+	if !ns.Valid {
+		return nil
+	}
+	t := timeFromNS(ns.Int64)
+	return &t
+}
+
+func nullString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/hitl_operation_store_test.go
+++ b/hitl_operation_store_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHITLOperationStoreCreatesMetadataOnlyOperation(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Unix(1_700_000_000, 123).UTC()
+
+	created, err := store.Create(ctx, HITLOperationCreate{
+		ID:                  "hitl_op_create",
+		ProfileID:           "agent",
+		PrincipalID:         "peer:100.64.0.2",
+		EndpointID:          "api",
+		ApprovalRuleID:      "rule:dangerous-write",
+		ApproverID:          "human_approver.ops",
+		Method:              "POST",
+		Scheme:              "https",
+		Host:                "api.example.test",
+		RedactedPath:        "/v1/write",
+		RedactedQuery:       "?account=[redacted]",
+		RedactedHeadersJSON: `{"content-type":"application/json"}`,
+		AuthBindingID:       "credential:api:v1",
+		FingerprintVersion:  "raw-body-hmac-v1",
+		HMACKeyID:           "hitl-hmac:v1",
+		RequestFingerprint:  "hmac-sha256:abcdef",
+		CreatedAt:           now,
+		SyncWaitDeadline:    now.Add(90 * time.Second),
+		ApprovalExpiresAt:   now.Add(15 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ID != "hitl_op_create" {
+		t.Fatalf("created ID = %q", created.ID)
+	}
+	if created.State != HITLOperationStateSyncWaiting {
+		t.Fatalf("state = %q, want %q", created.State, HITLOperationStateSyncWaiting)
+	}
+	if created.Version != 1 {
+		t.Fatalf("version = %d, want 1", created.Version)
+	}
+	if created.GrantConsumedAt != nil {
+		t.Fatalf("GrantConsumedAt = %v, want nil", created.GrantConsumedAt)
+	}
+
+	loaded, err := store.GetForPrincipal(ctx, created.ID, "agent", "peer:100.64.0.2")
+	if err != nil {
+		t.Fatalf("GetForPrincipal: %v", err)
+	}
+	if loaded.RequestFingerprint != "hmac-sha256:abcdef" || loaded.HMACKeyID != "hitl-hmac:v1" {
+		t.Fatalf("loaded fingerprint fields = %#v", loaded)
+	}
+	if loaded.RedactedQuery != "?account=[redacted]" {
+		t.Fatalf("RedactedQuery = %q", loaded.RedactedQuery)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		profileID string
+		principal string
+	}{
+		{name: "wrong profile", profileID: "other", principal: "peer:100.64.0.2"},
+		{name: "wrong principal", profileID: "agent", principal: "peer:100.64.0.9"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.GetForPrincipal(ctx, created.ID, tc.profileID, tc.principal)
+			if !errors.Is(err, ErrHITLOperationNotFound) {
+				t.Fatalf("GetForPrincipal err = %v, want ErrHITLOperationNotFound", err)
+			}
+		})
+	}
+
+	assertHITLOperationSchemaDoesNotStoreReplayableMaterial(t, db)
+}
+
+func TestHITLOperationStoreRejectsUnknownState(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	now := time.Unix(1_700_000_050, 0).UTC()
+
+	_, err := store.Create(context.Background(), HITLOperationCreate{
+		ID:                 "hitl_op_bad_state",
+		State:              HITLOperationState("surprising_new_state"),
+		ProfileID:          "agent",
+		PrincipalID:        "peer:100.64.0.2",
+		EndpointID:         "api",
+		ApprovalRuleID:     "rule:dangerous-write",
+		ApproverID:         "human_approver.ops",
+		Method:             "POST",
+		Scheme:             "https",
+		Host:               "api.example.test",
+		RedactedPath:       "/v1/write",
+		AuthBindingID:      "credential:api:v1",
+		FingerprintVersion: "raw-body-hmac-v1",
+		HMACKeyID:          "hitl-hmac:v1",
+		RequestFingerprint: "hmac-sha256:abcdef",
+		CreatedAt:          now,
+		SyncWaitDeadline:   now.Add(90 * time.Second),
+		ApprovalExpiresAt:  now.Add(15 * time.Minute),
+	})
+	if !errors.Is(err, ErrHITLOperationStoreInvalid) {
+		t.Fatalf("Create err = %v, want ErrHITLOperationStoreInvalid", err)
+	}
+}
+
+func TestHITLOperationStoreTransitionsWithCompareAndSwap(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Unix(1_700_000_100, 0).UTC()
+
+	op := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_cas",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now,
+		SyncWaitDeadline:  now.Add(-time.Second),
+		ApprovalExpiresAt: now.Add(15 * time.Minute),
+	})
+
+	updated, err := store.Transition(ctx, HITLOperationTransition{
+		ID:              op.ID,
+		FromState:       HITLOperationStatePendingApproval,
+		ToState:         HITLOperationStateApprovedWaitingForRetry,
+		ExpectedVersion: op.Version,
+		Now:             now.Add(30 * time.Second),
+		RetryExpiresAt:  now.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Transition: %v", err)
+	}
+	if updated.State != HITLOperationStateApprovedWaitingForRetry {
+		t.Fatalf("state = %q", updated.State)
+	}
+	if updated.Version != op.Version+1 {
+		t.Fatalf("version = %d, want %d", updated.Version, op.Version+1)
+	}
+	if updated.RetryExpiresAt == nil || !updated.RetryExpiresAt.Equal(now.Add(5*time.Minute)) {
+		t.Fatalf("RetryExpiresAt = %v", updated.RetryExpiresAt)
+	}
+
+	_, err = store.Transition(ctx, HITLOperationTransition{
+		ID:              op.ID,
+		FromState:       HITLOperationStatePendingApproval,
+		ToState:         HITLOperationStateDenied,
+		ExpectedVersion: op.Version,
+		Now:             now.Add(time.Minute),
+	})
+	if !errors.Is(err, ErrHITLOperationConflict) {
+		t.Fatalf("stale Transition err = %v, want ErrHITLOperationConflict", err)
+	}
+
+	loaded, err := store.GetForPrincipal(ctx, op.ID, "agent", "peer:100.64.0.2")
+	if err != nil {
+		t.Fatalf("reload after stale transition: %v", err)
+	}
+	if loaded.State != HITLOperationStateApprovedWaitingForRetry || loaded.Version != updated.Version {
+		t.Fatalf("stale transition changed operation: %#v", loaded)
+	}
+}
+
+func TestHITLOperationTransitionCannotConsumeRetryGrant(t *testing.T) {
+	if _, ok := reflect.TypeOf(HITLOperationTransition{}).FieldByName("GrantConsumedBy"); ok {
+		t.Fatal("generic HITLOperationTransition must not expose retry-grant consumption; use ConsumeRetryGrant")
+	}
+}
+
+func TestHITLOperationStoreConsumeRetryGrantIsOneShotAndMismatchSafe(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Unix(1_700_000_200, 0).UTC()
+
+	op := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_retry",
+		State:             HITLOperationStateApprovedWaitingForRetry,
+		CreatedAt:         now.Add(-2 * time.Minute),
+		SyncWaitDeadline:  now.Add(-90 * time.Second),
+		ApprovalExpiresAt: now.Add(10 * time.Minute),
+		RetryExpiresAt:    now.Add(5 * time.Minute),
+	})
+
+	_, err := store.ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
+		ID:                 op.ID,
+		ProfileID:          "agent",
+		PrincipalID:        "peer:100.64.0.2",
+		AuthBindingID:      "credential:other:v1",
+		RequestFingerprint: op.RequestFingerprint,
+		ConsumedBy:         "peer:100.64.0.2",
+		Now:                now,
+	})
+	if !errors.Is(err, ErrHITLRetryMismatch) {
+		t.Fatalf("mismatched auth binding err = %v, want ErrHITLRetryMismatch", err)
+	}
+	unchanged, err := store.GetForPrincipal(ctx, op.ID, "agent", "peer:100.64.0.2")
+	if err != nil {
+		t.Fatalf("reload after mismatch: %v", err)
+	}
+	if unchanged.State != HITLOperationStateApprovedWaitingForRetry || unchanged.GrantConsumedAt != nil {
+		t.Fatalf("mismatch consumed or changed grant: %#v", unchanged)
+	}
+
+	consumed, err := store.ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
+		ID:                 op.ID,
+		ProfileID:          "agent",
+		PrincipalID:        "peer:100.64.0.2",
+		AuthBindingID:      op.AuthBindingID,
+		RequestFingerprint: op.RequestFingerprint,
+		ConsumedBy:         "peer:100.64.0.2",
+		Now:                now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ConsumeRetryGrant: %v", err)
+	}
+	if consumed.State != HITLOperationStateExecutingUpstream {
+		t.Fatalf("state = %q, want %q", consumed.State, HITLOperationStateExecutingUpstream)
+	}
+	if !consumed.UpstreamCalled {
+		t.Fatal("UpstreamCalled = false, want true after consuming retry grant")
+	}
+	if consumed.GrantConsumedAt == nil || !consumed.GrantConsumedAt.Equal(now.Add(time.Second)) {
+		t.Fatalf("GrantConsumedAt = %v", consumed.GrantConsumedAt)
+	}
+	if consumed.GrantConsumedBy != "peer:100.64.0.2" {
+		t.Fatalf("GrantConsumedBy = %q", consumed.GrantConsumedBy)
+	}
+
+	_, err = store.ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
+		ID:                 op.ID,
+		ProfileID:          "agent",
+		PrincipalID:        "peer:100.64.0.2",
+		AuthBindingID:      op.AuthBindingID,
+		RequestFingerprint: op.RequestFingerprint,
+		ConsumedBy:         "peer:100.64.0.2",
+		Now:                now.Add(2 * time.Second),
+	})
+	if !errors.Is(err, ErrHITLGrantAlreadyConsumed) {
+		t.Fatalf("second ConsumeRetryGrant err = %v, want ErrHITLGrantAlreadyConsumed", err)
+	}
+}
+
+func openHITLOperationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func createTestHITLOperation(t *testing.T, store *HITLOperationStore, overrides HITLOperationCreate) HITLOperation {
+	t.Helper()
+	now := time.Unix(1_700_000_000, 0).UTC()
+	base := HITLOperationCreate{
+		ID:                  "hitl_op_test",
+		ProfileID:           "agent",
+		PrincipalID:         "peer:100.64.0.2",
+		EndpointID:          "api",
+		ApprovalRuleID:      "rule:dangerous-write",
+		ApproverID:          "human_approver.ops",
+		Method:              "POST",
+		Scheme:              "https",
+		Host:                "api.example.test",
+		RedactedPath:        "/v1/write",
+		RedactedQuery:       "",
+		RedactedHeadersJSON: `{"content-type":"application/json"}`,
+		AuthBindingID:       "credential:api:v1",
+		FingerprintVersion:  "raw-body-hmac-v1",
+		HMACKeyID:           "hitl-hmac:v1",
+		RequestFingerprint:  "hmac-sha256:abcdef",
+		CreatedAt:           now,
+		SyncWaitDeadline:    now.Add(90 * time.Second),
+		ApprovalExpiresAt:   now.Add(15 * time.Minute),
+	}
+	if overrides.ID != "" {
+		base.ID = overrides.ID
+	}
+	if overrides.State != "" {
+		base.State = overrides.State
+	}
+	if !overrides.CreatedAt.IsZero() {
+		base.CreatedAt = overrides.CreatedAt
+	}
+	if !overrides.SyncWaitDeadline.IsZero() {
+		base.SyncWaitDeadline = overrides.SyncWaitDeadline
+	}
+	if !overrides.ApprovalExpiresAt.IsZero() {
+		base.ApprovalExpiresAt = overrides.ApprovalExpiresAt
+	}
+	if !overrides.RetryExpiresAt.IsZero() {
+		base.RetryExpiresAt = overrides.RetryExpiresAt
+	}
+
+	created, err := store.Create(context.Background(), base)
+	if err != nil {
+		t.Fatalf("Create test operation: %v", err)
+	}
+	return created
+}
+
+func assertHITLOperationSchemaDoesNotStoreReplayableMaterial(t *testing.T, db *sql.DB) {
+	t.Helper()
+	rows, err := db.Query("PRAGMA table_info(hitl_operations)")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info(hitl_operations): %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		lower := strings.ToLower(name)
+		for _, forbidden := range []string{"raw_", "body", "authorization", "cookie", "secret"} {
+			if strings.Contains(lower, forbidden) {
+				t.Fatalf("hitl_operations column %q looks like replayable request material", name)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("table_info rows: %v", err)
+	}
+}

--- a/migrations/sqlite/0014_hitl_operations.sql
+++ b/migrations/sqlite/0014_hitl_operations.sql
@@ -1,0 +1,52 @@
+-- Durable metadata for async HITL approval-grant operations.
+--
+-- This table intentionally stores operation state, owner binding, safe
+-- display metadata, and versioned request fingerprints only. It must not
+-- store raw request bodies, raw Authorization/Cookie values, upstream
+-- secrets, or replayable request material.
+
+CREATE TABLE hitl_operations (
+  id                            TEXT PRIMARY KEY,
+  state                         TEXT NOT NULL,
+  version                       INTEGER NOT NULL DEFAULT 1,
+
+  profile_id                    TEXT NOT NULL,
+  principal_id                  TEXT NOT NULL,
+  endpoint_id                   TEXT NOT NULL,
+  approval_rule_id              TEXT NOT NULL,
+  approver_id                   TEXT NOT NULL,
+
+  method                        TEXT NOT NULL,
+  scheme                        TEXT NOT NULL,
+  host                          TEXT NOT NULL,
+  redacted_path                 TEXT NOT NULL,
+  redacted_query                TEXT,
+  redacted_headers_json         TEXT,
+
+  auth_binding_id               TEXT NOT NULL,
+  fingerprint_version           TEXT NOT NULL,
+  hmac_key_id                   TEXT NOT NULL,
+  request_fingerprint           TEXT NOT NULL,
+
+  created_ns                    INTEGER NOT NULL,
+  sync_wait_deadline_ns         INTEGER NOT NULL,
+  approval_expires_ns           INTEGER NOT NULL,
+  retry_expires_ns              INTEGER,
+  expired_reason                TEXT,
+  terminal_ns                   INTEGER,
+  terminal_retention_expires_ns INTEGER,
+
+  upstream_called               INTEGER NOT NULL DEFAULT 0,
+  grant_consumed_ns             INTEGER,
+  grant_consumed_by             TEXT,
+  slack_message_ref             TEXT,
+  dashboard_ref                 TEXT,
+  last_error                    TEXT
+);
+
+CREATE INDEX hitl_operations_owner_idx ON hitl_operations(profile_id, principal_id, id);
+CREATE INDEX hitl_operations_state_idx ON hitl_operations(state, approval_expires_ns, retry_expires_ns);
+CREATE INDEX hitl_operations_terminal_retention_idx ON hitl_operations(terminal_retention_expires_ns)
+  WHERE terminal_retention_expires_ns IS NOT NULL;
+
+INSERT INTO _schema (version) VALUES (14);


### PR DESCRIPTION
## Summary
- Adds the async HITL `hitl_operations` SQLite migration for durable metadata-only operation tracking.
- Adds `HITLOperationStore` APIs for create, owner-scoped lookup, compare-and-swap state transitions, and one-shot retry-grant consumption.
- Covers non-enumerating owner checks, unknown-state rejection, stale transition conflicts, retry mismatch/expiry safety, and the regression that generic transitions cannot consume retry grants.

This is stacked on #414 and intentionally stays schema/store-only. It does not add polling endpoints, raw-body HMAC computation, retry header handling, Slack/dashboard state, or upstream relay integration.

## Security notes
- The operation table persists metadata and fingerprints only.
- It does not store raw request bodies, `Authorization`, `Cookie`, upstream secrets, request headers, replay bodies, or other replayable request material.
- `ConsumeRetryGrant` is the only path that marks a retry grant consumed, and it checks profile/principal ownership, state, expiry, auth binding, fingerprint version/key, and request fingerprint before atomically moving to upstream execution.

## Test plan
- `npm --prefix www run build`
- `gofmt -l hitl_operation_store.go hitl_operation_store_test.go`
- `git diff --check`
- static added-line scan for hardcoded secrets / replayable-material storage patterns
- `go test . -run 'TestHITLOperationStore|TestHITLOperationTransitionCannotConsumeRetryGrant' -count=1`
- `go test ./...`

## Review
- Independent follow-up review after the retry-consumption blocker fix: `APPROVED_NO_FINDINGS`.
