### PR TITLE
site: drop stripe from flow diagram, add k8s + notion

### DIFF
--- a/site/docs-render.ts
+++ b/site/docs-render.ts
@@ -46,6 +46,7 @@ import { Footer } from "./src/components/Footer";
 import { Header } from "./src/components/Header";
 import { Landing } from "./src/Landing";
 import { Stripe } from "./src/components/Stripe";
+import { SITE_TITLE } from "./src/copy";
 
 export const SITE_ORIGIN = "https://clawpatrol.dev";
 export const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/clawpatrol.png`;
@@ -386,7 +387,7 @@ export function renderDocPage(
 export function prerenderLandingHtml(viteIndexHtml: string): string {
   const landingHtml = renderHtml(Landing);
   const meta = renderMetaTags({
-    title: "Claw Patrol — The security proxy for AI agents",
+    title: SITE_TITLE,
     description: LANDING_DESCRIPTION,
     url: `${SITE_ORIGIN}/`,
     type: "website",

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Claw Patrol — The security proxy for AI agents</title>
+    <title>Claw Patrol</title>
     <link
       rel="preload"
       as="font"

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -162,31 +162,22 @@ function Risers({ count }: { count: number }) {
 }
 
 function CenterNode({ label, sub }: { label: string; sub: string }) {
-  // The proxy. Icon sits in a light puck so its dark-navy fill stays
-  // visible against the navy node behind it; references the same
-  // public asset the header uses (no inline SVG duplication).
+  // Light surface keyed to the header's bg-navy-100 so the proxy node
+  // reads as the same brand surface; full Claw Patrol logo (icon +
+  // wordmark) is the same public asset the header uses.
   return (
     <div
-      class="squircle-md w-full bg-navy text-canvas border border-navy
+      class="squircle-md w-full bg-navy-100 text-text border border-navy
         px-5 py-5 text-center"
     >
-      <div class="flex items-center justify-center gap-2">
-        <span
-          class="bg-canvas rounded-full w-7 h-7 flex items-center
-            justify-center shrink-0"
-        >
-          <img
-            src="/claw-patrol-icon.svg"
-            alt=""
-            class="w-5 h-5"
-            aria-hidden="true"
-          />
-        </span>
-        <div class="font-display font-bold text-xl leading-none">{label}</div>
-      </div>
+      <img
+        src="/claw-patrol-logo.svg"
+        alt={label}
+        class="h-10 sm:h-12 w-auto mx-auto"
+      />
       <div
         class="font-mono text-[11px] uppercase tracking-wider mt-2
-          text-canvas/65"
+          text-text-muted"
       >
         {sub}
       </div>

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -16,7 +16,7 @@ export function FlowDiagram() {
 
       <CenterNode
         label="Claw Patrol"
-        sub="rules · approvals · credentials · audit"
+        sub="rules · approvals · credentials · analytics"
       />
 
       <Risers count={4} />

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -52,7 +52,7 @@ function InternetNode() {
         class="font-mono text-[11px] uppercase tracking-wider mt-2
           text-text-muted text-balance"
       >
-        stripe · postgres · clickhouse · slack · internal apis · …
+        postgres · clickhouse · k8s · slack · notion · internal apis · …
       </div>
     </div>
   );

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -52,7 +52,7 @@ function InternetNode() {
         class="font-mono text-[11px] uppercase tracking-wider mt-2
           text-text-muted text-balance"
       >
-        postgres · clickhouse · k8s · slack · notion · internal apis · …
+        postgres · clickhouse · k8s · github · slack · notion · …
       </div>
     </div>
   );

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -10,7 +10,7 @@ export function FlowDiagram() {
       role="img"
       aria-label="Many agents on the bottom send requests through Claw Patrol to many destinations on top"
     >
-      <InternetNode />
+      <ProductionNode />
 
       <Riser />
 
@@ -39,14 +39,14 @@ function CardRow({ children }: { children: ComponentChildren }) {
   );
 }
 
-function InternetNode() {
+function ProductionNode() {
   return (
     <div
       class="squircle-md w-full bg-canvas border border-navy-200
         text-text px-5 py-5 text-center"
     >
       <div class="font-display font-bold text-xl leading-none">
-        The Internet
+        Production
       </div>
       <div
         class="font-mono text-[11px] uppercase tracking-wider mt-2

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -52,7 +52,7 @@ function ProductionNode() {
         class="font-mono text-[11px] uppercase tracking-wider mt-2
           text-text-muted text-balance"
       >
-        postgres · clickhouse · k8s · github · slack · notion · …
+        postgres · clickhouse · k8s · aws · gcp · github · slack · notion · …
       </div>
     </div>
   );

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -162,14 +162,28 @@ function Risers({ count }: { count: number }) {
 }
 
 function CenterNode({ label, sub }: { label: string; sub: string }) {
-  // The proxy. Navy surface and centered type carry the emphasis;
-  // no icon needed.
+  // The proxy. Icon sits in a light puck so its dark-navy fill stays
+  // visible against the navy node behind it; references the same
+  // public asset the header uses (no inline SVG duplication).
   return (
     <div
       class="squircle-md w-full bg-navy text-canvas border border-navy
         px-5 py-5 text-center"
     >
-      <div class="font-display font-bold text-xl leading-none">{label}</div>
+      <div class="flex items-center justify-center gap-2">
+        <span
+          class="bg-canvas rounded-full w-7 h-7 flex items-center
+            justify-center shrink-0"
+        >
+          <img
+            src="/claw-patrol-icon.svg"
+            alt=""
+            class="w-5 h-5"
+            aria-hidden="true"
+          />
+        </span>
+        <div class="font-display font-bold text-xl leading-none">{label}</div>
+      </div>
       <div
         class="font-mono text-[11px] uppercase tracking-wider mt-2
           text-canvas/65"

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -16,7 +16,7 @@ export function FlowDiagram() {
 
       <CenterNode
         label="Claw Patrol"
-        sub="rules · approvals · credentials"
+        sub="rules · approvals · credentials · audit"
       />
 
       <Risers count={4} />

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -25,7 +25,7 @@ export function FlowDiagram() {
         <Card name="Claude" icon="/icons/anthropic.svg" />
         <Card name="Codex" icon="/icons/openai.svg" />
         <Card name="OpenClaw" icon="/icons/openclaw.svg" />
-        <Card name="Other agents" />
+        <Card name="Others" />
       </CardRow>
     </div>
   );

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -173,7 +173,7 @@ function CenterNode({ label, sub }: { label: string; sub: string }) {
       <img
         src="/claw-patrol-logo.svg"
         alt={label}
-        class="h-10 sm:h-12 w-auto mx-auto"
+        class="h-8 sm:h-10 w-auto mx-auto"
       />
       <div
         class="font-mono text-[11px] uppercase tracking-wider mt-2

--- a/site/src/copy.ts
+++ b/site/src/copy.ts
@@ -1,0 +1,7 @@
+// Single source of truth for the hero H1 and the page <title>.
+// HeroSection imports HERO_H1; vite.config.ts uses SITE_TITLE in a
+// transformIndexHtml hook, and docs-render.ts uses SITE_TITLE for the
+// prerender meta tags. Change here, both surfaces update.
+
+export const HERO_H1 = "Security proxy for agents";
+export const SITE_TITLE = `Claw Patrol - ${HERO_H1}`;

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -1,5 +1,6 @@
 import { FlowDiagram } from "../components/FlowDiagram";
 import { InstallTerminal } from "../components/InstallTerminal";
+import { HERO_H1 } from "../copy";
 
 export function HeroSection() {
   return (
@@ -15,11 +16,17 @@ export function HeroSection() {
           <h1
             class="text-4xl sm:text-5xl md:text-6xl md:text-[4rem]
               font-bold
-               mb-8 font-display text-balance
+               mb-4 font-display text-balance
               text-text"
           >
-            Give your agents read access. Gate the writes.
+            {HERO_H1}
           </h1>
+          <p
+            class="text-xl sm:text-2xl mb-6 max-w-lg font-display
+            font-semibold text-text text-balance"
+          >
+            Give your agents read access. Gate the writes.
+          </p>
           <p
             class="mb-10 max-w-lg
             text-text-muted"

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -25,7 +25,7 @@ export function HeroSection() {
             class="text-xl sm:text-2xl mb-6 max-w-lg font-display
             font-semibold text-text text-balance"
           >
-            Give your agents read access. Gate the writes.
+            Give your agents read access to any service. Gate the writes.
           </p>
           <p
             class="mb-10 max-w-lg

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -18,15 +18,16 @@ export function HeroSection() {
                mb-8 font-display text-balance
               text-text"
           >
-            Let your agents read prod. Lock down the writes.
+            Give your agents read access. Gate the writes.
           </h1>
           <p
             class="mb-10 max-w-lg
             text-text-muted"
           >
-            Claw Patrol inspects every outbound call — SQL, the Kubernetes API, HTTP semantics.
-            Reads pass through. Writes run against rules you write in HCL, with risky ones routed to
-            a human in Slack. Secrets live in the proxy, not the agent.
+            Plugins parse each protocol — SQL, Kubernetes, HTTPS, SSH — so your rules match on
+            semantics, not URLs. Block <code>DROP TABLE</code>. Route{" "}
+            <code>kubectl delete pod</code> to a human in Slack. Let an LLM judge whether a{" "}
+            <code>SELECT</code> leaks secrets. Secrets stay in the proxy, never the agent.
           </p>
           <InstallTerminal />
         </div>

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -24,9 +24,9 @@ export function HeroSection() {
             class="mb-10 max-w-lg
             text-text-muted"
           >
-            Plugins parse each protocol — SQL, Kubernetes, HTTPS, SSH — so your rules match on
-            semantics, not URLs. Block <code>DROP TABLE</code>. Route{" "}
-            <code>kubectl delete pod</code> to a human in Slack. Let an LLM judge whether a{" "}
+            You write the rules. Plugins parse each protocol (SQL, Kubernetes, HTTPS, SSH) so they
+            can match on semantics, not URLs: block <code>DROP TABLE</code>, require human approval
+            for <code>kubectl delete pod</code>, or have an LLM judge whether a{" "}
             <code>SELECT</code> leaks secrets. Secrets stay in the proxy, never the agent.
           </p>
           <InstallTerminal />

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -18,17 +18,15 @@ export function HeroSection() {
                mb-8 font-display text-balance
               text-text"
           >
-            Let your agents into production.
+            Let your agents read prod. Lock down the writes.
           </h1>
           <p
             class="mb-10 max-w-lg
             text-text-muted"
           >
-            An agent stuck in a sandbox is a toy. Handing it your prod keys is reckless. Claw Patrol
-            sits at the only universal checkpoint — the network — between your agents and real
-            systems. Every outbound action runs against rules you write in HCL. Risky ones get a
-            human in Slack or an LLM judge. Secrets live in the proxy, not the agent. Works with
-            Claude Code, Codex, or any agent — no code changes.
+            Claw Patrol inspects every outbound call — SQL, the Kubernetes API, HTTP semantics.
+            Reads pass through. Writes run against rules you write in HCL, with risky ones routed to
+            a human in Slack. Secrets live in the proxy, not the agent.
           </p>
           <InstallTerminal />
         </div>

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -24,7 +24,7 @@ export function HeroSection() {
             class="mb-10 max-w-lg
             text-text-muted"
           >
-            You write the rules. Plugins parse each protocol (SQL, Kubernetes, HTTPS, SSH) so they
+            You write the rules. Plugins parse each protocol (SQL, Kubernetes, HTTPS, SSH, …) so they
             can match on semantics, not URLs: block <code>DROP TABLE</code>, require human approval
             for <code>kubectl delete pod</code>, or have an LLM judge whether a{" "}
             <code>SELECT</code> leaks secrets. Secrets stay in the proxy, never the agent.

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -6,13 +6,12 @@ export function ProblemSection() {
       <SectionLabel>The problem</SectionLabel>
       <div class="max-w-3xl mx-auto">
         <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-console-dark text-center text-balance mb-8">
-          You can't audit what the agent thinks. Only what leaves it.
+          You can't control what the agent thinks. Only what it does.
         </h3>
         <p class="text-base text-text-muted text-center max-w-2xl mx-auto">
-          Tool outputs, RAG hits, MCP responses, files the agent reads: any can hide instructions
-          the model will follow. The model's intent isn't auditable; its egress is. Today's
-          alternatives are API keys in env vars and broad OAuth scopes, with no checkpoint between
-          intent and damage.
+          Tool outputs, fetched web pages, files the agent reads: any can hide instructions the
+          model will follow. Every credential in the agent's env is one you've given away. Gate the
+          requests. Hold the secrets. Stop trying to fix the thoughts.
         </p>
       </div>
     </section>

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -20,13 +20,12 @@ const PROBLEMS = [
       "granted.",
   },
   {
-    title: "You can't see what your agents do",
+    title: "Logs don't capture the action",
     body:
-      "A fleet of agents making thousands of requests across " +
-      "dozens of services leaves no shared trace. Debugging " +
-      "\"what did my agent just do?\" means per-service log " +
-      "spelunking, and by the time you notice the bad request, " +
-      "it's already gone through.",
+      "Reconstructing what an agent did means stitching together " +
+      "per-service logs, which usually don't capture the actual " +
+      "request payload. And by the time you notice the bad " +
+      "action, it's already gone through.",
   },
 ];
 

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -4,27 +4,29 @@ const PROBLEMS = [
   {
     title: "Your agent shouldn't see secrets",
     body:
-      "Every API key in the agent's env is one you've handed over. " +
-      "If the process is compromised (and prompts can compromise " +
-      "it), the keys leak with it. Rotation is hard. Per-action " +
-      "auditing is impossible.",
+      "Every API key in the agent's env is one you've handed " +
+      "over. If the process is compromised (and prompts can " +
+      "compromise it), the keys leak with it. Rotation is hard, " +
+      "and you can't easily revoke a single action's worth of " +
+      "access.",
   },
   {
     title: "Granting access doesn't gate actions",
     body:
       "OAuth scopes grant the agent broad permission inside a " +
       "service: any action the scope allows. A prompt-injected " +
-      "agent will use it against you. And every service has its " +
-      "own scope model, leaving no single place to gate actions " +
-      "across the stack.",
+      "agent will use that permission against you. You need to " +
+      "check what each request does, not just whether the agent " +
+      "is allowed to send something.",
   },
   {
     title: "You can't see what your agents do",
     body:
-      "A fleet of agents making thousands of requests across dozens " +
-      "of services leaves no shared trace. Debugging \"what did my " +
-      "agent just do?\" means per-service log spelunking. There's " +
-      "no single place to watch them.",
+      "A fleet of agents making thousands of requests across " +
+      "dozens of services leaves no shared trace. Debugging " +
+      "\"what did my agent just do?\" means per-service log " +
+      "spelunking, and by the time you notice the bad request, " +
+      "it's already gone through.",
   },
 ];
 

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -1,52 +1,19 @@
 import { SectionLabel } from "../components/SectionLabel";
 
-const PROBLEMS = [
-  {
-    title: "Agents are stuck without access",
-    body:
-      "An agent that can only edit files in a sandbox is a toy. The " +
-      "work that matters — running a migration, replying to a " +
-      "customer, fixing a deploy — lives behind API calls. But every " +
-      "credential you hand the agent is one you've given away.",
-  },
-  {
-    title: "Prompt injection turns every input into instructions",
-    body:
-      "Tool outputs, RAG hits, MCP responses, file contents the agent " +
-      "reads — any of it can hide instructions the model will follow. " +
-      "You can't audit the model's intent. The only thing you can " +
-      "constrain is what leaves the machine.",
-  },
-  {
-    title: "Today's options are no-access or YOLO",
-    body:
-      "API keys in env vars, broad OAuth scopes, no checkpoint " +
-      "between intent and damage. By the time you notice the agent " +
-      "ran DROP TABLE on prod, the table is gone — and you have no " +
-      "record of who decided what.",
-  },
-];
-
 export function ProblemSection() {
   return (
     <section class="max-w-5xl mx-auto px-6 sm:px-8 pt-20 pb-16 sm:pt-32 sm:pb-28 border-t border-navy-200/50">
       <SectionLabel>The problem</SectionLabel>
-      <div class="max-w-2xl mx-auto space-y-12 sm:space-y-20">
-        {PROBLEMS.map(({ title, body }, i) => (
-          <div key={title} class="grid grid-cols-[auto_1fr] gap-3 sm:gap-6">
-            <div class="flex items-center justify-center min-w-10 sm:min-w-16">
-              <span class="text-5xl sm:text-7xl font-bold font-display  select-none text-rust">
-                {i + 1}
-              </span>
-            </div>
-            <div class="py-1">
-              <h3 class="text-2xl sm:text-3xl font-display font-bold text-console-dark mb-3">
-                {title}
-              </h3>
-              <p class="text-base  text-text-muted">{body}</p>
-            </div>
-          </div>
-        ))}
+      <div class="max-w-3xl mx-auto">
+        <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-console-dark text-center text-balance mb-8">
+          You can't audit what the agent thinks. Only what leaves it.
+        </h3>
+        <p class="text-base text-text-muted text-center max-w-2xl mx-auto">
+          Tool outputs, RAG hits, MCP responses, files the agent reads: any can hide instructions
+          the model will follow. The model's intent isn't auditable; its egress is. Today's
+          alternatives are API keys in env vars and broad OAuth scopes, with no checkpoint between
+          intent and damage.
+        </p>
       </div>
     </section>
   );

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -2,15 +2,6 @@ import { SectionLabel } from "../components/SectionLabel";
 
 const PROBLEMS = [
   {
-    title: "Your agent shouldn't see secrets",
-    body:
-      "Every API key in the agent's env is one you've handed " +
-      "over. If the process is compromised (and prompts can " +
-      "compromise it), the keys leak with it. Rotation is hard, " +
-      "and you can't easily revoke a single action's worth of " +
-      "access.",
-  },
-  {
     title: "Granting access doesn't gate actions",
     body:
       "OAuth scopes, API keys, IAM roles, k8s RBAC: every " +
@@ -18,6 +9,15 @@ const PROBLEMS = [
       "correctly is its own project. Even when you get it right, " +
       "a prompt-injected agent will exploit whatever access you " +
       "granted.",
+  },
+  {
+    title: "Your agent shouldn't see secrets",
+    body:
+      "Every API key in the agent's env is one you've handed " +
+      "over. If the process is compromised (and prompts can " +
+      "compromise it), the keys leak with it. Rotation is hard, " +
+      "and you can't easily revoke a single action's worth of " +
+      "access.",
   },
   {
     title: "Logs don't capture the action",

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -13,11 +13,11 @@ const PROBLEMS = [
   {
     title: "Granting access doesn't gate actions",
     body:
-      "OAuth scopes grant the agent broad permission inside a " +
-      "service: any action the scope allows. A prompt-injected " +
-      "agent will use that permission against you. You need to " +
-      "check what each request does, not just whether the agent " +
-      "is allowed to send something.",
+      "OAuth scopes, API keys, IAM roles, k8s RBAC: every " +
+      "service has its own access model, and configuring each " +
+      "correctly is its own project. Even when you get it right, " +
+      "a prompt-injected agent will exploit whatever access you " +
+      "granted.",
   },
   {
     title: "You can't see what your agents do",

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -1,18 +1,53 @@
 import { SectionLabel } from "../components/SectionLabel";
 
+const PROBLEMS = [
+  {
+    title: "Your agent shouldn't see secrets",
+    body:
+      "Every API key in the agent's env is one you've handed over. " +
+      "If the process is compromised (and prompts can compromise " +
+      "it), the keys leak with it. Rotation is hard. Per-action " +
+      "auditing is impossible.",
+  },
+  {
+    title: "Granting access doesn't gate actions",
+    body:
+      "OAuth scopes grant the agent broad permission inside a " +
+      "service: any action the scope allows. A prompt-injected " +
+      "agent will use it against you. And every service has its " +
+      "own scope model, leaving no single place to gate actions " +
+      "across the stack.",
+  },
+  {
+    title: "You can't see what your agents do",
+    body:
+      "A fleet of agents making thousands of requests across dozens " +
+      "of services leaves no shared trace. Debugging \"what did my " +
+      "agent just do?\" means per-service log spelunking. There's " +
+      "no single place to watch them.",
+  },
+];
+
 export function ProblemSection() {
   return (
     <section class="max-w-5xl mx-auto px-6 sm:px-8 pt-20 pb-16 sm:pt-32 sm:pb-28 border-t border-navy-200/50">
       <SectionLabel>The problem</SectionLabel>
-      <div class="max-w-3xl mx-auto">
-        <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-console-dark text-center text-balance mb-8">
-          You can't control what the agent thinks. Only what it does.
-        </h3>
-        <p class="text-base text-text-muted text-center max-w-2xl mx-auto">
-          Tool outputs, fetched web pages, files the agent reads: any can hide instructions the
-          model will follow. Every credential in the agent's env is one you've given away. Gate the
-          requests. Hold the secrets. Stop trying to fix the thoughts.
-        </p>
+      <div class="max-w-2xl mx-auto space-y-12 sm:space-y-20">
+        {PROBLEMS.map(({ title, body }, i) => (
+          <div key={title} class="grid grid-cols-[auto_1fr] gap-3 sm:gap-6">
+            <div class="flex items-center justify-center min-w-10 sm:min-w-16">
+              <span class="text-5xl sm:text-7xl font-bold font-display select-none text-rust">
+                {i + 1}
+              </span>
+            </div>
+            <div class="py-1">
+              <h3 class="text-2xl sm:text-3xl font-display font-bold text-console-dark mb-3">
+                {title}
+              </h3>
+              <p class="text-base text-text-muted">{body}</p>
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -2,6 +2,23 @@ import { defineConfig, type Plugin } from "vite";
 import preact from "@preact/preset-vite";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
+import { SITE_TITLE } from "./src/copy";
+
+// Keep <title> in sync with HeroSection's H1. The constant lives in
+// src/copy.ts so HeroSection imports it directly; this plugin rewrites
+// index.html's <title> at dev-server time and at build time so static
+// crawlers see the same string.
+function injectTitle(): Plugin {
+  return {
+    name: "inject-title",
+    transformIndexHtml(html) {
+      return html.replace(
+        /<title>.*?<\/title>/,
+        `<title>${SITE_TITLE}</title>`,
+      );
+    },
+  };
+}
 
 function serveDocsInDev(): Plugin {
   return {
@@ -90,5 +107,11 @@ function reloadDocsOnChange(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [preact(), tailwindcss(), serveDocsInDev(), reloadDocsOnChange()],
+  plugins: [
+    preact(),
+    tailwindcss(),
+    injectTitle(),
+    serveDocsInDev(),
+    reloadDocsOnChange(),
+  ],
 });


### PR DESCRIPTION
The landing page's flow diagram listed stripe as a destination tag, but clawpatrol has no stripe plugin. Replaced with two we actually support (k8s, notion); rest unchanged.