### PR TITLE
Fix tsnet macOS NE register

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -295,7 +295,16 @@ func (r *AgentRegistry) fillIdentity(ip string) {
 		return
 	}
 	if who.Node != nil {
-		a.Hostname = who.Node.Hostinfo.Hostname()
+		// Onboard-supplied hostname (via /api/onboard/claim or
+		// /api/peer/ephemeral/tsnet/register) takes priority. The whois
+		// response reflects whatever the tsnet node registered with
+		// (e.g. "clawpatrol-run-<pid>" for per-process ephemeral runs
+		// or the *first* run's node for a promoted parent IP) — letting
+		// it overwrite would clobber the real machine name with the
+		// transient one.
+		if a.Hostname == "" {
+			a.Hostname = who.Node.Hostinfo.Hostname()
+		}
 		a.OS = who.Node.Hostinfo.OS()
 	}
 	if who.UserProfile != nil {

--- a/macos/Clawpatrol/main.swift
+++ b/macos/Clawpatrol/main.swift
@@ -41,12 +41,16 @@ case "start":
     guard CommandLine.arguments.count >= 3 else { usage() }
     startProxy(confPath: CommandLine.arguments[2])
 case "start-tsnet":
-    // args: authKey controlURL gwHost gwPort
+    // args: authKey controlURL gwHost gwPort [token hostname]
     guard CommandLine.arguments.count >= 6 else { usage() }
+    let token = CommandLine.arguments.count >= 7 ? CommandLine.arguments[6] : ""
+    let hostname = CommandLine.arguments.count >= 8 ? CommandLine.arguments[7] : ""
     startTsnetProxy(authKey: CommandLine.arguments[2],
                     controlURL: CommandLine.arguments[3],
                     gwHost: CommandLine.arguments[4],
-                    gwPort: CommandLine.arguments[5])
+                    gwPort: CommandLine.arguments[5],
+                    token: token,
+                    hostname: hostname)
 case "stop": stopProxy()
 case "wipe": wipeAllConfigs()
 case "run": runWrapped()    // synchronous; calls exit() — never reaches runloop
@@ -286,7 +290,7 @@ func startProxy(confPath: String) {
     }
 }
 
-func startTsnetProxy(authKey: String, controlURL: String, gwHost: String, gwPort: String) {
+func startTsnetProxy(authKey: String, controlURL: String, gwHost: String, gwPort: String, token: String, hostname: String) {
     NETransparentProxyManager.loadAllFromPreferences { managers, err in
         if let err = err { fail("loadAll: \(err)") }
         let existing = managers?.first(where: { $0.localizedDescription == proxyProfileName })
@@ -300,6 +304,8 @@ func startTsnetProxy(authKey: String, controlURL: String, gwHost: String, gwPort
             "tsnet-control-url": controlURL,
             "tsnet-gateway-host": gwHost,
             "tsnet-gateway-port": gwPort,
+            "tsnet-api-token": token,
+            "tsnet-hostname": hostname,
         ]
         manager.protocolConfiguration = proto
         manager.localizedDescription = proxyProfileName

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -60,6 +60,8 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                     userInfo: [NSLocalizedDescriptionKey: "missing tsnet config fields"]))
                 return
             }
