### PR TITLE
fix(tsnet): WG-mode parity, gateway port, CA fetch over tailnet

### DIFF
--- a/dnsvip/dnsvip.go
+++ b/dnsvip/dnsvip.go
@@ -531,6 +531,13 @@ func (a *Allocator) handleWire(in []byte, dstIP string) []byte {
 	return out
 }
 
+// HandlePacket processes a single raw DNS wire-format datagram and returns
+// the response datagram ready to send, or nil on parse error. Used by the
+// exit-node UDP DNS listener; callers write the returned bytes directly.
+func (a *Allocator) HandlePacket(in []byte, origDstIP string) []byte {
+	return a.handleWire(in, origDstIP)
+}
+
 // handleQuery is the actual responder. Splits intercepted from
 // non-intercepted: if any question targets a known VIP-hostname we
 // answer locally; otherwise we forward the entire message to dstIP

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -158,6 +158,39 @@ func (w *webMux) apiEphemeralTsnetPeer(rw http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// apiRegisterEphemeralTsnetIP handles POST /api/peer/ephemeral/tsnet/register.
+// Called by `clawpatrol run` (tsnet mode) immediately after the ephemeral tsnet
+// node joins and learns its 100.x.x.x address. Binds the ephemeral tailnet IP
+// to the parent device's profile so dispatch from that IP uses the right credentials.
+func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	parentIP := peerIPForAPIToken(w.g.db, token)
+	if parentIP == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	tsnetIP := r.URL.Query().Get("ip")
+	if tsnetIP == "" {
+		http.Error(rw, "missing ip", http.StatusBadRequest)
+		return
+	}
+	if _, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(tsnetIP, "1")); err != nil {
+		http.Error(rw, "invalid ip", http.StatusBadRequest)
+		return
+	}
+	if w.g.onboard == nil {
+		rw.WriteHeader(http.StatusNoContent)
+		return
+	}
+	profile := w.g.onboard.ProfileForIP(parentIP)
+	w.g.onboard.setEphemeralProfile(tsnetIP, parentIP, profile)
+	rw.WriteHeader(http.StatusNoContent)
+}
+
 // apiRemoveEphemeralPeer handles DELETE /api/peer/ephemeral?pubkey=<hex>.
 // Only the parent device (identified by bearer token) may remove its
 // own ephemeral peers.

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -151,10 +151,17 @@ func (w *webMux) apiEphemeralTsnetPeer(rw http.ResponseWriter, r *http.Request) 
 	if gwHost == "" {
 		gwHost = "clawpatrol-gateway"
 	}
