### PR TITLE
hitl: add retry grant relay

### DIFF
--- a/hitl_retry_relay.go
+++ b/hitl_retry_relay.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+const hitlRetryMismatchErrorValue = "hitl_retry_mismatch"
+
+type hitlRetryRelayInput struct {
+	OperationID string
+	ProfileID   string
+	PrincipalID string
+	Endpoint    *config.CompiledEndpoint
+	Rule        *config.CompiledRule
+	MatchReq    *match.Request
+	HTTPRequest *http.Request
+	RawBody     []byte
+	Truncated   bool
+}
+
+func (g *Gateway) consumeHITLRetryGrantForRequest(ctx context.Context, in hitlRetryRelayInput) (HITLOperation, error) {
+	if in.OperationID == "" {
+		return HITLOperation{}, fmt.Errorf("%w: missing retry operation id", ErrHITLRetryMismatch)
+	}
+	if in.Endpoint == nil || in.Rule == nil || in.HTTPRequest == nil {
+		return HITLOperation{}, fmt.Errorf("%w: retry request no longer matches the approved endpoint/rule", ErrHITLRetryMismatch)
+	}
+	if in.Truncated {
+		return HITLOperation{}, fmt.Errorf("%w: retry request body is not fully fingerprintable", ErrHITLRetryMismatch)
+	}
+	key, err := loadOrCreateHITLFingerprintKey(ctx, g.db)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	cc := runtime.ResolveCredential(in.Endpoint, in.MatchReq)
+	authBindingID, err := buildHITLAuthBindingID(ctx, g.db, in.ProfileID, cc)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	fp, err := ComputeHITLRequestFingerprint(HITLRequestFingerprintInput{
+		Key:            key,
+		ProfileID:      in.ProfileID,
+		PrincipalID:    in.PrincipalID,
+		EndpointID:     in.Endpoint.Name,
+		ApprovalRuleID: in.Rule.Name,
+		Method:         in.HTTPRequest.Method,
+		Scheme:         "https",
+		Host:           in.HTTPRequest.Host,
+		Path:           in.HTTPRequest.URL.Path,
+		RawQuery:       in.HTTPRequest.URL.RawQuery,
+		RawBody:        in.RawBody,
+		AuthBindingID:  authBindingID,
+	})
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	return NewHITLOperationStore(g.db).ConsumeRetryGrant(ctx, HITLRetryGrantConsume{
+		ID:                 in.OperationID,
+		ProfileID:          in.ProfileID,
+		PrincipalID:        in.PrincipalID,
+		AuthBindingID:      authBindingID,
+		FingerprintVersion: fp.Version,
+		HMACKeyID:          fp.HMACKeyID,
+		RequestFingerprint: fp.RequestFingerprint,
+		ConsumedBy:         in.PrincipalID,
+		Now:                time.Now().UTC(),
+	})
+}
+
+func (g *Gateway) transitionConsumedHITLRetryGrant(ctx context.Context, op HITLOperation, to HITLOperationState, lastErr string) error {
+	if g == nil || g.db == nil || op.ID == "" {
+		return nil
+	}
+	if op.State != HITLOperationStateExecutingUpstream {
+		return nil
+	}
+	_, err := NewHITLOperationStore(g.db).Transition(ctx, HITLOperationTransition{
+		ID:              op.ID,
+		FromState:       op.State,
+		ToState:         to,
+		ExpectedVersion: op.Version,
+		Now:             time.Now().UTC(),
+		UpstreamCalled:  true,
+		LastError:       lastErr,
+	})
+	return err
+}
+
+func hitlRetryRelayFailure(statusErr error) (status int, contentType string, body string) {
+	if errors.Is(statusErr, ErrHITLOperationNotFound) {
+		return http.StatusNotFound, "application/json", fmt.Sprintf("{\"error\":%q}\n", hitlOperationNotFoundErrorValue)
+	}
+	return http.StatusConflict, "application/json", fmt.Sprintf("{\"error\":%q}\n", hitlRetryMismatchErrorValue)
+}

