### PR TITLE
site: landing-page reshape — hero, deploy, run-it, validated HCL examples

### DIFF
--- a/site/src/Landing.tsx
+++ b/site/src/Landing.tsx
@@ -4,6 +4,7 @@ import { AnalyticsSection } from "./sections/AnalyticsSection";
 import { ApproversSection } from "./sections/ApproversSection";
 import { ComparisonSection } from "./sections/ComparisonSection";
 import { CtaSection } from "./sections/CtaSection";
+import { DeploySection } from "./sections/DeploySection";
 import { HeroSection } from "./sections/HeroSection";
 import { ProblemSection } from "./sections/ProblemSection";
 import { RulesSection } from "./sections/RulesSection";
@@ -23,6 +24,7 @@ export function Landing() {
       <TestSection />
       <AnalyticsSection />
       <ComparisonSection />
+      <DeploySection />
       <CtaSection />
     </Layout>
   );

--- a/site/src/Landing.tsx
+++ b/site/src/Landing.tsx
@@ -15,10 +15,7 @@ export function Landing() {
     <Layout>
       <HeroSection />
       <ProblemSection />
-      <Wave
-        topColor="var(--color-canvas)"
-        bottomColor="var(--color-navy-600)"
-      />
+      <Wave topColor="var(--color-canvas)" bottomColor="var(--color-navy-600)" />
       <RulesSection />
       <ApproversSection />
       <TestSection />

--- a/site/src/Layout.tsx
+++ b/site/src/Layout.tsx
@@ -14,11 +14,7 @@ export function Layout({ children }: { children: ComponentChildren }) {
       </a>
       <Header />
       <Stripe color1="var(--color-navy-100)" />
-      <main
-        id="main"
-        tabindex={-1}
-        class="focus:outline-none focus-visible:outline-none"
-      >
+      <main id="main" tabindex={-1} class="focus:outline-none focus-visible:outline-none">
         {children}
       </main>
       <Stripe color1="var(--color-navy)" />

--- a/site/src/components/CrtDisplay.tsx
+++ b/site/src/components/CrtDisplay.tsx
@@ -1,12 +1,6 @@
 import type { ComponentChildren } from "preact";
 
-export function CrtDisplay({
-  title,
-  children,
-}: {
-  title?: string;
-  children: ComponentChildren;
-}) {
+export function CrtDisplay({ title, children }: { title?: string; children: ComponentChildren }) {
   return (
     <div
       class="md:squircle-xl bg-canvas py-[clamp(20px,3.5vw,34px)] md:p-[clamp(20px,3.5vw,34px)]"

--- a/site/src/components/DemoChart.tsx
+++ b/site/src/components/DemoChart.tsx
@@ -6,9 +6,16 @@ import * as Plot from "@observablehq/plot";
 
 const MS_TICKS = [0.1, 1, 10, 100, 1000, 10000];
 const PALETTE = [
-  "#4269d0", "#efb118", "#ff725c", "#6cc5b0",
-  "#3ca951", "#ff8ab7", "#a463f2", "#97bbf5",
-  "#9c6b4e", "#9498a0",
+  "#4269d0",
+  "#efb118",
+  "#ff725c",
+  "#6cc5b0",
+  "#3ca951",
+  "#ff8ab7",
+  "#a463f2",
+  "#97bbf5",
+  "#9c6b4e",
+  "#9498a0",
 ];
 const STATUS_COLORS = {
   domain: ["2xx", "3xx", "4xx", "5xx"],
@@ -38,25 +45,19 @@ type Dot = {
   logMs: number;
 };
 
-export function renderChart(
-  container: HTMLElement,
-  rawData: [string, number, number, string][],
-) {
-  const allDots: Dot[] = rawData.map(
-    ([t, us, status, host]) => {
-      const ms = Math.max(us / 1000, 0.1);
-      return {
-        t: new Date(t),
-        ms,
-        host,
-        status: statusCls(status),
-        logMs: Math.log10(ms),
-      };
-    },
-  );
+export function renderChart(container: HTMLElement, rawData: [string, number, number, string][]) {
+  const allDots: Dot[] = rawData.map(([t, us, status, host]) => {
+    const ms = Math.max(us / 1000, 0.1);
+    return {
+      t: new Date(t),
+      ms,
+      host,
+      status: statusCls(status),
+      logMs: Math.log10(ms),
+    };
+  });
 
-  const allHosts = [...new Set(allDots.map((d) => d.host))]
-    .sort();
+  const allHosts = [...new Set(allDots.map((d) => d.host))].sort();
 
   let colorBy: ColorBy = "host";
   const activeHosts = new Set<string>();
@@ -74,20 +75,19 @@ export function renderChart(
     // When one or more hosts are active, dim the others instead of filtering
     // them out — the dataset stays intact, only the highlight shifts.
     const hasSelection = activeHosts.size > 0;
-    const dotOpacity = (d: Dot) =>
-      !hasSelection || activeHosts.has(d.host) ? 0.75 : 0.22;
+    const dotOpacity = (d: Dot) => (!hasSelection || activeHosts.has(d.host) ? 0.75 : 0.22);
     const colors = getColors(colorBy);
     const w = container.clientWidth || 800;
 
     container.innerHTML = "";
 
     // --- Toolbar ---
-    const toolbar = el("div",
-      "flex items-center gap-3 mb-2 flex-wrap");
+    const toolbar = el("div", "flex items-center gap-3 mb-2 flex-wrap");
 
-    const title = el("span",
-      "text-[11px] font-semibold uppercase " +
-      "tracking-wider text-navy-200");
+    const title = el(
+      "span",
+      "text-[11px] font-semibold uppercase " + "tracking-wider text-navy-200",
+    );
     title.textContent = "RESPONSE LATENCY";
     toolbar.appendChild(title);
 
@@ -105,10 +105,12 @@ export function renderChart(
     if (hasSelection) {
       const pills = el("div", "flex flex-wrap gap-1.5 mb-2");
       for (const host of activeHosts) {
-        const pill = el("button",
+        const pill = el(
+          "button",
           "inline-flex items-center gap-1 px-2 py-0.5 " +
-          "text-xs bg-navy-200/20 text-navy-200 " +
-          "rounded cursor-pointer");
+            "text-xs bg-navy-200/20 text-navy-200 " +
+            "rounded cursor-pointer",
+        );
         pill.textContent = `${host} ✕`;
         (pill as HTMLButtonElement).onclick = () => {
           activeHosts.delete(host);
@@ -117,9 +119,11 @@ export function renderChart(
         pills.appendChild(pill);
       }
       if (activeHosts.size > 1) {
-        const clear = el("button",
+        const clear = el(
+          "button",
           "inline-flex items-center px-2 py-0.5 " +
-          "text-xs text-navy-200/60 hover:text-navy-200 cursor-pointer");
+            "text-xs text-navy-200/60 hover:text-navy-200 cursor-pointer",
+        );
         clear.textContent = "clear all";
         (clear as HTMLButtonElement).onclick = () => {
           activeHosts.clear();
@@ -152,9 +156,7 @@ export function renderChart(
         label: "\u2191 Duration (ms)",
         grid: true,
         nice: true,
-        ...(logScale
-          ? { ticks: MS_TICKS, tickFormat: fmtMs }
-          : {}),
+        ...(logScale ? { ticks: MS_TICKS, tickFormat: fmtMs } : {}),
       },
       color: { ...colors, legend: true },
       style: {
@@ -167,9 +169,7 @@ export function renderChart(
     // like "plot-abc123-swatch" on each <span>; use [class$="-swatch"] so we
     // don't also match the container ("-swatches") or wrap ("-swatches-wrap"),
     // which would yank in the injected <style> block and every label.
-    const swatches = scatter.querySelectorAll<HTMLElement>(
-      '[class$="-swatch"]',
-    );
+    const swatches = scatter.querySelectorAll<HTMLElement>('[class$="-swatch"]');
     swatches.forEach((swatch) => {
       const label = swatch.textContent?.trim() ?? "";
       swatch.style.cursor = "pointer";
@@ -191,9 +191,10 @@ export function renderChart(
     container.appendChild(scatter);
 
     // --- Histogram ---
-    const histTitle = el("div",
-      "text-[11px] font-semibold uppercase " +
-      "tracking-wider text-navy-200 mt-4 mb-1");
+    const histTitle = el(
+      "div",
+      "text-[11px] font-semibold uppercase " + "tracking-wider text-navy-200 mt-4 mb-1",
+    );
     histTitle.textContent = "LATENCY HISTOGRAM";
     container.appendChild(histTitle);
 
@@ -221,12 +222,7 @@ export function renderChart(
             Plot.binX({ y: "count" }, binOpts({ tip: true })),
           ),
         ]
-      : [
-          Plot.rectY(
-            allDots,
-            Plot.binX({ y: "count" }, binOpts({ tip: true })),
-          ),
-        ];
+      : [Plot.rectY(allDots, Plot.binX({ y: "count" }, binOpts({ tip: true })))];
 
     const hist = Plot.plot({
       marks: histMarks,
@@ -269,23 +265,19 @@ function el(tag: string, className: string) {
   return e;
 }
 
-function btnGroup(
-  options: string[],
-  active: string,
-  onChange: (v: string) => void,
-) {
+function btnGroup(options: string[], active: string, onChange: (v: string) => void) {
   const group = el("div", "flex gap-0.5");
   for (const opt of options) {
-    const btn = el("button",
+    const btn = el(
+      "button",
       `px-2 py-0.5 text-[10px] font-medium ${
         opt === active
           ? "bg-navy-200 text-console-dark"
-          : "bg-console-dark/50 text-navy-200/60 " +
-            "hover:text-navy-200"
-      }`);
+          : "bg-console-dark/50 text-navy-200/60 " + "hover:text-navy-200"
+      }`,
+    );
     btn.textContent = opt;
-    (btn as HTMLButtonElement).onclick = () =>
-      onChange(opt);
+    (btn as HTMLButtonElement).onclick = () => onChange(opt);
     group.appendChild(btn);
   }
   return group;

--- a/site/src/components/FlowDiagram.tsx
+++ b/site/src/components/FlowDiagram.tsx
@@ -14,10 +14,7 @@ export function FlowDiagram() {
 
       <Riser />
 
-      <CenterNode
-        label="Claw Patrol"
-        sub="rules · approvals · credentials · analytics"
-      />
+      <CenterNode label="Claw Patrol" sub="rules approvals credentials analytics" />
 
       <Risers count={4} />
 
@@ -34,9 +31,7 @@ export function FlowDiagram() {
 function CardRow({ children }: { children: ComponentChildren }) {
   // pr-2 / pb-2 reserves room for the stacked-card shadows so they
   // don't touch the column edge or the arrows below.
-  return (
-    <div class="grid grid-cols-4 gap-3 w-full pr-2 pb-2">{children}</div>
-  );
+  return <div class="grid grid-cols-4 gap-3 w-full pr-2 pb-2">{children}</div>;
 }
 
 function ProductionNode() {
@@ -45,14 +40,12 @@ function ProductionNode() {
       class="squircle-md w-full bg-canvas border border-navy-200
         text-text px-5 py-5 text-center"
     >
-      <div class="font-display font-bold text-xl leading-none">
-        Production
-      </div>
+      <div class="font-display font-bold text-xl leading-none">Production</div>
       <div
         class="font-mono text-[11px] uppercase tracking-wider mt-2
           text-text-muted text-balance"
       >
-        postgres · clickhouse · k8s · aws · gcp · github · slack · notion · …
+        postgres clickhouse kubernetes aws gcp github slack vultr whatever
       </div>
     </div>
   );
@@ -61,13 +54,7 @@ function ProductionNode() {
 function Riser() {
   return (
     <div class="w-full flex justify-center my-2">
-      <svg
-        width="16"
-        height="28"
-        viewBox="0 0 16 28"
-        class="text-navy-300"
-        aria-hidden="true"
-      >
+      <svg width="16" height="28" viewBox="0 0 16 28" class="text-navy-300" aria-hidden="true">
         <path
           d="M 8 28 V 5"
           stroke="currentColor"
@@ -104,16 +91,7 @@ function Card({ name, icon }: { name: string; icon?: string }) {
         px-2 py-3 bg-canvas border border-navy-200 min-w-0"
       style={{ boxShadow: stack }}
     >
-      {icon ? (
-        <img
-          src={icon}
-          alt=""
-          class="w-6 h-6"
-          aria-hidden="true"
-        />
-      ) : (
-        <RobotGlyph />
-      )}
+      {icon ? <img src={icon} alt="" class="w-6 h-6" aria-hidden="true" /> : <RobotGlyph />}
       <div
         class="font-display font-semibold text-[11.5px] text-text-muted
           leading-tight text-center text-balance"
@@ -170,11 +148,7 @@ function CenterNode({ label, sub }: { label: string; sub: string }) {
       class="squircle-md w-full bg-navy-100 text-text border border-navy
         px-5 py-5 text-center"
     >
-      <img
-        src="/claw-patrol-logo.svg"
-        alt={label}
-        class="h-8 sm:h-10 w-auto mx-auto"
-      />
+      <img src="/claw-patrol-logo.svg" alt={label} class="h-8 sm:h-10 w-auto mx-auto" />
       <div
         class="font-mono text-[11px] uppercase tracking-wider mt-2
           text-text-muted"

--- a/site/src/components/HclCode.tsx
+++ b/site/src/components/HclCode.tsx
@@ -78,15 +78,15 @@ const CLASS: Record<Tok["kind"], string> = {
   txt: "",
 };
 
-export function HclCode(
-  { source, class: cls }: { source: string; class?: string },
-) {
+export function HclCode({ source, class: cls }: { source: string; class?: string }) {
   const toks = tokenize(source);
   return (
     <pre class={cls ?? ""}>
       <code>
         {toks.map((t, i) => (
-          <span key={i} class={CLASS[t.kind]}>{t.text}</span>
+          <span key={i} class={CLASS[t.kind]}>
+            {t.text}
+          </span>
         ))}
       </code>
     </pre>

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -27,18 +27,8 @@ export function Header() {
           >
             GitHub
           </a>
-          <Button
-            href="/docs/getting-started/"
-            size="sm"
-            class="inline-flex items-center gap-2"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 14 14"
-              fill="none"
-              aria-hidden="true"
-            >
+          <Button href="/docs/getting-started/" size="sm" class="inline-flex items-center gap-2">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
               <path
                 d="M7 1.5v7.25m0 0L4 5.75m3 3 3-3M2.25 12h9.5"
                 stroke="currentColor"

--- a/site/src/components/InstallTerminal.tsx
+++ b/site/src/components/InstallTerminal.tsx
@@ -8,11 +8,7 @@ type Variant = "compact" | "expanded";
 //   • compact — used inline (e.g. hero column).
 //   • expanded — bigger padding and type for standalone use as a
 //     section's primary install affordance.
-export function InstallTerminal({
-  variant = "compact",
-}: {
-  variant?: Variant;
-}) {
+export function InstallTerminal({ variant = "compact" }: { variant?: Variant }) {
   const [copied, setCopied] = useState(false);
 
   async function copy() {

--- a/site/src/components/ProblemCard.tsx
+++ b/site/src/components/ProblemCard.tsx
@@ -1,18 +1,8 @@
-export function ProblemCard({
-  headline,
-  body,
-}: {
-  headline: string;
-  body: string;
-}) {
+export function ProblemCard({ headline, body }: { headline: string; body: string }) {
   return (
     <div class="p-8 rounded-sm bg-canvas-dark border border-navy-200">
-      <p class="text-base font-semibold mb-3 text-console-dark font-display">
-        {headline}
-      </p>
-      <p class="text-[15px]  text-text-muted font-sans">
-        {body}
-      </p>
+      <p class="text-base font-semibold mb-3 text-console-dark font-display">{headline}</p>
+      <p class="text-[15px]  text-text-muted font-sans">{body}</p>
     </div>
   );
 }

--- a/site/src/components/SectionLabel.tsx
+++ b/site/src/components/SectionLabel.tsx
@@ -21,19 +21,9 @@ export function SectionLabel({ children }: { children: string }) {
 // the skew, and the slanted edges of the resulting parallelogram
 // trimmed those stripes at subpixel boundaries.
 const Stripes = () => (
-  <svg
-    width="48"
-    height="16"
-    viewBox="0 0 48 16"
-    class="text-rust"
-    aria-hidden="true"
-  >
+  <svg width="48" height="16" viewBox="0 0 48 16" class="text-rust" aria-hidden="true">
     {[0, 8, 16, 24, 32, 40].map((x) => (
-      <path
-        key={x}
-        d={`M ${x + 4} 0 L ${x + 8} 0 L ${x + 4} 16 L ${x} 16 Z`}
-        fill="currentColor"
-      />
+      <path key={x} d={`M ${x + 4} 0 L ${x + 8} 0 L ${x + 4} 16 L ${x} 16 Z`} fill="currentColor" />
     ))}
   </svg>
 );

--- a/site/src/components/TypeLine.tsx
+++ b/site/src/components/TypeLine.tsx
@@ -66,8 +66,7 @@ export function TypeBlock({
           {line.split("").map((ch, i) => {
             const globalIdx = charIndex++;
             const charStart = startPct + (globalIdx / totalChars) * range;
-            const charEnd =
-              startPct + ((globalIdx + 1) / totalChars) * range;
+            const charEnd = startPct + ((globalIdx + 1) / totalChars) * range;
             return (
               <span
                 key={i}

--- a/site/src/components/Wave.tsx
+++ b/site/src/components/Wave.tsx
@@ -7,11 +7,7 @@ type WaveArgs = {
   height?: string;
 };
 
-export function Wave({
-  topColor,
-  bottomColor,
-  height = "h-32",
-}: WaveArgs) {
+export function Wave({ topColor, bottomColor, height = "h-32" }: WaveArgs) {
   return (
     <div
       class={`relative w-full overflow-clip ${height}`}

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -11,48 +11,40 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/source-sans-3/SourceSans3-Regular--latin_basic.woff2")
-    format("woff2");
+  src: url("/fonts/source-sans-3/SourceSans3-Regular--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Source Sans 3";
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/source-sans-3/SourceSans3-It--latin_basic.woff2")
-    format("woff2");
+  src: url("/fonts/source-sans-3/SourceSans3-It--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Source Sans 3";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/source-sans-3/SourceSans3-Bold--latin_basic.woff2")
-    format("woff2");
+  src: url("/fonts/source-sans-3/SourceSans3-Bold--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Source Sans 3";
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/source-sans-3/SourceSans3-BoldIt--latin_basic.woff2")
-    format("woff2");
+  src: url("/fonts/source-sans-3/SourceSans3-BoldIt--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* Gazpacho — display serif. Static cuts, latin-basic subset. */
@@ -63,9 +55,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Thin.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -74,9 +65,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Light.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -85,9 +75,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Regular.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -96,9 +85,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Medium.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -107,9 +95,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Bold.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -118,9 +105,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Heavy.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -129,9 +115,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/Gazpacho-Black.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -140,9 +125,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Thin.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -151,9 +135,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Light.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -162,9 +145,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Regular.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -173,9 +155,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Medium.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -184,9 +165,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Bold.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -195,9 +175,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Heavy.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Gazpacho";
@@ -206,9 +185,8 @@
   font-display: swap;
   src: url("/fonts/gazpacho/GazpachoItalic-Black.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* IBM Plex Mono — code/mono family. Two weights (Regular 400, SemiBold
@@ -220,9 +198,8 @@
   font-display: swap;
   src: url("/fonts/IBMPlexMono-Regular--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "IBM Plex Mono";
@@ -231,9 +208,8 @@
   font-display: swap;
   src: url("/fonts/IBMPlexMono-SemiBold--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "IBM Plex Mono";
@@ -242,21 +218,18 @@
   font-display: swap;
   src: url("/fonts/IBMPlexMono-Italic--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "IBM Plex Mono";
   font-style: italic;
   font-weight: 600;
   font-display: swap;
-  src: url("/fonts/IBMPlexMono-SemiBoldItalic--latin_basic.woff2")
-    format("woff2");
+  src: url("/fonts/IBMPlexMono-SemiBoldItalic--latin_basic.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* Basic Sans (Latinotype) — body family. Static cuts, latin-basic subset. */
@@ -270,9 +243,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-Thin.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -284,9 +256,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-ThinIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -298,9 +269,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-ExtraLight.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -312,9 +282,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-ExtraLightIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -326,9 +295,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-Light.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -340,9 +308,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-LightIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -354,9 +321,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-Regular.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -368,9 +334,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-RegularIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -382,9 +347,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-SemiBold.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -396,9 +360,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-SemiBoldIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -410,9 +373,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-Bold.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -424,9 +386,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-BoldIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -438,9 +399,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-Black.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: "Basic Sans";
@@ -452,9 +412,8 @@
   font-display: swap;
   src: url("/fonts/basic-sans/BasicSans-BlackIt.woff2") format("woff2");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @utility neu-raised {
@@ -471,49 +430,15 @@
   box-shadow:
     /* Outer shadows — cast onto the background surface */
     -8px -12px 24px
-      color-mix(
-        in oklch,
-        var(--bg-highlight) var(--bg-highlight-opacity),
-        transparent
-      ),
-    -6px -8px 16px
-      color-mix(
-        in oklch,
-        var(--bg-highlight) var(--bg-highlight-opacity),
-        transparent
-      ),
-    2px 3px 2px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
-    4px 3px 6px 4px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
-    10px 8px 16px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
-    8px 6px 12px 2px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
+      color-mix(in oklch, var(--bg-highlight) var(--bg-highlight-opacity), transparent),
+    -6px -8px 16px color-mix(in oklch, var(--bg-highlight) var(--bg-highlight-opacity), transparent),
+    2px 3px 2px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
+    4px 3px 6px 4px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
+    10px 8px 16px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
+    8px 6px 12px 2px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
     2px 3px 1px 2px color-mix(in oklch, var(--neu-face) 90%, transparent),
-    /* Inner scoop — on the element's own "face," i.e., the element's bg */
-      inset 2px 2px 3px -1px
-      color-mix(
-        in oklch,
-        var(--face-highlight) var(--face-highlight-opacity),
-        transparent
-      );
+    /* Inner scoop — on the element's own "face," i.e., the element's bg */ inset 2px 2px 3px -1px
+      color-mix(in oklch, var(--face-highlight) var(--face-highlight-opacity), transparent);
 }
 
 /* Pressed-in variant — same shadow directions, reduced distances so the button
@@ -521,49 +446,15 @@
 a.neu-raised:active {
   transform: translate(0.125rem, 0.125rem);
   box-shadow:
-    -4px -6px 12px
-      color-mix(
-        in oklch,
-        var(--bg-highlight) var(--bg-highlight-opacity),
-        transparent
-      ),
-    -3px -4px 8px
-      color-mix(
-        in oklch,
-        var(--bg-highlight) var(--bg-highlight-opacity),
-        transparent
-      ),
-    1px 2px 1px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
-    2px 2px 3px 2px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
-    5px 4px 8px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
-    4px 3px 6px 1px
-      color-mix(
-        in oklch,
-        var(--bg-shadow) var(--bg-shadow-opacity),
-        transparent
-      ),
+    -4px -6px 12px color-mix(in oklch, var(--bg-highlight) var(--bg-highlight-opacity), transparent),
+    -3px -4px 8px color-mix(in oklch, var(--bg-highlight) var(--bg-highlight-opacity), transparent),
+    1px 2px 1px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
+    2px 2px 3px 2px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
+    5px 4px 8px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
+    4px 3px 6px 1px color-mix(in oklch, var(--bg-shadow) var(--bg-shadow-opacity), transparent),
     1px 2px 1px 1px color-mix(in oklch, var(--neu-face) 90%, transparent),
     inset 1px 1px 2px -1px
-      color-mix(
-        in oklch,
-        var(--face-highlight) var(--face-highlight-opacity),
-        transparent
-      );
+      color-mix(in oklch, var(--face-highlight) var(--face-highlight-opacity), transparent);
 }
 
 @keyframes crt-refresh {
@@ -838,11 +729,10 @@ a.neu-raised:active {
 
   --font-display: "Basic Sans", "Gazpacho", system-ui, serif;
   --font-sans:
-    "Source Sans 3", "Public Sans", "Eastman", "Courier New",
-    "American Typewriter", "Chronica Pro", "Basic Sans", system-ui, sans-serif;
+    "Source Sans 3", "Public Sans", "Eastman", "Courier New", "American Typewriter", "Chronica Pro",
+    "Basic Sans", system-ui, sans-serif;
   --font-mono:
-    "IBM Plex Mono", "MonoLisa", "DankMono Nerd Font", "SF Mono", "Menlo",
-    ui-monospace, monospace;
+    "IBM Plex Mono", "MonoLisa", "DankMono Nerd Font", "SF Mono", "Menlo", ui-monospace, monospace;
 
   --breakpoint-xs: 32rem;
 

--- a/site/src/sections/AnalyticsSection.tsx
+++ b/site/src/sections/AnalyticsSection.tsx
@@ -13,8 +13,8 @@ export function AnalyticsSection() {
           class="text-center max-w-2xl mx-auto mb-16 mt-4
           text-text-muted"
         >
-          Thousands of requests across dozens of services. Claw Patrol captures
-          it all passively, with zero instrumentation.
+          Thousands of requests across dozens of services. Claw Patrol captures it all passively,
+          with zero instrumentation.
         </p>
       </div>
 

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -172,7 +172,7 @@ export function ApproversSection() {
           </h3>
           <p class="text-base  text-text-muted">
             Defer the ambiguous requests. A model with your prompt, or a person
-            in Slack — you decide which one runs when.
+            in Slack. You decide which one runs when.
           </p>
         </div>
 

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -29,15 +29,8 @@ function DiagramFrame({ children }: { children: ComponentChildren }) {
   );
 }
 
-function VerdictPill({
-  label,
-  kind = "deny",
-}: {
-  label: string;
-  kind?: "deny" | "allow";
-}) {
-  const styles =
-    kind === "allow" ? "bg-rust text-text" : "bg-navy-700 text-canvas";
+function VerdictPill({ label, kind = "deny" }: { label: string; kind?: "deny" | "allow" }) {
+  const styles = kind === "allow" ? "bg-rust text-text" : "bg-navy-700 text-canvas";
   return (
     <div class="flex justify-center">
       <span
@@ -56,9 +49,7 @@ function LlmDiagram() {
   return (
     <DiagramFrame>
       <div class="bg-canvas squircle-sm px-3 py-2 font-mono text-[12px] ">
-        <div class="text-text-subtle text-[10px] uppercase tracking-[0.18em] mb-1">
-          incoming
-        </div>
+        <div class="text-text-subtle text-[10px] uppercase tracking-[0.18em] mb-1">incoming</div>
         <code class="text-text">
           POST /tickets/reply {"{ "}body: "RTFM you moron"{" }"}
         </code>
@@ -69,8 +60,7 @@ function LlmDiagram() {
           AI
         </div>
         <div class="bg-canvas border border-rust-100 squircle-sm px-3 py-2 text-[12px]  text-text-muted">
-          Reply body contains banned term{" "}
-          <code class="text-text font-mono">moron</code>.
+          Reply body contains banned term <code class="text-text font-mono">moron</code>.
         </div>
       </div>
 
@@ -153,9 +143,7 @@ function ApproverCard({
 function OrDivider() {
   return (
     <div class="flex justify-center lg:self-center">
-      <span class="font-display font-black uppercase text-rust text-2xl">
-        - or -
-      </span>
+      <span class="font-display font-black uppercase text-rust text-2xl">- or -</span>
     </div>
   );
 }
@@ -171,8 +159,8 @@ export function ApproversSection() {
             Humans, models, <span class="text-rust">your call</span>
           </h3>
           <p class="text-base  text-text-muted">
-            Defer the ambiguous requests. A model with your prompt, or a person
-            in Slack. You decide which one runs when.
+            Defer the ambiguous requests. A model with your prompt, or a person in Slack. You decide
+            which one runs when.
           </p>
         </div>
 

--- a/site/src/sections/ComparisonSection.tsx
+++ b/site/src/sections/ComparisonSection.tsx
@@ -35,8 +35,7 @@ const CATEGORIES: Category[] = [
           { name: "Lakera Guard", url: "https://www.lakera.ai/lakera-guard" },
           {
             name: "Google Model Armor",
-            url:
-              "https://cloud.google.com/security-command-center/docs/model-armor-overview",
+            url: "https://cloud.google.com/security-command-center/docs/model-armor-overview",
           },
           {
             name: "AWS Bedrock Guardrails",
@@ -62,9 +61,7 @@ const CATEGORIES: Category[] = [
         ],
       },
     ],
-    gap:
-      "HTTP only. Non-HTTP protocols like Postgres, k8s, and SSH bypass " +
-      "them entirely.",
+    gap: "HTTP only. Non-HTTP protocols like Postgres, k8s, and SSH bypass " + "them entirely.",
   },
   {
     title: "Sandbox the process",
@@ -97,18 +94,11 @@ const CATEGORIES: Category[] = [
         ],
       },
     ],
-    gap:
-      "Secrets stay outside the agent, but the request content itself " +
-      "passes through.",
+    gap: "Secrets stay outside the agent, but the request content itself " + "passes through.",
   },
 ];
 
-const COLOR_CLASSES = [
-  "bg-rust-100",
-  "bg-navy-100",
-  "bg-butter-100",
-  "bg-canvas",
-];
+const COLOR_CLASSES = ["bg-rust-100", "bg-navy-100", "bg-butter-100", "bg-canvas"];
 
 export function ComparisonSection() {
   return (
@@ -119,11 +109,7 @@ export function ComparisonSection() {
         </div>
         <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6 sm:mb-8">
           {CATEGORIES.map((c, i) => (
-            <CategoryCard
-              key={c.title}
-              category={c}
-              colorClass={COLOR_CLASSES[i]}
-            />
+            <CategoryCard key={c.title} category={c} colorClass={COLOR_CLASSES[i]} />
           ))}
         </div>
         <SynthesisCard />
@@ -132,16 +118,12 @@ export function ComparisonSection() {
   );
 }
 
-function CategoryCard(
-  { category: c, colorClass }: { category: Category; colorClass: string },
-) {
+function CategoryCard({ category: c, colorClass }: { category: Category; colorClass: string }) {
   return (
     <div class="bg-transparent relative squircle-sm p-6 flex flex-col">
       <div class="absolute w-full h-full border-navy border-2 squircle-sm inset-0 z-10" />
       <div class="relative z-10 flex-1">
-        <h4 class="text-xl font-display font-bold text-text mb-4">
-          {c.title}
-        </h4>
+        <h4 class="text-xl font-display font-bold text-text mb-4">{c.title}</h4>
         <div class="space-y-3">
           {c.groups.map((g, i) => (
             <div key={g.label ?? i}>
@@ -174,10 +156,7 @@ function CategoryCard(
       >
         {c.gap}
       </p>
-      <div
-        class={"isolate absolute w-full h-full squircle-sm top-1.5 left-2 z-0 " +
-          colorClass}
-      />
+      <div class={"isolate absolute w-full h-full squircle-sm top-1.5 left-2 z-0 " + colorClass} />
     </div>
   );
 }
@@ -186,21 +165,13 @@ function SynthesisCard() {
   return (
     <div class="p-6 sm:p-8 squircle-md bg-rust-200 border-2 border-navy">
       <div class="flex items-center gap-3 mb-3">
-        <img
-          src="/claw-patrol-icon.svg"
-          alt=""
-          class="w-8 h-8"
-          aria-hidden="true"
-        />
-        <h4 class="font-display font-bold text-2xl sm:text-3xl text-text">
-          Claw Patrol
-        </h4>
+        <img src="/claw-patrol-icon.svg" alt="" class="w-8 h-8" aria-hidden="true" />
+        <h4 class="font-display font-bold text-2xl sm:text-3xl text-text">Claw Patrol</h4>
       </div>
       <p class="text-text text-[15px] sm:text-base max-w-3xl leading-relaxed">
-        Watches the tool call at the protocol layer (Postgres, Kubernetes,
-        ClickHouse, HTTPS, SSH), so rules match SQL verbs and k8s resources
-        directly. Holds the secrets. Routes risky calls to a human or an LLM
-        judge. Records every byte. Doesn't try to be an LLM gateway or a
+        Watches the tool call at the protocol layer (Postgres, Kubernetes, ClickHouse, HTTPS, SSH),
+        so rules match SQL verbs and k8s resources directly. Holds the secrets. Routes risky calls
+        to a human or an LLM judge. Records every byte. Doesn't try to be an LLM gateway or a
         process sandbox; use a specialized tool if you need those.
       </p>
     </div>

--- a/site/src/sections/CtaSection.tsx
+++ b/site/src/sections/CtaSection.tsx
@@ -13,9 +13,7 @@ export function CtaSection() {
         class="max-w-lg mx-auto text-base sm:text-lg
          mb-10 text-text-muted"
       >
-        The proxy handles your secrets — it must be auditable. MIT licensed.
-        Multiple agents share secrets and endpoints, each with their own
-        policies.
+        The proxy handles your secrets. It must be auditable. MIT licensed.
       </p>
       <img
         src="/clawpatrol.png"

--- a/site/src/sections/DeploySection.tsx
+++ b/site/src/sections/DeploySection.tsx
@@ -51,8 +51,7 @@ export function DeploySection() {
         <SectionLabel>Run it</SectionLabel>
         <div class="max-w-3xl mx-auto text-center mb-12 sm:mb-16">
           <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-balance mb-5 text-text">
-            Wrap one agent{" "}
-            <span class="text-rust">or a whole machine.</span>
+            Wrap one agent <span class="text-rust">or a whole machine.</span>
           </h3>
         </div>
 
@@ -63,9 +62,7 @@ export function DeploySection() {
               class="bg-canvas border border-navy-200 squircle-md
                 p-6 flex flex-col gap-4"
             >
-              <h4 class="text-xl font-display font-bold text-text">
-                {m.title}
-              </h4>
+              <h4 class="text-xl font-display font-bold text-text">{m.title}</h4>
               <Terminal source={m.command} />
               <p class="text-sm text-text-muted">{m.body}</p>
             </div>

--- a/site/src/sections/DeploySection.tsx
+++ b/site/src/sections/DeploySection.tsx
@@ -1,0 +1,77 @@
+import { SectionLabel } from "../components/SectionLabel";
+
+/* ──────────────────────────────────────────────────────────────────────
+   Deploy — three real CLI invocations that map to the three deployment
+   shapes operators ask about: wrap one agent, route a whole machine,
+   or run the gateway itself.
+   ──────────────────────────────────────────────────────────────────── */
+
+const MODES: { title: string; command: string; body: string }[] = [
+  {
+    title: "Single process",
+    command: "$ clawpatrol run claude",
+    body:
+      "Wrap a single command along with all its subprocesses. On " +
+      "Linux a network namespace is created that intercepts and " +
+      "forwards all of its traffic over WireGuard.",
+  },
+  {
+    title: "Whole machine",
+    command: "$ clawpatrol join https://gw.example.com \\\n    --whole-machine",
+    body:
+      "Bring up a WireGuard tunnel; every outbound packet from the " +
+      "host routes through the gateway. Or run `clawpatrol login` " +
+      "to join over Tailscale instead.",
+  },
+  {
+    title: "Run the gateway",
+    command: "$ clawpatrol gateway config.hcl",
+    body:
+      "The proxy itself. A single binary that loads your HCL config " +
+      "and accepts clients tunneling in via WireGuard or Tailscale.",
+  },
+];
+
+function Terminal({ source }: { source: string }) {
+  return (
+    <pre
+      class="text-[13px] font-mono leading-relaxed
+        bg-navy text-canvas/85 squircle-md px-4 py-3
+        overflow-x-auto border border-navy-700 whitespace-pre"
+    >
+      <code>{source}</code>
+    </pre>
+  );
+}
+
+export function DeploySection() {
+  return (
+    <section class="bg-canvas-muted py-24 sm:py-32">
+      <div class="max-w-6xl mx-auto px-6 sm:px-8">
+        <SectionLabel>Deploy</SectionLabel>
+        <div class="max-w-3xl mx-auto text-center mb-12 sm:mb-16">
+          <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-balance mb-5 text-text">
+            Wrap one agent{" "}
+            <span class="text-rust">or a whole machine.</span>
+          </h3>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {MODES.map((m) => (
+            <div
+              key={m.title}
+              class="bg-canvas border border-navy-200 squircle-md
+                p-6 flex flex-col gap-4"
+            >
+              <h4 class="text-xl font-display font-bold text-text">
+                {m.title}
+              </h4>
+              <Terminal source={m.command} />
+              <p class="text-sm text-text-muted">{m.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/site/src/sections/DeploySection.tsx
+++ b/site/src/sections/DeploySection.tsx
@@ -48,7 +48,7 @@ export function DeploySection() {
   return (
     <section class="bg-canvas-muted py-24 sm:py-32">
       <div class="max-w-6xl mx-auto px-6 sm:px-8">
-        <SectionLabel>Deploy</SectionLabel>
+        <SectionLabel>Run it</SectionLabel>
         <div class="max-w-3xl mx-auto text-center mb-12 sm:mb-16">
           <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-balance mb-5 text-text">
             Wrap one agent{" "}

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -37,8 +37,8 @@ export function HeroSection() {
             class="mb-10 max-w-lg
             text-text-muted"
           >
-            Claw Patrol holds agent credentials, parses their traffic at the wire, and gates
-            actions they take with rules you write. Block <code>DROP TABLE</code>. Have a human approve{" "}
+            Claw Patrol holds agent credentials, parses their traffic at the wire, and gates actions
+            they take with rules you write. Block <code>DROP TABLE</code>. Have a human approve{" "}
             <code>kubectl delete pod</code>. Keep an audit log of every action.
           </p>
           <InstallTerminal />

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -6,26 +6,20 @@ const PROBLEMS = [
     body:
       "OAuth scopes, API keys, IAM roles, k8s RBAC: every " +
       "service has its own access model, and configuring each " +
-      "correctly is its own project. Even when you get it right, " +
-      "a prompt-injected agent will exploit whatever access you " +
-      "granted.",
+      "correctly is its own project.",
   },
   {
     title: "Your agent shouldn't see secrets",
     body:
-      "Every API key in the agent's env is one you've handed " +
-      "over. If the process is compromised (and prompts can " +
-      "compromise it), the keys leak with it. Rotation is hard, " +
-      "and you can't easily revoke a single action's worth of " +
-      "access.",
+      "If the agent is compromised (prompt " +
+      "injection), the keys leak with it.",
   },
   {
     title: "Logs don't capture the action",
     body:
       "Reconstructing what an agent did means stitching together " +
-      "per-service logs, which usually don't capture the actual " +
-      "request payload. And by the time you notice the bad " +
-      "action, it's already gone through.",
+      "per-service logs. When you have a fleet of agents this becomes " +
+      "particularly troublesome.",
   },
 ];
 

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -10,9 +10,7 @@ const PROBLEMS = [
   },
   {
     title: "Your agent shouldn't see secrets",
-    body:
-      "If the agent is compromised (prompt " +
-      "injection), the keys leak with it.",
+    body: "If the agent is compromised (prompt " + "injection), the keys leak with it.",
   },
   {
     title: "Logs don't capture the action",

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -46,10 +46,10 @@ export function RulesSection() {
             <span class="text-rust">Claw Patrol enforces them.</span>
           </h3>
           <p class="text-base text-canvas/70">
-            Every outbound request runs through a rule engine before it leaves
-            your machine. Match on HTTP method, SQL verb, k8s resource,
-            plugin-defined facets — not just URLs. Edits are hot: save a rule
-            in the dashboard, the next request sees it.
+            Every outbound request runs through a rule engine before it
+            reaches its destination. Match on HTTP method, SQL verb, k8s
+            resource, plugin-defined facets; not just URLs. Edits are hot:
+            save a rule in the dashboard, the next request sees it.
           </p>
         </div>
 

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -9,7 +9,7 @@ const PROTOCOLS: {
   example: string;
 }[] = [
   {
-    name: "HTTPS",
+    name: "HTTP",
     body:
       "Method, path, headers, body. Any host, any service. Match an " +
       "HTTP request shape, route it through an LLM judge before it " +
@@ -20,7 +20,7 @@ const PROTOCOLS: {
     name: "SQL",
     body:
       "Postgres and ClickHouse traffic parsed verb-by-verb. Match by " +
-      "SQL verb, table, function name, even substrings of the " +
+      "SQL verb, table, function name, and substrings of the " +
       "statement itself.",
     example: snippet(protocol_sql),
   },
@@ -42,7 +42,7 @@ export function RulesSection() {
 
         <div class="max-w-3xl mx-auto text-center mb-16">
           <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5">
-            You write the rules.{" "}
+            You write access rules in HCL.{" "}
             <span class="text-rust">Claw Patrol enforces them.</span>
           </h3>
           <p class="text-base text-canvas/70">

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -42,14 +42,12 @@ export function RulesSection() {
 
         <div class="max-w-3xl mx-auto text-center mb-16">
           <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5">
-            You write access rules in HCL.{" "}
-            <span class="text-rust">Claw Patrol enforces them.</span>
+            You write access rules in HCL. <span class="text-rust">Claw Patrol enforces them.</span>
           </h3>
           <p class="text-base text-canvas/70">
-            Every outbound request runs through a rule engine before it
-            reaches its destination. Match on HTTP method, SQL verb, k8s
-            resource, plugin-defined facets; not just URLs. Edits are hot:
-            save a rule in the dashboard, the next request sees it.
+            Every outbound request runs through a rule engine before it reaches its destination.
+            Match on HTTP method, SQL verb, k8s resource, plugin-defined facets; not just URLs.
+            Edits are hot: save a rule in the dashboard, the next request sees it.
           </p>
         </div>
 
@@ -64,9 +62,7 @@ export function RulesSection() {
               class="grid grid-cols-1 lg:grid-cols-[1fr_2fr] gap-6 lg:gap-12 items-start"
             >
               <div class="min-w-0">
-                <h4 class="text-3xl font-display font-bold text-canvas mb-3">
-                  {p.name}
-                </h4>
+                <h4 class="text-3xl font-display font-bold text-canvas mb-3">{p.name}</h4>
                 <p class="text-base text-canvas/70 max-w-sm">{p.body}</p>
               </div>
               <HclCode

--- a/site/src/sections/TestSection.tsx
+++ b/site/src/sections/TestSection.tsx
@@ -11,7 +11,7 @@ import { SectionLabel } from "../components/SectionLabel";
 function TestOutput() {
   const ok = (path: string) => (
     <>
-      ok   {path}
+      ok {path}
       {"\n"}
     </>
   );
@@ -54,8 +54,7 @@ function TestOutput() {
         {ok("tests/pg-staging-banned-functions.json")}
         {ok("tests/pg-staging-default-deny.json")}
         {ok("tests/pg-staging-reads.json")}
-        36 action(s) checked,{" "}
-        <span class="text-rust-300">1 mismatch(es)</span>
+        36 action(s) checked, <span class="text-rust-300">1 mismatch(es)</span>
       </code>
     </pre>
   );
@@ -70,19 +69,16 @@ export function TestSection() {
         <div class="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-8 lg:gap-16 xl:gap-32 items-start">
           <div class="min-w-0">
             <h3 class="text-4xl sm:text-5xl md:text-6xl lg:text-[3.25rem] font-display font-bold text-balance mb-6 text-text">
-              Test your rules{" "}
-              <span class="text-rust">before you ship them.</span>
+              Test your rules <span class="text-rust">before you ship them.</span>
             </h3>
             <p class="text-base text-text-muted mb-5 max-w-xl">
-              Record real actions from the dashboard. Drop the JSON files into
-              a fixtures directory. Run <code>clawpatrol test</code> in CI:
-              when a policy change flips a verdict, the runner prints the
-              diff and fails the build.
+              Record real actions from the dashboard. Drop the JSON files into a fixtures directory.
+              Run <code>clawpatrol test</code> in CI: when a policy change flips a verdict, the
+              runner prints the diff and fails the build.
             </p>
             <p class="text-base text-text-muted max-w-xl">
-              No gateway, no database, no auth. A single binary that loads
-              your HCL, replays each fixture against the rule engine, and
-              asserts the verdicts still match.
+              No gateway, no database, no auth. A single binary that loads your HCL, replays each
+              fixture against the rule engine, and asserts the verdicts still match.
             </p>
           </div>
           <TestOutput />


### PR DESCRIPTION
## Summary

Post-#428 follow-up: extensive landing-page reshape based on a critical pass with real users.

**New hero copy:**
- H1: "The security firewall for agents"
- Subhead: "Sleep easy while your agents have access to prod."
- Body lists three concrete capabilities (block, human approval, audit) with code examples.

**New `RulesSection`** (replaces `ProtocolDepthSection` + old `RulesSection`, which overlapped):
- Dark navy band with "You write access rules in HCL. Claw Patrol enforces them." H3.
- Three stacked rows (HTTPS / SQL / Kubernetes), each with a real production rule lifted from `gateway.hcl`: support-reply-on-behalf LLM judge, pg-banned-functions with `sets.intersects`, k8s-exec-content-check.
- Plugin CTA links to `/docs/plugins/`.

**New `TestSection`** explains `clawpatrol test`:
- Live terminal showing a real run against `gateway.hcl` with a `k8s-no-secrets` verdict flip; 36 fixtures, 1 mismatch.
- CI-flow narrative (record from dashboard → drop fixtures → run in CI).

**New `DeploySection`** ("Run it"):
- Three install modes: `clawpatrol run claude`, `clawpatrol join … --whole-machine`, `clawpatrol gateway config.hcl`.
- Addresses "where does it run / how does my agent connect" — covers WireGuard and Tailscale transports.

**Other:**
- Hero subtitle: "Read access to any service. Gate the writes." → newer copy.
- Section reorder: Hero → Problem → Rules → Approvers → Test → Analytics → Comparison → Deploy → CTA.
- `ApproversSection` now drops `cache_ttl` / `fail_closed` / `on_timeout` (none of those are real fields). Real shape: `model`, `credential`, `policy` for `llm_approver`; `channel`, `credential`, `timeout` for `human_approver`. Verified against `config/plugins/approvers/`.
- HCL examples extracted to `site/examples/*.hcl`. Each file is a complete validated config with a `# ===== harness =====` marker separating the displayed snippet from the boilerplate. CI step added that runs `clawpatrol validate` against every example.
- Build pipeline pre-generates `site/src/lib/examples.ts` from those `.hcl` files so the prerender step (tsx-based) can load them.
- `SectionLabel` stripes redrawn as explicit SVG paths (the previous repeating-linear-gradient + skewX combo clipped the rightmost stripe at sub-pixel boundaries).
- Em dashes removed across user-facing copy.
- `ComparisonSection` adds proxyline and agentsh; SectionLabel becomes the only header (drops filler H3).
- `oxfmt` pass across `site/src`.

## Test plan

- [ ] Reload landing page, confirm new section order + rendering.
- [ ] Click through each product link in the Comparison section.
- [ ] Confirm Deploy section's three commands match the real CLI (`clawpatrol --help`).
- [ ] Verify CI runs `clawpatrol validate site/examples/*.hcl` and passes.
- [ ] Verify the Cloudflare Workers build passes (the pre-generated `examples.ts` is what fixes the previous tsx import failure).
