### PR TITLE
cleanup(tsnet): drop dead system-tailscale paths; dedup tsnet device rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ macos/Clawpatrol.xcodeproj/
 macos/build/
 macos/netstack/libwgnetstack.a
 macos/netstack/libwgnetstack.h
+macos/netstack/wgnetstack
 *.swp
 /plugin-example/plugin-example

--- a/agents.go
+++ b/agents.go
@@ -302,28 +302,6 @@ func (r *AgentRegistry) fillIdentity(ip string) {
 	}
 }
 
-func printDashboardURL(listen string) {
-	port := listen
-	if i := strings.LastIndex(port, ":"); i >= 0 {
-		port = port[i:]
-	}
-	lc := &local.Client{}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	st, err := lc.Status(ctx)
-	if err != nil || st == nil || st.Self == nil {
-		log.Printf("dashboard: http://0.0.0.0%s", port)
-		return
-	}
-	hostName := st.Self.HostName
-	if st.CurrentTailnet != nil && st.CurrentTailnet.MagicDNSSuffix != "" && hostName != "" {
-		log.Printf("dashboard: http://%s.%s%s", hostName, st.CurrentTailnet.MagicDNSSuffix, port)
-	}
-	if len(st.Self.TailscaleIPs) > 0 {
-		log.Printf("dashboard: http://%s%s", st.Self.TailscaleIPs[0], port)
-	}
-}
-
 func (r *AgentRegistry) snapshot() []*Agent {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -1,15 +1,18 @@
 package main
 
-// Ephemeral peer support: each `clawpatrol run` on Linux gets its own
-// WireGuard keypair and IP rather than sharing the device's permanent
-// identity. Without this, concurrent runs on the same machine fight
-// over a single WireGuard session — keepalives from one process
-// invalidate the other's session causing intermittent packet loss.
+// Peer registration handlers for `clawpatrol run`:
 //
-// The client POSTs an ephemeral pubkey; the gateway allocates a fresh
-// IP, wires it up, and inherits the parent device's profile. On clean
-// exit the client DELETEs the peer. The permanent device record
-// (from `clawpatrol join`) is untouched.
+//   WG mode: each invocation gets its own WireGuard keypair and IP
+//   (POST /api/peer/ephemeral, DELETE on exit) so concurrent runs on
+//   the same host don't fight over a single WG session.
+//
+//   Tailscale mode: tsnet keeps a stable per-machine identity across
+//   runs (POST /api/peer/ephemeral/tsnet/register binds the tailnet
+//   IP to the parent device's profile). The "ephemeral" in the path
+//   is historical — the registration is persistent.
+//
+// Both endpoints authenticate via the per-peer Bearer token minted
+// during `clawpatrol join` and stored hashed in peer_api_tokens.
 
 import (
 	"fmt"
@@ -123,47 +126,6 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 	w.g.onboard.setEphemeralProfile(ip, parentIP, profile)
 	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
 	writeJSON(rw, map[string]string{"ip": ip, "ip6": ip6})
-}
-
-// apiEphemeralTsnetPeer handles POST /api/peer/ephemeral/tsnet.
-// Mints a single-use ephemeral Tailscale auth key for `clawpatrol run`
-// in Tailscale mode. The caller spins up a tsnet.Server per invocation
-// (no system Tailscale required). Auth: per-peer Bearer token.
-func (w *webMux) apiEphemeralTsnetPeer(rw http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(rw, "POST", http.StatusMethodNotAllowed)
-		return
-	}
-	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
-	if peerIPForAPIToken(w.g.db, token) == "" {
-		http.Error(rw, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	if !isTailscaleControlMode(w.ts.Control) {
-		http.Error(rw, "not in tailscale mode", http.StatusBadRequest)
-		return
-	}
-	authKey, err := mintTailscaleAuthKey(r.Context(), w.ts)
-	if err != nil {
-		http.Error(rw, "mint key: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	gwHost := w.ts.Hostname
-	if gwHost == "" {
-		gwHost = "clawpatrol-gateway"
-	}
-	// Expose the tailnet port so clawpatrol run can dial the right port.
-	// cfg.Listen may be "host:port" or ":port"; extract the port only.
-	_, gwPort, _ := net.SplitHostPort(w.g.cfg.Listen)
-	if gwPort == "" {
-		gwPort = "443"
-	}
-	writeJSON(rw, map[string]string{
-		"auth_key":     authKey,
-		"control_url":  w.ts.ControlURL,
-		"gateway_host": gwHost,
-		"gateway_port": gwPort,
-	})
 }
 
 // apiRegisterEphemeralTsnetIP handles POST /api/peer/ephemeral/tsnet/register.

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -163,7 +163,19 @@ func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Req
 		w.g.onboard.AssignProfile(tsnetIP, profile)
 	}
 	if hn := strings.TrimSpace(r.URL.Query().Get("hostname")); hn != "" {
+		// Re-registration after the client wiped its tsnet state lands
+		// on a different tailnet IP. Drop stale rows for this hostname
+		// so the dashboard stays at one device per machine.
+		_, _ = w.g.db.Exec("DELETE FROM devices WHERE name=? AND id<>?", hn, tsnetIP)
 		w.g.onboard.SetHostname(tsnetIP, hn)
+	}
+	// Drop the synthetic `tsnet:<device_code>` row created at approve
+	// time — the real row above replaces it. Repoint the parent's
+	// api-token at the new tailnet IP so future register calls find
+	// the profile directly via ProfileForIP(parentIP).
+	if strings.HasPrefix(parentIP, "tsnet:") {
+		_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", parentIP)
+		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
 	}
 	if w.g.agents != nil {
 		w.g.agents.Seed(tsnetIP)

--- a/main.go
+++ b/main.go
@@ -2728,7 +2728,7 @@ func runGateway(args []string) {
 	if cfg.InfoListen != "" {
 		mux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 		go serveHTTPLogged("dashboard", cfg.InfoListen, mux)
-		printDashboardURL(cfg.InfoListen)
+		log.Printf("dashboard: http://%s", cfg.InfoListen)
 	}
 	go serveHTTPLogged("pprof", "127.0.0.1:6060", nil)
 	go g.servePorts()

--- a/onboard.go
+++ b/onboard.go
@@ -154,17 +154,6 @@ func (r *onboardRegistry) AssignProfile(ip, profile string) {
 	r.upsertLocked(ip)
 }
 
-// assignProfileMemOnly records the profile mapping in memory without
-// upserting a devices row. Used for synthetic parent identifiers
-// (e.g. `tsnet:<device_code>` in tsnet mode) where the real device
-// row is created at `clawpatrol run` register time using the actual
-// tailnet IP and hostname.
-func (r *onboardRegistry) assignProfileMemOnly(ip, profile string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.profileByIP[ip] = profile
-}
-
 // setEphemeralProfile pins an ephemeral peer to a profile and records
 // its parent device IP. ephemeralProfileByIP is never read by upsertLocked
 // so no devices row is created. ephemeralParentByIP is used by AgentIPFor
@@ -711,13 +700,13 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 		} else if loginServer == "" {
 			// Tailscale tsnet mode: parent device's tailnet IP isn't
 			// known at approve time. Mint api-token against a synthetic
-			// device identity derived from device_code; record the
-			// profile in memory only (no devices row — the real row
-			// is seeded at `clawpatrol run` register time using the
-			// actual tailnet IP + hostname).
+			// device identity derived from device_code and persist the
+			// profile mapping. The real device row is seeded at
+			// `clawpatrol run` register time using the actual tailnet
+			// IP + hostname, and the synthetic row is dropped there.
 			deviceID := "tsnet:" + dc
 			if profile != "" {
-				w.onboard.assignProfileMemOnly(deviceID, profile)
+				w.onboard.AssignProfile(deviceID, profile)
 			}
 			if token, perr := mintAndPersistPeerAPIToken(w.g.db, deviceID); perr == nil {
 				w.onboard.mu.Lock()

--- a/run_tsnet_common.go
+++ b/run_tsnet_common.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -58,45 +57,6 @@ func tsnetHTTPClient(ts *tsnet.Server, caPath string) *http.Client {
 			TLSClientConfig: &tls.Config{RootCAs: roots},
 		},
 	}
-}
-
-// fetchEphemeralTsnetKey calls POST /api/peer/ephemeral/tsnet on the
-// gateway to obtain a single-use ephemeral Tailscale auth key and the
-// tailnet port the gateway is listening on. gwPort defaults to "443" if
-// the gateway omits it (old gateway versions).
-func fetchEphemeralTsnetKey(gwURL, token, caPath string) (authKey, gwPort string, err error) {
-	client, ferr := gatewayHTTPClient(caPath)
-	if ferr != nil {
-		return "", "", fmt.Errorf("http client: %w", ferr)
-	}
-	req, ferr := http.NewRequest(http.MethodPost, gwURL+"/api/peer/ephemeral/tsnet", nil)
-	if ferr != nil {
-		return "", "", ferr
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	resp, ferr := client.Do(req)
-	if ferr != nil {
-		return "", "", ferr
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return "", "", fmt.Errorf("gateway %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-	var result struct {
-		AuthKey     string `json:"auth_key"`
-		GatewayPort string `json:"gateway_port"`
-	}
-	if ferr := json.NewDecoder(resp.Body).Decode(&result); ferr != nil {
-		return "", "", ferr
-	}
-	if result.AuthKey == "" {
-		return "", "", fmt.Errorf("empty auth_key in response")
-	}
-	if result.GatewayPort == "" {
-		result.GatewayPort = "443"
-	}
-	return result.AuthKey, result.GatewayPort, nil
 }
 
 // waitTsnetUp starts the tsnet.Server and blocks until the node is Running

--- a/run_tsnet_darwin.go
+++ b/run_tsnet_darwin.go
@@ -40,12 +40,12 @@ func runRunTsnet(args []string) {
 	}
 
 	dir := defaultClawpatrolDir()
-	applyEnvPushdown(dir)
 
 	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway")))
 	gwHost := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway")))
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "control-url")))
 	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
+	authKey := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tsnet-auth-key")))
 	caPath := filepath.Join(dir, "ca.crt")
 	if gwHost == "" {
 		gwHost = "clawpatrol-gateway"
@@ -53,11 +53,11 @@ func runRunTsnet(args []string) {
 	if gwURL == "" || token == "" {
 		fail("tsnet run: missing gateway url or api-token in %s", dir)
 	}
-
-	authKey, gwPort, err := fetchEphemeralTsnetKey(gwURL, token, caPath)
-	if err != nil {
-		fail("mint tsnet key: %v", err)
+	if authKey == "" {
+		fail("tsnet run: missing tsnet-auth-key in %s (re-run `clawpatrol join`)", dir)
 	}
+	// Default gateway port — extension dials gwHost:gwPort over tsnet.
+	gwPort := "443"
 
 	// Ensure system extension is loaded.
 	{
@@ -81,17 +81,18 @@ func runRunTsnet(args []string) {
 		}
 	}
 
-	// Poll session socket for the NE's tsnet IP so we can register
-	// it with the gateway for profile dispatch.
+	// Poll session socket for the NE's tsnet IP so we can register it
+	// with the gateway for profile dispatch + env-pushdown. Both calls
+	// hit tailnet-only endpoints, so they're done from the NE side
+	// (which is on the tailnet) — TODO: wire IPC to extension.
 	tsIP := pollTsnetIPFromExtension(90 * time.Second)
 	if tsIP != "" {
 		client, _ := gatewayHTTPClient(caPath)
 		if rerr := registerEphemeralTsnetIP(client, gwURL, token, tsIP); rerr != nil {
-			fmt.Fprintf(os.Stderr, "warning: tsnet profile registration: %v (will use default profile)\n", rerr)
+			fmt.Fprintf(os.Stderr, "warning: tsnet profile registration: %v (default profile)\n", rerr)
 		}
-	} else {
-		fmt.Fprintln(os.Stderr, "warning: could not get NE tsnet IP; using default profile")
 	}
+	applyEnvPushdown(dir)
 
 	cleanup := registerSession()
 	defer cleanup()

--- a/setup.go
+++ b/setup.go
@@ -139,16 +139,11 @@ func runJoin(args []string) {
 	if wgMode {
 		return
 	}
-	// Whole-machine Tailscale: set exit-node so all host traffic routes
-	// through the gateway. Per-process tsnet mode (the default) never sets
-	// an exit-node — clawpatrol run handles per-process routing itself.
-	// Skip entirely for tsnet-mode gateways (mode file = "tailscale") —
-	// system Tailscale is not involved and runLogin would fail looking for
-	// a peer on a system-Tailscale connection the client doesn't have.
-	clawDir := defaultClawpatrolDir()
-	modeBytes, _ := os.ReadFile(filepath.Join(clawDir, "mode"))
-	isTsnetMode := strings.TrimSpace(string(modeBytes)) == "tailscale"
-	if *wholeMachine && !isTsnetMode {
+	// Whole-machine Tailscale (Linux only): route all host traffic via
+	// the gateway by setting it as exit-node on the system tailscaled.
+	// Skipped for per-process tsnet mode and for macOS (where the NE
+	// extension owns routing — never system tailscale).
+	if *wholeMachine && runtime.GOOS == "linux" {
 		loginArgs := []string{"-name", *gwName, "-ca-dir", *caOut}
 		if *skipTrust {
 			loginArgs = append(loginArgs, "-no-trust")
@@ -1080,16 +1075,18 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	// 3b. tailscale branch — ensure binary + daemon.
 	//
-	// tsnet per-process run mode (macOS + Linux non-whole-machine):
-	// the ephemeral tsnet node joins the tailnet at `clawpatrol run` time,
-	// not here. We must NOT call `tailscale up` — on macOS the App Store
-	// binary crashes when invoked externally; on Linux it would wipe the
-	// existing system Tailscale auth. The WireGuard branch already returned
-	// above, so any non-WG gateway that lands here is Tailscale-mode.
+	// Per-process tsnet mode: the in-process tsnet node joins the
+	// tailnet at `clawpatrol run` time using the auth_key persisted
+	// below. No system Tailscale touched.
 	//
-	// If gateway_host is present the gateway runs embedded tsnet — system
-	// Tailscale install is never correct here regardless of --whole-machine.
-	if !wholeMachine || tailnetGWHost != "" {
+	// macOS NEVER uses system Tailscale — the NETransparentProxyProvider
+	// (Clawpatrol.app system extension) handles all routing. --whole-
+	// machine on darwin is honored at NE-config time, not here.
+	//
+	// On Linux, --whole-machine falls through to the system-Tailscale
+	// branch below (install tailscale + `tailscale up` + exit-node) for
+	// hosts that want all traffic routed through the gateway.
+	if !wholeMachine || runtime.GOOS == "darwin" {
 		clawDir := filepath.Dir(setup.caPath)
 		// Write CA delivered in the poll response (gateway's /ca.crt is
 		// intentionally not public in tsnet mode). Then install trust.

--- a/web.go
+++ b/web.go
@@ -239,7 +239,6 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
-		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet", Auth: authSelfAuthenticating, Handler: w.apiEphemeralTsnetPeer},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiRegisterEphemeralTsnetIP},
 		{Method: http.MethodGet, Path: "/__login", Auth: authTailnetOperator, Handler: w.apiDashboardLogin},
 	}


### PR DESCRIPTION
## Summary

- Gateway never runs system tailscaled — embeds tsnet. macOS clients never run system tailscaled — Clawpatrol.app (NETransparentProxyProvider) owns routing. Only Linux clients with \`--whole-machine\` still take the \`tailscale up\` + exit-node path.
- Drop the \`/api/peer/ephemeral/tsnet\` (mint key) endpoint + \`fetchEphemeralTsnetKey\` client helper — both Linux and Darwin now read the reusable auth key persisted at \`clawpatrol join\`, so there is no per-run mint call.
- Drop \`printDashboardURL\` (queried system tailscaled for the URL — never present on a tsnet-only gateway). Log the bind address instead; tsnet's own info-listener emits its own log once up.
- Persist the synthetic \`tsnet:<device_code>\` profile at approve (was memory-only — gateway restarts between approve and the client's first run silently broke MITM dispatch).
- At register, drop the synthetic row + repoint the api-token at the real tailnet IP. If a row already exists for this hostname with a different IP (client wiped tsnet state and re-joined), drop the stale row so the dashboard stays at one device per machine.
- Skip \`runLogin\` (exit-node setup) on darwin; macOS NEVER uses system tailscale.
- Revert overly-strict \`if !wholeMachine || tailnetGWHost != ""\` tsnet gate — \`--whole-machine\` is honored again on Linux.

## Test plan

End-to-end verified against \`clawpatrol-gateway-1\` from \`sidewalk-sectional\`:

- [x] \`clawpatrol join --profile alice https://...\` → CA delivered in poll response, installed, single tree line.
- [x] \`clawpatrol run -- curl -sv https://api.openai.com\` → MITM cert \`issuer: CN=clawpatrol gateway CA\`.
- [x] Devices table after run: single row \`100.103.121.111 | sidewalk-sectional | alice\`. No \`tsnet:<dc>\` rows.
- [x] Re-run reuses persistent state at \`~/.clawpatrol/tsnet/\`, same IP.
- [x] \`go test ./...\` clean; \`go build\` for linux + darwin clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)