--- a/hitl_retry_relay_test.go
+++ b/hitl_retry_relay_test.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"database/sql"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+const (
+	hitlRetryRelayTestProfile      = "default"
+	hitlRetryRelayTestPeerIP       = "pipe"
+	hitlRetryRelayTestEndpoint     = "api"
+	hitlRetryRelayTestRule         = "approved-post"
+	hitlRetryRelayTestApprover     = "human_approver.ops"
+	hitlRetryRelayTestHost         = "api.example.test"
+	hitlRetryRelayTestPath         = "/v1/resources/update"
+	hitlRetryRelayTestCredential   = "pat"
+	hitlRetryRelayTestCredentialNS = int64(1_700_003_000_000_000_000)
+)
+
+type hitlRetryRelayDenyApprover struct {
+	calls atomic.Int32
+}
+
+func (a *hitlRetryRelayDenyApprover) Approve(_ context.Context, _ runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
+	a.calls.Add(1)
+	return runtime.ApproveVerdict{Decision: "deny", Reason: "approval chain should be bypassed by a retry grant", By: "test"}, nil
+}
+
+type hitlRetryRelayUpstreamRequest struct {
+	Body                string
+	RetryOperationValue string
+}
+
+type hitlRetryRelayHarness struct {
+	db          *sql.DB
+	store       *HITLOperationStore
+	gateway     *Gateway
+	endpoint    *config.CompiledEndpoint
+	approver    *hitlRetryRelayDenyApprover
+	fingerprint HITLFingerprintKey
+	authBinding string
+	upstream    chan hitlRetryRelayUpstreamRequest
+}
+
+func TestHITLRetryRelayConsumesApprovedGrantAndForwardsOnlyOnce(t *testing.T) {
+	h := newHITLRetryRelayHarness(t)
+	requestBody := `{"resource":"example","approved":true}`
+	op := h.createApprovedRetryOperation(t, "hitl_op_retry_match", requestBody)
+
+	resp := h.sendRetryRequest(t, op.ID, requestBody)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("first retry status = %d, body = %q; want upstream 200", resp.StatusCode, resp.Body)
+	}
+	if !strings.Contains(resp.Body, "relayed") {
+		t.Fatalf("first retry body = %q, want upstream response", resp.Body)
+	}
+	upstream := h.nextUpstreamRequest(t)
+	if upstream.Body != requestBody {
+		t.Fatalf("upstream body = %q, want original body %q", upstream.Body, requestBody)
+	}
+	if upstream.RetryOperationValue != "" {
+		t.Fatalf("upstream received internal %s header = %q", hitlRetryOperationHeader, upstream.RetryOperationValue)
+	}
+	if calls := h.approver.calls.Load(); calls != 0 {
+		t.Fatalf("approve chain calls after matching retry = %d, want 0", calls)
+	}
+
+	consumed := h.getOperation(t, op.ID)
+	if consumed.State != HITLOperationStateUpstreamSucceeded {
+		t.Fatalf("state after retry = %s, want %s", consumed.State, HITLOperationStateUpstreamSucceeded)
+	}
+	if consumed.TerminalAt == nil {
+		t.Fatal("TerminalAt = nil after successful retry, want terminal status for pollers")
+	}
+	if !consumed.UpstreamCalled {
+		t.Fatal("UpstreamCalled = false, want true")
+	}
+	if consumed.GrantConsumedAt == nil {
+		t.Fatal("GrantConsumedAt = nil, want consumed timestamp")
+	}
+	if consumed.GrantConsumedBy != hitlPeerPrincipalID(hitlRetryRelayTestPeerIP) {
+		t.Fatalf("GrantConsumedBy = %q, want %q", consumed.GrantConsumedBy, hitlPeerPrincipalID(hitlRetryRelayTestPeerIP))
+	}
+
+	second := h.sendRetryRequest(t, op.ID, requestBody)
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("second retry status = %d, body = %q; want safe one-shot conflict", second.StatusCode, second.Body)
+	}
+	h.assertNoUpstreamRequest(t)
+	if calls := h.approver.calls.Load(); calls != 0 {
+		t.Fatalf("approve chain calls after consumed retry = %d, want 0", calls)
+	}
+}
+
+func TestHITLRetryRelayMismatchDoesNotForwardOrFallBackToApproval(t *testing.T) {
+	h := newHITLRetryRelayHarness(t)
+	approvedBody := `{"resource":"example","approved":true}`
+	op := h.createApprovedRetryOperation(t, "hitl_op_retry_mismatch", approvedBody)
+
+	resp := h.sendRetryRequest(t, op.ID, approvedBody+"\n")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("mismatched retry status = %d, body = %q; want safe conflict", resp.StatusCode, resp.Body)
+	}
+	h.assertNoUpstreamRequest(t)
+	if calls := h.approver.calls.Load(); calls != 0 {
+		t.Fatalf("approve chain calls after mismatched retry = %d, want 0", calls)
+	}
+
+	unchanged := h.getOperation(t, op.ID)
+	if unchanged.State != HITLOperationStateApprovedWaitingForRetry {
+		t.Fatalf("state after mismatch = %s, want %s", unchanged.State, HITLOperationStateApprovedWaitingForRetry)
+	}
+	if unchanged.UpstreamCalled {
+		t.Fatal("UpstreamCalled = true after mismatch, want false")
+	}
+	if unchanged.GrantConsumedAt != nil {
+		t.Fatalf("GrantConsumedAt = %v after mismatch, want nil", unchanged.GrantConsumedAt)
+	}
+}
+
+func TestHITLRetryRelayFingerprintsRetryBodyForDeleteRequests(t *testing.T) {
+	h := newHITLRetryRelayHarness(t)
+	requestBody := `{"resource":"example","delete":true}`
+	op := h.createApprovedRetryOperationForMethod(t, "hitl_op_retry_delete", http.MethodDelete, requestBody)
+
+	resp := h.sendRetryRequestWithMethod(t, op.ID, http.MethodDelete, requestBody)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete retry status = %d, body = %q; want upstream 200", resp.StatusCode, resp.Body)
+	}
+	upstream := h.nextUpstreamRequest(t)
+	if upstream.Body != requestBody {
+		t.Fatalf("delete upstream body = %q, want original body %q", upstream.Body, requestBody)
+	}
+	if upstream.RetryOperationValue != "" {
+		t.Fatalf("upstream received internal %s header = %q", hitlRetryOperationHeader, upstream.RetryOperationValue)
+	}
+	if calls := h.approver.calls.Load(); calls != 0 {
+		t.Fatalf("approve chain calls after delete retry = %d, want 0", calls)
+	}
+	consumed := h.getOperation(t, op.ID)
+	if consumed.State != HITLOperationStateUpstreamSucceeded {
+		t.Fatalf("delete retry state = %s, want %s", consumed.State, HITLOperationStateUpstreamSucceeded)
+	}
+	if consumed.TerminalAt == nil {
+		t.Fatal("delete retry TerminalAt = nil, want terminal status for pollers")
+	}
+}
+
+type hitlRetryRelayResponse struct {
+	StatusCode int
+	Body       string
+}
+
+func newHITLRetryRelayHarness(t *testing.T) *hitlRetryRelayHarness {
+	t.Helper()
+
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	fingerprintKey := HITLFingerprintKey{
+		ID:   "hitl-hmac:v1",
+		Root: []byte("retry relay test hmac root; deterministic and not a real secret"),
+	}
+	persistHITLRetryRelayFingerprintKey(t, db, fingerprintKey)
+	persistHITLRetryRelayCredentialSecret(t, db)
+
+	authBinding, err := BuildHITLCredentialAuthBindingID(HITLCredentialAuthBindingInput{
+		ProfileID:    hitlRetryRelayTestProfile,
+		CredentialID: hitlRetryRelayTestCredential,
+		Generation:   fmt.Sprintf("credential-secret:%d", hitlRetryRelayTestCredentialNS),
+	})
+	if err != nil {
+		t.Fatalf("BuildHITLCredentialAuthBindingID: %v", err)
+	}
+
+	gw, diags := config.LoadBytes([]byte(`
+public_url = "https://gateway.example.test"
+insecure_no_dashboard_secret = true
+
+credential "bearer_token" "pat" {}
+endpoint "https" "api" {
+  hosts      = ["api.example.test"]
+  credential = pat
+}
+approver "human_approver" "ops" {
+  channel = "#ops"
+}
+rule "approved-post" {
+  endpoint  = api
+  condition = "(http.method == 'POST' || http.method == 'DELETE') && http.path == '/v1/resources/update'"
+  approve   = [ops]
+}
+profile "default" {
+  endpoints = [api]
+  hitl_async_grants = true
+}
+`), "hitl-retry-relay-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load config: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile config: %v", err)
+	}
+	ep := policy.Endpoints[hitlRetryRelayTestEndpoint]
+	if ep == nil {
+		t.Fatal("missing compiled api endpoint")
+	}
+
+	approver := &hitlRetryRelayDenyApprover{}
+	policy.Approvers["ops"] = &config.Entity{Symbol: &config.Symbol{Name: "ops"}, Body: approver}
+
+	upstreamRequests := make(chan hitlRetryRelayUpstreamRequest, 2)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream body: %v", err)
+		}
+		upstreamRequests <- hitlRetryRelayUpstreamRequest{
+			Body:                string(body),
+			RetryOperationValue: r.Header.Get(hitlRetryOperationHeader),
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("relayed by upstream"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamAddr := upstream.Listener.Addr().String()
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upstreamAddr)
+		},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: false,
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	t.Cleanup(func() { close(sink.ch) })
+
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{
+		cfg:     gw,
+		db:      db,
+		certs:   certs,
+		sink:    sink,
+		hitl:    newHITLRegistry(sink),
+		secrets: newGatewaySecretStore(db, nil),
+	}
+	g.policy.Store(policy)
+	g.transports.Store(ep, transport)
+
+	return &hitlRetryRelayHarness{
+		db:          db,
+		store:       NewHITLOperationStore(db),
+		gateway:     g,
+		endpoint:    ep,
+		approver:    approver,
+		fingerprint: fingerprintKey,
+		authBinding: authBinding,
+		upstream:    upstreamRequests,
+	}
+}
+
+func persistHITLRetryRelayFingerprintKey(t *testing.T, db *sql.DB, key HITLFingerprintKey) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO gateway_blobs (kind, name, value, updated_ns) VALUES (?, ?, ?, ?)`, "hitl_fingerprint_hmac", key.ID, key.Root, time.Now().UnixNano())
+	if err != nil {
+		t.Fatalf("persist fingerprint key: %v", err)
+	}
+}
+
+func persistHITLRetryRelayCredentialSecret(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO credential_secrets (credential, slot, value, updated_ns) VALUES (?, ?, ?, ?)`, hitlRetryRelayTestCredential, "", "retry-relay-test-token", hitlRetryRelayTestCredentialNS)
+	if err != nil {
+		t.Fatalf("persist credential secret: %v", err)
+	}
+}
+
+func (h *hitlRetryRelayHarness) createApprovedRetryOperation(t *testing.T, id, requestBody string) HITLOperation {
+	t.Helper()
+	return h.createApprovedRetryOperationForMethod(t, id, http.MethodPost, requestBody)
+}
+
+func (h *hitlRetryRelayHarness) createApprovedRetryOperationForMethod(t *testing.T, id, method, requestBody string) HITLOperation {
+	t.Helper()
+	fp := h.fingerprintForMethodAndBody(t, method, requestBody)
+	now := time.Now().UTC()
+	op, err := h.store.Create(context.Background(), HITLOperationCreate{
+		ID:                  id,
+		State:               HITLOperationStateApprovedWaitingForRetry,
+		ProfileID:           hitlRetryRelayTestProfile,
+		PrincipalID:         hitlPeerPrincipalID(hitlRetryRelayTestPeerIP),
+		EndpointID:          hitlRetryRelayTestEndpoint,
+		ApprovalRuleID:      hitlRetryRelayTestRule,
+		ApproverID:          hitlRetryRelayTestApprover,
+		Method:              method,
+		Scheme:              "https",
+		Host:                hitlRetryRelayTestHost,
+		RedactedPath:        hitlRetryRelayTestPath,
+		RedactedHeadersJSON: `{"content-type":"application/json"}`,
+		AuthBindingID:       h.authBinding,
+		FingerprintVersion:  fp.Version,
+		HMACKeyID:           fp.HMACKeyID,
+		RequestFingerprint:  fp.RequestFingerprint,
+		CreatedAt:           now.Add(-2 * time.Minute),
+		SyncWaitDeadline:    now.Add(-time.Minute),
+		ApprovalExpiresAt:   now.Add(10 * time.Minute),
+		RetryExpiresAt:      now.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create retry operation: %v", err)
+	}
+	return op
+}
+
+func (h *hitlRetryRelayHarness) fingerprintForBody(t *testing.T, requestBody string) HITLRequestFingerprintResult {
+	t.Helper()
+	return h.fingerprintForMethodAndBody(t, http.MethodPost, requestBody)
+}
+
+func (h *hitlRetryRelayHarness) fingerprintForMethodAndBody(t *testing.T, method, requestBody string) HITLRequestFingerprintResult {
+	t.Helper()
+	result, err := ComputeHITLRequestFingerprint(HITLRequestFingerprintInput{
+		Key:            h.fingerprint,
+		ProfileID:      hitlRetryRelayTestProfile,
+		PrincipalID:    hitlPeerPrincipalID(hitlRetryRelayTestPeerIP),
+		EndpointID:     hitlRetryRelayTestEndpoint,
+		ApprovalRuleID: hitlRetryRelayTestRule,
+		Method:         method,
+		Scheme:         "https",
+		Host:           hitlRetryRelayTestHost,
+		Path:           hitlRetryRelayTestPath,
+		RawBody:        []byte(requestBody),
+		AuthBindingID:  h.authBinding,
+	})
+	if err != nil {
+		t.Fatalf("ComputeHITLRequestFingerprint: %v", err)
+	}
+	return result
+}
+
+func (h *hitlRetryRelayHarness) sendRetryRequest(t *testing.T, operationID, requestBody string) hitlRetryRelayResponse {
+	t.Helper()
+	return h.sendRetryRequestWithMethod(t, operationID, http.MethodPost, requestBody)
+}
+
+func (h *hitlRetryRelayHarness) sendRetryRequestWithMethod(t *testing.T, operationID, method, requestBody string) hitlRetryRelayResponse {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.gateway.mitmHTTPS(serverConn, hitlRetryRelayTestHost, h.endpoint)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: hitlRetryRelayTestHost})
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+
+	req, err := http.NewRequest(method, "https://"+hitlRetryRelayTestHost+hitlRetryRelayTestPath, strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(hitlRetryOperationHeader, operationID)
+	if err := req.Write(clientTLS); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientTLS), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	_ = resp.Body.Close()
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
+	}
+	return hitlRetryRelayResponse{StatusCode: resp.StatusCode, Body: string(body)}
+}
+
+func (h *hitlRetryRelayHarness) nextUpstreamRequest(t *testing.T) hitlRetryRelayUpstreamRequest {
+	t.Helper()
+	select {
+	case req := <-h.upstream:
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream request")
+	}
+	return hitlRetryRelayUpstreamRequest{}
+}
+
+func (h *hitlRetryRelayHarness) assertNoUpstreamRequest(t *testing.T) {
+	t.Helper()
+	select {
+	case req := <-h.upstream:
+		t.Fatalf("unexpected upstream request: body=%q retry_header=%q", req.Body, req.RetryOperationValue)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func (h *hitlRetryRelayHarness) getOperation(t *testing.T, id string) HITLOperation {
+	t.Helper()
+	op, err := h.store.GetForPrincipal(context.Background(), id, hitlRetryRelayTestProfile, hitlPeerPrincipalID(hitlRetryRelayTestPeerIP))
+	if err != nil {
+		t.Fatalf("GetForPrincipal: %v", err)
+	}
+	return op
+}

--- a/main.go
+++ b/main.go
@@ -1739,15 +1739,18 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// Body buffering. Any rule with a `body_json` or
 		// `body_contains` match facet needs the body up-front; we
 		// don't know which yet, so for any POST/PUT/PATCH with a
-		// body we read up to 1 MiB and re-attach. Reads beyond 1 MiB
-		// stream through unbuffered (rare for agent traffic) but
-		// surface as Truncated=true so the dispatcher can fail-close
-		// any rule reading http.body / http.body_json — bytes past
-		// the cap aren't in matchBody and policy that needed them
-		// can't be honestly evaluated.
+		// body we read up to 1 MiB and re-attach. Retry-grant
+		// requests additionally buffer regardless of method: the
+		// one-shot grant fingerprint is a same-request check, so a
+		// body-bearing DELETE/GET must bind the exact bytes that will
+		// continue to upstream. Reads beyond 1 MiB stream through
+		// unbuffered (rare for agent traffic) but surface as
+		// Truncated=true so the dispatcher/retry relay can fail-close
+		// any path that needed the complete body.
 		var matchBody []byte
 		var truncated bool
-		if req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH" {
+		retryOperationID := strings.TrimSpace(req.Header.Get(hitlRetryOperationHeader))
+		if req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH" || retryOperationID != "" {
 			matchBody, truncated = bufferHTTPBodyForMatchTruncated(req)
 		}
 
@@ -1798,12 +1801,47 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 			ev.Rule = cr.Name
 		}
 
