### PR TITLE
hitl: update Slack prompts for async states

### DIFF
--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -161,7 +162,7 @@ func (g *Gateway) transitionAsyncHITLOperation(ctx context.Context, op HITLOpera
 	if g == nil || g.db == nil || op.ID == "" {
 		return op, nil
 	}
-	return NewHITLOperationStore(g.db).Transition(ctx, HITLOperationTransition{
+	updated, err := NewHITLOperationStore(g.db).Transition(ctx, HITLOperationTransition{
 		ID:              op.ID,
 		FromState:       op.State,
 		ToState:         to,
@@ -169,6 +170,71 @@ func (g *Gateway) transitionAsyncHITLOperation(ctx context.Context, op HITLOpera
 		Now:             time.Now().UTC(),
 		LastError:       lastErr,
 	})
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	g.updateHITLOperationMessage(context.Background(), updated)
+	return updated, nil
+}
+
+func (g *Gateway) recordHITLOperationMessageRef(ctx context.Context, operationID, ref string) error {
+	if g == nil || g.db == nil || operationID == "" || ref == "" {
+		return nil
+	}
+	op, err := NewHITLOperationStore(g.db).SetApproverMessageRef(ctx, operationID, ref)
+	if err != nil {
+		return err
+	}
+	if op.State != HITLOperationStateSyncWaiting {
+		g.updateHITLOperationMessage(context.Background(), op)
+	}
+	return nil
+}
+
+func (g *Gateway) updateHITLOperationMessage(ctx context.Context, op HITLOperation) {
+	if g == nil || op.ID == "" || op.ApproverMessageRef == "" {
+		return
+	}
+	policy := g.Policy()
+	if policy == nil {
+		return
+	}
+	approver := policy.Approvers[op.ApproverID]
+	if approver == nil {
+		return
+	}
+	type humanCredentialer interface{ HumanApproverCredential() string }
+	credName := ""
+	if h, ok := approver.Body.(humanCredentialer); ok {
+		credName = h.HumanApproverCredential()
+	}
+	if credName == "" {
+		return
+	}
+	cred := policy.Credentials[credName]
+	if cred == nil {
+		return
+	}
+	updater, ok := cred.Body.(runtime.HITLMessageUpdater)
+	if !ok {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := updater.UpdateHITLMessage(ctx, g.secrets, runtime.HITLMessageUpdate{
+		MessageRef:     op.ApproverMessageRef,
+		OperationID:    op.ID,
+		State:          runtime.HITLOperationState(op.State),
+		Method:         op.Method,
+		Host:           op.Host,
+		Path:           op.RedactedPath,
+		Profile:        op.ProfileID,
+		UpstreamCalled: op.UpstreamCalled,
+		LastError:      op.LastError,
+	}); err != nil {
+		log.Printf("hitl async operation message update %s: %v", op.ID, err)
+	}
 }
 
 func (g *Gateway) resolveAsyncHITLGrant(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult {
@@ -210,7 +276,7 @@ func (g *Gateway) resolveAsyncHITLGrant(operationID string, d runtime.HITLDecisi
 	if err != nil {
 		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: err.Error()}
 	}
-	_ = updated
+	g.updateHITLOperationMessage(context.Background(), updated)
 	return runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
 }
 

--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -203,9 +203,8 @@ func (g *Gateway) updateHITLOperationMessage(ctx context.Context, op HITLOperati
 	if approver == nil {
 		return
 	}
-	type humanCredentialer interface{ HumanApproverCredential() string }
 	credName := ""
-	if h, ok := approver.Body.(humanCredentialer); ok {
+	if h, ok := approver.Body.(runtime.HITLHumanCredentialer); ok {
 		credName = h.HumanApproverCredential()
 	}
 	if credName == "" {

--- a/cmd/clawpatrol/hitl_operation_store.go
+++ b/cmd/clawpatrol/hitl_operation_store.go
@@ -172,6 +172,27 @@ func (s *HITLOperationStore) GetForPrincipal(ctx context.Context, id, profileID,
 	return s.scanOne(ctx, `SELECT `+hitlOperationColumns+` FROM hitl_operations WHERE id = ? AND profile_id = ? AND principal_id = ?`, id, profileID, principalID)
 }
 
+func (s *HITLOperationStore) SetApproverMessageRef(ctx context.Context, id, ref string) (HITLOperation, error) {
+	if s == nil || s.db == nil {
+		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if id == "" || ref == "" {
+		return HITLOperation{}, fmt.Errorf("%w: incomplete message ref", ErrHITLOperationStoreInvalid)
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE hitl_operations SET approver_message_ref = ? WHERE id = ?`, ref, id)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	changed, err := res.RowsAffected()
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	if changed != 1 {
+		return HITLOperation{}, ErrHITLOperationNotFound
+	}
+	return s.get(ctx, id)
+}
+
 func (s *HITLOperationStore) Transition(ctx context.Context, tr HITLOperationTransition) (HITLOperation, error) {
 	if s == nil || s.db == nil {
 		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)

--- a/cmd/clawpatrol/hitl_operation_store_test.go
+++ b/cmd/clawpatrol/hitl_operation_store_test.go
@@ -579,6 +579,29 @@ func TestHITLOperationStoreMaintenancePurgesTerminalOperations(t *testing.T) {
 	}
 }
 
+func TestHITLOperationStoreSetsApproverMessageRef(t *testing.T) {
+	db := openHITLOperationTestDB(t)
+	store := NewHITLOperationStore(db)
+	ctx := context.Background()
+	op := createTestHITLOperation(t, store, HITLOperationCreate{ID: "hitl_op_message_ref"})
+
+	updated, err := store.SetApproverMessageRef(ctx, op.ID, `{"type":"slack","credential":"slack-approvals","channel":"C123","ts":"1778764174.925659"}`)
+	if err != nil {
+		t.Fatalf("SetApproverMessageRef: %v", err)
+	}
+	if updated.ApproverMessageRef == "" {
+		t.Fatalf("ApproverMessageRef was not persisted")
+	}
+
+	loaded, err := store.GetForPrincipal(ctx, op.ID, op.ProfileID, op.PrincipalID)
+	if err != nil {
+		t.Fatalf("GetForPrincipal: %v", err)
+	}
+	if loaded.ApproverMessageRef != updated.ApproverMessageRef {
+		t.Fatalf("loaded ApproverMessageRef = %q, want %q", loaded.ApproverMessageRef, updated.ApproverMessageRef)
+	}
+}
+
 func openHITLOperationTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := OpenDB(filepath.Join(t.TempDir(), "clawpatrol.db"))

--- a/cmd/clawpatrol/hitl_retry_relay.go
+++ b/cmd/clawpatrol/hitl_retry_relay.go
@@ -82,7 +82,7 @@ func (g *Gateway) transitionConsumedHITLRetryGrant(ctx context.Context, op HITLO
 	if op.State != HITLOperationStateExecutingUpstream {
 		return nil
 	}
-	_, err := NewHITLOperationStore(g.db).Transition(ctx, HITLOperationTransition{
+	updated, err := NewHITLOperationStore(g.db).Transition(ctx, HITLOperationTransition{
 		ID:              op.ID,
 		FromState:       op.State,
 		ToState:         to,
@@ -91,7 +91,11 @@ func (g *Gateway) transitionConsumedHITLRetryGrant(ctx context.Context, op HITLO
 		UpstreamCalled:  true,
 		LastError:       lastErr,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	g.updateHITLOperationMessage(context.Background(), updated)
+	return nil
 }
 
 func hitlRetryRelayFailure(statusErr error) (status int, contentType string, body string) {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2517,6 +2517,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			Secrets:                   g.secrets,
 			DashboardURL:              g.cfg.PublicURL,
 			Policy:                    policy,
+			MessageUpdateSink:         g.recordHITLOperationMessageRef,
 		}
 		v, err := ar.Approve(ctx, req)
 		// Stamp the entity name + plugin type on every verdict so the

--- a/internal/config/plugins/approvers/human.go
+++ b/internal/config/plugins/approvers/human.go
@@ -149,18 +149,19 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					msg = expandMessage(h.Message, req)
 				}
 				target := runtime.HITLTarget{
-					CredentialName:  h.Credential,
-					Channel:         h.Channel,
-					Interactive:     h.Interactive,
-					PendingID:       id,
-					DashboardURL:    req.DashboardURL,
-					ThreadTS:        req.ThreadTS,
-					OperationState:  pending.OperationState,
-					ApprovalEffect:  pending.ApprovalEffect,
-					UpstreamCalled:  pending.UpstreamCalled,
-					ApprovalMessage: pending.ApprovalMessage,
-					Summary:         summary,
-					Message:         msg,
+					CredentialName:    h.Credential,
+					Channel:           h.Channel,
+					Interactive:       h.Interactive,
+					PendingID:         id,
+					DashboardURL:      req.DashboardURL,
+					ThreadTS:          req.ThreadTS,
+					OperationState:    pending.OperationState,
+					ApprovalEffect:    pending.ApprovalEffect,
+					UpstreamCalled:    pending.UpstreamCalled,
+					ApprovalMessage:   pending.ApprovalMessage,
+					Summary:           summary,
+					Message:           msg,
+					MessageUpdateSink: req.MessageUpdateSink,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {

--- a/internal/config/plugins/credentials/slack.go
+++ b/internal/config/plugins/credentials/slack.go
@@ -40,6 +40,7 @@ type SlackTokens struct{}
 
 var (
 	slackPostMessageURL     = "https://slack.com/api/chat.postMessage"
+	slackUpdateMessageURL   = "https://slack.com/api/chat.update"
 	slackHTTPClient         = &http.Client{Timeout: 5 * time.Second}
 	slackNotifyRetryBackoff = 500 * time.Millisecond
 )
@@ -236,8 +237,15 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 		body["thread_ts"] = target.ThreadTS
 	}
 	buf, _ := json.Marshal(body)
-	if err := slackPostHITLMessage(ctx, bot, buf); err != nil {
+	posted, err := slackPostHITLMessage(ctx, bot, buf)
+	if err != nil {
 		return err
+	}
+	if target.MessageUpdateSink != nil && req.AsyncOperationID != "" && posted.Channel != "" && posted.TS != "" {
+		ref := encodeSlackMessageRef(slackMessageRef{Credential: target.CredentialName, Channel: posted.Channel, TS: posted.TS, PendingID: target.PendingID, Interactive: target.Interactive})
+		if err := target.MessageUpdateSink(ctx, req.AsyncOperationID, ref); err != nil {
+			log.Printf("slack notify: record HITL message ref for %s: %v", req.AsyncOperationID, err)
+		}
 	}
 	return nil
 }
@@ -261,7 +269,12 @@ func slackHITLApprovalGuidance(target runtime.HITLTarget) string {
 	return runtime.HITLApprovalMessage(state, effect, target.UpstreamCalled)
 }
 
-func slackPostHITLMessage(ctx context.Context, bot string, buf []byte) error {
+type slackPostedMessage struct {
+	Channel string
+	TS      string
+}
+
+func slackPostHITLMessage(ctx context.Context, bot string, buf []byte) (slackPostedMessage, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -269,14 +282,15 @@ func slackPostHITLMessage(ctx context.Context, bot string, buf []byte) error {
 	for attempt := 1; attempt <= 2; attempt++ {
 		hreq, err := http.NewRequestWithContext(ctx, "POST", slackPostMessageURL, bytes.NewReader(buf))
 		if err != nil {
-			return err
+			return slackPostedMessage{}, err
 		}
 		hreq.Header.Set("Authorization", "Bearer "+bot)
 		hreq.Header.Set("Content-Type", "application/json; charset=utf-8")
 
+		var posted slackPostedMessage
 		resp, err := slackHTTPClient.Do(hreq)
 		if err == nil {
-			lastErr = slackDecodePostMessageResponse(resp)
+			posted, lastErr = slackDecodePostMessageResponse(resp)
 			if closeErr := resp.Body.Close(); lastErr == nil && closeErr != nil {
 				lastErr = closeErr
 			}
@@ -284,37 +298,39 @@ func slackPostHITLMessage(ctx context.Context, bot string, buf []byte) error {
 			lastErr = err
 		}
 		if lastErr == nil {
-			return nil
+			return posted, nil
 		}
 		if attempt == 2 || !slackShouldRetryPostMessage(resp, err) {
-			return lastErr
+			return slackPostedMessage{}, lastErr
 		}
 		log.Printf("slack notify: chat.postMessage failed on attempt %d, retrying once: %v", attempt, lastErr)
 		if err := slackWaitBeforeRetry(ctx, resp); err != nil {
-			return err
+			return slackPostedMessage{}, err
 		}
 	}
-	return lastErr
+	return slackPostedMessage{}, lastErr
 }
 
-func slackDecodePostMessageResponse(resp *http.Response) error {
+func slackDecodePostMessageResponse(resp *http.Response) (slackPostedMessage, error) {
 	if resp == nil {
-		return fmt.Errorf("slack chat.postMessage error: missing response")
+		return slackPostedMessage{}, fmt.Errorf("slack chat.postMessage error: missing response")
 	}
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	var result struct {
-		OK    bool   `json:"ok"`
-		Error string `json:"error"`
+		OK      bool   `json:"ok"`
+		Error   string `json:"error"`
+		Channel string `json:"channel"`
+		TS      string `json:"ts"`
 	}
 	_ = json.Unmarshal(respBody, &result)
 	if resp.StatusCode >= 400 || !result.OK {
 		log.Printf("slack notify: chat.postMessage failed: status=%d ok=%v error=%q", resp.StatusCode, result.OK, result.Error)
 		if result.Error != "" {
-			return fmt.Errorf("slack chat.postMessage error: %s", result.Error)
+			return slackPostedMessage{}, fmt.Errorf("slack chat.postMessage error: %s", result.Error)
 		}
-		return fmt.Errorf("slack chat.postMessage error: HTTP %d", resp.StatusCode)
+		return slackPostedMessage{}, fmt.Errorf("slack chat.postMessage error: HTTP %d", resp.StatusCode)
 	}
-	return nil
+	return slackPostedMessage{Channel: result.Channel, TS: result.TS}, nil
 }
 
 func slackShouldRetryPostMessage(resp *http.Response, err error) bool {
@@ -347,6 +363,144 @@ func slackWaitBeforeRetry(ctx context.Context, resp *http.Response) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+type slackMessageRef struct {
+	Type        string `json:"type"`
+	Credential  string `json:"credential"`
+	Channel     string `json:"channel"`
+	TS          string `json:"ts"`
+	PendingID   string `json:"pending_id,omitempty"`
+	Interactive bool   `json:"interactive,omitempty"`
+}
+
+func encodeSlackMessageRef(ref slackMessageRef) string {
+	ref.Type = "slack"
+	b, _ := json.Marshal(ref)
+	return string(b)
+}
+
+func decodeSlackMessageRef(raw string) (slackMessageRef, bool) {
+	var ref slackMessageRef
+	if err := json.Unmarshal([]byte(raw), &ref); err != nil || ref.Type != "slack" || ref.Credential == "" || ref.Channel == "" || ref.TS == "" {
+		return slackMessageRef{}, false
+	}
+	return ref, true
+}
+
+func (s *SlackTokens) UpdateHITLMessage(ctx context.Context, secrets runtime.SecretStore, update runtime.HITLMessageUpdate) error {
+	ref, ok := decodeSlackMessageRef(update.MessageRef)
+	if !ok {
+		return nil
+	}
+	if secrets == nil {
+		return fmt.Errorf("no secret store on request")
+	}
+	sec, err := secrets.Get(ref.Credential)
+	if err != nil {
+		return fmt.Errorf("fetch credential %s: %w", ref.Credential, err)
+	}
+	bot := sec.Extras["bot"]
+	if bot == "" && len(sec.Bytes) > 0 {
+		bot = string(sec.Bytes)
+	}
+	if bot == "" {
+		return fmt.Errorf("credential %s has no bot token", ref.Credential)
+	}
+	blocks := slackHITLUpdateBlocks(update, ref)
+	body := map[string]any{
+		"channel": ref.Channel,
+		"ts":      ref.TS,
+		"text":    "clawpatrol: HITL " + string(update.State),
+		"blocks":  blocks,
+	}
+	buf, _ := json.Marshal(body)
+	return slackPostJSON(ctx, slackUpdateMessageURL, bot, buf, "chat.update")
+}
+
+func slackHITLUpdateBlocks(update runtime.HITLMessageUpdate, ref slackMessageRef) []map[string]any {
+	path := update.Path
+	if path == "" {
+		path = "/"
+	}
+	detail := "*" + slackTrunc(update.Method+" "+update.Host, 200) + "*\n```" + slackTrunc(path, 800) + "```"
+	blocks := []map[string]any{
+		{"type": "header", "text": map[string]any{"type": "plain_text", "text": "Claw Patrol HITL"}},
+		{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": detail}},
+	}
+	guidance := runtime.HITLApprovalMessage(update.State, runtime.HITLApprovalEffectForOperationState(update.State), update.UpstreamCalled)
+	if strings.TrimSpace(guidance) != "" {
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": slackTrunc(guidance, 1000)}})
+	}
+	if update.State == runtime.HITLOperationStatePendingApproval && ref.Interactive && ref.PendingID != "" {
+		blocks = append(blocks, map[string]any{
+			"type": "actions",
+			"elements": []map[string]any{
+				{"type": "button", "text": map[string]any{"type": "plain_text", "text": "Approve"}, "action_id": "approve", "value": ref.PendingID, "style": "primary"},
+				{"type": "button", "text": map[string]any{"type": "plain_text", "text": "Deny"}, "action_id": "deny", "value": ref.PendingID, "style": "danger"},
+			},
+		})
+	}
+	status := slackOperationStatus(update)
+	blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{{"type": "mrkdwn", "text": status}}})
+	return blocks
+}
+
+func slackOperationStatus(update runtime.HITLMessageUpdate) string {
+	switch update.State {
+	case runtime.HITLOperationStatePendingApproval:
+		return ":hourglass_flowing_sand: HITL approval is pending"
+	case runtime.HITLOperationStateApprovedWaitingForRetry:
+		return ":white_check_mark: Approved — waiting for matching client retry"
+	case runtime.HITLOperationStateExecutingUpstream:
+		return ":arrow_forward: Matching retry received — executing upstream"
+	case runtime.HITLOperationStateUpstreamSucceeded:
+		return ":white_check_mark: Upstream request succeeded"
+	case runtime.HITLOperationStateUpstreamFailed:
+		if update.LastError != "" {
+			return ":x: Upstream request failed: " + slackTrunc(update.LastError, 300)
+		}
+		return ":x: Upstream request failed"
+	case runtime.HITLOperationStateDenied:
+		return ":no_entry: Denied"
+	case runtime.HITLOperationStateExpired:
+		return ":alarm_clock: HITL approval expired"
+	case runtime.HITLOperationStateClientDisconnected:
+		return ":warning: Original client disconnected before async polling handle was returned"
+	default:
+		return "HITL state: `" + string(update.State) + "`"
+	}
+}
+
+func slackPostJSON(ctx context.Context, endpoint, bot string, buf []byte, method string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	hreq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	hreq.Header.Set("Authorization", "Bearer "+bot)
+	hreq.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp, err := slackHTTPClient.Do(hreq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(respBody, &result)
+	if resp.StatusCode >= 400 || !result.OK {
+		log.Printf("slack notify: %s failed: status=%d ok=%v error=%q", method, resp.StatusCode, result.OK, result.Error)
+		if result.Error != "" {
+			return fmt.Errorf("slack %s error: %s", method, result.Error)
+		}
+		return fmt.Errorf("slack %s error: HTTP %d", method, resp.StatusCode)
+	}
+	return nil
 }
 
 func hitlClassificationEmoji(c string) string {

--- a/internal/config/plugins/credentials/slack.go
+++ b/internal/config/plugins/credentials/slack.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -131,38 +132,7 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 	queryLabel := runtime.HITLQueryLabel(req.Endpoint)
 
 	title := slackTrunc(runtime.HITLTitle(req.Method, endpoint), 140)
-	var blocks []map[string]any
-	switch {
-	case target.Message != "":
-		blocks = []map[string]any{
-			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
-			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": slackTrunc(target.Message, 3000)}},
-		}
-	case target.Summary != nil:
-		s := target.Summary
-		headerText := s.TicketID
-		if headerText == "" {
-			headerText = title
-		}
-		emoji := hitlClassificationEmoji(s.Classification)
-		classLine := emoji + " " + s.Classification
-		if s.Confidence > 0 {
-			classLine += fmt.Sprintf(" (%d%%)", s.Confidence)
-		}
-		sectionText := "*Classification:* " + classLine + "\n*Summary:* " + slackTrunc(s.Text, 500)
-		blocks = []map[string]any{
-			{"type": "header", "text": map[string]any{"type": "plain_text", "text": slackTrunc(headerText, 140)}},
-			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": sectionText}},
-		}
-	default:
-		blocks = []map[string]any{
-			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
-			{"type": "section", "text": map[string]any{
-				"type": "mrkdwn",
-				"text": "*" + queryLabel + "*\n```" + slackTrunc(req.Path, 800) + "```",
-			}},
-		}
-	}
+	blocks := slackHITLContentBlocks(title, queryLabel, req.Path, target.Message, target.Summary)
 	contextBlocks := []map[string]any{}
 	if req.Profile != "" {
 		contextBlocks = append(contextBlocks, map[string]any{
@@ -242,7 +212,7 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 		return err
 	}
 	if target.MessageUpdateSink != nil && req.AsyncOperationID != "" && posted.Channel != "" && posted.TS != "" {
-		ref := encodeSlackMessageRef(slackMessageRef{Credential: target.CredentialName, Channel: posted.Channel, TS: posted.TS, PendingID: target.PendingID, Interactive: target.Interactive})
+		ref := encodeSlackMessageRef(slackMessageRef{Credential: target.CredentialName, Channel: posted.Channel, TS: posted.TS, PendingID: target.PendingID, Interactive: target.Interactive, Message: target.Message, Summary: target.Summary})
 		if err := target.MessageUpdateSink(ctx, req.AsyncOperationID, ref); err != nil {
 			log.Printf("slack notify: record HITL message ref for %s: %v", req.AsyncOperationID, err)
 		}
@@ -267,6 +237,40 @@ func slackHITLApprovalGuidance(target runtime.HITLTarget) string {
 		effect = runtime.HITLApprovalEffectForOperationState(state)
 	}
 	return runtime.HITLApprovalMessage(state, effect, target.UpstreamCalled)
+}
+
+func slackHITLContentBlocks(title, queryLabel, path, message string, summary *runtime.HITLSummary) []map[string]any {
+	switch {
+	case message != "":
+		return []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
+			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": slackTrunc(message, 3000)}},
+		}
+	case summary != nil:
+		s := summary
+		headerText := s.TicketID
+		if headerText == "" {
+			headerText = title
+		}
+		emoji := hitlClassificationEmoji(s.Classification)
+		classLine := emoji + " " + s.Classification
+		if s.Confidence > 0 {
+			classLine += fmt.Sprintf(" (%d%%)", s.Confidence)
+		}
+		sectionText := "*Classification:* " + classLine + "\n*Summary:* " + slackTrunc(s.Text, 500)
+		return []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": slackTrunc(headerText, 140)}},
+			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": sectionText}},
+		}
+	default:
+		return []map[string]any{
+			{"type": "header", "text": map[string]any{"type": "plain_text", "text": title}},
+			{"type": "section", "text": map[string]any{
+				"type": "mrkdwn",
+				"text": "*" + queryLabel + "*\n```" + slackTrunc(path, 800) + "```",
+			}},
+		}
+	}
 }
 
 type slackPostedMessage struct {
@@ -366,12 +370,14 @@ func slackWaitBeforeRetry(ctx context.Context, resp *http.Response) error {
 }
 
 type slackMessageRef struct {
-	Type        string `json:"type"`
-	Credential  string `json:"credential"`
-	Channel     string `json:"channel"`
-	TS          string `json:"ts"`
-	PendingID   string `json:"pending_id,omitempty"`
-	Interactive bool   `json:"interactive,omitempty"`
+	Type        string               `json:"type"`
+	Credential  string               `json:"credential"`
+	Channel     string               `json:"channel"`
+	TS          string               `json:"ts"`
+	PendingID   string               `json:"pending_id,omitempty"`
+	Interactive bool                 `json:"interactive,omitempty"`
+	Message     string               `json:"message,omitempty"`
+	Summary     *runtime.HITLSummary `json:"summary,omitempty"`
 }
 
 func encodeSlackMessageRef(ref slackMessageRef) string {
@@ -423,11 +429,8 @@ func slackHITLUpdateBlocks(update runtime.HITLMessageUpdate, ref slackMessageRef
 	if path == "" {
 		path = "/"
 	}
-	detail := "*" + slackTrunc(update.Method+" "+update.Host, 200) + "*\n```" + slackTrunc(path, 800) + "```"
-	blocks := []map[string]any{
-		{"type": "header", "text": map[string]any{"type": "plain_text", "text": "Claw Patrol HITL"}},
-		{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": detail}},
-	}
+	title := slackTrunc(runtime.HITLTitle(update.Method, update.Host), 140)
+	blocks := slackHITLContentBlocks(title, "Path", path, ref.Message, ref.Summary)
 	guidance := runtime.HITLApprovalMessage(update.State, runtime.HITLApprovalEffectForOperationState(update.State), update.UpstreamCalled)
 	if strings.TrimSpace(guidance) != "" {
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": slackTrunc(guidance, 1000)}})
@@ -458,7 +461,7 @@ func slackOperationStatus(update runtime.HITLMessageUpdate) string {
 		return ":white_check_mark: Upstream request succeeded"
 	case runtime.HITLOperationStateUpstreamFailed:
 		if update.LastError != "" {
-			return ":x: Upstream request failed: " + slackTrunc(update.LastError, 300)
+			return ":x: Upstream request failed: " + slackTrunc(slackRedactStatusText(update.LastError), 300)
 		}
 		return ":x: Upstream request failed"
 	case runtime.HITLOperationStateDenied:
@@ -476,17 +479,41 @@ func slackPostJSON(ctx context.Context, endpoint, bot string, buf []byte, method
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	hreq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(buf))
-	if err != nil {
-		return err
+	var lastErr error
+	for attempt := 1; attempt <= 2; attempt++ {
+		hreq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(buf))
+		if err != nil {
+			return err
+		}
+		hreq.Header.Set("Authorization", "Bearer "+bot)
+		hreq.Header.Set("Content-Type", "application/json; charset=utf-8")
+		resp, err := slackHTTPClient.Do(hreq)
+		if err == nil {
+			lastErr = slackDecodeJSONResponse(resp, method)
+			if closeErr := resp.Body.Close(); lastErr == nil && closeErr != nil {
+				lastErr = closeErr
+			}
+		} else {
+			lastErr = err
+		}
+		if lastErr == nil {
+			return nil
+		}
+		if attempt == 2 || !slackShouldRetryPostMessage(resp, err) {
+			return lastErr
+		}
+		log.Printf("slack notify: %s failed on attempt %d, retrying once: %v", method, attempt, lastErr)
+		if err := slackWaitBeforeRetry(ctx, resp); err != nil {
+			return err
+		}
 	}
-	hreq.Header.Set("Authorization", "Bearer "+bot)
-	hreq.Header.Set("Content-Type", "application/json; charset=utf-8")
-	resp, err := slackHTTPClient.Do(hreq)
-	if err != nil {
-		return err
+	return lastErr
+}
+
+func slackDecodeJSONResponse(resp *http.Response, method string) error {
+	if resp == nil {
+		return fmt.Errorf("slack %s error: missing response", method)
 	}
-	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	var result struct {
 		OK    bool   `json:"ok"`
@@ -501,6 +528,23 @@ func slackPostJSON(ctx context.Context, endpoint, bot string, buf []byte, method
 		return fmt.Errorf("slack %s error: HTTP %d", method, resp.StatusCode)
 	}
 	return nil
+}
+
+var (
+	slackSensitiveQueryValue  = regexp.MustCompile(`(?i)([?&][^=]*(?:auth|token|secret|key|password|cookie)[^=]*=)[^&\s]+`)
+	slackSensitiveURLPath     = regexp.MustCompile(`(?i)(https?://hooks\.slack\.com/services/)[^\s,;]+`)
+	slackSensitivePathSegment = regexp.MustCompile(`(?i)(/(?:auth|token|secret|key|password|cookie)(?:/|=))[^/\s,;]+`)
+	slackAuthorizationValue   = regexp.MustCompile(`(?i)\b(authorization\s*[:=]\s*)(?:bearer|bot|basic)\s+[^\s,;]+`)
+	slackSensitiveHeaderValue = regexp.MustCompile(`(?i)\b([A-Za-z0-9-]*(?:auth|token|secret|key|password|cookie)[A-Za-z0-9-]*\s*[:=]\s*)([^\s,;]+)`)
+)
+
+func slackRedactStatusText(s string) string {
+	s = slackSensitiveQueryValue.ReplaceAllString(s, `${1}[redacted]`)
+	s = slackSensitiveURLPath.ReplaceAllString(s, `${1}[redacted]`)
+	s = slackSensitivePathSegment.ReplaceAllString(s, `${1}[redacted]`)
+	s = slackAuthorizationValue.ReplaceAllString(s, `${1}[redacted]`)
+	s = slackSensitiveHeaderValue.ReplaceAllString(s, `${1}[redacted]`)
+	return s
 }
 
 func hitlClassificationEmoji(c string) string {

--- a/internal/config/plugins/credentials/slack_update_test.go
+++ b/internal/config/plugins/credentials/slack_update_test.go
@@ -1,0 +1,145 @@
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func TestSlackNotifyHITLRecordsMessageRefForAsyncOperation(t *testing.T) {
+	var recordedOperationID, recordedRef string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer xoxb-test" {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1778764174.925659"}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackPostMessageURL
+	oldClient := slackHTTPClient
+	oldBackoff := slackNotifyRetryBackoff
+	slackPostMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	slackNotifyRetryBackoff = 0
+	defer func() {
+		slackPostMessageURL = oldURL
+		slackHTTPClient = oldClient
+		slackNotifyRetryBackoff = oldBackoff
+	}()
+
+	err := (&SlackTokens{}).NotifyHITL(context.Background(), runtime.ApproveRequest{
+		Secrets: testSecretStore{
+			"slack-approvals": {Extras: map[string]string{"bot": "xoxb-test"}},
+		},
+		AsyncOperationID: "op-123",
+		Method:           "POST",
+		Host:             "api.example.test",
+		Path:             "/v1/resources/update",
+	}, runtime.HITLTarget{
+		CredentialName: "slack-approvals",
+		Channel:        "C123",
+		PendingID:      "pending-123",
+		Interactive:    true,
+		MessageUpdateSink: func(_ context.Context, operationID, ref string) error {
+			recordedOperationID = operationID
+			recordedRef = ref
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyHITL returned error: %v", err)
+	}
+	if recordedOperationID != "op-123" {
+		t.Fatalf("recorded operation ID = %q", recordedOperationID)
+	}
+	ref, ok := decodeSlackMessageRef(recordedRef)
+	if !ok {
+		t.Fatalf("recorded ref did not decode: %q", recordedRef)
+	}
+	if ref.Credential != "slack-approvals" || ref.Channel != "C123" || ref.TS != "1778764174.925659" || ref.PendingID != "pending-123" || !ref.Interactive {
+		t.Fatalf("recorded ref = %#v", ref)
+	}
+}
+
+func TestSlackUpdateHITLMessageUsesChatUpdate(t *testing.T) {
+	var body struct {
+		Channel string           `json:"channel"`
+		TS      string           `json:"ts"`
+		Text    string           `json:"text"`
+		Blocks  []map[string]any `json:"blocks"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer xoxb-test" {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode chat.update payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackUpdateMessageURL
+	oldClient := slackHTTPClient
+	slackUpdateMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	defer func() {
+		slackUpdateMessageURL = oldURL
+		slackHTTPClient = oldClient
+	}()
+
+	ref := encodeSlackMessageRef(slackMessageRef{Credential: "slack-approvals", Channel: "C123", TS: "1778764174.925659", PendingID: "pending-123", Interactive: true})
+	err := (&SlackTokens{}).UpdateHITLMessage(context.Background(), testSecretStore{
+		"slack-approvals": {Extras: map[string]string{"bot": "xoxb-test"}},
+	}, runtime.HITLMessageUpdate{
+		MessageRef:     ref,
+		OperationID:    "op-123",
+		State:          runtime.HITLOperationStateUpstreamSucceeded,
+		Method:         "POST",
+		Host:           "api.example.test",
+		Path:           "/v1/resources/update",
+		UpstreamCalled: true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateHITLMessage returned error: %v", err)
+	}
+	if body.Channel != "C123" || body.TS != "1778764174.925659" {
+		t.Fatalf("chat.update target = %q/%q", body.Channel, body.TS)
+	}
+	buf, _ := json.Marshal(body.Blocks)
+	text := string(buf)
+	if !strings.Contains(text, "Upstream request succeeded") {
+		t.Fatalf("chat.update blocks = %s, want upstream success status", text)
+	}
+	if strings.Contains(text, "action_id") {
+		t.Fatalf("terminal chat.update should not keep action buttons: %s", text)
+	}
+}
+
+func TestSlackUpdateHITLMessageDoesNotAddButtonsForNonInteractivePrompt(t *testing.T) {
+	blocks := slackHITLUpdateBlocks(runtime.HITLMessageUpdate{
+		State:  runtime.HITLOperationStatePendingApproval,
+		Method: "POST",
+		Host:   "api.example.test",
+		Path:   "/v1/resources/update",
+	}, slackMessageRef{
+		Credential:  "slack-approvals",
+		Channel:     "C123",
+		TS:          "1778764174.925659",
+		PendingID:   "pending-123",
+		Interactive: false,
+	})
+	buf, _ := json.Marshal(blocks)
+	text := string(buf)
+	if strings.Contains(text, "action_id") || strings.Contains(text, "pending-123") {
+		t.Fatalf("non-interactive update should not introduce Slack buttons: %s", text)
+	}
+}

--- a/internal/config/plugins/credentials/slack_update_test.go
+++ b/internal/config/plugins/credentials/slack_update_test.go
@@ -68,6 +68,63 @@ func TestSlackNotifyHITLRecordsMessageRefForAsyncOperation(t *testing.T) {
 	}
 }
 
+func TestSlackNotifyHITLRecordsMessageOverrideForUpdates(t *testing.T) {
+	var recordedRef string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1778764174.925659"}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackPostMessageURL
+	oldClient := slackHTTPClient
+	oldBackoff := slackNotifyRetryBackoff
+	slackPostMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	slackNotifyRetryBackoff = 0
+	defer func() {
+		slackPostMessageURL = oldURL
+		slackHTTPClient = oldClient
+		slackNotifyRetryBackoff = oldBackoff
+	}()
+
+	customMessage := "deploying to prod, contact @oncall"
+	err := (&SlackTokens{}).NotifyHITL(context.Background(), runtime.ApproveRequest{
+		Secrets:          testSecretStore{"slack-approvals": {Extras: map[string]string{"bot": "xoxb-test"}}},
+		AsyncOperationID: "op-123",
+		Method:           "POST",
+		Host:             "api.example.test",
+		Path:             "/v1/resources/update",
+	}, runtime.HITLTarget{
+		CredentialName: "slack-approvals",
+		Channel:        "C123",
+		PendingID:      "pending-123",
+		Interactive:    true,
+		Message:        customMessage,
+		MessageUpdateSink: func(_ context.Context, _, ref string) error {
+			recordedRef = ref
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyHITL returned error: %v", err)
+	}
+	ref, ok := decodeSlackMessageRef(recordedRef)
+	if !ok {
+		t.Fatalf("recorded ref did not decode: %q", recordedRef)
+	}
+	blocks := slackHITLUpdateBlocks(runtime.HITLMessageUpdate{
+		State:  runtime.HITLOperationStateApprovedWaitingForRetry,
+		Method: "POST",
+		Host:   "api.example.test",
+		Path:   "/v1/resources/update",
+	}, ref)
+	buf, _ := json.Marshal(blocks)
+	if !strings.Contains(string(buf), customMessage) {
+		t.Fatalf("updated blocks lost custom message override: %s", buf)
+	}
+}
+
 func TestSlackUpdateHITLMessageUsesChatUpdate(t *testing.T) {
 	var body struct {
 		Channel string           `json:"channel"`
@@ -121,6 +178,70 @@ func TestSlackUpdateHITLMessageUsesChatUpdate(t *testing.T) {
 	}
 	if strings.Contains(text, "action_id") {
 		t.Fatalf("terminal chat.update should not keep action buttons: %s", text)
+	}
+}
+
+func TestSlackUpdateHITLMessageRetriesTransientChatUpdateFailure(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		if attempts == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"ratelimited"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackUpdateMessageURL
+	oldClient := slackHTTPClient
+	oldBackoff := slackNotifyRetryBackoff
+	slackUpdateMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	slackNotifyRetryBackoff = 0
+	defer func() {
+		slackUpdateMessageURL = oldURL
+		slackHTTPClient = oldClient
+		slackNotifyRetryBackoff = oldBackoff
+	}()
+
+	ref := encodeSlackMessageRef(slackMessageRef{Credential: "slack-approvals", Channel: "C123", TS: "1778764174.925659"})
+	err := (&SlackTokens{}).UpdateHITLMessage(context.Background(), testSecretStore{
+		"slack-approvals": {Extras: map[string]string{"bot": "xoxb-test"}},
+	}, runtime.HITLMessageUpdate{
+		MessageRef: ref,
+		State:      runtime.HITLOperationStateUpstreamSucceeded,
+		Method:     "POST",
+		Host:       "api.example.test",
+		Path:       "/v1/resources/update",
+	})
+	if err != nil {
+		t.Fatalf("UpdateHITLMessage returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("chat.update attempts = %d, want retry after transient failure", attempts)
+	}
+}
+
+func TestSlackUpdateHITLMessageRedactsSensitiveLastError(t *testing.T) {
+	blocks := slackHITLUpdateBlocks(runtime.HITLMessageUpdate{
+		State:     runtime.HITLOperationStateUpstreamFailed,
+		Method:    "POST",
+		Host:      "api.example.test",
+		Path:      "/v1/resources/update",
+		LastError: "upstream 500: https://api.example.test/v1/resources/update?api_key=sk-live-secret&ok=1 https://hooks.slack.com/services/T000/B000/path-secret Authorization: Bearer xoxb-real-token X-Api-Key: abc123",
+	}, slackMessageRef{Credential: "slack-approvals", Channel: "C123", TS: "1778764174.925659"})
+	buf, _ := json.Marshal(blocks)
+	text := string(buf)
+	for _, leaked := range []string{"sk-live-secret", "xoxb-real-token", "abc123", "path-secret"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("updated blocks leaked sensitive LastError value %q: %s", leaked, text)
+		}
+	}
+	if !strings.Contains(text, "api_key=[redacted]") || !strings.Contains(text, "Authorization: [redacted]") || !strings.Contains(text, "X-Api-Key: [redacted]") {
+		t.Fatalf("updated blocks did not show redacted placeholders: %s", text)
 	}
 }
 

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -311,6 +311,30 @@ type HITLNotifier interface {
 	NotifyHITL(ctx context.Context, req ApproveRequest, target HITLTarget) error
 }
 
+// HITLMessageUpdateSink records a channel-specific message reference
+// (for example Slack channel/ts) after a notifier posts a prompt.
+// Implementations must not store tokens or other secrets in ref.
+type HITLMessageUpdateSink func(ctx context.Context, operationID, ref string) error
+
+// HITLMessageUpdater is optionally implemented by notifier credentials that
+// can update an already-posted HITL prompt as the durable operation moves
+// through async states.
+type HITLMessageUpdater interface {
+	UpdateHITLMessage(ctx context.Context, secrets SecretStore, update HITLMessageUpdate) error
+}
+
+type HITLMessageUpdate struct {
+	MessageRef     string
+	OperationID    string
+	State          HITLOperationState
+	Method         string
+	Host           string
+	Path           string
+	Profile        string
+	UpstreamCalled bool
+	LastError      string
+}
+
 // HITLTarget is the per-approver config the notifier needs:
 // where to send the prompt, whether to render interactive buttons,
 // and the pending entry's id (for action_id payload encoding).
@@ -336,6 +360,9 @@ type HITLTarget struct {
 	// notifiers use it as the section text, overriding the default path
 	// display and the Summary card.
 	Message string
+	// MessageUpdateSink records a notifier-specific, non-secret message ref
+	// for async HITL operation status updates.
+	MessageUpdateSink HITLMessageUpdateSink
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.
@@ -405,6 +432,9 @@ type ApproveRequest struct {
 	// HumanApprover uses it to look up its referenced credential
 	// entity and dispatch via HITLNotifier.
 	Policy *config.CompiledPolicy
+	// MessageUpdateSink records channel message references for async HITL
+	// operation updates after notifiers successfully post prompts.
+	MessageUpdateSink HITLMessageUpdateSink
 }
 
 // ApproveVerdict is what an approver returns. "" Decision means the

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -323,6 +323,12 @@ type HITLMessageUpdater interface {
 	UpdateHITLMessage(ctx context.Context, secrets SecretStore, update HITLMessageUpdate) error
 }
 
+// HITLHumanCredentialer is implemented by approvers that route human HITL
+// prompts through a named credential notifier.
+type HITLHumanCredentialer interface {
+	HumanApproverCredential() string
+}
+
 type HITLMessageUpdate struct {
 	MessageRef     string
 	OperationID    string


### PR DESCRIPTION
## Summary
- Persist Slack `chat.postMessage` channel/ts references for async HITL operations without storing Slack tokens or secrets.
- Add a notifier update hook so async HITL state transitions refresh the original Slack prompt via `chat.update`.
- Keep Slack buttons tied to the original `interactive` setting and remove buttons from terminal state updates.

## Test plan
- `npm ci && npm run build` in `dashboard/`
- `go test ./internal/config/plugins/credentials ./cmd/clawpatrol`
- `go test ./...`
- `git diff --check`

## Review
- Independent pre-commit review initially found a non-interactive Slack prompt regression risk.
- Fixed by recording `interactive` in the non-secret Slack message ref and gating updated action buttons on that flag.
- Follow-up independent review verdict: `APPROVED_PREVIOUS_FINDINGS_FIXED`.
