### PR TITLE
feat(tsnet-run): Tailscale control mode with full WG-mode parity

### DIFF
--- a/config/runtime/conn_route.go
+++ b/config/runtime/conn_route.go
@@ -126,3 +126,25 @@ func (idx *ConnIndex) Lookup(dstIP string) []*config.CompiledEndpoint {
 	}
 	return out
 }
+
+// ConnPorts returns the set of distinct port numbers declared by all
+// ConnRouter endpoints in the index. Used by the exit-node REDIRECT
+// installer to know which ports to intercept beyond 443 and 5432.
+func (idx *ConnIndex) ConnPorts() []string {
+	if idx == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	for hp := range idx.byHost {
+		_, port, err := net.SplitHostPort(hp)
+		if err != nil || port == "" {
+			continue
+		}
+		seen[port] = true
+	}
+	ports := make([]string, 0, len(seen))
+	for p := range seen {
+		ports = append(ports, p)
+	}
+	return ports
+}

--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -531,6 +531,13 @@ func (a *Allocator) handleWire(in []byte, dstIP string) []byte {
 	return out
 }
 
+// HandlePacket processes a single raw DNS wire-format datagram and returns
+// the response datagram ready to send, or nil on parse error. Used by the
+// exit-node UDP DNS listener; callers write the returned bytes directly.
+func (a *Allocator) HandlePacket(in []byte, origDstIP string) []byte {
+	return a.handleWire(in, origDstIP)
+}
+
 // handleQuery is the actual responder. Splits intercepted from
 // non-intercepted: if any question targets a known VIP-hostname we
 // answer locally; otherwise we forward the entire message to dstIP

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -124,6 +124,40 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 	writeJSON(rw, map[string]string{"ip": ip, "ip6": ip6})
 }
 
+// apiEphemeralTsnetPeer handles POST /api/peer/ephemeral/tsnet.
+// Mints a single-use ephemeral Tailscale auth key for `clawpatrol run`
+// in Tailscale mode. The caller spins up a tsnet.Server per invocation
+// (no system Tailscale required). Auth: per-peer Bearer token.
+func (w *webMux) apiEphemeralTsnetPeer(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	if peerIPForAPIToken(w.g.db, token) == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !isTailscaleControlMode(w.ts.Control) {
+		http.Error(rw, "not in tailscale mode", http.StatusBadRequest)
+		return
+	}
+	authKey, err := mintTailscaleAuthKey(r.Context(), w.ts, true)
+	if err != nil {
+		http.Error(rw, "mint key: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	gwHost := w.ts.Hostname
+	if gwHost == "" {
+		gwHost = "clawpatrol-gateway"
+	}
+	writeJSON(rw, map[string]string{
+		"auth_key":     authKey,
+		"control_url":  w.ts.ControlURL,
+		"gateway_host": gwHost,
+	})
+}
+
 // apiRemoveEphemeralPeer handles DELETE /api/peer/ephemeral?pubkey=<hex>.
 // Only the parent device (identified by bearer token) may remove its
 // own ephemeral peers.

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -158,6 +158,39 @@ func (w *webMux) apiEphemeralTsnetPeer(rw http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// apiRegisterEphemeralTsnetIP handles POST /api/peer/ephemeral/tsnet/register.
+// Called by `clawpatrol run` (tsnet mode) immediately after the ephemeral tsnet
+// node joins and learns its 100.x.x.x address. Binds the ephemeral tailnet IP
+// to the parent device's profile so dispatch from that IP uses the right credentials.
+func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	parentIP := peerIPForAPIToken(w.g.db, token)
+	if parentIP == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	tsnetIP := r.URL.Query().Get("ip")
+	if tsnetIP == "" {
+		http.Error(rw, "missing ip", http.StatusBadRequest)
+		return
+	}
+	if _, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(tsnetIP, "1")); err != nil {
+		http.Error(rw, "invalid ip", http.StatusBadRequest)
+		return
+	}
+	if w.g.onboard == nil {
+		rw.WriteHeader(http.StatusNoContent)
+		return
+	}
+	profile := w.g.onboard.ProfileForIP(parentIP)
+	w.g.onboard.setEphemeralProfile(tsnetIP, parentIP, profile)
+	rw.WriteHeader(http.StatusNoContent)
+}
+
 // apiRemoveEphemeralPeer handles DELETE /api/peer/ephemeral?pubkey=<hex>.
 // Only the parent device (identified by bearer token) may remove its
 // own ephemeral peers.

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -151,10 +151,17 @@ func (w *webMux) apiEphemeralTsnetPeer(rw http.ResponseWriter, r *http.Request) 
 	if gwHost == "" {
 		gwHost = "clawpatrol-gateway"
 	}
+	// Expose the tailnet port so clawpatrol run can dial the right port.
+	// cfg.Listen may be "host:port" or ":port"; extract the port only.
+	_, gwPort, _ := net.SplitHostPort(w.g.cfg.Listen)
+	if gwPort == "" {
+		gwPort = "443"
+	}
 	writeJSON(rw, map[string]string{
 		"auth_key":     authKey,
 		"control_url":  w.ts.ControlURL,
 		"gateway_host": gwHost,
+		"gateway_port": gwPort,
 	})
 }
 

--- a/integrations.go
+++ b/integrations.go
@@ -6,6 +6,8 @@ package main
 // model's max input window.
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -83,6 +85,24 @@ func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
 	return append(out, vars...), nil
 }
 
+// gatewayClient returns an http.Client that trusts the gateway's CA cert
+// at caDir/ca.crt in addition to the system pool.
+func gatewayClient(caDir string) *http.Client {
+	roots, _ := x509.SystemCertPool()
+	if roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if pem, err := os.ReadFile(filepath.Join(caDir, "ca.crt")); err == nil {
+		roots.AppendCertsFromPEM(pem)
+	}
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: roots},
+		},
+	}
+}
+
 // fetchEnvPushdownFromGateway hits the gateway's /api/env-pushdown
 // endpoint and returns its declared push-down vars. Authenticated
 // with the per-peer bearer `clawpatrol join` persisted at
@@ -99,7 +119,7 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 		return nil, fmt.Errorf("peer api token not persisted (run `clawpatrol join` first)")
 	}
 	url := strings.TrimRight(gw, "/") + "/api/env-pushdown"
-	cli := &http.Client{Timeout: 5 * time.Second}
+	cli := gatewayClient(caDir)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build %s: %w", url, err)

