### PR TITLE
test: reject SQL fixture facets that disagree with the parser

### DIFF
--- a/action_file.go
+++ b/action_file.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -327,22 +328,31 @@ func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*mat
 		if stmt == "" {
 			break
 		}
-		// Derive verb / tables / functions via SQLParser, then let
-		// any explicit fixture fields override. Keeps SQL fixtures
-		// hand-editable (one field) while accepting full structs.
 		if parseSQL == nil {
 			return nil, fmt.Errorf("sql: endpoint runtime does not implement SQLParser")
 		}
+		// Parser is authoritative for verb / tables / functions —
+		// they're derivable from the statement. If a fixture also
+		// declares them, they must agree; otherwise the rule
+		// evaluator would silently see a fiction. database isn't
+		// in the statement (PG StartupMessage / CH session), so it
+		// stays a fixture-provided override.
 		meta := parseSQL(stmt)
 		if m, ok := meta.(*sqlfacet.Meta); ok {
-			if a.SQL.Verb != "" {
-				m.Verb = a.SQL.Verb
+			if a.SQL.Verb != "" && !strings.EqualFold(a.SQL.Verb, m.Verb) {
+				return nil, fmt.Errorf(
+					"sql.verb mismatch: fixture=%q parser=%q (statement=%q)",
+					a.SQL.Verb, m.Verb, stmt)
 			}
-			if len(a.SQL.Tables) > 0 {
-				m.Tables = a.SQL.Tables
+			if len(a.SQL.Tables) > 0 && !sameStringSet(a.SQL.Tables, m.Tables) {
+				return nil, fmt.Errorf(
+					"sql.tables mismatch: fixture=%v parser=%v (statement=%q)",
+					a.SQL.Tables, m.Tables, stmt)
 			}
-			if len(a.SQL.Functions) > 0 {
-				m.Functions = a.SQL.Functions
+			if len(a.SQL.Functions) > 0 && !sameStringSet(a.SQL.Functions, m.Functions) {
+				return nil, fmt.Errorf(
+					"sql.functions mismatch: fixture=%v parser=%v (statement=%q)",
+					a.SQL.Functions, m.Functions, stmt)
 			}
 			if a.SQL.Database != "" {
 				m.Database = a.SQL.Database
@@ -351,4 +361,23 @@ func (f *Fixture) ToMatchRequest(family string, parseSQL func(string) any) (*mat
 		req.Meta = meta
 	}
 	return req, nil
+}
+
+// sameStringSet treats two []string as equal-as-sets. Used to compare
+// fixture-declared table/function lists against the parser's output:
+// order is incidental, presence is what matters for rule matching.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	a_ := append([]string(nil), a...)
+	b_ := append([]string(nil), b...)
+	sort.Strings(a_)
+	sort.Strings(b_)
+	for i := range a_ {
+		if a_[i] != b_[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/action_file_test.go
+++ b/action_file_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denoland/clawpatrol/config"
+	sqlfacet "github.com/denoland/clawpatrol/config/plugins/facets/sql"
 )
 
 func TestFixtureUnmarshalAcceptsMissingEndpoint(t *testing.T) {
@@ -102,6 +103,99 @@ func TestMatchFromCompiledRule(t *testing.T) {
 			got := MatchFromCompiledRule(tc.cr, ep)
 			if got != tc.want {
 				t.Fatalf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// SQL fixture's verb / tables / functions must agree with what the
+// parser derives from `statement`. Disagreement = either a stale
+// fixture or a parser bug, and the rule evaluator must not silently
+// see a fiction either way.
+func TestFixtureSQLStrictAgainstParser(t *testing.T) {
+	mkFixture := func(sql SQLAction) *Fixture {
+		return &Fixture{Action: Action{Host: "pg.internal:5432", SQL: &sql}}
+	}
+	// Fake parser: pretends the statement is `SELECT count(*) FROM users`
+	// regardless of input, so the assertions below have a known truth.
+	parser := func(string) any {
+		return &sqlfacet.Meta{
+			Verb: "select", Tables: []string{"users"},
+			Functions: []string{"count"}, Statement: "stub",
+		}
+	}
+
+	cases := []struct {
+		name    string
+		sql     SQLAction
+		wantErr string // substring; "" = expect success
+	}{
+		{
+			name: "all-derived-only",
+			sql:  SQLAction{Statement: "SELECT count(*) FROM users"},
+		},
+		{
+			name: "matching-verb-and-tables",
+			sql: SQLAction{
+				Statement: "SELECT count(*) FROM users",
+				Verb:      "select",
+				Tables:    []string{"users"},
+				Functions: []string{"count"},
+			},
+		},
+		{
+			name: "tables-reordered-still-ok", // set semantics
+			sql: SQLAction{
+				Statement: "x",
+				Tables:    []string{"users"},
+			},
+		},
+		{
+			name: "verb-mismatch",
+			sql: SQLAction{
+				Statement: "SELECT count(*) FROM users",
+				Verb:      "delete",
+			},
+			wantErr: "sql.verb mismatch",
+		},
+		{
+			name: "tables-mismatch",
+			sql: SQLAction{
+				Statement: "SELECT count(*) FROM users",
+				Tables:    []string{"secrets"},
+			},
+			wantErr: "sql.tables mismatch",
+		},
+		{
+			name: "functions-mismatch",
+			sql: SQLAction{
+				Statement: "SELECT count(*) FROM users",
+				Functions: []string{"sum"},
+			},
+			wantErr: "sql.functions mismatch",
+		},
+		{
+			name: "database-allowed-as-override", // parser can't see it
+			sql: SQLAction{
+				Statement: "SELECT count(*) FROM users",
+				Database:  "prod",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := mkFixture(tc.sql).ToMatchRequest("sql", parser)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
test: reject SQL fixture facets that disagree with the parser

`ToMatchRequest` previously let a fixture's `sql.verb / .tables /
.functions` *override* the parser's output silently. A fixture
declaring `statement = "SELECT * FROM users"` paired with
`verb = "delete"` would have the rule engine evaluate against
`verb=delete` — fictional state the operator hand-authored,
masking both parser bugs and policy gaps.

This is wrong: the parser is authoritative for anything derivable
from the statement. When a fixture also declares those fields,
they must agree.

  - `verb`: case-insensitive scalar compare
  - `tables`, `functions`: set equality (order-insensitive)
  - `database`: still allowed as a fixture override — it comes
    from the connection context (PG StartupMessage, CH session),
    not from the SQL, so the parser can't see it.

Includes a focused unit test
(`TestFixtureSQLStrictAgainstParser`) covering the success cases,
the three mismatch errors, and the database override.

All existing in-tree tests + the deno.clawpatrol policy's 36
fixtures still pass.