+	// Expose the tailnet port so clawpatrol run can dial the right port.
+	// cfg.Listen may be "host:port" or ":port"; extract the port only.
+	_, gwPort, _ := net.SplitHostPort(w.g.cfg.Listen)
+	if gwPort == "" {
+		gwPort = "443"
+	}
 	writeJSON(rw, map[string]string{
 		"auth_key":     authKey,
 		"control_url":  w.ts.ControlURL,
 		"gateway_host": gwHost,
+		"gateway_port": gwPort,
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -2809,6 +2809,7 @@ func runGateway(args []string) {
 	g.listenPort = listenPort
 	if isTailscaleControlMode(cfg.Control) {
 		installExitNodeRedirect(listenPort, g.connIdx.Load().ConnPorts())
+		startUDPDNSListener(listenPort, g.dnsvip)
 	}
 	for {
 		c, err := ln.Accept()

--- a/main.go
+++ b/main.go
@@ -349,6 +349,8 @@ type Gateway struct {
 	// transports memoizes one http.Transport per endpoint. Avoids the
 	// per-request allocation + idle-conn-pool reset of the old path.
 	transports sync.Map // *config.CompiledEndpoint -> *http.Transport
+	// listenPort is set once at startup; watchConfig reads it to reinstall iptables rules on reload.
+	listenPort int
 }
 
 // transportFor returns the cached http.Transport for ep, building it
@@ -451,7 +453,11 @@ func (g *Gateway) watchConfig(path string) {
 		}
 		g.policy.Store(policy)
 		registerOAuthCredentials(g.oauth, policy)
-		g.connIdx.Store(runtime.BuildConnIndex(policy))
+		newConnIdx := runtime.BuildConnIndex(policy)
+		g.connIdx.Store(newConnIdx)
+		if isTailscaleControlMode(g.cfg.Control) && g.listenPort != 0 {
+			installExitNodeRedirect(g.listenPort, newConnIdx.ConnPorts())
+		}
 		if g.tunnels != nil {
 			g.tunnels.SetPolicy(context.Background(), policy)
 		}
@@ -2800,6 +2806,7 @@ func runGateway(args []string) {
 	tsnetDashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 	tsnetDashPort := portOf(cfg.InfoListen)
 	listenPort := portOf(ln.Addr().String())
+	g.listenPort = listenPort
 	if isTailscaleControlMode(cfg.Control) {
 		installExitNodeRedirect(listenPort, g.connIdx.Load().ConnPorts())
 	}

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -79,10 +79,13 @@ func installExitNodeRedirect(listenPort int, extraPorts []string) {
 	}
 
 	portStr := strconv.Itoa(listenPort)
-	// Always intercept HTTPS and Postgres; add any other ports declared by
+	// Always intercept HTTPS, Postgres, and DNS; add any other ports declared by
 	// ConnRouter endpoints (clickhouse_native 9000/9440, etc.).
-	seen := map[string]bool{"443": true, "5432": true}
-	ports := []string{"443", "5432"}
+	// Port 53 is TCP-only: UDP DNS is left unREJECTed so exit-node clients that
+	// use UDP DNS still get real resolution; VIP names resolve via TCP DNS.
+	seen := map[string]bool{"53": true, "443": true, "5432": true}
+	tcpOnly := map[string]bool{"53": true} // no UDP REJECT for DNS
+	ports := []string{"53", "443", "5432"}
 	for _, p := range extraPorts {
 		if !seen[p] {
 			seen[p] = true
@@ -99,6 +102,9 @@ func installExitNodeRedirect(listenPort int, extraPorts []string) {
 			} else {
 				log.Printf("exit-node redirect: installed iptables REDIRECT tcp/%s → %s", dport, portStr)
 			}
+		}
+		if tcpOnly[dport] {
+			continue
 		}
 		// UDP: REJECT so QUIC/HTTP3 fails fast and clients fall back to TCP.
 		// Without this, UDP 443 bypasses MITM — on par with WireGuard mode which

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -9,16 +9,21 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/denoland/clawpatrol/dnsvip"
 )
 
-const soOriginalDst = 80 // SO_ORIGINAL_DST, linux/in.h
+const (
+	soOriginalDst     = 80 // SO_ORIGINAL_DST / IP6T_SO_ORIGINAL_DST (linux/in.h, linux/netfilter_ipv6/ip6_tables.h)
+	ipRecvOrigDstAddr = 20 // IP_RECVORIGDSTADDR (linux/in.h) — ancillary per-datagram original dst
+)
 
-// originalDst returns the pre-NAT destination of c when the connection
-// was redirected by an iptables REDIRECT rule. Returns ok=false on
-// non-Linux, for non-TCP conns, or when no NAT entry exists (direct
-// connection — getsockopt returns ENOPROTOOPT or ENOENT).
+// originalDst returns the pre-NAT destination of c when the connection was
+// redirected by an iptables REDIRECT rule. Tries IPv4 first then IPv6.
+// Returns ok=false for non-TCP conns or when no NAT entry exists.
 func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 	tc := unwrapTCPConn(c)
 	if tc == nil {
@@ -28,96 +33,239 @@ func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 	if err != nil {
 		return "", 0, false
 	}
-	var sa syscall.RawSockaddrInet4
-	saLen := uint32(syscall.SizeofSockaddrInet4)
+
+	// IPv4
+	var sa4 syscall.RawSockaddrInet4
+	saLen4 := uint32(syscall.SizeofSockaddrInet4)
 	var soErr error
 	_ = raw.Control(func(fd uintptr) {
-		_, _, errno := syscall.Syscall6(
-			syscall.SYS_GETSOCKOPT,
-			fd,
-			syscall.IPPROTO_IP,
-			soOriginalDst,
-			uintptr(unsafe.Pointer(&sa)),
-			uintptr(unsafe.Pointer(&saLen)),
-			0,
-		)
+		_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT,
+			fd, syscall.IPPROTO_IP, soOriginalDst,
+			uintptr(unsafe.Pointer(&sa4)),
+			uintptr(unsafe.Pointer(&saLen4)),
+			0)
 		if errno != 0 {
 			soErr = errno
 		}
 	})
-	if soErr != nil {
-		return "", 0, false
+	if soErr == nil {
+		dstIP := net.IP(sa4.Addr[:]).String()
+		dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa4.Port))[:])
+		return dstIP, dstPort, true
 	}
-	dstIP := net.IP(sa.Addr[:]).String()
-	dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa.Port))[:])
-	return dstIP, dstPort, true
+
+	// IPv6 (IP6T_SO_ORIGINAL_DST, same constant value on IPPROTO_IPV6)
+	var sa6 syscall.RawSockaddrInet6
+	saLen6 := uint32(syscall.SizeofSockaddrInet6)
+	soErr = nil
+	_ = raw.Control(func(fd uintptr) {
+		_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT,
+			fd, syscall.IPPROTO_IPV6, soOriginalDst,
+			uintptr(unsafe.Pointer(&sa6)),
+			uintptr(unsafe.Pointer(&saLen6)),
+			0)
+		if errno != 0 {
+			soErr = errno
+		}
+	})
+	if soErr == nil {
+		dstIP := net.IP(sa6.Addr[:]).String()
+		dstPort := binary.BigEndian.Uint16((*[2]byte)(unsafe.Pointer(&sa6.Port))[:])
+		return dstIP, dstPort, true
+	}
+	return "", 0, false
 }
 