+		hitlRetryBypassedApproval := false
+		var hitlRetryConsumedOperation *HITLOperation
+		if retryOperationID != "" {
+			principalID := hitlPeerPrincipalID(pip)
+			consumed, err := g.consumeHITLRetryGrantForRequest(req.Context(), hitlRetryRelayInput{
+				OperationID: retryOperationID,
+				ProfileID:   profile,
+				PrincipalID: principalID,
+				Endpoint:    ep,
+				Rule:        cr,
+				MatchReq:    mreq,
+				HTTPRequest: req,
+				RawBody:     matchBody,
+				Truncated:   truncated,
+			})
+			if err != nil {
+				status, contentType, body := hitlRetryRelayFailure(err)
+				log.Printf("hitl retry rejected %s %s %s operation %q: %v", host, req.Method, req.URL.Path, retryOperationID, err)
+				_, _ = fmt.Fprintf(tc, "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", status, http.StatusText(status), contentType, len(body), body)
+				ev.Status = status
+				ev.Action = "hitl_retry_rejected"
+				ev.Reason = hitlRetryMismatchErrorValue
+				if status == http.StatusNotFound {
+					ev.Reason = hitlOperationNotFoundErrorValue
+				}
+				ev.Ms = time.Since(start).Milliseconds()
+				g.emitEnd(ev)
+				return
+			}
+			hitlRetryConsumedOperation = &consumed
+			hitlRetryBypassedApproval = true
+			ev.Action = "hitl_retry_approved"
+			log.Printf("hitl retry approved %s %s %s operation %q by %s", host, req.Method, req.URL.Path, retryOperationID, principalID)
+		}
+
 		// Approve chain — dispatch each stage to its approver
 		// runtime (config/plugins/approvers). All stages must
 		// allow; first deny short-circuits.
 		var asyncOp HITLOperation
 		var asyncSyncWait time.Duration
