### PR TITLE
action download: include verb / tables / functions / database for SQL actions

### DIFF
--- a/web.go
+++ b/web.go
@@ -1228,15 +1228,49 @@ func exportK8s(ev *Event) *K8sAction {
 	return a
 }
 
-// exportSQL pulls the raw statement out of Event.Facets (set by
-// sqlfacet.Report). The loader re-derives verb / tables / functions
-// from the statement via SQLParser at replay time.
+// exportSQL pulls the SQL facet fields out of Event.Facets (set by
+// sqlfacet.Report). Statement is required; verb / tables / functions
+// / database are emitted when the recorded facets supply them so the
+// downloaded fixture mirrors what the dashboard renders and stays
+// self-contained for `clawpatrol test` (the loader still tolerates
+// missing facets — the SQLParser re-derives them at replay).
 func exportSQL(ev *Event) *SQLAction {
 	stmt, _ := ev.Facets["statement"].(string)
 	if stmt == "" {
 		return nil
 	}
-	return &SQLAction{Statement: stmt}
+	a := &SQLAction{Statement: stmt}
+	if v, ok := ev.Facets["verb"].(string); ok {
+		a.Verb = v
+	}
+	a.Tables = stringSliceFromFacet(ev.Facets["tables"])
+	a.Functions = stringSliceFromFacet(ev.Facets["functions"])
+	if v, ok := ev.Facets["database"].(string); ok {
+		a.Database = v
+	}
+	return a
+}
+
+// stringSliceFromFacet narrows a JSON-unmarshalled facet list into
+// []string. Event.Facets is decoded as map[string]any, so list-typed
+// facets land as []any.
+func stringSliceFromFacet(v any) []string {
+	raw, ok := v.([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, x := range raw {
+		s, ok := x.(string)
+		if !ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // headersToMultiValue widens the Sink's single-value header map to

--- a/web_fixture_export_test.go
+++ b/web_fixture_export_test.go
@@ -200,6 +200,105 @@ profile "default" { endpoints = [pg] }
 	}
 }
 
+// SQL exporter must include verb / tables / functions / database
+// when the recorded facets supply them — the dashboard's request
+// detail view already renders these, and `clawpatrol test` fixtures
+// are supposed to be self-contained (cl-m6wv).
+func TestExporterSQLEmitsAllFacets(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "postgres_credential" "pg-cred" { user = "agent" }
+endpoint "postgres" "pg" {
+  host       = "pg.internal:5432"
+  database   = "postgres"
+  credential = pg-cred
+}
+profile "default" { endpoints = [pg] }
+`
+	w := &webMux{g: gatewayWithPolicy(t, hcl)}
+	// Facets shaped as if reloaded from the events table (JSON
+	// round-trip turns []string into []any).
+	ev := &Event{
+		ID: "evt-sql-facets", Mode: "pg", Family: "sql",
+		Host: "10.0.0.5", Action: "allow", Endpoint: "pg",
+		Rule: "pg-reads",
+		Facets: map[string]any{
+			"statement": "SELECT count(*) FROM users",
+			"verb":      "select",
+			"tables":    []any{"users"},
+			"functions": []any{"count"},
+			"database":  "prod",
+		},
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatalf("reparse: %v\nbody=%s", err, rw.Body.String())
+	}
+	if f.Action.SQL == nil {
+		t.Fatal("expected sql block")
+	}
+	sql := f.Action.SQL
+	if sql.Statement != "SELECT count(*) FROM users" {
+		t.Errorf("statement=%q", sql.Statement)
+	}
+	if sql.Verb != "select" {
+		t.Errorf("verb=%q want select", sql.Verb)
+	}
+	if len(sql.Tables) != 1 || sql.Tables[0] != "users" {
+		t.Errorf("tables=%v want [users]", sql.Tables)
+	}
+	if len(sql.Functions) != 1 || sql.Functions[0] != "count" {
+		t.Errorf("functions=%v want [count]", sql.Functions)
+	}
+	if sql.Database != "prod" {
+		t.Errorf("database=%q want prod", sql.Database)
+	}
+}
+
+// Older recordings (or wire frames that never produced verb / tables
+// / functions / database) still export cleanly with only statement —
+// fixture stays additive (cl-m6wv).
+func TestExporterSQLStatementOnlyBackcompat(t *testing.T) {
+	const hcl = `
+admin_email = "x@example.com"
+credential "postgres_credential" "pg-cred" { user = "agent" }
+endpoint "postgres" "pg" {
+  host       = "pg.internal:5432"
+  database   = "postgres"
+  credential = pg-cred
+}
+profile "default" { endpoints = [pg] }
+`
+	w := &webMux{g: gatewayWithPolicy(t, hcl)}
+	ev := &Event{
+		ID: "evt-sql-bare", Mode: "pg", Family: "sql",
+		Host: "10.0.0.5", Action: "allow", Endpoint: "pg",
+		Rule:   "pg-reads",
+		Facets: map[string]any{"statement": "SELECT 1"},
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatalf("reparse: %v\nbody=%s", err, rw.Body.String())
+	}
+	if f.Action.SQL == nil || f.Action.SQL.Statement != "SELECT 1" {
+		t.Errorf("sql=%+v want statement=SELECT 1", f.Action.SQL)
+	}
+	if f.Action.SQL.Verb != "" || len(f.Action.SQL.Tables) != 0 ||
+		len(f.Action.SQL.Functions) != 0 || f.Action.SQL.Database != "" {
+		t.Errorf("expected empty derived fields, got %+v", f.Action.SQL)
+	}
+}
+
 func TestExporterSQLRejectsMissingStatement(t *testing.T) {
 	const hcl = `
 admin_email = "x@example.com"


### PR DESCRIPTION
The action download endpoint (used by the dashboard's "download action" button to produce `clawpatrol test` fixture files) was emitting only `statement` for SQL actions, dropping `verb`, `tables`, `functions`, and `database` — the same facets the dashboard's action detail view renders.

Aligns the download serializer with the detail-view serializer so the downloaded JSON contains every populated SQL facet. Adds a fixture export test that asserts a SQL action with all four facets populated round-trips through the download path.

Backwards-compatible: existing fixture files with only `statement` continue to load.