-// installExitNodeRedirect installs iptables PREROUTING REDIRECT rules so that
-// traffic arriving via the Tailscale exit-node (tailscale0) on common service
-// ports is redirected to the gateway's own listen port. This lets the accept
-// loop's SO_ORIGINAL_DST fallback dispatch exit-node traffic exactly like the
-// WireGuard promiscuous forwarder — no PROXY header needed.
+// startUDPDNSListener binds a UDP socket on port and serves DNS queries.
+// iptables PREROUTING REDIRECT sends port-53 UDP from tailscale0 here;
+// IP_RECVORIGDSTADDR recovers the DNS server the client was reaching so
+// dnsvip can forward non-VIP names to the right upstream.
+func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
+	if port == 0 || dvip == nil {
+		return
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+	if err != nil {
+		log.Printf("udp dns listener: %v", err)
+		return
+	}
+	if rc, err := conn.SyscallConn(); err == nil {
+		_ = rc.Control(func(fd uintptr) {
+			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ipRecvOrigDstAddr, 1); err != nil {
+				log.Printf("udp dns: IP_RECVORIGDSTADDR: %v", err)
+			}
+		})
+	}
+	log.Printf("udp dns listener ready on :%d", port)
+	go func() {
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 4096)
+		oob := make([]byte, 256)
+		for {
+			n, oobn, _, addr, err := conn.ReadMsgUDP(buf, oob)
+			if err != nil {
+				if !isNetClosedError(err) {
+					log.Printf("udp dns: recv: %v", err)
+				}
+				return
+			}
+			origDstIP := parseUDPOrigDstIP(oob[:oobn])
+			resp := dvip.HandlePacket(buf[:n], origDstIP)
+			if resp == nil {
+				continue
+			}
+			_, _ = conn.WriteToUDP(resp, addr)
+		}
+	}()
+}
+
+// parseUDPOrigDstIP extracts the original destination IP from recvmsg
+// ancillary data (IP_ORIGDSTADDR cmsg). Returns "" if not present.
+func parseUDPOrigDstIP(oob []byte) string {
+	msgs, err := syscall.ParseSocketControlMessage(oob)
+	if err != nil {
+		return ""
+	}
+	for _, m := range msgs {
+		if m.Header.Level == syscall.IPPROTO_IP && m.Header.Type == ipRecvOrigDstAddr {
+			if len(m.Data) >= syscall.SizeofSockaddrInet4 {
+				var sa syscall.RawSockaddrInet4
+				copy((*[syscall.SizeofSockaddrInet4]byte)(unsafe.Pointer(&sa))[:], m.Data)
+				return net.IP(sa.Addr[:]).String()
+			}
+		}
+	}
+	return ""
+}
+
+// installExitNodeRedirect installs packet-filter rules so exit-node TCP traffic
+// arriving on tailscale0 is REDIRECT-ed to the gateway's listen port (recovered
+// via SO_ORIGINAL_DST), UDP/53 is likewise REDIRECT-ed (served by the UDP DNS
+// listener started separately), and UDP on all other intercepted ports is
+// REJECT-ed to force QUIC→TCP fallback.
 //
-// Idempotent: each rule is checked with -C before insertion. Failures are
-// logged but not fatal; operators can install the rules manually if the
-// process lacks CAP_NET_ADMIN.
+// Tries iptables/ip6tables first; falls back to nft (nftables) on systems where
+// iptables is not installed. nftables uses an inet table which covers both
+// address families in one ruleset.
+//
+// Idempotent: iptables rules are checked with -C before insertion; the nft path
+// flushes and rebuilds the clawpatrol table on every call.
 func installExitNodeRedirect(listenPort int, extraPorts []string) {
 	if listenPort == 0 {
 		return
 	}
-	// Ensure ip_forward is on — exit-node forwarding silently breaks without it.
-	// Write to sysctl.d for persistence across reboots.
 	if err := os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1\n"), 0o644); err != nil {
 		log.Printf("exit-node redirect: ip_forward: %v", err)
 	}
 	const sysctlConf = "/etc/sysctl.d/99-clawpatrol-forward.conf"
 	if _, err := os.Stat(sysctlConf); os.IsNotExist(err) {
-		if err := os.WriteFile(sysctlConf, []byte("net.ipv4.ip_forward=1\n"), 0o644); err != nil {
-			log.Printf("exit-node redirect: persist ip_forward: %v", err)
-		}
+		_ = os.WriteFile(sysctlConf, []byte("net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\n"), 0o644)
 	}
 
 	portStr := strconv.Itoa(listenPort)
-	// Always intercept HTTPS, Postgres, and DNS; add any other ports declared by
-	// ConnRouter endpoints (clickhouse_native 9000/9440, etc.).
-	// Port 53 is TCP-only: UDP DNS is left unREJECTed so exit-node clients that
-	// use UDP DNS still get real resolution; VIP names resolve via TCP DNS.
+
+	// Port 53 is TCP-only REDIRECT + UDP REDIRECT (served by DNS listener).
+	// Other ports get TCP REDIRECT + UDP REJECT (force QUIC→TCP fallback).
 	seen := map[string]bool{"53": true, "443": true, "5432": true}
-	tcpOnly := map[string]bool{"53": true} // no UDP REJECT for DNS
-	ports := []string{"53", "443", "5432"}
+	tcpPorts := []string{"53", "443", "5432"} // TCP REDIRECT
+	udpDNSPorts := []string{"53"}             // UDP REDIRECT → dns listener
+	udpRejectPorts := []string{"443", "5432"} // UDP REJECT → QUIC fallback
 	for _, p := range extraPorts {
 		if !seen[p] {
 			seen[p] = true
-			ports = append(ports, p)
+			tcpPorts = append(tcpPorts, p)
+			udpRejectPorts = append(udpRejectPorts, p)
 		}
 	}
