### PR TITLE
feat: add async HITL runtime fallback

### DIFF
--- a/config/plugins/approvers/human.go
+++ b/config/plugins/approvers/human.go
@@ -11,6 +11,7 @@ package approvers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -119,7 +120,12 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 	pending := buildPending(req)
 	pending.ExpiresAt = pending.CreatedAt.Add(timeout)
 	id, ch := req.Pool.Add(pending)
-	defer req.Pool.Discard(id)
+	discardOnReturn := true
+	defer func() {
+		if discardOnReturn {
+			req.Pool.Discard(id)
+		}
+	}()
 
 	var summary *runtime.HITLSummary
 	if h.Classifier != "" && req.Policy != nil {
@@ -185,6 +191,23 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 			Reason: reason,
 		}, nil
 	case <-ctx.Done():
+		if req.AsyncPendingOnSyncTimeout && errors.Is(ctx.Err(), context.DeadlineExceeded) && req.AsyncOperationID != "" {
+			reason := fmt.Sprintf("approver %q sync wait timed out; upstream request was not sent and async approval remains pending", req.ApproverName)
+			if updater, ok := req.Pool.(runtime.HITLPoolUpdater); ok {
+				updated := updater.Update(id, func(p *runtime.HITLPending) {
+					p.OperationID = req.AsyncOperationID
+					p.OperationState = runtime.HITLOperationStatePendingApproval
+					p.ApprovalEffect = runtime.HITLApprovalEffectCreateRetryGrant
+					p.UpstreamCalled = false
+					p.ApprovalMessage = ""
+					runtime.NormalizeHITLPendingApproval(p)
+				})
+				if updated {
+					discardOnReturn = false
+					return runtime.ApproveVerdict{Decision: runtime.ApproveDecisionAsyncPending, Reason: reason}, nil
+				}
+			}
+		}
 		state, reason := hitlCancelStateForContext(ctx.Err())
 		result := cancelPending(req.Pool, id, state, reason)
 		if verdict, ok := terminalDecisionVerdict(result, ch); ok {

--- a/config/plugins/approvers/human_test.go
+++ b/config/plugins/approvers/human_test.go
@@ -19,7 +19,9 @@ type captureHITLPool struct {
 
 	mu           sync.Mutex
 	pending      runtime.HITLPending
+	updated      runtime.HITLPending
 	cancelResult runtime.HITLResolveResult
+	discarded    bool
 }
 
 func newCaptureHITLPool() *captureHITLPool {
@@ -38,7 +40,22 @@ func (p *captureHITLPool) Add(pending runtime.HITLPending) (string, <-chan runti
 	return p.id, p.decision
 }
 
-func (p *captureHITLPool) Discard(string) {}
+func (p *captureHITLPool) Discard(string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.discarded = true
+}
+
+func (p *captureHITLPool) Update(id string, mutate func(*runtime.HITLPending)) bool {
+	if id != p.id {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	mutate(&p.pending)
+	p.updated = p.pending
+	return true
+}
 
 func (p *captureHITLPool) Decide(string, runtime.HITLDecision) bool { return false }
 
@@ -59,6 +76,56 @@ func (p *captureHITLPool) capturedCancel() runtime.HITLResolveResult {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.cancelResult
+}
+
+func (p *captureHITLPool) capturedUpdate() runtime.HITLPending {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.updated
+}
+
+func (p *captureHITLPool) wasDiscarded() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.discarded
+}
+
+func TestHumanApproverAsyncSyncWaitTimeoutLeavesPromptPendingForRetryGrant(t *testing.T) {
+	pool := newCaptureHITLPool()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	verdict, err := (&HumanApprover{Timeout: 60}).Approve(ctx, runtime.ApproveRequest{
+		Pool:                      pool,
+		ApproverName:              "ops",
+		Method:                    "POST",
+		Host:                      "api.example.test",
+		Path:                      "/v1/write",
+		AsyncOperationID:          "op_123",
+		AsyncPendingOnSyncTimeout: true,
+	})
+	if err != nil {
+		t.Fatalf("Approve error = %v, want nil async pending verdict", err)
+	}
+	if verdict.Decision != runtime.ApproveDecisionAsyncPending {
+		t.Fatalf("Decision = %q, want %q", verdict.Decision, runtime.ApproveDecisionAsyncPending)
+	}
+	if pool.wasDiscarded() {
+		t.Fatal("pending prompt was discarded on sync wait timeout; want it left for human approval")
+	}
+	updated := pool.capturedUpdate()
+	if updated.OperationID != "op_123" {
+		t.Fatalf("updated OperationID = %q, want op_123", updated.OperationID)
+	}
+	if updated.OperationState != runtime.HITLOperationStatePendingApproval {
+		t.Fatalf("updated OperationState = %q, want pending_approval", updated.OperationState)
+	}
+	if updated.ApprovalEffect != runtime.HITLApprovalEffectCreateRetryGrant {
+		t.Fatalf("updated ApprovalEffect = %q, want create_retry_grant", updated.ApprovalEffect)
+	}
+	if !strings.Contains(updated.ApprovalMessage, "allow the client to retry") {
+		t.Fatalf("updated ApprovalMessage = %q, want retry-grant guidance", updated.ApprovalMessage)
+	}
 }
 
 func TestHumanApproverPendingExpirationUsesApproverTimeout(t *testing.T) {

--- a/config/plugins/approvers/util.go
+++ b/config/plugins/approvers/util.go
@@ -22,17 +22,18 @@ func buildPending(req runtime.ApproveRequest) runtime.HITLPending {
 		family = req.Endpoint.Family
 	}
 	pending := runtime.HITLPending{
-		AgentIP:    req.AgentIP,
-		Host:       req.Host,
-		Method:     req.Method,
-		Path:       req.Path,
-		Endpoint:   runtime.HITLEndpointLabel(req),
-		Family:     family,
-		UA:         req.UA,
-		BodySample: req.BodySample,
-		Reason:     req.Reason,
-		Approvers:  []string{req.ApproverName},
-		CreatedAt:  now,
+		OperationID: req.AsyncOperationID,
+		AgentIP:     req.AgentIP,
+		Host:        req.Host,
+		Method:      req.Method,
+		Path:        req.Path,
+		Endpoint:    runtime.HITLEndpointLabel(req),
+		Family:      family,
+		UA:          req.UA,
+		BodySample:  req.BodySample,
+		Reason:      req.Reason,
+		Approvers:   []string{req.ApproverName},
+		CreatedAt:   now,
 	}
 	runtime.NormalizeHITLPendingApproval(&pending)
 	return pending

--- a/config/runtime/runtime.go
+++ b/config/runtime/runtime.go
@@ -383,6 +383,11 @@ type ApproveRequest struct {
 	// prompt as a reply in this Slack thread rather than top-level.
 	// Populated from the X-HITL-Thread-TS request header.
 	ThreadTS string
+	// AsyncOperationID binds the prompt to a durable async operation.
+	// If AsyncPendingOnSyncTimeout is true and ctx hits DeadlineExceeded,
+	// human_approver leaves the prompt pending and returns async_pending.
+	AsyncOperationID          string
+	AsyncPendingOnSyncTimeout bool
 
 	// Pool exposes the gateway's shared pending-approval list — the
 	// dashboard / Slack approvers use it to publish a pending entry
@@ -411,8 +416,10 @@ type ApproveRequest struct {
 // dashboard event with the deciding approver's kind (human / llm /
 // dashboard) and id (the HCL block name) — operators looking at a
 // `denied` row see *why* without having to drill into the rule.
+const ApproveDecisionAsyncPending = "async_pending"
+
 type ApproveVerdict struct {
-	Decision     string // "allow" | "deny" | ""
+	Decision     string // "allow" | "deny" | "async_pending" | ""
 	Reason       string
 	By           string // who decided ("dashboard:<user>" / "slack:#chan" / "llm:<model>")
 	ApproverName string // HCL block name, e.g. "pg-staging-secret-columns-judge"
@@ -458,6 +465,19 @@ type HITLPoolDecider interface {
 // decision (timeout, client disconnect, gateway cancellation).
 type HITLPoolCanceler interface {
 	Cancel(id string, state HITLState, reason string) HITLResolveResult
+}
+
+// HITLPoolUpdater is implemented by pools that can update operator-facing
+// safety-copy metadata for an existing pending prompt without resolving it.
+type HITLPoolUpdater interface {
+	Update(id string, mutate func(*HITLPending)) bool
+}
+
+// HITLPoolAsyncGrantResolver lets pools bind a pending human decision to a
+// durable async operation. Implementations must not execute upstream here;
+// approval only moves the operation to a retry-grant state.
+type HITLPoolAsyncGrantResolver interface {
+	ResolveAsyncHITLGrant(operationID string, d HITLDecision) HITLResolveResult
 }
 
 // HITLState names the lifecycle state of a human approval prompt.
@@ -518,11 +538,12 @@ type HITLResolveResult struct {
 // tags match the dashboard's existing field names — that endpoint is
 // public API to the in-tree React UI.
 type HITLPending struct {
-	ID      string `json:"id"`
-	AgentIP string `json:"agent_ip"`
-	Host    string `json:"host"`
-	Method  string `json:"method"`
-	Path    string `json:"path"`
+	ID          string `json:"id"`
+	OperationID string `json:"operation_id,omitempty"`
+	AgentIP     string `json:"agent_ip"`
+	Host        string `json:"host"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
 	// OperationState and ApprovalEffect are safety-boundary display
 	// metadata. They let dashboard/Slack copy distinguish the initial
 	// synchronous wait (approval forwards upstream immediately) from async

--- a/hitl_async_runtime.go
+++ b/hitl_async_runtime.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/config/match"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+const (
+	hitlFingerprintHMACBlobKind = "hitl_fingerprint_hmac"
+	hitlFingerprintHMACKeyIDV1  = "hitl-hmac:v1"
+)
+
+type hitlAsyncGrantRuntime interface {
+	HITLAsyncGrantEnabled() bool
+	HITLSyncWaitTimeout() time.Duration
+	HITLAsyncApprovalTTL() time.Duration
+	HITLAsyncApprovedRetryTTL() time.Duration
+	HITLAsyncMaxBodyBytes() int64
+	HITLAsyncFingerprintBody() string
+}
+
+type hitlAsyncOperationInput struct {
+	ProfileID   string
+	PrincipalID string
+	Endpoint    *config.CompiledEndpoint
+	Rule        *config.CompiledRule
+	ApproverID  string
+	Approver    hitlAsyncGrantRuntime
+	MatchReq    *match.Request
+	HTTPRequest *http.Request
+	RawBody     []byte
+	Truncated   bool
+	Now         time.Time
+}
+
+type hitlAsyncOperationStart struct {
+	Operation       HITLOperation
+	SyncWaitTimeout time.Duration
+}
+
+func (g *Gateway) asyncHumanApproverFor(stages []config.ApproveStage) (string, hitlAsyncGrantRuntime, bool) {
+	if len(stages) != 1 || stages[0].Name == "dashboard" {
+		return "", nil, false
+	}
+	policy := g.Policy()
+	if policy == nil {
+		return "", nil, false
+	}
+	ent := policy.Approvers[stages[0].Name]
+	if ent == nil {
+		return "", nil, false
+	}
+	rt, ok := ent.Body.(hitlAsyncGrantRuntime)
+	if !ok || !rt.HITLAsyncGrantEnabled() {
+		return "", nil, false
+	}
+	return stages[0].Name, rt, true
+}
+
+func (g *Gateway) maybeStartAsyncHITLOperation(ctx context.Context, in hitlAsyncOperationInput) (hitlAsyncOperationStart, bool, error) {
+	if g == nil || g.db == nil || g.cfg == nil || g.cfg.PublicURL == "" || in.HTTPRequest == nil || in.Endpoint == nil || in.Rule == nil || in.Approver == nil {
+		return hitlAsyncOperationStart{}, false, nil
+	}
+	if in.ProfileID == "" || in.PrincipalID == "" || in.ApproverID == "" || in.MatchReq == nil {
+		return hitlAsyncOperationStart{}, false, nil
+	}
+	policy := g.Policy()
+	if policy == nil || policy.Profiles[in.ProfileID] == nil || !policy.Profiles[in.ProfileID].HITLAsyncGrants || !in.Approver.HITLAsyncGrantEnabled() {
+		return hitlAsyncOperationStart{}, false, nil
+	}
+	syncWait := in.Approver.HITLSyncWaitTimeout()
+	if syncWait <= 0 {
+		return hitlAsyncOperationStart{}, false, nil
+	}
+	if in.Approver.HITLAsyncFingerprintBody() != config.HITLAsyncFingerprintRawBody || in.Truncated || int64(len(in.RawBody)) > in.Approver.HITLAsyncMaxBodyBytes() {
+		return hitlAsyncOperationStart{}, false, nil
+	}
+	key, err := loadOrCreateHITLFingerprintKey(ctx, g.db)
+	if err != nil {
+		return hitlAsyncOperationStart{}, false, err
+	}
+	cc := runtime.ResolveCredential(in.Endpoint, in.MatchReq)
+	authBindingID, err := buildHITLAuthBindingID(ctx, g.db, in.ProfileID, cc)
+	if err != nil {
+		return hitlAsyncOperationStart{}, false, err
+	}
+	selectedHeaders, err := SelectHITLFingerprintHeaders(in.HTTPRequest.Header, nil)
+	if err != nil {
+		return hitlAsyncOperationStart{}, false, err
+	}
+	fp, err := ComputeHITLRequestFingerprint(HITLRequestFingerprintInput{
+		Key:             key,
+		ProfileID:       in.ProfileID,
+		PrincipalID:     in.PrincipalID,
+		EndpointID:      in.Endpoint.Name,
+		ApprovalRuleID:  in.Rule.Name,
+		Method:          in.HTTPRequest.Method,
+		Scheme:          "https",
+		Host:            in.HTTPRequest.Host,
+		Path:            in.HTTPRequest.URL.Path,
+		RawQuery:        in.HTTPRequest.URL.RawQuery,
+		SelectedHeaders: selectedHeaders,
+		RawBody:         in.RawBody,
+		AuthBindingID:   authBindingID,
+	})
+	if err != nil {
+		return hitlAsyncOperationStart{}, false, err
+	}
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	redactedHeadersJSON := ""
+	if len(selectedHeaders) > 0 {
+		if b, err := json.Marshal(selectedHeaders); err == nil {
+			redactedHeadersJSON = string(b)
+		}
+	}
+	op, err := NewHITLOperationStore(g.db).Create(ctx, HITLOperationCreate{
+		State:               HITLOperationStateSyncWaiting,
+		ProfileID:           in.ProfileID,
+		PrincipalID:         in.PrincipalID,
+		EndpointID:          in.Endpoint.Name,
+		ApprovalRuleID:      in.Rule.Name,
+		ApproverID:          in.ApproverID,
+		Method:              in.HTTPRequest.Method,
+		Scheme:              "https",
+		Host:                in.HTTPRequest.Host,
+		RedactedPath:        in.HTTPRequest.URL.EscapedPath(),
+		RedactedQuery:       "",
+		RedactedHeadersJSON: redactedHeadersJSON,
+		AuthBindingID:       authBindingID,
+		FingerprintVersion:  fp.Version,
+		HMACKeyID:           fp.HMACKeyID,
+		RequestFingerprint:  fp.RequestFingerprint,
+		CreatedAt:           now,
+		SyncWaitDeadline:    now.Add(syncWait),
+		ApprovalExpiresAt:   now.Add(in.Approver.HITLAsyncApprovalTTL()),
+		RetryExpiresAt:      now.Add(in.Approver.HITLAsyncApprovedRetryTTL()),
+	})
+	if err != nil {
+		return hitlAsyncOperationStart{}, false, err
+	}
+	return hitlAsyncOperationStart{Operation: op, SyncWaitTimeout: syncWait}, true, nil
+}
+
+func (g *Gateway) transitionAsyncHITLOperation(ctx context.Context, op HITLOperation, to HITLOperationState, lastErr string) (HITLOperation, error) {
+	if g == nil || g.db == nil || op.ID == "" {
+		return op, nil
+	}
+	return NewHITLOperationStore(g.db).Transition(ctx, HITLOperationTransition{
+		ID:              op.ID,
+		FromState:       op.State,
+		ToState:         to,
+		ExpectedVersion: op.Version,
+		Now:             time.Now().UTC(),
+		LastError:       lastErr,
+	})
+}
+
+func (g *Gateway) resolveAsyncHITLGrant(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult {
+	if g == nil || g.db == nil {
+		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "async HITL operation store is unavailable"}
+	}
+	store := NewHITLOperationStore(g.db)
+	op, err := store.get(context.Background(), operationID)
+	if errors.Is(err, ErrHITLOperationNotFound) {
+		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "async HITL operation not found"}
+	}
+	if err != nil {
+		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "load async HITL operation"}
+	}
+	to := HITLOperationStateDenied
+	state := runtime.HITLStateDenied
+	reason := "denied by approver"
+	tr := HITLOperationTransition{
+		ID:              op.ID,
+		FromState:       op.State,
+		ExpectedVersion: op.Version,
+		Now:             time.Now().UTC(),
+	}
+	if d.Allow {
+		to = HITLOperationStateApprovedWaitingForRetry
+		state = runtime.HITLStateApproved
+		reason = "approved; waiting for matching client retry"
+		if op.RetryExpiresAt != nil {
+			tr.RetryExpiresAt = *op.RetryExpiresAt
+		}
+		if !tr.RetryExpiresAt.After(tr.Now) {
+			tr.RetryExpiresAt = tr.Now.Add(config.HITLAsyncDefaultApprovedRetryTTL)
+		}
+	} else if d.Reason != "" {
+		reason = d.Reason
+	}
+	tr.ToState = to
+	updated, err := store.Transition(context.Background(), tr)
+	if err != nil {
+		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: err.Error()}
+	}
+	_ = updated
+	return runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
+}
+
+func loadOrCreateHITLFingerprintKey(ctx context.Context, db *sql.DB) (HITLFingerprintKey, error) {
+	if db == nil {
+		return HITLFingerprintKey{}, fmt.Errorf("%w: nil db", ErrHITLFingerprintInvalid)
+	}
+	key, ok, err := getHITLFingerprintKey(ctx, db)
+	if err != nil || ok {
+		return key, err
+	}
+	root := make([]byte, 32)
+	if _, err := rand.Read(root); err != nil {
+		return HITLFingerprintKey{}, fmt.Errorf("generate hitl fingerprint key: %w", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO gateway_blobs (kind, name, value, updated_ns) VALUES (?, ?, ?, ?)`, hitlFingerprintHMACBlobKind, hitlFingerprintHMACKeyIDV1, root, time.Now().UnixNano())
+	if err != nil {
+		if key, ok, getErr := getHITLFingerprintKey(ctx, db); getErr != nil {
+			return HITLFingerprintKey{}, err
+		} else if ok {
+			return key, nil
+		}
+		return HITLFingerprintKey{}, err
+	}
+	return HITLFingerprintKey{ID: hitlFingerprintHMACKeyIDV1, Root: root}, nil
+}
+
+func getHITLFingerprintKey(ctx context.Context, db *sql.DB) (HITLFingerprintKey, bool, error) {
+	var root []byte
+	err := db.QueryRowContext(ctx, `SELECT value FROM gateway_blobs WHERE kind = ? AND name = ?`, hitlFingerprintHMACBlobKind, hitlFingerprintHMACKeyIDV1).Scan(&root)
+	if errors.Is(err, sql.ErrNoRows) {
+		return HITLFingerprintKey{}, false, nil
+	}
+	if err != nil {
+		return HITLFingerprintKey{}, false, err
+	}
+	return HITLFingerprintKey{ID: hitlFingerprintHMACKeyIDV1, Root: root}, true, nil
+}
+
+func buildHITLAuthBindingID(ctx context.Context, db *sql.DB, profileID string, cc *config.CompiledCredential) (string, error) {
+	credentialID := "none"
+	generation := "none"
+	if cc != nil && cc.Credential != nil && cc.Credential.Symbol != nil {
+		credentialID = cc.Credential.Symbol.Name
+		gen, err := hitlCredentialGeneration(ctx, db, credentialID)
+		if err != nil {
+			return "", err
+		}
+		generation = gen
+	}
+	return BuildHITLCredentialAuthBindingID(HITLCredentialAuthBindingInput{ProfileID: profileID, CredentialID: credentialID, Generation: generation})
+}
+
+func hitlCredentialGeneration(ctx context.Context, db *sql.DB, credentialID string) (string, error) {
+	if db == nil {
+		return "env-or-empty:" + credentialID, nil
+	}
+	var secretNS sql.NullInt64
+	if err := db.QueryRowContext(ctx, `SELECT MAX(updated_ns) FROM credential_secrets WHERE credential = ?`, credentialID).Scan(&secretNS); err != nil {
+		return "", err
+	}
+	if secretNS.Valid && secretNS.Int64 > 0 {
+		return fmt.Sprintf("credential-secret:%d", secretNS.Int64), nil
+	}
+	var oauthNS sql.NullInt64
+	if err := db.QueryRowContext(ctx, `SELECT MAX(updated_ns) FROM credentials WHERE id = ?`, credentialID).Scan(&oauthNS); err != nil {
+		return "", err
+	}
+	if oauthNS.Valid && oauthNS.Int64 > 0 {
+		return fmt.Sprintf("oauth-credential:%d", oauthNS.Int64), nil
+	}
+	return "env-or-empty:" + credentialID, nil
+}
+
+func writeHITLOperationAcceptedToConn(w io.Writer, op HITLOperation, publicURL string) {
+	if w == nil {
+		return
+	}
+	rr := httptest.NewRecorder()
+	writeHITLOperationAccepted(rr, op, publicURL)
+	resp := rr.Result()
+	defer func() { _ = resp.Body.Close() }()
+	_ = resp.Write(w)
+}
+
+func hitlAsyncFailureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
+}

--- a/hitl_registry_test.go
+++ b/hitl_registry_test.go
@@ -12,6 +12,42 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 )
 
+func TestHITLRegistryAsyncPendingApprovalCreatesRetryGrantInsteadOfSendingChannelDecision(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	var gotOp string
+	var gotDecision runtime.HITLDecision
+	registry.asyncGrantResolver = func(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult {
+		gotOp = operationID
+		gotDecision = d
+		return runtime.HITLResolveResult{OK: true, State: runtime.HITLStateApproved, Reason: "retry grant created"}
+	}
+	id, ch := registry.Add(runtime.HITLPending{
+		OperationID:    "op_123",
+		OperationState: runtime.HITLOperationStatePendingApproval,
+		ApprovalEffect: runtime.HITLApprovalEffectCreateRetryGrant,
+		Host:           "api.example.test",
+		Method:         "POST",
+		Path:           "/v1/write",
+		CreatedAt:      time.Now(),
+	})
+
+	result := registry.DecideWithResult(id, runtime.HITLDecision{Allow: true, By: "dashboard"})
+	if !result.OK {
+		t.Fatalf("DecideWithResult OK = false, want true: %#v", result)
+	}
+	if gotOp != "op_123" {
+		t.Fatalf("async resolver operationID = %q, want op_123", gotOp)
+	}
+	if !gotDecision.Allow || gotDecision.By != "dashboard" {
+		t.Fatalf("async resolver decision = %#v, want dashboard approval", gotDecision)
+	}
+	select {
+	case decision := <-ch:
+		t.Fatalf("decision channel received %#v; async pending approval must not execute upstream directly", decision)
+	default:
+	}
+}
+
 func TestHITLRegistryDecideWithResultRecordsTerminalState(t *testing.T) {
 	registry := newHITLRegistry(nil)
 	id, ch := registry.Add(runtime.HITLPending{

--- a/main.go
+++ b/main.go
@@ -1801,14 +1801,61 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		// Approve chain — dispatch each stage to its approver
 		// runtime (config/plugins/approvers). All stages must
 		// allow; first deny short-circuits.
+		var asyncOp HITLOperation
+		var asyncSyncWait time.Duration
 		if cr != nil && len(cr.Outcome.Approve) > 0 {
+			if approverID, asyncApprover, ok := g.asyncHumanApproverFor(cr.Outcome.Approve); ok {
+				start, started, err := g.maybeStartAsyncHITLOperation(req.Context(), hitlAsyncOperationInput{
+					ProfileID:   profile,
+					PrincipalID: hitlPeerPrincipalID(agentAddr),
+					Endpoint:    ep,
+					Rule:        cr,
+					ApproverID:  approverID,
+					Approver:    asyncApprover,
+					MatchReq:    mreq,
+					HTTPRequest: req,
+					RawBody:     matchBody,
+					Truncated:   truncated,
+					Now:         time.Now().UTC(),
+				})
+				if err != nil {
+					log.Printf("hitl async operation start %s %s: %v", host, req.URL.Path, err)
+				} else if started {
+					asyncOp = start.Operation
+					asyncSyncWait = start.SyncWaitTimeout
+				}
+			}
 			v := g.runApproveChain(req.Context(), cr.Outcome.Approve, runApproveCtx{
 				AgentIP: agentAddr, Host: host, Method: req.Method, Path: req.URL.RequestURI(),
 				UA: req.Header.Get("User-Agent"), BodySample: string(matchBody), Reason: cr.Outcome.Reason,
 				ThreadTS: req.Header.Get("X-HITL-Thread-TS"),
 				Endpoint: ep, Rule: cr, Profile: profile, Request: mreq,
+				AsyncOperationID: asyncOp.ID, AsyncPendingOnSyncTimeout: asyncOp.ID != "", AsyncSyncWaitTimeout: asyncSyncWait,
 			})
 			if v.Decision != "allow" {
+				if v.Decision == runtime.ApproveDecisionAsyncPending && asyncOp.ID != "" {
+					updated, err := g.transitionAsyncHITLOperation(req.Context(), asyncOp, HITLOperationStatePendingApproval, "")
+					if err != nil {
+						log.Printf("hitl async operation pending %s: %v", asyncOp.ID, err)
+					} else {
+						asyncOp = updated
+					}
+					writeHITLOperationAcceptedToConn(tc, asyncOp, g.cfg.PublicURL)
+					ev.Status = http.StatusAccepted
+					ev.Action = "hitl_async_pending"
+					ev.Approver = v.ApproverName
+					ev.ApproverType = v.ApproverType
+					ev.ApproverBy = v.By
+					ev.Reason = v.Reason
+					ev.Ms = time.Since(start).Milliseconds()
+					g.emitEnd(ev)
+					return
+				}
+				if asyncOp.ID != "" {
+					if _, err := g.transitionAsyncHITLOperation(req.Context(), asyncOp, HITLOperationStateDenied, v.Reason); err != nil {
+						log.Printf("hitl async operation deny %s: %v", asyncOp.ID, err)
+					}
+				}
 				reason := v.Reason
 				if reason == "" {
 					reason = "denied by approver"
@@ -1825,6 +1872,13 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				ev.Ms = time.Since(start).Milliseconds()
 				g.emitEnd(ev)
 				return
+			}
+			if asyncOp.ID != "" {
+				if updated, err := g.transitionAsyncHITLOperation(req.Context(), asyncOp, HITLOperationStateExecutingUpstream, ""); err != nil {
+					log.Printf("hitl async operation executing %s: %v", asyncOp.ID, err)
+				} else {
+					asyncOp = updated
+				}
 			}
 			log.Printf("approved %s %s %s by %s/%s/%s",
 				host, req.Method, req.URL.Path, v.ApproverType, v.ApproverName, v.By)
@@ -2027,6 +2081,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		resp, err := transport.RoundTrip(req.WithContext(context.WithValue(req.Context(), profileCtxKey{}, profile)))
 		rtDur := time.Since(rtStart)
 		if err != nil {
+			if asyncOp.ID != "" {
+				if _, trErr := g.transitionAsyncHITLOperation(req.Context(), asyncOp, HITLOperationStateUpstreamFailed, hitlAsyncFailureReason(err)); trErr != nil {
+					log.Printf("hitl async operation upstream failed %s: %v", asyncOp.ID, trErr)
+				}
+			}
 			log.Printf("mitm upstream %s %s: %v", host, req.URL.Path, err)
 			_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 			ev.Status = 502
@@ -2090,6 +2149,17 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 		if ev.Action == "" {
 			ev.Action = "allow"
 		}
+		if asyncOp.ID != "" {
+			to := HITLOperationStateUpstreamSucceeded
+			lastErr := ""
+			if writeErr != nil {
+				to = HITLOperationStateUpstreamFailed
+				lastErr = hitlAsyncFailureReason(writeErr)
+			}
+			if _, err := g.transitionAsyncHITLOperation(req.Context(), asyncOp, to, lastErr); err != nil {
+				log.Printf("hitl async operation upstream terminal %s: %v", asyncOp.ID, err)
+			}
+		}
 		ev.Status = resp.StatusCode
 		ev.ReqHeaders = flatHeaders(req.Header)
 		ev.In = reqS.n
@@ -2127,18 +2197,21 @@ func secretEnvName(credName string) string {
 // runApproveCtx is the context blob the dispatcher passes per stage —
 // HITL prompt fields + the matching rule + the device's profile.
 type runApproveCtx struct {
-	AgentIP    string
-	Host       string
-	Method     string
-	Path       string
-	UA         string
-	BodySample string
-	Reason     string
-	ThreadTS   string
-	Endpoint   *config.CompiledEndpoint
-	Rule       *config.CompiledRule
-	Profile    string
-	Request    *match.Request
+	AgentIP                   string
+	Host                      string
+	Method                    string
+	Path                      string
+	UA                        string
+	BodySample                string
+	Reason                    string
+	ThreadTS                  string
+	Endpoint                  *config.CompiledEndpoint
+	Rule                      *config.CompiledRule
+	Profile                   string
+	Request                   *match.Request
+	AsyncOperationID          string
+	AsyncPendingOnSyncTimeout bool
+	AsyncSyncWaitTimeout      time.Duration
 }
 
 // runApproveChain dispatches each stage of an approve = [...] list to
@@ -2166,25 +2239,32 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 		if ar == nil {
 			return runtime.ApproveVerdict{Decision: "deny", Reason: "approver " + st.Name + " not found", By: "gateway", ApproverName: st.Name}
 		}
+		if c.AsyncPendingOnSyncTimeout && c.AsyncSyncWaitTimeout > 0 && c.AsyncOperationID != "" {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, c.AsyncSyncWaitTimeout)
+			defer cancel()
+		}
 		req := runtime.ApproveRequest{
-			Stage:        st,
-			Endpoint:     c.Endpoint,
-			Rule:         c.Rule,
-			Request:      c.Request,
-			ApproverName: st.Name,
-			AgentIP:      c.AgentIP,
-			Profile:      c.Profile,
-			Method:       c.Method,
-			Host:         c.Host,
-			Path:         c.Path,
-			UA:           c.UA,
-			BodySample:   c.BodySample,
-			Reason:       c.Reason,
-			ThreadTS:     c.ThreadTS,
-			Pool:         g.hitl,
-			Secrets:      g.secrets,
-			DashboardURL: g.cfg.PublicURL,
-			Policy:       policy,
+			Stage:                     st,
+			Endpoint:                  c.Endpoint,
+			Rule:                      c.Rule,
+			Request:                   c.Request,
+			ApproverName:              st.Name,
+			AgentIP:                   c.AgentIP,
+			Profile:                   c.Profile,
+			Method:                    c.Method,
+			Host:                      c.Host,
+			Path:                      c.Path,
+			UA:                        c.UA,
+			BodySample:                c.BodySample,
+			Reason:                    c.Reason,
+			ThreadTS:                  c.ThreadTS,
+			AsyncOperationID:          c.AsyncOperationID,
+			AsyncPendingOnSyncTimeout: c.AsyncPendingOnSyncTimeout,
+			Pool:                      g.hitl,
+			Secrets:                   g.secrets,
+			DashboardURL:              g.cfg.PublicURL,
+			Policy:                    policy,
 		}
 		v, err := ar.Approve(ctx, req)
 		// Stamp the entity name + plugin type on every verdict so the
@@ -2419,6 +2499,7 @@ func runGateway(args []string) {
 	}
 	log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
 	g.secrets = newGatewaySecretStore(db, oauthReg)
+	g.hitl.asyncGrantResolver = g.resolveAsyncHITLGrant
 	g.tunnels = NewTunnelManager(g.secrets, stateDir)
 	registerOAuthCredentials(oauthReg, policy)
 	g.policy.Store(policy)

--- a/web.go
+++ b/web.go
@@ -2235,10 +2235,11 @@ func wrapBodySampler(rc io.ReadCloser, s *sampler) io.ReadCloser {
 const hitlTerminalTTL = 30 * time.Minute
 
 type HITLRegistry struct {
-	mu       sync.Mutex
-	pending  map[string]*pendingEntry
-	terminal map[string]terminalHITLEntry
-	sink     *Sink // SSE fan-out for the dashboard
+	mu                 sync.Mutex
+	pending            map[string]*pendingEntry
+	terminal           map[string]terminalHITLEntry
+	sink               *Sink // SSE fan-out for the dashboard
+	asyncGrantResolver func(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult
 }
 
 type pendingEntry struct {
@@ -2291,6 +2292,21 @@ func (r *HITLRegistry) Discard(id string) {
 	r.mu.Unlock()
 }
 
+func (r *HITLRegistry) Update(id string, mutate func(*runtime.HITLPending)) bool {
+	if mutate == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.pending[id]
+	if e == nil {
+		return false
+	}
+	mutate(&e.p)
+	runtime.NormalizeHITLPendingApproval(&e.p)
+	return true
+}
+
 func (r *HITLRegistry) List() []runtime.HITLPending {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2326,14 +2342,30 @@ func (r *HITLRegistry) DecideWithResult(id string, d runtime.HITLDecision) runti
 	}
 	now := time.Now()
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.pruneTerminalLocked(now)
 	e := r.pending[id]
 	if e == nil {
 		if terminal, ok := r.terminal[id]; ok {
+			r.mu.Unlock()
 			return terminal.result
 		}
+		r.mu.Unlock()
 		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "unknown or expired HITL request"}
+	}
+	if e.p.OperationID != "" && e.p.OperationState == runtime.HITLOperationStatePendingApproval && e.p.ApprovalEffect == runtime.HITLApprovalEffectCreateRetryGrant {
+		resolver := r.asyncGrantResolver
+		if resolver == nil {
+			r.mu.Unlock()
+			return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "async HITL retry-grant resolver is unavailable"}
+		}
+		delete(r.pending, id)
+		r.mu.Unlock()
+
+		result := resolver(e.p.OperationID, d)
+		r.mu.Lock()
+		r.terminal[id] = terminalHITLEntry{result: staleHITLResolveResult(result), expiresAt: now.Add(hitlTerminalTTL)}
+		r.mu.Unlock()
+		return result
 	}
 	e.decision <- d
 	delete(r.pending, id)
@@ -2341,7 +2373,13 @@ func (r *HITLRegistry) DecideWithResult(id string, d runtime.HITLDecision) runti
 		result:    runtime.HITLResolveResult{OK: false, State: state, Reason: reason},
 		expiresAt: now.Add(hitlTerminalTTL),
 	}
+	r.mu.Unlock()
 	return runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
+}
+
+func staleHITLResolveResult(result runtime.HITLResolveResult) runtime.HITLResolveResult {
+	result.OK = false
+	return result
 }
 
 // Cancel resolves a pending entry without delivering a human decision.


### PR DESCRIPTION
## Summary
- Creates durable async HITL operations for eligible single-stage human approvals before entering the synchronous approval wait.
- Returns `202 Accepted` with operation status metadata when `sync_wait_timeout` elapses, while leaving the human prompt pending for an approved retry grant.
- Wires async grant approval resolution to the operation store and records upstream terminal states for sync-approved requests.

## Test Plan
- `go test . ./config/plugins/approvers -run 'TestHumanApproverAsyncSyncWaitTimeoutLeavesPromptPendingForRetryGrant|TestHITLRegistryAsyncPendingApprovalCreatesRetryGrantInsteadOfSendingChannelDecision' -count=1`
- `go test . -count=1`
- `git diff --check`
- `go test ./...`

Stack note: this implements the runtime fallback slice and is intended to precede/compose with retry relay follow-up work such as #426.
