### PR TITLE
Revert "wg: drop default tunnel MTU 1420 → 1220"

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -50,10 +50,7 @@ const (
 	runNoAutoExposeEnv = "CLAWPATROL_RUN_NO_AUTO_EXPOSE"
 	runTsnetChildEnv   = "CLAWPATROL_RUN_TSNET_CHILD"
 	tunIfName          = "wg0"
-	// Match wgTunMTU in wireguard.go (1220 — fits Tailscale's
-	// 1280-byte underlay after WG/UDP/IP encap). v6 unavailable; see
-	// the comment over there.
-	tunMTU = 1220
+	tunMTU             = 1420
 )
 
 // runRun is `clawpatrol run`. Re-execs self in new user+net+mnt namespaces
@@ -722,7 +719,7 @@ func ephemeralPeer(cfg *runConf) (cleanup func(), err error) {
 	}
 
 	cfg.PrivateKey = privB64
-	cfg.Address = result.IP + "/32"
+	cfg.Address = result.IP + "/32, " + result.IP6 + "/128"
 	_ = os.Setenv("CLAWPATROL_EPHEMERAL_ADDR", cfg.Address)
 
 	return func() {

--- a/cmd/clawpatrol/wireguard.go
+++ b/cmd/clawpatrol/wireguard.go
@@ -53,21 +53,6 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-// wgTunMTU is the IP MTU of every clawpatrol-WG tunnel — server-side
-// netstack, issued wg.conf, Linux per-process TUN, macOS netstack
-// client. 1220 = 1280 (Tailscale's tailscale0 MTU) - 60 (IPv4 + UDP
-// + WG header). At 1420 (wireguard-go's bare-metal default) the
-// outer-encap packet is 1480 bytes which fragments on tailscale0
-// and TCP collapses to <2 KB/s. At 1220 inner-encap is exactly 1280
-// outer and fragmentation goes away (688 KB/s sustained in tests).
-//
-// 1220 is < 1280 (RFC 8200 IPv6 minimum), so Linux refuses
-// `ip addr add <v6>/128 dev wg0`. The wg.conf issued below omits
-// the v6 client address and uses AllowedIPs = 0.0.0.0/0 only;
-// inside-tunnel IPv6 is unavailable. Acceptable for the agent
-// use case (api.github.com, openai.com, claude.ai are all IPv4).
-const wgTunMTU = 1220
-
 // netTun is our own wireguard-go tun.Device backed by a gVisor stack +
 // channel.Endpoint. Can't use golang.zx2c4.com/wireguard/tun/netstack
 // because it builds the stack with HandleLocal=true; combined with
@@ -335,7 +320,7 @@ func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	serverIP := prefix.Addr().Next() // x.x.x.1
 	serverIP6 := wg6FromV4(serverIP) // fd77::<last-octet>
 
-	tun, err := newNetTUN(serverIP, serverIP6, wgTunMTU)
+	tun, err := newNetTUN(serverIP, serverIP6, 1420)
 	if err != nil {
 		return nil, err
 	}
@@ -863,19 +848,19 @@ func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string, _ bool) 
 	// Avoiding `DNS =` because wg-quick needs resolvconf/openresolv
 	// for that, which many minimal images lack. Backup-then-restore
 	// keeps system DNS sane after `wg-quick down`.
+	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
 	conf := fmt.Sprintf(`[Interface]
 PrivateKey = %s
-Address = %s/32
-MTU = %d
+Address = %s/32, %s/128
 PostUp = cp /etc/resolv.conf /etc/resolv.conf.clawpatrol.bak 2>/dev/null; printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
 PostDown = mv /etc/resolv.conf.clawpatrol.bak /etc/resolv.conf 2>/dev/null || true
 
 [Peer]
 PublicKey = %s
 Endpoint = %s
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = 0.0.0.0/0, ::/0
 PersistentKeepalive = 25
-`, clientPrivB64, ip, wgTunMTU, serverPubB64, clientEndpoint)
+`, clientPrivB64, ip, ip6, serverPubB64, clientEndpoint)
 	return conf, "wireguard://" + w.iface(), ip, nil
 }
 

--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -97,11 +97,6 @@ func (n *epNotify) WriteNotify() {
 // whole-machine bursts; 16384 absorbs realistic spikes.
 const netstackQueueSize = 16384
 
-// wgTunMTU matches wireguard.go's constant. 1220 fits Tailscale's
-// 1280-byte underlay without IP fragmentation. v6 unavailable inside
-// the tunnel; see the comment over there.
-const wgTunMTU = 1220
-
 func newNetTUN(addr netip.Addr, addr6 netip.Addr, mtu int) (*netTun, error) {
 	t := &netTun{
 		ep: channel.New(netstackQueueSize, uint32(mtu), ""),
@@ -319,7 +314,7 @@ func wg_netstack_init(confC *C.char, errBuf *C.char, errLen C.int) C.int {
 		setErr(errBuf, errLen, "parse client IP: no IPv4 in Address")
 		return -1
 	}
-	t, err := newNetTUN(clientIP, clientIP6, wgTunMTU)
+	t, err := newNetTUN(clientIP, clientIP6, 1420)
 	if err != nil {
 		setErr(errBuf, errLen, "newNetTUN: "+err.Error())
 		return -1


### PR DESCRIPTION
## Summary

Reverts #411 — the MTU 1420 → 1220 drop.

The 1220 MTU was a workaround for running clawpatrol-WG over a Tailscale underlay: at 1420 inner, the outer-encap packet hit 1480 bytes and fragmented on tailscale0's 1280-byte MTU, collapsing TCP to <2 KB/s.

We no longer route clawpatrol-WG through Tailscale, so the workaround is moot. Restoring 1420 also re-enables client-side IPv6 inside the tunnel — 1220 is below RFC 8200's 1280 minimum, so Linux refuses to add a v6 `/128` with that MTU, which is why the wg.conf had been hardcoded to `0.0.0.0/0` AllowedIPs and no v6 address.

## Visible result

Before: `clawpatrol run curl https://tinyclouds.org/` mysteriously failed with `SSL_ERROR_SYSCALL` or "Empty reply from server" because curl preferred IPv6 and the v6 traffic was either escaping the tunnel or half-intercepted. Workaround was `curl -4`.

After: v6 traffic enters the tunnel and is routed by the gateway like v4. No `-4` needed.

## Test plan
- [x] `go test ./...` passes
- [x] local `clawpatrol gateway dev.hcl` + `clawpatrol run curl https://...` end-to-end with v6 (no `-4` flag)
- [ ] CI green
