### PR TITLE
feat: add async HITL status capability URLs

### DIFF
--- a/cmd/clawpatrol/hitl_async_e2e_test.go
+++ b/cmd/clawpatrol/hitl_async_e2e_test.go
@@ -49,14 +49,16 @@ func TestHITLAsyncApprovalGrantEndToEndHTTPFlow(t *testing.T) {
 	if accepted["upstream_called"] != false {
 		t.Fatalf("202 upstream_called = %v, want false", accepted["upstream_called"])
 	}
-	if accepted["status_url"] != "https://gateway.example.test/api/hitl/operations/"+operationID+"/status" {
-		t.Fatalf("status_url = %v, want public status URL for operation", accepted["status_url"])
+	statusURL, _ := accepted["status_url"].(string)
+	wantStatusURLPrefix := "https://gateway.example.test/api/hitl/operations/" + operationID + "/status?token="
+	if !strings.HasPrefix(statusURL, wantStatusURLPrefix) || strings.TrimPrefix(statusURL, wantStatusURLPrefix) == "" {
+		t.Fatalf("status_url = %v, want public operation-scoped capability URL with token", accepted["status_url"])
 	}
 	if _, ok := accepted["retry_header_name"]; ok {
 		t.Fatalf("initial 202 included retry_header_name before approval: %#v", accepted)
 	}
 
-	pendingStatus := h.pollStatus(t, operationID)
+	pendingStatus := h.pollStatusURL(t, statusURL)
 	if pendingStatus.Code != http.StatusOK {
 		t.Fatalf("pending status code = %d, body = %s", pendingStatus.Code, pendingStatus.Body.String())
 	}
@@ -86,7 +88,7 @@ func TestHITLAsyncApprovalGrantEndToEndHTTPFlow(t *testing.T) {
 	if !decision.OK || decision.State != runtime.HITLStateApproved {
 		t.Fatalf("approve result = %#v, want approved retry grant", decision)
 	}
-	approvedStatus := h.pollStatus(t, operationID)
+	approvedStatus := h.pollStatusURL(t, statusURL)
 	approvedBody := decodeJSONBody(t, approvedStatus)
 	if approvedBody["state"] != string(HITLOperationStateApprovedWaitingForRetry) {
 		t.Fatalf("status state after approval = %v, want %s", approvedBody["state"], HITLOperationStateApprovedWaitingForRetry)
@@ -110,7 +112,7 @@ func TestHITLAsyncApprovalGrantEndToEndHTTPFlow(t *testing.T) {
 		t.Fatalf("upstream received internal %s header = %q", hitlRetryOperationHeader, upstream.RetryOperationValue)
 	}
 
-	finalStatus := h.pollStatus(t, operationID)
+	finalStatus := h.pollStatusURL(t, statusURL)
 	finalBody := decodeJSONBody(t, finalStatus)
 	if finalBody["state"] != string(HITLOperationStateUpstreamSucceeded) {
 		t.Fatalf("final state = %v, want %s", finalBody["state"], HITLOperationStateUpstreamSucceeded)
@@ -283,9 +285,21 @@ func (h *hitlAsyncE2EHarness) sendMITMRequest(t *testing.T, method, operationID,
 
 func (h *hitlAsyncE2EHarness) pollStatus(t *testing.T, operationID string) *httptest.ResponseRecorder {
 	t.Helper()
+	return h.pollStatusRequest(t, "/api/hitl/operations/"+operationID+"/status", true)
+}
+
+func (h *hitlAsyncE2EHarness) pollStatusURL(t *testing.T, statusURL string) *httptest.ResponseRecorder {
+	t.Helper()
+	return h.pollStatusRequest(t, statusURL, false)
+}
+
+func (h *hitlAsyncE2EHarness) pollStatusRequest(t *testing.T, target string, withBearer bool) *httptest.ResponseRecorder {
+	t.Helper()
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/hitl/operations/"+operationID+"/status", nil)
-	req.Header.Set("Authorization", "Bearer "+h.token)
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	if withBearer {
+		req.Header.Set("Authorization", "Bearer "+h.token)
+	}
 	h.handler.ServeHTTP(rr, req)
 	return rr
 }

--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -175,6 +175,7 @@ func (g *Gateway) transitionAsyncHITLOperation(ctx context.Context, op HITLOpera
 	if err != nil {
 		return HITLOperation{}, err
 	}
+	updated.StatusToken = op.StatusToken
 	g.updateHITLOperationMessage(context.Background(), updated)
 	return updated, nil
 }

--- a/cmd/clawpatrol/hitl_operation_api_test.go
+++ b/cmd/clawpatrol/hitl_operation_api_test.go
@@ -213,6 +213,42 @@ func TestHITLOperationStatusEndpointFallsBackToBearerWhenCapabilityTokenIsWrong(
 	}
 }
 
+func TestHITLOperationStatusFunnelRejectsPeerAPIBearerFallback(t *testing.T) {
+	h := newHITLOperationAPITestHarness(t)
+	op := h.createOperation(t, HITLOperationCreate{ID: "hitl_op_funnel_bearer_rejected", State: HITLOperationStatePendingApproval})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/hitl/operations/"+op.ID+"/status?token=wrong-token", nil)
+	req.Header.Set("Authorization", "Bearer "+h.ownerToken)
+	h.funnelHandler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", rr.Code, rr.Body.String())
+	}
+	body := decodeJSONBody(t, rr)
+	if body["error"] != "hitl_operation_not_found" {
+		t.Fatalf("error = %v, want hitl_operation_not_found; body = %#v", body["error"], body)
+	}
+}
+
+func TestHITLOperationStatusFunnelAcceptsCapabilityTokenEvenWithBearer(t *testing.T) {
+	h := newHITLOperationAPITestHarness(t)
+	op := h.createOperation(t, HITLOperationCreate{ID: "hitl_op_funnel_capability", State: HITLOperationStatePendingApproval})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/hitl/operations/"+op.ID+"/status?token="+op.StatusToken, nil)
+	req.Header.Set("Authorization", "Bearer "+h.ownerToken)
+	h.funnelHandler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	body := decodeJSONBody(t, rr)
+	if body["operation_id"] != op.ID {
+		t.Fatalf("operation_id = %v, want %q", body["operation_id"], op.ID)
+	}
+}
+
 func TestHITLOperationStatusRequiresPeerAPIToken(t *testing.T) {
 	h := newHITLOperationAPITestHarness(t)
 	op := h.createOperation(t, HITLOperationCreate{ID: "hitl_op_requires_auth", State: HITLOperationStatePendingApproval})
@@ -479,10 +515,11 @@ func TestHITLOperationStatusEndpointDoesNotExposeReplayableMaterial(t *testing.T
 }
 
 type hitlOperationAPITestHarness struct {
-	handler    http.Handler
-	store      *HITLOperationStore
-	ownerToken string
-	otherToken string
+	handler       http.Handler
+	funnelHandler http.Handler
+	store         *HITLOperationStore
+	ownerToken    string
+	otherToken    string
 }
 
 func newHITLOperationAPITestHarness(t *testing.T) hitlOperationAPITestHarness {
@@ -506,10 +543,11 @@ func newHITLOperationAPITestHarness(t *testing.T) hitlOperationAPITestHarness {
 	g := &Gateway{cfg: gwCfg, db: db, onboard: newOnboardRegistry()}
 	w := newWebMux(g, gwCfg.Join(), gwCfg.PublicURL)
 	return hitlOperationAPITestHarness{
-		handler:    w,
-		store:      NewHITLOperationStore(db),
-		ownerToken: ownerToken,
-		otherToken: otherToken,
+		handler:       w,
+		funnelHandler: funnelPublicHandler(w),
+		store:         NewHITLOperationStore(db),
+		ownerToken:    ownerToken,
+		otherToken:    otherToken,
 	}
 }
 

--- a/cmd/clawpatrol/hitl_operation_api_test.go
+++ b/cmd/clawpatrol/hitl_operation_api_test.go
@@ -22,6 +22,7 @@ func TestHITLOperationAcceptedResponseIncludesPollingEnvelope(t *testing.T) {
 	op := HITLOperation{
 		ID:                "hitl_op_202",
 		State:             HITLOperationStatePendingApproval,
+		StatusToken:       "status-token-202",
 		ApprovalExpiresAt: now.Add(15 * time.Minute),
 	}
 
@@ -36,6 +37,7 @@ func TestHITLOperationAcceptedRawConnResponseHasDelimitedJSONBody(t *testing.T) 
 	op := HITLOperation{
 		ID:                "hitl_op_202",
 		State:             HITLOperationStatePendingApproval,
+		StatusToken:       "status-token-202",
 		ApprovalExpiresAt: now.Add(15 * time.Minute),
 	}
 
@@ -60,6 +62,7 @@ func TestHITLOperationAcceptedRawConnResponseWritesCompleteEnvelopeInOnePayload(
 	op := HITLOperation{
 		ID:                "hitl_op_202",
 		State:             HITLOperationStatePendingApproval,
+		StatusToken:       "status-token-202",
 		ApprovalExpiresAt: now.Add(15 * time.Minute),
 	}
 	w := &singleWriteRecorder{}
@@ -104,7 +107,7 @@ func assertHITLOperationAcceptedResponse(t *testing.T, status int, header http.H
 	if status != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202; body = %s", status, string(bodyBytes))
 	}
-	wantURL := "https://gateway.example.test/api/hitl/operations/hitl_op_202/status"
+	wantURL := "https://gateway.example.test/api/hitl/operations/hitl_op_202/status?token=status-token-202"
 	if got := header.Get("Location"); got != wantURL {
 		t.Fatalf("Location = %q, want %q", got, wantURL)
 	}
@@ -139,6 +142,74 @@ func assertHITLOperationAcceptedResponse(t *testing.T, status int, header http.H
 	}
 	if msg, _ := body["message"].(string); !strings.Contains(msg, "upstream service") || !strings.Contains(msg, "status_url") {
 		t.Fatalf("message is not useful agent guidance: %q", msg)
+	}
+}
+
+func TestHITLOperationStatusEndpointAcceptsOperationScopedCapabilityToken(t *testing.T) {
+	h := newHITLOperationAPITestHarness(t)
+	op := h.createOperation(t, HITLOperationCreate{ID: "hitl_op_capability", State: HITLOperationStatePendingApproval})
+	if op.StatusToken == "" {
+		t.Fatalf("created operation did not expose a status token for the initial 202 response")
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/hitl/operations/"+op.ID+"/status?token="+op.StatusToken, nil)
+	h.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if got := rr.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q, want no-referrer", got)
+	}
+	body := decodeJSONBody(t, rr)
+	if body["operation_id"] != op.ID {
+		t.Fatalf("operation_id = %v, want %q", body["operation_id"], op.ID)
+	}
+	wantStatusURL := "https://gateway.example.test/api/hitl/operations/" + op.ID + "/status?token=" + op.StatusToken
+	if body["status_url"] != wantStatusURL {
+		t.Fatalf("status_url = %v, want %q", body["status_url"], wantStatusURL)
+	}
+}
+
+func TestHITLOperationStatusEndpointRejectsWrongCapabilityToken(t *testing.T) {
+	h := newHITLOperationAPITestHarness(t)
+	op := h.createOperation(t, HITLOperationCreate{ID: "hitl_op_wrong_capability", State: HITLOperationStatePendingApproval})
+
+	for _, path := range []string{
+		"/api/hitl/operations/" + op.ID + "/status?token=wrong-token",
+		"/api/hitl/operations/hitl_op_missing/status?token=" + op.StatusToken,
+	} {
+		t.Run(path, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			h.handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404; body = %s", rr.Code, rr.Body.String())
+			}
+			body := decodeJSONBody(t, rr)
+			if body["error"] != "hitl_operation_not_found" {
+				t.Fatalf("error = %v, want hitl_operation_not_found; body = %#v", body["error"], body)
+			}
+		})
+	}
+}
+
+func TestHITLOperationStatusEndpointFallsBackToBearerWhenCapabilityTokenIsWrong(t *testing.T) {
+	h := newHITLOperationAPITestHarness(t)
+	op := h.createOperation(t, HITLOperationCreate{ID: "hitl_op_bearer_fallback", State: HITLOperationStatePendingApproval})
+
+	rr := h.pollPath(t, "/api/hitl/operations/"+op.ID+"/status?token=wrong-token", h.ownerToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 via bearer fallback; body = %s", rr.Code, rr.Body.String())
+	}
+	body := decodeJSONBody(t, rr)
+	if body["operation_id"] != op.ID {
+		t.Fatalf("operation_id = %v, want %q", body["operation_id"], op.ID)
 	}
 }
 
@@ -559,8 +630,13 @@ func applyHITLOperationCreateOverrides(base *HITLOperationCreate, overrides HITL
 
 func (h hitlOperationAPITestHarness) poll(t *testing.T, operationID, token string) *httptest.ResponseRecorder {
 	t.Helper()
+	return h.pollPath(t, "/api/hitl/operations/"+operationID+"/status", token)
+}
+
+func (h hitlOperationAPITestHarness) pollPath(t *testing.T, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/hitl/operations/"+operationID+"/status", nil)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	h.handler.ServeHTTP(rr, req)
 	return rr

--- a/cmd/clawpatrol/hitl_operation_store.go
+++ b/cmd/clawpatrol/hitl_operation_store.go
@@ -55,6 +55,8 @@ type HITLOperationCreate struct {
 	FingerprintVersion  string
 	HMACKeyID           string
 	RequestFingerprint  string
+	StatusToken         string
+	StatusTokenHash     string
 	CreatedAt           time.Time
 	SyncWaitDeadline    time.Time
 	ApprovalExpiresAt   time.Time
@@ -113,6 +115,8 @@ type HITLOperation struct {
 	FingerprintVersion         string
 	HMACKeyID                  string
 	RequestFingerprint         string
+	StatusToken                string
+	StatusTokenHash            string
 	CreatedAt                  time.Time
 	SyncWaitDeadline           time.Time
 	ApprovalExpiresAt          time.Time
@@ -142,6 +146,15 @@ func (s *HITLOperationStore) Create(ctx context.Context, in HITLOperationCreate)
 	if in.State == "" {
 		in.State = HITLOperationStateSyncWaiting
 	}
+	if in.StatusToken == "" && in.StatusTokenHash == "" {
+		var err error
+		in.StatusToken, in.StatusTokenHash, err = mintHITLOperationStatusToken()
+		if err != nil {
+			return HITLOperation{}, err
+		}
+	} else if in.StatusTokenHash == "" {
+		in.StatusTokenHash = hashHITLOperationStatusToken(in.StatusToken)
+	}
 	if err := validateHITLOperationCreate(in); err != nil {
 		return HITLOperation{}, err
 	}
@@ -150,19 +163,24 @@ INSERT INTO hitl_operations (
   id, state, version,
   profile_id, principal_id, endpoint_id, approval_rule_id, approver_id,
   method, scheme, host, redacted_path, redacted_query, redacted_headers_json,
-  auth_binding_id, fingerprint_version, hmac_key_id, request_fingerprint,
+  auth_binding_id, fingerprint_version, hmac_key_id, request_fingerprint, status_token_hash,
   created_ns, sync_wait_deadline_ns, approval_expires_ns, retry_expires_ns
-) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		in.ID, string(in.State),
 		in.ProfileID, in.PrincipalID, in.EndpointID, in.ApprovalRuleID, in.ApproverID,
 		in.Method, in.Scheme, in.Host, in.RedactedPath, nullString(in.RedactedQuery), nullString(in.RedactedHeadersJSON),
-		in.AuthBindingID, in.FingerprintVersion, in.HMACKeyID, in.RequestFingerprint,
+		in.AuthBindingID, in.FingerprintVersion, in.HMACKeyID, in.RequestFingerprint, in.StatusTokenHash,
 		timeNS(in.CreatedAt), timeNS(in.SyncWaitDeadline), timeNS(in.ApprovalExpiresAt), nullTimeNS(in.RetryExpiresAt),
 	)
 	if err != nil {
 		return HITLOperation{}, err
 	}
-	return s.get(ctx, in.ID)
+	op, err := s.get(ctx, in.ID)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	op.StatusToken = in.StatusToken
+	return op, nil
 }
 
 func (s *HITLOperationStore) GetForPrincipal(ctx context.Context, id, profileID, principalID string) (HITLOperation, error) {
@@ -170,6 +188,23 @@ func (s *HITLOperationStore) GetForPrincipal(ctx context.Context, id, profileID,
 		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
 	}
 	return s.scanOne(ctx, `SELECT `+hitlOperationColumns+` FROM hitl_operations WHERE id = ? AND profile_id = ? AND principal_id = ?`, id, profileID, principalID)
+}
+
+func (s *HITLOperationStore) GetForStatusToken(ctx context.Context, id, token string) (HITLOperation, error) {
+	if s == nil || s.db == nil {
+		return HITLOperation{}, fmt.Errorf("%w: nil store", ErrHITLOperationStoreInvalid)
+	}
+	if id == "" || token == "" {
+		return HITLOperation{}, ErrHITLOperationNotFound
+	}
+	op, err := s.get(ctx, id)
+	if err != nil {
+		return HITLOperation{}, err
+	}
+	if !verifyHITLOperationStatusTokenHash(token, op.StatusTokenHash) {
+		return HITLOperation{}, ErrHITLOperationNotFound
+	}
+	return op, nil
 }
 
 func (s *HITLOperationStore) SetApproverMessageRef(ctx context.Context, id, ref string) (HITLOperation, error) {
@@ -420,7 +455,7 @@ const hitlOperationColumns = `
 id, state, version,
 profile_id, principal_id, endpoint_id, approval_rule_id, approver_id,
 method, scheme, host, redacted_path, redacted_query, redacted_headers_json,
-auth_binding_id, fingerprint_version, hmac_key_id, request_fingerprint,
+auth_binding_id, fingerprint_version, hmac_key_id, request_fingerprint, status_token_hash,
 created_ns, sync_wait_deadline_ns, approval_expires_ns, retry_expires_ns,
 expired_reason, terminal_ns, terminal_retention_expires_ns,
 upstream_called, grant_consumed_ns, grant_consumed_by, approver_message_ref, dashboard_ref, last_error`
@@ -436,13 +471,14 @@ func (s *HITLOperationStore) scanOne(ctx context.Context, query string, args ...
 	var redactedQuery, redactedHeaders sql.NullString
 	var retryExpiresNS, terminalNS, terminalRetentionNS, grantConsumedNS sql.NullInt64
 	var expiredReason, grantConsumedBy, approverMessageRef, dashboardRef, lastError sql.NullString
+	var statusTokenHash sql.NullString
 	var upstreamCalled int
 	var createdNS, syncWaitDeadlineNS, approvalExpiresNS int64
 	err := row.Scan(
 		&op.ID, &state, &op.Version,
 		&op.ProfileID, &op.PrincipalID, &op.EndpointID, &op.ApprovalRuleID, &op.ApproverID,
 		&op.Method, &op.Scheme, &op.Host, &op.RedactedPath, &redactedQuery, &redactedHeaders,
-		&op.AuthBindingID, &op.FingerprintVersion, &op.HMACKeyID, &op.RequestFingerprint,
+		&op.AuthBindingID, &op.FingerprintVersion, &op.HMACKeyID, &op.RequestFingerprint, &statusTokenHash,
 		&createdNS, &syncWaitDeadlineNS, &approvalExpiresNS, &retryExpiresNS,
 		&expiredReason, &terminalNS, &terminalRetentionNS,
 		&upstreamCalled, &grantConsumedNS, &grantConsumedBy, &approverMessageRef, &dashboardRef, &lastError,
@@ -456,6 +492,7 @@ func (s *HITLOperationStore) scanOne(ctx context.Context, query string, args ...
 	op.State = HITLOperationState(state)
 	op.RedactedQuery = redactedQuery.String
 	op.RedactedHeadersJSON = redactedHeaders.String
+	op.StatusTokenHash = statusTokenHash.String
 	op.CreatedAt = timeFromNS(createdNS)
 	op.SyncWaitDeadline = timeFromNS(syncWaitDeadlineNS)
 	op.ApprovalExpiresAt = timeFromNS(approvalExpiresNS)
@@ -488,6 +525,7 @@ func validateHITLOperationCreate(in HITLOperationCreate) error {
 		"fingerprint_version": in.FingerprintVersion,
 		"hmac_key_id":         in.HMACKeyID,
 		"request_fingerprint": in.RequestFingerprint,
+		"status_token_hash":   in.StatusTokenHash,
 	} {
 		if value == "" {
 			return fmt.Errorf("%w: missing %s", ErrHITLOperationStoreInvalid, name)

--- a/cmd/clawpatrol/hitl_operation_store.go
+++ b/cmd/clawpatrol/hitl_operation_store.go
@@ -97,24 +97,28 @@ type HITLOperationMaintenanceResult struct {
 }
 
 type HITLOperation struct {
-	ID                         string
-	State                      HITLOperationState
-	Version                    int64
-	ProfileID                  string
-	PrincipalID                string
-	EndpointID                 string
-	ApprovalRuleID             string
-	ApproverID                 string
-	Method                     string
-	Scheme                     string
-	Host                       string
-	RedactedPath               string
-	RedactedQuery              string
-	RedactedHeadersJSON        string
-	AuthBindingID              string
-	FingerprintVersion         string
-	HMACKeyID                  string
-	RequestFingerprint         string
+	ID                  string
+	State               HITLOperationState
+	Version             int64
+	ProfileID           string
+	PrincipalID         string
+	EndpointID          string
+	ApprovalRuleID      string
+	ApproverID          string
+	Method              string
+	Scheme              string
+	Host                string
+	RedactedPath        string
+	RedactedQuery       string
+	RedactedHeadersJSON string
+	AuthBindingID       string
+	FingerprintVersion  string
+	HMACKeyID           string
+	RequestFingerprint  string
+	// StatusToken is the raw operation-scoped capability token. It is only
+	// populated on the operation returned from Create or when explicitly
+	// threaded through runtime transitions before the initial 202 response;
+	// fresh store reads intentionally populate only StatusTokenHash.
 	StatusToken                string
 	StatusTokenHash            string
 	CreatedAt                  time.Time

--- a/cmd/clawpatrol/hitl_operation_store_test.go
+++ b/cmd/clawpatrol/hitl_operation_store_test.go
@@ -79,6 +79,13 @@ func TestHITLOperationStoreCreatesMetadataOnlyOperation(t *testing.T) {
 	if _, err := store.GetForStatusToken(ctx, created.ID, "wrong-status-token"); !errors.Is(err, ErrHITLOperationNotFound) {
 		t.Fatalf("GetForStatusToken(wrong) err = %v, want ErrHITLOperationNotFound", err)
 	}
+	var redundantIndexes int
+	if err := db.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'hitl_operations_status_token_idx'`).Scan(&redundantIndexes); err != nil {
+		t.Fatalf("query status token indexes: %v", err)
+	}
+	if redundantIndexes != 0 {
+		t.Fatalf("hitl_operations_status_token_idx exists but id is already primary key and status token lookups verify by id in Go")
+	}
 
 	for _, tc := range []struct {
 		name      string

--- a/cmd/clawpatrol/hitl_operation_store_test.go
+++ b/cmd/clawpatrol/hitl_operation_store_test.go
@@ -64,6 +64,21 @@ func TestHITLOperationStoreCreatesMetadataOnlyOperation(t *testing.T) {
 	if loaded.RedactedQuery != "?account=[redacted]" {
 		t.Fatalf("RedactedQuery = %q", loaded.RedactedQuery)
 	}
+	if created.StatusToken == "" {
+		t.Fatalf("created operation did not return raw status token")
+	}
+	if loaded.StatusToken != "" {
+		t.Fatalf("loaded StatusToken = %q, want empty because raw token must not be persisted", loaded.StatusToken)
+	}
+	if loaded.StatusTokenHash == "" || loaded.StatusTokenHash == created.StatusToken {
+		t.Fatalf("loaded StatusTokenHash = %q, want non-empty hash distinct from raw token", loaded.StatusTokenHash)
+	}
+	if got, err := store.GetForStatusToken(ctx, created.ID, created.StatusToken); err != nil || got.ID != created.ID {
+		t.Fatalf("GetForStatusToken(valid) = (%#v, %v), want operation %q", got, err, created.ID)
+	}
+	if _, err := store.GetForStatusToken(ctx, created.ID, "wrong-status-token"); !errors.Is(err, ErrHITLOperationNotFound) {
+		t.Fatalf("GetForStatusToken(wrong) err = %v, want ErrHITLOperationNotFound", err)
+	}
 
 	for _, tc := range []struct {
 		name      string

--- a/cmd/clawpatrol/hitl_status_tokens.go
+++ b/cmd/clawpatrol/hitl_status_tokens.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+)
+
+func mintHITLOperationStatusToken() (string, string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", "", fmt.Errorf("mint hitl status token: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw[:])
+	return token, hashHITLOperationStatusToken(token), nil
+}
+
+func hashHITLOperationStatusToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func verifyHITLOperationStatusTokenHash(token, expectedHash string) bool {
+	if token == "" || expectedHash == "" {
+		return false
+	}
+	candidateHash := hashHITLOperationStatusToken(token)
+	return subtle.ConstantTimeCompare([]byte(candidateHash), []byte(expectedHash)) == 1
+}

--- a/cmd/clawpatrol/migrations/sqlite/0018_hitl_operation_status_tokens.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0018_hitl_operation_status_tokens.sql
@@ -1,0 +1,11 @@
+-- Operation-scoped capability token hashes for public async HITL status polling.
+-- Raw status tokens are returned only in the initial 202 status_url and are
+-- never persisted.
+
+ALTER TABLE hitl_operations ADD COLUMN status_token_hash TEXT;
+
+CREATE UNIQUE INDEX hitl_operations_status_token_idx
+  ON hitl_operations(id, status_token_hash)
+  WHERE status_token_hash IS NOT NULL;
+
+INSERT INTO _schema (version) VALUES (18);

--- a/cmd/clawpatrol/migrations/sqlite/0018_hitl_operation_status_tokens.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0018_hitl_operation_status_tokens.sql
@@ -4,8 +4,4 @@
 
 ALTER TABLE hitl_operations ADD COLUMN status_token_hash TEXT;
 
-CREATE UNIQUE INDEX hitl_operations_status_token_idx
-  ON hitl_operations(id, status_token_hash)
-  WHERE status_token_hash IS NOT NULL;
-
 INSERT INTO _schema (version) VALUES (18);

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -144,14 +144,25 @@ func startFunnelListener(s *tsnet.Server, mux http.Handler) {
 		return
 	}
 	log.Printf("tsnet: Funnel listening on :443 — allowlist: /api/onboard/{start,poll,claim}, /api/cred/*, /api/hitl/operations/*/status")
-	filtered := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	go func() { _ = http.Serve(ln, funnelPublicHandler(mux)) }()
+}
+
+type funnelPublicRequestContextKey struct{}
+
+func funnelPublicHandler(mux http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if funnelAllowsPublicPath(r.URL.Path) {
-			mux.ServeHTTP(rw, r)
+			ctx := context.WithValue(r.Context(), funnelPublicRequestContextKey{}, true)
+			mux.ServeHTTP(rw, r.WithContext(ctx))
 			return
 		}
 		http.NotFound(rw, r)
 	})
-	go func() { _ = http.Serve(ln, filtered) }()
+}
+
+func isFunnelPublicRequest(ctx context.Context) bool {
+	fromFunnel, _ := ctx.Value(funnelPublicRequestContextKey{}).(bool)
+	return fromFunnel
 }
 
 func funnelAllowsPublicPath(path string) bool {

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -131,6 +131,9 @@ func openListener(cfg *config.Gateway, stateDir string) (*tsnet.Server, net.List
 //     identity at that point).
 //   - /api/cred/*: signed/HMAC'd credential webhooks (OAuth callbacks
 //     from Notion/GitHub/etc.) which arrive from external providers.
+//   - /api/hitl/operations/*/status: operation-scoped capability URLs
+//     returned in async HITL 202 responses so off-tailnet agents can poll
+//     without exposing their peer API bearer token.
 //
 // Everything else (dashboard, /api/onboard/approve, lookup, peer APIs,
 // env-pushdown, /ca.crt) is reachable only over the tailnet.
@@ -140,21 +143,27 @@ func startFunnelListener(s *tsnet.Server, mux http.Handler) {
 		log.Printf("tsnet: funnel :443: %v (join/webhook endpoints not internet-reachable; enable Funnel for this node in the Tailscale admin console)", err)
 		return
 	}
-	allowed := map[string]bool{
-		"/api/onboard/start": true,
-		"/api/onboard/poll":  true,
-		"/api/onboard/claim": true,
-	}
-	log.Printf("tsnet: Funnel listening on :443 — allowlist: /api/onboard/{start,poll,claim}, /api/cred/*")
+	log.Printf("tsnet: Funnel listening on :443 — allowlist: /api/onboard/{start,poll,claim}, /api/cred/*, /api/hitl/operations/*/status")
 	filtered := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		p := r.URL.Path
-		if allowed[p] || strings.HasPrefix(p, "/api/cred/") {
+		if funnelAllowsPublicPath(r.URL.Path) {
 			mux.ServeHTTP(rw, r)
 			return
 		}
 		http.NotFound(rw, r)
 	})
 	go func() { _ = http.Serve(ln, filtered) }()
+}
+
+func funnelAllowsPublicPath(path string) bool {
+	switch path {
+	case "/api/onboard/start", "/api/onboard/poll", "/api/onboard/claim":
+		return true
+	}
+	if strings.HasPrefix(path, "/api/cred/") {
+		return true
+	}
+	_, ok := hitlOperationIDFromStatusPath(path)
+	return ok
 }
 
 // tsnetCertDomain returns the first HTTPS cert domain for the embedded

--- a/cmd/clawpatrol/tailscale_funnel_test.go
+++ b/cmd/clawpatrol/tailscale_funnel_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestFunnelAllowlistIncludesOnlyPublicBootstrapWebhookAndHITLStatus(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{path: "/api/onboard/start", want: true},
+		{path: "/api/onboard/poll", want: true},
+		{path: "/api/onboard/claim", want: true},
+		{path: "/api/cred/slack/interactive", want: true},
+		{path: "/api/hitl/operations/hitl_op_test/status", want: true},
+		{path: "/api/hitl/operations/hitl_op_test/status/extra", want: false},
+		{path: "/api/hitl/pending", want: false},
+		{path: "/api/hitl/decide", want: false},
+		{path: "/api/config", want: false},
+		{path: "/api/onboard/approve", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := funnelAllowsPublicPath(tc.path); got != tc.want {
+				t.Fatalf("funnelAllowsPublicPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -748,21 +748,44 @@ func (w *webMux) apiHITLOperationStatus(rw http.ResponseWriter, r *http.Request)
 		http.Error(rw, http.MethodGet, http.StatusMethodNotAllowed)
 		return
 	}
-	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
-	peerIP := peerIPForAPIToken(w.g.db, token)
-	if peerIP == "" {
-		http.Error(rw, "unknown or missing peer api token", http.StatusUnauthorized)
-		return
+	store := NewHITLOperationStore(w.g.db)
+	var op HITLOperation
+	var err error
+	statusToken := r.URL.Query().Get("token")
+	if statusToken != "" {
+		operationID, ok := hitlOperationIDFromStatusPath(r.URL.Path)
+		if !ok {
+			writeHITLOperationNotFound(rw)
+			return
+		}
+		op, err = store.GetForStatusToken(r.Context(), operationID, statusToken)
+		if err == nil {
+			op.StatusToken = statusToken
+		} else if !errors.Is(err, ErrHITLOperationNotFound) {
+			log.Printf("hitl operation status %s: %v", operationID, err)
+			http.Error(rw, "failed to load HITL operation", http.StatusInternalServerError)
+			return
+		} else if bearerFromAuthHeader(r.Header.Get("Authorization")) == "" {
+			writeHITLOperationNotFound(rw)
+			return
+		}
 	}
-
-	operationID, ok := hitlOperationIDFromStatusPath(r.URL.Path)
-	if !ok {
-		writeHITLOperationNotFound(rw)
-		return
+	if op.ID == "" {
+		token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+		peerIP := peerIPForAPIToken(w.g.db, token)
+		if peerIP == "" {
+			http.Error(rw, "unknown or missing peer api token", http.StatusUnauthorized)
+			return
+		}
+		operationID, ok := hitlOperationIDFromStatusPath(r.URL.Path)
+		if !ok {
+			writeHITLOperationNotFound(rw)
+			return
+		}
+		profileID := w.g.profileFor(peerIP)
+		principalID := hitlPeerPrincipalID(peerIP)
+		op, err = store.GetForPrincipal(r.Context(), operationID, profileID, principalID)
 	}
-	profileID := w.g.profileFor(peerIP)
-	principalID := hitlPeerPrincipalID(peerIP)
-	op, err := NewHITLOperationStore(w.g.db).GetForPrincipal(r.Context(), operationID, profileID, principalID)
 	if errors.Is(err, ErrHITLOperationNotFound) {
 		writeHITLOperationNotFound(rw)
 		return
@@ -807,20 +830,22 @@ func hitlPeerPrincipalID(peerIP string) string {
 }
 
 func writeHITLOperationAccepted(rw http.ResponseWriter, op HITLOperation, publicURL string) {
-	statusURL := hitlOperationStatusURL(publicURL, op.ID)
+	statusURL := hitlOperationStatusURL(publicURL, op.ID, op.StatusToken)
 	rw.Header().Set("Location", statusURL)
 	rw.Header().Set("Retry-After", strconv.Itoa(hitlDefaultRetryAfterSeconds))
 	writeHITLOperationResponse(rw, http.StatusAccepted, op, statusURL)
 }
 
 func writeHITLOperationStatus(rw http.ResponseWriter, op HITLOperation, publicURL string) {
-	statusURL := hitlOperationStatusURL(publicURL, op.ID)
+	statusURL := hitlOperationStatusURL(publicURL, op.ID, op.StatusToken)
 	writeHITLOperationResponse(rw, http.StatusOK, op, statusURL)
 }
 
 func writeHITLOperationResponse(rw http.ResponseWriter, status int, op HITLOperation, statusURL string) {
 	upstreamCalled := hitlOperationUpstreamCalled(op)
 	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Cache-Control", "no-store")
+	rw.Header().Set("Referrer-Policy", "no-referrer")
 	rw.Header().Set("Clawpatrol-HITL-State", string(op.State))
 	rw.Header().Set("Clawpatrol-Upstream-Called", strconv.FormatBool(upstreamCalled))
 	if op.State == HITLOperationStatePendingApproval || op.State == HITLOperationStateSyncWaiting {
@@ -903,9 +928,12 @@ func hitlOperationUpstreamCalled(op HITLOperation) bool {
 	}
 }
 
-func hitlOperationStatusURL(publicURL, operationID string) string {
+func hitlOperationStatusURL(publicURL, operationID, statusToken string) string {
 	base := strings.TrimRight(publicURL, "/")
 	path := hitlOperationStatusPrefix + url.PathEscape(operationID) + hitlOperationStatusSuffix
+	if statusToken != "" {
+		path += "?token=" + url.QueryEscape(statusToken)
+	}
 	if base == "" {
 		return path
 	}
@@ -914,6 +942,8 @@ func hitlOperationStatusURL(publicURL, operationID string) string {
 
 func writeHITLOperationNotFound(rw http.ResponseWriter) {
 	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Cache-Control", "no-store")
+	rw.Header().Set("Referrer-Policy", "no-referrer")
 	rw.WriteHeader(http.StatusNotFound)
 	_ = json.NewEncoder(rw).Encode(map[string]any{"error": hitlOperationNotFoundErrorValue})
 }

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -771,6 +771,10 @@ func (w *webMux) apiHITLOperationStatus(rw http.ResponseWriter, r *http.Request)
 		}
 	}
 	if op.ID == "" {
+		if isFunnelPublicRequest(r.Context()) {
+			writeHITLOperationNotFound(rw)
+			return
+		}
 		token := bearerFromAuthHeader(r.Header.Get("Authorization"))
 		peerIP := peerIPForAPIToken(w.g.db, token)
 		if peerIP == "" {

--- a/cmd/clawpatrol/web_auth_test.go
+++ b/cmd/clawpatrol/web_auth_test.go
@@ -183,6 +183,7 @@ func TestRouteAuthRequirementsDocumentOnboardingBoundary(t *testing.T) {
 		{path: "/api/onboard/approve", want: authDashboardOrTailnetOperator, wantDashboardPublic: false, wantTailnetPublic: false},
 		{path: "/api/config", want: authDashboard, wantDashboardPublic: false, wantTailnetPublic: false},
 		{path: "/api/env-pushdown", want: authSelfAuthenticating, wantDashboardPublic: true, wantTailnetPublic: true},
+		{path: "/api/hitl/operations/hitl_op_test/status", want: authSelfAuthenticating, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/info", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/ca.crt", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		// Login-page assets — the login page is authPublic and so are


### PR DESCRIPTION
## Summary
- mint operation-scoped async HITL status tokens and persist only SHA-256 hashes
- include `?token=...` capability URLs in async HITL `status_url`/`Location` responses while preserving bearer-token status polling
- expose only `/api/hitl/operations/*/status` through the Tailscale Funnel allowlist, not the rest of the HITL/dashboard APIs
- add `Cache-Control: no-store` and `Referrer-Policy: no-referrer` on HITL polling responses

## Tests
- `go test ./cmd/clawpatrol -run 'TestHITLAsyncApprovalGrantEndToEndHTTPFlow|TestHITLOperationStatusEndpoint|TestHITLOperationStoreCreatesMetadataOnlyOperation' -count=1`
- `go test ./cmd/clawpatrol -count=1`
- `go test ./...`
- `(cd dashboard && deno task format:check)`
- `gofmt -l .`
- `git diff --check`

## Review
- Independent delegate review: `APPROVED_NO_FINDINGS`
