### PR TITLE
docs: refresh for tsnet-as-default

### DIFF
--- a/site/doc/architecture.md
+++ b/site/doc/architecture.md
@@ -130,83 +130,56 @@ The gateway pulls in three plugin families:
 
 ## Connection modes
 
-There are three ways to connect a device to the gateway. Onboarding
-runs through `clawpatrol join <gateway>`: the dashboard mints
-a WireGuard keypair, allocates a `/32` from the configured subnet,
-registers the peer with the running wireguard-go device, and the
-device persists the resulting `wg-quick`-style config at
-`~/.config/clawpatrol/wg.conf`. Each connection mode is what
-happens after that.
+`clawpatrol join <gateway>` enrolls the device. What the gateway
+mints + what the client installs depends on the gateway's
+`control` mode.
 
-### `clawpatrol join --whole-machine` (Linux)
+### Tailscale mode (recommended)
 
-Routes every byte the host emits through the gateway. The CLI
-calls `wg-quick up` against `/etc/wireguard/clawpatrol.conf` (the
-config has `AllowedIPs = 0.0.0.0/0, ::/0`), which uses the kernel
-WireGuard module to add the route and replace the default gateway.
-Reference: `setup.go:wgQuickUp`, `wireguard.go`.
+The gateway embeds tsnet; it joins the tailnet in-process and
+exposes only `/api/onboard/{start,poll,claim}` + `/api/cred/*` on
+:443 via Funnel. Every other route is tailnet-only. At onboard the
+gateway mints a Tailscale auth key (`reusable=true, ephemeral=true`
+for per-process; `ephemeral=false` for `--whole-machine`) via OAuth
+and the CA + api-token are delivered inside the approved Funnel
+response.
 
-- **Tunnel mechanism.** Kernel WireGuard via `wg-quick`. The kernel
-  driver owns the tunnel lifetime; clawpatrol does not run a
-  userspace WG on the device.
-- **What's installed on the device.** `/etc/wireguard/clawpatrol.conf`
-  (root-owned, mode `0o600`); `wg-quick` activates the `clawpatrol`
-  network interface and adds default routes through it.
-- **Scope.** Whole host. Every process on the device, including the
-  operator's shell, browser, and unrelated daemons, dials through
-  the gateway.
+**`clawpatrol run -- <cmd>` (Linux + macOS).** Each invocation is
+its own ephemeral tailnet node. On Linux a new user + net + mnt
+namespace runs userspace wireguard-go inside `tsnet.Server` with
+`MkdirTemp` state (`Ephemeral: true`); on macOS the
+`NETransparentProxyProvider` extension hosts the tsnet stack and
+PPID-filters flows. Concurrent runs on one host don't share state.
+Reference: `run_tsnet_linux.go`, `run_tsnet_darwin.go`,
+`macos/netstack/wgnetstack.go`.
 
-### `clawpatrol run -- <cmd>` (Linux)
+**`clawpatrol join --whole-machine` (Linux).** Installs system
+Tailscale (`tailscale up --authkey=...`), sets the gateway as the
+exit node, and routes the whole host through. The auth key for
+this path is minted with `ephemeral=false` so the node persists.
+Reference: `setup.go:runLogin`.
 
-Routes one process tree through the gateway, leaves the rest of
-the device alone. The CLI re-execs itself in fresh user, network,
-and mount namespaces with `CAP_NET_ADMIN` in the ambient set,
-opens a TUN inside the new netns, runs userspace wireguard-go
-against it, configures `default dev wg0`, drops the ambient cap,
-and execs the wrapped command. Reference: `run_linux.go:runRun` /
-`runRunChild`.
+**`clawpatrol join --whole-machine` (macOS).** The NE owns whole-
+host routing — no system Tailscale touched. macOS never runs
+system tailscaled.
 
