### PR TITLE
tsnet: ephemeral runs, Funnel allowlist, parent-IP attribution

### DIFF
--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -162,7 +162,7 @@ func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Req
 		return
 	}
 	profile := w.g.onboard.ProfileForIP(parentIP)
-	hostname := w.g.onboard.HostnameForIP(parentIP)
+	hostname := strings.TrimSpace(r.URL.Query().Get("hostname"))
 	// First-run promotion: synthetic parent → real tailnet IP. Repoint
 	// the api-token and clean up the placeholder row so the dashboard
 	// surfaces a single device keyed on the actual 100.x address.
@@ -170,6 +170,9 @@ func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Req
 		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
 		_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", parentIP)
 		w.g.onboard.ForgetIP(parentIP)
+		if w.g.agents != nil {
+			w.g.agents.Delete(parentIP)
+		}
 		if profile != "" {
 			w.g.onboard.AssignProfile(tsnetIP, profile)
 		}

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
-	"strings"
 	"sync"
 )
 
@@ -129,11 +128,12 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 }
 
 // apiRegisterEphemeralTsnetIP handles POST /api/peer/ephemeral/tsnet/register.
-// Called by `clawpatrol run` (tsnet mode) immediately after the tsnet node
-// joins and learns its 100.x.x.x address. With persistent tsnet state on the
-// client, the same machine gets the same tailnet IP across runs — we assign
-// the IP directly to the parent's profile and seed a real device row so the
-// dashboard shows ONE entry per machine (not per ephemeral run).
+// Called by `clawpatrol run` (tsnet mode) right after the ephemeral tsnet
+// node joins. Records the run's tailnet IP as an ephemeral peer of the
+// parent device so profile dispatch + dashboard attribution roll up to
+// the parent (same model as WG-mode ephemeralPeer). No devices row is
+// created per run — the parent's row was seeded at /api/onboard/approve
+// time using the synthetic `tsnet:<device_code>` ID.
 func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)
@@ -159,29 +159,9 @@ func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Req
 		return
 	}
 	profile := w.g.onboard.ProfileForIP(parentIP)
-	if profile != "" {
-		w.g.onboard.AssignProfile(tsnetIP, profile)
-	}
-	if hn := strings.TrimSpace(r.URL.Query().Get("hostname")); hn != "" {
-		// Re-registration after the client wiped its tsnet state lands
-		// on a different tailnet IP. Drop stale rows for this hostname
-		// so the dashboard stays at one device per machine.
-		_, _ = w.g.db.Exec("DELETE FROM devices WHERE name=? AND id<>?", hn, tsnetIP)
-		w.g.onboard.SetHostname(tsnetIP, hn)
-	}
-	// Drop the synthetic `tsnet:<device_code>` row created at approve
-	// time — the real row above replaces it. Repoint the parent's
-	// api-token at the new tailnet IP so future register calls find
-	// the profile directly via ProfileForIP(parentIP).
-	if strings.HasPrefix(parentIP, "tsnet:") {
-		_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", parentIP)
-		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
-	}
-	if w.g.agents != nil {
-		w.g.agents.Seed(tsnetIP)
-	}
-	// Same v4→v6 alias seeding as claim — per-process tsnet runs also
-	// originate on the IPv6 ULA half of the time.
+	w.g.onboard.setEphemeralProfile(tsnetIP, parentIP, profile)
+	// Map the ephemeral run's IPv6 ULA too — whole-machine + per-process
+	// tsnet traffic both arrive on fd7a:115c:a1e0::/48.
 	w.g.seedTsnetIPv6Alias(tsnetIP)
 	rw.WriteHeader(http.StatusNoContent)
 }

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -180,6 +180,9 @@ func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Req
 	if w.g.agents != nil {
 		w.g.agents.Seed(tsnetIP)
 	}
+	// Same v4→v6 alias seeding as claim — per-process tsnet runs also
+	// originate on the IPv6 ULA half of the time.
+	w.g.seedTsnetIPv6Alias(tsnetIP)
 	rw.WriteHeader(http.StatusNoContent)
 }
 

--- a/ephemeral_peer.go
+++ b/ephemeral_peer.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"strings"
 	"sync"
 )
 
@@ -128,12 +129,14 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 }
 
 // apiRegisterEphemeralTsnetIP handles POST /api/peer/ephemeral/tsnet/register.
-// Called by `clawpatrol run` (tsnet mode) right after the ephemeral tsnet
-// node joins. Records the run's tailnet IP as an ephemeral peer of the
-// parent device so profile dispatch + dashboard attribution roll up to
-// the parent (same model as WG-mode ephemeralPeer). No devices row is
-// created per run — the parent's row was seeded at /api/onboard/approve
-// time using the synthetic `tsnet:<device_code>` ID.
+// Called by `clawpatrol run` right after the ephemeral tsnet node joins.
+//
+// First run from a machine promotes its tailnet IP to the device's
+// stable parent: the synthetic `tsnet-<hostname>` placeholder created
+// at approve time is replaced by a real devices row keyed on the
+// 100.x IP. Subsequent concurrent runs attribute their (different)
+// ephemeral IPs to the same parent via ephemeralParentByIP — exactly
+// the WG-mode ephemeralPeer model.
 func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)
@@ -159,9 +162,29 @@ func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Req
 		return
 	}
 	profile := w.g.onboard.ProfileForIP(parentIP)
