### PR TITLE
dashboard auth: make login-page assets reachable without a cookie

### DIFF
--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -139,7 +139,26 @@ func (w *webMux) authRequirementForPath(path string) authRequirement {
 			return req
 		}
 	}
+	// The login page is authPublic — its assets must be too, or the
+	// browser would chase /claw-patrol-logo.svg through dashboardAuthGate,
+	// land on an HTML redirect, and render a broken-image icon on every
+	// logged-out visit.
+	if isLoginPageAsset(path) {
+		return authPublic
+	}
 	return authDashboard
+}
+
+// isLoginPageAsset matches the exact set of static assets the login
+// page (www/login.html) loads while the user is unauthenticated:
+// favicon, logo, and the woff2 font subset. Anything else under /
+// stays gated.
+func isLoginPageAsset(path string) bool {
+	switch path {
+	case "/claw-patrol-icon.svg", "/claw-patrol-logo.svg":
+		return true
+	}
+	return strings.HasPrefix(path, "/fonts/")
 }
 
 // skipsDashboardPassword returns true for routes whose handlers

--- a/cmd/clawpatrol/web_auth_test.go
+++ b/cmd/clawpatrol/web_auth_test.go
@@ -169,6 +169,13 @@ func TestRouteAuthRequirementsDocumentOnboardingBoundary(t *testing.T) {
 		{path: "/api/env-pushdown", want: authSelfAuthenticating, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/info", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/ca.crt", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
+		// Login-page assets — the login page is authPublic and so are
+		// the static resources it references; otherwise a logged-out
+		// visit would chase the logo through the gate and render a
+		// broken-image icon.
+		{path: "/claw-patrol-logo.svg", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
+		{path: "/claw-patrol-icon.svg", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
+		{path: "/fonts/funnel-sans/FunnelSans-Variable--latin_basic.woff2", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {


### PR DESCRIPTION
\`dashboardAuthGate\` redirects every non-public request to
\`/__login\`. That breaks the login page itself: the browser fetches
\`/claw-patrol-logo.svg\`, \`/claw-patrol-icon.svg\`, and the woff2
font subset under \`/fonts/\`, each gets a 302 to \`/__login\`, and
the embedded HTML renders as a broken-image icon (the page also
loses its custom typography for the same reason).

Add \`isLoginPageAsset()\` and treat the three asset paths as
\`authPublic\` in \`authRequirementForPath\`. The login form itself
is \`authPublic\`, so its dependencies have to be too. Anything else
under \`/\` stays gated.

Repro: visit any clawpatrol instance running #454 with no \`cp_dash\`
cookie. The login form renders with a broken-image placeholder
above the password field.