### PR TITLE
fix: write async HITL raw response atomically

### DIFF
--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"database/sql"
@@ -361,7 +362,12 @@ func writeHITLOperationAcceptedToConn(w io.Writer, op HITLOperation, publicURL s
 	defer func() { _ = resp.Body.Close() }()
 	resp.ContentLength = int64(rr.Body.Len())
 	resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
-	_ = resp.Write(w)
+
+	var raw bytes.Buffer
+	if err := resp.Write(&raw); err != nil {
+		return
+	}
+	_, _ = w.Write(raw.Bytes())
 }
 
 func hitlAsyncFailureReason(err error) string {

--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -352,9 +352,9 @@ func hitlCredentialGeneration(ctx context.Context, db *sql.DB, credentialID stri
 	return "env-or-empty:" + credentialID, nil
 }
 
-func writeHITLOperationAcceptedToConn(w io.Writer, op HITLOperation, publicURL string) {
+func writeHITLOperationAcceptedToConn(w io.Writer, op HITLOperation, publicURL string) error {
 	if w == nil {
-		return
+		return nil
 	}
 	rr := httptest.NewRecorder()
 	writeHITLOperationAccepted(rr, op, publicURL)
@@ -362,12 +362,14 @@ func writeHITLOperationAcceptedToConn(w io.Writer, op HITLOperation, publicURL s
 	defer func() { _ = resp.Body.Close() }()
 	resp.ContentLength = int64(rr.Body.Len())
 	resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
+	resp.Header.Set("Connection", "close")
 
 	var raw bytes.Buffer
 	if err := resp.Write(&raw); err != nil {
-		return
+		return err
 	}
-	_, _ = w.Write(raw.Bytes())
+	_, err := w.Write(raw.Bytes())
+	return err
 }
 
 func hitlAsyncFailureReason(err error) string {

--- a/cmd/clawpatrol/hitl_operation_api_test.go
+++ b/cmd/clawpatrol/hitl_operation_api_test.go
@@ -40,7 +40,9 @@ func TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody(t *testing.T) 
 	}
 
 	var raw bytes.Buffer
-	writeHITLOperationAcceptedToConn(&raw, op, "https://gateway.example.test/")
+	if err := writeHITLOperationAcceptedToConn(&raw, op, "https://gateway.example.test/"); err != nil {
+		t.Fatalf("write raw response: %v", err)
+	}
 	resp, body := parseRawHITLOperationAcceptedResponse(t, raw.Bytes())
 	defer func() { _ = resp.Body.Close() }()
 
@@ -62,7 +64,9 @@ func TestHITLOperationAcceptedRawConnResponseWritesCompleteEnvelopeInOnePayload(
 	}
 	w := &singleWriteRecorder{}
 
-	writeHITLOperationAcceptedToConn(w, op, "https://gateway.example.test/")
+	if err := writeHITLOperationAcceptedToConn(w, op, "https://gateway.example.test/"); err != nil {
+		t.Fatalf("write raw response: %v", err)
+	}
 	if w.writes != 1 {
 		t.Fatalf("writes = %d, want a single complete response write; raw response:\n%s", w.writes, w.buf.String())
 	}

--- a/cmd/clawpatrol/hitl_operation_api_test.go
+++ b/cmd/clawpatrol/hitl_operation_api_test.go
@@ -41,15 +41,8 @@ func TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody(t *testing.T) 
 
 	var raw bytes.Buffer
 	writeHITLOperationAcceptedToConn(&raw, op, "https://gateway.example.test/")
-	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(raw.Bytes())), nil)
-	if err != nil {
-		t.Fatalf("read raw response: %v\nraw response:\n%s", err, raw.String())
-	}
+	resp, body := parseRawHITLOperationAcceptedResponse(t, raw.Bytes())
 	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read raw response body: %v", err)
-	}
 
 	if resp.ContentLength <= 0 {
 		t.Fatalf("ContentLength = %d, want explicit positive Content-Length; raw response:\n%s", resp.ContentLength, raw.String())
@@ -58,6 +51,48 @@ func TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody(t *testing.T) 
 		t.Fatalf("ContentLength = %d, body length = %d", resp.ContentLength, len(body))
 	}
 	assertHITLOperationAcceptedResponse(t, resp.StatusCode, resp.Header, body, op)
