### PR TITLE
fix(test): drop invalid `database` arg from postgres endpoint HCL

### DIFF
--- a/web_fixture_export_test.go
+++ b/web_fixture_export_test.go
@@ -209,7 +209,6 @@ admin_email = "x@example.com"
 credential "postgres_credential" "pg-cred" { user = "agent" }
 endpoint "postgres" "pg" {
   host       = "pg.internal:5432"
-  database   = "postgres"
   credential = pg-cred
 }
 profile "default" { endpoints = [pg] }
@@ -268,7 +267,6 @@ admin_email = "x@example.com"
 credential "postgres_credential" "pg-cred" { user = "agent" }
 endpoint "postgres" "pg" {
   host       = "pg.internal:5432"
-  database   = "postgres"
   credential = pg-cred
 }
 profile "default" { endpoints = [pg] }


### PR DESCRIPTION
TestExporterSQLEmitsAllFacets + TestExporterSQLStatementOnlyBackcompat (added in #416) put `database = "postgres"` inside `endpoint "postgres" { ... }`. The postgres endpoint plugin does not accept that argument — per-database routing landed for `clickhouse_native` / `clickhouse_https` in #404, not for postgres. CI on `main` went red on the merge of #416 for this reason.

The arg is not load-bearing for the test (which verifies the EVENT facet `database = "prod"` flows through the exporter, not the endpoint config), so just drop the two offending lines. Both tests pass locally afterwards; full `go test ./...` clean.