-- **Tunnel mechanism.** Userspace wireguard-go embedded in the
-  `clawpatrol` binary; the TUN lives only inside the unshared
-  netns.
-- **What's installed on the device.** Nothing persistent — no
-  kernel module, no `/etc/wireguard/`, no system service. Just the
-  `clawpatrol` binary and `~/.config/clawpatrol/wg.conf` from
-  onboarding.
-- **Scope.** The wrapped process and all its descendants. The host
-  default route is untouched. Other shells and processes on the
-  device keep their original network.
+### WireGuard mode (legacy)
 
-### `clawpatrol run -- <cmd>` (macOS)
+The gateway runs an in-process WireGuard server (wireguard-go +
+gVisor netstack). At onboard it mints a keypair, allocates a `/32`
+from `wg_subnet_cidr`, and persists the wg-quick config at
+`~/.config/clawpatrol/wg.conf`.
 
-Routes the wrapped process tree through the gateway via a Network
-Extension. The CLI hands the command off to
-`/Applications/Clawpatrol.app/Contents/MacOS/Clawpatrol`, which
-forks the agent as a child of the `.app` and ensures the
-`NETransparentProxyProvider` system extension is loaded.
-Reference: `run_darwin.go`,
+**`clawpatrol run -- <cmd>` (Linux).** Per-process ephemeral WG
+peer in a fresh netns. Reference: `run_linux.go`.
+
+**`clawpatrol join --whole-machine` (Linux).** Kernel WireGuard via
+`wg-quick up`. Default route flips to the WG tunnel. Reference:
+`setup.go:wgQuickUp`, `wireguard.go`.
+
+**`clawpatrol run -- <cmd>` (macOS).** WG userspace inside the NE,
+PPID-filtered. Reference: `run_darwin.go`,
 `macos/ClawpatrolExtension/Provider.swift`.
-
-The extension intercepts every outbound TCP and UDP flow on the
-host and filters in `handleNewFlow`: it walks each flow's
-originating PPID chain and tunnels only those flows whose ancestor
-is the wrapped `.app` process. Matched flows are bridged into a
-userspace wireguard-go tunnel + gVisor netstack inside the
-extension; non-matched flows return `false` and proceed via the
-host's normal network. A `--whole-machine` mode skips the PPID
-filter and tunnels every flow.
-
-- **Tunnel mechanism.** Userspace wireguard-go + gVisor netstack
-  inside the system extension (`macos/netstack/`). Apple's per-app
-  `NEPacketTunnel` routing is gated behind MDM, so the extension
-  uses `NETransparentProxyProvider` and applies the per-process
-  scope itself.
-- **What's installed on the device.** `Clawpatrol.app` in
-  `/Applications/`, plus its system extension (one-time approval
-  prompt at first install). The first `clawpatrol run` activates
-  the extension; subsequent runs are no-ops.
-- **Scope.** The wrapped process and its descendants, identified
-  by PPID walk against the parent app's signing identifier.
 
 ## Network traffic processing
 

--- a/site/doc/architecture.md
+++ b/site/doc/architecture.md
@@ -134,7 +134,7 @@ The gateway pulls in three plugin families:
 mints + what the client installs depends on the gateway's
 `control` mode.
 
-### Tailscale mode (recommended)
+### Tailscale mode
 
 The gateway embeds tsnet; it joins the tailnet in-process and
 exposes only `/api/onboard/{start,poll,claim}` + `/api/cred/*` on
@@ -163,7 +163,7 @@ Reference: `setup.go:runLogin`.
 host routing — no system Tailscale touched. macOS never runs
 system tailscaled.
 
-### WireGuard mode (legacy)
+### WireGuard mode
 
 The gateway runs an in-process WireGuard server (wireguard-go +
 gVisor netstack). At onboard it mints a keypair, allocates a `/32`

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -48,10 +48,10 @@ clawpatrol join <gateway-url> [flags]
 |---|---|---|
 | `--hostname NAME` | OS hostname | Device name registered with the gateway |
 | `--profile NAME` | gateway default | Profile to assign at approval time |
