### PR TITLE
docs(glossary): merge Facet/Family entries; add Facet field

### DIFF
--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -72,7 +72,7 @@ One unit of agent work the gateway sees and applies policy to — one
 HTTP call, one SQL query, one `kubectl` invocation, one SSH command.
 Each action targets an [endpoint](#endpoint), is gated by the matching
 [rule](#rule)'s [outcome](#outcome), and surfaces in the dashboard's
-live request feed (action [families](#facet): `http`, `sql`, `k8s`,
+live request feed (action [families](#family): `http`, `sql`, `k8s`,
 `ssh`) with its own detail page. "Action" is the operator-visible concept of "the
 thing the agent did."
 
@@ -80,43 +80,55 @@ thing the agent did."
 
 One policy decision targeting one or more [endpoints](#endpoint). A
 rule has a CEL [`condition`](#cel-condition) string that matches against
-the [facet fields](#facet-field) of the rule's [facet](#facet)
+the [facet fields](#facet-field) the rule's [family](#family) exposes
 (inferred from its endpoints), an optional `credential` predicate, and
 an [outcome](#outcome) — either a literal `verdict` or an
 `approve = [...]` chain. Rules are one HCL block kind
-(`rule "<name>" { ... }`); the facet is inferred from the endpoint(s)
-at load time, and mixed-facet endpoint sets are a load error.
+(`rule "<name>" { ... }`); the family is inferred from the endpoint(s)
+at load time, and mixed-family endpoint sets are a load error.
+
+### Family
+
+The protocol class an [action](#action) belongs to. An action belongs
+to exactly one family; built-in families are `http`, `sql`, `ssh`, and
+`k8s`. A [rule](#rule)'s family is inferred from its endpoint(s) at
+load time, and mixed-family endpoint sets are a load error. Each
+family includes one or more [facets](#facet) into the action's data:
+the `sql` family includes the `sql` facet; the `http` family includes
+the `http` facet; the `k8s` family includes both the `http` facet
+(k8s traffic is HTTPS on the wire) and the `k8s` facet.
 
 ### Facet
 
-*Alias: **Family**.* The protocol class an [action](#action) belongs
-to. An action belongs to exactly one facet; built-in facets are `http`,
-`sql`, `ssh`, and `k8s`. A [rule](#rule)'s facet is inferred from its
-endpoint(s) at load time, and mixed-facet endpoint sets are a load
-error. Each facet exposes its own set of named matchable
-[fields](#facet-field) to a rule's CEL [`condition`](#cel-condition).
+A named collection of [fields](#facet-field) a [family](#family) folds
+into an [action](#action)'s data, addressable in a
+[rule](#rule)'s CEL [`condition`](#cel-condition) as `<facet>.<field>`.
+A facet is not the same as a family: a family is the protocol class an
+action belongs to, while a facet is a field group that contributes to
+the action's matchable surface. Built-in facets are `http`, `sql`, and
+`k8s`; most families include a single facet of the same name, but the
+`k8s` family includes both the `http` and `k8s` facets.
 
 ### Facet field
 
-*Alias: **Family field**.* A single named matchable property a
-[facet](#facet) exposes to a [rule](#rule)'s CEL
-[`condition`](#cel-condition), addressed as `<facet>.<field>` in CEL.
-Each facet defines its own group of fields — for example, the `sql`
-facet has `sql.verb`, `sql.functions`, `sql.tables`, `sql.statement`,
-and `sql.database`; the `http` facet has `http.method`, `http.path`,
-`http.query`, `http.headers`, `http.body`, and `http.body_json`; the
-`k8s` facet has `k8s.verb`, `k8s.resource`, `k8s.namespace`,
-`k8s.name`, and `k8s.params`. Per-field types vary — `method` and
-`verb` are scalar strings, `tables` / `functions` are lists,
-`query` / `headers` / `params` are maps, and `body_json` is parsed-JSON
-`dyn`.
+A single named matchable property a [facet](#facet) exposes to a
+[rule](#rule)'s CEL [`condition`](#cel-condition), addressed as
+`<facet>.<field>` in CEL. Each facet defines its own group of fields
+— the `sql` facet has `sql.verb`, `sql.functions`, `sql.tables`,
+`sql.statement`, and `sql.database`; the `http` facet has
+`http.method`, `http.path`, `http.query`, `http.headers`, `http.body`,
+and `http.body_json`; the `k8s` facet has `k8s.verb`, `k8s.resource`,
+`k8s.namespace`, `k8s.name`, and `k8s.params`. Per-field types vary —
+`method` and `verb` are scalar strings, `tables` / `functions` are
+lists, `query` / `headers` / `params` are maps, and `body_json` is
+parsed-JSON `dyn`.
 
 ### CEL condition
 
 The boolean expression a [rule](#rule)'s `condition = "..."` field
 carries. CEL ([Common Expression Language](https://github.com/google/cel-spec))
-is evaluated against the [facet fields](#facet-field) of the rule's
-inferred [facet](#facet). Idioms: equality / membership
+is evaluated against the [facet fields](#facet-field) the rule's
+inferred [family](#family) exposes. Idioms: equality / membership
 (`http.method == 'POST'`,
 `sql.verb in ['select', 'show']`), prefix / suffix / substring
 (`k8s.name.startsWith('debug-')`, `http.body.contains('secret')`),

--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -70,33 +70,39 @@ See [Configuration vocabulary](#configuration-vocabulary).
 
 One unit of agent work the gateway sees and applies policy to — one
 HTTP call, one SQL query, one `kubectl` invocation, one SSH command.
-Each action targets an [endpoint](#endpoint), is gated by the matching
-[rule](#rule)'s [outcome](#outcome), and surfaces in the dashboard's
-live request feed (action [families](#family): `http`, `sql`, `k8s`,
-`ssh`) with its own detail page. "Action" is the operator-visible concept of "the
-thing the agent did."
+Every action belongs to exactly one [family](#family) — the protocol
+class (`http`, `sql`, `ssh`, `k8s`) the gateway used to intercept it —
+and that family fixes the data the gateway extracts from the wire and
+exposes to policy. The action targets one [endpoint](#endpoint), the
+matching [rule](#rule)'s [outcome](#outcome) gates it, and it surfaces
+in the dashboard's live request feed with its own detail page.
+"Action" is the operator-visible concept of "the thing the agent did."
 
 ### Rule
 
 One policy decision targeting one or more [endpoints](#endpoint). A
 rule has a CEL [`condition`](#cel-condition) string that matches against
-the [facet fields](#facet-field) the rule's [family](#family) exposes
-(inferred from its endpoints), an optional `credential` predicate, and
-an [outcome](#outcome) — either a literal `verdict` or an
-`approve = [...]` chain. Rules are one HCL block kind
-(`rule "<name>" { ... }`); the family is inferred from the endpoint(s)
-at load time, and mixed-family endpoint sets are a load error.
+the [facet fields](#facet-field) those endpoints' [family](#family)
+exposes, an optional `credential` predicate, and an [outcome](#outcome)
+— either a literal `verdict` or an `approve = [...]` chain. All
+endpoints listed by one rule must share a family — mixed-family
+endpoint sets are a load error — so that the CEL condition sees a
+single, well-defined set of facet fields. Rules are one HCL block
+kind (`rule "<name>" { ... }`).
 
 ### Family
 
 The protocol class an [action](#action) belongs to. An action belongs
 to exactly one family; built-in families are `http`, `sql`, `ssh`, and
-`k8s`. A [rule](#rule)'s family is inferred from its endpoint(s) at
-load time, and mixed-family endpoint sets are a load error. Each
-family includes one or more [facets](#facet) into the action's data:
-the `sql` family includes the `sql` facet; the `http` family includes
-the `http` facet; the `k8s` family includes both the `http` facet
-(k8s traffic is HTTPS on the wire) and the `k8s` facet.
+`k8s`. An [endpoint](#endpoint)'s type carries an implied family — an
+`https` endpoint accepts `http` actions, a `postgres` endpoint accepts
+`sql` actions — and that propagates to [rules](#rule): all endpoints
+listed by one rule must share a family, so the rule's CEL condition
+sees a single, well-defined set of facet fields. Each family includes
+one or more [facets](#facet) into the action's data: the `sql` family
+includes the `sql` facet; the `http` family includes the `http` facet;
+the `k8s` family includes both the `http` facet (k8s traffic is HTTPS
+on the wire) and the `k8s` facet.
 
 ### Facet
 
@@ -127,8 +133,8 @@ parsed-JSON `dyn`.
 
 The boolean expression a [rule](#rule)'s `condition = "..."` field
 carries. CEL ([Common Expression Language](https://github.com/google/cel-spec))
-is evaluated against the [facet fields](#facet-field) the rule's
-inferred [family](#family) exposes. Idioms: equality / membership
+is evaluated against the [facet fields](#facet-field) exposed by the
+[family](#family) of the rule's endpoints. Idioms: equality / membership
 (`http.method == 'POST'`,
 `sql.verb in ['select', 'show']`), prefix / suffix / substring
 (`k8s.name.startsWith('debug-')`, `http.body.contains('secret')`),

--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -72,8 +72,8 @@ One unit of agent work the gateway sees and applies policy to — one
 HTTP call, one SQL query, one `kubectl` invocation, one SSH command.
 Each action targets an [endpoint](#endpoint), is gated by the matching
 [rule](#rule)'s [outcome](#outcome), and surfaces in the dashboard's
-live request feed (record kinds: `http`, `sql`, `k8s`, `ssh`) with its
-own detail page. "Action" is the operator-visible concept of "the
+live request feed (action [families](#facet): `http`, `sql`, `k8s`,
+`ssh`) with its own detail page. "Action" is the operator-visible concept of "the
 thing the agent did."
 
 ### Rule

--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -80,31 +80,44 @@ thing the agent did."
 
 One policy decision targeting one or more [endpoints](#endpoint). A
 rule has a CEL [`condition`](#cel-condition) string that matches against
-the [facets](#facet) of the rule's protocol family (inferred from its
-endpoints), an optional `credential` predicate, and an [outcome](#outcome)
-— either a literal `verdict` or an `approve = [...]` chain. Rules are
-one HCL block kind (`rule "<name>" { ... }`); the family is inferred
-from the endpoint(s) at load time, and mixed-family endpoint sets are
-a load error.
+the [facet fields](#facet-field) of the rule's [facet](#facet)
+(inferred from its endpoints), an optional `credential` predicate, and
+an [outcome](#outcome) — either a literal `verdict` or an
+`approve = [...]` chain. Rules are one HCL block kind
+(`rule "<name>" { ... }`); the facet is inferred from the endpoint(s)
+at load time, and mixed-facet endpoint sets are a load error.
 
 ### Facet
 
-A single named matchable property exposed to a [rule](#rule)'s CEL
-[`condition`](#cel-condition). Each protocol family exposes its own
-top-level struct-typed variable: `http.method` / `http.path` /
-`http.query` / `http.headers` / `http.body` / `http.body_json`;
-`sql.verb` / `sql.tables` / `sql.functions` / `sql.statement`;
-`k8s.verb` / `k8s.resource` / `k8s.namespace` / `k8s.name` /
-`k8s.params`. Per-facet types vary — `method` and `verb` are scalar
-strings, `tables` / `functions` are lists, `query` / `headers` /
-`params` are maps, and `body_json` is parsed-JSON `dyn`.
+*Alias: **Family**.* The protocol class an [action](#action) belongs
+to. An action belongs to exactly one facet; built-in facets are `http`,
+`sql`, `ssh`, and `k8s`. A [rule](#rule)'s facet is inferred from its
+endpoint(s) at load time, and mixed-facet endpoint sets are a load
+error. Each facet exposes its own set of named matchable
+[fields](#facet-field) to a rule's CEL [`condition`](#cel-condition).
+
+### Facet field
+
+*Alias: **Family field**.* A single named matchable property a
+[facet](#facet) exposes to a [rule](#rule)'s CEL
+[`condition`](#cel-condition), addressed as `<facet>.<field>` in CEL.
+Each facet defines its own group of fields — for example, the `sql`
+facet has `sql.verb`, `sql.functions`, `sql.tables`, `sql.statement`,
+and `sql.database`; the `http` facet has `http.method`, `http.path`,
+`http.query`, `http.headers`, `http.body`, and `http.body_json`; the
+`k8s` facet has `k8s.verb`, `k8s.resource`, `k8s.namespace`,
+`k8s.name`, and `k8s.params`. Per-field types vary — `method` and
+`verb` are scalar strings, `tables` / `functions` are lists,
+`query` / `headers` / `params` are maps, and `body_json` is parsed-JSON
+`dyn`.
 
 ### CEL condition
 
 The boolean expression a [rule](#rule)'s `condition = "..."` field
 carries. CEL ([Common Expression Language](https://github.com/google/cel-spec))
-is evaluated against the [facets](#facet) of the rule's inferred
-family. Idioms: equality / membership (`http.method == 'POST'`,
+is evaluated against the [facet fields](#facet-field) of the rule's
+inferred [facet](#facet). Idioms: equality / membership
+(`http.method == 'POST'`,
 `sql.verb in ['select', 'show']`), prefix / suffix / substring
 (`k8s.name.startsWith('debug-')`, `http.body.contains('secret')`),
 regex (`sql.statement.matches('(?i)\\bpassword\\b')`), list overlap


### PR DESCRIPTION
## Summary

The previous glossary treated **Facet** and **Family** as distinct
concepts. They are synonyms: both name the protocol class an action
belongs to (`http`, `sql`, `ssh`, `k8s`). The matchable properties a
rule's CEL condition reads are **facet fields** (alias: family fields).

## Changes (`site/doc/glossary.md`)

- Rewrote **Facet** to describe the protocol class, with **Family**
  called out as the alias. Lists the built-in facets.
- Added **Facet field** (alias: **Family field**) covering the
  per-facet field sets, with examples for `sql` (including
  `sql.database`), `http`, and `k8s`.
- Updated the **Rule** and **CEL condition** cross-references so links
  to matchable properties resolve to `#facet-field` rather than
  `#facet`.

Build: `cd site && npm run build` is clean.

## Follow-ups (not in this PR)

The same Facet-vs-Family-vs-facet-field framing isn't reflected in
`site/doc/approval-rules.md` or `config/README.md` — they still mix
"facet" and "family" loosely. Worth a separate pass.