### PR TITLE
doc: explain inspection-buffer overflow in approval-rules

### DIFF
--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -281,11 +281,13 @@ byte-for-byte. What's bounded is the matcher's view of it. The
 frontend flags the request as truncated, and the dispatcher
 fails-closed per rule.
 
-| Endpoint | Inspected slice | Cap |
-|----------|-----------------|-----|
-| `https`, `kubernetes`, `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB |
-| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB |
-| `clickhouse_native` | `Query` packet body | 1 MiB |
+| Endpoint | Inspected slice | Cap | Truncatable facets |
+|----------|-----------------|-----|--------------------|
+| `https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `http.body`, `http.body_json` |
+| `kubernetes` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | *(none — every `k8s.*` facet is derived from the URL and method)* |
+| `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
+| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
+| `clickhouse_native` | `Query` packet body | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
 
 The caps are per-plugin constants in the gateway source — **not
 operator-tunable** today, and not surfaced in `gateway.hcl`. Header

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -281,7 +281,7 @@ byte-for-byte. What's bounded is the matcher's view of it. The
 endpoint flags the request as truncated, and the dispatcher
 fails-closed per rule.
 
-| Endpoint | Inspected slice | Cap | Truncatable facets |
+| Endpoint | Inspected slice | Cap | Truncatable facet fields |
 |----------|-----------------|-----|--------------------|
 | `https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `http.body`, `http.body_json` |
 | `kubernetes` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | *(none — every `k8s.*` facet is derived from the URL and method)* |
@@ -302,13 +302,14 @@ rules in priority order as usual. For each rule:
 
 - **Catch-all rule** (no `condition`): fires as written. A truncated
   body can't poison a rule that reads nothing.