-| `--whole-machine` | off | Bring up `wg-quick` and route every packet through the gateway (default: persist conf only and use `clawpatrol run`) |
+| `--whole-machine` | off | Route every packet through the gateway. Linux installs system Tailscale (or `wg-quick` for WG gateways); macOS uses the NE in whole-host config. Default: per-process via `clawpatrol run`. |
 | `--no-trust` | off | Fetch the CA but skip system trust install |
 | `--ca-dir DIR` | `~/.clawpatrol` | Where to store the fetched CA |
-| `--name NAME` | `clawpatrol` | Exit-node hostname (only used when the gateway is on Tailscale) |
+| `--name NAME` | `clawpatrol` | Exit-node hostname (Tailscale gateway, `--whole-machine` only) |
 
 ### `clawpatrol login`
 

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -31,37 +31,19 @@ into it, and edit the operational fields:
 
 ```hcl
 info_listen = "127.0.0.1:9080"   # bind the dashboard private — see below
+public_url  = "https://gw.example.com"
 admin_email = "you@example.com"
 state_dir   = "/opt/clawpatrol"
 
-# Embedded Tailscale: no system tailscaled, no iptables, no
-# WireGuard port to open. The gateway joins the tailnet in-process
-# via tsnet and exposes the bootstrap routes
-# (/api/onboard/{start,poll,claim}, /api/cred/*) on :443 via Funnel.
-control             = "tailscale"
-funnel              = true
-listen              = ":8443"
-oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
-oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
-tailscale_tags      = ["tag:bot"]
+control        = "wireguard"
+wg_subnet_cidr = "10.55.0.0/24"
 ```
 