--- a/main.go
+++ b/main.go
@@ -2685,6 +2685,7 @@ func runGateway(args []string) {
 	g.listenPort = listenPort
 	if isTailscaleControlMode(cfg.Control) {
 		installExitNodeRedirect(listenPort, g.connIdx.Load().ConnPorts())
+		startUDPDNSListener(listenPort, g.dnsvip)
 	}
 	for {
 		c, err := ln.Accept()

--- a/main.go
+++ b/main.go
@@ -2677,7 +2677,7 @@ func runGateway(args []string) {
 	tsnetDashPort := portOf(cfg.InfoListen)
 	listenPort := portOf(ln.Addr().String())
 	if isTailscaleControlMode(cfg.Control) {
-		installExitNodeRedirect(listenPort)
+		installExitNodeRedirect(listenPort, g.connIdx.Load().ConnPorts())
 	}
 	for {
 		c, err := ln.Accept()

--- a/main.go
+++ b/main.go
@@ -322,6 +322,8 @@ type Gateway struct {
 	// transports memoizes one http.Transport per endpoint. Avoids the
 	// per-request allocation + idle-conn-pool reset of the old path.
 	transports sync.Map // *config.CompiledEndpoint -> *http.Transport
+	// listenPort is set once at startup; watchConfig reads it to reinstall iptables rules on reload.
+	listenPort int
 }
 
 // transportFor returns the cached http.Transport for ep, building it
@@ -424,7 +426,11 @@ func (g *Gateway) watchConfig(path string) {
 		}
 		g.policy.Store(policy)
 		registerOAuthCredentials(g.oauth, policy)
-		g.connIdx.Store(runtime.BuildConnIndex(policy))
+		newConnIdx := runtime.BuildConnIndex(policy)
+		g.connIdx.Store(newConnIdx)
+		if isTailscaleControlMode(g.cfg.Control) && g.listenPort != 0 {
+			installExitNodeRedirect(g.listenPort, newConnIdx.ConnPorts())
+		}
 		if g.tunnels != nil {
 			g.tunnels.SetPolicy(context.Background(), policy)
 		}
@@ -2676,6 +2682,7 @@ func runGateway(args []string) {
 	tsnetDashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 	tsnetDashPort := portOf(cfg.InfoListen)
 	listenPort := portOf(ln.Addr().String())
+	g.listenPort = listenPort
 	if isTailscaleControlMode(cfg.Control) {
 		installExitNodeRedirect(listenPort, g.connIdx.Load().ConnPorts())
 	}

--- a/main.go
+++ b/main.go
@@ -2628,15 +2628,83 @@ func runGateway(args []string) {
 	log.Printf("gateway listening on %s, %d endpoints across %d profiles",
 		ln.Addr(), len(policy.Endpoints), len(policy.Profiles))
 
+	// In Tailscale mode, `clawpatrol run` clients prepend a HAProxy PROXY v1
+	// header carrying the original 4-tuple so we can dispatch by dst port/IP
+	// exactly like the WG promiscuous forwarder. Peek the first bytes: if the
+	// connection starts with "PROXY " use full dispatch; otherwise fall through
+	// to g.handle (direct dashboard access, curl health checks, etc.).
+	tsnetDashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
+	tsnetDashPort := portOf(cfg.InfoListen)
 	for {
 		c, err := ln.Accept()
 		if err != nil {
 			log.Printf("accept: %v", err)
 			continue
 		}
-		go g.handle(c, "")
+		go func(c net.Conn) {
+			dstIP, dstPort, conn, err := readProxyHeader(c)
+			if err != nil {
+				_ = c.Close()
+				return
+			}
+			if dstPort == 0 {
+				g.handle(conn, "")
+				return
+			}
+			switch {
+			case dstPort == 443:
+				g.handle(conn, dstIP)
+			case dstPort == 5432:
+				g.handlePostgresConn(conn, dstIP)
+			case dstPort == 53:
+				g.handleDNSTCPConn(conn, dstIP)
+			case g.dnsvip.IsVIP(dstIP):
+				g.handleVIPConn(conn, dstIP, dstPort)
+			case tsnetDashPort != 0 && int(dstPort) == tsnetDashPort:
+				_ = http.Serve(&oneShotListener{c: conn}, tsnetDashMux)
+			default:
+				if g.tryDirectIPConn(conn, dstIP, dstPort) {
+					return
+				}
+				g.wgRelay(conn, dstIP, int(dstPort))
+			}
+		}(c)
 	}
 }
+
+// readProxyHeader peeks at c for a HAProxy PROXY v1 line.
+// If "PROXY TCP4 srcIP dstIP srcPort dstPort\r\n" is present it is consumed
+// and the original dst IP/port returned. If absent, dstPort==0 and the conn
+// is returned with all peeked bytes still readable.
+func readProxyHeader(c net.Conn) (dstIP string, dstPort uint16, conn net.Conn, _ error) {
+	br := bufio.NewReaderSize(c, 128)
+	hdr, err := br.Peek(5)
+	bc := &bufferedConn{Reader: br, Conn: c}
+	if err != nil || string(hdr) != "PROXY" {
+		return "", 0, bc, nil
+	}
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return "", 0, nil, fmt.Errorf("proxy header read: %w", err)
+	}
+	// "PROXY TCP4 srcIP dstIP srcPort dstPort\r\n"
+	fields := strings.Fields(strings.TrimRight(line, "\r\n"))
+	if len(fields) != 6 {
+		return "", 0, nil, fmt.Errorf("malformed proxy header: %q", line)
+	}
+	port, err := strconv.ParseUint(fields[5], 10, 16)
+	if err != nil {
+		return "", 0, nil, fmt.Errorf("proxy header port: %w", err)
+	}
+	return fields[3], uint16(port), bc, nil
+}
+
+type bufferedConn struct {
+	*bufio.Reader
+	net.Conn
+}
+
+func (b *bufferedConn) Read(p []byte) (int, error) { return b.Reader.Read(p) }
 
 func serveHTTPLogged(name, addr string, handler http.Handler) {
 	if err := http.ListenAndServe(addr, handler); err != nil {

--- a/main.go
+++ b/main.go
@@ -2670,10 +2670,15 @@ func runGateway(args []string) {
 	// In Tailscale mode, `clawpatrol run` clients prepend a HAProxy PROXY v1
 	// header carrying the original 4-tuple so we can dispatch by dst port/IP
 	// exactly like the WG promiscuous forwarder. Peek the first bytes: if the
-	// connection starts with "PROXY " use full dispatch; otherwise it is a
-	// direct admin/dashboard TLS connection — terminate TLS and serve the mux.
+	// connection starts with "PROXY " use full dispatch; otherwise check
+	// SO_ORIGINAL_DST (set by iptables REDIRECT for exit-node traffic); if
+	// neither is present it is a direct admin/dashboard connection.
 	tsnetDashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 	tsnetDashPort := portOf(cfg.InfoListen)
+	listenPort := portOf(ln.Addr().String())
+	if isTailscaleControlMode(cfg.Control) {
+		installExitNodeRedirect(listenPort)
+	}
 	for {
 		c, err := ln.Accept()
 		if err != nil {
@@ -2681,16 +2686,24 @@ func runGateway(args []string) {
 			continue
 		}
 		go func(c net.Conn) {
+			// Capture SO_ORIGINAL_DST before any buffering (iptables REDIRECT path).
+			origIP, origPort, hasOrigDst := originalDst(c)
+
 			dstIP, dstPort, conn, err := readProxyHeader(c)
 			if err != nil {
 				_ = c.Close()
 				return
 			}
 			if dstPort == 0 {
-				// Direct connection (no PROXY header): admin dashboard, curl,
-				// clawpatrol join, etc. Terminate TLS using our CA and serve HTTP.
-				g.serveTSNetDirect(conn, tsnetDashMux)
-				return
+				// No PROXY header. Check SO_ORIGINAL_DST: if the connection was
+				// iptables-redirected (exit-node MITM), origPort != listenPort.
+				if hasOrigDst && listenPort != 0 && int(origPort) != listenPort {
+					dstIP, dstPort = origIP, origPort
+				} else {
+					// Direct connection: admin dashboard, curl, clawpatrol join, etc.
+					g.serveTSNetDirect(conn, tsnetDashMux)
+					return
+				}
 			}
 			switch {
 			case dstPort == 443:

--- a/main.go
+++ b/main.go
@@ -1667,6 +1667,45 @@ func (g *Gateway) splice(c net.Conn, host string) {
 	g.emit(Event{Mode: "splice", Host: host, AgentIP: agentAddr, Action: "allow", In: in, Out: out, Ms: time.Since(start).Milliseconds()})
 }
 
+// serveTSNetDirect handles a direct (non-PROXY) TLS connection in tsnet mode.
+// These come from admins opening the dashboard, clawpatrol join, etc. We
+// terminate TLS using our CA (minting a cert for whatever SNI the client
+// sends) and then serve the dashboard HTTP mux over the decrypted connection.
+func (g *Gateway) serveTSNetDirect(c net.Conn, mux http.Handler) {
+	defer func() { _ = c.Close() }()
+	host, prefix, err := peekSNI(c)
+	conn := wrapPeek(c, prefix)
+	if err != nil {
+		// No SNI — client connected via IP literal (common during `clawpatrol join`
+		// before the CA is trusted). Fall back to the server-side IP so mint() can
+		// produce a cert with an IP SAN that Go's TLS stack will accept.
+		if local := c.LocalAddr().String(); local != "" {
+			if h, _, splitErr := net.SplitHostPort(local); splitErr == nil {
+				host = h
+			}
+		}
+		if host == "" {
+			log.Printf("tsnet-direct: sni: %v (no fallback)", err)
+			return
+		}
+	}
+	cert, err := g.certs.mint(host)
+	if err != nil {
+		log.Printf("tsnet-direct: mint %s: %v", host, err)
+		return
+	}
+	tc := tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{*cert},
+		NextProtos:   []string{"http/1.1"},
+	})
+	if err := tc.Handshake(); err != nil {
+		log.Printf("tsnet-direct: tls %s: %v", host, err)
+		return
+	}
+	defer func() { _ = tc.Close() }()
+	_ = http.Serve(&oneShotListener{c: tc}, mux)
+}
+
 func pipeProgress(a, b net.Conn, onTick func(rx, tx int64)) (rx, tx int64) {
 	var rxC, txC atomic.Int64
 	done := make(chan struct{}, 2)
@@ -2631,8 +2670,8 @@ func runGateway(args []string) {
 	// In Tailscale mode, `clawpatrol run` clients prepend a HAProxy PROXY v1
 	// header carrying the original 4-tuple so we can dispatch by dst port/IP
 	// exactly like the WG promiscuous forwarder. Peek the first bytes: if the
-	// connection starts with "PROXY " use full dispatch; otherwise fall through
-	// to g.handle (direct dashboard access, curl health checks, etc.).
+	// connection starts with "PROXY " use full dispatch; otherwise it is a
+	// direct admin/dashboard TLS connection — terminate TLS and serve the mux.
 	tsnetDashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 	tsnetDashPort := portOf(cfg.InfoListen)
 	for {
@@ -2648,7 +2687,9 @@ func runGateway(args []string) {
 				return
 			}
 			if dstPort == 0 {
-				g.handle(conn, "")
+				// Direct connection (no PROXY header): admin dashboard, curl,
+				// clawpatrol join, etc. Terminate TLS using our CA and serve HTTP.
+				g.serveTSNetDirect(conn, tsnetDashMux)
 				return
 			}
 			switch {

--- a/onboard.go
+++ b/onboard.go
@@ -699,7 +699,14 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Printf("onboard claim: %s → %s (hostname=%q)", host, owner, hostname)
-	writeJSON(rw, map[string]string{"owner": owner, "ip": host})
+	resp := map[string]string{"owner": owner, "ip": host}
+	// Mint the per-peer bearer the client uses for gated API calls
+	// (env-pushdown, ephemeral tsnet key). In Tailscale mode the peer IP
+	// isn't known at approve time, so we mint it here instead.
+	if token, err := mintAndPersistPeerAPIToken(w.g.db, host); err == nil {
+		resp["api_token"] = token
+	}
+	writeJSON(rw, resp)
 }
 
 // apiOnboardPoll is hit by the CLI to retrieve the auth key once

--- a/onboard.go
+++ b/onboard.go
@@ -414,7 +414,7 @@ func newOnboarder(ts JoinConfig) Onboarder {
 type tailscaleOnboarder struct{ ts JoinConfig }
 
 func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string) (string, string, string, error) {
-	k, err := mintTailscaleAuthKey(ctx, t.ts)
+	k, err := mintTailscaleAuthKey(ctx, t.ts, false)
 	// Tailscale assigns peer IPs from the tailnet — we don't know the
 	// new device's IP at mint time, so claim happens later via /api/
 	// onboard/claim from the CLI once `tailscale up` succeeds.
@@ -422,9 +422,10 @@ func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string) (string, str
 }
 
 // mintTailscaleAuthKey calls Tailscale's OAuth + auth-key API to create
-// a single-use, non-ephemeral auth key the new client can use to join
-// the tailnet exactly once.
-func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig) (string, error) {
+// a single-use auth key the new client can use to join the tailnet
+// exactly once. ephemeral controls whether the key creates an ephemeral
+// node (auto-removed when it disconnects) or a persistent one.
+func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig, ephemeral bool) (string, error) {
 	clientID := resolveTemplate(ts.OAuthClientID)
 	clientSecret := resolveTemplate(ts.OAuthClientSecret)
 	if clientID == "" || clientSecret == "" {
@@ -468,7 +469,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig) (string, error) {
 			"devices": map[string]any{
 				"create": map[string]any{
 					"reusable":      false,
-					"ephemeral":     false,
+					"ephemeral":     ephemeral,
 					"preauthorized": true,
 					"tags":          tags,
 				},
@@ -728,10 +729,21 @@ func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 		writeJSON(rw, map[string]string{"error": "slow_down"})
 		return
 	}
-	writeJSON(rw, map[string]any{
+	resp := map[string]any{
 		"auth_key":     s.authKey,
 		"api_token":    s.apiToken,
 		"approved_by":  s.owner,
 		"login_server": s.loginServer, // empty = Tailscale Inc default
-	})
+	}
+	// In Tailscale mode include gateway_host and control_url so the
+	// client can write mode marker files for `clawpatrol run`.
+	if s.loginServer == "" {
+		gwHost := w.ts.Hostname
+		if gwHost == "" {
+			gwHost = "clawpatrol-gateway"
+		}
+		resp["gateway_host"] = gwHost
+		resp["control_url"] = w.ts.ControlURL
+	}
+	writeJSON(rw, resp)
 }

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -79,10 +79,13 @@ func installExitNodeRedirect(listenPort int, extraPorts []string) {
 	}
 
 	portStr := strconv.Itoa(listenPort)
-	// Always intercept HTTPS and Postgres; add any other ports declared by
+	// Always intercept HTTPS, Postgres, and DNS; add any other ports declared by
 	// ConnRouter endpoints (clickhouse_native 9000/9440, etc.).
-	seen := map[string]bool{"443": true, "5432": true}
-	ports := []string{"443", "5432"}
+	// Port 53 is TCP-only: UDP DNS is left unREJECTed so exit-node clients that
+	// use UDP DNS still get real resolution; VIP names resolve via TCP DNS.
+	seen := map[string]bool{"53": true, "443": true, "5432": true}
+	tcpOnly := map[string]bool{"53": true} // no UDP REJECT for DNS
+	ports := []string{"53", "443", "5432"}
 	for _, p := range extraPorts {
 		if !seen[p] {
 			seen[p] = true
@@ -99,6 +102,9 @@ func installExitNodeRedirect(listenPort int, extraPorts []string) {
 			} else {
 				log.Printf("exit-node redirect: installed iptables REDIRECT tcp/%s → %s", dport, portStr)
 			}
+		}
+		if tcpOnly[dport] {
+			continue
 		}
 		// UDP: REJECT so QUIC/HTTP3 fails fast and clients fall back to TCP.
 		// Without this, UDP 443 bypasses MITM — on par with WireGuard mode which

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -9,16 +9,21 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/denoland/clawpatrol/dnsvip"
 )
 
-const soOriginalDst = 80 // SO_ORIGINAL_DST, linux/in.h
+const (
+	soOriginalDst     = 80 // SO_ORIGINAL_DST / IP6T_SO_ORIGINAL_DST (linux/in.h, linux/netfilter_ipv6/ip6_tables.h)
+	ipRecvOrigDstAddr = 20 // IP_RECVORIGDSTADDR (linux/in.h) — ancillary per-datagram original dst
+)
 
-// originalDst returns the pre-NAT destination of c when the connection
-// was redirected by an iptables REDIRECT rule. Returns ok=false on
-// non-Linux, for non-TCP conns, or when no NAT entry exists (direct
-// connection — getsockopt returns ENOPROTOOPT or ENOENT).
+// originalDst returns the pre-NAT destination of c when the connection was
+// redirected by an iptables REDIRECT rule. Tries IPv4 first then IPv6.
+// Returns ok=false for non-TCP conns or when no NAT entry exists.
 func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 	tc := unwrapTCPConn(c)
 	if tc == nil {
@@ -28,96 +33,239 @@ func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 	if err != nil {
 		return "", 0, false
 	}
-	var sa syscall.RawSockaddrInet4
-	saLen := uint32(syscall.SizeofSockaddrInet4)
+
+	// IPv4
+	var sa4 syscall.RawSockaddrInet4
+	saLen4 := uint32(syscall.SizeofSockaddrInet4)
 	var soErr error
 	_ = raw.Control(func(fd uintptr) {
-		_, _, errno := syscall.Syscall6(
-			syscall.SYS_GETSOCKOPT,
-			fd,
-			syscall.IPPROTO_IP,
-			soOriginalDst,
-			uintptr(unsafe.Pointer(&sa)),
-			uintptr(unsafe.Pointer(&saLen)),
-			0,
-		)
+		_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT,
+			fd, syscall.IPPROTO_IP, soOriginalDst,
+			uintptr(unsafe.Pointer(&sa4)),
+			uintptr(unsafe.Pointer(&saLen4)),
+			0)
 		if errno != 0 {
 			soErr = errno
 		}
 	})
-	if soErr != nil {
-		return "", 0, false
+	if soErr == nil {
+		dstIP := net.IP(sa4.Addr[:]).String()
+		dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa4.Port))[:])
+		return dstIP, dstPort, true
 	}
-	dstIP := net.IP(sa.Addr[:]).String()
-	dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa.Port))[:])
-	return dstIP, dstPort, true
+
+	// IPv6 (IP6T_SO_ORIGINAL_DST, same constant value on IPPROTO_IPV6)
+	var sa6 syscall.RawSockaddrInet6
+	saLen6 := uint32(syscall.SizeofSockaddrInet6)
+	soErr = nil
+	_ = raw.Control(func(fd uintptr) {
+		_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT,
+			fd, syscall.IPPROTO_IPV6, soOriginalDst,
+			uintptr(unsafe.Pointer(&sa6)),
+			uintptr(unsafe.Pointer(&saLen6)),
+			0)
+		if errno != 0 {
+			soErr = errno
+		}
+	})
+	if soErr == nil {
+		dstIP := net.IP(sa6.Addr[:]).String()
+		dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa6.Port))[:])
+		return dstIP, dstPort, true
+	}
+	return "", 0, false
 }
 
-// installExitNodeRedirect installs iptables PREROUTING REDIRECT rules so that
-// traffic arriving via the Tailscale exit-node (tailscale0) on common service
-// ports is redirected to the gateway's own listen port. This lets the accept
-// loop's SO_ORIGINAL_DST fallback dispatch exit-node traffic exactly like the
-// WireGuard promiscuous forwarder — no PROXY header needed.
+// startUDPDNSListener binds a UDP socket on port and serves DNS queries.
+// iptables PREROUTING REDIRECT sends port-53 UDP from tailscale0 here;
+// IP_RECVORIGDSTADDR recovers the DNS server the client was reaching so
+// dnsvip can forward non-VIP names to the right upstream.
+func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
+	if port == 0 || dvip == nil {
+		return
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+	if err != nil {
+		log.Printf("udp dns listener: %v", err)
+		return
+	}
+	if rc, err := conn.SyscallConn(); err == nil {
+		_ = rc.Control(func(fd uintptr) {
+			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ipRecvOrigDstAddr, 1); err != nil {
+				log.Printf("udp dns: IP_RECVORIGDSTADDR: %v", err)
+			}
+		})
+	}
+	log.Printf("udp dns listener ready on :%d", port)
+	go func() {
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 4096)
+		oob := make([]byte, 256)
+		for {
+			n, oobn, _, addr, err := conn.ReadMsgUDP(buf, oob)
+			if err != nil {
+				if !isNetClosedError(err) {
+					log.Printf("udp dns: recv: %v", err)
+				}
+				return
+			}
+			origDstIP := parseUDPOrigDstIP(oob[:oobn])
+			resp := dvip.HandlePacket(buf[:n], origDstIP)
+			if resp == nil {
+				continue
+			}
+			_, _ = conn.WriteToUDP(resp, addr)
+		}
+	}()
+}
+
+// parseUDPOrigDstIP extracts the original destination IP from recvmsg
+// ancillary data (IP_ORIGDSTADDR cmsg). Returns "" if not present.
+func parseUDPOrigDstIP(oob []byte) string {
+	msgs, err := syscall.ParseSocketControlMessage(oob)
+	if err != nil {
+		return ""
+	}
+	for _, m := range msgs {
+		if m.Header.Level == syscall.IPPROTO_IP && m.Header.Type == ipRecvOrigDstAddr {
+			if len(m.Data) >= syscall.SizeofSockaddrInet4 {
+				var sa syscall.RawSockaddrInet4
+				copy((*[syscall.SizeofSockaddrInet4]byte)(unsafe.Pointer(&sa))[:], m.Data)
+				return net.IP(sa.Addr[:]).String()
+			}
+		}
+	}
+	return ""
+}
+
+// installExitNodeRedirect installs packet-filter rules so exit-node TCP traffic
+// arriving on tailscale0 is REDIRECT-ed to the gateway's listen port (recovered
+// via SO_ORIGINAL_DST), UDP/53 is likewise REDIRECT-ed (served by the UDP DNS
+// listener started separately), and UDP on all other intercepted ports is
+// REJECT-ed to force QUIC→TCP fallback.
 //
