### PR TITLE
site: copy + structure pass on landing

### DIFF
--- a/site/src/Landing.tsx
+++ b/site/src/Landing.tsx
@@ -4,10 +4,10 @@ import { AnalyticsSection } from "./sections/AnalyticsSection";
 import { ApproversSection } from "./sections/ApproversSection";
 import { ComparisonSection } from "./sections/ComparisonSection";
 import { CtaSection } from "./sections/CtaSection";
-import { DeploySection } from "./sections/DeploySection";
 import { HeroSection } from "./sections/HeroSection";
 import { ProblemSection } from "./sections/ProblemSection";
 import { RulesSection } from "./sections/RulesSection";
+import { RunSection } from "./sections/RunSection";
 import { TestSection } from "./sections/TestSection";
 
 export function Landing() {
@@ -15,13 +15,13 @@ export function Landing() {
     <Layout>
       <HeroSection />
       <ProblemSection />
-      <Wave topColor="var(--color-canvas)" bottomColor="var(--color-navy-600)" />
+      <RunSection />
+      <Wave topColor="var(--color-canvas-muted)" bottomColor="var(--color-navy-600)" />
       <RulesSection />
       <ApproversSection />
       <TestSection />
       <AnalyticsSection />
       <ComparisonSection />
-      <DeploySection />
       <CtaSection />
     </Layout>
   );

--- a/site/src/sections/AnalyticsSection.tsx
+++ b/site/src/sections/AnalyticsSection.tsx
@@ -13,8 +13,8 @@ export function AnalyticsSection() {
           class="text-center max-w-2xl mx-auto mb-16 mt-4
           text-text-muted"
         >
-          Thousands of requests across dozens of services. Claw Patrol captures it all passively,
-          with zero instrumentation.
+          Thousands of requests across dozens of services. Nothing to instrument; the gateway
+          already sees every byte.
         </p>
       </div>
 

--- a/site/src/sections/ApproversSection.tsx
+++ b/site/src/sections/ApproversSection.tsx
@@ -152,7 +152,7 @@ export function ApproversSection() {
   return (
     <section class="bg-rust-50 py-24 sm:py-32">
       <div class="max-w-6xl mx-auto px-6 sm:px-8">
-        <SectionLabel>Approvers</SectionLabel>
+        <SectionLabel>Approval flows</SectionLabel>
 
         <div class="max-w-3xl mb-14">
           <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5 text-text">

--- a/site/src/sections/ComparisonSection.tsx
+++ b/site/src/sections/ComparisonSection.tsx
@@ -169,10 +169,10 @@ function SynthesisCard() {
         <h4 class="font-display font-bold text-2xl sm:text-3xl text-text">Claw Patrol</h4>
       </div>
       <p class="text-text text-[15px] sm:text-base max-w-3xl leading-relaxed">
-        Watches the tool call at the protocol layer (Postgres, Kubernetes, ClickHouse, HTTPS, SSH),
-        so rules match SQL verbs and k8s resources directly. Holds the secrets. Routes risky calls
-        to a human or an LLM judge. Records every byte. Doesn't try to be an LLM gateway or a
-        process sandbox; use a specialized tool if you need those.
+        Watches the tool call at the protocol layer (Postgres, Kubernetes, HTTPS, with a plugin API
+        for the rest), so rules match SQL verbs and k8s resources directly. Holds the secrets.
+        Routes risky calls to a human or an LLM judge. Records every byte. Doesn't try to be an LLM
+        gateway or a process sandbox; use a specialized tool if you need those.
       </p>
     </div>
   );

--- a/site/src/sections/CtaSection.tsx
+++ b/site/src/sections/CtaSection.tsx
@@ -13,7 +13,8 @@ export function CtaSection() {
         class="max-w-lg mx-auto text-base sm:text-lg
          mb-10 text-text-muted"
       >
-        The proxy handles your secrets. It must be auditable. MIT licensed.
+        The proxy holds your secrets and watches every byte your agents send. It has to be
+        auditable, so it's MIT licensed.
       </p>
       <img
         src="/clawpatrol.png"

--- a/site/src/sections/ProblemSection.tsx
+++ b/site/src/sections/ProblemSection.tsx
@@ -10,7 +10,10 @@ const PROBLEMS = [
   },
   {
     title: "Your agent shouldn't see secrets",
-    body: "If the agent is compromised (prompt " + "injection), the keys leak with it.",
+    body:
+      "If the agent is compromised by prompt injection, the credentials " +
+      "it holds leak with it. Keys should live somewhere the agent can " +
+      "never see.",
   },
   {
     title: "Logs don't capture the action",

--- a/site/src/sections/RulesSection.tsx
+++ b/site/src/sections/RulesSection.tsx
@@ -38,11 +38,11 @@ export function RulesSection() {
   return (
     <section class="bg-navy-600 py-24 sm:py-32 text-canvas">
       <div class="max-w-6xl mx-auto px-6 sm:px-8">
-        <SectionLabel>Approval rules</SectionLabel>
+        <SectionLabel>Rules</SectionLabel>
 
         <div class="max-w-3xl mx-auto text-center mb-16">
           <h3 class="text-4xl sm:text-5xl md:text-6xl font-display font-bold text-balance mb-5">
-            You write access rules in HCL. <span class="text-rust">Claw Patrol enforces them.</span>
+            You write access rules. <span class="text-rust">Claw Patrol enforces them.</span>
           </h3>
           <p class="text-base text-canvas/70">
             Every outbound request runs through a rule engine before it reaches its destination.
@@ -76,7 +76,7 @@ export function RulesSection() {
         </div>
 
         <p class="mt-14 text-sm text-canvas/70 text-center max-w-xl mx-auto">
-          Extend Claw Patrol with your own protocol plugins.{" "}
+          Extend Claw Patrol with plugins{" "}
           <a
             href="/docs/plugins/"
             class="text-rust-300 hover:text-rust-200 underline underline-offset-4"

--- a/site/src/sections/RunSection.tsx
+++ b/site/src/sections/RunSection.tsx
@@ -1,7 +1,7 @@
 import { SectionLabel } from "../components/SectionLabel";
 
 /* ──────────────────────────────────────────────────────────────────────
-   Deploy — three real CLI invocations that map to the three deployment
+   Run — three real CLI invocations that map to the three deployment
    shapes operators ask about: wrap one agent, route a whole machine,
    or run the gateway itself.
    ──────────────────────────────────────────────────────────────────── */
@@ -44,15 +44,19 @@ function Terminal({ source }: { source: string }) {
   );
 }
 
-export function DeploySection() {
+export function RunSection() {
   return (
     <section class="bg-canvas-muted py-24 sm:py-32">
       <div class="max-w-6xl mx-auto px-6 sm:px-8">
         <SectionLabel>Run it</SectionLabel>
         <div class="max-w-3xl mx-auto text-center mb-12 sm:mb-16">
           <h3 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-balance mb-5 text-text">
-            Wrap one agent <span class="text-rust">or a whole machine.</span>
+            Three ways in.
           </h3>
+          <p class="text-base text-text-muted">
+            The gateway is a single binary. Agent traffic reaches it over WireGuard or Tailscale;
+            nothing in the agent changes.
+          </p>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- Move RunSection (formerly DeploySection) above RulesSection so the install model precedes the rule examples
- Run H3 becomes "Three ways in." with a one-line subhead about the WireGuard/Tailscale model
- Rename labels "Approval rules" -> "Rules" and "Approvers" -> "Approval flows" so adjacent sections don't share a root
- ProblemSection #2: balance length with #1/#3, drop awkward parenthetical
- ComparisonSection synthesis card: trim protocol claims to match what RulesSection actually demonstrates
- CtaSection: tie the audit/MIT sentences together
- AnalyticsSection: drop the "passively, with zero instrumentation" marketing-speak

## Test plan
- [x] `npm run build` clean
- [ ] visual check against deployed preview