-Pick the control mode that fits your shape:
-
-- **Tailscale** (shown above) — least host setup. tsnet runs
-  in-process, Funnel covers the public TLS, no kernel module or
-  UDP port to expose. Operators are auto-identified via tailnet
-  whois. Needs a tailnet + an OAuth client.
-- **WireGuard** — `control = "wireguard"` +
-  `wg_subnet_cidr = "10.55.0.0/24"`. Self-contained: the gateway
-  is the WG server, no Tailscale dependency. Costs one open UDP
-  port (default `51820`) and `iptables -I INPUT -p udp --dport
-  51820 -j ACCEPT` on the host. See
-  [`gateway.example.hcl`](https://github.com/denoland/clawpatrol/blob/main/gateway.example.hcl)
-  for the WG shape.
-
-The rest of this guide uses the Tailscale shape; the WG flow is
-identical apart from the per-mode host setup.
+(Prefer Tailscale? Swap `control` to `"tailscale"`, add `funnel =
+true`, `listen = ":8443"`, and `oauth_client_id` /
+`oauth_client_secret` / `tailscale_tags`. Embedded tsnet joins the
+tailnet in-process, no UDP port or iptables rule needed. The rest
+of this guide works the same way.)
 
 **`info_listen` should bind privately.** The dashboard holds the
 credential vault — the gateway refuses to boot when `info_listen`
@@ -89,22 +71,10 @@ and the rest of the credential / endpoint / rule blocks.
 
 ## Run the gateway
 
-Tailscale mode needs only the OAuth client ID + secret (mint at
-<https://login.tailscale.com/admin/settings/oauth> with the
-`auth_keys` write scope; tag the client with `tag:bot` to match
-`tailscale_tags`). Drop them in an EnvironmentFile so they're not
-checked in:
-
-```bash
-echo 'TS_OAUTH_CLIENT_ID=...'     | sudo tee -a /opt/clawpatrol/secrets.env
-echo 'TS_OAUTH_CLIENT_SECRET=...' | sudo tee -a /opt/clawpatrol/secrets.env
-sudo chmod 600 /opt/clawpatrol/secrets.env
-```
-
-No iptables, no UDP port. The gateway joins the tailnet from inside
-the process and Tailscale Funnel routes the bootstrap public TLS for
-you. Leave the dashboard port closed to the public internet; reach
-it via the private bind you chose above.
+Open the WireGuard UDP port on the host firewall —
+`iptables -I INPUT -p udp --dport 51820 -j ACCEPT`. Leave the
+dashboard port closed to the public internet; reach it via the
+private bind you chose above.
 
 ```bash
 clawpatrol gateway /opt/clawpatrol/gateway.hcl
@@ -166,26 +136,17 @@ startup when `state_dir` or `clawpatrol.db` is readable beyond owner.
 On the machine you want to route through the gateway:
 
 ```bash
-clawpatrol join https://<gateway>.tail<tailnet-id>.ts.net
+clawpatrol join http://<gateway-host>:9080
 ```
 
-The URL is the gateway's Tailscale Funnel hostname — the only
-publicly reachable surface the gateway exposes. (For WireGuard
-gateways, use `http://<gateway-host>:9080` instead.)
-
 You'll see a one-time code. Open the URL it prints, confirm the code
-matches, and approve. Once approved the device is enrolled, the
-gateway CA is installed in your system trust store, and
-`clawpatrol env` is wired into your shell rc.
+matches, and approve. Once approved the device is enrolled, the gateway
+CA is installed in your system trust store, and `clawpatrol env` is wired
+into your shell rc.
 
 By default `join` sets up per-process routing: only commands you wrap
-with `clawpatrol run` go through the gateway. Each invocation is its
-own ephemeral tailnet node, freed automatically on exit, so
-concurrent runs on the same host don't collide.
-
-Pass `--whole-machine` (Linux only) if you want every packet on the
-host to route through the gateway. macOS handles whole-machine
-routing through the Network Extension instead — same flag.
+with `clawpatrol run` go through the gateway. Pass `--whole-machine` if
+you want every packet on the host to route through it.
 
 On macOS, the first join prompts you to approve the Claw Patrol
 Network Extension in **System Settings → Privacy & Security**.
@@ -227,9 +188,9 @@ Claw Patrol gateway:
 
 - **`clawpatrol join --whole-machine` is for client devices only.**
   Running it on (or pointed at) the gateway host itself routes the
-  host's own traffic through its own tunnel — a loop that breaks
-  DNS, outbound traffic from the gateway daemon, and the
-  dashboard's reachability. Per-process routing (the default
+  host's own traffic through its own WireGuard endpoint — a loop
+  that breaks DNS, outbound traffic from the gateway daemon, and
+  the dashboard's reachability. Per-process routing (the default
   `clawpatrol join` + `clawpatrol run` shape) is also what most
   people actually want on a multi-purpose laptop, so they don't
   accidentally route every browser tab through the gateway.

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -34,9 +34,9 @@ info_listen = "127.0.0.1:9080"   # bind the dashboard private — see below
 admin_email = "you@example.com"
 state_dir   = "/opt/clawpatrol"
 
-# Embedded Tailscale (recommended): no system tailscaled, no
-# iptables, no WireGuard port to open. The gateway joins the tailnet
-# in-process via tsnet and exposes the bootstrap routes
+# Embedded Tailscale: no system tailscaled, no iptables, no
+# WireGuard port to open. The gateway joins the tailnet in-process
+# via tsnet and exposes the bootstrap routes
 # (/api/onboard/{start,poll,claim}, /api/cred/*) on :443 via Funnel.
 control             = "tailscale"
 funnel              = true