-// Idempotent: each rule is checked with -C before insertion. Failures are
-// logged but not fatal; operators can install the rules manually if the
-// process lacks CAP_NET_ADMIN.
+// Tries iptables/ip6tables first; falls back to nft (nftables) on systems where
+// iptables is not installed. nftables uses an inet table which covers both
+// address families in one ruleset.
+//
+// Idempotent: iptables rules are checked with -C before insertion; the nft path
+// flushes and rebuilds the clawpatrol table on every call.
 func installExitNodeRedirect(listenPort int, extraPorts []string) {
 	if listenPort == 0 {
 		return
 	}
-	// Ensure ip_forward is on — exit-node forwarding silently breaks without it.
-	// Write to sysctl.d for persistence across reboots.
 	if err := os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1\n"), 0o644); err != nil {
 		log.Printf("exit-node redirect: ip_forward: %v", err)
 	}
 	const sysctlConf = "/etc/sysctl.d/99-clawpatrol-forward.conf"
 	if _, err := os.Stat(sysctlConf); os.IsNotExist(err) {
-		if err := os.WriteFile(sysctlConf, []byte("net.ipv4.ip_forward=1\n"), 0o644); err != nil {
-			log.Printf("exit-node redirect: persist ip_forward: %v", err)
-		}
+		_ = os.WriteFile(sysctlConf, []byte("net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\n"), 0o644)
 	}
 
 	portStr := strconv.Itoa(listenPort)
-	// Always intercept HTTPS, Postgres, and DNS; add any other ports declared by
-	// ConnRouter endpoints (clickhouse_native 9000/9440, etc.).
-	// Port 53 is TCP-only: UDP DNS is left unREJECTed so exit-node clients that
-	// use UDP DNS still get real resolution; VIP names resolve via TCP DNS.
+
+	// Port 53 is TCP-only REDIRECT + UDP REDIRECT (served by DNS listener).
+	// Other ports get TCP REDIRECT + UDP REJECT (force QUIC→TCP fallback).
 	seen := map[string]bool{"53": true, "443": true, "5432": true}
-	tcpOnly := map[string]bool{"53": true} // no UDP REJECT for DNS
-	ports := []string{"53", "443", "5432"}
+	tcpPorts := []string{"53", "443", "5432"} // TCP REDIRECT
+	udpDNSPorts := []string{"53"}             // UDP REDIRECT → dns listener
+	udpRejectPorts := []string{"443", "5432"} // UDP REJECT → QUIC fallback
 	for _, p := range extraPorts {
 		if !seen[p] {
 			seen[p] = true
-			ports = append(ports, p)
+			tcpPorts = append(tcpPorts, p)
+			udpRejectPorts = append(udpRejectPorts, p)
 		}
 	}
-	for _, dport := range ports {
-		// TCP: REDIRECT to our listen port so SO_ORIGINAL_DST can recover the dst.
-		tcpArgs := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
-		if exec.Command("iptables", append([]string{"-C", "PREROUTING"}, tcpArgs...)...).Run() != nil {
-			insert := exec.Command("iptables", append([]string{"-I", "PREROUTING", "1"}, tcpArgs...)...)
-			if out, err := insert.CombinedOutput(); err != nil {
-				log.Printf("exit-node redirect: iptables tcp dport %s: %v: %s", dport, err, out)
-			} else {
-				log.Printf("exit-node redirect: installed iptables REDIRECT tcp/%s → %s", dport, portStr)
-			}
-		}
-		if tcpOnly[dport] {
+
+	_, iptablesErr := exec.LookPath("iptables")
+	if iptablesErr == nil {
+		installIPTables(portStr, tcpPorts, udpDNSPorts, udpRejectPorts)
+	} else {
+		installNFTables(portStr, tcpPorts, udpDNSPorts, udpRejectPorts)
+	}
+}
+
+// installIPTables installs rules via iptables + ip6tables.
+func installIPTables(portStr string, tcpPorts, udpDNSPorts, udpRejectPorts []string) {
+	for _, bin := range []string{"iptables", "ip6tables"} {
+		if _, err := exec.LookPath(bin); err != nil {
 			continue
 		}
-		// UDP: REJECT so QUIC/HTTP3 fails fast and clients fall back to TCP.
-		// Without this, UDP 443 bypasses MITM — on par with WireGuard mode which
-		// captures all traffic on the tun interface.
-		udpArgs := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
-		if exec.Command("iptables", append([]string{"-C", "FORWARD"}, udpArgs...)...).Run() != nil {
-			insert := exec.Command("iptables", append([]string{"-I", "FORWARD", "1"}, udpArgs...)...)
-			if out, err := insert.CombinedOutput(); err != nil {
-				log.Printf("exit-node redirect: iptables udp dport %s: %v: %s", dport, err, out)
-			} else {
-				log.Printf("exit-node redirect: installed iptables REJECT udp/%s (force TCP fallback)", dport)
+		for _, dport := range tcpPorts {
+			args := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
+			if exec.Command(bin, append([]string{"-C", "PREROUTING"}, args...)...).Run() != nil {
+				if out, err := exec.Command(bin, append([]string{"-I", "PREROUTING", "1"}, args...)...).CombinedOutput(); err != nil {
+					log.Printf("exit-node redirect: %s tcp/%s: %v: %s", bin, dport, err, out)
+				} else {
+					log.Printf("exit-node redirect: %s REDIRECT tcp/%s → %s", bin, dport, portStr)
+				}
 			}
 		}
+		for _, dport := range udpDNSPorts {
+			args := []string{"-t", "nat", "-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
+			if exec.Command(bin, append([]string{"-C", "PREROUTING"}, args...)...).Run() != nil {
+				if out, err := exec.Command(bin, append([]string{"-I", "PREROUTING", "1"}, args...)...).CombinedOutput(); err != nil {
+					log.Printf("exit-node redirect: %s udp/%s: %v: %s", bin, dport, err, out)
+				} else {
+					log.Printf("exit-node redirect: %s REDIRECT udp/%s → %s", bin, dport, portStr)
+				}
+			}
+		}
+		for _, dport := range udpRejectPorts {
+			args := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
+			if exec.Command(bin, append([]string{"-C", "FORWARD"}, args...)...).Run() != nil {
+				if out, err := exec.Command(bin, append([]string{"-I", "FORWARD", "1"}, args...)...).CombinedOutput(); err != nil {
+					log.Printf("exit-node redirect: %s REJECT udp/%s: %v: %s", bin, dport, err, out)
+				} else {
+					log.Printf("exit-node redirect: %s REJECT udp/%s (QUIC fallback)", bin, dport)
+				}
+			}
+		}
+	}
+}
+
+// installNFTables installs rules via nft (nftables) using an inet table
+// that covers both IPv4 and IPv6 in a single ruleset. Idempotent: the
+// clawpatrol table is flushed and rebuilt on every call.
+func installNFTables(portStr string, tcpPorts, udpDNSPorts, udpRejectPorts []string) {
+	if _, err := exec.LookPath("nft"); err != nil {
+		log.Printf("exit-node redirect: neither iptables nor nft found; install one of them")
+		return
+	}
+
+	tcpSet := "{ " + strings.Join(tcpPorts, ", ") + " }"
+	udpDNSSet := "{ " + strings.Join(udpDNSPorts, ", ") + " }"
+
+	// Flush + rebuild our dedicated table for idempotency.
+	exec.Command("nft", "delete", "table", "inet", "clawpatrol").Run() //nolint:errcheck
+
+	script := strings.Join([]string{
+		"table inet clawpatrol {",
+		"  chain prerouting {",
+		"    type nat hook prerouting priority -100;",
+		`    iifname "tailscale0" tcp dport ` + tcpSet + " redirect to :" + portStr + ";",
+		`    iifname "tailscale0" udp dport ` + udpDNSSet + " redirect to :" + portStr + ";",
+		"  }",
+	}, "\n")
+
+	if len(udpRejectPorts) > 0 {
+		udpRejectSet := "{ " + strings.Join(udpRejectPorts, ", ") + " }"
+		script += "\n" + strings.Join([]string{
+			"  chain forward {",
+			"    type filter hook forward priority 0;",
+			`    iifname "tailscale0" udp dport ` + udpRejectSet + " reject;",
+			"  }",
+		}, "\n")
+	}
+	script += "\n}"
+
+	cmd := exec.Command("nft", "-f", "-")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Printf("exit-node redirect: nft: %v: %s", err, out)
+	} else {
+		log.Printf("exit-node redirect: nftables rules installed (inet clawpatrol, covers IPv4+IPv6)")
 	}
 }
 
@@ -131,4 +279,8 @@ func unwrapTCPConn(c net.Conn) *net.TCPConn {
 		}
 	}
 	return nil
+}
+
+func isNetClosedError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "use of closed network connection")
 }

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -1,5 +1,48 @@
 //go:build linux
 
