### PR TITLE
hitl: add request fingerprint binding

### DIFF
--- a/hitl_fingerprint.go
+++ b/hitl_fingerprint.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	HITLFingerprintVersionV1 = "v1"
+
+	hitlRequestFingerprintDomainV1 = "clawpatrol hitl request fingerprint v1"
+	hitlBodyFingerprintDomainV1    = "clawpatrol hitl body fingerprint v1"
+)
+
+var ErrHITLFingerprintInvalid = errors.New("invalid hitl fingerprint input")
+
+type HITLFingerprintKey struct {
+	ID   string
+	Root []byte
+}
+
+type HITLFingerprintHeader struct {
+	Name   string
+	Values []string
+}
+
+type HITLRequestFingerprintInput struct {
+	Key             HITLFingerprintKey
+	ProfileID       string
+	PrincipalID     string
+	EndpointID      string
+	ApprovalRuleID  string
+	Method          string
+	Scheme          string
+	Host            string
+	Path            string
+	RawQuery        string
+	SelectedHeaders []HITLFingerprintHeader
+	RawBody         []byte
+	AuthBindingID   string
+}
+
+type HITLRequestFingerprintResult struct {
+	Version            string
+	HMACKeyID          string
+	BodyHMAC           string
+	RequestFingerprint string
+}
+
+type HITLCredentialAuthBindingInput struct {
+	ProfileID    string
+	CredentialID string
+	Generation   string
+	SubjectID    string
+}
+
+func ComputeHITLRequestFingerprint(in HITLRequestFingerprintInput) (HITLRequestFingerprintResult, error) {
+	if err := validateHITLFingerprintInput(in); err != nil {
+		return HITLRequestFingerprintResult{}, err
+	}
+
+	normalizedHeaders, err := normalizeHITLFingerprintHeaders(in.SelectedHeaders)
+	if err != nil {
+		return HITLRequestFingerprintResult{}, err
+	}
+	in.SelectedHeaders = normalizedHeaders
+
+	bodyKey := deriveHITLHMACKey(in.Key.Root, hitlBodyFingerprintDomainV1)
+	bodyHMAC := "hmac-sha256:" + hex.EncodeToString(computeHITLHMAC(bodyKey, in.RawBody))
+
+	canonical := canonicalHITLRequestV1(in, bodyHMAC)
+	requestKey := deriveHITLHMACKey(in.Key.Root, hitlRequestFingerprintDomainV1)
+	requestFingerprint := "hmac-sha256:" + hex.EncodeToString(computeHITLHMAC(requestKey, canonical))
+
+	return HITLRequestFingerprintResult{
+		Version:            HITLFingerprintVersionV1,
+		HMACKeyID:          in.Key.ID,
+		BodyHMAC:           bodyHMAC,
+		RequestFingerprint: requestFingerprint,
+	}, nil
+}
+
+func SelectHITLFingerprintHeaders(headers http.Header, allowlist []string) ([]HITLFingerprintHeader, error) {
+	if len(allowlist) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(allowlist))
+	selected := make([]HITLFingerprintHeader, 0, len(allowlist))
+	for _, name := range allowlist {
+		canonicalName := strings.ToLower(strings.TrimSpace(name))
+		if canonicalName == "" {
+			return nil, fmt.Errorf("%w: empty fingerprint header allowlist entry", ErrHITLFingerprintInvalid)
+		}
+		if isForbiddenHITLFingerprintHeader(canonicalName) {
+			return nil, fmt.Errorf("%w: header %q must not be used for HITL request fingerprinting", ErrHITLFingerprintInvalid, canonicalName)
+		}
+		if _, ok := seen[canonicalName]; ok {
+			return nil, fmt.Errorf("%w: duplicate fingerprint header %q", ErrHITLFingerprintInvalid, canonicalName)
+		}
+		seen[canonicalName] = struct{}{}
+
+		values := headers.Values(canonicalName)
+		if len(values) == 0 {
+			continue
+		}
+		trimmed := make([]string, 0, len(values))
+		for _, value := range values {
+			trimmed = append(trimmed, strings.TrimSpace(value))
+		}
+		selected = append(selected, HITLFingerprintHeader{Name: canonicalName, Values: trimmed})
+	}
+	return selected, nil
+}
+
+func BuildHITLCredentialAuthBindingID(in HITLCredentialAuthBindingInput) (string, error) {
+	if in.ProfileID == "" {
+		return "", fmt.Errorf("%w: profile_id is required for auth binding", ErrHITLFingerprintInvalid)
+	}
+	if in.CredentialID == "" {
+		return "", fmt.Errorf("%w: credential_id is required for auth binding", ErrHITLFingerprintInvalid)
+	}
+	if in.Generation == "" {
+		return "", fmt.Errorf("%w: credential generation is required for auth binding", ErrHITLFingerprintInvalid)
+	}
+
+	var b bytes.Buffer
+	writeHITLCanonicalField(&b, "kind", "credential")
+	writeHITLCanonicalField(&b, "version", HITLFingerprintVersionV1)
+	writeHITLCanonicalField(&b, "profile_id", in.ProfileID)
+	writeHITLCanonicalField(&b, "credential_id", in.CredentialID)
+	writeHITLCanonicalField(&b, "generation", in.Generation)
+	writeHITLCanonicalField(&b, "subject_id", in.SubjectID)
+	sum := sha256.Sum256(b.Bytes())
+	return "credential:v1:" + base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+func validateHITLFingerprintInput(in HITLRequestFingerprintInput) error {
+	required := map[string]string{
+		"hmac_key_id":      in.Key.ID,
+		"profile_id":       in.ProfileID,
+		"principal_id":     in.PrincipalID,
+		"endpoint_id":      in.EndpointID,
+		"approval_rule_id": in.ApprovalRuleID,
+		"method":           in.Method,
+		"scheme":           in.Scheme,
+		"host":             in.Host,
+		"path":             in.Path,
+		"auth_binding_id":  in.AuthBindingID,
+	}
+	for name, value := range required {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%w: %s is required", ErrHITLFingerprintInvalid, name)
+		}
+	}
+	if len(in.Key.Root) == 0 {
+		return fmt.Errorf("%w: hmac root key is required", ErrHITLFingerprintInvalid)
+	}
+	return nil
+}
+
+func normalizeHITLFingerprintHeaders(headers []HITLFingerprintHeader) ([]HITLFingerprintHeader, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	out := make([]HITLFingerprintHeader, 0, len(headers))
+	for _, h := range headers {
+		name := strings.ToLower(strings.TrimSpace(h.Name))
+		if name == "" {
+			return nil, fmt.Errorf("%w: empty selected fingerprint header name", ErrHITLFingerprintInvalid)
+		}
+		if isForbiddenHITLFingerprintHeader(name) {
+			return nil, fmt.Errorf("%w: header %q must not be used for HITL request fingerprinting", ErrHITLFingerprintInvalid, name)
+		}
+		values := make([]string, 0, len(h.Values))
+		for _, value := range h.Values {
+			values = append(values, strings.TrimSpace(value))
+		}
+		out = append(out, HITLFingerprintHeader{Name: name, Values: values})
+	}
+	return out, nil
+}
+
+func canonicalHITLRequestV1(in HITLRequestFingerprintInput, bodyHMAC string) []byte {
+	var b bytes.Buffer
+	writeHITLCanonicalField(&b, "fingerprint_version", HITLFingerprintVersionV1)
+	writeHITLCanonicalField(&b, "profile_id", in.ProfileID)
+	writeHITLCanonicalField(&b, "principal_id", in.PrincipalID)
+	writeHITLCanonicalField(&b, "endpoint_id", in.EndpointID)
+	writeHITLCanonicalField(&b, "approval_rule_id", in.ApprovalRuleID)
+	writeHITLCanonicalField(&b, "method", strings.ToUpper(in.Method))
+	writeHITLCanonicalField(&b, "scheme", strings.ToLower(in.Scheme))
+	writeHITLCanonicalField(&b, "host", strings.ToLower(in.Host))
+	writeHITLCanonicalField(&b, "path", in.Path)
+	writeHITLCanonicalField(&b, "raw_query", in.RawQuery)
+	writeHITLCanonicalField(&b, "selected_header_count", strconv.Itoa(len(in.SelectedHeaders)))
+	for _, h := range in.SelectedHeaders {
+		writeHITLCanonicalField(&b, "selected_header_name", strings.ToLower(h.Name))
+		writeHITLCanonicalField(&b, "selected_header_value_count", strconv.Itoa(len(h.Values)))
+		for _, value := range h.Values {
+			writeHITLCanonicalField(&b, "selected_header_value", strings.TrimSpace(value))
+		}
+	}
+	writeHITLCanonicalField(&b, "body_hmac", bodyHMAC)
+	writeHITLCanonicalField(&b, "auth_binding_id", in.AuthBindingID)
+	return b.Bytes()
+}
+
+func writeHITLCanonicalField(b *bytes.Buffer, name, value string) {
+	b.WriteString(strconv.Itoa(len([]byte(name))))
+	b.WriteByte(':')
+	b.WriteString(name)
+	b.WriteByte('=')
+	b.WriteString(strconv.Itoa(len([]byte(value))))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte('\n')
+}
+
+func deriveHITLHMACKey(root []byte, domain string) []byte {
+	return computeHITLHMAC(root, []byte(domain))
+}
+
+func computeHITLHMAC(key, msg []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(msg)
+	return mac.Sum(nil)
+}
+
+func isForbiddenHITLFingerprintHeader(name string) bool {
+	name = strings.ToLower(name)
+	for _, marker := range []string{"auth", "token", "secret", "key", "password", "cookie"} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	switch name {
+	case "user-agent",
+		"date",
+		"x-request-id",
+		"traceparent",
+		"via",
+		"connection",
+		"transfer-encoding",
+		"accept-encoding":
+		return true
+	default:
+		return strings.HasPrefix(name, "x-b3-")
+	}
+}