+}
+
+func TestHITLOperationAcceptedRawConnResponseWritesCompleteEnvelopeInOnePayload(t *testing.T) {
+	now := time.Now().UTC()
+	op := HITLOperation{
+		ID:                "hitl_op_202",
+		State:             HITLOperationStatePendingApproval,
+		ApprovalExpiresAt: now.Add(15 * time.Minute),
+	}
+	w := &singleWriteRecorder{}
+
+	writeHITLOperationAcceptedToConn(w, op, "https://gateway.example.test/")
+	if w.writes != 1 {
+		t.Fatalf("writes = %d, want a single complete response write; raw response:\n%s", w.writes, w.buf.String())
+	}
+	resp, body := parseRawHITLOperationAcceptedResponse(t, w.buf.Bytes())
+	defer func() { _ = resp.Body.Close() }()
+	assertHITLOperationAcceptedResponse(t, resp.StatusCode, resp.Header, body, op)
+}
+
+func parseRawHITLOperationAcceptedResponse(t *testing.T, raw []byte) (*http.Response, []byte) {
+	t.Helper()
+	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(raw)), nil)
+	if err != nil {
+		t.Fatalf("read raw response: %v\nraw response:\n%s", err, string(raw))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("read raw response body: %v", err)
+	}
+	return resp, body
+}
+
+type singleWriteRecorder struct {
+	buf    bytes.Buffer
+	writes int
+}
+
+func (w *singleWriteRecorder) Write(p []byte) (int, error) {
+	w.writes++
+	return w.buf.Write(p)
 }
 
 func assertHITLOperationAcceptedResponse(t *testing.T, status int, header http.Header, bodyBytes []byte, op HITLOperation) {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2061,7 +2061,11 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 					} else {
 						asyncOp = updated
 					}
-					writeHITLOperationAcceptedToConn(tc, asyncOp, g.cfg.PublicURL)
+					_ = tc.SetWriteDeadline(time.Now().Add(10 * time.Second))
+					if err := writeHITLOperationAcceptedToConn(tc, asyncOp, g.cfg.PublicURL); err != nil {
+						log.Printf("hitl async pending response write %s: %v", asyncOp.ID, err)
+					}
+					_ = tc.SetWriteDeadline(time.Time{})
 					ev.Status = http.StatusAccepted
 					ev.Action = "hitl_async_pending"
 					ev.Approver = v.ApproverName


### PR DESCRIPTION
## Summary
- Follow up on #465 by serializing async HITL raw `202 Accepted` responses into a full in-memory HTTP response before writing to the tunnel connection.
- Add regression coverage that requires the raw response path to emit the complete polling envelope in a single write.

## Why
After #465 deployed, production showed `Content-Length` was now present, but `curl` still timed out with `0 out of 661 bytes received`. The raw response path was still using `http.Response.Write` directly on the tunnel writer, which can emit headers and body as many small writes. The observed shape (headers received, body never received before timeout) matches a partial/raw-write issue rather than a missing `Content-Length` issue.

## Test plan
- [x] `go test ./cmd/clawpatrol -run 'TestHITLOperationAcceptedRawConnResponseWritesCompleteEnvelopeInOnePayload|TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody|TestHITLOperationAcceptedResponseIncludesPollingEnvelope' -count=1 -v`
- [x] `go test ./cmd/clawpatrol -run 'TestHITL(OperationAccepted|AsyncApprovalGrantEndToEndHTTPFlow|OperationStatus|RetryRelay|RequestFingerprint|CredentialAuthBinding|Async)' -count=1`
- [x] `go test ./cmd/clawpatrol -count=1`
- [x] `go test ./...`
- [x] `(cd dashboard && deno task format:check)`
- [x] `gofmt -l .`
- [x] `git diff --check`
- [x] Independent read-only review: `APPROVED_NO_FINDINGS`