@@ -46,7 +46,22 @@ oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
 tailscale_tags      = ["tag:bot"]
 ```
 
-(WireGuard mode — `control = "wireguard"` + `wg_subnet_cidr = "10.55.0.0/24"` — is still supported; see [`gateway.example.hcl`](https://github.com/denoland/clawpatrol/blob/main/gateway.example.hcl) for the full shape. The rest of this guide assumes Tailscale mode.)
+Pick the control mode that fits your shape:
+
+- **Tailscale** (shown above) — least host setup. tsnet runs
+  in-process, Funnel covers the public TLS, no kernel module or
+  UDP port to expose. Operators are auto-identified via tailnet
+  whois. Needs a tailnet + an OAuth client.
+- **WireGuard** — `control = "wireguard"` +
+  `wg_subnet_cidr = "10.55.0.0/24"`. Self-contained: the gateway
+  is the WG server, no Tailscale dependency. Costs one open UDP
+  port (default `51820`) and `iptables -I INPUT -p udp --dport
+  51820 -j ACCEPT` on the host. See
+  [`gateway.example.hcl`](https://github.com/denoland/clawpatrol/blob/main/gateway.example.hcl)
+  for the WG shape.
+
+The rest of this guide uses the Tailscale shape; the WG flow is
+identical apart from the per-mode host setup.
 
 **`info_listen` should bind privately.** The dashboard holds the
 credential vault — the gateway refuses to boot when `info_listen`

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -31,13 +31,22 @@ into it, and edit the operational fields:
 
 ```hcl
 info_listen = "127.0.0.1:9080"   # bind the dashboard private — see below
-public_url  = "https://gw.example.com"
 admin_email = "you@example.com"
 state_dir   = "/opt/clawpatrol"
 
-control        = "wireguard"
-wg_subnet_cidr = "10.55.0.0/24"
+# Embedded Tailscale (recommended): no system tailscaled, no
+# iptables, no WireGuard port to open. The gateway joins the tailnet
+# in-process via tsnet and exposes the bootstrap routes
+# (/api/onboard/{start,poll,claim}, /api/cred/*) on :443 via Funnel.
+control             = "tailscale"
+funnel              = true
+listen              = ":8443"
+oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
+oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
+tailscale_tags      = ["tag:bot"]
 ```
+
+(WireGuard mode — `control = "wireguard"` + `wg_subnet_cidr = "10.55.0.0/24"` — is still supported; see [`gateway.example.hcl`](https://github.com/denoland/clawpatrol/blob/main/gateway.example.hcl) for the full shape. The rest of this guide assumes Tailscale mode.)
 
 **`info_listen` should bind privately.** The dashboard holds the
 credential vault — the gateway refuses to boot when `info_listen`
@@ -65,10 +74,22 @@ and the rest of the credential / endpoint / rule blocks.
 
 ## Run the gateway
 
-Open the WireGuard UDP port on the host firewall —
-`iptables -I INPUT -p udp --dport 51820 -j ACCEPT`. Leave the
-dashboard port closed to the public internet; reach it via the
-private bind you chose above.
+Tailscale mode needs only the OAuth client ID + secret (mint at
+<https://login.tailscale.com/admin/settings/oauth> with the
+`auth_keys` write scope; tag the client with `tag:bot` to match
+`tailscale_tags`). Drop them in an EnvironmentFile so they're not
+checked in:
+
+```bash
+echo 'TS_OAUTH_CLIENT_ID=...'     | sudo tee -a /opt/clawpatrol/secrets.env
+echo 'TS_OAUTH_CLIENT_SECRET=...' | sudo tee -a /opt/clawpatrol/secrets.env
+sudo chmod 600 /opt/clawpatrol/secrets.env
+```
+
+No iptables, no UDP port. The gateway joins the tailnet from inside
+the process and Tailscale Funnel routes the bootstrap public TLS for
+you. Leave the dashboard port closed to the public internet; reach
+it via the private bind you chose above.
 
 ```bash
 clawpatrol gateway /opt/clawpatrol/gateway.hcl
@@ -130,17 +151,26 @@ startup when `state_dir` or `clawpatrol.db` is readable beyond owner.
 On the machine you want to route through the gateway:
 
 ```bash
-clawpatrol join http://<gateway-host>:9080
+clawpatrol join https://<gateway>.tail<tailnet-id>.ts.net
 ```
 
+The URL is the gateway's Tailscale Funnel hostname — the only
+publicly reachable surface the gateway exposes. (For WireGuard
+gateways, use `http://<gateway-host>:9080` instead.)
+
 You'll see a one-time code. Open the URL it prints, confirm the code