-	for _, dport := range ports {
-		// TCP: REDIRECT to our listen port so SO_ORIGINAL_DST can recover the dst.
-		tcpArgs := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
-		if exec.Command("iptables", append([]string{"-C", "PREROUTING"}, tcpArgs...)...).Run() != nil {
-			insert := exec.Command("iptables", append([]string{"-I", "PREROUTING", "1"}, tcpArgs...)...)
-			if out, err := insert.CombinedOutput(); err != nil {
-				log.Printf("exit-node redirect: iptables tcp dport %s: %v: %s", dport, err, out)
-			} else {
-				log.Printf("exit-node redirect: installed iptables REDIRECT tcp/%s → %s", dport, portStr)
-			}
-		}
-		if tcpOnly[dport] {
+
+	_, iptablesErr := exec.LookPath("iptables")
+	if iptablesErr == nil {
+		installIPTables(portStr, tcpPorts, udpDNSPorts, udpRejectPorts)
+	} else {
+		installNFTables(portStr, tcpPorts, udpDNSPorts, udpRejectPorts)
+	}
+}
+
+// installIPTables installs rules via iptables + ip6tables.
+func installIPTables(portStr string, tcpPorts, udpDNSPorts, udpRejectPorts []string) {
+	for _, bin := range []string{"iptables", "ip6tables"} {
+		if _, err := exec.LookPath(bin); err != nil {
 			continue
 		}
-		// UDP: REJECT so QUIC/HTTP3 fails fast and clients fall back to TCP.
-		// Without this, UDP 443 bypasses MITM — on par with WireGuard mode which
-		// captures all traffic on the tun interface.
-		udpArgs := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
-		if exec.Command("iptables", append([]string{"-C", "FORWARD"}, udpArgs...)...).Run() != nil {
-			insert := exec.Command("iptables", append([]string{"-I", "FORWARD", "1"}, udpArgs...)...)
-			if out, err := insert.CombinedOutput(); err != nil {
-				log.Printf("exit-node redirect: iptables udp dport %s: %v: %s", dport, err, out)
-			} else {
-				log.Printf("exit-node redirect: installed iptables REJECT udp/%s (force TCP fallback)", dport)
+		for _, dport := range tcpPorts {
+			args := []string{"-t", "nat", "-i", "tailscale0", "-p", "tcp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
+			if exec.Command(bin, append([]string{"-C", "PREROUTING"}, args...)...).Run() != nil {
+				if out, err := exec.Command(bin, append([]string{"-I", "PREROUTING", "1"}, args...)...).CombinedOutput(); err != nil {
+					log.Printf("exit-node redirect: %s tcp/%s: %v: %s", bin, dport, err, out)
+				} else {
+					log.Printf("exit-node redirect: %s REDIRECT tcp/%s → %s", bin, dport, portStr)
+				}
 			}
 		}
+		for _, dport := range udpDNSPorts {
+			args := []string{"-t", "nat", "-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REDIRECT", "--to-port", portStr}
+			if exec.Command(bin, append([]string{"-C", "PREROUTING"}, args...)...).Run() != nil {
+				if out, err := exec.Command(bin, append([]string{"-I", "PREROUTING", "1"}, args...)...).CombinedOutput(); err != nil {
+					log.Printf("exit-node redirect: %s udp/%s: %v: %s", bin, dport, err, out)
+				} else {
+					log.Printf("exit-node redirect: %s REDIRECT udp/%s → %s", bin, dport, portStr)
+				}
+			}
+		}
+		for _, dport := range udpRejectPorts {
+			args := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
+			if exec.Command(bin, append([]string{"-C", "FORWARD"}, args...)...).Run() != nil {
+				if out, err := exec.Command(bin, append([]string{"-I", "FORWARD", "1"}, args...)...).CombinedOutput(); err != nil {
+					log.Printf("exit-node redirect: %s REJECT udp/%s: %v: %s", bin, dport, err, out)
+				} else {
+					log.Printf("exit-node redirect: %s REJECT udp/%s (QUIC fallback)", bin, dport)
+				}
+			}
+		}
+	}
+}
+
+// installNFTables installs rules via nft (nftables) using an inet table
+// that covers both IPv4 and IPv6 in a single ruleset. Idempotent: the
+// clawpatrol table is flushed and rebuilt on every call.
+func installNFTables(portStr string, tcpPorts, udpDNSPorts, udpRejectPorts []string) {
+	if _, err := exec.LookPath("nft"); err != nil {
+		log.Printf("exit-node redirect: neither iptables nor nft found; install one of them")
+		return
+	}
+
+	tcpSet := "{ " + strings.Join(tcpPorts, ", ") + " }"
+	udpDNSSet := "{ " + strings.Join(udpDNSPorts, ", ") + " }"
+
+	// Flush + rebuild our dedicated table for idempotency.
+	exec.Command("nft", "delete", "table", "inet", "clawpatrol").Run() //nolint:errcheck
+
+	script := strings.Join([]string{
+		"table inet clawpatrol {",
+		"  chain prerouting {",
+		"    type nat hook prerouting priority -100;",
+		`    iifname "tailscale0" tcp dport ` + tcpSet + " redirect to :" + portStr + ";",
+		`    iifname "tailscale0" udp dport ` + udpDNSSet + " redirect to :" + portStr + ";",
+		"  }",
+	}, "\n")
+
+	if len(udpRejectPorts) > 0 {
+		udpRejectSet := "{ " + strings.Join(udpRejectPorts, ", ") + " }"
+		script += "\n" + strings.Join([]string{
+			"  chain forward {",
+			"    type filter hook forward priority 0;",
+			`    iifname "tailscale0" udp dport ` + udpRejectSet + " reject;",
+			"  }",
+		}, "\n")
+	}
+	script += "\n}"
+
+	cmd := exec.Command("nft", "-f", "-")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Printf("exit-node redirect: nft: %v: %s", err, out)
+	} else {
+		log.Printf("exit-node redirect: nftables rules installed (inet clawpatrol, covers IPv4+IPv6)")
 	}
 }
 
@@ -131,4 +279,8 @@ func unwrapTCPConn(c net.Conn) *net.TCPConn {
 		}
 	}
 	return nil
+}
+
+func isNetClosedError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "use of closed network connection")
 }

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -1,5 +1,48 @@
 //go:build linux
 