-		if cr != nil && len(cr.Outcome.Approve) > 0 {
+		if cr != nil && len(cr.Outcome.Approve) > 0 && !hitlRetryBypassedApproval {
 			if approverID, asyncApprover, ok := g.asyncHumanApproverFor(cr.Outcome.Approve); ok {
 				start, started, err := g.maybeStartAsyncHITLOperation(req.Context(), hitlAsyncOperationInput{
 					ProfileID:   profile,
@@ -1895,6 +1933,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				reason = "denied by policy"
 			}
 			log.Printf("deny %s %s %s: %s (rule %q)", host, req.Method, req.URL.Path, reason, cr.Name)
+			if hitlRetryConsumedOperation != nil {
+				if err := g.transitionConsumedHITLRetryGrant(context.Background(), *hitlRetryConsumedOperation, HITLOperationStateUpstreamFailed, reason); err != nil {
+					log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, HITLOperationStateUpstreamFailed, err)
+				}
+			}
 			_, _ = fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
 			ev.Status = 403
 			ev.Action = "deny"
@@ -1916,6 +1959,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		req.URL.Host = host
 		req.Host = host
 		req.RequestURI = ""
+		req.Header.Del(hitlRetryOperationHeader)
 		if !isWSUpgrade(req) {
 			for _, h := range []string{
 				"Connection", "Keep-Alive", "Proxy-Authenticate",
@@ -1953,8 +1997,20 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				// an upstream lookup can't accidentally leak them.
 				stripAuthResponseHeaders(r.Header)
 				stripAuthResponseHeaders(r.Trailer)
-				if err := r.Write(tc); err != nil {
-					log.Printf("synth write %s %s: %v", host, req.URL.Path, err)
+				writeErr := r.Write(tc)
+				if hitlRetryConsumedOperation != nil {
+					toState := HITLOperationStateUpstreamSucceeded
+					lastErr := ""
+					if writeErr != nil {
+						toState = HITLOperationStateUpstreamFailed
+						lastErr = writeErr.Error()
+					}
+					if err := g.transitionConsumedHITLRetryGrant(context.Background(), *hitlRetryConsumedOperation, toState, lastErr); err != nil {
+						log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, toState, err)
+					}
+				}
+				if writeErr != nil {
+					log.Printf("synth write %s %s: %v", host, req.URL.Path, writeErr)
 				}
 				ev.Ms = time.Since(start).Milliseconds()
 				g.emitEnd(ev)
@@ -2048,6 +2104,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				})
 			}
 			g.handleWSUpgrade(tc, br, req, host, frameEmit, ep, profile, rewriteWSPayload)
+			if hitlRetryConsumedOperation != nil {
+				if err := g.transitionConsumedHITLRetryGrant(context.Background(), *hitlRetryConsumedOperation, HITLOperationStateUpstreamSucceeded, ""); err != nil {
+					log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, HITLOperationStateUpstreamSucceeded, err)
+				}
+			}
 			ev.Status = 101
 			ev.Ms = time.Since(start).Milliseconds()
 			g.emitEnd(ev)
@@ -2087,6 +2148,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				}
 			}
 			log.Printf("mitm upstream %s %s: %v", host, req.URL.Path, err)
