### PR TITLE
join: pin resolv.conf on non-resolved hosts + dedupe v6 agent rows

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -456,7 +456,13 @@ func (g *Gateway) seedTsnetIPv6Alias(peerIP string) {
 		if !ip.Is6() {
 			continue
 		}
-		g.onboard.RegisterIPAlias(ip.String(), peerIP)
+		alias := ip.String()
+		g.onboard.RegisterIPAlias(alias, peerIP)
+		// Drop any ghost agent row that was seeded under the v6 before
+		// the alias landed — traffic now folds to the v4 parent.
+		if g.agents != nil {
+			g.agents.Delete(alias)
+		}
 	}
 }
 

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -76,7 +76,8 @@ type onboardRegistry struct {
 	ephemeralParentByIP  map[string]string // ephemeral IP → parent device IP
 	extV4ByIP            map[string]string
 	extV6ByIP            map[string]string
-	knownDeviceIPs       map[string]bool // all IPs present in devices table
+	canonicalByAlias     map[string]string // alias IP → canonical device IP (e.g. fd7a:115c:a1e0::… → 100.x.x.x)
+	knownDeviceIPs       map[string]bool   // all IPs present in devices table
 	db                   *sql.DB
 }
 
@@ -91,6 +92,7 @@ func newOnboardRegistry() *onboardRegistry {
 		ephemeralParentByIP:  map[string]string{},
 		extV4ByIP:            map[string]string{},
 		extV6ByIP:            map[string]string{},
+		canonicalByAlias:     map[string]string{},
 		knownDeviceIPs:       map[string]bool{},
 	}
 }
@@ -149,6 +151,7 @@ func (r *onboardRegistry) RegisterIPAlias(alias, canonical string) {
 	if p := r.profileByIP[canonical]; p != "" {
 		r.profileByIP[alias] = p
 	}
+	r.canonicalByAlias[alias] = canonical
 }
 
 // AssignProfile records that a peer IP belongs to a named profile.
@@ -189,6 +192,9 @@ func (r *onboardRegistry) AgentIPFor(ip string) string {
 	defer r.mu.Unlock()
 	if parent := r.ephemeralParentByIP[ip]; parent != "" {
 		return parent
+	}
+	if canonical := r.canonicalByAlias[ip]; canonical != "" {
+		return canonical
 	}
 	return ip
 }

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -342,13 +344,18 @@ func runLogin(args []string) {
 	// On Linux, `tailscale set` requires sudo unless --operator=$USER
 	// was passed to `tailscale up`. tsSet handles either case.
 	//
-	// Leave DNS to tailscaled (--accept-dns=true default). VIP-routed
-	// endpoint hostnames must be dialed by IP literal until there's a
-	// reconcile-safe DNS strategy.
 	if !*skipExitNode {
 		if err := tsSet(tscli, "--exit-node="+*gwName); err != nil {
 			fail("tailscale set --exit-node=%s: %v", *gwName, err)
 		}
+		// tsnet has no UDP fallback — outbound DNS from the client
+		// (e.g. resolv.conf nameserver 1.1.1.1) is silently dropped at
+		// the gateway's netstack. Hosts running systemd-resolved get
+		// away with it because their queries source-bind to a non-
+		// tailnet link; plain-resolv.conf hosts hang. Point DNS at the
+		// gateway's tsnet IP so queries hit serveTsnetDNSUDP instead.
+		// Skip when systemd-resolved is active.
+		pinDNSAtGatewayIfNeeded(peer.TailscaleIPs[0])
 	}
 
 	fmt.Println()
@@ -666,6 +673,46 @@ func manualTrustHint(caPath string) string {
 		return fmt.Sprintf("sudo cp %s /usr/local/share/ca-certificates/clawpatrol.crt && sudo update-ca-certificates", caPath)
 	}
 	return "manually add " + caPath + " to your system trust store"
+}
+
+// pinDNSAtGatewayIfNeeded writes /etc/resolv.conf → nameserver gwIP on
+// Linux hosts that don't run systemd-resolved. tsnet has no UDP
+// fallback, so client DNS to a public nameserver via the exit-node is
+// silently dropped at the gateway's netstack. Pointing the client at
+// the gateway routes queries through serveTsnetDNSUDP. Hosts running
+// systemd-resolved are already fine — their queries source-bind to
+// the physical link DNS and bypass the exit-node.
+func pinDNSAtGatewayIfNeeded(gwIP string) {
+	if runtime.GOOS != "linux" || gwIP == "" {
+		return
+	}
+	if exec.Command("systemctl", "is-active", "--quiet", "systemd-resolved").Run() == nil {
+		return
+	}
+	const path = "/etc/resolv.conf"
+	cur, _ := os.ReadFile(path)
+	desired := fmt.Sprintf("# clawpatrol: routed via Tailscale exit-node\nnameserver %s\n", gwIP)
+	if strings.Contains(string(cur), gwIP) && strings.Contains(string(cur), "clawpatrol:") {
+		return
+	}
+	if _, err := os.Stat(path + ".clawpatrol.bak"); errors.Is(err, os.ErrNotExist) && len(cur) > 0 {
+		_ = writeSudo(path+".clawpatrol.bak", cur)
+	}
+	if err := writeSudo(path, []byte(desired)); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ resolv.conf: %v\n", err)
+		return
+	}
+	fmt.Printf("DNS pinned to gateway (%s)\n", gwIP)
+}
+
+func writeSudo(path string, content []byte) error {
+	cmd := exec.Command("sudo", "tee", path)
+	cmd.Stdin = bytes.NewReader(content)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+	return nil
 }
 
 func defaultClawpatrolDir() string {


### PR DESCRIPTION
## Summary
Two fixes for whole-machine Tailscale clients:

**1. Plain-resolv.conf hosts hang after exit-node.** tsnet has no UDP fallback for outbound exit-node traffic — only `RegisterFallbackTCPHandler`. Client DNS (e.g. `nameserver 1.1.1.1`) silently drops at the gateway's netstack. Hosts running systemd-resolved bypass this because their queries source-bind to the physical link's DHCP DNS (dev2 path). Plain `/etc/resolv.conf` hosts (ops-bot, ephemeral VMs without resolved) hang every DNS query.

Detect that case in `runLogin` and write `/etc/resolv.conf` → `nameserver <gateway-tsnet-ip>`. Queries hit `serveTsnetDNSUDP` (no-self-relay fix from #457). Backup at `/etc/resolv.conf.clawpatrol.bak`; idempotent via marker line. Skipped when systemd-resolved is active.

**2. Duplicate v4 + v6 agent rows.** Whole-machine clients send traffic from both 100.x and fd7a:115c:a1e0::/48. `seedTsnetIPv6Alias` only mirrored profile mapping onto v6, not attribution. Dashboard showed two rows per device.

Add `canonicalByAlias` reverse map; `AgentIPFor` folds v6 → v4. Existing v6 ghost rows deleted at alias-registration time.

## Test plan
- [x] `go build ./...`, `go test ./cmd/clawpatrol/`
- [x] Manual on ops-bot: `nameserver 100.79.206.14` works; `curl https://github.com` 200
- [ ] Re-join from ops-bot, verify single agent row + working DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)