### PR TITLE
fix: delimit async HITL raw 202 responses

### DIFF
--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"time"
 
@@ -358,6 +359,8 @@ func writeHITLOperationAcceptedToConn(w io.Writer, op HITLOperation, publicURL s
 	writeHITLOperationAccepted(rr, op, publicURL)
 	resp := rr.Result()
 	defer func() { _ = resp.Body.Close() }()
+	resp.ContentLength = int64(rr.Body.Len())
+	resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
 	_ = resp.Write(w)
 }
 

--- a/cmd/clawpatrol/hitl_operation_api_test.go
+++ b/cmd/clawpatrol/hitl_operation_api_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -14,8 +17,8 @@ import (
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
 )
 
-func TestHITLOperationAcceptedResponseUsesConfiguredPublicURL(t *testing.T) {
-	now := time.Unix(1_700_001_000, 0).UTC()
+func TestHITLOperationAcceptedResponseIncludesPollingEnvelope(t *testing.T) {
+	now := time.Now().UTC()
 	op := HITLOperation{
 		ID:                "hitl_op_202",
 		State:             HITLOperationStatePendingApproval,
@@ -25,24 +28,64 @@ func TestHITLOperationAcceptedResponseUsesConfiguredPublicURL(t *testing.T) {
 	rr := httptest.NewRecorder()
 	writeHITLOperationAccepted(rr, op, "https://gateway.example.test/")
 
-	if rr.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want 202; body = %s", rr.Code, rr.Body.String())
+	assertHITLOperationAcceptedResponse(t, rr.Code, rr.Header(), rr.Body.Bytes(), op)
+}
+
+func TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody(t *testing.T) {
+	now := time.Now().UTC()
+	op := HITLOperation{
+		ID:                "hitl_op_202",
+		State:             HITLOperationStatePendingApproval,
+		ApprovalExpiresAt: now.Add(15 * time.Minute),
+	}
+
+	var raw bytes.Buffer
+	writeHITLOperationAcceptedToConn(&raw, op, "https://gateway.example.test/")
+	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(raw.Bytes())), nil)
+	if err != nil {
+		t.Fatalf("read raw response: %v\nraw response:\n%s", err, raw.String())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read raw response body: %v", err)
+	}
+
+	if resp.ContentLength <= 0 {
+		t.Fatalf("ContentLength = %d, want explicit positive Content-Length; raw response:\n%s", resp.ContentLength, raw.String())
+	}
+	if resp.ContentLength != int64(len(body)) {
+		t.Fatalf("ContentLength = %d, body length = %d", resp.ContentLength, len(body))
+	}
+	assertHITLOperationAcceptedResponse(t, resp.StatusCode, resp.Header, body, op)
+}
+
+func assertHITLOperationAcceptedResponse(t *testing.T, status int, header http.Header, bodyBytes []byte, op HITLOperation) {
+	t.Helper()
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", status, string(bodyBytes))
 	}
 	wantURL := "https://gateway.example.test/api/hitl/operations/hitl_op_202/status"
-	if got := rr.Header().Get("Location"); got != wantURL {
+	if got := header.Get("Location"); got != wantURL {
 		t.Fatalf("Location = %q, want %q", got, wantURL)
 	}
-	if got := rr.Header().Get("Retry-After"); got != "5" {
+	if got := header.Get("Retry-After"); got != "5" {
 		t.Fatalf("Retry-After = %q, want 5", got)
 	}
-	if got := rr.Header().Get("Clawpatrol-HITL-State"); got != string(HITLOperationStatePendingApproval) {
+	if got := header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	if got := header.Get("Clawpatrol-HITL-State"); got != string(HITLOperationStatePendingApproval) {
 		t.Fatalf("Clawpatrol-HITL-State = %q", got)
 	}
-	if got := rr.Header().Get("Clawpatrol-Upstream-Called"); got != "false" {
+	if got := header.Get("Clawpatrol-Upstream-Called"); got != "false" {
 		t.Fatalf("Clawpatrol-Upstream-Called = %q", got)
 	}
 
-	body := decodeJSONBody(t, rr)
+	var body map[string]any
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		t.Fatalf("decode json body: %v; body = %q", err, string(bodyBytes))
+	}
 	if body["operation_id"] != op.ID {
 		t.Fatalf("operation_id = %v, want %q", body["operation_id"], op.ID)
 	}


### PR DESCRIPTION
## Summary
- Add regression coverage for async HITL `202 Accepted` responses written directly to the HTTPS tunnel/raw connection path.
- Set an explicit `Content-Length` on that raw response so clients can read the JSON polling envelope (`operation_id`, `status_url`, etc.) without waiting for connection close.

## Test plan
- `deno install && deno task build` from `dashboard/`
- `go test ./cmd/clawpatrol -run 'TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody|TestHITLOperationAcceptedResponseIncludesPollingEnvelope' -count=1 -v`
- `go test ./cmd/clawpatrol -run 'TestHITL(OperationAccepted|AsyncApprovalGrantEndToEndHTTPFlow|OperationStatus|RetryRelay|RequestFingerprint|CredentialAuthBinding|Async)' -count=1`
- `go test ./cmd/clawpatrol -count=1`
- `go test ./...`
- `deno task format:check` from `dashboard/`
- `git diff --check`

## Notes
The bug was observable when an async HITL request over the HTTPS tunnel returned only headers to `curl` and then waited until timeout. The normal HTTP response helper already produced the polling JSON; the raw connection writer was missing an explicit message boundary.