--- a/hitl_fingerprint_test.go
+++ b/hitl_fingerprint_test.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHITLRequestFingerprintUsesRawBodyHMACAndDomainSeparatedRequestHMAC(t *testing.T) {
+	key := HITLFingerprintKey{
+		ID:   "hitl-hmac:v1",
+		Root: []byte("test root key used only for deterministic HMAC tests"),
+	}
+	input := HITLRequestFingerprintInput{
+		Key:            key,
+		ProfileID:      "agent",
+		PrincipalID:    "peer:100.64.0.10",
+		EndpointID:     "dangerous-api",
+		ApprovalRuleID: "approved-post",
+		Method:         "post",
+		Scheme:         "HTTPS",
+		Host:           "API.EXAMPLE.TEST:8443",
+		Path:           "/v1/resources/../resources/%32",
+		RawQuery:       "b=two&a=one&a=again",
+		SelectedHeaders: []HITLFingerprintHeader{
+			{Name: "Content-Type", Values: []string{" application/json "}},
+			{Name: "If-Match", Values: []string{" \"rev-1\" "}},
+		},
+		RawBody:       []byte(`{"resource":"demo","approved":true}`),
+		AuthBindingID: "credential:v1:test-binding",
+	}
+
+	got, err := ComputeHITLRequestFingerprint(input)
+	if err != nil {
+		t.Fatalf("ComputeHITLRequestFingerprint err = %v", err)
+	}
+
+	bodyKey := testHITLHMAC(key.Root, "clawpatrol hitl body fingerprint v1", nil)
+	wantBodyHMAC := "hmac-sha256:" + hex.EncodeToString(testHITLHMAC(bodyKey, "", input.RawBody))
+	if got.BodyHMAC != wantBodyHMAC {
+		t.Fatalf("BodyHMAC = %q, want %q", got.BodyHMAC, wantBodyHMAC)
+	}
+
+	canonical := testCanonicalHITLRequest(input, wantBodyHMAC)
+	requestKey := testHITLHMAC(key.Root, "clawpatrol hitl request fingerprint v1", nil)
+	wantRequest := "hmac-sha256:" + hex.EncodeToString(testHITLHMAC(requestKey, "", canonical))
+	if got.RequestFingerprint != wantRequest {
+		t.Fatalf("RequestFingerprint = %q, want %q", got.RequestFingerprint, wantRequest)
+	}
+	if got.Version != HITLFingerprintVersionV1 {
+		t.Fatalf("Version = %q, want %q", got.Version, HITLFingerprintVersionV1)
+	}
+	if got.HMACKeyID != key.ID {
+		t.Fatalf("HMACKeyID = %q, want %q", got.HMACKeyID, key.ID)
+	}
+	for _, out := range []string{got.BodyHMAC, got.RequestFingerprint} {
+		if strings.Contains(out, string(key.Root)) || strings.Contains(out, string(input.RawBody)) {
+			t.Fatalf("fingerprint output leaked secret or raw body material: %q", out)
+		}
+	}
+}
+
+func TestHITLRequestFingerprintCanonicalizationIsStrictAndRaw(t *testing.T) {
+	base := testHITLFingerprintInput()
+	baseResult := mustComputeHITLFingerprint(t, base)
+
+	caseFolded := base
+	caseFolded.Method = "POST"
+	caseFolded.Scheme = "https"
+	caseFolded.Host = "api.example.test"
+	if got := mustComputeHITLFingerprint(t, caseFolded); got.RequestFingerprint != baseResult.RequestFingerprint {
+		t.Fatalf("method/scheme/host canonicalization changed fingerprint: %q vs %q", got.RequestFingerprint, baseResult.RequestFingerprint)
+	}
+
+	changedPath := base
+	changedPath.Path = "/v1/resources/2"
+	if got := mustComputeHITLFingerprint(t, changedPath); got.RequestFingerprint == baseResult.RequestFingerprint {
+		t.Fatal("path normalization must not hide byte-level path changes")
+	}
+
+	changedQueryOrder := base
+	changedQueryOrder.RawQuery = "a=one&b=two"
+	if got := mustComputeHITLFingerprint(t, changedQueryOrder); got.RequestFingerprint == baseResult.RequestFingerprint {
+		t.Fatal("raw query sorting/normalization must not hide query byte-order changes")
+	}
+
+	changedHeaderOrder := base
+	changedHeaderOrder.SelectedHeaders = []HITLFingerprintHeader{
+		{Name: "If-Match", Values: []string{"rev-1"}},
+		{Name: "Content-Type", Values: []string{"application/json"}},
+	}
+	if got := mustComputeHITLFingerprint(t, changedHeaderOrder); got.RequestFingerprint == baseResult.RequestFingerprint {
+		t.Fatal("selected header order must remain part of canonical request bytes")
+	}
+
+	changedBodyWhitespace := base
+	changedBodyWhitespace.RawBody = append([]byte(nil), base.RawBody...)
+	changedBodyWhitespace.RawBody = append(changedBodyWhitespace.RawBody, '\n')
+	if got := mustComputeHITLFingerprint(t, changedBodyWhitespace); got.RequestFingerprint == baseResult.RequestFingerprint || got.BodyHMAC == baseResult.BodyHMAC {
+		t.Fatal("raw body HMAC must change when exact body bytes change")
+	}
+}
+
+func TestSelectHITLFingerprintHeadersUsesAllowlistOrderAndRejectsAuthHeaders(t *testing.T) {
+	headers := http.Header{}
+	headers.Add("Content-Type", " application/json ")
+	headers.Add("If-Match", " \"rev-1\" ")
+	headers.Add("X-Request-Id", "trace-me")
+	headers.Add("Authorization", "Bearer must-not-enter-fingerprint")
+	headers.Add("Cookie", "session=must-not-enter-fingerprint")
+
+	selected, err := SelectHITLFingerprintHeaders(headers, []string{"If-Match", "Content-Type"})
+	if err != nil {
+		t.Fatalf("SelectHITLFingerprintHeaders err = %v", err)
+	}
+	want := []HITLFingerprintHeader{
+		{Name: "if-match", Values: []string{"\"rev-1\""}},
+		{Name: "content-type", Values: []string{"application/json"}},
+	}
+	if !equalHITLHeaders(selected, want) {
+		t.Fatalf("selected headers = %#v, want %#v", selected, want)
+	}
+	for _, h := range selected {
+		if h.Name == "authorization" || h.Name == "cookie" || strings.Contains(strings.Join(h.Values, ","), "must-not-enter") {
+			t.Fatalf("selected auth-bearing header material: %#v", selected)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"Authorization",
+		"Cookie",
+		"Proxy-Authorization",
+		"Connection",
+		"Transfer-Encoding",
+		"X-Request-Id",
+		"Traceparent",
+		"X-API-Key",
+		"API-Key",
+		"X-Auth-Token",
+		"X-Authorization",
+		"X-Secret",
+		"Idempotency-Key",
+	} {
+		if _, err := SelectHITLFingerprintHeaders(headers, []string{forbidden}); err == nil {
+			t.Fatalf("SelectHITLFingerprintHeaders(%q) err = nil, want rejection", forbidden)
+		}
+	}
+}
+
+func TestHITLCredentialAuthBindingIDUsesNonSecretIdentityAndGeneration(t *testing.T) {
+	binding, err := BuildHITLCredentialAuthBindingID(HITLCredentialAuthBindingInput{
+		ProfileID:    "agent",
+		CredentialID: "deploy-api",
+		Generation:   "generation-1",
+		SubjectID:    "tenant-42",
+	})
+	if err != nil {
+		t.Fatalf("BuildHITLCredentialAuthBindingID err = %v", err)
+	}
+	if !strings.HasPrefix(binding, "credential:v1:") {
+		t.Fatalf("binding = %q, want credential:v1 prefix", binding)
+	}
+	if strings.Contains(binding, "agent") || strings.Contains(binding, "deploy-api") || strings.Contains(binding, "generation-1") || strings.Contains(binding, "tenant-42") {
+		t.Fatalf("binding should be an opaque non-secret identifier, got %q", binding)
+	}
+
+	same, err := BuildHITLCredentialAuthBindingID(HITLCredentialAuthBindingInput{
+		ProfileID:    "agent",
+		CredentialID: "deploy-api",
+		Generation:   "generation-1",
+		SubjectID:    "tenant-42",
+	})
+	if err != nil {
+		t.Fatalf("same binding err = %v", err)
+	}
+	if same != binding {
+		t.Fatalf("binding not stable: %q vs %q", same, binding)
+	}
+
+	rotated, err := BuildHITLCredentialAuthBindingID(HITLCredentialAuthBindingInput{
+		ProfileID:    "agent",
+		CredentialID: "deploy-api",
+		Generation:   "generation-2",
+		SubjectID:    "tenant-42",
+	})
+	if err != nil {
+		t.Fatalf("rotated binding err = %v", err)
+	}
+	if rotated == binding {
+		t.Fatal("credential generation change must change auth binding id")
+	}
+
+	if _, err := BuildHITLCredentialAuthBindingID(HITLCredentialAuthBindingInput{ProfileID: "agent", CredentialID: "deploy-api"}); err == nil {
+		t.Fatal("missing generation err = nil, want invalid input")
+	}
+}
+
+func testHITLFingerprintInput() HITLRequestFingerprintInput {
+	return HITLRequestFingerprintInput{
+		Key: HITLFingerprintKey{
+			ID:   "hitl-hmac:v1",
+			Root: []byte("test root key used only for deterministic HMAC tests"),
+		},
+		ProfileID:      "agent",
+		PrincipalID:    "peer:100.64.0.10",
+		EndpointID:     "dangerous-api",
+		ApprovalRuleID: "approved-post",
+		Method:         "post",
+		Scheme:         "HTTPS",
+		Host:           "API.EXAMPLE.TEST",
+		Path:           "/v1/resources/%32",
+		RawQuery:       "b=two&a=one",
+		SelectedHeaders: []HITLFingerprintHeader{
+			{Name: "Content-Type", Values: []string{" application/json "}},
+			{Name: "If-Match", Values: []string{" rev-1 "}},
+		},
+		RawBody:       []byte(`{"resource":"demo","approved":true}`),
+		AuthBindingID: "credential:v1:test-binding",
+	}
+}
+
+func mustComputeHITLFingerprint(t *testing.T, in HITLRequestFingerprintInput) HITLRequestFingerprintResult {
+	t.Helper()
+	got, err := ComputeHITLRequestFingerprint(in)
+	if err != nil {
+		t.Fatalf("ComputeHITLRequestFingerprint err = %v", err)
+	}
+	return got
+}
+
+func testHITLHMAC(key []byte, domain string, msg []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	if domain != "" {
+		_, _ = mac.Write([]byte(domain))
+	}
+	if msg != nil {
+		_, _ = mac.Write(msg)
+	}
+	return mac.Sum(nil)
+}
+
+func testCanonicalHITLRequest(in HITLRequestFingerprintInput, bodyHMAC string) []byte {
+	var b bytes.Buffer
+	testWriteCanonicalField(&b, "fingerprint_version", HITLFingerprintVersionV1)
+	testWriteCanonicalField(&b, "profile_id", in.ProfileID)
+	testWriteCanonicalField(&b, "principal_id", in.PrincipalID)
+	testWriteCanonicalField(&b, "endpoint_id", in.EndpointID)
+	testWriteCanonicalField(&b, "approval_rule_id", in.ApprovalRuleID)
+	testWriteCanonicalField(&b, "method", strings.ToUpper(in.Method))
+	testWriteCanonicalField(&b, "scheme", strings.ToLower(in.Scheme))
+	testWriteCanonicalField(&b, "host", strings.ToLower(in.Host))
+	testWriteCanonicalField(&b, "path", in.Path)
+	testWriteCanonicalField(&b, "raw_query", in.RawQuery)
+	testWriteCanonicalField(&b, "selected_header_count", strconv.Itoa(len(in.SelectedHeaders)))
+	for _, h := range in.SelectedHeaders {
+		testWriteCanonicalField(&b, "selected_header_name", strings.ToLower(h.Name))
+		testWriteCanonicalField(&b, "selected_header_value_count", strconv.Itoa(len(h.Values)))
+		for _, v := range h.Values {
+			testWriteCanonicalField(&b, "selected_header_value", strings.TrimSpace(v))
+		}
+	}
+	testWriteCanonicalField(&b, "body_hmac", bodyHMAC)
+	testWriteCanonicalField(&b, "auth_binding_id", in.AuthBindingID)
+	return b.Bytes()
+}
+
+func testWriteCanonicalField(b *bytes.Buffer, name, value string) {
+	b.WriteString(strconv.Itoa(len(name)))
+	b.WriteByte(':')
+	b.WriteString(name)
+	b.WriteByte('=')
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte('\n')
+}
+
+func equalHITLHeaders(a, b []HITLFingerprintHeader) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || len(a[i].Values) != len(b[i].Values) {
+			return false
+		}
+		for j := range a[i].Values {
+			if a[i].Values[j] != b[i].Values[j] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/hitl_operation_store.go
+++ b/hitl_operation_store.go
@@ -79,6 +79,8 @@ type HITLRetryGrantConsume struct {
 	ProfileID          string
 	PrincipalID        string
 	AuthBindingID      string
+	FingerprintVersion string
+	HMACKeyID          string
 	RequestFingerprint string
 	ConsumedBy         string
 	Now                time.Time
@@ -216,7 +218,7 @@ func (s *HITLOperationStore) ConsumeRetryGrant(ctx context.Context, in HITLRetry
 	if s == nil || s.db == nil {
 		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
 	}
-	if in.ID == "" || in.ProfileID == "" || in.PrincipalID == "" || in.Now.IsZero() {
+	if in.ID == "" || in.ProfileID == "" || in.PrincipalID == "" || in.AuthBindingID == "" || in.FingerprintVersion == "" || in.HMACKeyID == "" || in.RequestFingerprint == "" || in.ConsumedBy == "" || in.Now.IsZero() {
 		return HITLOperation{}, fmt.Errorf("%w: incomplete retry consume", ErrHITLOperationStoreInvalid)
 	}
 	op, err := s.GetForPrincipal(ctx, in.ID, in.ProfileID, in.PrincipalID)
@@ -232,7 +234,7 @@ func (s *HITLOperationStore) ConsumeRetryGrant(ctx context.Context, in HITLRetry
 	if op.RetryExpiresAt == nil || !in.Now.Before(*op.RetryExpiresAt) {
 		return HITLOperation{}, ErrHITLRetryExpired
 	}
-	if op.AuthBindingID != in.AuthBindingID || op.RequestFingerprint != in.RequestFingerprint {
+	if op.AuthBindingID != in.AuthBindingID || op.FingerprintVersion != in.FingerprintVersion || op.HMACKeyID != in.HMACKeyID || op.RequestFingerprint != in.RequestFingerprint {
 		return HITLOperation{}, ErrHITLRetryMismatch
 	}
 	res, err := s.db.ExecContext(ctx, `
@@ -246,9 +248,11 @@ WHERE id = ?
   AND grant_consumed_ns IS NULL
   AND retry_expires_ns > ?
   AND auth_binding_id = ?
+  AND fingerprint_version = ?
+  AND hmac_key_id = ?
   AND request_fingerprint = ?`,
 		string(HITLOperationStateExecutingUpstream), timeNS(in.Now), in.ConsumedBy,
-		in.ID, in.ProfileID, in.PrincipalID, string(HITLOperationStateApprovedWaitingForRetry), op.Version, timeNS(in.Now), in.AuthBindingID, in.RequestFingerprint,
+		in.ID, in.ProfileID, in.PrincipalID, string(HITLOperationStateApprovedWaitingForRetry), op.Version, timeNS(in.Now), in.AuthBindingID, in.FingerprintVersion, in.HMACKeyID, in.RequestFingerprint,
 	)
 	if err != nil {
 		return HITLOperation{}, err
@@ -271,7 +275,7 @@ WHERE id = ?
 		if latest.RetryExpiresAt == nil || !in.Now.Before(*latest.RetryExpiresAt) {
 			return HITLOperation{}, ErrHITLRetryExpired
 		}
-		if latest.AuthBindingID != in.AuthBindingID || latest.RequestFingerprint != in.RequestFingerprint {
+		if latest.AuthBindingID != in.AuthBindingID || latest.FingerprintVersion != in.FingerprintVersion || latest.HMACKeyID != in.HMACKeyID || latest.RequestFingerprint != in.RequestFingerprint {
 			return HITLOperation{}, ErrHITLRetryMismatch
 		}
 		return HITLOperation{}, ErrHITLOperationConflict

--- a/hitl_operation_store_test.go
+++ b/hitl_operation_store_test.go
@@ -31,7 +31,7 @@ func TestHITLOperationStoreCreatesMetadataOnlyOperation(t *testing.T) {
 		RedactedQuery:       "?account=[redacted]",
 		RedactedHeadersJSON: `{"content-type":"application/json"}`,
 		AuthBindingID:       "credential:api:v1",
-		FingerprintVersion:  "raw-body-hmac-v1",
+		FingerprintVersion:  HITLFingerprintVersionV1,
 		HMACKeyID:           "hitl-hmac:v1",
 		RequestFingerprint:  "hmac-sha256:abcdef",
 		CreatedAt:           now,
@@ -102,7 +102,7 @@ func TestHITLOperationStoreRejectsUnknownState(t *testing.T) {
 		Host:               "api.example.test",
 		RedactedPath:       "/v1/write",
 		AuthBindingID:      "credential:api:v1",
-		FingerprintVersion: "raw-body-hmac-v1",
+		FingerprintVersion: HITLFingerprintVersionV1,
 		HMACKeyID:          "hitl-hmac:v1",
 		RequestFingerprint: "hmac-sha256:abcdef",
 		CreatedAt:          now,
@@ -190,24 +190,65 @@ func TestHITLOperationStoreConsumeRetryGrantIsOneShotAndMismatchSafe(t *testing.
 		RetryExpiresAt:    now.Add(5 * time.Minute),
 	})
 
-	_, err := store.ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
-		ID:                 op.ID,
-		ProfileID:          "agent",
-		PrincipalID:        "peer:100.64.0.2",
-		AuthBindingID:      "credential:other:v1",
-		RequestFingerprint: op.RequestFingerprint,
-		ConsumedBy:         "peer:100.64.0.2",
-		Now:                now,
-	})
-	if !errors.Is(err, ErrHITLRetryMismatch) {
-		t.Fatalf("mismatched auth binding err = %v, want ErrHITLRetryMismatch", err)
-	}
-	unchanged, err := store.GetForPrincipal(ctx, op.ID, "agent", "peer:100.64.0.2")
-	if err != nil {
-		t.Fatalf("reload after mismatch: %v", err)
-	}
-	if unchanged.State != HITLOperationStateApprovedWaitingForRetry || unchanged.GrantConsumedAt != nil {
-		t.Fatalf("mismatch consumed or changed grant: %#v", unchanged)
+	for _, tc := range []struct {
+		name               string
+		authBindingID      string
+		fingerprintVersion string
+		hmacKeyID          string
+		requestFingerprint string
+	}{
+		{
+			name:               "auth binding",
+			authBindingID:      "credential:other:v1",
+			fingerprintVersion: op.FingerprintVersion,
+			hmacKeyID:          op.HMACKeyID,
+			requestFingerprint: op.RequestFingerprint,
+		},
+		{
+			name:               "fingerprint version",
+			authBindingID:      op.AuthBindingID,
+			fingerprintVersion: "v2",
+			hmacKeyID:          op.HMACKeyID,
+			requestFingerprint: op.RequestFingerprint,
+		},
+		{
+			name:               "hmac key id",
+			authBindingID:      op.AuthBindingID,
+			fingerprintVersion: op.FingerprintVersion,
+			hmacKeyID:          "hitl-hmac:v2",
+			requestFingerprint: op.RequestFingerprint,
+		},
+		{
+			name:               "request fingerprint",
+			authBindingID:      op.AuthBindingID,
+			fingerprintVersion: op.FingerprintVersion,
+			hmacKeyID:          op.HMACKeyID,
+			requestFingerprint: "hmac-sha256:other",
+		},
+	} {
+		t.Run("mismatched "+tc.name, func(t *testing.T) {
+			_, err := store.ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
+				ID:                 op.ID,
+				ProfileID:          "agent",
+				PrincipalID:        "peer:100.64.0.2",
+				AuthBindingID:      tc.authBindingID,
+				FingerprintVersion: tc.fingerprintVersion,
+				HMACKeyID:          tc.hmacKeyID,
+				RequestFingerprint: tc.requestFingerprint,
+				ConsumedBy:         "peer:100.64.0.2",
+				Now:                now,
+			})
+			if !errors.Is(err, ErrHITLRetryMismatch) {
+				t.Fatalf("mismatched %s err = %v, want ErrHITLRetryMismatch", tc.name, err)
+			}
+			unchanged, err := store.GetForPrincipal(ctx, op.ID, "agent", "peer:100.64.0.2")
+			if err != nil {
+				t.Fatalf("reload after mismatch: %v", err)
+			}
+			if unchanged.State != HITLOperationStateApprovedWaitingForRetry || unchanged.GrantConsumedAt != nil {
+				t.Fatalf("mismatch consumed or changed grant: %#v", unchanged)
+			}
+		})
 	}
 
 	consumed, err := store.ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
@@ -215,6 +256,8 @@ func TestHITLOperationStoreConsumeRetryGrantIsOneShotAndMismatchSafe(t *testing.
 		ProfileID:          "agent",
 		PrincipalID:        "peer:100.64.0.2",
 		AuthBindingID:      op.AuthBindingID,
+		FingerprintVersion: op.FingerprintVersion,
+		HMACKeyID:          op.HMACKeyID,
 		RequestFingerprint: op.RequestFingerprint,
 		ConsumedBy:         "peer:100.64.0.2",
 		Now:                now.Add(time.Second),
@@ -240,6 +283,8 @@ func TestHITLOperationStoreConsumeRetryGrantIsOneShotAndMismatchSafe(t *testing.
 		ProfileID:          "agent",
 		PrincipalID:        "peer:100.64.0.2",
 		AuthBindingID:      op.AuthBindingID,
+		FingerprintVersion: op.FingerprintVersion,
+		HMACKeyID:          op.HMACKeyID,
 		RequestFingerprint: op.RequestFingerprint,
 		ConsumedBy:         "peer:100.64.0.2",
 		Now:                now.Add(2 * time.Second),
@@ -276,7 +321,7 @@ func createTestHITLOperation(t *testing.T, store *HITLOperationStore, overrides 
 		RedactedQuery:       "",
 		RedactedHeadersJSON: `{"content-type":"application/json"}`,
 		AuthBindingID:       "credential:api:v1",
-		FingerprintVersion:  "raw-body-hmac-v1",
+		FingerprintVersion:  HITLFingerprintVersionV1,
 		HMACKeyID:           "hitl-hmac:v1",
 		RequestFingerprint:  "hmac-sha256:abcdef",
 		CreatedAt:           now,


### PR DESCRIPTION
## Summary

- Adds HITL request fingerprint helpers for the async approval-grant flow:
  - domain-separated raw-body HMAC (`BodyHMAC`)
  - domain-separated canonical request HMAC (`RequestFingerprint`)
  - explicit `fingerprint_version` (`v1`) and `hmac_key_id`
- Adds stable credential auth binding IDs without persisting or exposing credential material.
- Extends retry-grant consumption to verify `auth_binding_id`, `fingerprint_version`, `hmac_key_id`, and `request_fingerprint` before and inside the atomic consume update.
- Keeps this as a helper/library slice only; runtime 202/polling integration is intentionally left for the next PR.

Stacked after #419; #419 is merged and this PR now targets main.

## Security notes

- Uses HMAC-SHA256 rather than plain SHA for body/request fingerprints.
- Does not store raw request bodies, Authorization/Cookie values, upstream secrets, or replayable request material.
- Rejects fingerprint header allowlist entries that are auth/secret-bearing (`auth`, `token`, `secret`, `key`, `password`, `cookie`) or volatile/hop-by-hop tracing headers.
- Retry grant consumption remains one-shot and owner-scoped, and now also binds `fingerprint_version` and `hmac_key_id`.

## Test plan

- `gofmt -l hitl_fingerprint.go hitl_fingerprint_test.go hitl_operation_store.go hitl_operation_store_test.go`
- `git diff --check`
- static added-line scan for hardcoded secrets / risky eval-shell-SQL patterns: `No static security scan findings`
- `go test . -run 'TestHITLRequestFingerprint|TestSelectHITLFingerprintHeaders|TestHITLCredentialAuthBindingID|TestHITLOperationStore' -count=1`
- `go test ./...`
- `npm --prefix www run build`
- read-only delegate review after sensitive-header fix: `APPROVED_NO_FINDINGS`