+// Exit-node MITM via SO_ORIGINAL_DST
+//
+// Problem: Tailscale's built-in exit-node feature routes all client traffic
+// through this machine and out to the internet — but it does so transparently.
+// The kernel forwards packets without any userspace process seeing the payload,
+// so there is no hook for credential injection, policy enforcement, or logging.
+// Tailscale itself provides no API to intercept exit-node traffic.
+//
+// Solution: run this gateway process on the same machine as the Tailscale exit
+// node and bend the packet path so that specific TCP/UDP flows hit the gateway's
+// listener before the kernel forwards them outbound.
+//
+// How it works:
+//
+//  1. iptables/ip6tables PREROUTING REDIRECT (or nftables equivalent) rewrites
+//     the destination of matching packets arriving on tailscale0 to
+//     127.0.0.1:<listenPort>. The kernel records the pre-NAT destination in the
+//     conntrack table but delivers the SYN to the gateway's own listen socket.
+//
+//  2. SO_ORIGINAL_DST getsockopt on the accepted TCP conn (or IP_RECVORIGDSTADDR
+//     ancdata on UDP) reads that conntrack entry, recovering the IP:port the
+//     client originally dialed (e.g., api.openai.com:443 or 10.78.0.1:22).
+//
+//  3. The accept loop dispatches on the recovered destination exactly as the
+//     WireGuard promiscuous forwarder does: port 443 → HTTPS MITM, port 5432 →
+//     Postgres, dnsvip VIP → SSH, ConnRouter ports → binary protocol endpoints.
+//
+//  4. DNS (port 53) is intercepted so the dnsvip allocator can answer A/AAAA
+//     queries for SSH-endpoint hostnames with virtual IPs, enabling the VIP→SSH
+//     dispatch path that the WireGuard mode uses. Non-VIP names are forwarded
+//     upstream to whatever DNS server the client was originally querying.
+//
+//  5. UDP on non-DNS intercepted ports (443, 5432, …) is REJECT-ed with
+//     ICMP port-unreachable. QUIC (HTTP/3) uses UDP/443 and cannot be
+//     REDIRECT-ed by iptables (UDP is connectionless, no conntrack SYN state).
+//     The ICMP rejection forces clients to fall back to TCP, which the REDIRECT
+//     rule catches. This matches WireGuard mode where the tun interface captures
+//     all traffic and UDP 443 simply has no handler.
+//
+// Without these rules the exit node behaves like a plain NAT gateway: traffic
+// leaves with the gateway's public IP but the gateway process never sees it,
+// so no credentials are injected and no policies are enforced.
+
 package main
 
 import (

--- a/origdst_linux.go
+++ b/origdst_linux.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	soOriginalDst     = 80 // SO_ORIGINAL_DST / IP6T_SO_ORIGINAL_DST (linux/in.h, linux/netfilter_ipv6/ip6_tables.h)
-	ipRecvOrigDstAddr = 20 // IP_RECVORIGDSTADDR (linux/in.h) — ancillary per-datagram original dst
+	soOriginalDst       = 80 // SO_ORIGINAL_DST / IP6T_SO_ORIGINAL_DST (linux/in.h, linux/netfilter_ipv6/ip6_tables.h)
+	ipRecvOrigDstAddr   = 20 // IP_RECVORIGDSTADDR / IP_ORIGDSTADDR (linux/in.h)
+	ipv6RecvOrigDstAddr = 74 // IPV6_RECVORIGDSTADDR / IPV6_ORIGDSTADDR (linux/in6.h)
 )
 
 // originalDst returns the pre-NAT destination of c when the connection was
@@ -76,27 +77,32 @@ func originalDst(c net.Conn) (ip string, port uint16, ok bool) {
 	return "", 0, false
 }
 
