### PR TITLE
hitl: maintain async operation lifecycle

### DIFF
--- a/hitl_operation_store.go
+++ b/hitl_operation_store.go
@@ -86,6 +86,14 @@ type HITLRetryGrantConsume struct {
 	Now                time.Time
 }
 
+type HITLOperationMaintenanceResult struct {
+	PendingApprovalExpired int64
+	ApprovedRetryExpired   int64
+	SyncWaitingRecovered   int64
+	ExecutingRecovered     int64
+	PurgedTerminal         int64
+}
+
 type HITLOperation struct {
 	ID                         string
 	State                      HITLOperationState
@@ -212,6 +220,110 @@ func (s *HITLOperationStore) Transition(ctx context.Context, tr HITLOperationTra
 		return HITLOperation{}, ErrHITLOperationConflict
 	}
 	return s.get(ctx, tr.ID)
+}
+
+func (s *HITLOperationStore) ExpireDueOperations(ctx context.Context, now time.Time, terminalRetention time.Duration) (HITLOperationMaintenanceResult, error) {
+	if s == nil || s.db == nil {
+		return HITLOperationMaintenanceResult{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if now.IsZero() {
+		return HITLOperationMaintenanceResult{}, fmt.Errorf("%w: missing maintenance time", ErrHITLOperationStoreInvalid)
+	}
+	retentionExpires := now
+	if terminalRetention > 0 {
+		retentionExpires = now.Add(terminalRetention)
+	}
+	var out HITLOperationMaintenanceResult
+	changed, err := s.updateTerminalByDeadline(ctx, HITLOperationStatePendingApproval, "approval_expires_ns", now, retentionExpires, "approval_ttl_expired", false, "")
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.PendingApprovalExpired = changed
+	changed, err = s.updateTerminalByDeadline(ctx, HITLOperationStateApprovedWaitingForRetry, "retry_expires_ns", now, retentionExpires, "approved_retry_ttl_expired", false, "")
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.ApprovedRetryExpired = changed
+	return out, nil
+}
+
+func (s *HITLOperationStore) RecoverStaleInProgressOperations(ctx context.Context, now time.Time, terminalRetention time.Duration) (HITLOperationMaintenanceResult, error) {
+	if s == nil || s.db == nil {
+		return HITLOperationMaintenanceResult{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if now.IsZero() {
+		return HITLOperationMaintenanceResult{}, fmt.Errorf("%w: missing maintenance time", ErrHITLOperationStoreInvalid)
+	}
+	retentionExpires := now
+	if terminalRetention > 0 {
+		retentionExpires = now.Add(terminalRetention)
+	}
+	var out HITLOperationMaintenanceResult
+	changed, err := s.updateTerminalByDeadline(ctx, HITLOperationStateSyncWaiting, "sync_wait_deadline_ns", now, retentionExpires, "", false, "")
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.SyncWaitingRecovered = changed
+	changed, err = s.updateTerminalState(ctx, HITLOperationStateExecutingUpstream, HITLOperationStateUpstreamFailed, now, retentionExpires, "", true, "gateway restarted while HITL operation was executing upstream")
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.ExecutingRecovered = changed
+	return out, nil
+}
+
+func (s *HITLOperationStore) PurgeTerminalOperations(ctx context.Context, now time.Time) (int64, error) {
+	if s == nil || s.db == nil {
+		return 0, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if now.IsZero() {
+		return 0, fmt.Errorf("%w: missing maintenance time", ErrHITLOperationStoreInvalid)
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM hitl_operations
+WHERE state IN (?, ?, ?, ?, ?)
+  AND terminal_retention_expires_ns IS NOT NULL
+  AND terminal_retention_expires_ns <= ?`,
+		string(HITLOperationStateDenied), string(HITLOperationStateExpired), string(HITLOperationStateUpstreamSucceeded), string(HITLOperationStateUpstreamFailed), string(HITLOperationStateClientDisconnected), timeNS(now),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (s *HITLOperationStore) updateTerminalByDeadline(ctx context.Context, from HITLOperationState, deadlineColumn string, now, retentionExpires time.Time, expiredReason string, upstreamCalled bool, lastError string) (int64, error) {
+	to := HITLOperationStateExpired
+	if from == HITLOperationStateSyncWaiting {
+		to = HITLOperationStateClientDisconnected
+	}
+	return s.updateTerminalStateWhere(ctx, from, to, now, retentionExpires, expiredReason, upstreamCalled, lastError, deadlineColumn+" IS NOT NULL AND "+deadlineColumn+" <= ?", timeNS(now))
+}
+
+func (s *HITLOperationStore) updateTerminalState(ctx context.Context, from, to HITLOperationState, now, retentionExpires time.Time, expiredReason string, upstreamCalled bool, lastError string) (int64, error) {
+	return s.updateTerminalStateWhere(ctx, from, to, now, retentionExpires, expiredReason, upstreamCalled, lastError, "1 = 1")
+}
+
+func (s *HITLOperationStore) updateTerminalStateWhere(ctx context.Context, from, to HITLOperationState, now, retentionExpires time.Time, expiredReason string, upstreamCalled bool, lastError string, extraWhere string, extraArgs ...any) (int64, error) {
+	sets := []string{"state = ?", "version = version + 1", "terminal_ns = ?", "terminal_retention_expires_ns = ?"}
+	args := []any{string(to), timeNS(now), timeNS(retentionExpires)}
+	if expiredReason != "" {
+		sets = append(sets, "expired_reason = ?")
+		args = append(args, expiredReason)
+	}
+	if upstreamCalled {
+		sets = append(sets, "upstream_called = 1")
+	}
+	if lastError != "" {
+		sets = append(sets, "last_error = ?")
+		args = append(args, lastError)
+	}
+	args = append(args, string(from))
+	args = append(args, extraArgs...)
+	res, err := s.db.ExecContext(ctx, `UPDATE hitl_operations SET `+strings.Join(sets, ", ")+` WHERE state = ? AND `+extraWhere, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 func (s *HITLOperationStore) ConsumeRetryGrant(ctx context.Context, in HITLRetryGrantConsume) (HITLOperation, error) {

--- a/hitl_operation_store_test.go
+++ b/hitl_operation_store_test.go
@@ -294,6 +294,291 @@ func TestHITLOperationStoreConsumeRetryGrantIsOneShotAndMismatchSafe(t *testing.
 	}
 }
 
+func TestHITLOperationStoreMaintenanceExpiresDueOperations(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Unix(1_700_000_300, 0).UTC()
+	retention := 24 * time.Hour
+
+	pendingExpired := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_pending_expired",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-30 * time.Minute),
+		SyncWaitDeadline:  now.Add(-29 * time.Minute),
+		ApprovalExpiresAt: now.Add(-time.Second),
+	})
+	pendingFuture := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_pending_future",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-time.Minute),
+		SyncWaitDeadline:  now.Add(-30 * time.Second),
+		ApprovalExpiresAt: now.Add(time.Minute),
+	})
+	retryExpired := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_retry_expired",
+		State:             HITLOperationStateApprovedWaitingForRetry,
+		CreatedAt:         now.Add(-30 * time.Minute),
+		SyncWaitDeadline:  now.Add(-29 * time.Minute),
+		ApprovalExpiresAt: now.Add(time.Minute),
+		RetryExpiresAt:    now.Add(-time.Second),
+	})
+	retryFuture := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_retry_future",
+		State:             HITLOperationStateApprovedWaitingForRetry,
+		CreatedAt:         now.Add(-30 * time.Minute),
+		SyncWaitDeadline:  now.Add(-29 * time.Minute),
+		ApprovalExpiresAt: now.Add(time.Minute),
+		RetryExpiresAt:    now.Add(time.Minute),
+	})
+
+	result, err := store.ExpireDueOperations(ctx, now, retention)
+	if err != nil {
+		t.Fatalf("ExpireDueOperations: %v", err)
+	}
+	if result.PendingApprovalExpired != 1 || result.ApprovedRetryExpired != 1 {
+		t.Fatalf("ExpireDueOperations result = %#v, want one pending and one retry expiration", result)
+	}
+
+	assertExpired := func(t *testing.T, op HITLOperation, wantReason string) {
+		t.Helper()
+		loaded, err := store.GetForPrincipal(ctx, op.ID, op.ProfileID, op.PrincipalID)
+		if err != nil {
+			t.Fatalf("GetForPrincipal(%s): %v", op.ID, err)
+		}
+		if loaded.State != HITLOperationStateExpired {
+			t.Fatalf("%s state = %q, want expired", op.ID, loaded.State)
+		}
+		if loaded.ExpiredReason != wantReason {
+			t.Fatalf("%s ExpiredReason = %q, want %q", op.ID, loaded.ExpiredReason, wantReason)
+		}
+		if loaded.TerminalAt == nil || !loaded.TerminalAt.Equal(now) {
+			t.Fatalf("%s TerminalAt = %v, want %v", op.ID, loaded.TerminalAt, now)
+		}
+		if loaded.TerminalRetentionExpiresAt == nil || !loaded.TerminalRetentionExpiresAt.Equal(now.Add(retention)) {
+			t.Fatalf("%s TerminalRetentionExpiresAt = %v, want %v", op.ID, loaded.TerminalRetentionExpiresAt, now.Add(retention))
+		}
+		if loaded.UpstreamCalled {
+			t.Fatalf("%s UpstreamCalled = true, want false for expiry", op.ID)
+		}
+	}
+	assertExpired(t, pendingExpired, "approval_ttl_expired")
+	assertExpired(t, retryExpired, "approved_retry_ttl_expired")
+
+	for _, op := range []HITLOperation{pendingFuture, retryFuture} {
+		loaded, err := store.GetForPrincipal(ctx, op.ID, op.ProfileID, op.PrincipalID)
+		if err != nil {
+			t.Fatalf("GetForPrincipal(%s): %v", op.ID, err)
+		}
+		if loaded.State != op.State {
+			t.Fatalf("%s state = %q, want unchanged %q", op.ID, loaded.State, op.State)
+		}
+	}
+}
+
+func TestHITLOperationStoreMaintenanceRecoversStaleStartupStates(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Unix(1_700_000_400, 0).UTC()
+	retention := 24 * time.Hour
+
+	staleSync := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_stale_sync",
+		State:             HITLOperationStateSyncWaiting,
+		CreatedAt:         now.Add(-10 * time.Minute),
+		SyncWaitDeadline:  now.Add(-9 * time.Minute),
+		ApprovalExpiresAt: now.Add(5 * time.Minute),
+	})
+	freshSync := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_fresh_sync",
+		State:             HITLOperationStateSyncWaiting,
+		CreatedAt:         now.Add(-time.Second),
+		SyncWaitDeadline:  now.Add(time.Minute),
+		ApprovalExpiresAt: now.Add(5 * time.Minute),
+	})
+	executing := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_executing",
+		State:             HITLOperationStateExecutingUpstream,
+		CreatedAt:         now.Add(-10 * time.Minute),
+		SyncWaitDeadline:  now.Add(-9 * time.Minute),
+		ApprovalExpiresAt: now.Add(5 * time.Minute),
+	})
+
+	result, err := store.RecoverStaleInProgressOperations(ctx, now, retention)
+	if err != nil {
+		t.Fatalf("RecoverStaleInProgressOperations: %v", err)
+	}
+	if result.SyncWaitingRecovered != 1 || result.ExecutingRecovered != 1 {
+		t.Fatalf("RecoverStaleInProgressOperations result = %#v, want one sync and one executing recovery", result)
+	}
+
+	loadedSync, err := store.GetForPrincipal(ctx, staleSync.ID, staleSync.ProfileID, staleSync.PrincipalID)
+	if err != nil {
+		t.Fatalf("GetForPrincipal(stale sync): %v", err)
+	}
+	if loadedSync.State != HITLOperationStateClientDisconnected || loadedSync.UpstreamCalled {
+		t.Fatalf("stale sync = %#v, want client_disconnected without upstream call", loadedSync)
+	}
+
+	loadedExecuting, err := store.GetForPrincipal(ctx, executing.ID, executing.ProfileID, executing.PrincipalID)
+	if err != nil {
+		t.Fatalf("GetForPrincipal(executing): %v", err)
+	}
+	if loadedExecuting.State != HITLOperationStateUpstreamFailed || !loadedExecuting.UpstreamCalled || loadedExecuting.LastError == "" {
+		t.Fatalf("executing = %#v, want upstream_failed with upstream_called and diagnostic", loadedExecuting)
+	}
+
+	loadedFresh, err := store.GetForPrincipal(ctx, freshSync.ID, freshSync.ProfileID, freshSync.PrincipalID)
+	if err != nil {
+		t.Fatalf("GetForPrincipal(fresh sync): %v", err)
+	}
+	if loadedFresh.State != HITLOperationStateSyncWaiting {
+		t.Fatalf("fresh sync state = %q, want unchanged sync_waiting", loadedFresh.State)
+	}
+}
+
+func TestHITLOperationStartupMaintenanceRunsRecoveryExpiryAndPurge(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Now().Add(-time.Hour).UTC()
+
+	staleSync := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_startup_stale_sync",
+		State:             HITLOperationStateSyncWaiting,
+		CreatedAt:         now.Add(-10 * time.Minute),
+		SyncWaitDeadline:  now.Add(-9 * time.Minute),
+		ApprovalExpiresAt: now.Add(5 * time.Minute),
+	})
+	duePending := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_startup_due_pending",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-30 * time.Minute),
+		SyncWaitDeadline:  now.Add(-29 * time.Minute),
+		ApprovalExpiresAt: now.Add(-time.Minute),
+	})
+	oldTerminal := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_startup_old_terminal",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-48 * time.Hour),
+		SyncWaitDeadline:  now.Add(-48 * time.Hour),
+		ApprovalExpiresAt: now.Add(-47 * time.Hour),
+	})
+	_, err := store.Transition(ctx, HITLOperationTransition{
+		ID:                         oldTerminal.ID,
+		FromState:                  HITLOperationStatePendingApproval,
+		ToState:                    HITLOperationStateExpired,
+		ExpectedVersion:            oldTerminal.Version,
+		Now:                        now.Add(-25 * time.Hour),
+		ExpiredReason:              "approval_ttl_expired",
+		TerminalRetentionExpiresAt: now.Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("transition old terminal: %v", err)
+	}
+
+	result, err := runHITLOperationStartupMaintenance(ctx, db)
+	if err != nil {
+		t.Fatalf("runHITLOperationStartupMaintenance: %v", err)
+	}
+	if result.SyncWaitingRecovered != 1 || result.PendingApprovalExpired != 1 || result.PurgedTerminal != 1 {
+		t.Fatalf("runHITLOperationStartupMaintenance result = %#v, want recovery, expiry, and purge", result)
+	}
+
+	loadedSync, err := store.GetForPrincipal(ctx, staleSync.ID, staleSync.ProfileID, staleSync.PrincipalID)
+	if err != nil {
+		t.Fatalf("GetForPrincipal(stale sync): %v", err)
+	}
+	if loadedSync.State != HITLOperationStateClientDisconnected {
+		t.Fatalf("stale sync state = %q, want client_disconnected", loadedSync.State)
+	}
+	loadedPending, err := store.GetForPrincipal(ctx, duePending.ID, duePending.ProfileID, duePending.PrincipalID)
+	if err != nil {
+		t.Fatalf("GetForPrincipal(due pending): %v", err)
+	}
+	if loadedPending.State != HITLOperationStateExpired {
+		t.Fatalf("due pending state = %q, want expired", loadedPending.State)
+	}
+	_, err = store.GetForPrincipal(ctx, oldTerminal.ID, oldTerminal.ProfileID, oldTerminal.PrincipalID)
+	if !errors.Is(err, ErrHITLOperationNotFound) {
+		t.Fatalf("old terminal err = %v, want ErrHITLOperationNotFound", err)
+	}
+}
+
+func TestHITLOperationStoreMaintenancePurgesTerminalOperations(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	now := time.Unix(1_700_000_500, 0).UTC()
+
+	oldTerminal := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_old_terminal",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-48 * time.Hour),
+		SyncWaitDeadline:  now.Add(-48 * time.Hour),
+		ApprovalExpiresAt: now.Add(-47 * time.Hour),
+	})
+	_, err := store.Transition(ctx, HITLOperationTransition{
+		ID:                         oldTerminal.ID,
+		FromState:                  HITLOperationStatePendingApproval,
+		ToState:                    HITLOperationStateExpired,
+		ExpectedVersion:            oldTerminal.Version,
+		Now:                        now.Add(-25 * time.Hour),
+		ExpiredReason:              "approval_ttl_expired",
+		TerminalRetentionExpiresAt: now.Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("transition old terminal: %v", err)
+	}
+
+	keptTerminal := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_kept_terminal",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-48 * time.Hour),
+		SyncWaitDeadline:  now.Add(-48 * time.Hour),
+		ApprovalExpiresAt: now.Add(-47 * time.Hour),
+	})
+	_, err = store.Transition(ctx, HITLOperationTransition{
+		ID:                         keptTerminal.ID,
+		FromState:                  HITLOperationStatePendingApproval,
+		ToState:                    HITLOperationStateExpired,
+		ExpectedVersion:            keptTerminal.Version,
+		Now:                        now.Add(-time.Hour),
+		ExpiredReason:              "approval_ttl_expired",
+		TerminalRetentionExpiresAt: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("transition kept terminal: %v", err)
+	}
+
+	pending := createTestHITLOperation(t, store, HITLOperationCreate{
+		ID:                "hitl_op_pending_not_purged",
+		State:             HITLOperationStatePendingApproval,
+		CreatedAt:         now.Add(-time.Minute),
+		SyncWaitDeadline:  now.Add(-30 * time.Second),
+		ApprovalExpiresAt: now.Add(time.Minute),
+	})
+
+	purged, err := store.PurgeTerminalOperations(ctx, now)
+	if err != nil {
+		t.Fatalf("PurgeTerminalOperations: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("PurgeTerminalOperations purged = %d, want 1", purged)
+	}
+
+	_, err = store.GetForPrincipal(ctx, oldTerminal.ID, oldTerminal.ProfileID, oldTerminal.PrincipalID)
+	if !errors.Is(err, ErrHITLOperationNotFound) {
+		t.Fatalf("old terminal err = %v, want ErrHITLOperationNotFound", err)
+	}
+	for _, op := range []HITLOperation{keptTerminal, pending} {
+		if _, err := store.GetForPrincipal(ctx, op.ID, op.ProfileID, op.PrincipalID); err != nil {
+			t.Fatalf("operation %s should remain: %v", op.ID, err)
+		}
+	}
+}
+
 func openHITLOperationTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := OpenDB(filepath.Join(t.TempDir(), "clawpatrol.db"))

--- a/main.go
+++ b/main.go
@@ -58,6 +58,33 @@ func resolveStateDir(cfg *config.Gateway) string {
 	return filepath.Join(home, ".clawpatrol")
 }
 
+const hitlOperationTerminalRetention = 7 * 24 * time.Hour
+
+func runHITLOperationStartupMaintenance(ctx context.Context, db *sql.DB) (HITLOperationMaintenanceResult, error) {
+	store := NewHITLOperationStore(db)
+	now := time.Now().UTC()
+	retention := hitlOperationTerminalRetention
+	var out HITLOperationMaintenanceResult
+	recovered, err := store.RecoverStaleInProgressOperations(ctx, now, retention)
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.SyncWaitingRecovered = recovered.SyncWaitingRecovered
+	out.ExecutingRecovered = recovered.ExecutingRecovered
+	expired, err := store.ExpireDueOperations(ctx, now, retention)
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.PendingApprovalExpired = expired.PendingApprovalExpired
+	out.ApprovedRetryExpired = expired.ApprovedRetryExpired
+	purged, err := store.PurgeTerminalOperations(ctx, now)
+	if err != nil {
+		return HITLOperationMaintenanceResult{}, err
+	}
+	out.PurgedTerminal = purged
+	return out, nil
+}
+
 // warnIfStateLooselyPermissioned logs a warning when state_dir or
 // clawpatrol.db is readable by group / others. The sqlite db holds
 // the CA private key, OAuth tokens, and audit log — anything not
@@ -2382,6 +2409,11 @@ func runGateway(args []string) {
 	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
 	if err != nil {
 		log.Fatalf("db: %v", err)
+	}
+	if result, err := runHITLOperationStartupMaintenance(context.Background(), db); err != nil {
+		log.Fatalf("hitl operation maintenance: %v", err)
+	} else if result.PendingApprovalExpired != 0 || result.ApprovedRetryExpired != 0 || result.SyncWaitingRecovered != 0 || result.ExecutingRecovered != 0 || result.PurgedTerminal != 0 {
+		log.Printf("hitl operation maintenance: expired pending=%d retry=%d recovered sync=%d executing=%d purged=%d", result.PendingApprovalExpired, result.ApprovedRetryExpired, result.SyncWaitingRecovered, result.ExecutingRecovered, result.PurgedTerminal)
 	}
 	warnIfStateLooselyPermissioned(stateDir)
 	setDB(db)


### PR DESCRIPTION
## Summary

Adds the async HITL operation lifecycle maintenance slice.

- Expires `pending_approval` operations when `approval_ttl` elapses.
- Expires `approved_waiting_for_retry` operations when the retry grant TTL elapses.
- Recovers stale startup states: `sync_waiting` becomes `client_disconnected`, and `executing_upstream` becomes `upstream_failed` with a diagnostic.
- Purges terminal operations after their retention deadline.
- Runs the maintenance pass during gateway startup and logs non-zero maintenance counts.

## Tests

- `npm --prefix www ci && npm --prefix www run build`
- `go test . -run 'TestHITLOperationStoreMaintenance' -count=1`
- `go test . -run 'TestHITLOperationStartupMaintenance' -count=1`
- `go test . -run 'TestHITL(OperationStore|OperationStatus|RetryRelay|RequestFingerprint|CredentialAuthBinding|Body)' -count=1`
- `go test ./...`
- `gofmt -l .`
- `git diff --check`

Independent delegate review: `APPROVED_NO_FINDINGS`.