-	w.g.onboard.setEphemeralProfile(tsnetIP, parentIP, profile)
-	// Map the ephemeral run's IPv6 ULA too — whole-machine + per-process
-	// tsnet traffic both arrive on fd7a:115c:a1e0::/48.
+	hostname := w.g.onboard.HostnameForIP(parentIP)
+	// First-run promotion: synthetic parent → real tailnet IP. Repoint
+	// the api-token and clean up the placeholder row so the dashboard
+	// surfaces a single device keyed on the actual 100.x address.
+	if strings.HasPrefix(parentIP, "tsnet-") {
+		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
+		_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", parentIP)
+		w.g.onboard.ForgetIP(parentIP)
+		if profile != "" {
+			w.g.onboard.AssignProfile(tsnetIP, profile)
+		}
+		if hostname != "" {
+			w.g.onboard.SetHostname(tsnetIP, hostname)
+		}
+		if w.g.agents != nil {
+			w.g.agents.Seed(tsnetIP)
+		}
+	} else {
+		// Subsequent concurrent run — attribute to the existing parent.
+		w.g.onboard.setEphemeralProfile(tsnetIP, parentIP, profile)
+	}
+	// Map the ephemeral run's IPv6 ULA too — tsnet traffic frequently
+	// arrives on fd7a:115c:a1e0::/48 rather than the 100.x.
 	w.g.seedTsnetIPv6Alias(tsnetIP)
 	rw.WriteHeader(http.StatusNoContent)
 }

--- a/main.go
+++ b/main.go
@@ -1669,6 +1669,30 @@ func (g *Gateway) serveTSNetDirect(c net.Conn, mux http.Handler) {
 	_ = http.Serve(&oneShotListener{c: tc}, mux)
 }
 
+// serveTsnetDNSUDP pumps UDP/53 datagrams from the tsnet listener
+// through dnsvip.HandlePacket. Used for whole-machine exit-node
+// clients so the gateway allocates VIPs for intercepted hostnames
+// before the client's TCP follow-up arrives.
+func serveTsnetDNSUDP(pc net.PacketConn, vip *dnsvip.Allocator) {
+	defer func() { _ = pc.Close() }()
+	buf := make([]byte, 4<<10)
+	for {
+		n, src, err := pc.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		dstIP := ""
+		if la, ok := pc.LocalAddr().(*net.UDPAddr); ok && la.IP != nil {
+			dstIP = la.IP.String()
+		}
+		resp := vip.HandlePacket(buf[:n], dstIP)
+		if resp == nil {
+			continue
+		}
+		_, _ = pc.WriteTo(resp, src)
+	}
+}
+
 func pipeProgress(a, b net.Conn, onTick func(rx, tx int64)) (rx, tx int64) {
 	var rxC, txC atomic.Int64
 	done := make(chan struct{}, 2)
@@ -2879,6 +2903,20 @@ func runGateway(args []string) {
 		}
 		if cfg.Funnel {
 			startFunnelListener(tsnetServer, tsnetDashMux)
+		}
+		// UDP/53 DNS server on the tsnet node. Whole-machine clients with
+		// the gateway as exit-node send DNS via UDP/53 to the gateway's
+		// tailnet IP; dnsvip allocates a VIP per intercepted hostname so
+		// the subsequent TCP connection has a VIP the gateway recognises
+		// and dispatches. WG mode's promiscuous forwarder caught this
+		// already; tsnet exit-node needs an explicit listener.
+		if g.dnsvip != nil {
+			if pc, err := tsnetServer.ListenPacket("udp", ":53"); err != nil {
+				log.Printf("tsnet: udp :53 (dns): %v", err)
+			} else {
+				go serveTsnetDNSUDP(pc, g.dnsvip)
+				log.Printf("tsnet: dnsvip UDP listener on tsnet :53")
+			}
 		}
 		// Intercept all TCP forwarded through this exit node (whole-machine
 		// clients). dst is the original internet destination — same dispatch

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/denoland/clawpatrol/config/runtime"
 	"github.com/denoland/clawpatrol/dnsvip"
 	"github.com/google/uuid"
+	"tailscale.com/client/local"
 )
 
 // JoinConfig aliases config.JoinConfig so call sites (newWebMux /
@@ -358,6 +359,11 @@ type Gateway struct {
 	// resolves a conflict. Included in onboard join responses as
 	// gateway_host so clawpatrol-run peer lookups succeed.
 	tailscaleHostname string
+	// tsnetLC is the embedded tsnet's LocalClient. Used to resolve a
+	// peer's full address set (e.g. IPv4 → IPv6 ULA) when seeding
+	// profile mappings — tsnet whole-machine traffic arrives on the
+	// IPv6 ULA, so the IPv4 entry alone isn't enough.
+	tsnetLC *local.Client
 }
 
 // transportFor returns the cached http.Transport for ep, building it
@@ -404,8 +410,54 @@ func (g *Gateway) profileFor(peerIP string) string {
 		if p := g.onboard.ProfileForIP(peerIP); p != "" {
 			return p
 		}
+		// Lazy IPv6 → IPv4 resolution: whole-machine tsnet traffic
+		// often arrives on the peer's fd7a:115c:a1e0::/48 ULA. If the
+		// onboard table only has the IPv4 entry (peers registered
+		// before seedTsnetIPv6Alias existed), resolve via tsnet WhoIs
+		// once and stamp the alias.
+		if g.tsnetLC != nil && strings.HasPrefix(peerIP, "fd7a:") {
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+			if w, err := g.tsnetLC.WhoIs(ctx, peerIP+":0"); err == nil && w != nil && w.Node != nil {
+				for _, addr := range w.Node.Addresses {
+					ip := addr.Addr()
+					if !ip.Is4() {
+						continue
+					}
+					if p := g.onboard.ProfileForIP(ip.String()); p != "" {
+						g.onboard.RegisterIPAlias(peerIP, ip.String())
+						return p
+					}
+				}
+			}
+		}
 	}
 	return defaultProfileName(g.cfg.Policy)