-matches, and approve. Once approved the device is enrolled, the gateway
-CA is installed in your system trust store, and `clawpatrol env` is wired
-into your shell rc.
+matches, and approve. Once approved the device is enrolled, the
+gateway CA is installed in your system trust store, and
+`clawpatrol env` is wired into your shell rc.
 
 By default `join` sets up per-process routing: only commands you wrap
-with `clawpatrol run` go through the gateway. Pass `--whole-machine` if
-you want every packet on the host to route through it.
+with `clawpatrol run` go through the gateway. Each invocation is its
+own ephemeral tailnet node, freed automatically on exit, so
+concurrent runs on the same host don't collide.
+
+Pass `--whole-machine` (Linux only) if you want every packet on the
+host to route through the gateway. macOS handles whole-machine
+routing through the Network Extension instead — same flag.
 
 On macOS, the first join prompts you to approve the Claw Patrol
 Network Extension in **System Settings → Privacy & Security**.
@@ -182,9 +212,9 @@ Claw Patrol gateway:
 
 - **`clawpatrol join --whole-machine` is for client devices only.**
   Running it on (or pointed at) the gateway host itself routes the
-  host's own traffic through its own WireGuard endpoint — a loop
-  that breaks DNS, outbound traffic from the gateway daemon, and
-  the dashboard's reachability. Per-process routing (the default
+  host's own traffic through its own tunnel — a loop that breaks
+  DNS, outbound traffic from the gateway daemon, and the
+  dashboard's reachability. Per-process routing (the default
   `clawpatrol join` + `clawpatrol run` shape) is also what most
   people actually want on a multi-purpose laptop, so they don't
   accidentally route every browser tab through the gateway.

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -108,7 +108,7 @@ profile "default" { endpoints = [github] }
 | `public_url` | Public URL handed out at join time. Auto-derived from the Funnel cert domain when `funnel = true`. |
 | `dashboard_secret` | Required only if `info_listen` binds publicly. |
 | `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol`. |
-| `control` | `"tailscale"` (embedded tsnet, recommended) or `"wireguard"`. |
+| `control` | `"tailscale"` (embedded tsnet, Funnel-fronted) or `"wireguard"` (in-process WG server). Both first-class. |
 | `funnel` | Tailscale Funnel on :443 — strict allowlist for the join bootstrap + credential webhooks. |
 | `oauth_client_id` / `oauth_client_secret` | Tailscale OAuth client (auth-key scope) for tsnet identity + per-client ephemeral keys. |
 | `tailscale_tags` | Tags applied to minted auth keys, e.g. `["tag:bot"]`. |

