### PR TITLE
hitl: show async approval state in dashboard

### DIFF
--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -143,14 +143,18 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					msg = expandMessage(h.Message, req)
 				}
 				target := runtime.HITLTarget{
-					CredentialName: h.Credential,
-					Channel:        h.Channel,
-					Interactive:    h.Interactive,
-					PendingID:      id,
-					DashboardURL:   req.DashboardURL,
-					ThreadTS:       req.ThreadTS,
-					Summary:        summary,
-					Message:        msg,
+					CredentialName:  h.Credential,
+					Channel:         h.Channel,
+					Interactive:     h.Interactive,
+					PendingID:       id,
+					DashboardURL:    req.DashboardURL,
+					ThreadTS:        req.ThreadTS,
+					OperationState:  pending.OperationState,
+					ApprovalEffect:  pending.ApprovalEffect,
+					UpstreamCalled:  pending.UpstreamCalled,
+					ApprovalMessage: pending.ApprovalMessage,
+					Summary:         summary,
+					Message:         msg,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {

--- a/config/plugins/approvers/human_test.go
+++ b/config/plugins/approvers/human_test.go
@@ -3,6 +3,7 @@ package approvers
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -73,6 +74,22 @@ func TestHumanApproverPendingExpirationUsesPolicyTimeoutFallback(t *testing.T) {
 func TestHumanApproverPendingExpirationUsesDefaultTimeoutFallback(t *testing.T) {
 	pending := captureHumanPending(t, &HumanApprover{}, nil)
 	assertPendingLifetime(t, pending, 10*time.Minute)
+}
+
+func TestHumanApproverPendingIncludesSyncApprovalGuidance(t *testing.T) {
+	pending := captureHumanPending(t, &HumanApprover{Timeout: 17}, &config.CompiledPolicy{HumanTimeout: 600})
+	if pending.OperationState != runtime.HITLOperationStateSyncWaiting {
+		t.Fatalf("OperationState = %q, want %q", pending.OperationState, runtime.HITLOperationStateSyncWaiting)
+	}
+	if pending.ApprovalEffect != runtime.HITLApprovalEffectExecuteUpstream {
+		t.Fatalf("ApprovalEffect = %q, want %q", pending.ApprovalEffect, runtime.HITLApprovalEffectExecuteUpstream)
+	}
+	if pending.UpstreamCalled {
+		t.Fatal("UpstreamCalled = true, want false before approval")
+	}
+	if !strings.Contains(pending.ApprovalMessage, "send this request upstream immediately") {
+		t.Fatalf("ApprovalMessage = %q, want immediate upstream guidance", pending.ApprovalMessage)
+	}
 }
 
 func TestHumanApproverTimeoutRecordsTimedOutTerminalState(t *testing.T) {

--- a/config/plugins/approvers/util.go
+++ b/config/plugins/approvers/util.go
@@ -21,7 +21,7 @@ func buildPending(req runtime.ApproveRequest) runtime.HITLPending {
 	if req.Endpoint != nil {
 		family = req.Endpoint.Family
 	}
-	return runtime.HITLPending{
+	pending := runtime.HITLPending{
 		AgentIP:    req.AgentIP,
 		Host:       req.Host,
 		Method:     req.Method,
@@ -34,6 +34,8 @@ func buildPending(req runtime.ApproveRequest) runtime.HITLPending {
 		Approvers:  []string{req.ApproverName},
 		CreatedAt:  now,
 	}
+	runtime.NormalizeHITLPendingApproval(&pending)
+	return pending
 }
 
 func decision(allow bool) string {

--- a/config/plugins/credentials/slack.go
+++ b/config/plugins/credentials/slack.go
@@ -187,6 +187,12 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 			"text": map[string]any{"type": "mrkdwn", "text": "*Body*\n```" + slackTrunc(bs, 1000) + "```"},
 		})
 	}
+	if guidance := slackHITLApprovalGuidance(target); guidance != "" {
+		blocks = append(blocks, map[string]any{
+			"type": "section",
+			"text": map[string]any{"type": "mrkdwn", "text": slackTrunc(guidance, 1000)},
+		})
+	}
 	if target.Interactive {
 		blocks = append(blocks, map[string]any{
 			"type": "actions",
@@ -234,6 +240,25 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 		return err
 	}
 	return nil
+}
+
+func slackHITLApprovalGuidance(target runtime.HITLTarget) string {
+	message := strings.TrimSpace(target.ApprovalMessage)
+	if message != "" {
+		return message
+	}
+	if target.OperationState == "" && target.ApprovalEffect == "" && !target.UpstreamCalled {
+		return ""
+	}
+	state := target.OperationState
+	if state == "" {
+		state = runtime.HITLOperationStateSyncWaiting
+	}
+	effect := target.ApprovalEffect
+	if effect == "" {
+		effect = runtime.HITLApprovalEffectForOperationState(state)
+	}
+	return runtime.HITLApprovalMessage(state, effect, target.UpstreamCalled)
 }
 
 func slackPostHITLMessage(ctx context.Context, bot string, buf []byte) error {

--- a/config/plugins/credentials/slack_notify_test.go
+++ b/config/plugins/credentials/slack_notify_test.go
@@ -129,6 +129,70 @@ func TestSlackNotifyHITLRetriesOnceAfterTransportTimeout(t *testing.T) {
 	}
 }
 
+func TestSlackNotifyHITLExplainsAsyncRetryGrantApproval(t *testing.T) {
+	var body struct {
+		Blocks []map[string]any `json:"blocks"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode Slack payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackPostMessageURL
+	oldClient := slackHTTPClient
+	oldBackoff := slackNotifyRetryBackoff
+	slackPostMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	slackNotifyRetryBackoff = 0
+	defer func() {
+		slackPostMessageURL = oldURL
+		slackHTTPClient = oldClient
+		slackNotifyRetryBackoff = oldBackoff
+	}()
+
+	err := (&SlackTokens{}).NotifyHITL(context.Background(), runtime.ApproveRequest{
+		Secrets: testSecretStore{
+			"slack-avocet": {Extras: map[string]string{"bot": "xoxb-test"}},
+		},
+		Method: "POST",
+		Host:   "console.deno.com",
+		Path:   "/api/admin.supportTickets.updateStatus",
+	}, runtime.HITLTarget{
+		CredentialName: "slack-avocet",
+		Channel:        "C123",
+		PendingID:      "pending-123",
+		Interactive:    true,
+		OperationState: runtime.HITLOperationStatePendingApproval,
+		ApprovalEffect: runtime.HITLApprovalEffectCreateRetryGrant,
+		UpstreamCalled: false,
+	})
+	if err != nil {
+		t.Fatalf("NotifyHITL returned error: %v", err)
+	}
+
+	buf, err := json.Marshal(body.Blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(buf)
+	for _, want := range []string{
+		"Upstream has not been called",
+		"Approve will not send the request upstream now",
+		"Approve will allow the client to retry the same request once",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Slack blocks = %s, want substring %q", text, want)
+		}
+	}
+	if strings.Contains(text, "send this request upstream immediately") {
+		t.Fatalf("Slack blocks used sync-waiting copy for async retry grant: %s", text)
+	}
+}
+
 func TestSlackNotifyHITLDoesNotRetryNonTransientSlackError(t *testing.T) {
 	var attempts int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -321,6 +321,14 @@ type HITLTarget struct {
 	PendingID      string // pool's pending entry id
 	DashboardURL   string // for fallback dashboard link in non-interactive mode
 	ThreadTS       string // if set, post as a reply in this Slack thread
+	// OperationState / ApprovalEffect / UpstreamCalled / ApprovalMessage
+	// mirror HITLPending's safety copy so channel notifiers can tell
+	// operators whether an approval executes upstream immediately or only
+	// authorizes a one-shot retry grant.
+	OperationState  HITLOperationState
+	ApprovalEffect  HITLApprovalEffect
+	UpstreamCalled  bool
+	ApprovalMessage string
 	// Summary is an optional pre-computed classification. When non-nil,
 	// notifiers render a richer card instead of the generic method/path display.
 	Summary *HITLSummary
@@ -466,6 +474,34 @@ const (
 	HITLStateUnknown            HITLState = "unknown"
 )
 
+// HITLOperationState is the durable async-HITL operation state copied
+// into human-facing pending prompts. It intentionally lives in runtime
+// (instead of main) so dashboard and channel notifiers can share the same
+// wire labels without importing the gateway package.
+type HITLOperationState string
+
+const (
+	HITLOperationStateSyncWaiting             HITLOperationState = "sync_waiting"
+	HITLOperationStatePendingApproval         HITLOperationState = "pending_approval"
+	HITLOperationStateApprovedWaitingForRetry HITLOperationState = "approved_waiting_for_retry"
+	HITLOperationStateDenied                  HITLOperationState = "denied"
+	HITLOperationStateExpired                 HITLOperationState = "expired"
+	HITLOperationStateExecutingUpstream       HITLOperationState = "executing_upstream"
+	HITLOperationStateUpstreamSucceeded       HITLOperationState = "upstream_succeeded"
+	HITLOperationStateUpstreamFailed          HITLOperationState = "upstream_failed"
+	HITLOperationStateClientDisconnected      HITLOperationState = "client_disconnected"
+)
+
+// HITLApprovalEffect tells an operator what clicking approve does for
+// the current state. This is separate from OperationState so the UI can
+// render a stable affordance even while async operation wiring evolves.
+type HITLApprovalEffect string
+
+const (
+	HITLApprovalEffectExecuteUpstream  HITLApprovalEffect = "execute_upstream"
+	HITLApprovalEffectCreateRetryGrant HITLApprovalEffect = "create_retry_grant"
+)
+
 // HITLResolveResult is returned by structured HITL resolution APIs.
 // OK means this call transitioned an active pending request. State and
 // Reason are still populated for stale/duplicate decisions so Slack and
@@ -487,6 +523,14 @@ type HITLPending struct {
 	Host    string `json:"host"`
 	Method  string `json:"method"`
 	Path    string `json:"path"`
+	// OperationState and ApprovalEffect are safety-boundary display
+	// metadata. They let dashboard/Slack copy distinguish the initial
+	// synchronous wait (approval forwards upstream immediately) from async
+	// fallback (approval only grants one matching client retry).
+	OperationState  HITLOperationState `json:"operation_state,omitempty"`
+	ApprovalEffect  HITLApprovalEffect `json:"approval_effect,omitempty"`
+	UpstreamCalled  bool               `json:"upstream_called"`
+	ApprovalMessage string             `json:"approval_message,omitempty"`
 	// Endpoint is the operator-readable identifier for what's being
 	// called. HITLEndpointLabel-derived: hostname for HTTPS, resource
 	// name for SQL / k8s where Host is a virtual IP.
@@ -501,6 +545,64 @@ type HITLPending struct {
 	Approvers  []string  `json:"approvers,omitempty"`
 	CreatedAt  time.Time `json:"created_at"`
 	ExpiresAt  time.Time `json:"expires_at"`
+}
+
+// NormalizeHITLPendingApproval fills safety copy defaults for a pending
+// HITL prompt. Existing synchronous human-approval prompts start in
+// sync_waiting: approving while the original request is still held sends
+// the request upstream immediately. Async grant code can override the
+// state/effect/message when sync_wait_timeout has already returned 202.
+func NormalizeHITLPendingApproval(p *HITLPending) {
+	if p == nil {
+		return
+	}
+	if p.OperationState == "" {
+		p.OperationState = HITLOperationStateSyncWaiting
+	}
+	if p.ApprovalEffect == "" {
+		p.ApprovalEffect = HITLApprovalEffectForOperationState(p.OperationState)
+	}
+	if p.ApprovalMessage == "" {
+		p.ApprovalMessage = HITLApprovalMessage(p.OperationState, p.ApprovalEffect, p.UpstreamCalled)
+	}
+}
+
+func HITLApprovalEffectForOperationState(state HITLOperationState) HITLApprovalEffect {
+	switch state {
+	case HITLOperationStatePendingApproval:
+		return HITLApprovalEffectCreateRetryGrant
+	default:
+		return HITLApprovalEffectExecuteUpstream
+	}
+}
+
+func HITLApprovalMessage(state HITLOperationState, effect HITLApprovalEffect, upstreamCalled bool) string {
+	if upstreamCalled {
+		switch state {
+		case HITLOperationStateExecutingUpstream:
+			return "The client retried the approved request.\nForwarding upstream now."
+		case HITLOperationStateUpstreamSucceeded:
+			return "Done. The approved request completed upstream."
+		case HITLOperationStateUpstreamFailed:
+			return "Approved and retried, but the forwarding attempt failed or did not complete successfully.\nThe upstream side effect status may be unknown."
+		}
+	}
+	switch state {
+	case HITLOperationStatePendingApproval:
+		return "The original synchronous wait ended and Claw Patrol returned an async polling response to the client.\nUpstream has not been called.\nApprove will not send the request upstream now.\nApprove will allow the client to retry the same request once."
+	case HITLOperationStateApprovedWaitingForRetry:
+		return "Approved.\nWaiting for the client to retry the original request.\nUpstream has not been called yet."
+	case HITLOperationStateDenied:
+		return "Denied.\nUpstream was not called."
+	case HITLOperationStateExpired:
+		return "Approval expired.\nUpstream was not called."
+	case HITLOperationStateClientDisconnected:
+		return "The original client connection closed before Claw Patrol could return an async polling handle.\nUpstream was not called.\nThis prompt is stale."
+	}
+	if effect == HITLApprovalEffectCreateRetryGrant {
+		return "Upstream has not been called.\nApprove will not send the request upstream now.\nApprove will allow the client to retry the same request once."
+	}
+	return "Pending human approval.\nIf approved soon, Claw Patrol will send this request upstream immediately and return the real upstream response to the client."
 }
 
 // HITLDecision is what the pool delivers when an operator approves

--- a/www/src/components/HITLBar.tsx
+++ b/www/src/components/HITLBar.tsx
@@ -66,6 +66,7 @@ export function HITLBar() {
               // paths don't start with `/`; insert a space so we get
               // "users-db UPDATE ..." rather than "users-dbUPDATE ...".
               const sep = p.path && !p.path.startsWith("/") ? " " : "";
+              const approval = hitlApprovalDisplay(p);
               return (
                 <tr
                   key={p.id}
@@ -84,13 +85,23 @@ export function HITLBar() {
                     {p.reason && (
                       <div className="text-2xs text-text-muted truncate">{p.reason}</div>
                     )}
+                    {approval && (
+                      <div className="mt-1 flex gap-2 text-2xs leading-snug text-text-muted">
+                        <span className="shrink-0 rounded-sm border border-navy-200 bg-navy-50 px-1.5 py-0.5 font-sans uppercase tracking-wide text-navy">
+                          {approval.label}
+                        </span>
+                        <span className="whitespace-pre-line">{approval.message}</span>
+                      </div>
+                    )}
                   </Td>
                   <Td className="text-right">
                     <div className="flex gap-1.5 justify-end">
                       <Button variant="outline" onClick={() => decide(p.id, false)}>
                         deny
                       </Button>
-                      <Button onClick={() => decide(p.id, true)}>allow</Button>
+                      <Button onClick={() => decide(p.id, true)}>
+                        {approval?.approveLabel ?? "allow"}
+                      </Button>
                     </div>
                   </Td>
                 </tr>
@@ -101,6 +112,62 @@ export function HITLBar() {
       )}
     </div>
   );
+}
+
+function hitlApprovalDisplay(
+  p: HITLPending,
+): { label: string; message: string; approveLabel: string } | null {
+  const effect = p.approval_effect;
+  const state = p.operation_state;
+  const message = (
+    p.approval_message || hitlApprovalFallbackMessage(state, effect, p.upstream_called)
+  ).trim();
+  if (!message && !state && !effect) return null;
+  if (effect === "create_retry_grant" || state === "pending_approval") {
+    return {
+      label: "retry grant",
+      message:
+        message || "Upstream has not been called. Approval allows one matching client retry.",
+      approveLabel: "approve retry",
+    };
+  }
+  if (p.upstream_called) {
+    return {
+      label: "upstream called",
+      message: message || "The approved request has been retried and forwarded upstream.",
+      approveLabel: "allow",
+    };
+  }
+  return {
+    label: state === "sync_waiting" ? "sync wait" : humanizeHITLState(state || "pending"),
+    message: message || "Approval sends this request upstream immediately while the client waits.",
+    approveLabel: "allow",
+  };
+}
+
+function hitlApprovalFallbackMessage(
+  state: HITLPending["operation_state"],
+  effect: HITLPending["approval_effect"],
+  upstreamCalled?: boolean,
+): string {
+  if (upstreamCalled) return "The approved request has been retried and forwarded upstream.";
+  if (effect === "create_retry_grant" || state === "pending_approval") {
+    return "Upstream has not been called. Approve will not send the request upstream now; it only allows one matching client retry.";
+  }
+  if (state === "approved_waiting_for_retry") {
+    return "Approved. Waiting for the client to retry the original request. Upstream has not been called yet.";
+  }
+  if (state === "denied" || state === "expired" || state === "client_disconnected") {
+    return "Upstream was not called.";
+  }
+  if (state === "sync_waiting" || effect === "execute_upstream") {
+    return "Approval sends this request upstream immediately while the client waits.";
+  }
+  return "";
+}
+
+function humanizeHITLState(state: string): string {
+  return state.replaceAll("_", " ");
 }
 
 function hitlDecisionNotice(result: HITLResolveResult): string {

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -245,6 +245,10 @@ export type HITLPending = {
   host: string;
   method: string;
   path: string;
+  operation_state?: HITLOperationState;
+  approval_effect?: HITLApprovalEffect;
+  upstream_called?: boolean;
+  approval_message?: string;
   // Operator-readable endpoint identifier (hostname for HTTPS,
   // resource name for SQL/k8s where host is a virtual IP).
   // Computed server-side; falls back to host when unset.
@@ -258,6 +262,19 @@ export type HITLPending = {
   created_at: string;
   expires_at: string;
 };
+
+export type HITLOperationState =
+  | "sync_waiting"
+  | "pending_approval"
+  | "approved_waiting_for_retry"
+  | "denied"
+  | "expired"
+  | "executing_upstream"
+  | "upstream_succeeded"
+  | "upstream_failed"
+  | "client_disconnected";
+
+export type HITLApprovalEffect = "execute_upstream" | "create_retry_grant";
 
 export async function getHITLPending(): Promise<HITLPending[]> {
   const r = await api("/api/hitl/pending");


### PR DESCRIPTION
## Summary

Stacked on #420 (`agent/hitl-async-api`).

This slice makes HITL approval prompts explain what an operator approval will do once async fallback is in play:

- Adds additive pending-approval metadata to shared runtime types: `operation_state`, `approval_effect`, `upstream_called`, and `approval_message`.
- Normalizes sync HITL pending payloads so dashboard/Slack can say approval forwards the waiting request upstream immediately.
- Propagates pending metadata through `human_approver` into channel notifiers.
- Adds Slack guidance copy before action buttons for async retry-grant approvals, explicitly saying upstream has not been called and approval only allows one matching client retry.
- Updates dashboard pending rows to show sync/async approval state and use `approve retry` for retry-grant approvals.
- Extends dashboard TypeScript API types with optional fields for backward-compatible payload handling.

## Safety notes

- This is display/wire metadata only; it does not connect retry-grant relay or server-side replay.
- The new fields are additive and avoid exposing raw request bodies, `Authorization`, `Cookie`, upstream secrets, fingerprints, auth-binding IDs, or replayable request material.
- Async copy avoids implying that Claw Patrol replays the request server-side.

## Test plan

- RED confirmed before implementation:
  - `go test ./config/plugins/approvers -run 'TestHumanApproverPendingIncludesSyncApprovalGuidance' -count=1`
  - `go test ./config/plugins/credentials -run 'TestSlackNotifyHITLExplainsAsyncRetryGrantApproval' -count=1`
- `go test ./config/plugins/approvers -run 'TestHumanApproverPendingIncludesSyncApprovalGuidance' -count=1`
- `go test ./config/plugins/credentials -run 'TestSlackNotifyHITLExplainsAsyncRetryGrantApproval' -count=1`
- `go test ./config/plugins/approvers ./config/plugins/credentials -count=1`
- `npm --prefix www ci`
- `npm --prefix www run format`
- `npm --prefix www run format:check`
- `npm --prefix www run lint:github`
- `npm --prefix www run build`
- `go test . -run 'TestHITLRegistry|TestHITLOperation' -count=1`
- `git diff --check`
- `go test ./...`
- Added-line static scan: no findings
- Independent pre-commit review: `APPROVED_NO_FINDINGS`