+}
+
+// seedTsnetIPv6Alias resolves peerIP (IPv4) to the peer's IPv6 ULA via
+// tsnet WhoIs and mirrors the same profile mapping onto the v6 in the
+// onboard registry. Whole-machine tsnet traffic frequently arrives on
+// the fd7a:115c:a1e0::/48 ULA rather than the 100.x IPv4 — without
+// the alias profileFor falls back to "default" and dispatch misses
+// every endpoint declared on the actual profile.
+func (g *Gateway) seedTsnetIPv6Alias(peerIP string) {
+	if g.tsnetLC == nil || g.onboard == nil || peerIP == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	w, err := g.tsnetLC.WhoIs(ctx, peerIP+":0")
+	if err != nil || w == nil || w.Node == nil {
+		return
+	}
+	for _, addr := range w.Node.Addresses {
+		ip := addr.Addr()
+		if !ip.Is6() {
+			continue
+		}
+		g.onboard.RegisterIPAlias(ip.String(), peerIP)
+	}
 }
 
 // agentIPFor returns the IP to use for traffic attribution. Ephemeral
@@ -2887,6 +2939,7 @@ func runGateway(args []string) {
 		// work on machines without a system tailscaled daemon.
 		if lc, err := tsnetServer.LocalClient(); err == nil {
 			g.agents.SetLocalClient(lc)
+			g.tsnetLC = lc
 		} else {
 			log.Printf("tsnet: LocalClient for whois: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -2910,13 +2910,26 @@ func runGateway(args []string) {
 		// the subsequent TCP connection has a VIP the gateway recognises
 		// and dispatches. WG mode's promiscuous forwarder caught this
 		// already; tsnet exit-node needs an explicit listener.
+		//
+		// ListenPacket requires a concrete IP (not the wildcard). Wait
+		// for the tailnet IP to be assigned, then bind there.
 		if g.dnsvip != nil {
-			if pc, err := tsnetServer.ListenPacket("udp", ":53"); err != nil {
-				log.Printf("tsnet: udp :53 (dns): %v", err)
-			} else {
-				go serveTsnetDNSUDP(pc, g.dnsvip)
-				log.Printf("tsnet: dnsvip UDP listener on tsnet :53")
-			}
+			go func() {
+				for i := 0; i < 60 && g.tailscaleIP == ""; i++ {
+					time.Sleep(500 * time.Millisecond)
+				}
+				if g.tailscaleIP == "" {
+					log.Printf("tsnet: dnsvip UDP listener skipped — no tailscale IP")
+					return
+				}
+				pc, err := tsnetServer.ListenPacket("udp", g.tailscaleIP+":53")
+				if err != nil {
+					log.Printf("tsnet: udp %s:53 (dns): %v", g.tailscaleIP, err)
+					return
+				}
+				log.Printf("tsnet: dnsvip UDP listener on %s:53", g.tailscaleIP)
+				serveTsnetDNSUDP(pc, g.dnsvip)
+			}()
 		}
 		// Intercept all TCP forwarded through this exit node (whole-machine
 		// clients). dst is the original internet destination — same dispatch

--- a/main.go
+++ b/main.go
@@ -418,7 +418,7 @@ func (g *Gateway) profileFor(peerIP string) string {
 		if g.tsnetLC != nil && strings.HasPrefix(peerIP, "fd7a:") {
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
-			if w, err := g.tsnetLC.WhoIs(ctx, peerIP+":0"); err == nil && w != nil && w.Node != nil {
+			if w, err := g.tsnetLC.WhoIs(ctx, net.JoinHostPort(peerIP, "0")); err == nil && w != nil && w.Node != nil {
 				for _, addr := range w.Node.Addresses {
 					ip := addr.Addr()
 					if !ip.Is4() {
@@ -447,7 +447,7 @@ func (g *Gateway) seedTsnetIPv6Alias(peerIP string) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	w, err := g.tsnetLC.WhoIs(ctx, peerIP+":0")
+	w, err := g.tsnetLC.WhoIs(ctx, net.JoinHostPort(peerIP, "0"))
 	if err != nil || w == nil || w.Node == nil {
 		return
 	}

--- a/onboard.go
+++ b/onboard.go
@@ -160,6 +160,16 @@ func (r *onboardRegistry) AssignProfile(ip, profile string) {
 	r.upsertLocked(ip)
 }
 
+// assignProfileMemOnly records the profile mapping in memory without
+// upserting a devices row. Used for synthetic placeholder IDs (e.g.
+// `tsnet-<hostname>` between approve and the first `clawpatrol run`
+// register call) where we don't want a ghost dashboard row.
+func (r *onboardRegistry) assignProfileMemOnly(ip, profile string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.profileByIP[ip] = profile
+}
+
 // setEphemeralProfile pins an ephemeral peer to a profile and records
 // its parent device IP. ephemeralProfileByIP is never read by upsertLocked
 // so no devices row is created. ephemeralParentByIP is used by AgentIPFor
@@ -709,26 +719,18 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 				log.Printf("api-token mint for %s: %v", peerIP, perr)
 			}
 		} else if loginServer == "" && !s.wholeMachine {
-			// Per-process tsnet mode: each `clawpatrol run` is its own
-			// ephemeral tailnet node — no persistent IP to key the
-			// parent row on. Use a stable hostname-based identifier so
-			// re-joins from the same machine reuse the same parent row,
-			// and ephemeral runs attribute through ephemeralParentByIP.
-			// (Whole-machine tailscale lands here too but skips this
-			// branch — its real tailnet IP is registered via /claim.)
+			// Per-process tsnet mode: no devices row yet — the first
+			// `clawpatrol run` register call promotes its ephemeral
+			// tailnet IP to the device's parent row. Hold the profile
+			// in memory only against a synthetic placeholder and bind
+			// the api-token to it; both get repointed at register time.
 			s2 := w.onboard.byDeviceCode(dc)
 			parentID := "tsnet-" + dc
 			if s2 != nil && s2.hostname != "" {
 				parentID = "tsnet-" + s2.hostname
 			}
 			if profile != "" {
-				w.onboard.AssignProfile(parentID, profile)
-			}
-			if s2 != nil && s2.hostname != "" {
-				w.onboard.SetHostname(parentID, s2.hostname)
-			}
-			if w.g.agents != nil {
-				w.g.agents.Seed(parentID)
+				w.onboard.assignProfileMemOnly(parentID, profile)
 			}
 			if token, perr := mintAndPersistPeerAPIToken(w.g.db, parentID); perr == nil {
 				w.onboard.mu.Lock()

--- a/onboard.go
+++ b/onboard.go
@@ -717,9 +717,9 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			// (Whole-machine tailscale lands here too but skips this
 			// branch — its real tailnet IP is registered via /claim.)
 			s2 := w.onboard.byDeviceCode(dc)
-			parentID := "tsnet:" + dc
+			parentID := "tsnet-" + dc
 			if s2 != nil && s2.hostname != "" {
-				parentID = "tsnet:" + s2.hostname
+				parentID = "tsnet-" + s2.hostname
 			}
 			if profile != "" {
 				w.onboard.AssignProfile(parentID, profile)

--- a/onboard.go
+++ b/onboard.go
@@ -54,6 +54,11 @@ type onboardSession struct {
 	profile     string // profile assigned at approval time
 	hostname    string // client-supplied (os.Hostname) at /api/onboard/start
 	apiToken    string // per-peer bearer for gated client API calls (env-pushdown)
+	// wholeMachine: client asked at /start to install a persistent tailnet
+	// node (system tailscale on linux, NE-routed on macOS) rather than
+	// per-process tsnet. Determines whether the minted auth key is
+	// ephemeral (per-process) or not (whole-machine).
+	wholeMachine bool
 }
 
 // onboardRegistry persists onboarded peers in the `devices` table,
@@ -425,7 +430,7 @@ type Onboarder interface {
 	// non-empty, is the IP the server allocated for this peer — the
 	// caller registers it in the onboard registry so per-user OAuth
 	// lookup works without a separate claim round-trip from the CLI.
-	MintKey(ctx context.Context, reuseIP string) (authKey, loginServer, peerIP string, err error)
+	MintKey(ctx context.Context, reuseIP string, wholeMachine bool) (authKey, loginServer, peerIP string, err error)
 }
 
 func newOnboarder(ts JoinConfig) Onboarder {
@@ -439,21 +444,21 @@ func newOnboarder(ts JoinConfig) Onboarder {
 
 type tailscaleOnboarder struct{ ts JoinConfig }
 
-func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string) (string, string, string, error) {
-	// Reusable, non-ephemeral, long-lived key. Persistent so the device
-	// keeps the same tailnet IP across `clawpatrol run` invocations
-	// (gateway sees ONE device per machine, like WG mode). Reusable so
-	// the key still works if the client's tsnet state is wiped and the
-	// machine has to re-register.
-	k, err := mintTailscaleAuthKey(ctx, t.ts)
+func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string, wholeMachine bool) (string, string, string, error) {
+	// Per-process tsnet (default): ephemeral=true so each `clawpatrol run`
+	// gets a fresh node that auto-cleans on exit (matches macOS NE +
+	// WG-mode ephemeralPeer). Whole-machine: ephemeral=false so the
+	// system tailscale node persists across reboots.
+	k, err := mintTailscaleAuthKey(ctx, t.ts, !wholeMachine)
 	return k, "", "", err
 }
 
 // mintTailscaleAuthKey calls Tailscale's OAuth + auth-key API to mint
-// a reusable, non-ephemeral, long-lived auth key. Reusable so the same
-// key can rebuild client state after a wipe; non-ephemeral so each
-// device keeps a stable tailnet identity across reconnects.
-func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig) (string, error) {
+// a reusable auth key. ephemeral=true makes each registered node
+// auto-disappear on disconnect (used by per-process tsnet runs);
+// ephemeral=false keeps the node registered across reconnects (used
+// by whole-machine joins).
+func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig, ephemeral bool) (string, error) {
 	clientID := resolveTemplate(ts.OAuthClientID)
 	clientSecret := resolveTemplate(ts.OAuthClientSecret)
 	if clientID == "" || clientSecret == "" {
@@ -497,7 +502,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig) (string, error) {
 			"devices": map[string]any{
 				"create": map[string]any{
 					"reusable":      true,
-					"ephemeral":     false,
+					"ephemeral":     ephemeral,
 					"preauthorized": true,
 					"tags":          tags,
 				},
@@ -544,7 +549,11 @@ func (w *webMux) apiOnboardStart(rw http.ResponseWriter, r *http.Request) {
 	// doesn't have to pick it manually. Stored as the session-level
 	// suggestion; the dashboard's approve call can still override.
 	prof := strings.TrimSpace(r.URL.Query().Get("profile"))
-	if hn != "" || prof != "" {
+	// `clawpatrol join --whole-machine` → persistent tailnet node
+	// (auth key minted with ephemeral=false). Default = per-process
+	// tsnet (ephemeral=true), matching macOS NE behavior.
+	wm := r.URL.Query().Get("whole_machine") == "1"
+	if hn != "" || prof != "" || wm {
 		w.onboard.mu.Lock()
 		if hn != "" {
 			s.hostname = hn
@@ -552,6 +561,7 @@ func (w *webMux) apiOnboardStart(rw http.ResponseWriter, r *http.Request) {
 		if prof != "" {
 			s.profile = prof
 		}
+		s.wholeMachine = wm
 		w.onboard.mu.Unlock()
 	}
 	// Build the verify URL that points at the dashboard approval page.
@@ -661,7 +671,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		key, loginServer, peerIP, err := newOnboarder(w.ts).MintKey(ctx, reuseIP)
+		key, loginServer, peerIP, err := newOnboarder(w.ts).MintKey(ctx, reuseIP, s.wholeMachine)
 		w.onboard.mu.Lock()
 		if err != nil {
 			s.err = err.Error()
@@ -698,23 +708,34 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			} else {
 				log.Printf("api-token mint for %s: %v", peerIP, perr)
 			}
-		} else if loginServer == "" {
-			// Tailscale tsnet mode: parent device's tailnet IP isn't
-			// known at approve time. Mint api-token against a synthetic
-			// device identity derived from device_code and persist the
-			// profile mapping. The real device row is seeded at
-			// `clawpatrol run` register time using the actual tailnet
-			// IP + hostname, and the synthetic row is dropped there.
-			deviceID := "tsnet:" + dc
-			if profile != "" {
-				w.onboard.AssignProfile(deviceID, profile)
+		} else if loginServer == "" && !s.wholeMachine {
+			// Per-process tsnet mode: each `clawpatrol run` is its own
+			// ephemeral tailnet node — no persistent IP to key the
+			// parent row on. Use a stable hostname-based identifier so
+			// re-joins from the same machine reuse the same parent row,
+			// and ephemeral runs attribute through ephemeralParentByIP.
+			// (Whole-machine tailscale lands here too but skips this
+			// branch — its real tailnet IP is registered via /claim.)
+			s2 := w.onboard.byDeviceCode(dc)
+			parentID := "tsnet:" + dc
+			if s2 != nil && s2.hostname != "" {
+				parentID = "tsnet:" + s2.hostname
 			}
-			if token, perr := mintAndPersistPeerAPIToken(w.g.db, deviceID); perr == nil {
+			if profile != "" {
+				w.onboard.AssignProfile(parentID, profile)
+			}
+			if s2 != nil && s2.hostname != "" {
+				w.onboard.SetHostname(parentID, s2.hostname)
+			}
+			if w.g.agents != nil {
+				w.g.agents.Seed(parentID)
+			}
+			if token, perr := mintAndPersistPeerAPIToken(w.g.db, parentID); perr == nil {
 				w.onboard.mu.Lock()
 				s.apiToken = token
 				w.onboard.mu.Unlock()
 			} else {
-				log.Printf("api-token mint for %s: %v", deviceID, perr)
+				log.Printf("api-token mint for %s: %v", parentID, perr)
 			}
 		}
 	}()
@@ -760,13 +781,6 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 	// 100.x IPv4 that claim() registered.
 	w.g.seedTsnetIPv6Alias(host)
 	resp := map[string]string{"owner": owner, "ip": host}
-	// Drop the synthetic `tsnet:<device_code>` row + its api-token created
-	// at approve time. Whole-machine joins land here with the real tailnet
-	// IP and never call /api/peer/ephemeral/tsnet/register (which is what
-	// per-process tsnet runs use to clean up the synthetic).
-	syntheticID := "tsnet:" + dc
-	_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", syntheticID)
-	_, _ = w.g.db.Exec("DELETE FROM peer_api_tokens WHERE peer_ip=?", syntheticID)
 	// Mint the per-peer bearer the client uses for gated API calls
 	// (env-pushdown, ephemeral tsnet key). In Tailscale mode the peer IP
 	// isn't known at approve time, so we mint it here instead.

--- a/onboard.go
+++ b/onboard.go
@@ -755,6 +755,10 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Printf("onboard claim: %s → %s (hostname=%q)", host, owner, hostname)
+	// Mirror profile mapping onto the peer's IPv6 ULA — whole-machine
+	// tsnet traffic frequently arrives on fd7a:115c:a1e0::/48 not the
+	// 100.x IPv4 that claim() registered.
+	w.g.seedTsnetIPv6Alias(host)
 	resp := map[string]string{"owner": owner, "ip": host}
 	// Drop the synthetic `tsnet:<device_code>` row + its api-token created
 	// at approve time. Whole-machine joins land here with the real tailnet

--- a/onboard.go
+++ b/onboard.go
@@ -756,6 +756,13 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 	}
 	log.Printf("onboard claim: %s → %s (hostname=%q)", host, owner, hostname)
 	resp := map[string]string{"owner": owner, "ip": host}
+	// Drop the synthetic `tsnet:<device_code>` row + its api-token created
+	// at approve time. Whole-machine joins land here with the real tailnet
+	// IP and never call /api/peer/ephemeral/tsnet/register (which is what
+	// per-process tsnet runs use to clean up the synthetic).
+	syntheticID := "tsnet:" + dc
+	_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", syntheticID)
+	_, _ = w.g.db.Exec("DELETE FROM peer_api_tokens WHERE peer_ip=?", syntheticID)
 	// Mint the per-peer bearer the client uses for gated API calls
 	// (env-pushdown, ephemeral tsnet key). In Tailscale mode the peer IP
 	// isn't known at approve time, so we mint it here instead.

--- a/onboard.go
+++ b/onboard.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -816,6 +817,16 @@ func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 		resp["control_url"] = w.ts.ControlURL
 		if w.g != nil && w.g.tailscaleIP != "" {
 			resp["gateway_ip"] = w.g.tailscaleIP
+		}
+		// Tailscale Funnel owns :443 on the tsnet node, so cfg.Listen
+		// for the agent listener is usually :8443. Communicate it so
+		// `clawpatrol run` dials the right port.
+		if w.g != nil {
+			_, port, _ := net.SplitHostPort(w.g.cfg.Listen)
+			if port == "" {
+				port = "443"
+			}
+			resp["gateway_port"] = port
 		}
 		// CA cert delivered over the approved Funnel/onboard channel —
 		// the gateway's /ca.crt is intentionally not exposed publicly

--- a/run_tsnet_darwin.go
+++ b/run_tsnet_darwin.go
@@ -56,8 +56,12 @@ func runRunTsnet(args []string) {
 	if authKey == "" {
 		fail("tsnet run: missing tsnet-auth-key in %s (re-run `clawpatrol join`)", dir)
 	}
-	// Default gateway port — extension dials gwHost:gwPort over tsnet.
-	gwPort := "443"
+	// Gateway agent port persisted at join (Tailscale Funnel owns :443,
+	// so this is typically :8443).
+	gwPort := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway-port")))
+	if gwPort == "" {
+		gwPort = "443"
+	}
 
 	// Ensure system extension is loaded.
 	{

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -104,9 +104,12 @@ func runRunTsnet(args []string) {
 	if authKey == "" {
 		fail("tsnet run: missing tsnet-auth-key in %s (re-run `clawpatrol join`)", dir)
 	}
-	// Gateway port for direct-dial fallback (rarely used; tsnet exit-node
-	// routing is the normal path). Default 443.
-	gwPort := "443"
+	// Gateway agent port (where the MITM listener lives). Tsnet Funnel
+	// owns :443, so the listener is typically :8443. Persisted at join.
+	gwPort := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway-port")))
+	if gwPort == "" {
+		gwPort = "443"
+	}
 
 	// 2. Spin up tsnet.Server with PERSISTENT state — same node identity
 	// (same tailnet IP, same hostname) across `clawpatrol run` invocations

--- a/run_tsnet_linux.go
+++ b/run_tsnet_linux.go
@@ -3,33 +3,28 @@
 package main
 
 // `clawpatrol run` in Tailscale mode. Spins up an ephemeral tsnet.Server
-// per invocation and bridges the child's netns TUN to the gateway via
-// gVisor's TCP stack. No system-wide Tailscale required — tsnet runs
-// entirely in-process.
+// per invocation — fresh node identity each time, auto-removed on
+// disconnect by Tailscale (ephemeral=true). Mirrors macOS NE
+// (macos/netstack/wgnetstack.go) + WG-mode ephemeralPeer flow so
+// concurrent `clawpatrol run` invocations on one machine don't fight
+// over a shared state lock.
 //
-// Why PROXY headers:
-//
-// `clawpatrol run` clients are NOT exit-node clients. The child process runs
-// in its own network namespace with a gVisor TCP/IP stack as the default
-// route. Each TCP connection the child makes is intercepted by gVisor and
-// dialed out via tsnet directly to the gateway node over the tailnet — a
-// peer-to-peer connection. The connection arrives at the gateway's TCP
-// listener as a direct tailnet connection from the ephemeral node's 100.x.x.x.
-// The PROXY header carries the original 4-tuple so the gateway dispatches it
-// the same way as WireGuard and whole-machine exit-node paths.
-//
-// The PROXY header carries the original 4-tuple (srcIP, dstIP, srcPort,
-// dstPort) so the gateway accept loop recovers what the child process was
-// actually trying to reach (e.g., api.openai.com:443) and dispatches it
-// identically to the WireGuard and exit-node paths.
+// The auth key persisted at join is reusable + ephemeral=true, so each
+// run consumes the same key but spawns a distinct tailnet node.
 //
 // Flow:
-//  1. POST /api/peer/ephemeral/tsnet → ephemeral Tailscale auth key
-//  2. tsnet.Server{Ephemeral: true} joins the gateway's tailnet
-//  3. Child in new user+net+mnt ns creates TUN, sends fd via SCM_RIGHTS
-//  4. gVisor netstack reads from TUN, promiscuous TCP forwarder
-//  5. Each TCP connection → tsnet.Dial(gwHost:gwPort) + HAProxy PROXY v1 header
-//  6. Gateway recovers original dst from PROXY header, dispatches normally
+//  1. Read persisted reusable+ephemeral auth_key from ~/.clawpatrol/.
+//  2. tsnet.Server{Ephemeral: true, Dir: MkdirTemp(...)} joins the
+//     gateway's tailnet under a fresh hostname.
+//  3. Register the new tailnet IP with the gateway — register handler
+//     attributes traffic back to the parent device via
+//     ephemeralParentByIP so the dashboard shows ONE row per machine.
+//  4. Child in a new user+net+mnt ns creates the TUN, sends fd via
+//     SCM_RIGHTS.
+//  5. gVisor TCP forwarder dials gateway via tsnet + HAProxy PROXY v1
+//     header carrying original src/dst/ports.
+//  6. Gateway recovers original dst from the PROXY header and
+//     dispatches like WireGuard / exit-node paths.
 
 import (
 	"context"
@@ -111,24 +106,22 @@ func runRunTsnet(args []string) {
 		gwPort = "443"
 	}
 
-	// 2. Spin up tsnet.Server with PERSISTENT state — same node identity
-	// (same tailnet IP, same hostname) across `clawpatrol run` invocations
-	// so the gateway sees ONE device per machine, not a new ephemeral
-	// node per run. The reusable auth key is only consumed on first
-	// startup; subsequent runs load saved state and skip the login.
-	stateDir := filepath.Join(dir, "tsnet")
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+	// 2. Spin up an ephemeral tsnet.Server per invocation. tmpdir state
+	// + Ephemeral:true means each run is a fresh tailnet node, freed
+	// automatically when this process exits. Concurrent runs on the same
+	// host don't collide on tsnet's exclusive state lock.
+	stateDir, err := os.MkdirTemp("", "clawpatrol-tsnet-*")
+	if err != nil {
 		fail("tsnet state dir: %v", err)
 	}
-	hn, _ := os.Hostname()
-	if hn == "" {
-		hn = fmt.Sprintf("clawpatrol-%d", os.Getpid())
-	}
+	defer func() { _ = os.RemoveAll(stateDir) }()
+	hn := fmt.Sprintf("clawpatrol-run-%d", os.Getpid())
 	tsServer := &tsnet.Server{
 		Hostname:   hn,
 		AuthKey:    authKey,
 		ControlURL: controlURL,
 		Dir:        stateDir,
+		Ephemeral:  true,
 		Logf:       func(string, ...any) {},
 	}
 	defer func() { _ = tsServer.Close() }()

--- a/setup.go
+++ b/setup.go
@@ -953,7 +953,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	stopSpin := startSpinner("Waiting for approval")
 	authKey, loginServer, apiToken := "", "", ""
-	var tailnetGWHost, tailnetControlURL, gatewayIP, caPEM string
+	var tailnetGWHost, tailnetControlURL, gatewayIP, gatewayPort, caPEM string
 	for time.Now().Before(deadline) {
 		time.Sleep(interval)
 		pr, err := cli.Post(gateway+"/api/onboard/poll?device_code="+start.DeviceCode, "application/json", nil)
@@ -970,6 +970,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			tailnetGWHost = pv["gateway_host"]
 			tailnetControlURL = pv["control_url"]
 			gatewayIP = pv["gateway_ip"]
+			gatewayPort = pv["gateway_port"]
 			caPEM = pv["ca_pem"]
 			break
 		}
@@ -1119,6 +1120,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		// start a fresh ephemeral tsnet node without a Funnel-exposed
 		// peer-API call (which we intentionally block).
 		_ = os.WriteFile(filepath.Join(clawDir, "tsnet-auth-key"), []byte(authKey+"\n"), 0o600)
+		if gatewayPort != "" {
+			_ = os.WriteFile(filepath.Join(clawDir, "gateway-port"), []byte(gatewayPort+"\n"), 0o600)
+		}
 		items := []string{"Joined (tsnet mode — ephemeral node joins tailnet at run time)"}
 		items = append(items, setupSummaryItems(*setup)...)
 		printTreeItems(items)

--- a/setup.go
+++ b/setup.go
@@ -144,7 +144,15 @@ func runJoin(args []string) {
 	// Skipped for per-process tsnet mode and for macOS (where the NE
 	// extension owns routing — never system tailscale).
 	if *wholeMachine && runtime.GOOS == "linux" {
-		loginArgs := []string{"-name", *gwName, "-ca-dir", *caOut}
+		// Use the actual registered tsnet node name as the exit-node
+		// target, not the --name default. onboardViaDeviceFlow's
+		// whole-machine branch persists this at tailnet-gateway.
+		exitNode := *gwName
+		gwHostFile := strings.TrimSpace(readFileSilent(filepath.Join(*caOut, "tailnet-gateway")))
+		if gwHostFile != "" {
+			exitNode = gwHostFile
+		}
+		loginArgs := []string{"-name", exitNode, "-ca-dir", *caOut}
 		if *skipTrust {
 			loginArgs = append(loginArgs, "-no-trust")
 		}
@@ -587,7 +595,20 @@ func tailscaleStatus(bin string) (*tsStatus, error) {
 	return &s, nil
 }
 
+// findPeerByName looks up a peer by its tailnet-unique short name. Multiple
+// peers may share HostName (Tailscale uses the value the node reports at
+// registration — unchanged by name collisions), so prefer matching the
+// first label of DNSName which Tailscale disambiguates with "-1", "-2"…
 func findPeerByName(s *tsStatus, name string) *tsPeer {
+	for _, p := range s.Peer {
+		short := p.DNSName
+		if i := strings.IndexByte(short, '.'); i > 0 {
+			short = short[:i]
+		}
+		if short == name {
+			return p
+		}
+	}
 	for _, p := range s.Peer {
 		if p.HostName == name {
 			return p

--- a/setup.go
+++ b/setup.go
@@ -914,6 +914,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	if profile != "" {
 		q.Set("profile", profile)
 	}
+	if wholeMachine {
+		q.Set("whole_machine", "1")
+	}
 	startURL := gateway + "/api/onboard/start"
 	if encoded := q.Encode(); encoded != "" {
 		startURL += "?" + encoded

--- a/wireguard.go
+++ b/wireguard.go
@@ -819,7 +819,7 @@ func wgClientEndpoint(wgEndpoint, publicURL string) (string, error) {
 	return net.JoinHostPort(hostOverride, strconv.Itoa(port)), nil
 }
 
-func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string) (string, string, string, error) {
+func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string, _ bool) (string, string, string, error) {
 	if w.ts.WGSubnetCIDR == "" {
 		return "", "", "", fmt.Errorf("wireguard not configured (set wg_subnet_cidr)")
 	}


### PR DESCRIPTION
Follow-up to #444 with everything needed to make `clawpatrol run` + `clawpatrol join --whole-machine` actually work end-to-end against the deployed `clawpatrol-gateway` (GCP) and verified live on `sidewalk-sectional` + `dev2`.

## Funnel exposure

Strict allowlist for the public Funnel listener — only the bootstrap routes a client genuinely cannot reach via the tailnet:

- `/api/onboard/start`, `/api/onboard/poll`, `/api/onboard/claim`
- `/api/cred/*` (signed credential webhooks)

Everything else (dashboard, peer APIs, env-pushdown, `/ca.crt`, register) is tailnet-only and 404s on Funnel. CA delivered inside the LE-authenticated Funnel TLS via `/api/onboard/poll` after operator approval — `/ca.crt` is never public.

## Two-mode model

- **`--whole-machine`** (Linux only — macOS NE owns routing): system tailscale, `tailscale up` with non-ephemeral key, exit-node setup, peer claimed via `/api/onboard/claim`.
- **Per-process tsnet** (default; Linux + macOS): each `clawpatrol run` is a fresh ephemeral tailnet node. `MkdirTemp` + `Ephemeral: true` so concurrent runs on the same machine don't fight over the state lock (fixes #448). First run from a machine promotes its tailnet IP to a stable parent row; subsequent runs attribute as ephemeral peers (matches WG-mode `ephemeralPeer` model). Single dashboard row per machine, real 100.x IP, real hostname.

## Auth-key shape

`mintTailscaleAuthKey` now takes a `wholeMachine` arg via the new session-level `wholeMachine` flag plumbed through `/api/onboard/start?whole_machine=1`. Per-process joins mint `ephemeral=true, reusable=true` keys (each run = fresh node, Tailscale auto-removes on disconnect); whole-machine joins keep `ephemeral=false` so the system node persists.

## Networking

- `gateway_port` (from `cfg.Listen`) returned in `/api/onboard/poll`; client persists at `~/.clawpatrol/gateway-port` and uses it when dialing (`:8443` instead of hardcoded `:443`, since Tailscale Funnel owns `:443`).
- UDP `:53` listener on the gateway's tailnet IP — whole-machine exit-node clients allocate VIPs via dnsvip, matching WG-mode behavior. tsnet rejects wildcard bind so the listener waits for `tailscaleIP` then binds explicitly.
- Whole-machine traffic frequently arrives on the peer's `fd7a:115c:a1e0::/48` IPv6 ULA, not the 100.x. `profileFor` does lazy v6→v4 resolution via `tsnetLC.WhoIs` (with `net.JoinHostPort` for the IPv6-needs-brackets parse). `seedTsnetIPv6Alias` mirrors the mapping eagerly at claim + register.

## Misc fixes

- `findPeerByName` matches DNSName first-label (`HostName` can collide across nodes; only DNSName is disambiguated with `-1`/`-2`).
- `clawpatrol run` reads the reusable auth key persisted at join — no per-run mint call against the gateway (would need to be Funnel-exposed; intentionally isn't).
- macOS `clawpatrol run` mirrors Linux (reads persisted key, no `fetchEphemeralTsnetKey` call).
- Drop the dead `/api/peer/ephemeral/tsnet` mint endpoint and `fetchEphemeralTsnetKey` client helper.
- Drop `printDashboardURL` (queried system tailscaled; not present on a tsnet-only gateway).

## Test plan

Verified live against `clawpatrol-gateway` (GCP, `100.79.206.14`):

- [x] `sidewalk-sectional` per-process tsnet (alice profile): join → ephemeral run → single dashboard row `100.110.193.1 | sidewalk-sectional | alice` (no synthetic).
- [x] Concurrent runs from one machine — both join as fresh ephemeral nodes, both MITM'd, single row attributing both.
- [x] MITM working across endpoints in profile (anthropic, openai, chatgpt, github, telegram) — `issuer: CN=clawall gateway CA`. Non-policy hosts (example.com) pass through with real upstream cert.
- [x] `dev2` whole-machine join: exit-node = `clawpatrol-gateway`, DNS via gateway, VIP allocation, pg/clickhouse dispatch through the configured tunnels.
- [x] `go test ./...`, `go build`, `GOOS=darwin go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)