+			if hitlRetryConsumedOperation != nil {
+				if transitionErr := g.transitionConsumedHITLRetryGrant(context.Background(), *hitlRetryConsumedOperation, HITLOperationStateUpstreamFailed, err.Error()); transitionErr != nil {
+					log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, HITLOperationStateUpstreamFailed, transitionErr)
+				}
+			}
 			_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 			ev.Status = 502
 			ev.Action = "error"
@@ -2144,6 +2210,18 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				}
 			}
 			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint)
+		}
+
+		if hitlRetryConsumedOperation != nil {
+			toState := HITLOperationStateUpstreamSucceeded
+			lastErr := ""
+			if writeErr != nil {
+				toState = HITLOperationStateUpstreamFailed
+				lastErr = writeErr.Error()
+			}
+			if err := g.transitionConsumedHITLRetryGrant(context.Background(), *hitlRetryConsumedOperation, toState, lastErr); err != nil {
+				log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, toState, err)
+			}
 		}
 
 		if ev.Action == "" {


### PR DESCRIPTION
## Summary

Adds the async HITL retry-grant relay slice on top of the dashboard/status work.

- Accepts an agent retry carrying the HITL operation header and consumes the approved retry grant exactly once.
- Recomputes the retry fingerprint from the live request using the same profile, principal, endpoint/rule, auth binding, and raw request body bytes.
- Bypasses the human approval chain only after a matching grant is consumed; mismatches fail closed and do not fall back to a new approval attempt.
- Strips the internal retry operation header before forwarding upstream.
- Buffers retry bodies for any HTTP method, including DELETE-with-body, so the fingerprinted bytes are the bytes forwarded upstream.
- Transitions consumed operations from `executing_upstream` to `upstream_succeeded` / `upstream_failed` so polling clients and dashboard state do not hang.

## Safety / v1 invariants

- No raw request body, Authorization/Cookie value, upstream secret, or replayable request material is persisted.
- Retry consume remains one-shot via the existing durable operation store state/version/consumed timestamp checks.
- Wrong owner / unknown operation still uses the non-enumerating operation lookup path.
- Retry mismatch returns a safe conflict response and does not call upstream.

## Tests

- `go test . -run 'TestHITLRetryRelay' -count=1`
- `go test . -run 'TestHITL(RequestFingerprint|CredentialAuthBinding|OperationStore|OperationStatus|Body|RetryRelay)' -count=1`
- `test -z "$(gofmt -l main.go hitl_retry_relay.go hitl_retry_relay_test.go)"`
- `git diff --check`
- `go test ./...`

Independent delegate review: `APPROVE`.
