### PR TITLE
dashboard: credentials redesign — type cards + expanding details table

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -583,6 +583,14 @@ type IntegrationRow struct {
 	// Never contains secret material — secret bytes live in the
 	// secrets store, not in the HCL block.
 	Config map[string]string `json:"config,omitempty"`
+	// UpdatedAt is the Unix-seconds timestamp of the most recent
+	// persistence event for this credential — the max of
+	// credential_secrets.updated_ns and the OAuth row's updated_ns.
+	// Zero when neither store has a row (declared-only credential).
+	// The dashboard sorts the per-type details table by this so the
+	// most recently connected credential surfaces at the top of the
+	// non-pending rows.
+	UpdatedAt int64 `json:"updated_at,omitempty"`
 }
 
 // TailscaleAuthStatusUI is the dashboard-facing slice of a
@@ -692,6 +700,7 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 		}
 		row.Profiles, row.Endpoints = credentialBindings(policy, name)
 		row.Config = credentialConfig(ent, name)
+		row.UpdatedAt = credentialUpdatedAt(w.g.db, name)
 		out = append(out, row)
 	}
 	return out

--- a/agents.go
+++ b/agents.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"tailscale.com/client/local"
 
 	"github.com/denoland/clawpatrol/config"
@@ -567,6 +568,21 @@ type IntegrationRow struct {
 	AvatarURL        string                 `json:"avatar_url,omitempty"`
 	HasTailscaleAuth bool                   `json:"has_tailscale_auth,omitempty"`
 	TailscaleAuth    *TailscaleAuthStatusUI `json:"tailscale_auth,omitempty"`
+
+	// Profiles is the sorted list of profile names that route any
+	// endpoint or tunnel binding this credential. Empty when the
+	// credential is declared but no profile references it.
+	Profiles []string `json:"profiles,omitempty"`
+	// Endpoints is the sorted list of endpoint names whose `credential`
+	// / `credentials` binding (directly or transitively via the
+	// endpoint's tunnel) resolves to this credential.
+	Endpoints []string `json:"endpoints,omitempty"`
+	// Config exposes the operator-set HCL block attributes for the
+	// credential (e.g. `user = "postgres"`) keyed by attribute name.
+	// Values are the raw HCL token text (quoted strings included).
+	// Never contains secret material — secret bytes live in the
+	// secrets store, not in the HCL block.
+	Config map[string]string `json:"config,omitempty"`
 }
 
 // TailscaleAuthStatusUI is the dashboard-facing slice of a
@@ -674,7 +690,91 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 				DisconnectURL: "/api/tailscale/disconnect?id=" + name,
 			}
 		}
+		row.Profiles, row.Endpoints = credentialBindings(policy, name)
+		row.Config = credentialConfig(ent, name)
 		out = append(out, row)
+	}
+	return out
+}
+
+// credentialBindings reports every profile + endpoint that references
+// the named credential, walking endpoint.Credentials AND the chain of
+// tunnels the endpoint dials through. The dashboard's details table
+// renders one column for profiles and one for endpoints so an
+// operator can see at a glance where a credential is in play.
+func credentialBindings(policy *config.CompiledPolicy, credName string) (profiles, endpoints []string) {
+	if policy == nil {
+		return nil, nil
+	}
+	epSet := map[string]bool{}
+	for epName, ep := range policy.Endpoints {
+		if endpointBindsCredential(ep, credName) {
+			epSet[epName] = true
+		}
+	}
+	if len(epSet) > 0 {
+		endpoints = make([]string, 0, len(epSet))
+		for n := range epSet {
+			endpoints = append(endpoints, n)
+		}
+		sort.Strings(endpoints)
+	}
+	profSet := map[string]bool{}
+	for pname, prof := range policy.Profiles {
+		for epName, ep := range prof.Endpoints {
+			if epSet[epName] || endpointBindsCredential(ep, credName) {
+				profSet[pname] = true
+				break
+			}
+		}
+	}
+	if len(profSet) > 0 {
+		profiles = make([]string, 0, len(profSet))
+		for n := range profSet {
+			profiles = append(profiles, n)
+		}
+		sort.Strings(profiles)
+	}
+	return profiles, endpoints
+}
+
+func endpointBindsCredential(ep *config.CompiledEndpoint, credName string) bool {
+	if ep == nil {
+		return false
+	}
+	for _, cb := range ep.Credentials {
+		if cb.Credential != nil && cb.Credential.Symbol.Name == credName {
+			return true
+		}
+	}
+	for tun := ep.Tunnel; tun != nil; tun = tun.Via {
+		if tun.Credential != nil && tun.Credential.Symbol.Name == credName {
+			return true
+		}
+	}
+	return false
+}
+
+// credentialConfig surfaces the operator-set HCL attributes on a
+// credential block (`user = "x"`, `region = "us-east-1"`, …). Built
+// by replaying the plugin's Emit hook into a throwaway hclwrite Body
+// and harvesting the attributes back out — secret bytes never live
+// in the HCL block (they're in the secrets store), so this is safe
+// to render as-is. Returns nil when the plugin emits no attributes.
+func credentialConfig(ent *config.Entity, name string) map[string]string {
+	if ent == nil || ent.Plugin == nil || ent.Plugin.Emit == nil {
+		return nil
+	}
+	file := hclwrite.NewEmptyFile()
+	ent.Plugin.Emit(ent.Body, name, file.Body())
+	attrs := file.Body().Attributes()
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(attrs))
+	for n, a := range attrs {
+		raw := string(a.Expr().BuildTokens(nil).Bytes())
+		out[n] = strings.TrimSpace(raw)
 	}
 	return out
 }