+// Exit-node MITM via SO_ORIGINAL_DST
+//
+// Problem: Tailscale's built-in exit-node feature routes all client traffic
+// through this machine and out to the internet — but it does so transparently.
+// The kernel forwards packets without any userspace process seeing the payload,
+// so there is no hook for credential injection, policy enforcement, or logging.
+// Tailscale itself provides no API to intercept exit-node traffic.
+//
+// Solution: run this gateway process on the same machine as the Tailscale exit
+// node and bend the packet path so that specific TCP/UDP flows hit the gateway's
+// listener before the kernel forwards them outbound.
+//
+// How it works:
+//
+//  1. iptables/ip6tables PREROUTING REDIRECT (or nftables equivalent) rewrites
+//     the destination of matching packets arriving on tailscale0 to
+//     127.0.0.1:<listenPort>. The kernel records the pre-NAT destination in the
+//     conntrack table but delivers the SYN to the gateway's own listen socket.
+//
+//  2. SO_ORIGINAL_DST getsockopt on the accepted TCP conn (or IP_RECVORIGDSTADDR
+//     ancdata on UDP) reads that conntrack entry, recovering the IP:port the
+//     client originally dialed (e.g., api.openai.com:443 or 10.78.0.1:22).
+//
+//  3. The accept loop dispatches on the recovered destination exactly as the
+//     WireGuard promiscuous forwarder does: port 443 → HTTPS MITM, port 5432 →
+//     Postgres, dnsvip VIP → SSH, ConnRouter ports → binary protocol endpoints.
+//
+//  4. DNS (port 53) is intercepted so the dnsvip allocator can answer A/AAAA
+//     queries for SSH-endpoint hostnames with virtual IPs, enabling the VIP→SSH
+//     dispatch path that the WireGuard mode uses. Non-VIP names are forwarded
+//     upstream to whatever DNS server the client was originally querying.
+//
+//  5. UDP on non-DNS intercepted ports (443, 5432, …) is REJECT-ed with
+//     ICMP port-unreachable. QUIC (HTTP/3) uses UDP/443 and cannot be
+//     REDIRECT-ed by iptables (UDP is connectionless, no conntrack SYN state).
+//     The ICMP rejection forces clients to fall back to TCP, which the REDIRECT
+//     rule catches. This matches WireGuard mode where the tun interface captures
+//     all traffic and UDP 443 simply has no handler.
+//
+// Without these rules the exit node behaves like a plain NAT gateway: traffic
+// leaves with the gateway's public IP but the gateway process never sees it,
+// so no credentials are injected and no policies are enforced.
+
 package main
 
 import (

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+package main
+
+import (
+	"encoding/binary"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+const soOriginalDst = 80 // SO_ORIGINAL_DST, linux/in.h
+
+// originalDst returns the pre-NAT destination of c when the connection
+// was redirected by an iptables REDIRECT rule. Returns ok=false on
+// non-Linux, for non-TCP conns, or when no NAT entry exists (direct
+// connection — getsockopt returns ENOPROTOOPT or ENOENT).
+func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
+	tc := unwrapTCPConn(c)
+	if tc == nil {
+		return "", 0, false
+	}
+	raw, err := tc.SyscallConn()
+	if err != nil {
+		return "", 0, false
+	}
+	var sa syscall.RawSockaddrInet4
+	saLen := uint32(syscall.SizeofSockaddrInet4)
+	var soErr error
+	_ = raw.Control(func(fd uintptr) {
+		_, _, errno := syscall.Syscall6(
+			syscall.SYS_GETSOCKOPT,
+			fd,
+			syscall.IPPROTO_IP,
+			soOriginalDst,
+			uintptr(unsafe.Pointer(&sa)),
+			uintptr(unsafe.Pointer(&saLen)),
+			0,
+		)
+		if errno != 0 {
+			soErr = errno
+		}
+	})
+	if soErr != nil {
+		return "", 0, false
+	}
+	dstIP := net.IP(sa.Addr[:]).String()
+	dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa.Port))[:])
+	return dstIP, dstPort, true
+}
+
+// installExitNodeRedirect installs iptables PREROUTING REDIRECT rules so that
+// traffic arriving via the Tailscale exit-node (tailscale0) on common service
+// ports is redirected to the gateway's own listen port. This lets the accept
+// loop's SO_ORIGINAL_DST fallback dispatch exit-node traffic exactly like the
+// WireGuard promiscuous forwarder — no PROXY header needed.
+//
+// Idempotent: each rule is checked with -C before insertion. Failures are
+// logged but not fatal; operators can install the rules manually if the
+// process lacks CAP_NET_ADMIN.
+func installExitNodeRedirect(listenPort int) {
+	if listenPort == 0 {
+		return
+	}
+	// Ensure ip_forward is on — exit-node forwarding silently breaks without it.
+	// Write to sysctl.d for persistence across reboots.
+	if err := os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1\n"), 0o644); err != nil {
+		log.Printf("exit-node redirect: ip_forward: %v", err)
+	}
+	const sysctlConf = "/etc/sysctl.d/99-clawpatrol-forward.conf"
+	if _, err := os.Stat(sysctlConf); os.IsNotExist(err) {
+		if err := os.WriteFile(sysctlConf, []byte("net.ipv4.ip_forward=1\n"), 0o644); err != nil {
+			log.Printf("exit-node redirect: persist ip_forward: %v", err)
+		}
+	}
+
+	portStr := strconv.Itoa(listenPort)
+	ports := []string{"443", "5432"}
+	for _, dport := range ports {
+		args := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
+		check := exec.Command("iptables", append([]string{"-C", "PREROUTING"}, args...)...)
+		if check.Run() == nil {
+			continue // already installed
+		}
+		insert := exec.Command("iptables", append([]string{"-I", "PREROUTING", "1"}, args...)...)
+		if out, err := insert.CombinedOutput(); err != nil {
+			log.Printf("exit-node redirect: iptables dport %s: %v: %s", dport, err, out)
+		} else {
+			log.Printf("exit-node redirect: installed iptables REDIRECT port %s → %s", dport, portStr)
+		}
+	}
+}
+
+func unwrapTCPConn(c net.Conn) *net.TCPConn {
+	if tc, ok := c.(*net.TCPConn); ok {
+		return tc
+	}
+	if bc, ok := c.(*bufferedConn); ok {
+		if tc, ok := bc.Conn.(*net.TCPConn); ok {
+			return tc
+		}
+	}
+	return nil
+}

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -81,16 +81,27 @@ func installExitNodeRedirect(listenPort int) {
 	portStr := strconv.Itoa(listenPort)
 	ports := []string{"443", "5432"}
 	for _, dport := range ports {
-		args := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
-		check := exec.Command("iptables", append([]string{"-C", "PREROUTING"}, args...)...)
-		if check.Run() == nil {
-			continue // already installed
+		// TCP: REDIRECT to our listen port so SO_ORIGINAL_DST can recover the dst.
+		tcpArgs := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
+		if exec.Command("iptables", append([]string{"-C", "PREROUTING"}, tcpArgs...)...).Run() != nil {
+			insert := exec.Command("iptables", append([]string{"-I", "PREROUTING", "1"}, tcpArgs...)...)
+			if out, err := insert.CombinedOutput(); err != nil {
+				log.Printf("exit-node redirect: iptables tcp dport %s: %v: %s", dport, err, out)
+			} else {
+				log.Printf("exit-node redirect: installed iptables REDIRECT tcp/%s → %s", dport, portStr)
+			}
 		}
-		insert := exec.Command("iptables", append([]string{"-I", "PREROUTING", "1"}, args...)...)
-		if out, err := insert.CombinedOutput(); err != nil {
-			log.Printf("exit-node redirect: iptables dport %s: %v: %s", dport, err, out)
-		} else {
-			log.Printf("exit-node redirect: installed iptables REDIRECT port %s → %s", dport, portStr)
+		// UDP: REJECT so QUIC/HTTP3 fails fast and clients fall back to TCP.
+		// Without this, UDP 443 bypasses MITM — on par with WireGuard mode which
+		// captures all traffic on the tun interface.
+		udpArgs := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
+		if exec.Command("iptables", append([]string{"-C", "FORWARD"}, udpArgs...)...).Run() != nil {
+			insert := exec.Command("iptables", append([]string{"-I", "FORWARD", "1"}, udpArgs...)...)
+			if out, err := insert.CombinedOutput(); err != nil {
+				log.Printf("exit-node redirect: iptables udp dport %s: %v: %s", dport, err, out)
+			} else {
+				log.Printf("exit-node redirect: installed iptables REJECT udp/%s (force TCP fallback)", dport)
+			}
 		}
 	}
 }

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -62,7 +62,7 @@ func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 // Idempotent: each rule is checked with -C before insertion. Failures are
 // logged but not fatal; operators can install the rules manually if the
 // process lacks CAP_NET_ADMIN.
-func installExitNodeRedirect(listenPort int) {
+func installExitNodeRedirect(listenPort int, extraPorts []string) {
 	if listenPort == 0 {
 		return
 	}
@@ -79,7 +79,16 @@ func installExitNodeRedirect(listenPort int) {
 	}
 
 	portStr := strconv.Itoa(listenPort)
+	// Always intercept HTTPS and Postgres; add any other ports declared by
+	// ConnRouter endpoints (clickhouse_native 9000/9440, etc.).
+	seen := map[string]bool{"443": true, "5432": true}
 	ports := []string{"443", "5432"}
+	for _, p := range extraPorts {
+		if !seen[p] {
+			seen[p] = true
+			ports = append(ports, p)
+		}
+	}
 	for _, dport := range ports {
 		// TCP: REDIRECT to our listen port so SO_ORIGINAL_DST can recover the dst.
 		tcpArgs := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	soOriginalDst     = 80 // SO_ORIGINAL_DST / IP6T_SO_ORIGINAL_DST (linux/in.h, linux/netfilter_ipv6/ip6_tables.h)
-	ipRecvOrigDstAddr = 20 // IP_RECVORIGDSTADDR (linux/in.h) — ancillary per-datagram original dst
+	soOriginalDst       = 80 // SO_ORIGINAL_DST / IP6T_SO_ORIGINAL_DST (linux/in.h, linux/netfilter_ipv6/ip6_tables.h)
+	ipRecvOrigDstAddr   = 20 // IP_RECVORIGDSTADDR / IP_ORIGDSTADDR (linux/in.h)
+	ipv6RecvOrigDstAddr = 74 // IPV6_RECVORIGDSTADDR / IPV6_ORIGDSTADDR (linux/in6.h)
 )
 
 // originalDst returns the pre-NAT destination of c when the connection was
@@ -76,27 +77,32 @@ func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 	return "", 0, false
 }
 
-// startUDPDNSListener binds a UDP socket on port and serves DNS queries.
-// iptables PREROUTING REDIRECT sends port-53 UDP from tailscale0 here;
-// IP_RECVORIGDSTADDR recovers the DNS server the client was reaching so
-// dnsvip can forward non-VIP names to the right upstream.
+// startUDPDNSListener binds UDP sockets (IPv4 and IPv6) on port and serves
+// DNS queries redirected by iptables/ip6tables PREROUTING REDIRECT.
+// IP_RECVORIGDSTADDR / IPV6_RECVORIGDSTADDR recover the DNS server the client
+// was reaching so dnsvip can forward non-VIP names to the right upstream.
 func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
 	if port == 0 || dvip == nil {
 		return
 	}
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+	startUDPDNSListenerFamily("udp4", syscall.IPPROTO_IP, ipRecvOrigDstAddr, port, dvip)
+	startUDPDNSListenerFamily("udp6", syscall.IPPROTO_IPV6, ipv6RecvOrigDstAddr, port, dvip)
+}
+
+func startUDPDNSListenerFamily(network string, level, opt, port int, dvip *dnsvip.Allocator) {
+	conn, err := net.ListenUDP(network, &net.UDPAddr{Port: port})
 	if err != nil {
-		log.Printf("udp dns listener: %v", err)
+		log.Printf("udp dns %s listener: %v", network, err)
 		return
 	}
 	if rc, err := conn.SyscallConn(); err == nil {
 		_ = rc.Control(func(fd uintptr) {
-			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ipRecvOrigDstAddr, 1); err != nil {
-				log.Printf("udp dns: IP_RECVORIGDSTADDR: %v", err)
+			if err := syscall.SetsockoptInt(int(fd), level, opt, 1); err != nil {
+				log.Printf("udp dns %s: RECVORIGDSTADDR: %v", network, err)
 			}
 		})
 	}
-	log.Printf("udp dns listener ready on :%d", port)
+	log.Printf("udp dns %s listener ready on :%d", network, port)
 	go func() {
 		defer func() { _ = conn.Close() }()
 		buf := make([]byte, 4096)
@@ -105,7 +111,7 @@ func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
 			n, oobn, _, addr, err := conn.ReadMsgUDP(buf, oob)
 			if err != nil {
 				if !isNetClosedError(err) {
-					log.Printf("udp dns: recv: %v", err)
+					log.Printf("udp dns %s: recv: %v", network, err)
 				}
 				return
 			}
@@ -120,17 +126,24 @@ func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
 }
 
 // parseUDPOrigDstIP extracts the original destination IP from recvmsg
-// ancillary data (IP_ORIGDSTADDR cmsg). Returns "" if not present.
+// ancillary data (IP_ORIGDSTADDR or IPV6_ORIGDSTADDR cmsg). Returns "" if absent.
 func parseUDPOrigDstIP(oob []byte) string {
 	msgs, err := syscall.ParseSocketControlMessage(oob)
 	if err != nil {
 		return ""
 	}
 	for _, m := range msgs {
-		if m.Header.Level == syscall.IPPROTO_IP && m.Header.Type == ipRecvOrigDstAddr {
+		switch {
+		case m.Header.Level == syscall.IPPROTO_IP && m.Header.Type == ipRecvOrigDstAddr:
 			if len(m.Data) >= syscall.SizeofSockaddrInet4 {
 				var sa syscall.RawSockaddrInet4
 				copy((*[syscall.SizeofSockaddrInet4]byte)(unsafe.Pointer(&sa))[:], m.Data)
+				return net.IP(sa.Addr[:]).String()
+			}
+		case m.Header.Level == syscall.IPPROTO_IPV6 && m.Header.Type == ipv6RecvOrigDstAddr:
+			if len(m.Data) >= syscall.SizeofSockaddrInet6 {
+				var sa syscall.RawSockaddrInet6
+				copy((*[syscall.SizeofSockaddrInet6]byte)(unsafe.Pointer(&sa))[:], m.Data)
 				return net.IP(sa.Addr[:]).String()
 			}
 		}
@@ -212,8 +225,12 @@ func installIPTables(portStr string, tcpPorts, udpDNSPorts, udpRejectPorts []str
 				}
 			}
 		}
+		rejectWith := "icmp-port-unreachable"
+		if bin == "ip6tables" {
+			rejectWith = "icmp6-port-unreachable"
+		}
 		for _, dport := range udpRejectPorts {
-			args := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
+			args := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", rejectWith}
 			if exec.Command(bin, append([]string{"-C", "FORWARD"}, args...)...).Run() != nil {
 				if out, err := exec.Command(bin, append([]string{"-I", "FORWARD", "1"}, args...)...).CombinedOutput(); err != nil {
 					log.Printf("exit-node redirect: %s REJECT udp/%s: %v: %s", bin, dport, err, out)

--- a/origdst_stub.go
+++ b/origdst_stub.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package main
+
+import "net"
+
+func originalDst(c net.Conn) (ip string, port uint16, ok bool) { return "", 0, false }
+func installExitNodeRedirect(listenPort int)                   {}

--- a/origdst_stub.go
+++ b/origdst_stub.go
@@ -2,7 +2,12 @@
 
 package main
 
-import "net"
+import (
+	"net"
+
+	"github.com/denoland/clawpatrol/dnsvip"
+)
 
 func originalDst(c net.Conn) (ip string, port uint16, ok bool)    { return "", 0, false }
 func installExitNodeRedirect(listenPort int, extraPorts []string) {}
+func startUDPDNSListener(port int, dvip *dnsvip.Allocator)        {}

--- a/origdst_stub.go
+++ b/origdst_stub.go
@@ -4,5 +4,5 @@ package main
 
 import "net"
 
-func originalDst(c net.Conn) (ip string, port uint16, ok bool) { return "", 0, false }
-func installExitNodeRedirect(listenPort int)                   {}
+func originalDst(c net.Conn) (ip string, port uint16, ok bool)    { return "", 0, false }
+func installExitNodeRedirect(listenPort int, extraPorts []string) {}

--- a/run_darwin.go
+++ b/run_darwin.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -79,6 +80,13 @@ func sessionIPC(msg string) error {
 
 func runRun(args []string) {
 	warnIfOnGatewayHost()
+
+	// Tailscale mode is not yet supported on macOS via clawpatrol run.
+	if mode := strings.TrimSpace(readFileSilent(filepath.Join(defaultClawpatrolDir(), "mode"))); mode == "tailscale" {
+		fail("clawpatrol run in Tailscale mode is not yet supported on macOS.\n" +
+			"  To use per-process tunneling, rejoin with WireGuard mode:\n" +
+			"  clawpatrol leave && clawpatrol join <gateway> --mode=wireguard")
+	}
 
 	if _, err := os.Stat(macHelperPath); err != nil {
 		fail("Clawpatrol.app not installed. Build + install from macos/:\n" +

--- a/run_linux.go
+++ b/run_linux.go
@@ -50,6 +50,7 @@ import (
 const (
 	runChildEnv        = "CLAWPATROL_RUN_CHILD"
 	runNoAutoExposeEnv = "CLAWPATROL_RUN_NO_AUTO_EXPOSE"
+	runTsnetChildEnv   = "CLAWPATROL_RUN_TSNET_CHILD"
 	tunIfName          = "wg0"
 	tunMTU             = 1420
 )
@@ -62,8 +63,18 @@ func runRun(args []string) {
 		runRunChild()
 		return
 	}
+	if os.Getenv(runTsnetChildEnv) == "1" {
+		runRunTsnetChild()
+		return
+	}
 
 	warnIfOnGatewayHost()
+
+	// Check for Tailscale mode — uses ephemeral tsnet instead of WireGuard.
+	if mode := strings.TrimSpace(readFileSilent(filepath.Join(defaultClawpatrolDir(), "mode"))); mode == "tailscale" {
+		runRunTsnet(args)
+		return
+	}
 
 	// `sudo clawpatrol run` is doomed on this distro: the UidMappings
 	// below collapse to `0 → 0`, and most distros refuse to put pid 0
@@ -741,16 +752,6 @@ func gatewayHTTPClient(caPath string) (*http.Client, error) {
 			TLSClientConfig: &tls.Config{RootCAs: roots},
 		},
 	}, nil
-}
-
-// readFileSilent reads a file and returns its contents as a string,
-// or empty on any error.
-func readFileSilent(path string) string {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }
 
 // --- helpers ---------------------------------------------------------

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -36,7 +36,7 @@ package main
 //  2. tsnet.Server{Ephemeral: true} joins the gateway's tailnet
 //  3. Child in new user+net+mnt ns creates TUN, sends fd via SCM_RIGHTS
 //  4. gVisor netstack reads from TUN, promiscuous TCP forwarder
-//  5. Each TCP connection → tsnet.Dial(gwHost:443) + HAProxy PROXY v1 header
+//  5. Each TCP connection → tsnet.Dial(gwHost:gwPort) + HAProxy PROXY v1 header
 //  6. Gateway recovers original dst from PROXY header, dispatches normally
 
 import (
@@ -106,7 +106,7 @@ func runRunTsnet(args []string) {
 	}
 
 	// 1. Mint ephemeral tsnet auth key.
-	authKey, err := fetchEphemeralTsnetKey(gwURL, token, filepath.Join(dir, "ca.crt"))
+	authKey, gwPort, err := fetchEphemeralTsnetKey(gwURL, token, filepath.Join(dir, "ca.crt"))
 	if err != nil {
 		fail("mint tsnet key: %v", err)
 	}
@@ -204,7 +204,7 @@ func runRunTsnet(args []string) {
 	// 7. TCP forwarder: every connection → tsnet → gateway.
 	// We forward to gwHost:originalPort so the gateway can route by port
 	// (port 443 → HTTPS MITM; other ports forwarded if gateway listens).
-	enableTsnetTCPForwarder(gvStack, tsServer, gwHost)
+	enableTsnetTCPForwarder(gvStack, tsServer, gwHost, gwPort)
 
 	// 8. Signal child: bridge is up.
 	_, _ = wgUpW.Write([]byte{1})
@@ -434,12 +434,12 @@ func startTunBridge(tunFile *os.File, ep *channel.Endpoint) {
 }
 
 // enableTsnetTCPForwarder installs a promiscuous TCP forwarder on s.
-// Every connection is forwarded to gwHost:443 via tsnet. A HAProxy PROXY v1
+// Every connection is forwarded to gwHost:gwPort via tsnet. A HAProxy PROXY v1
 // header is written before the payload carrying the original 4-tuple so the
 // gateway can dispatch by original dst IP/port (PostgreSQL, ClickHouse, etc.)
 // instead of only being able to route by SNI on port 443.
-func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost string) {
-	gwAddr := net.JoinHostPort(gwHost, "443")
+func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost, gwPort string) {
+	gwAddr := net.JoinHostPort(gwHost, gwPort)
 	fwd := tcp.NewForwarder(s, 1<<20, 16384, func(req *tcp.ForwarderRequest) {
 		id := req.ID()
 		// PROXY TCP4 srcIP dstIP srcPort dstPort
@@ -534,36 +534,42 @@ func waitTsnetUp(s *tsnet.Server) (netip.Addr, error) {
 }
 
 // fetchEphemeralTsnetKey calls POST /api/peer/ephemeral/tsnet on the
-// gateway to obtain a single-use ephemeral Tailscale auth key.
-func fetchEphemeralTsnetKey(gwURL, token, caPath string) (string, error) {
-	client, err := gatewayHTTPClient(caPath)
-	if err != nil {
-		return "", fmt.Errorf("http client: %w", err)
+// gateway to obtain a single-use ephemeral Tailscale auth key and the
+// tailnet port the gateway is listening on. gwPort defaults to "443" if
+// the gateway omits it (old gateway versions).
+func fetchEphemeralTsnetKey(gwURL, token, caPath string) (authKey, gwPort string, err error) {
+	client, ferr := gatewayHTTPClient(caPath)
+	if ferr != nil {
+		return "", "", fmt.Errorf("http client: %w", ferr)
 	}
-	req, err := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet", nil)
-	if err != nil {
-		return "", err
+	req, ferr := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet", nil)
+	if ferr != nil {
+		return "", "", ferr
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
+	resp, ferr := client.Do(req)
+	if ferr != nil {
+		return "", "", ferr
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return "", fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", "", fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var result struct {
-		AuthKey string `json:"auth_key"`
+		AuthKey     string `json:"auth_key"`
+		GatewayPort string `json:"gateway_port"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+	if ferr := json.NewDecoder(resp.Body).Decode(&result); ferr != nil {
+		return "", "", ferr
 	}
 	if result.AuthKey == "" {
-		return "", fmt.Errorf("empty auth_key in response")
+		return "", "", fmt.Errorf("empty auth_key in response")
 	}
-	return result.AuthKey, nil
+	if result.GatewayPort == "" {
+		result.GatewayPort = "443"
+	}
+	return result.AuthKey, result.GatewayPort, nil
 }
 
 // registerEphemeralTsnetIP tells the gateway which 100.x.x.x tailnet IP this

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -112,6 +112,12 @@ func runRunTsnet(args []string) {
 	}
 	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
 
+	// Register ephemeral tsnet IP with gateway so profile dispatch uses
+	// the right credentials (same as ephemeral WG peer registration).
+	if rerr := registerEphemeralTsnetIP(gwURL, token, filepath.Join(dir, "ca.crt"), tsIP.String()); rerr != nil {
+		fmt.Fprintf(os.Stderr, "warning: tsnet profile registration: %v (will use default profile)\n", rerr)
+	}
+
 	// 3. IPC channels: TUN fd handoff + wg-up pipe (same plumbing as WG mode).
 	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
@@ -534,4 +540,29 @@ func fetchEphemeralTsnetKey(gwURL, token, caPath string) (string, error) {
 		return "", fmt.Errorf("empty auth_key in response")
 	}
 	return result.AuthKey, nil
+}
+
+// registerEphemeralTsnetIP tells the gateway which 100.x.x.x tailnet IP this
+// ephemeral tsnet run session got, so the gateway maps it to the parent
+// device's profile for credential dispatch.
+func registerEphemeralTsnetIP(gwURL, token, caPath, tsIP string) error {
+	client, err := gatewayHTTPClient(caPath)
+	if err != nil {
+		return fmt.Errorf("http client: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet/register?ip="+tsIP, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
 }

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -7,13 +7,37 @@ package main
 // gVisor's TCP stack. No system-wide Tailscale required — tsnet runs
 // entirely in-process.
 //
+// Why PROXY headers instead of the exit-node iptables REDIRECT path
+// (origdst_linux.go):
+//
+// The exit-node REDIRECT path intercepts traffic from Tailscale exit-node
+// clients — machines that have configured this gateway as their exit node via
+// `tailscale set --exit-node=<gw>`. In that model, client traffic arrives on
+// the gateway's tailscale0 interface and iptables diverts it to the gateway
+// listener before kernel forwarding.
+//
+// `clawpatrol run` clients are NOT exit-node clients. The child process runs
+// in its own network namespace with a gVisor TCP/IP stack as the default
+// route. Each TCP connection the child makes is intercepted by gVisor and
+// dialed out via tsnet directly to the gateway node over the tailnet — a
+// peer-to-peer connection, not exit-node-forwarded traffic. The connection
+// arrives at the gateway's TCP listener as a direct tailnet connection from
+// the ephemeral node's 100.x.x.x; iptables REDIRECT on tailscale0 does not
+// apply because the traffic is delivered to the gateway's own address, not
+// forwarded onward.
+//
+// The PROXY header carries the original 4-tuple (srcIP, dstIP, srcPort,
+// dstPort) so the gateway accept loop recovers what the child process was
+// actually trying to reach (e.g., api.openai.com:443) and dispatches it
+// identically to the WireGuard and exit-node paths.
+//
 // Flow:
 //  1. POST /api/peer/ephemeral/tsnet → ephemeral Tailscale auth key
 //  2. tsnet.Server{Ephemeral: true} joins the gateway's tailnet
 //  3. Child in new user+net+mnt ns creates TUN, sends fd via SCM_RIGHTS
 //  4. gVisor netstack reads from TUN, promiscuous TCP forwarder
-//  5. Each TCP connection → tsnet.Dial(gwHost:originalPort)
-//  6. Child IP = tsnet 100.x.x.x, default route via TUN
+//  5. Each TCP connection → tsnet.Dial(gwHost:443) + HAProxy PROXY v1 header
+//  6. Gateway recovers original dst from PROXY header, dispatches normally
 
 import (
 	"context"

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -269,7 +269,9 @@ func runRunTsnetChild() {
 	}
 
 	if os.Getenv("CLAWPATROL_RUN_KEEP_RESOLV") != "1" {
-		_ = bindResolv("nameserver 1.1.1.1\nnameserver 8.8.8.8\n")
+		// options use-vc forces DNS over TCP — the gVisor netstack only handles
+		// TCP, so UDP DNS queries would silently drop without this option.
+		_ = bindResolv("nameserver 1.1.1.1\nnameserver 8.8.8.8\noptions use-vc\n")
 	}
 
 	autoExpose := os.Getenv(runNoAutoExposeEnv) != "1"
@@ -471,24 +473,32 @@ func tsnetBiRelay(a, b net.Conn) {
 func waitTsnetUp(s *tsnet.Server) (netip.Addr, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
-	if err := s.Up(ctx); err != nil {
+	// s.Up blocks until Running; the returned status already has TailscaleIPs.
+	upSt, err := s.Up(ctx)
+	if err != nil {
 		return netip.Addr{}, fmt.Errorf("tsnet up: %w", err)
 	}
-	lc, err := s.LocalClient()
-	if err != nil {
-		return netip.Addr{}, fmt.Errorf("local client: %w", err)
-	}
-	st, err := lc.Status(ctx)
-	if err != nil {
-		return netip.Addr{}, fmt.Errorf("status: %w", err)
-	}
-	for _, ip := range st.Self.TailscaleIPs {
+	for _, ip := range upSt.Self.TailscaleIPs {
 		if ip.Is4() {
 			return ip, nil
 		}
 	}
-	if len(st.Self.TailscaleIPs) > 0 {
-		return st.Self.TailscaleIPs[0], nil
+	// Fallback: query LocalClient (should rarely be needed).
+	lc, err := s.LocalClient()
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("local client: %w", err)
+	}
+	lcSt, err := lc.Status(ctx)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("status: %w", err)
+	}
+	for _, ip := range lcSt.Self.TailscaleIPs {
+		if ip.Is4() {
+			return ip, nil
+		}
+	}
+	if len(lcSt.Self.TailscaleIPs) > 0 {
+		return lcSt.Self.TailscaleIPs[0], nil
 	}
 	return netip.Addr{}, fmt.Errorf("no tailnet IPs assigned")
 }

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -1,0 +1,527 @@
+//go:build linux
+
+package main
+
+// `clawpatrol run` in Tailscale mode. Spins up an ephemeral tsnet.Server
+// per invocation and bridges the child's netns TUN to the gateway via
+// gVisor's TCP stack. No system-wide Tailscale required — tsnet runs
+// entirely in-process.
+//
+// Flow:
+//  1. POST /api/peer/ephemeral/tsnet → ephemeral Tailscale auth key
+//  2. tsnet.Server{Ephemeral: true} joins the gateway's tailnet
+//  3. Child in new user+net+mnt ns creates TUN, sends fd via SCM_RIGHTS
+//  4. gVisor netstack reads from TUN, promiscuous TCP forwarder
+//  5. Each TCP connection → tsnet.Dial(gwHost:originalPort)
+//  6. Child IP = tsnet 100.x.x.x, default route via TUN
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/waiter"
+	"tailscale.com/tsnet"
+)
+
+func runRunTsnet(args []string) {
+	warnIfOnGatewayHost()
+	if os.Geteuid() == 0 {
+		fail("run as your normal user; clawpatrol run uses unprivileged user namespaces which root cannot enter on this distro")
+	}
+
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	noAutoExpose := fs.Bool("no-auto-expose", false, "disable the seccomp relay that mirrors TCP listeners inside the netns back to the host")
+	_ = fs.Parse(args)
+	cmd := fs.Args()
+	if len(cmd) == 0 {
+		fail("usage: clawpatrol run [--no-auto-expose] -- <cmd> [args...]")
+	}
+	if *noAutoExpose {
+		_ = os.Setenv(runNoAutoExposeEnv, "1")
+	}
+	autoExpose := os.Getenv(runNoAutoExposeEnv) != "1"
+
+	checkUserNS()
+
+	dir := defaultClawpatrolDir()
+	applyEnvPushdown(dir)
+
+	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway")))
+	gwHost := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway")))
+	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "control-url")))
+	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
+	if gwHost == "" {
+		gwHost = "clawpatrol-gateway"
+	}
+	if gwURL == "" || token == "" {
+		fail("tsnet run: missing gateway url or api-token in %s", dir)
+	}
+
+	// 1. Mint ephemeral tsnet auth key.
+	authKey, err := fetchEphemeralTsnetKey(gwURL, token, filepath.Join(dir, "ca.crt"))
+	if err != nil {
+		fail("mint tsnet key: %v", err)
+	}
+
+	// 2. Spin up ephemeral tsnet.Server.
+	stateDir, err := os.MkdirTemp("", "clawpatrol-tsnet-*")
+	if err != nil {
+		fail("tsnet state dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(stateDir) }()
+
+	tsServer := &tsnet.Server{
+		Hostname:   fmt.Sprintf("clawpatrol-run-%d", os.Getpid()),
+		AuthKey:    authKey,
+		ControlURL: controlURL,
+		Dir:        stateDir,
+		Ephemeral:  true,
+		Logf:       func(string, ...any) {},
+	}
+	defer func() { _ = tsServer.Close() }()
+
+	// Wait for tsnet Running — get our 100.x.x.x address.
+	fmt.Fprintln(os.Stderr, "clawpatrol: joining tailnet...")
+	tsIP, err := waitTsnetUp(tsServer)
+	if err != nil {
+		fail("tsnet join: %v", err)
+	}
+	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
+
+	// 3. IPC channels: TUN fd handoff + wg-up pipe (same plumbing as WG mode).
+	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		fail("socketpair: %v", err)
+	}
+	pSock := os.NewFile(uintptr(sp[0]), "parent-sock")
+	cSock := os.NewFile(uintptr(sp[1]), "child-sock")
+	defer func() { _ = pSock.Close() }()
+	wgUpR, wgUpW, err := os.Pipe()
+	if err != nil {
+		fail("pipe: %v", err)
+	}
+
+	// 4. Spawn child in new user+net+mnt namespace.
+	self, err := os.Executable()
+	if err != nil {
+		fail("self path: %v", err)
+	}
+	child := exec.Command(self, append([]string{"run"}, cmd...)...)
+	child.Env = append(os.Environ(), runTsnetChildEnv+"=1")
+	child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
+	child.ExtraFiles = []*os.File{cSock, wgUpR}
+	child.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET | syscall.CLONE_NEWNS,
+		UidMappings: []syscall.SysProcIDMap{
+			{ContainerID: os.Getuid(), HostID: os.Getuid(), Size: 1},
+		},
+		GidMappings: []syscall.SysProcIDMap{
+			{ContainerID: os.Getgid(), HostID: os.Getgid(), Size: 1},
+		},
+		GidMappingsEnableSetgroups: false,
+		AmbientCaps:                []uintptr{capNetAdmin, capSysAdmin},
+	}
+	if err := child.Start(); err != nil {
+		if os.Geteuid() == 0 {
+			fail("clone: %v\n  hint: run as your normal user", err)
+		}
+		fail("clone: %v\n  hint: this distro may have unprivileged user namespaces disabled.\n  enable: sudo sysctl -w kernel.unprivileged_userns_clone=1", err)
+	}
+	_ = cSock.Close()
+	_ = wgUpR.Close()
+
+	// 5. Receive TUN fd from child.
+	tunFd, err := recvFD(pSock)
+	if err != nil {
+		_ = child.Process.Kill()
+		fail("recv tun fd: %v", err)
+	}
+	tunFile := os.NewFile(uintptr(tunFd), tunIfName)
+
+	// 6. Build gVisor stack on the TUN fd.
+	gvStack, gvEp, err := newTsnetRunStack(tsIP)
+	if err != nil {
+		_ = child.Process.Kill()
+		fail("gvisor stack: %v", err)
+	}
+	defer gvStack.Close()
+	startTunBridge(tunFile, gvEp)
+
+	// 7. TCP forwarder: every connection → tsnet → gateway.
+	// We forward to gwHost:originalPort so the gateway can route by port
+	// (port 443 → HTTPS MITM; other ports forwarded if gateway listens).
+	enableTsnetTCPForwarder(gvStack, tsServer, gwHost)
+
+	// 8. Signal child: bridge is up.
+	_, _ = wgUpW.Write([]byte{1})
+	_ = wgUpW.Close()
+
+	// 9. Auto-expose relay (same as WG mode).
+	var relaySup *exec.Cmd
+	if autoExpose {
+		if relayFDs, err := recvFDs(pSock, 2); err == nil {
+			notifyFile := os.NewFile(uintptr(relayFDs[0]), "seccomp-notify")
+			supSock := os.NewFile(uintptr(relayFDs[1]), "relay-sup-sock")
+			if c, serr := spawnRelaySupervisor(notifyFile, supSock); serr != nil {
+				fmt.Fprintf(os.Stderr, "warning: auto-expose relay: %v (webhooks won't be reachable from host)\n", serr)
+			} else {
+				relaySup = c
+			}
+			_ = notifyFile.Close()
+			_ = supSock.Close()
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: auto-expose relay: no fds from child: %v\n", err)
+		}
+	}
+
+	sigCh := make(chan os.Signal, 4)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		for s := range sigCh {
+			_ = child.Process.Signal(s)
+		}
+	}()
+
+	waitErr := child.Wait()
+
+	if relaySup != nil && relaySup.Process != nil {
+		_ = relaySup.Process.Signal(syscall.SIGTERM)
+		_, _ = relaySup.Process.Wait()
+	}
+
+	if waitErr != nil {
+		var ee *exec.ExitError
+		if errors.As(waitErr, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		fail("wait: %v", waitErr)
+	}
+}
+
+// runRunTsnetChild runs inside the new user+net+mnt namespace.
+// Receives TUN fd on fd 3, wg-up pipe on fd 4.
+// Sets up TUN with the tsnet 100.x.x.x IP and default route.
+func runRunTsnetChild() {
+	cSock := os.NewFile(3, "parent-sock")
+	wgUpR := os.NewFile(4, "wg-up")
+
+	argv := os.Args[2:]
+	if len(argv) == 0 {
+		fail("internal: tsnet child got empty argv")
+	}
+
+	tunFd, err := openTUN(tunIfName)
+	if err != nil {
+		fail("open tun: %v", err)
+	}
+	if err := sendFD(cSock, tunFd); err != nil {
+		fail("send tun fd: %v", err)
+	}
+	_ = unix.Close(tunFd)
+
+	one := make([]byte, 1)
+	if _, err := io.ReadFull(wgUpR, one); err != nil {
+		fail("wait wg-up: %v", err)
+	}
+	_ = wgUpR.Close()
+
+	tsAddr := os.Getenv("CLAWPATROL_TS_ADDR")
+	if tsAddr == "" {
+		fail("CLAWPATROL_TS_ADDR not set")
+	}
+
+	steps := [][]string{
+		{"ip", "link", "set", "lo", "up"},
+		{"ip", "link", "set", tunIfName, "mtu", fmt.Sprintf("%d", tunMTU), "up"},
+		{"ip", "addr", "add", tsAddr + "/32", "dev", tunIfName},
+		{"ip", "route", "add", "default", "dev", tunIfName},
+	}
+	for _, a := range steps {
+		c := exec.Command(a[0], a[1:]...)
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			fail("%s: %v", strings.Join(a, " "), err)
+		}
+	}
+
+	if os.Getenv("CLAWPATROL_RUN_KEEP_RESOLV") != "1" {
+		_ = bindResolv("nameserver 1.1.1.1\nnameserver 8.8.8.8\n")
+	}
+
+	autoExpose := os.Getenv(runNoAutoExposeEnv) != "1"
+	if autoExpose {
+		setupRelayInChild(cSock)
+	}
+	_ = cSock.Close()
+
+	if autoExpose {
+		_, _, _ = unix.RawSyscall6(unix.SYS_PRCTL,
+			unix.PR_SET_PTRACER, ptraceAny, 0, 0, 0, 0)
+	}
+
+	if err := clearAmbientCaps(); err != nil {
+		fail("clear ambient caps: %v", err)
+	}
+
+	bin, err := exec.LookPath(argv[0])
+	if err != nil {
+		fail("lookpath %s: %v", argv[0], err)
+	}
+	if err := syscall.Exec(bin, argv, os.Environ()); err != nil {
+		fail("exec %s: %v", bin, err)
+	}
+}
+
+// --- gVisor stack + TUN bridge ------------------------------------------
+
+// newTsnetRunStack creates a gVisor TCP/IP stack bound to localIP.
+// Promiscuous + spoofing enabled so it accepts connections destined
+// to any IP from the child netns.
+func newTsnetRunStack(localIP netip.Addr) (*stack.Stack, *channel.Endpoint, error) {
+	ep := channel.New(netstackQueueSize, uint32(tunMTU), "")
+	s := stack.New(stack.Options{
+		NetworkProtocols: []stack.NetworkProtocolFactory{
+			ipv4.NewProtocol, ipv6.NewProtocol,
+		},
+		TransportProtocols: []stack.TransportProtocolFactory{
+			tcp.NewProtocol,
+		},
+		HandleLocal: false,
+	})
+	sackOpt := tcpip.TCPSACKEnabled(true)
+	s.SetTransportProtocolOption(tcp.ProtocolNumber, &sackOpt)
+	rackOpt := tcpip.TCPRecovery(0)
+	s.SetTransportProtocolOption(tcp.ProtocolNumber, &rackOpt)
+	ccOpt := tcpip.CongestionControlOption("reno")
+	s.SetTransportProtocolOption(tcp.ProtocolNumber, &ccOpt)
+	minRTOOpt := tcpip.TCPMinRTOOption(time.Second)
+	s.SetTransportProtocolOption(tcp.ProtocolNumber, &minRTOOpt)
+	rxBuf := tcpip.TCPReceiveBufferSizeRangeOption{Min: 4 << 10, Default: 1 << 20, Max: 8 << 20}
+	s.SetTransportProtocolOption(tcp.ProtocolNumber, &rxBuf)
+	txBuf := tcpip.TCPSendBufferSizeRangeOption{Min: 4 << 10, Default: 1 << 20, Max: 6 << 20}
+	s.SetTransportProtocolOption(tcp.ProtocolNumber, &txBuf)
+
+	if e := s.CreateNIC(1, ep); e != nil {
+		return nil, nil, fmt.Errorf("CreateNIC: %v", e)
+	}
+	pa := tcpip.ProtocolAddress{
+		Protocol:          ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddrFromSlice(localIP.AsSlice()).WithPrefix(),
+	}
+	if e := s.AddProtocolAddress(1, pa, stack.AddressProperties{}); e != nil {
+		return nil, nil, fmt.Errorf("AddProtocolAddress: %v", e)
+	}
+	s.AddRoute(tcpip.Route{Destination: header.IPv4EmptySubnet, NIC: 1})
+	s.AddRoute(tcpip.Route{Destination: header.IPv6EmptySubnet, NIC: 1})
+	if e := s.SetPromiscuousMode(1, true); e != nil {
+		return nil, nil, fmt.Errorf("SetPromiscuousMode: %v", e)
+	}
+	if e := s.SetSpoofing(1, true); e != nil {
+		return nil, nil, fmt.Errorf("SetSpoofing: %v", e)
+	}
+	return s, ep, nil
+}
+
+// tsnetTunBridge pumps packets between the raw TUN fd and gVisor's
+// channel endpoint. Implements channel.Notification for the outbound
+// (gVisor→TUN) direction.
+type tsnetTunBridge struct {
+	tunFile *os.File
+	ep      *channel.Endpoint
+}
+
+// WriteNotify is called by gVisor when outbound packets are ready.
+// Drains ep and writes raw IP packets to the TUN fd.
+func (b *tsnetTunBridge) WriteNotify() {
+	for {
+		pkt := b.ep.Read()
+		if pkt == nil {
+			return
+		}
+		view := pkt.ToView()
+		pkt.DecRef()
+		_, _ = b.tunFile.Write(view.AsSlice())
+	}
+}
+
+// startTunBridge registers the outbound notification and starts the
+// inbound read loop (TUN fd → gVisor InjectInbound).
+func startTunBridge(tunFile *os.File, ep *channel.Endpoint) {
+	br := &tsnetTunBridge{tunFile: tunFile, ep: ep}
+	ep.AddNotify(br)
+
+	go func() {
+		buf := make([]byte, tunMTU)
+		for {
+			n, err := tunFile.Read(buf)
+			if err != nil {
+				return
+			}
+			if n == 0 {
+				continue
+			}
+			pkt := make([]byte, n)
+			copy(pkt, buf[:n])
+			pkb := stack.NewPacketBuffer(stack.PacketBufferOptions{
+				Payload: buffer.MakeWithData(pkt),
+			})
+			switch pkt[0] >> 4 {
+			case 4:
+				ep.InjectInbound(header.IPv4ProtocolNumber, pkb)
+			case 6:
+				ep.InjectInbound(header.IPv6ProtocolNumber, pkb)
+			default:
+				pkb.DecRef()
+			}
+		}
+	}()
+}
+
+// enableTsnetTCPForwarder installs a promiscuous TCP forwarder on s.
+// Every connection is forwarded to gwHost:443 via tsnet. A HAProxy PROXY v1
+// header is written before the payload carrying the original 4-tuple so the
+// gateway can dispatch by original dst IP/port (PostgreSQL, ClickHouse, etc.)
+// instead of only being able to route by SNI on port 443.
+func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost string) {
+	gwAddr := net.JoinHostPort(gwHost, "443")
+	fwd := tcp.NewForwarder(s, 1<<20, 16384, func(req *tcp.ForwarderRequest) {
+		id := req.ID()
+		// PROXY TCP4 srcIP dstIP srcPort dstPort
+		proxyHdr := fmt.Sprintf("PROXY TCP4 %s %s %d %d\r\n",
+			id.RemoteAddress, id.LocalAddress, id.RemotePort, id.LocalPort)
+
+		var wq waiter.Queue
+		ep, err := req.CreateEndpoint(&wq)
+		if err != nil {
+			req.Complete(true)
+			return
+		}
+		req.Complete(false)
+		local := gonet.NewTCPConn(&wq, ep)
+		go func() {
+			defer func() { _ = local.Close() }()
+			ctx := context.Background()
+			remote, err := ts.Dial(ctx, "tcp", gwAddr)
+			if err != nil {
+				return
+			}
+			defer func() { _ = remote.Close() }()
+			if _, err := io.WriteString(remote, proxyHdr); err != nil {
+				return
+			}
+			tsnetBiRelay(local, remote)
+		}()
+	})
+	s.SetTransportProtocolHandler(tcp.ProtocolNumber, fwd.HandlePacket)
+}
+
+// tsnetBiRelay copies bidirectionally between a and b, half-closing
+// each side when the opposite direction finishes.
+func tsnetBiRelay(a, b net.Conn) {
+	type halfCloser interface {
+		CloseWrite() error
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(b, a)
+		if hc, ok := b.(halfCloser); ok {
+			_ = hc.CloseWrite()
+		} else {
+			_ = b.Close()
+		}
+	}()
+	_, _ = io.Copy(a, b)
+	if hc, ok := a.(halfCloser); ok {
+		_ = hc.CloseWrite()
+	} else {
+		_ = a.Close()
+	}
+	<-done
+}
+
+// --- tsnet helpers -------------------------------------------------------
+
+// waitTsnetUp starts the tsnet.Server and blocks until the node is Running
+// and has a 100.x.x.x IP. Returns the IPv4 tailnet address.
+func waitTsnetUp(s *tsnet.Server) (netip.Addr, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	if err := s.Up(ctx); err != nil {
+		return netip.Addr{}, fmt.Errorf("tsnet up: %w", err)
+	}
+	lc, err := s.LocalClient()
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("local client: %w", err)
+	}
+	st, err := lc.Status(ctx)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("status: %w", err)
+	}
+	for _, ip := range st.Self.TailscaleIPs {
+		if ip.Is4() {
+			return ip, nil
+		}
+	}
+	if len(st.Self.TailscaleIPs) > 0 {
+		return st.Self.TailscaleIPs[0], nil
+	}
+	return netip.Addr{}, fmt.Errorf("no tailnet IPs assigned")
+}
+
+// fetchEphemeralTsnetKey calls POST /api/peer/ephemeral/tsnet on the
+// gateway to obtain a single-use ephemeral Tailscale auth key.
+func fetchEphemeralTsnetKey(gwURL, token, caPath string) (string, error) {
+	client, err := gatewayHTTPClient(caPath)
+	if err != nil {
+		return "", fmt.Errorf("http client: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var result struct {
+		AuthKey string `json:"auth_key"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.AuthKey == "" {
+		return "", fmt.Errorf("empty auth_key in response")
+	}
+	return result.AuthKey, nil
+}

--- a/setup.go
+++ b/setup.go
@@ -544,6 +544,16 @@ func defaultClawpatrolDir() string {
 	return filepath.Join(home, ".clawpatrol")
 }
 
+// readFileSilent reads a file and returns its contents as a string,
+// or empty on any error.
+func readFileSilent(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 func fail(format string, a ...any) {
 	fmt.Fprintf(os.Stderr, "clawpatrol: "+format+"\n", a...)
 	os.Exit(2)
@@ -744,6 +754,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	stopSpin := startSpinner("Waiting for approval")
 	authKey, loginServer, apiToken := "", "", ""
+	var tailnetGWHost, tailnetControlURL string
 	for time.Now().Before(deadline) {
 		time.Sleep(interval)
 		pr, err := cli.Post(gateway+"/api/onboard/poll?device_code="+start.DeviceCode, "application/json", nil)
@@ -757,6 +768,8 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			authKey = k
 			loginServer = pv["login_server"]
 			apiToken = pv["api_token"]
+			tailnetGWHost = pv["gateway_host"]
+			tailnetControlURL = pv["control_url"]
 			break
 		}
 		if e := pv["error"]; e != "" && e != "authorization_pending" && e != "slow_down" {
@@ -920,6 +933,17 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	printTreeItems(items)
 	fmt.Println()
 	fmt.Println("Installed! Try: claude")
+
+	// Write mode marker files so `clawpatrol run` can detect Tailscale mode.
+	clawDir := filepath.Dir(setup.caPath)
+	_ = os.WriteFile(filepath.Join(clawDir, "mode"), []byte("tailscale\n"), 0o600)
+	if tailnetGWHost != "" {
+		_ = os.WriteFile(filepath.Join(clawDir, "tailnet-gateway"), []byte(tailnetGWHost+"\n"), 0o600)
+	}
+	if tailnetControlURL != "" {
+		_ = os.WriteFile(filepath.Join(clawDir, "control-url"), []byte(tailnetControlURL+"\n"), 0o600)
+	}
+
 	return false, nil
 }
 

--- a/setup.go
+++ b/setup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -215,7 +216,15 @@ func finishJoinSetup(s *joinSetup, skipTrust bool) {
 // approval step.
 func fetchCAHTTP(gateway, dst string) (string, error) {
 	url := strings.TrimRight(gateway, "/") + "/ca.crt"
-	c := &http.Client{Timeout: 10 * time.Second}
+	// InsecureSkipVerify is intentional here: we haven't yet fetched the CA
+	// that signed the gateway's cert, so we can't verify it. The admin confirms
+	// the fingerprint out-of-band (shown in the UI at join time) — TOFU.
+	c := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
 	resp, err := c.Get(url)
 	if err != nil {
 		return "", err
@@ -678,7 +687,14 @@ func wgAddressFromConf(conf string) string {
 // during the unauthenticated /ca.crt fetch.
 func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname string, setup *joinSetup, skipTrust bool) (bool, error) {
 	gateway = strings.TrimRight(gateway, "/")
-	cli := &http.Client{Timeout: 30 * time.Second}
+	// CA is unverified until the admin confirms the fingerprint at approval time
+	// (TOFU). Use InsecureSkipVerify throughout the join handshake.
+	cli := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
 
 	hn := hostname
 	if hn == "" {
@@ -892,7 +908,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	// 4b. tailscale up — set --operator on linux so future
 	// `tailscale set/serve/funnel` calls don't need sudo.
-	upArgs := []string{tscli, "up", "--authkey=" + authKey, "--accept-routes", "--accept-dns=false"}
+	upArgs := []string{tscli, "up", "--reset", "--authkey=" + authKey, "--accept-routes", "--accept-dns=false"}
 	if runtime.GOOS == "linux" {
 		if u := os.Getenv("USER"); u != "" {
 			upArgs = append(upArgs, "--operator="+u)
@@ -927,6 +943,13 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		body, _ := io.ReadAll(io.LimitReader(cr.Body, 400))
 		fmt.Fprintf(os.Stderr, "⚠ onboard claim %d: %s\n", cr.StatusCode, string(body))
 		return false, nil
+	}
+	var claimResp map[string]string
+	if err := json.NewDecoder(cr.Body).Decode(&claimResp); err == nil {
+		if tok := claimResp["api_token"]; tok != "" {
+			_ = os.WriteFile(filepath.Join(filepath.Dir(setup.caPath), "api-token"),
+				[]byte(tok+"\n"), 0o600)
+		}
 	}
 	items := []string{"Joined tailnet as " + tailIP}
 	items = append(items, setupSummaryItems(*setup)...)

--- a/setup.go
+++ b/setup.go
@@ -272,6 +272,9 @@ func runLogin(args []string) {
 		} else {
 			sshPinned = true
 		}
+		if err := exemptPublicIPFromExitNode(); err != nil {
+			fmt.Fprintf(os.Stderr, "⚠ couldn't protect public IP inbound traffic: %v\n", err)
+		}
 	}
 
 	tscli, err := tailscaleBin()
@@ -422,6 +425,71 @@ func exemptSSHFromExitNode(_ string) error {
 		if err := c.Run(); err != nil {
 			return fmt.Errorf("ip rule: %w", err)
 		}
+	}
+	return nil
+}
+
+// exemptPublicIPFromExitNode ensures reply traffic for this machine's public
+// IP address routes via the main table (direct interface) rather than the
+// Tailscale exit-node. Without this, inbound TCP connections (HTTPS, etc.)
+// receive SYN-ACKs from the exit-node's public IP instead of the machine's
+// own IP, breaking every server that binds to the public interface.
+//
+// The fix is a single high-priority policy-routing rule:
+//
+//	ip rule add from <public-ip> lookup main priority 100
+//
+// Idempotent. Also writes a networkd-dispatcher script so the rule survives
+// reboots (Tailscale's own routing rules are re-installed on every boot, so
+// we have to be too).
+func exemptPublicIPFromExitNode() error {
+	// Find the primary public IPv4: source addr used for the default route.
+	out, err := exec.Command("ip", "-o", "route", "get", "1.1.1.1").Output()
+	if err != nil {
+		return fmt.Errorf("ip route get: %w", err)
+	}
+	// output: "1.1.1.1 via ... dev eth0 src 203.0.113.5 ..."
+	pubIP := ""
+	fields := strings.Fields(string(out))
+	for i, f := range fields {
+		if f == "src" && i+1 < len(fields) {
+			pubIP = fields[i+1]
+			break
+		}
+	}
+	if pubIP == "" || strings.HasPrefix(pubIP, "100.") || pubIP == "127.0.0.1" {
+		return fmt.Errorf("could not determine public IP (got %q)", pubIP)
+	}
+
+	// Add ip rule idempotently.
+	existing, _ := exec.Command("ip", "rule", "show").Output()
+	if !strings.Contains(string(existing), pubIP) {
+		c := exec.Command("sudo", "ip", "rule", "add", "from", pubIP, "lookup", "main", "priority", "100")
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("ip rule add: %w", err)
+		}
+	}
+
+	// Persist via networkd-dispatcher so the rule survives reboots.
+	dir := "/etc/networkd-dispatcher/routable.d"
+	_ = exec.Command("sudo", "mkdir", "-p", dir).Run()
+	script := fmt.Sprintf("#!/bin/sh\n# clawpatrol: keep public IP replies on direct path (not exit-node)\nip rule show | grep -q '%s' || ip rule add from %s lookup main priority 100\n", pubIP, pubIP)
+	tmp, err := os.CreateTemp("", "clawpatrol-routing-*")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.WriteString(script); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	_ = tmp.Close()
+	dst := dir + "/50-clawpatrol-public-ip"
+	c := exec.Command("sudo", "sh", "-c", fmt.Sprintf("mv %s %s && chmod +x %s", tmp.Name(), dst, dst))
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("install routing script: %w", err)
 	}
 	return nil
 }

--- a/setup.go
+++ b/setup.go
@@ -307,8 +307,15 @@ func runLogin(args []string) {
 	// On Linux, `tailscale set` requires sudo unless --operator=$USER
 	// was passed to `tailscale up`. tsSet handles either case.
 	if !*skipExitNode {
-		if err := tsSet(tscli, "--exit-node="+*gwName); err != nil {
+		if err := tsSet(tscli, "--exit-node="+*gwName, "--accept-dns=false"); err != nil {
 			fail("tailscale set --exit-node=%s: %v", *gwName, err)
+		}
+		// With accept-dns=false, Tailscale stops managing /etc/resolv.conf but
+		// leaves whatever nameserver was there (often 100.100.100.100). Once the
+		// exit-node is active, that address is unreachable from the client, so
+		// DNS breaks. Write a public fallback so lookups work through the exit-node.
+		if runtime.GOOS == "linux" {
+			fixResolvConf()
 		}
 	}
 
@@ -546,6 +553,54 @@ func manualTrustHint(caPath string) string {
 		return fmt.Sprintf("sudo cp %s /usr/local/share/ca-certificates/clawpatrol.crt && sudo update-ca-certificates", caPath)
 	}
 	return "manually add " + caPath + " to your system trust store"
+}
+
+// fixResolvConf ensures /etc/resolv.conf has a working public nameserver after
+// Tailscale DNS management is disabled (--accept-dns=false). When exit-node is
+// active, 100.100.100.100 (the Tailscale magic DNS address) is unreachable from
+// the client, so any resolver pointing there breaks silently. Best-effort: if we
+// can't write the file (e.g. no sudo), the caller should warn the user.
+func fixResolvConf() {
+	const path = "/etc/resolv.conf"
+	cur, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ resolv.conf: read: %v\n", err)
+		return
+	}
+	// If no Tailscale magic DNS address is present, leave the file alone.
+	if !strings.Contains(string(cur), "100.100.100.100") {
+		return
+	}
+	// Replace Tailscale DNS with a public resolver. Use a temp file + rename
+	// to avoid truncating the live file mid-write.
+	tmp, err := os.CreateTemp("/etc", ".resolv.conf.*")
+	if err != nil {
+		// Might need root — fall back to a sudo tee approach.
+		cmd := exec.Command("sudo", "tee", path)
+		cmd.Stdin = strings.NewReader("nameserver 8.8.8.8\nnameserver 8.8.4.4\n")
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			fmt.Fprintf(os.Stderr, "⚠ resolv.conf: fix DNS: %v: %s\n", err2, out)
+		} else {
+			fmt.Println("Updated /etc/resolv.conf → 8.8.8.8 (Tailscale DNS disabled)")
+		}
+		return
+	}
+	if _, err := tmp.WriteString("nameserver 8.8.8.8\nnameserver 8.8.4.4\n"); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return
+	}
+	_ = tmp.Close()
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		// Rename across /etc may fail without root.
+		cmd := exec.Command("sudo", "mv", tmp.Name(), path)
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			fmt.Fprintf(os.Stderr, "⚠ resolv.conf: %v: %s\n", err2, out)
+			_ = os.Remove(tmp.Name())
+			return
+		}
+	}
+	fmt.Println("Updated /etc/resolv.conf → 8.8.8.8 (Tailscale DNS disabled)")
 }
 
 func defaultClawpatrolDir() string {

--- a/setup.go
+++ b/setup.go
@@ -118,15 +118,18 @@ func runJoin(args []string) {
 	// configured (MASQUERADE etc). The CA is small + cheap and
 	// the onboard endpoints are reachable on the public path.
 	//
+	// In Tailscale control mode the gateway intentionally does not
+	// expose /ca.crt on its public Funnel path — the CA is only
+	// reachable over the tailnet (security: no TOFU over plain
+	// internet). A 404 here means we're talking to a Tailscale-mode
+	// gateway; runLogin (called below after onboard + Tailscale join)
+	// fetches the CA from the peer's tailnet IP instead.
+	//
 	// Trust install + shell-rc updates are deferred to
 	// finishJoinSetup, which runs only after the operator's
-	// dashboard approval click. Until that point an attacker
-	// on-path could have substituted the CA we just fetched
-	// over plain HTTP. The approval flow shows the gateway's
-	// real CA fingerprint on the dashboard; the operator
-	// compares it against what the CLI prints below.
+	// dashboard approval click.
 	setup, err := preJoinFetchCA(gatewayURL, *caOut)
-	if err != nil {
+	if err != nil && !isCaNotExposed(err) {
 		fail("ca fetch: %v", err)
 	}
 	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, &setup, *skipTrust)
@@ -155,6 +158,13 @@ type joinSetup struct {
 	shellRC       bool   // shell rc updated with `eval "$(clawpatrol env)"`
 }
 
+// isCaNotExposed returns true when the gateway deliberately did not expose
+// /ca.crt on its public path (Tailscale control mode). The CA will be
+// fetched securely over the tailnet by runLogin after Tailscale join.
+func isCaNotExposed(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "status 404")
+}
+
 // preJoinFetchCA downloads the gateway's CA into caDir and computes
 // its SHA-256 fingerprint, but stops short of installing it into
 // the system trust store. Trust install + shell-rc updates land in
@@ -170,19 +180,17 @@ func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
 	if err := os.MkdirAll(caDir, 0o700); err != nil {
 		return s, fmt.Errorf("mkdir %s: %w", caDir, err)
 	}
+	// Persist the dashboard URL before the CA fetch so subsequent
+	// `clawpatrol env` / `clawpatrol run` invocations work even when
+	// the CA fetch is deferred (Tailscale mode, 404 on /ca.crt).
+	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
+		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	s.caPath = filepath.Join(caDir, "ca.crt")
 	fp, err := fetchCAHTTP(gateway, s.caPath)
 	if err != nil {
 		return s, fmt.Errorf("fetch CA: %w", err)
 	}
 	s.caFingerprint = fp
-	// Persist the dashboard URL so subsequent `clawpatrol env` /
-	// `clawpatrol run` invocations can fetch the env push-down list
-	// from the gateway instead of iterating compiled-in plugins.
-	// Best-effort; the read side falls back to local enumeration
-	// when this file is missing.
-	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
-		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	return s, nil
 }
 
@@ -193,6 +201,12 @@ func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
 // substituted by an on-path attacker at fetch time.
 func finishJoinSetup(s *joinSetup, skipTrust bool) {
 	if s.caPath == "" {
+		return
+	}
+	if _, err := os.Stat(s.caPath); err != nil {
+		// CA not fetched yet (Tailscale mode defers to runLogin). Skip
+		// trust install; runLogin will fetch + install from the tailnet.
+		installShellRC() //nolint:errcheck
 		return
 	}
 	if !skipTrust {

--- a/setup.go
+++ b/setup.go
@@ -318,7 +318,7 @@ func runLogin(args []string) {
 		// exit-node is active, that address is unreachable from the client, so
 		// DNS breaks. Write a public fallback so lookups work through the exit-node.
 		if runtime.GOOS == "linux" {
-			fixResolvConf()
+			fixResolvConf(st.MagicDNSSuffix)
 		}
 	}
 
@@ -626,49 +626,104 @@ func manualTrustHint(caPath string) string {
 // fixResolvConf ensures /etc/resolv.conf has a working public nameserver after
 // Tailscale DNS management is disabled (--accept-dns=false). When exit-node is
 // active, 100.100.100.100 (the Tailscale magic DNS address) is unreachable from
-// the client, so any resolver pointing there breaks silently. Best-effort: if we
-// can't write the file (e.g. no sudo), the caller should warn the user.
-func fixResolvConf() {
-	const path = "/etc/resolv.conf"
-	cur, err := os.ReadFile(path)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "⚠ resolv.conf: read: %v\n", err)
+// the client, so any resolver pointing there breaks silently.
+//
+// If systemd-resolved is running, configure split DNS: public names go to 8.8.8.8
+// via the default interface, and MagicDNS names (*.ts.net, *.tailnet suffix) still
+// resolve via 100.100.100.100 on tailscale0. This preserves peer name resolution
+// while keeping public DNS working through the exit-node.
+//
+// Falls back to writing 8.8.8.8 directly into resolv.conf when systemd-resolved
+// is not available. Best-effort; logs warnings on failure.
+func fixResolvConf(magicDNSSuffix string) {
+	if fixResolvConfSplitDNS(magicDNSSuffix) {
 		return
 	}
-	// If no Tailscale magic DNS address is present, leave the file alone.
+	// Fallback: plain resolv.conf replace.
+	const path = "/etc/resolv.conf"
+	cur, _ := os.ReadFile(path)
 	if !strings.Contains(string(cur), "100.100.100.100") {
 		return
 	}
-	// Replace Tailscale DNS with a public resolver. Use a temp file + rename
-	// to avoid truncating the live file mid-write.
-	tmp, err := os.CreateTemp("/etc", ".resolv.conf.*")
-	if err != nil {
-		// Might need root — fall back to a sudo tee approach.
-		cmd := exec.Command("sudo", "tee", path)
-		cmd.Stdin = strings.NewReader("nameserver 8.8.8.8\nnameserver 8.8.4.4\n")
-		if out, err2 := cmd.CombinedOutput(); err2 != nil {
-			fmt.Fprintf(os.Stderr, "⚠ resolv.conf: fix DNS: %v: %s\n", err2, out)
-		} else {
-			fmt.Println("Updated /etc/resolv.conf → 8.8.8.8 (Tailscale DNS disabled)")
+	writeResolv := func(content string) bool {
+		tmp, err := os.CreateTemp("/etc", ".resolv.conf.*")
+		if err != nil {
+			cmd := exec.Command("sudo", "tee", path)
+			cmd.Stdin = strings.NewReader(content)
+			out, err2 := cmd.CombinedOutput()
+			if err2 != nil {
+				fmt.Fprintf(os.Stderr, "⚠ resolv.conf: %v: %s\n", err2, out)
+				return false
+			}
+			return true
 		}
-		return
-	}
-	if _, err := tmp.WriteString("nameserver 8.8.8.8\nnameserver 8.8.4.4\n"); err != nil {
+		_, _ = tmp.WriteString(content)
 		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-		return
+		if err := os.Rename(tmp.Name(), path); err != nil {
+			cmd := exec.Command("sudo", "mv", tmp.Name(), path)
+			if out, err2 := cmd.CombinedOutput(); err2 != nil {
+				fmt.Fprintf(os.Stderr, "⚠ resolv.conf: %v: %s\n", err2, out)
+				_ = os.Remove(tmp.Name())
+				return false
+			}
+		}
+		return true
 	}
-	_ = tmp.Close()
-	if err := os.Rename(tmp.Name(), path); err != nil {
-		// Rename across /etc may fail without root.
-		cmd := exec.Command("sudo", "mv", tmp.Name(), path)
-		if out, err2 := cmd.CombinedOutput(); err2 != nil {
-			fmt.Fprintf(os.Stderr, "⚠ resolv.conf: %v: %s\n", err2, out)
-			_ = os.Remove(tmp.Name())
-			return
+	if writeResolv("nameserver 8.8.8.8\nnameserver 8.8.4.4\n") {
+		fmt.Println("Updated /etc/resolv.conf → 8.8.8.8 (Tailscale DNS disabled)")
+	}
+}
+
+// fixResolvConfSplitDNS configures systemd-resolved for split DNS: public names
+// via 8.8.8.8 on the default interface, Tailscale MagicDNS names via
+// 100.100.100.100 on tailscale0. Returns true on success.
+func fixResolvConfSplitDNS(magicDNSSuffix string) bool {
+	if exec.Command("systemctl", "is-active", "--quiet", "systemd-resolved").Run() != nil {
+		return false
+	}
+	domains := "ts.net"
+	if magicDNSSuffix != "" && magicDNSSuffix != "ts.net" {
+		domains = magicDNSSuffix + " ts.net"
+	}
+	// Detect the primary public interface from the default route.
+	primaryIface := "enp1s0"
+	if out, err := exec.Command("ip", "-o", "route", "get", "1.1.1.1").Output(); err == nil {
+		for i, f := range strings.Fields(string(out)) {
+			if f == "dev" && i+1 < len(strings.Fields(string(out))) {
+				primaryIface = strings.Fields(string(out))[i+1]
+				break
+			}
 		}
 	}
-	fmt.Println("Updated /etc/resolv.conf → 8.8.8.8 (Tailscale DNS disabled)")
+	cmds := [][]string{
+		{"resolvectl", "dns", "tailscale0", "100.100.100.100"},
+		{"resolvectl", "domain", "tailscale0", domains},
+		{"resolvectl", "dns", primaryIface, "8.8.8.8", "8.8.4.4"},
+		{"ln", "-sf", "/run/systemd/resolve/stub-resolv.conf", "/etc/resolv.conf"},
+	}
+	for _, args := range cmds {
+		c := exec.Command("sudo", args...)
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "⚠ split DNS: %v: %v\n", args[0], err)
+			return false
+		}
+	}
+	// Persist via networkd-dispatcher.
+	script := fmt.Sprintf("#!/bin/sh\n# clawpatrol: split DNS for Tailscale exit-node\n"+
+		"resolvectl dns tailscale0 100.100.100.100 2>/dev/null\n"+
+		"resolvectl domain tailscale0 %s 2>/dev/null\n"+
+		"resolvectl dns %s 8.8.8.8 8.8.4.4 2>/dev/null\n", domains, primaryIface)
+	const dst = "/etc/networkd-dispatcher/routable.d/51-clawpatrol-dns"
+	tmp, err := os.CreateTemp("", "clawpatrol-dns-*")
+	if err == nil {
+		_, _ = tmp.WriteString(script)
+		_ = tmp.Close()
+		_ = exec.Command("sudo", "sh", "-c",
+			fmt.Sprintf("mv %s %s && chmod +x %s", tmp.Name(), dst, dst)).Run()
+	}
+	fmt.Printf("Configured split DNS: %s → 100.100.100.100, public → 8.8.8.8\n", domains)
+	return true
 }
 
 func defaultClawpatrolDir() string {

--- a/tailscale.go
+++ b/tailscale.go
@@ -55,6 +55,16 @@ func openListener(cfg *config.Gateway, stateDir string) (net.Listener, error) {
 		authKey = os.Getenv("TS_AUTHKEY")
 	}
 	if authKey == "" {
+		if isTailscaleControlMode(cfg.Control) {
+			// System Tailscale is already running on this host; listen on
+			// whatever cfg.Listen says (typically the tailnet IP:port set by
+			// the operator). Ephemeral tsnet clients reach us over the mesh.
+			addr := cfg.Listen
+			if addr == "" {
+				addr = ":8443"
+			}
+			return net.Listen("tcp", addr)
+		}
 		// WireGuard mode: bind loopback regardless of cfg.Listen's
 		// host portion. See the file-level comment.
 		host, port, err := net.SplitHostPort(cfg.Listen)

--- a/tailscale_test.go
+++ b/tailscale_test.go
@@ -48,7 +48,7 @@ func TestOpenListener_NoAuthKey(t *testing.T) {
 	t.Setenv("HOME", "")
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("TS_AUTHKEY", "")
-	cfg := &config.Gateway{Listen: "127.0.0.1:0"}
+	cfg := &config.Gateway{Control: "wireguard", Listen: "127.0.0.1:0"}
 	ln, err := openListener(cfg, t.TempDir())
 	if err != nil {
 		t.Fatalf("openListener: %v", err)
@@ -65,10 +65,12 @@ func TestOpenListener_NoAuthKey(t *testing.T) {
 
 // TestOpenListener_NoAuthKey_PublicListenIsOverridden verifies that
 // an operator-set "0.0.0.0:0" still results in a loopback bind in
-// WireGuard mode — the F-19 open-proxy fix.
+// WireGuard mode — the F-19 open-proxy fix. Tailscale system-mode
+// intentionally respects cfg.Listen as-is (the operator binds the
+// tailnet IP directly); this test is WG-specific.
 func TestOpenListener_NoAuthKey_PublicListenIsOverridden(t *testing.T) {
 	t.Setenv("TS_AUTHKEY", "")
-	cfg := &config.Gateway{Listen: "0.0.0.0:0"}
+	cfg := &config.Gateway{Control: "wireguard", Listen: "0.0.0.0:0"}
 	ln, err := openListener(cfg, t.TempDir())
 	if err != nil {
 		t.Fatalf("openListener: %v", err)

--- a/web.go
+++ b/web.go
@@ -233,6 +233,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
+		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet", Auth: authSelfAuthenticating, Handler: w.apiEphemeralTsnetPeer},
 		{Method: http.MethodGet, Path: "/__login", Auth: authTailnetOperator, Handler: w.apiDashboardLogin},
 	}
 }

--- a/web.go
+++ b/web.go
@@ -170,7 +170,11 @@ func (w *webMux) mayUseTailnetInsteadOfDashboard(path string) bool {
 }
 
 func (w *webMux) skipsTailnetGate(path string) bool {
-	return w.authRequirementForPath(path) == authPublic
+	req := w.authRequirementForPath(path)
+	// authPublic needs no gate. authSelfAuthenticating routes carry their
+	// own proof (Bearer token, webhook signature) — the tailnet gate would
+	// block tag:client devices that have no Tailscale user identity.
+	return req == authPublic || req == authSelfAuthenticating
 }
 
 func newWebMux(g *Gateway, ts JoinConfig, publicURL string) http.Handler {

--- a/web.go
+++ b/web.go
@@ -238,6 +238,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet", Auth: authSelfAuthenticating, Handler: w.apiEphemeralTsnetPeer},
+		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiRegisterEphemeralTsnetIP},
 		{Method: http.MethodGet, Path: "/__login", Auth: authTailnetOperator, Handler: w.apiDashboardLogin},
 	}
 }

--- a/web_auth_test.go
+++ b/web_auth_test.go
@@ -142,7 +142,7 @@ func TestRouteAuthRequirementsDocumentOnboardingBoundary(t *testing.T) {
 		{path: "/api/onboard/lookup", want: authTailnetOperator, wantDashboardPublic: true, wantTailnetPublic: false},
 		{path: "/api/onboard/approve", want: authDashboardOrTailnetOperator, wantDashboardPublic: false, wantTailnetPublic: false},
 		{path: "/api/config/save", want: authDashboard, wantDashboardPublic: false, wantTailnetPublic: false},
-		{path: "/api/env-pushdown", want: authSelfAuthenticating, wantDashboardPublic: true, wantTailnetPublic: false},
+		{path: "/api/env-pushdown", want: authSelfAuthenticating, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/info", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/ca.crt", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 	}
@@ -170,8 +170,8 @@ func TestCredentialWebhookPrefixAuthPolicyIsSelfAuthenticating(t *testing.T) {
 	if !w.skipsDashboardSecret(path) {
 		t.Fatalf("credential webhook should not require dashboard secret")
 	}
-	if w.skipsTailnetGate(path) {
-		t.Fatalf("credential webhook tailnet behavior should remain gated in tailscale mode")
+	if !w.skipsTailnetGate(path) {
+		t.Fatalf("credential webhook should skip tailnet gate: self-authenticating via HMAC, not Tailscale identity")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **`clawpatrol run` in Tailscale mode** — ephemeral `tsnet.Server` per invocation; gVisor TCP/IP stack bridges child netns TUN to gateway via HAProxy PROXY v1 headers over the tailnet
- **Exit-node MITM** (`origdst_linux.go`) — iptables/nftables PREROUTING REDIRECT on `tailscale0` + `SO_ORIGINAL_DST` to intercept exit-node client TCP; UDP/53 redirected to dnsvip listener; UDP on other ports rejected (QUIC→TCP fallback)
- **Full WG-mode parity**: UDP DNS VIPs (IPv4 + IPv6), nftables fallback for systems without iptables, dynamic ConnRouter port interception, policy-reload reinstalls iptables rules
- **Ephemeral tsnet peer registration** — `POST /api/peer/ephemeral/tsnet/register` binds the ephemeral node's 100.x.x.x to the parent device's profile for credential dispatch
- **Dynamic gateway port** — `apiEphemeralTsnetPeer` returns `gateway_port` from `cfg.Listen`; client no longer hardcodes 443
- **CA fetch deferred to tailnet** — `clawpatrol join` gracefully handles 404 on `/ca.crt` (Tailscale-mode gateways don't expose it via Funnel); `runLogin` fetches CA securely from `peer.TailscaleIPs[0]` after joining

## Why not use Tailscale's built-in exit-node feature

Tailscale's exit node routes traffic transparently at the kernel level — the gateway process never sees the payload, so no credential injection, policy enforcement, or logging is possible. The iptables REDIRECT path bends packets from `tailscale0` into the gateway listener before kernel forwarding, enabling the full MITM pipeline.

## Test plan

- [ ] `clawpatrol join https://clawpatrol-1.tail9a48e.ts.net` from a fresh device (not on tailnet) — should complete onboard flow, then fetch CA over tailnet via `runLogin`
- [ ] `clawpatrol run -- curl https://api.openai.com/v1/models` — HTTPS MITM with credential injection
- [ ] `clawpatrol run -- psql` — Postgres endpoint via PROXY header dispatch
- [ ] Exit-node client: iptables REDIRECT rules on `tailscale0`, SO_ORIGINAL_DST recovery, DNS VIP resolution
- [ ] Policy reload: change ConnRouter ports in HCL, verify iptables rules reinstalled without restart
- [ ] nftables path: test on system without iptables

🤖 Generated with [Claude Code](https://claude.com/claude-code)