-// startUDPDNSListener binds a UDP socket on port and serves DNS queries.
-// iptables PREROUTING REDIRECT sends port-53 UDP from tailscale0 here;
-// IP_RECVORIGDSTADDR recovers the DNS server the client was reaching so
-// dnsvip can forward non-VIP names to the right upstream.
+// startUDPDNSListener binds UDP sockets (IPv4 and IPv6) on port and serves
+// DNS queries redirected by iptables/ip6tables PREROUTING REDIRECT.
+// IP_RECVORIGDSTADDR / IPV6_RECVORIGDSTADDR recover the DNS server the client
+// was reaching so dnsvip can forward non-VIP names to the right upstream.
 func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
 	if port == 0 || dvip == nil {
 		return
 	}
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+	startUDPDNSListenerFamily("udp4", syscall.IPPROTO_IP, ipRecvOrigDstAddr, port, dvip)
+	startUDPDNSListenerFamily("udp6", syscall.IPPROTO_IPV6, ipv6RecvOrigDstAddr, port, dvip)
+}
+
+func startUDPDNSListenerFamily(network string, level, opt, port int, dvip *dnsvip.Allocator) {
+	conn, err := net.ListenUDP(network, &net.UDPAddr{Port: port})
 	if err != nil {
-		log.Printf("udp dns listener: %v", err)
+		log.Printf("udp dns %s listener: %v", network, err)
 		return
 	}
 	if rc, err := conn.SyscallConn(); err == nil {
 		_ = rc.Control(func(fd uintptr) {
-			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ipRecvOrigDstAddr, 1); err != nil {
-				log.Printf("udp dns: IP_RECVORIGDSTADDR: %v", err)
+			if err := syscall.SetsockoptInt(int(fd), level, opt, 1); err != nil {
+				log.Printf("udp dns %s: RECVORIGDSTADDR: %v", network, err)
 			}
 		})
 	}
-	log.Printf("udp dns listener ready on :%d", port)
+	log.Printf("udp dns %s listener ready on :%d", network, port)
 	go func() {
 		defer func() { _ = conn.Close() }()
 		buf := make([]byte, 4096)
@@ -105,7 +111,7 @@ func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
 			n, oobn, _, addr, err := conn.ReadMsgUDP(buf, oob)
 			if err != nil {
 				if !isNetClosedError(err) {
-					log.Printf("udp dns: recv: %v", err)
+					log.Printf("udp dns %s: recv: %v", network, err)
 				}
 				return
 			}
@@ -120,17 +126,24 @@ func startUDPDNSListener(port int, dvip *dnsvip.Allocator) {
 }
 
 // parseUDPOrigDstIP extracts the original destination IP from recvmsg
-// ancillary data (IP_ORIGDSTADDR cmsg). Returns "" if not present.
+// ancillary data (IP_ORIGDSTADDR or IPV6_ORIGDSTADDR cmsg). Returns "" if absent.
 func parseUDPOrigDstIP(oob []byte) string {
 	msgs, err := syscall.ParseSocketControlMessage(oob)
 	if err != nil {
 		return ""
 	}
 	for _, m := range msgs {
-		if m.Header.Level == syscall.IPPROTO_IP && m.Header.Type == ipRecvOrigDstAddr {
+		switch {
+		case m.Header.Level == syscall.IPPROTO_IP && m.Header.Type == ipRecvOrigDstAddr:
 			if len(m.Data) >= syscall.SizeofSockaddrInet4 {
 				var sa syscall.RawSockaddrInet4
 				copy((*[syscall.SizeofSockaddrInet4]byte)(unsafe.Pointer(&sa))[:], m.Data)
+				return net.IP(sa.Addr[:]).String()
+			}
+		case m.Header.Level == syscall.IPPROTO_IPV6 && m.Header.Type == ipv6RecvOrigDstAddr:
+			if len(m.Data) >= syscall.SizeofSockaddrInet6 {
+				var sa syscall.RawSockaddrInet6
+				copy((*[syscall.SizeofSockaddrInet6]byte)(unsafe.Pointer(&sa))[:], m.Data)
 				return net.IP(sa.Addr[:]).String()
 			}
 		}
@@ -212,8 +225,12 @@ func installIPTables(portStr string, tcpPorts, udpDNSPorts, udpRejectPorts []str
 				}
 			}
 		}
+		rejectWith := "icmp-port-unreachable"
+		if bin == "ip6tables" {
+			rejectWith = "icmp6-port-unreachable"
+		}
 		for _, dport := range udpRejectPorts {
-			args := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"}
+			args := []string{"-i", "tailscale0", "-p", "udp", "--dport", dport, "-j", "REJECT", "--reject-with", rejectWith}
 			if exec.Command(bin, append([]string{"-C", "FORWARD"}, args...)...).Run() != nil {
 				if out, err := exec.Command(bin, append([]string{"-I", "FORWARD", "1"}, args...)...).CombinedOutput(); err != nil {
 					log.Printf("exit-node redirect: %s REJECT udp/%s: %v: %s", bin, dport, err, out)

--- a/origdst_stub.go
+++ b/origdst_stub.go
@@ -2,7 +2,12 @@
 
 package main
 
-import "net"
+import (
+	"net"
+
+	"github.com/denoland/clawpatrol/dnsvip"
+)
 
 func originalDst(c net.Conn) (ip string, port uint16, ok bool)    { return "", 0, false }
 func installExitNodeRedirect(listenPort int, extraPorts []string) {}
+func startUDPDNSListener(port int, dvip *dnsvip.Allocator)        {}

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -36,7 +36,7 @@ package main
 //  2. tsnet.Server{Ephemeral: true} joins the gateway's tailnet
 //  3. Child in new user+net+mnt ns creates TUN, sends fd via SCM_RIGHTS
 //  4. gVisor netstack reads from TUN, promiscuous TCP forwarder
-//  5. Each TCP connection → tsnet.Dial(gwHost:443) + HAProxy PROXY v1 header
+//  5. Each TCP connection → tsnet.Dial(gwHost:gwPort) + HAProxy PROXY v1 header
 //  6. Gateway recovers original dst from PROXY header, dispatches normally
 
 import (
@@ -106,7 +106,7 @@ func runRunTsnet(args []string) {
 	}
 
 	// 1. Mint ephemeral tsnet auth key.
-	authKey, err := fetchEphemeralTsnetKey(gwURL, token, filepath.Join(dir, "ca.crt"))
+	authKey, gwPort, err := fetchEphemeralTsnetKey(gwURL, token, filepath.Join(dir, "ca.crt"))
 	if err != nil {
 		fail("mint tsnet key: %v", err)
 	}
@@ -204,7 +204,7 @@ func runRunTsnet(args []string) {
 	// 7. TCP forwarder: every connection → tsnet → gateway.
 	// We forward to gwHost:originalPort so the gateway can route by port
 	// (port 443 → HTTPS MITM; other ports forwarded if gateway listens).
-	enableTsnetTCPForwarder(gvStack, tsServer, gwHost)
+	enableTsnetTCPForwarder(gvStack, tsServer, gwHost, gwPort)
 
 	// 8. Signal child: bridge is up.
 	_, _ = wgUpW.Write([]byte{1})
@@ -434,12 +434,12 @@ func startTunBridge(tunFile *os.File, ep *channel.Endpoint) {
 }
 
 // enableTsnetTCPForwarder installs a promiscuous TCP forwarder on s.
-// Every connection is forwarded to gwHost:443 via tsnet. A HAProxy PROXY v1
+// Every connection is forwarded to gwHost:gwPort via tsnet. A HAProxy PROXY v1
 // header is written before the payload carrying the original 4-tuple so the
 // gateway can dispatch by original dst IP/port (PostgreSQL, ClickHouse, etc.)
 // instead of only being able to route by SNI on port 443.
-func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost string) {
-	gwAddr := net.JoinHostPort(gwHost, "443")
+func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost, gwPort string) {
+	gwAddr := net.JoinHostPort(gwHost, gwPort)
 	fwd := tcp.NewForwarder(s, 1<<20, 16384, func(req *tcp.ForwarderRequest) {
 		id := req.ID()
 		// PROXY TCP4 srcIP dstIP srcPort dstPort
@@ -534,36 +534,42 @@ func waitTsnetUp(s *tsnet.Server) (netip.Addr, error) {
 }
 
 // fetchEphemeralTsnetKey calls POST /api/peer/ephemeral/tsnet on the
-// gateway to obtain a single-use ephemeral Tailscale auth key.
-func fetchEphemeralTsnetKey(gwURL, token, caPath string) (string, error) {
-	client, err := gatewayHTTPClient(caPath)
-	if err != nil {
-		return "", fmt.Errorf("http client: %w", err)
+// gateway to obtain a single-use ephemeral Tailscale auth key and the
+// tailnet port the gateway is listening on. gwPort defaults to "443" if
+// the gateway omits it (old gateway versions).
+func fetchEphemeralTsnetKey(gwURL, token, caPath string) (authKey, gwPort string, err error) {
+	client, ferr := gatewayHTTPClient(caPath)
+	if ferr != nil {
+		return "", "", fmt.Errorf("http client: %w", ferr)
 	}
-	req, err := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet", nil)
-	if err != nil {
-		return "", err
+	req, ferr := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet", nil)
+	if ferr != nil {
+		return "", "", ferr
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
+	resp, ferr := client.Do(req)
+	if ferr != nil {
+		return "", "", ferr
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return "", fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", "", fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var result struct {
-		AuthKey string `json:"auth_key"`
+		AuthKey     string `json:"auth_key"`
+		GatewayPort string `json:"gateway_port"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+	if ferr := json.NewDecoder(resp.Body).Decode(&result); ferr != nil {
+		return "", "", ferr
 	}
 	if result.AuthKey == "" {
-		return "", fmt.Errorf("empty auth_key in response")
+		return "", "", fmt.Errorf("empty auth_key in response")
 	}
-	return result.AuthKey, nil
+	if result.GatewayPort == "" {
+		result.GatewayPort = "443"
+	}
+	return result.AuthKey, result.GatewayPort, nil
 }
 
 // registerEphemeralTsnetIP tells the gateway which 100.x.x.x tailnet IP this

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -112,6 +112,12 @@ func runRunTsnet(args []string) {
 	}
 	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
 
+	// Register ephemeral tsnet IP with gateway so profile dispatch uses
+	// the right credentials (same as ephemeral WG peer registration).
+	if rerr := registerEphemeralTsnetIP(gwURL, token, filepath.Join(dir, "ca.crt"), tsIP.String()); rerr != nil {
+		fmt.Fprintf(os.Stderr, "warning: tsnet profile registration: %v (will use default profile)\n", rerr)
+	}
+
 	// 3. IPC channels: TUN fd handoff + wg-up pipe (same plumbing as WG mode).
 	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
@@ -534,4 +540,29 @@ func fetchEphemeralTsnetKey(gwURL, token, caPath string) (string, error) {
 		return "", fmt.Errorf("empty auth_key in response")
 	}
 	return result.AuthKey, nil
+}
+
+// registerEphemeralTsnetIP tells the gateway which 100.x.x.x tailnet IP this
+// ephemeral tsnet run session got, so the gateway maps it to the parent
+// device's profile for credential dispatch.
+func registerEphemeralTsnetIP(gwURL, token, caPath, tsIP string) error {
+	client, err := gatewayHTTPClient(caPath)
+	if err != nil {
+		return fmt.Errorf("http client: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet/register?ip="+tsIP, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
 }

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -7,13 +7,37 @@ package main
 // gVisor's TCP stack. No system-wide Tailscale required — tsnet runs
 // entirely in-process.
 //
+// Why PROXY headers instead of the exit-node iptables REDIRECT path
+// (origdst_linux.go):
+//
+// The exit-node REDIRECT path intercepts traffic from Tailscale exit-node
+// clients — machines that have configured this gateway as their exit node via
+// `tailscale set --exit-node=<gw>`. In that model, client traffic arrives on
+// the gateway's tailscale0 interface and iptables diverts it to the gateway
+// listener before kernel forwarding.
+//
+// `clawpatrol run` clients are NOT exit-node clients. The child process runs
+// in its own network namespace with a gVisor TCP/IP stack as the default
+// route. Each TCP connection the child makes is intercepted by gVisor and
+// dialed out via tsnet directly to the gateway node over the tailnet — a
+// peer-to-peer connection, not exit-node-forwarded traffic. The connection
+// arrives at the gateway's TCP listener as a direct tailnet connection from
+// the ephemeral node's 100.x.x.x; iptables REDIRECT on tailscale0 does not
+// apply because the traffic is delivered to the gateway's own address, not
+// forwarded onward.
+//
+// The PROXY header carries the original 4-tuple (srcIP, dstIP, srcPort,
+// dstPort) so the gateway accept loop recovers what the child process was
+// actually trying to reach (e.g., api.openai.com:443) and dispatches it
+// identically to the WireGuard and exit-node paths.
+//
 // Flow:
 //  1. POST /api/peer/ephemeral/tsnet → ephemeral Tailscale auth key
 //  2. tsnet.Server{Ephemeral: true} joins the gateway's tailnet
 //  3. Child in new user+net+mnt ns creates TUN, sends fd via SCM_RIGHTS
 //  4. gVisor netstack reads from TUN, promiscuous TCP forwarder
-//  5. Each TCP connection → tsnet.Dial(gwHost:originalPort)
-//  6. Child IP = tsnet 100.x.x.x, default route via TUN
+//  5. Each TCP connection → tsnet.Dial(gwHost:443) + HAProxy PROXY v1 header
+//  6. Gateway recovers original dst from PROXY header, dispatches normally
 
 import (
 	"context"

--- a/setup.go
+++ b/setup.go
@@ -118,15 +118,18 @@ func runJoin(args []string) {
 	// configured (MASQUERADE etc). The CA is small + cheap and
 	// the onboard endpoints are reachable on the public path.
 	//
+	// In Tailscale control mode the gateway intentionally does not
+	// expose /ca.crt on its public Funnel path — the CA is only
+	// reachable over the tailnet (security: no TOFU over plain
+	// internet). A 404 here means we're talking to a Tailscale-mode
+	// gateway; runLogin (called below after onboard + Tailscale join)
+	// fetches the CA from the peer's tailnet IP instead.
+	//
 	// Trust install + shell-rc updates are deferred to
 	// finishJoinSetup, which runs only after the operator's
-	// dashboard approval click. Until that point an attacker
-	// on-path could have substituted the CA we just fetched
-	// over plain HTTP. The approval flow shows the gateway's
-	// real CA fingerprint on the dashboard; the operator
-	// compares it against what the CLI prints below.
+	// dashboard approval click.
 	setup, err := preJoinFetchCA(gatewayURL, *caOut)
-	if err != nil {
+	if err != nil && !isCaNotExposed(err) {
 		fail("ca fetch: %v", err)
 	}
 	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, &setup, *skipTrust)
@@ -155,6 +158,13 @@ type joinSetup struct {
 	shellRC       bool   // shell rc updated with `eval "$(clawpatrol env)"`
 }
 
+// isCaNotExposed returns true when the gateway deliberately did not expose
+// /ca.crt on its public path (Tailscale control mode). The CA will be
+// fetched securely over the tailnet by runLogin after Tailscale join.
+func isCaNotExposed(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "status 404")
+}
+
 // preJoinFetchCA downloads the gateway's CA into caDir and computes
 // its SHA-256 fingerprint, but stops short of installing it into
 // the system trust store. Trust install + shell-rc updates land in
@@ -170,19 +180,17 @@ func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
 	if err := os.MkdirAll(caDir, 0o700); err != nil {
 		return s, fmt.Errorf("mkdir %s: %w", caDir, err)
 	}
+	// Persist the dashboard URL before the CA fetch so subsequent
+	// `clawpatrol env` / `clawpatrol run` invocations work even when
+	// the CA fetch is deferred (Tailscale mode, 404 on /ca.crt).
+	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
+		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	s.caPath = filepath.Join(caDir, "ca.crt")
 	fp, err := fetchCAHTTP(gateway, s.caPath)
 	if err != nil {
 		return s, fmt.Errorf("fetch CA: %w", err)
 	}
 	s.caFingerprint = fp
-	// Persist the dashboard URL so subsequent `clawpatrol env` /
-	// `clawpatrol run` invocations can fetch the env push-down list
-	// from the gateway instead of iterating compiled-in plugins.
-	// Best-effort; the read side falls back to local enumeration
-	// when this file is missing.
-	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
-		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	return s, nil
 }
 
@@ -193,6 +201,12 @@ func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
 // substituted by an on-path attacker at fetch time.
 func finishJoinSetup(s *joinSetup, skipTrust bool) {
 	if s.caPath == "" {
+		return
+	}
+	if _, err := os.Stat(s.caPath); err != nil {
+		// CA not fetched yet (Tailscale mode defers to runLogin). Skip
+		// trust install; runLogin will fetch + install from the tailnet.
+		installShellRC() //nolint:errcheck
 		return
 	}
 	if !skipTrust {

--- a/web.go
+++ b/web.go
@@ -240,6 +240,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet", Auth: authSelfAuthenticating, Handler: w.apiEphemeralTsnetPeer},
+		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiRegisterEphemeralTsnetIP},
 		{Method: http.MethodGet, Path: "/__login", Auth: authTailnetOperator, Handler: w.apiDashboardLogin},
 	}
 }


### PR DESCRIPTION
## Summary

Follow-ups to #413:

- **Full WG-mode parity for Tailscale exit-node mode** — UDP DNS (IPv4 + IPv6), nftables fallback (for systems without iptables), policy-reload reinstalls iptables rules on ConnRouter port changes, IPv6 ICMP reject type fix
- **Dynamic gateway port** — `apiEphemeralTsnetPeer` returns `gateway_port` from `cfg.Listen`; `enableTsnetTCPForwarder` no longer hardcodes 443 (breaks on deployments like Deno's where gateway listens on 8443)
- **Ephemeral tsnet IP registration** — `POST /api/peer/ephemeral/tsnet/register` binds the ephemeral node's 100.x.x.x to the parent device's profile so credential dispatch uses the right credentials
- **CA fetch deferred to tailnet on join** — `clawpatrol join` now handles 404 on `/ca.crt` gracefully (Tailscale-mode gateways don't expose it via Funnel — TOFU over public internet is unnecessary when the CA can be fetched securely from `peer.TailscaleIPs[0]` after joining). `runLogin` already did the right thing; `runJoin` now doesn't fail-fast on 404.
- **iptables/nftables comment** — explains why exit-node MITM requires iptables REDIRECT instead of Tailscale's built-in exit-node feature

## Test plan

- [ ] `clawpatrol join https://clawpatrol-1.tail9a48e.ts.net` — 404 on `/ca.crt` silently deferred, CA fetched from tailnet after join
- [ ] `clawpatrol run` on gateway listening on non-443 port — forwarder dials correct port
- [ ] Policy reload with changed ConnRouter ports — iptables rules reinstalled without restart
- [ ] nftables path on system without iptables
- [ ] UDP DNS VIP resolution for exit-node clients (IPv4 + IPv6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)