--- a/credential_bindings_test.go
+++ b/credential_bindings_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all" // register builtin plugins
+)
+
+// TestCredentialBindings verifies the IntegrationRow Profiles +
+// Endpoints fan-out: each declared credential gathers the endpoint
+// names it's bound to (directly or via a tunnel) and the profiles
+// whose endpoint set references any of those endpoints.
+func TestCredentialBindings(t *testing.T) {
+	src := `
+credential "bearer_token" "alpha" {}
+credential "bearer_token" "beta" {}
+credential "bearer_token" "orphan" {}
+
+endpoint "https" "alpha_api" {
+  hosts      = ["alpha.example"]
+  credential = alpha
+}
+endpoint "https" "beta_api" {
+  hosts      = ["beta.example"]
+  credential = beta
+}
+endpoint "https" "beta_api_2" {
+  hosts      = ["beta2.example"]
+  credential = beta
+}
+
+profile "prod" {
+  endpoints = [alpha_api, beta_api]
+}
+profile "staging" {
+  endpoints = [beta_api_2]
+}
+
+rule "default-allow" {
+  verdict   = "allow"
+  endpoints = [alpha_api, beta_api, beta_api_2]
+}
+`
+	gw, diags := config.LoadBytes([]byte(src), "bindings-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		profiles  []string
+		endpoints []string
+	}{
+		{"alpha", []string{"prod"}, []string{"alpha_api"}},
+		{"beta", []string{"prod", "staging"}, []string{"beta_api", "beta_api_2"}},
+		{"orphan", nil, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			profs, eps := credentialBindings(policy, c.name)
+			if !sliceEq(profs, c.profiles) {
+				t.Errorf("profiles got %v want %v", profs, c.profiles)
+			}
+			if !sliceEq(eps, c.endpoints) {
+				t.Errorf("endpoints got %v want %v", eps, c.endpoints)
+			}
+		})
+	}
+}
+
+// TestCredentialConfigOperatorFields extracts the per-credential
+// operator-set HCL attrs back from the Emit hook. Postgres exposes
+// `user`; the dashboard's details table renders it as a column.
+func TestCredentialConfigOperatorFields(t *testing.T) {
+	src := `
+credential "postgres_credential" "db" {
+  user = "ro_app"
+}
+`
+	gw, diags := config.LoadBytes([]byte(src), "cfg-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ent := policy.Credentials["db"]
+	if ent == nil {
+		t.Fatal("missing db credential")
+	}
+	cfg := credentialConfig(ent, "db")
+	got, ok := cfg["user"]
+	if !ok {
+		t.Fatalf("expected user attr, got %v", cfg)
+	}
+	if !strings.Contains(got, "ro_app") {
+		t.Errorf("user value %q does not contain ro_app", got)
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/secrets.go
+++ b/secrets.go
@@ -127,6 +127,32 @@ func clearCredentialSecrets(db *sql.DB, credential string) error {
 	return err
 }
 
+// credentialUpdatedAt returns the most recent persistence timestamp
+// across credential_secrets and the OAuth credentials row for the
+// named credential, in Unix seconds. Zero when neither store carries
+// a row — declared-only credentials with no operator action yet.
+func credentialUpdatedAt(db *sql.DB, credential string) int64 {
+	if db == nil {
+		return 0
+	}
+	var best int64
+	var secretNS sql.NullInt64
+	if err := db.QueryRow(
+		`SELECT MAX(updated_ns) FROM credential_secrets WHERE credential = ?`,
+		credential,
+	).Scan(&secretNS); err == nil && secretNS.Valid && secretNS.Int64 > best {
+		best = secretNS.Int64
+	}
+	var oauthNS sql.NullInt64
+	if err := db.QueryRow(
+		`SELECT updated_ns FROM credentials WHERE id = ?`,
+		credential,
+	).Scan(&oauthNS); err == nil && oauthNS.Valid && oauthNS.Int64 > best {
+		best = oauthNS.Int64
+	}
+	return best / int64(time.Second)
+}
+
 // credentialSlotPresence returns the set of slots persisted for the
 // named credential. Used by the dashboard to render per-slot
 // "filled / empty" status without leaking the secret bytes.

--- a/www/src/components/CredentialsTypeGrid.tsx
+++ b/www/src/components/CredentialsTypeGrid.tsx
@@ -11,7 +11,12 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Integration, TailscaleNodeState } from "../lib/api";
 import { clearCredential, oauthRevoke, tailscaleConnect, tailscaleDisconnect } from "../lib/api";
-import { credentialTypeLabel } from "../lib/credentialLabels";
+import {
+  CREDENTIAL_CATEGORY_RANK,
+  type CredentialCategory,
+  credentialCategory,
+  credentialTypeLabel,
+} from "../lib/credentialLabels";
 import { fmtExpiry } from "../lib/format";
 import { CredentialSecretsModal } from "./CredentialSecretsModal";
 import { IntegrationIcon } from "./Logos";
@@ -19,6 +24,7 @@ import { IntegrationIcon } from "./Logos";
 type Group = {
   type: string;
   label: string;
+  category: CredentialCategory;
   items: Integration[];
   connected: number;
   total: number;
@@ -47,6 +53,7 @@ function groupByType(list: Integration[]): Group[] {
       g = {
         type: key,
         label: credentialTypeLabel(key, key),
+        category: credentialCategory(key),
         items: [],
         connected: 0,
         total: 0,
@@ -60,16 +67,40 @@ function groupByType(list: Integration[]): Group[] {
     else if (isAuthable(i)) g.pending++;
   }
   const out = [...groups.values()];
-  // Sort by pending desc (operator attention first), then by
-  // unconnected total desc, then alphabetically for stability.
+  // Order, by priority (most operator-relevant first):
+  //   1. types with at least one pending credential beat types that
+  //      are fully connected (or have nothing left to connect);
+  //   2. within a tier, category rank — LLM > messaging > database
+  //      > 3rd-party > generic-token > other;
+  //   3. pending count descending, so the busiest type leads;
+  //   4. label, alphabetical, for stable ties.
   out.sort((a, b) => {
+    const aPending = a.pending > 0 ? 0 : 1;
+    const bPending = b.pending > 0 ? 0 : 1;
+    if (aPending !== bPending) return aPending - bPending;
+    const aRank = CREDENTIAL_CATEGORY_RANK[a.category];
+    const bRank = CREDENTIAL_CATEGORY_RANK[b.category];
+    if (aRank !== bRank) return aRank - bRank;
     if (a.pending !== b.pending) return b.pending - a.pending;
-    const aRest = a.total - a.connected;
-    const bRest = b.total - b.connected;
-    if (aRest !== bRest) return bRest - aRest;
     return a.label.localeCompare(b.label);
   });
   return out;
+}
+
+// sortDetailRows hoists pending-to-connect credentials to the top of
+// the per-type details table and sorts within each bucket by
+// updated_at descending — so the first non-pending row is the most
+// recently connected credential.
+function sortDetailRows(items: Integration[]): Integration[] {
+  return [...items].sort((a, b) => {
+    const aPending = !isConnected(a) && isAuthable(a) ? 0 : 1;
+    const bPending = !isConnected(b) && isAuthable(b) ? 0 : 1;
+    if (aPending !== bPending) return aPending - bPending;
+    const aTs = a.updated_at ?? 0;
+    const bTs = b.updated_at ?? 0;
+    if (aTs !== bTs) return bTs - aTs;
+    return a.name.localeCompare(b.name);
+  });
 }
 
 // Approximate per-card minimum width. The grid is JS-driven (not
@@ -305,6 +336,7 @@ function DetailsPanel({
   const configKeys = Array.from(
     new Set(group.items.flatMap((i) => Object.keys(i.config ?? {}))),
   ).sort();
+  const rows = sortDetailRows(group.items);
   return (
     <div className="bg-canvas-light border-2 border-navy overflow-hidden">
       <div className="flex items-center justify-between gap-3 px-4 py-2.5 bg-navy-100 border-b border-navy">
@@ -336,7 +368,7 @@ function DetailsPanel({
             </tr>
           </thead>
           <tbody>
-            {group.items.map((i) => (
+            {rows.map((i) => (
               <DetailsRow
                 key={i.id}
                 integration={i}

--- a/www/src/components/CredentialsTypeGrid.tsx
+++ b/www/src/components/CredentialsTypeGrid.tsx
@@ -1,0 +1,488 @@
+// Settings-page credentials view: a grid of per-type cards (logo,
+// display name, connected/total count) that expand a full-width
+// details table immediately below the card's row when clicked.
+//
+// The card grid is rendered row-by-row so the details table can sit
+// between the row of the active card and the next row — clicking a
+// card on row 2 folds whatever is open and reopens the table below
+// row 2. Sort is by pending-connection count descending so the
+// types operators need to act on surface first.
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { Integration, TailscaleNodeState } from "../lib/api";
+import { clearCredential, oauthRevoke, tailscaleConnect, tailscaleDisconnect } from "../lib/api";
+import { credentialTypeLabel } from "../lib/credentialLabels";
+import { fmtExpiry } from "../lib/format";
+import { CredentialSecretsModal } from "./CredentialSecretsModal";
+import { IntegrationIcon } from "./Logos";
+
+type Group = {
+  type: string;
+  label: string;
+  items: Integration[];
+  connected: number;
+  total: number;
+  pending: number;
+};
+
+function isConnected(i: Integration) {
+  return i.connected || (i.tailscale_auth?.connected ?? false);
+}
+
+function isAuthable(i: Integration) {
+  // A credential is "authable" if there's a connect surface for it
+  // — OAuth, secret slots, or a Tailscale auth flow. Credentials
+  // without any of these are declared-only (e.g. api-key-only types
+  // wired through env or static HCL) and don't move toward
+  // "connected" via dashboard actions.
+  return Boolean(i.has_oauth || i.has_tailscale_auth || (i.slots && i.slots.length > 0));
+}
+
+function groupByType(list: Integration[]): Group[] {
+  const groups = new Map<string, Group>();
+  for (const i of list) {
+    const key = i.type || "unknown";
+    let g = groups.get(key);
+    if (!g) {
+      g = {
+        type: key,
+        label: credentialTypeLabel(key, key),
+        items: [],
+        connected: 0,
+        total: 0,
+        pending: 0,
+      };
+      groups.set(key, g);
+    }
+    g.items.push(i);
+    g.total++;
+    if (isConnected(i)) g.connected++;
+    else if (isAuthable(i)) g.pending++;
+  }
+  const out = [...groups.values()];
+  // Sort by pending desc (operator attention first), then by
+  // unconnected total desc, then alphabetically for stability.
+  out.sort((a, b) => {
+    if (a.pending !== b.pending) return b.pending - a.pending;
+    const aRest = a.total - a.connected;
+    const bRest = b.total - b.connected;
+    if (aRest !== bRest) return bRest - aRest;
+    return a.label.localeCompare(b.label);
+  });
+  return out;
+}
+
+// Approximate per-card minimum width. The grid is JS-driven (not
+// CSS grid auto-placement) because we need to know which row the
+// active card lives in so the details panel can be injected between
+// rows. CSS `grid-column: 1 / -1` would auto-place at the next free
+// row, not below a specific card's row.
+const CARD_MIN_PX = 220;
+
+function useColumnCount(ref: React.RefObject<HTMLDivElement>): number {
+  const [cols, setCols] = useState(4);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const w = el.clientWidth;
+      // Match the gap baked into the row's flex layout (10px gap).
+      const next = Math.max(1, Math.floor((w + 10) / (CARD_MIN_PX + 10)));
+      setCols(next);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref]);
+  return cols;
+}
+
+export function CredentialsTypeGrid({
+  list,
+  onConnect,
+  onRefresh,
+}: {
+  list: Integration[];
+  onConnect: (id: string) => void;
+  onRefresh: () => void;
+}) {
+  const [activeType, setActiveType] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Integration | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cols = useColumnCount(containerRef);
+
+  const groups = groupByType(list);
+
+  // Drop the active type if it disappears from the list (e.g. a
+  // reload removed every credential of that type).
+  useEffect(() => {
+    if (activeType && !groups.some((g) => g.type === activeType)) {
+      setActiveType(null);
+    }
+  }, [activeType, groups]);
+
+  function handleConnect(i: Integration) {
+    if (i.has_tailscale_auth && i.tailscale_auth) {
+      // Open the parked URL synchronously so popup blockers honor
+      // the user gesture; the POST runs in parallel and refreshes
+      // when tsnet reports "already joined". See IntegrationsCards
+      // for the longer rationale.
+      const parked = i.tailscale_auth.pending_url;
+      if (parked) {
+        window.open(parked, "_blank", "noopener,noreferrer");
+      }
+      tailscaleConnect(i.tailscale_auth.connect_url)
+        .then((r) => {
+          if (r.connected) {
+            onRefresh();
+            return;
+          }
+          if (!parked) {
+            const url = r.auth_url || r.pending_url;
+            if (url) {
+              window.open(url, "_blank", "noopener,noreferrer");
+            }
+          }
+        })
+        .catch(() => {
+          /* surfaced on the next refresh */
+        });
+      return;
+    }
+    if (i.has_oauth) {
+      onConnect(i.id);
+      return;
+    }
+    if (i.slots && i.slots.length > 0) {
+      setEditing(i);
+    }
+  }
+
+  function handleDisconnect(i: Integration) {
+    const label = credentialTypeLabel(i.type, i.name);
+    const what = i.has_oauth
+      ? "revoke the OAuth token"
+      : i.has_tailscale_auth
+        ? "disconnect the Tailscale node"
+        : "clear the stored secrets";
+    if (
+      !confirm(
+        `Disconnect ${label} (${i.id})?\n\nThis will ${what}. You'll need to reconnect to use it again.`,
+      )
+    ) {
+      return;
+    }
+    if (i.has_tailscale_auth && i.tailscale_auth) {
+      tailscaleDisconnect(i.tailscale_auth.disconnect_url).then(onRefresh);
+      return;
+    }
+    if (i.has_oauth) {
+      oauthRevoke(i.id).then(onRefresh);
+    } else {
+      clearCredential(i.id).then(onRefresh);
+    }
+  }
+
+  // Bucket groups into rows of `cols` cards. The details table is
+  // emitted between rows immediately after the row the active card
+  // belongs to, so a click on row 2's third card opens the table at
+  // the same position regardless of what other rows look like.
+  const rows: Group[][] = [];
+  for (let i = 0; i < groups.length; i += cols) {
+    rows.push(groups.slice(i, i + cols));
+  }
+  const activeIndex = activeType ? groups.findIndex((g) => g.type === activeType) : -1;
+  const activeRow = activeIndex >= 0 ? Math.floor(activeIndex / cols) : -1;
+  const activeGroup = activeIndex >= 0 ? groups[activeIndex] : null;
+
+  return (
+    <>
+      <div ref={containerRef} className="flex flex-col gap-2.5">
+        {rows.map((rowGroups, rowIdx) => (
+          <div key={rowIdx} className="flex flex-col gap-2.5">
+            <div
+              className="grid gap-2.5"
+              style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+            >
+              {rowGroups.map((g) => (
+                <TypeCard
+                  key={g.type}
+                  group={g}
+                  active={g.type === activeType}
+                  onClick={() => setActiveType((prev) => (prev === g.type ? null : g.type))}
+                />
+              ))}
+            </div>
+            {rowIdx === activeRow && activeGroup && (
+              <DetailsPanel
+                group={activeGroup}
+                onClose={() => setActiveType(null)}
+                onConnect={handleConnect}
+                onDisconnect={handleDisconnect}
+                onEdit={(i) => setEditing(i)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {editing && (
+        <CredentialSecretsModal
+          integration={editing}
+          mode={isConnected(editing) ? "update" : "connect"}
+          onClose={() => setEditing(null)}
+          onSaved={onRefresh}
+        />
+      )}
+    </>
+  );
+}
+
+function TypeCard({
+  group: g,
+  active,
+  onClick,
+}: {
+  group: Group;
+  active: boolean;
+  onClick: () => void;
+}) {
+  // Pick a representative item so the icon picker (which keys off
+  // the credential id for legacy names like "claude" / "github")
+  // still gets the right brand glyph when the type label alone
+  // wouldn't disambiguate.
+  const rep = g.items[0];
+  const allConnected = g.connected === g.total && g.total > 0;
+  const noneConnected = g.connected === 0;
+  return (
+    <button
+      onClick={onClick}
+      className={
+        "group flex flex-col items-start gap-2 px-3 py-3 bg-canvas-light text-left transition-colors border-2 " +
+        (active ? "border-text bg-navy-50" : "border-navy hover:bg-navy-50 cursor-pointer")
+      }
+    >
+      <div className="flex items-center gap-2 w-full">
+        <IntegrationIcon id={rep.id} type={rep.type} className="w-[18px] h-[18px] shrink-0" />
+        <span className="text-xs font-semibold text-text truncate" title={g.label}>
+          {g.label}
+        </span>
+        <span
+          className={
+            "ml-auto w-[6px] h-[6px] rounded-full shrink-0 " +
+            (allConnected ? "bg-success-500" : noneConnected ? "bg-text-subtle" : "bg-butter-500")
+          }
+        />
+      </div>
+      <div className="text-2xs tabular-nums text-text-muted">
+        <span className="font-semibold text-text">{g.connected}</span>
+        <span className="text-text-subtle">/{g.total}</span>
+        <span className="ml-1">connected</span>
+        {g.pending > 0 && <span className="ml-2 text-rust-700">{g.pending} pending</span>}
+      </div>
+    </button>
+  );
+}
+
+function DetailsPanel({
+  group,
+  onClose,
+  onConnect,
+  onDisconnect,
+  onEdit,
+}: {
+  group: Group;
+  onClose: () => void;
+  onConnect: (i: Integration) => void;
+  onDisconnect: (i: Integration) => void;
+  onEdit: (i: Integration) => void;
+}) {
+  // Config columns: the union of HCL attribute names across all
+  // credentials of this type, in stable (sorted) order. Per the
+  // bead: name / status / profile(s) / endpoint(s) come first, then
+  // the per-field block contents fan out after.
+  const configKeys = Array.from(
+    new Set(group.items.flatMap((i) => Object.keys(i.config ?? {}))),
+  ).sort();
+  return (
+    <div className="bg-canvas-light border-2 border-navy overflow-hidden">
+      <div className="flex items-center justify-between gap-3 px-4 py-2.5 bg-navy-100 border-b border-navy">
+        <div className="text-xs uppercase tracking-wider text-navy font-bold">
+          {group.label} · {group.total} declared · {group.connected} connected
+        </div>
+        <button
+          onClick={onClose}
+          className="text-text-subtle hover:text-text text-sm leading-none px-1"
+          title="fold"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead className="text-2xs uppercase tracking-wider text-text-muted">
+            <tr className="border-b border-canvas-dark">
+              <th className="text-left font-semibold px-3 py-2">Name</th>
+              <th className="text-left font-semibold px-3 py-2">Status</th>
+              <th className="text-left font-semibold px-3 py-2">Profiles</th>
+              <th className="text-left font-semibold px-3 py-2">Endpoints</th>
+              {configKeys.map((k) => (
+                <th key={k} className="text-left font-semibold px-3 py-2 whitespace-nowrap">
+                  {k}
+                </th>
+              ))}
+              <th className="text-right font-semibold px-3 py-2">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {group.items.map((i) => (
+              <DetailsRow
+                key={i.id}
+                integration={i}
+                configKeys={configKeys}
+                onConnect={() => onConnect(i)}
+                onDisconnect={() => onDisconnect(i)}
+                onEdit={() => onEdit(i)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DetailsRow({
+  integration: i,
+  configKeys,
+  onConnect,
+  onDisconnect,
+  onEdit,
+}: {
+  integration: Integration;
+  configKeys: string[];
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onEdit: () => void;
+}) {
+  const connected = isConnected(i);
+  const hasSlots = (i.slots?.length ?? 0) > 0;
+  const canReset = i.has_tailscale_auth && (i.tailscale_auth?.has_state ?? false);
+  const canConnect = !connected && (i.has_oauth || hasSlots || i.has_tailscale_auth);
+  const canDisconnect = connected || canReset;
+  const status = rowStatus(i, connected, hasSlots);
+  const subtitle = rowSubtitle(i, connected);
+  const profiles = i.profiles ?? [];
+  const endpoints = i.endpoints ?? [];
+  const cfg = i.config ?? {};
+  return (
+    <tr className="border-b border-canvas-dark last:border-b-0">
+      <td className="px-3 py-2 align-top">
+        <div className="font-mono text-text">{i.name}</div>
+        {subtitle && <div className="text-2xs text-text-muted mt-0.5">{subtitle}</div>}
+      </td>
+      <td className="px-3 py-2 align-top">
+        <span className="inline-flex items-center gap-1.5">
+          <span
+            className={
+              "w-[6px] h-[6px] rounded-full " + (connected ? "bg-success-500" : "bg-text-subtle")
+            }
+          />
+          <span className="text-text">{status}</span>
+        </span>
+      </td>
+      <td className="px-3 py-2 align-top">
+        <CellList items={profiles} />
+      </td>
+      <td className="px-3 py-2 align-top">
+        <CellList items={endpoints} />
+      </td>
+      {configKeys.map((k) => (
+        <td key={k} className="px-3 py-2 align-top font-mono text-text">
+          {cfg[k] ?? <span className="text-text-subtle">—</span>}
+        </td>
+      ))}
+      <td className="px-3 py-2 align-top whitespace-nowrap text-right">
+        {canConnect && (
+          <button
+            onClick={onConnect}
+            className="text-text hover:text-rust-700 underline underline-offset-2"
+          >
+            Connect
+          </button>
+        )}
+        {connected && hasSlots && (
+          <button
+            onClick={onEdit}
+            className="text-text hover:text-rust-700 underline underline-offset-2 ml-3"
+          >
+            Update
+          </button>
+        )}
+        {canDisconnect && (
+          <button
+            onClick={onDisconnect}
+            className="text-text-subtle hover:text-danger-500 underline underline-offset-2 ml-3"
+          >
+            Disconnect
+          </button>
+        )}
+        {!canConnect && !canDisconnect && <span className="text-text-subtle">—</span>}
+      </td>
+    </tr>
+  );
+}
+
+function CellList({ items }: { items: string[] }) {
+  if (!items.length) return <span className="text-text-subtle">—</span>;
+  return (
+    <div className="flex flex-wrap gap-1 max-w-[18rem]">
+      {items.map((n) => (
+        <span key={n} className="font-mono text-text bg-canvas-dark/30 px-1.5 py-0.5 rounded">
+          {n}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function rowStatus(i: Integration, connected: boolean, hasSlots: boolean): string {
+  if (connected) {
+    return i.expires_at ? "expires " + fmtExpiry(i.expires_at) : "connected";
+  }
+  if (i.has_tailscale_auth) {
+    return tailscaleStatusLabel(i.tailscale_auth?.state);
+  }
+  if (i.has_oauth) return "click to connect";
+  if (hasSlots) return "paste secret";
+  return "api key only";
+}
+
+function rowSubtitle(i: Integration, connected: boolean): string {
+  if (connected && i.display_name) return i.display_name;
+  if (!connected && i.has_tailscale_auth) {
+    const s = i.tailscale_auth?.state;
+    if (s === "needs_login" || s === "needs_machine_auth") return "awaiting authentication";
+    if (s === "in_use_other_user") return "in use by another user";
+  }
+  return "";
+}
+
+function tailscaleStatusLabel(state: TailscaleNodeState | undefined): string {
+  switch (state) {
+    case "needs_login":
+    case "needs_machine_auth":
+      return "awaiting authentication";
+    case "starting":
+      return "starting";
+    case "stopped":
+      return "stopped";
+    case "in_use_other_user":
+      return "error: in use by another user";
+    case "running":
+      return "connected";
+    default:
+      return "not connected";
+  }
+}

--- a/www/src/components/SettingsPage.tsx
+++ b/www/src/components/SettingsPage.tsx
@@ -5,8 +5,8 @@
 
 import { useEffect, useState } from "react";
 import { getConfigHCL, type Integration } from "../lib/api";
+import { CredentialsTypeGrid } from "./CredentialsTypeGrid";
 import { HCLEditor } from "./HCLEditor";
-import { IntegrationsCards } from "./IntegrationsCards";
 import { Main } from "./Main";
 import { PageTitle } from "./PageTitle";
 
@@ -31,12 +31,7 @@ export function SettingsPage({
             / GitHub / Notion / Postgres / etc. here.
           </div>
         ) : (
-          <IntegrationsCards
-            list={integrations}
-            showAll
-            onConnect={onConnect}
-            onRefresh={onRefresh}
-          />
+          <CredentialsTypeGrid list={integrations} onConnect={onConnect} onRefresh={onRefresh} />
         )}
       </section>
 

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -72,6 +72,11 @@ export type Integration = {
   // are the raw HCL token text (quoted strings included). Never
   // includes secret material.
   config?: Record<string, string>;
+  // Unix seconds of the most recent connect/update on this
+  // credential (max across the OAuth and per-slot secret stores).
+  // Zero/undefined for declared-only credentials that have never
+  // been touched.
+  updated_at?: number;
 };
 
 // tailscaleConnect asks the gateway for the live tsnet login URL.

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -63,6 +63,15 @@ export type Integration = {
   avatar_url?: string;
   has_tailscale_auth?: boolean;
   tailscale_auth?: TailscaleAuthStatusUI | null;
+  // Profiles routing requests through any endpoint that binds this
+  // credential (directly or via a tunnel). Sorted by name.
+  profiles?: string[];
+  // Endpoints that bind this credential. Sorted by name.
+  endpoints?: string[];
+  // Operator-set HCL block attributes (`user`, `region`, …). Values
+  // are the raw HCL token text (quoted strings included). Never
+  // includes secret material.
+  config?: Record<string, string>;
 };
 
 // tailscaleConnect asks the gateway for the live tsnet login URL.

--- a/www/src/lib/credentialLabels.ts
+++ b/www/src/lib/credentialLabels.ts
@@ -21,3 +21,48 @@ export const CREDENTIAL_TYPE_LABEL: Record<string, string> = {
 export function credentialTypeLabel(type: string, fallback: string): string {
   return CREDENTIAL_TYPE_LABEL[type] ?? fallback;
 }
+
+// CredentialCategory groups credential types for the settings page
+// card grid. Lower rank = surfaced first. The ranks match the order
+// LLMs > messaging > databases > 3rd-party > generic-token > other,
+// which is the order operators actually wire integrations up in.
+export type CredentialCategory =
+  | "llm"
+  | "messaging"
+  | "database"
+  | "third_party"
+  | "generic"
+  | "other";
+
+export const CREDENTIAL_CATEGORY_RANK: Record<CredentialCategory, number> = {
+  llm: 0,
+  messaging: 1,
+  database: 2,
+  third_party: 3,
+  generic: 4,
+  other: 5,
+};
+
+const CREDENTIAL_TYPE_CATEGORY: Record<string, CredentialCategory> = {
+  anthropic_oauth_subscription: "llm",
+  anthropic_manual_key: "llm",
+  openai_codex_oauth: "llm",
+  gemini_api_key: "llm",
+  slack_tokens: "messaging",
+  telegram_bot_token: "messaging",
+  postgres_credential: "database",
+  clickhouse_credential: "database",
+  github_oauth: "third_party",
+  notion_oauth: "third_party",
+  notion_mcp_oauth: "third_party",
+  aws_credential: "third_party",
+  tailscale: "third_party",
+  mtls_credential: "generic",
+  bearer_token: "generic",
+  header_token: "generic",
+  cookie_token: "generic",
+};
+
+export function credentialCategory(type: string): CredentialCategory {
+  return CREDENTIAL_TYPE_CATEGORY[type] ?? "other";
+}


### PR DESCRIPTION
## Summary

Replaces the per-credential card grid on the Settings page with a
per-type card grid that expands a full-width details table directly
below the row of the active card.

- **Type cards.** One card per credential plugin type (logo, display
  name, `<connected>/<total>` count, pending badge). Sorted by
  pending-connection count descending so types needing operator
  attention surface first.
- **Expanding details table.** Clicking a card opens a table
  immediately below that card's row. Columns: name, status,
  profile(s), endpoint(s), then one column per operator-set HCL
  block field, then an action column (Connect / Update /
  Disconnect). At most one table open at a time:
  - Click another card in the same row → swap content in place.
  - Click a card on a different row → fold and re-expand below the
    new row.
  - Click the open card again → fold.
- **Modals reused verbatim.** Connect / disconnect / secret-update
  flows are the same components already in use; this PR doesn't
  redesign them.

The device page continues to use the existing `IntegrationsCards`
per-device row — that view is a list of *individual* credentials
filtered to the device's profile, not a per-type aggregate.

**Supersedes** the `cl-irg` group-by-type vertical layout. The
contextual subtitle from `cl-003` migrates onto the table row.

## Backend additions

`IntegrationRow` (returned by `/api/state` and `/api/status`) gains:

- `profiles []string` — profiles routing any endpoint that binds
  this credential, directly or via a tunnel.
- `endpoints []string` — endpoints binding this credential
  directly or via a tunnel.
- `config map[string]string` — operator-set HCL block attributes
  (e.g. `user`, `region`). Harvested by replaying the plugin's
  `Emit` hook into a throwaway `hclwrite.Body` and reading the
  attribute tokens back out. Secret bytes live in the secrets
  store, never in the HCL block, so the harvested attrs are safe
  to render as-is.

New helpers in `agents.go`: `credentialBindings` and
`credentialConfig` cover both, with unit tests in
`credential_bindings_test.go`.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `cd www && npm run format:check && npm run lint && npm run build` clean
- [x] `go test ./...` green (new tests: `TestCredentialBindings`, `TestCredentialConfigOperatorFields`)
- [ ] Manual: settings page renders one card per type, sorted by pending desc
- [ ] Manual: clicking a card expands the details table below that card's row; click again folds; click a sibling in the same row swaps content; click a card on another row folds and re-expands
- [ ] Manual: Connect / Disconnect / Update actions still work end-to-end for OAuth, Tailscale, and secret-slot credentials