--- a/site/doc/skill.md
+++ b/site/doc/skill.md
@@ -62,11 +62,18 @@ are bare (`credential = github-pat`, never `credential.github-pat`).
 ### Minimal complete example
 
 ```hcl
-admin_email      = "you@example.com"
-dashboard_secret = "change-me-long-random"
+admin_email = "you@example.com"
+info_listen = "127.0.0.1:9080"      # loopback bind — no dashboard_secret needed
+state_dir   = "/opt/clawpatrol"
 
-control        = "wireguard"
-wg_subnet_cidr = "10.55.0.0/24"
+# Embedded Tailscale: tsnet runs in-process, Funnel exposes the
+# bootstrap on :443. No system tailscaled, no iptables.
+control             = "tailscale"
+funnel              = true
+listen              = ":8443"
+oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
+oauth_client_secret = "{{secret:TS_OAUTH_CLIENT_SECRET}}"
+tailscale_tags      = ["tag:bot"]
 
 credential "bearer_token" "github-pat" {}
 
@@ -96,13 +103,16 @@ profile "default" { endpoints = [github] }
 | Field | Notes |
 |---|---|
 | `admin_email` | Required. |
-| `listen` | TLS gateway bind. Meaningful only in Tailscale mode (tsnet listener); in WireGuard mode the agent path uses the WG tunnel and this socket is forced to loopback. |
-| `info_listen` | Dashboard + API bind. |
-| `public_url` | Dashboard URL handed out at join time. |
-| `dashboard_secret` | Required (or `insecure_no_dashboard_secret = true` for local testing). |
+| `listen` | TLS gateway bind (typically `:8443` in Tailscale mode — Funnel owns :443). In WireGuard mode this socket is forced to loopback. |
+| `info_listen` | Dashboard + API bind. Loopback / private network = no `dashboard_secret` needed. |
+| `public_url` | Public URL handed out at join time. Auto-derived from the Funnel cert domain when `funnel = true`. |
+| `dashboard_secret` | Required only if `info_listen` binds publicly. |
 | `state_dir` | Directory holding `clawpatrol.db`. Defaults to `~/.clawpatrol`. |
-| `control` | `"wireguard"` or `"tailscale"`. |
-| `wg_endpoint` / `wg_subnet_cidr` | WG listener + device subnet. |
+| `control` | `"tailscale"` (embedded tsnet, recommended) or `"wireguard"`. |
+| `funnel` | Tailscale Funnel on :443 — strict allowlist for the join bootstrap + credential webhooks. |
+| `oauth_client_id` / `oauth_client_secret` | Tailscale OAuth client (auth-key scope) for tsnet identity + per-client ephemeral keys. |
+| `tailscale_tags` | Tags applied to minted auth keys, e.g. `["tag:bot"]`. |
+| `wg_endpoint` / `wg_subnet_cidr` | WireGuard mode only: WG listener + device subnet. |
 | `unknown_host` | `"passthrough"` (default) or `"deny"` for traffic no endpoint claims. |
 
 Full list: [Config reference](/docs/config-reference/#top-level-fields).
@@ -284,17 +294,23 @@ without paging.
 ## Onboard a device
 
 ```
-clawpatrol join http://<gateway-host>:9080
+clawpatrol join https://<gateway>.tail<id>.ts.net   # Tailscale gateway (Funnel)
+clawpatrol join http://<gateway-host>:9080          # WireGuard gateway
 ```
 
 Prints a one-time code; operator confirms it in the dashboard,
-assigns a profile, approves. Persists the WG conf to
-`~/.config/clawpatrol/wg.conf`, installs the gateway CA, adds
-`eval "$(clawpatrol env)"` to your shell rc.
+assigns a profile, approves. Persists the auth key + CA + api-token
+under `~/.clawpatrol/`, and adds `eval "$(clawpatrol env)"` to your
+shell rc.
 
 Flags: `--hostname`, `--profile`, `--whole-machine` (route every
 packet through the gateway instead of just `clawpatrol run`),
 `--no-trust` (skip system trust install).
+
+In Tailscale mode `clawpatrol run` is per-invocation ephemeral —
+each run is a fresh tailnet node, auto-removed on exit. Concurrent
+runs on the same machine don't share state. WireGuard mode mints
+an ephemeral WG peer per run with the same property.
 
 macOS first join: approve the Network Extension in **System
 Settings → Privacy & Security**.


### PR DESCRIPTION
Docs in \`site/doc/\` defaulted to the old WireGuard-mode shape. Post-#446 / #450 the gateway recommends embedded tsnet + Funnel.

## Changes

- **getting-started.md**: HCL example switched to \`control = "tailscale"\` (OAuth client, funnel, tag:bot). Dropped the WG UDP port instructions + iptables rule. WireGuard mode noted as still-supported fallback. Join URL is the Funnel hostname (\`https://<gw>.tail<id>.ts.net\`).
- **skill.md**: minimal config uses tsnet; loopback \`info_listen\` (no \`dashboard_secret\` needed). Top-level fields table covers \`funnel\`, OAuth, tailscale_tags. Onboarding section notes per-run ephemeral identity.
- **architecture.md**: connection-modes section restructured around control mode — Tailscale primary, WireGuard legacy. macOS never runs system tailscaled. Per-process tsnet uses \`MkdirTemp\` + \`Ephemeral: true\`.
- **cli.md**: \`--whole-machine\` description covers Linux (system tailscale / wg-quick) + macOS (NE whole-host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)