+            let token = (cfg["tsnet-api-token"] as? String) ?? ""
+            let hostname = (cfg["tsnet-hostname"] as? String) ?? ""
             os_log("startProxy: tsnet mode — joining tailnet", log: log, type: .info)
             DispatchQueue.global(qos: .userInitiated).async {
                 var errBuf = [CChar](repeating: 0, count: 512)
@@ -67,12 +69,18 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                     controlURL.withCString { cuC in
                         gwHost.withCString { ghC in
                             gwPort.withCString { gpC in
-                                errBuf.withUnsafeMutableBufferPointer { ebuf in
-                                    ts_netstack_init(UnsafeMutablePointer(mutating: akC),
-                                                     UnsafeMutablePointer(mutating: cuC),
-                                                     UnsafeMutablePointer(mutating: ghC),
-                                                     UnsafeMutablePointer(mutating: gpC),
-                                                     ebuf.baseAddress, Int32(ebuf.count))
+                                token.withCString { tkC in
+                                    hostname.withCString { hnC in
+                                        errBuf.withUnsafeMutableBufferPointer { ebuf in
+                                            ts_netstack_init(UnsafeMutablePointer(mutating: akC),
+                                                             UnsafeMutablePointer(mutating: cuC),
+                                                             UnsafeMutablePointer(mutating: ghC),
+                                                             UnsafeMutablePointer(mutating: gpC),
+                                                             UnsafeMutablePointer(mutating: tkC),
+                                                             UnsafeMutablePointer(mutating: hnC),
+                                                             ebuf.baseAddress, Int32(ebuf.count))
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -30,7 +30,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/netip"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -810,7 +812,7 @@ var (
 // success, -1 on failure.
 //
 //export ts_netstack_init
-func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, errBuf *C.char, errLen C.int) C.int {
+func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, tokenC, hostnameC, errBuf *C.char, errLen C.int) C.int {
 	tsMu.Lock()
 	defer tsMu.Unlock()
 	if tsStarted {
@@ -821,6 +823,8 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, errBuf *C.char, 
 	controlURL := C.GoString(controlURLС)
 	gwHost := C.GoString(gwHostC)
 	gwPort := C.GoString(gwPortC)
+	token := C.GoString(tokenC)
+	hostname := C.GoString(hostnameC)
 
 	stateDir, err := os.MkdirTemp("", "clawpatrol-tsnet-ne-*")
 	if err != nil {
@@ -862,7 +866,42 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, errBuf *C.char, 
 	tsGwAddr = net.JoinHostPort(gwHost, gwPort)
 	tsNodeIP = ip4
 	tsStarted = true
+
+	// Register this NE's tsnet IP with the gateway so profile dispatch
+	// + dashboard attribution roll up to the parent device. Done from
+	// inside the extension because the parent process is on the host
+	// network and can't dial gateway tailnet IPs directly; tsnet
+	// (running here) IS on the tailnet.
+	if token != "" && ip4 != "" {
+		go registerEphemeralOverTsnet(s, gwHost, token, ip4, hostname)
+	}
 	return 0
+}
+
+// registerEphemeralOverTsnet POSTs to the gateway's tailnet-only
+// /api/peer/ephemeral/tsnet/register endpoint using tsnet.Server.Dial
+// so the call reaches a 100.x tailnet IP that the parent process
+// (host network) cannot. Best-effort: on failure the run still works
+// but lands in the gateway's default profile.
+func registerEphemeralOverTsnet(s *tsnet.Server, gwHost, token, tsIP, hostname string) {
+	client := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: &http.Transport{DialContext: s.Dial},
+	}
+	u := "http://" + gwHost + ":8080/api/peer/ephemeral/tsnet/register?ip=" + tsIP
+	if hostname != "" {
+		u += "&hostname=" + url.QueryEscape(hostname)
+	}
+	req, err := http.NewRequest(http.MethodPost, u, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
 }
 
 // ts_netstack_get_ip writes the tsnet node's 100.x.x.x address into

--- a/main.go
+++ b/main.go
@@ -2884,11 +2884,21 @@ func runGateway(args []string) {
 	if tsnetServer != nil && cfg.Funnel && cfg.PublicURL == "" {
 		// Auto-derive public_url from the tsnet cert domain so that
 		// join responses, HITL status links, and OAuth redirect URIs use
-		// the correct internet-reachable URL when funnel = true.
-		if domain := tsnetCertDomain(tsnetServer); domain != "" {
-			cfg.PublicURL = domain
-			log.Printf("tsnet: funnel public_url auto-derived: %s", cfg.PublicURL)
-		}
+		// the correct internet-reachable URL when funnel = true. Cert
+		// provisioning can lag Funnel listener start by a few seconds,
+		// so retry async.
+		go func() {
+			deadline := time.Now().Add(60 * time.Second)
+			for time.Now().Before(deadline) {
+				if domain := tsnetCertDomain(tsnetServer); domain != "" {
+					cfg.PublicURL = domain
+					log.Printf("tsnet: funnel public_url auto-derived: %s", cfg.PublicURL)
+					return
+				}
+				time.Sleep(2 * time.Second)
+			}
+			log.Printf("tsnet: funnel public_url not derived after 60s — dashboard will show the loopback URL in join hints")
+		}()
 	}
 	tsnetDashMux := newWebMux(g, cfg.Join(), cfg.PublicURL)
 	tsnetDashPort := portOf(cfg.InfoListen)

--- a/onboard.go
+++ b/onboard.go
@@ -580,6 +580,9 @@ func (w *webMux) apiOnboardStart(rw http.ResponseWriter, r *http.Request) {
 	// don't have to go through the Funnel HTTPS relay. Use IP directly
 	// to avoid MagicDNS resolution issues with OS-hostname vs registered name.
 	verifyURL := w.publicURL
+	if w.g != nil && w.g.cfg != nil && w.g.cfg.PublicURL != "" {
+		verifyURL = w.g.cfg.PublicURL
+	}
 	if w.g != nil && w.g.tailscaleIP != "" && w.g.cfg.InfoListen != "" {
 		port := w.g.cfg.InfoListen
 		if i := strings.LastIndexByte(port, ':'); i >= 0 {

--- a/run_tsnet_darwin.go
+++ b/run_tsnet_darwin.go
@@ -46,7 +46,6 @@ func runRunTsnet(args []string) {
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "control-url")))
 	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
 	authKey := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tsnet-auth-key")))
-	caPath := filepath.Join(dir, "ca.crt")
 	if gwHost == "" {
 		gwHost = "clawpatrol-gateway"
 	}
@@ -71,10 +70,14 @@ func runRunTsnet(args []string) {
 	}
 
 	// Start NE in tsnet mode. ts_netstack_init inside the extension
-	// blocks until the tsnet node joins the tailnet (≤90s).
+	// blocks until the tsnet node joins the tailnet (≤90s). Pass
+	// token + hostname so the NE itself can POST to the gateway's
+	// tailnet-only register endpoint (parent process is on the host
+	// network and can't dial a 100.x address from here).
+	hn, _ := os.Hostname()
 	fmt.Fprintln(os.Stderr, "clawpatrol: joining tailnet via NE...")
 	{
-		c := exec.Command(macHelperPath, "start-tsnet", authKey, controlURL, gwHost, gwPort)
+		c := exec.Command(macHelperPath, "start-tsnet", authKey, controlURL, gwHost, gwPort, token, hn)
 		c.Stdout, c.Stderr = os.Stdout, os.Stderr
 		if err := c.Run(); err != nil {
 			var ee *exec.ExitError
@@ -85,16 +88,13 @@ func runRunTsnet(args []string) {
 		}
 	}
 
-	// Poll session socket for the NE's tsnet IP so we can register it
-	// with the gateway for profile dispatch + env-pushdown. Both calls
-	// hit tailnet-only endpoints, so they're done from the NE side
-	// (which is on the tailnet) — TODO: wire IPC to extension.
+	// Wait until the NE reports the tsnet IP so we know the
+	// extension finished initializing. The actual /register POST
+	// happens *inside* ts_netstack_init via tsServer.Dial — the
+	// parent process can't dial 100.x addresses on macOS.
 	tsIP := pollTsnetIPFromExtension(90 * time.Second)
-	if tsIP != "" {
-		client, _ := gatewayHTTPClient(caPath)
-		if rerr := registerEphemeralTsnetIP(client, gwURL, token, tsIP); rerr != nil {
-			fmt.Fprintf(os.Stderr, "warning: tsnet profile registration: %v (default profile)\n", rerr)
-		}
+	if tsIP == "" {
+		fmt.Fprintln(os.Stderr, "warning: NE never reported tsnet IP — run will land in the default profile")
 	}
 	applyEnvPushdown(dir)
 

--- a/web.go
+++ b/web.go
@@ -602,13 +602,12 @@ func (w *webMux) apiHITLOperationStatus(rw http.ResponseWriter, r *http.Request)
 }
 
 func (w *webMux) hitlPublicURL() string {
-	if w.publicURL != "" {
-		return w.publicURL
-	}
-	if w.g != nil && w.g.cfg != nil {
+	// Prefer the live config — public_url may be auto-derived from the
+	// tsnet Funnel cert AFTER webMux is constructed.
+	if w.g != nil && w.g.cfg != nil && w.g.cfg.PublicURL != "" {
 		return w.g.cfg.PublicURL
 	}
-	return ""
+	return w.publicURL
 }
 
 func hitlOperationIDFromStatusPath(path string) (string, bool) {


### PR DESCRIPTION
Follow-up to #446 — three fixes surfaced during further testing.

## Changes

1. **`public_url` auto-derive retries async.** Funnel cert provisioning lags the gateway start by a few seconds. Single-shot derive at startup silently gave up and the dashboard's "clawpatrol join <url>" hint pointed at the loopback URL. Retry for 60s and update `cfg.PublicURL` in place; `hitlPublicURL` + onboard `verifyURL` read live from `cfg.PublicURL` so the updated value flows through.

2. **`fillIdentity` preserves onboard hostname.** Per-process tsnet runs register their tsnet hostname as `clawpatrol-run-<pid>`. The first run's IP gets promoted to the device's parent row; subsequent calls to `fillIdentity` then ran `WhoIs` and unconditionally overwrote `a.Hostname` with the (transient) `clawpatrol-run-…` value. The dashboard fell back to the IP in the Device column. Skip the overwrite when the agent already has a hostname from onboard (claim / register).

3. **macOS NE registers from inside the extension.** Parent process on macOS dials through the host network, which can't reach gateway tailnet IPs (NE owns routing). It hit Funnel and 404'd on the peer-API register endpoint, leaving the run in the default profile. `ts_netstack_init` now takes the api-token + parent hostname and POSTs to `http://<gwHost>:8080/api/peer/ephemeral/tsnet/register` via `tsnet.Server.Dial` (the NE *is* on the tailnet). Swift glue follow-up in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)