### PR TITLE
site: add favicon links

### DIFF
--- a/site/docs-render.ts
+++ b/site/docs-render.ts
@@ -138,6 +138,7 @@ function renderMetaTags(m: PageMeta): string {
   return `
   <meta name="description" content="${desc}" />
   <link rel="canonical" href="${m.url}" />
+  <link rel="icon" type="image/svg+xml" href="/claw-patrol-icon.svg" />
   <meta property="og:title" content="${title}" />
   <meta property="og:description" content="${desc}" />
   <meta property="og:url" content="${m.url}" />

--- a/site/index.html
+++ b/site/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Claw Patrol</title>
+    <link rel="icon" type="image/svg+xml" href="/claw-patrol-icon.svg" />
     <link
       rel="preload"
       as="font"

--- a/www/index.html
+++ b/www/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Claw Patrol</title>
+    <link rel="icon" type="image/svg+xml" href="/claw-patrol-icon.svg" />
   </head>
   <body class="font-mono bg-canvas text-text">
     <div id="root"></div>

--- a/www/login.html
+++ b/www/login.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Log in — Claw Patrol</title>
+    <link rel="icon" type="image/svg+xml" href="/claw-patrol-icon.svg" />
     <style>
       /* ── Minimal subset of the dashboard's design tokens ─────────
          Only the values used on this page; mirrors www/src/index.css.


### PR DESCRIPTION
## Summary
- Add SVG favicon links to the public landing page.
- Add the same favicon metadata to generated docs pages.
- Add favicon links to the embedded dashboard and login page.

## Test plan
- `cd www && npm ci`
- `cd www && npm run format:check`
- `cd www && npm run build`
- `cd site && npm ci && npm run build`
- `git diff --check`
- Confirmed built outputs include favicon links and copied `claw-patrol-icon.svg` assets.