-- **Rule whose CEL reads no truncatable facet** (e.g.
+- **Rule whose CEL reads no truncatable facet field** (e.g.
   `http.method == 'GET'`, `credential = X`, any `k8s.*` predicate):
   the matcher runs normally — the truncated bytes are irrelevant to
   its decision.
-- **Rule whose CEL reads a truncatable facet**: the matcher is **not**
-  called. The dispatcher synthesizes a deny attributed to that rule,
-  with this exact reason:
+- **Rule whose CEL reads a truncatable facet field**: the rule is
+  automatically matched without comparing the matching values. The
+  dispatcher synthesizes a deny attributed to that rule, with this
+  exact reason:
 
   ```
   rule "<name>" reads a request facet whose bytes were truncated by the gateway's inspection buffer; failing closed
@@ -318,11 +319,9 @@ rules in priority order as usual. For each rule:
   so logs and dashboards still attribute the deny to the rule whose
   contract the truncation broke.
 
-`credential` (the top-level rule attribute) is always non-truncatable
-— it's resolved off the connection's authenticated identity. The
-upshot: a method-only or credential-only rule on an `https` endpoint
-still fires on a 2 MiB body, but a `http.body_json.field == "x"` rule
-auto-denies.
+The upshot: a rule matching on `http.method` and/or `credential` on
+an `https` endpoint still fires on a 2 MiB body, but a
+`http.body_json.field == "x"` rule auto-denies.
 
 A matched rule with `approve = [...]` on a truncated postgres frame
 is forced to deny without paging the approver (HITL can't reason about
@@ -350,7 +349,7 @@ driver doesn't disconnect:
 A truncated body might contain content that *would* have triggered a
 deny rule the gateway can't see, so refusing is the safe default. If
 legitimate traffic is expected to exceed the cap, write the rules
-against non-truncatable facets only (see the table above) — those
+against non-truncatable facet fields only (see the table above) — those
 rules still match on a truncated request and won't auto-deny.
 
 

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -356,10 +356,7 @@ driver doesn't disconnect:
 A truncated body might contain content that *would* have triggered a
 deny rule the gateway can't see, so refusing is the safe default.
 Operators who hit the cap on legitimate traffic need the constant
-raised in source — for SQL specifically,
-[denoland/clawpatrol#386](https://github.com/denoland/clawpatrol/issues/386)
-tracks a streaming-parse rework that could lift the `sql_rule` cap;
-this section will need updating when that lands.
+raised in source.
 
 
 ## Examples

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -281,11 +281,11 @@ byte-for-byte. What's bounded is the matcher's view of it. The
 frontend flags the request as truncated, and the dispatcher
 fails-closed per rule.
 
-| Endpoint | Inspected slice | Cap | Source constant |
-|----------|-----------------|-----|------------------|
-| `https`, `kubernetes`, `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `maxHTTPMatchBody` (`main.go`) |
-| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB | `maxPgMessage` (`config/plugins/endpoints/postgres.go`) |
-| `clickhouse_native` | `Query` packet body | 1 MiB | `chMaxQueryBody` (`config/plugins/endpoints/clickhouse_native_runtime.go`) |
+| Endpoint | Inspected slice | Cap |
+|----------|-----------------|-----|
+| `https`, `kubernetes`, `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB |
+| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB |
+| `clickhouse_native` | `Query` packet body | 1 MiB |
 
 The caps are per-plugin constants in the gateway source — **not
 operator-tunable** today, and not surfaced in `gateway.hcl`. Header

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -274,11 +274,11 @@ per endpoint to invert this.
 
 ## Inspection-buffer overflow
 
-To bound memory, the wire frontends cap how much of each request they
+To bound memory, the wire endpoints cap how much of each request they
 buffer for the matcher. A request that exceeds its cap is **not**
 dropped on the floor — the frame still forwards to upstream
 byte-for-byte. What's bounded is the matcher's view of it. The
-frontend flags the request as truncated, and the dispatcher
+endpoint flags the request as truncated, and the dispatcher
 fails-closed per rule.
 
 | Endpoint | Inspected slice | Cap | Truncatable facets |
@@ -326,7 +326,7 @@ auto-denies.
 
 A matched rule with `approve = [...]` on a truncated postgres frame
 is forced to deny without paging the approver (HITL can't reason about
-bytes that aren't there); the postgres frontend surfaces this with the
+bytes that aren't there); the postgres endpoint surfaces this with the
 reason `"approval required but request was truncated by inspection
 buffer"`.
 

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -277,9 +277,14 @@ per endpoint to invert this.
 To bound memory, the wire endpoints cap how much of each request they
 buffer for the matcher. A request that exceeds its cap is **not**
 dropped on the floor — the frame still forwards to upstream
-byte-for-byte. What's bounded is the matcher's view of it. The
-endpoint flags the request as truncated, and the dispatcher
-fails-closed per rule.
+byte-for-byte. What's bounded is the matcher's view of it: the
+endpoint truncates the buffered slice and flags the request as
+truncated. The facet fields that draw their value from this slice
+are **truncatable facet fields** (listed per-endpoint in the table
+below). When a rule's CEL reads a truncatable facet field on a
+request that was flagged truncated, the rule is automatically
+matched without comparing the matching values, and the dispatcher
+returns a deny verdict for it.
 
 | Endpoint | Inspected slice | Cap | Truncatable facet fields |
 |----------|-----------------|-----|--------------------|
@@ -295,7 +300,7 @@ and URL bytes are bounded separately by `net/http`'s defaults and
 aren't covered here; the `ssh` endpoint has no rule family, so no
 inspection cap.
 
-### Per-rule fail-closed
+### Rule matching semantics on truncated fields
 
 When a request overflows its cap, the dispatcher walks the endpoint's
 rules in priority order as usual. For each rule:

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -316,14 +316,6 @@ rules in priority order as usual. For each rule:
   so logs and dashboards still attribute the deny to the rule whose
   contract the truncation broke.
 
-The truncatable-facet set is family-specific:
-
-| Family | Truncatable facets | Non-truncatable facets |
-|--------|---------------------|-------------------------|
-| `http` | `http.body`, `http.body_json` | `http.method`, `http.path`, `http.query`, `http.headers` |
-| `sql`  | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` | `sql.database` (resolved off StartupMessage / `Hello` / URL+header, not the frame body) |
-| `k8s`  | — | `k8s.verb`, `k8s.resource`, `k8s.namespace`, `k8s.name`, `k8s.params` (all derived from URL + method) |
-
 `credential` (the top-level rule attribute) is always non-truncatable
 — it's resolved off the connection's authenticated identity. The
 upshot: a method-only or credential-only rule on an `https` endpoint

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -354,9 +354,10 @@ driver doesn't disconnect:
 ### Why fail-closed
 
 A truncated body might contain content that *would* have triggered a
-deny rule the gateway can't see, so refusing is the safe default.
-Operators who hit the cap on legitimate traffic need the constant
-raised in source.
+deny rule the gateway can't see, so refusing is the safe default. If
+legitimate traffic is expected to exceed the cap, write the rules
+against non-truncatable facets only (see the table above) — those
+rules still match on a truncated request and won't auto-deny.
 
 
 ## Examples

--- a/site/doc/approval-rules.md
+++ b/site/doc/approval-rules.md
@@ -272,6 +272,96 @@ default-deny. Add a `priority = -100, verdict = "deny"` catch-all
 per endpoint to invert this.
 
 
+## Inspection-buffer overflow
+
+To bound memory, the wire frontends cap how much of each request they
+buffer for the matcher. A request that exceeds its cap is **not**
+dropped on the floor — the frame still forwards to upstream
+byte-for-byte. What's bounded is the matcher's view of it. The
+frontend flags the request as truncated, and the dispatcher
+fails-closed per rule.
+
+| Endpoint | Inspected slice | Cap | Source constant |
+|----------|-----------------|-----|------------------|
+| `https`, `kubernetes`, `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `maxHTTPMatchBody` (`main.go`) |
+| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB | `maxPgMessage` (`config/plugins/endpoints/postgres.go`) |
+| `clickhouse_native` | `Query` packet body | 1 MiB | `chMaxQueryBody` (`config/plugins/endpoints/clickhouse_native_runtime.go`) |
+
+The caps are per-plugin constants in the gateway source — **not
+operator-tunable** today, and not surfaced in `gateway.hcl`. Header
+and URL bytes are bounded separately by `net/http`'s defaults and
+aren't covered here; the `ssh` endpoint has no rule family, so no
+inspection cap.
+
+### Per-rule fail-closed
+
+When a request overflows its cap, the dispatcher walks the endpoint's
+rules in priority order as usual. For each rule:
+
+- **Catch-all rule** (no `condition`): fires as written. A truncated
+  body can't poison a rule that reads nothing.
+- **Rule whose CEL reads no truncatable facet** (e.g.
+  `http.method == 'GET'`, `credential = X`, any `k8s.*` predicate):
+  the matcher runs normally — the truncated bytes are irrelevant to
+  its decision.
+- **Rule whose CEL reads a truncatable facet**: the matcher is **not**
+  called. The dispatcher synthesizes a deny attributed to that rule,
+  with this exact reason:
+
+  ```
+  rule "<name>" reads a request facet whose bytes were truncated by the gateway's inspection buffer; failing closed
+  ```
+
+  The synthesized rule keeps the original rule's name and priority,
+  so logs and dashboards still attribute the deny to the rule whose
+  contract the truncation broke.
+
+The truncatable-facet set is family-specific:
+
+| Family | Truncatable facets | Non-truncatable facets |
+|--------|---------------------|-------------------------|
+| `http` | `http.body`, `http.body_json` | `http.method`, `http.path`, `http.query`, `http.headers` |
+| `sql`  | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` | `sql.database` (resolved off StartupMessage / `Hello` / URL+header, not the frame body) |
+| `k8s`  | — | `k8s.verb`, `k8s.resource`, `k8s.namespace`, `k8s.name`, `k8s.params` (all derived from URL + method) |
+
+`credential` (the top-level rule attribute) is always non-truncatable
+— it's resolved off the connection's authenticated identity. The
+upshot: a method-only or credential-only rule on an `https` endpoint
+still fires on a 2 MiB body, but a `http.body_json.field == "x"` rule
+auto-denies.
+
+A matched rule with `approve = [...]` on a truncated postgres frame
+is forced to deny without paging the approver (HITL can't reason about
+bytes that aren't there); the postgres frontend surfaces this with the
+reason `"approval required but request was truncated by inspection
+buffer"`.
+
+### How the deny reaches the agent
+
+Each protocol synthesizes the deny in its native shape so the agent's
+driver doesn't disconnect:
+
+- **`https`, `kubernetes`, `clickhouse_https`** — `HTTP/1.1 403
+  Forbidden`, `Content-Type: text/plain`, reason in the body,
+  `Connection: close`.
+- **`postgres`** — `ErrorResponse` (severity `ERROR`, SQLSTATE
+  `42501`, message = reason), followed by `ReadyForQuery` in idle
+  state. The session stays open; the agent can run the next query.
+- **`clickhouse_native`** — server `Exception` packet with the
+  reason. The unread tail of the oversize `Query` body is drained off
+  the wire so the next packet frames correctly.
+
+### Why fail-closed
+
+A truncated body might contain content that *would* have triggered a
+deny rule the gateway can't see, so refusing is the safe default.
+Operators who hit the cap on legitimate traffic need the constant
+raised in source — for SQL specifically,
+[denoland/clawpatrol#386](https://github.com/denoland/clawpatrol/issues/386)
+tracks a streaming-parse rework that could lift the `sql_rule` cap;
+this section will need updating when that lands.
+
+
 ## Examples
 
 ### Allow / deny pair (HTTP)


### PR DESCRIPTION
Adds an *Inspection-buffer overflow* section to `site/doc/approval-rules.md` covering the fail-closed-on-truncation contract introduced earlier.

Documents:

- The per-plugin 1 MiB caps (`maxHTTPMatchBody`, `maxPgMessage`, `chMaxQueryBody`) and where they live in source.
- That an overflowed frame still forwards byte-for-byte; only the matcher's view is bounded.
- The per-rule fail-closed dispatch: catch-alls and rules that don't read a truncatable facet fire normally; rules that do read one auto-deny with the synthesized reason from `runtime.synthesizeTruncatedDeny`.
- The truncatable / non-truncatable facet split per family (`http`, `sql`, `k8s`).
- The per-protocol deny shape each frontend writes (HTTP 403, postgres `ErrorResponse` + `ReadyForQuery`, clickhouse_native `Exception`).
- Forward reference to denoland/clawpatrol#386 for the streaming-parse track that may lift the SQL cap.

Doc-only, no behaviour change.