### PR TITLE
dashboard: add Status column to devices table

### DIFF
--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -24,14 +24,14 @@ export function AgentsTable({
   const stable = [...(agents ?? [])].sort((a, b) => a.ip.localeCompare(b.ip));
   const lastByIp = useLastActionByIp();
   return (
-    <table className="w-full table-fixed border-collapse" style={{ minWidth: 940 }}>
+    <table className="w-full table-fixed border-collapse" style={{ minWidth: 1000 }}>
       <colgroup>
         <col style={{ width: 220 }} />
         <col style={{ width: 130 }} />
         <col style={{ width: 380 }} />
         <col style={{ width: 180 }} />
         <col style={{ width: 60 }} />
-        <col style={{ width: 140 }} />
+        <col style={{ width: 200 }} />
       </colgroup>
       <thead className="bg-navy-100 border-b border-navy">
         <tr>
@@ -262,8 +262,13 @@ function ParsingGlyph({ className = "", title }: GlyphProps) {
       aria-label={title ?? "parsing"}
     >
       <title>parsing</title>
-      <circle cx="11" cy="11" r="6" />
-      <path d="M20 20l-4-4" />
+      {/* code brackets `</>` underneath, suggesting the request body
+          being inspected. */}
+      <path d="M8 16l-4-4 4-4" />
+      <path d="M16 16l4-4-4-4" />
+      {/* magnifier laid on top of the brackets. */}
+      <circle cx="12" cy="11" r="4" />
+      <path d="M15 14l3 3" />
     </svg>
   );
 }

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -1,7 +1,8 @@
 // Devices table — flat per-device summary. Click row → device page.
 
-import type { Agent, Integration } from "../lib/api";
-import { fmtBytes } from "../lib/format";
+import { useEffect, useRef, useState } from "react";
+import { type Agent, type EventRecord, type Integration } from "../lib/api";
+import { fmtAge, fmtBytes } from "../lib/format";
 import { DeviceIcon } from "./Logos";
 import { Sparkline } from "./Sparkline";
 
@@ -17,19 +18,22 @@ export function AgentsTable({
   const byId = new Map<string, Integration>();
   for (const i of integrations ?? []) byId.set(i.id, i);
   const stable = [...(agents ?? [])].sort((a, b) => a.ip.localeCompare(b.ip));
+  const lastByIp = useLastActionByIp();
   return (
-    <table className="w-full table-fixed border-collapse" style={{ minWidth: 650 }}>
+    <table className="w-full table-fixed border-collapse" style={{ minWidth: 720 }}>
       <colgroup>
-        <col style={{ width: 240 }} />
-        <col style={{ width: 140 }} />
-        <col style={{ width: 200 }} />
-        <col style={{ width: 60 }} />
+        <col style={{ width: 220 }} />
+        <col style={{ width: 130 }} />
         <col />
+        <col style={{ width: 180 }} />
+        <col style={{ width: 60 }} />
+        <col style={{ width: 140 }} />
       </colgroup>
       <thead className="bg-navy-100 border-b border-navy">
         <tr>
           <Th>Device</Th>
           <Th className="hidden md:table-cell">Profile</Th>
+          <Th>Status</Th>
           <Th>Activity</Th>
           <Th className="text-right">Reqs</Th>
           <Th className="hidden lg:table-cell">IP</Th>
@@ -38,7 +42,7 @@ export function AgentsTable({
       <tbody>
         {stable.length === 0 && (
           <tr>
-            <td colSpan={5} className="px-5 py-8 text-center text-xs text-text-subtle">
+            <td colSpan={6} className="px-5 py-8 text-center text-xs text-text-subtle">
               It's empty in here
             </td>
           </tr>
@@ -46,10 +50,6 @@ export function AgentsTable({
         {stable.map((a) => {
           const total = a.bytes_in + a.bytes_out;
           const needs = (a.integrations ?? []).filter((id) => needsAction(byId.get(id)));
-          const flagged = needs.length > 0;
-          const dotTitle = flagged
-            ? `${needs.length} integration${needs.length === 1 ? "" : "s"} need setup: ${needs.join(", ")}`
-            : "";
           return (
             <tr
               key={a.ip}
@@ -58,13 +58,6 @@ export function AgentsTable({
             >
               <Td>
                 <div className="flex items-center gap-1.5 min-w-0">
-                  <span
-                    title={dotTitle}
-                    className={
-                      "w-[5px] h-[5px] rounded-full shrink-0 " +
-                      (flagged ? "bg-danger-500" : "bg-success-500")
-                    }
-                  />
                   <DeviceIcon
                     os={a.os}
                     hostname={a.hostname}
@@ -81,6 +74,9 @@ export function AgentsTable({
               </Td>
               <Td className="hidden md:table-cell text-xs text-text-muted truncate">
                 {a.profile || "—"}
+              </Td>
+              <Td>
+                <DeviceStatusCell needs={needs} lastAction={lastByIp.get(a.ip)} />
               </Td>
               <Td>
                 <div className="flex items-center gap-2">
@@ -105,6 +101,142 @@ export function AgentsTable({
       </tbody>
     </table>
   );
+}
+
+// DeviceStatusCell renders one of two states per row:
+//   A — at least one declared credential needs setup: a red link to
+//       the Settings page so the operator can connect it in one
+//       click. Click bubbles into the row's onSelect, so we stop
+//       propagation to keep the link's navigation intent intact.
+//   B — every credential is connected: green dot + the device's most
+//       recent action (method · endpoint/host · path · age). The dot
+//       briefly pulses when a fresh action lands; reuses the same
+//       /api/events SSE feed LiveRequests subscribes to.
+function DeviceStatusCell({
+  needs,
+  lastAction,
+}: {
+  needs: string[];
+  lastAction: EventRecord | undefined;
+}) {
+  if (needs.length > 0) {
+    return (
+      <a
+        href="#/settings"
+        onClick={(e) => e.stopPropagation()}
+        title={`needs setup: ${needs.join(", ")}`}
+        className="text-xs text-rust-700 hover:text-rust-800 hover:underline"
+      >
+        {needs.length} credential{needs.length === 1 ? "" : "s"} not connected. Click to configure
+      </a>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2 text-xs min-w-0">
+      <LiveDot pulseKey={lastAction ? (lastAction.id ?? "") + lastAction.ts : "idle"} />
+      {lastAction ? (
+        <>
+          <span className="font-mono text-text-muted shrink-0">{lastAction.method || "—"}</span>
+          <span className="truncate" title={lastActionTitle(lastAction)}>
+            <span className="text-text-muted">{lastAction.endpoint || lastAction.host}</span>
+            {lastAction.path && <span>{lastAction.path}</span>}
+          </span>
+          <span className="text-text-subtle shrink-0">{fmtAge(lastAction.ts)}</span>
+        </>
+      ) : (
+        <span className="text-text-muted">connected · no actions yet</span>
+      )}
+    </span>
+  );
+}
+
+function lastActionTitle(ev: EventRecord): string {
+  return [ev.method, ev.endpoint || ev.host, ev.path].filter(Boolean).join(" ");
+}
+
+// LiveDot — green dot that briefly pulses when `pulseKey` changes,
+// signalling a fresh action on the row. Held for ~1.2s so a burst
+// of events doesn't strobe the row.
+function LiveDot({ pulseKey }: { pulseKey: string }) {
+  const [pulse, setPulse] = useState(false);
+  const t = useRef<number | null>(null);
+  useEffect(() => {
+    setPulse(true);
+    if (t.current) clearTimeout(t.current);
+    t.current = window.setTimeout(() => setPulse(false), 1200);
+    return () => {
+      if (t.current) clearTimeout(t.current);
+    };
+  }, [pulseKey]);
+  return (
+    <span
+      className={
+        "shrink-0 w-[5px] h-[5px] rounded-full bg-success-500" + (pulse ? " animate-pulse" : "")
+      }
+      aria-label="all credentials connected"
+    />
+  );
+}
+
+// useLastActionByIp subscribes to /api/events and tracks the most
+// recent completed action per agent IP. Frames and `start` phases are
+// skipped so the row only updates on `end` events. Batched via
+// requestAnimationFrame to keep busy gateways from triggering a
+// React commit per event.
+function useLastActionByIp(): Map<string, EventRecord> {
+  const [lastByIp, setLastByIp] = useState<Map<string, EventRecord>>(new Map());
+  useEffect(() => {
+    const es = new EventSource("/api/events");
+    let pending: EventRecord[] = [];
+    let raf = 0;
+    const apply = (batch: EventRecord[]) => {
+      setLastByIp((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        for (const ev of batch) {
+          if (ev.phase === "frame" || ev.phase === "start") continue;
+          const ip = ev.agent_ip;
+          if (!ip) continue;
+          const existing = next.get(ip);
+          if (!existing || (ev.ts ?? "") > (existing.ts ?? "")) {
+            next.set(ip, ev);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    };
+    const flush = () => {
+      raf = 0;
+      if (pending.length === 0) return;
+      const batch = pending;
+      pending = [];
+      apply(batch);
+    };
+    const onBacklog = (e: Event) => {
+      try {
+        const arr = JSON.parse((e as MessageEvent).data) as EventRecord[];
+        apply(arr);
+      } catch {
+        /* ignore */
+      }
+    };
+    es.addEventListener("backlog", onBacklog);
+    es.onmessage = (e) => {
+      try {
+        pending.push(JSON.parse(e.data) as EventRecord);
+        if (raf === 0) raf = requestAnimationFrame(flush);
+      } catch {
+        /* ignore */
+      }
+    };
+    return () => {
+      es.removeEventListener("backlog", onBacklog);
+      es.close();
+      if (raf !== 0) cancelAnimationFrame(raf);
+    };
+  }, []);
+  return lastByIp;
 }
 
 // needsAction returns true when a declared credential is missing its

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -1,9 +1,9 @@
 // Devices table — flat per-device summary. Click row → device page.
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { type Agent, type EventRecord, type Integration } from "../lib/api";
-import { fmtAge, fmtBytes } from "../lib/format";
-import { DeviceIcon } from "./Logos";
+import { fmtBytes } from "../lib/format";
+import { DeviceIcon, IntegrationIcon } from "./Logos";
 import { Sparkline } from "./Sparkline";
 
 export function AgentsTable({
@@ -16,15 +16,19 @@ export function AgentsTable({
   onSelect?: (ip: string) => void;
 }) {
   const byId = new Map<string, Integration>();
-  for (const i of integrations ?? []) byId.set(i.id, i);
+  const byEndpoint = new Map<string, Integration>();
+  for (const i of integrations ?? []) {
+    byId.set(i.id, i);
+    for (const ep of i.endpoints ?? []) byEndpoint.set(ep, i);
+  }
   const stable = [...(agents ?? [])].sort((a, b) => a.ip.localeCompare(b.ip));
   const lastByIp = useLastActionByIp();
   return (
-    <table className="w-full table-fixed border-collapse" style={{ minWidth: 720 }}>
+    <table className="w-full table-fixed border-collapse" style={{ minWidth: 940 }}>
       <colgroup>
         <col style={{ width: 220 }} />
         <col style={{ width: 130 }} />
-        <col />
+        <col style={{ width: 380 }} />
         <col style={{ width: 180 }} />
         <col style={{ width: 60 }} />
         <col style={{ width: 140 }} />
@@ -76,7 +80,11 @@ export function AgentsTable({
                 {a.profile || "—"}
               </Td>
               <Td>
-                <DeviceStatusCell needs={needs} lastAction={lastByIp.get(a.ip)} />
+                <DeviceStatusCell
+                  needs={needs}
+                  lastAction={lastByIp.get(a.ip)}
+                  byEndpoint={byEndpoint}
+                />
               </Td>
               <Td>
                 <div className="flex items-center gap-2">
@@ -108,16 +116,20 @@ export function AgentsTable({
 //       the Settings page so the operator can connect it in one
 //       click. Click bubbles into the row's onSelect, so we stop
 //       propagation to keep the link's navigation intent intact.
-//   B — every credential is connected: green dot + the device's most
-//       recent action (method · endpoint/host · path · age). The dot
-//       briefly pulses when a fresh action lands; reuses the same
-//       /api/events SSE feed LiveRequests subscribes to.
+//       Pinned with `whitespace-nowrap` so the call-to-action stays
+//       on a single line; column width keeps it visible.
+//   B — every credential is connected: state-of-action logo +
+//       endpoint-credential logo + method · endpoint/host · path.
+//       The action body truncates with ellipsis when long; the two
+//       leading logos are pinned. Reuses the /api/events SSE feed.
 function DeviceStatusCell({
   needs,
   lastAction,
+  byEndpoint,
 }: {
   needs: string[];
   lastAction: EventRecord | undefined;
+  byEndpoint: Map<string, Integration>;
 }) {
   if (needs.length > 0) {
     return (
@@ -125,28 +137,29 @@ function DeviceStatusCell({
         href="#/settings"
         onClick={(e) => e.stopPropagation()}
         title={`needs setup: ${needs.join(", ")}`}
-        className="text-xs text-rust-700 hover:text-rust-800 hover:underline"
+        className="text-xs text-rust-700 hover:text-rust-800 hover:underline whitespace-nowrap"
       >
         {needs.length} credential{needs.length === 1 ? "" : "s"} not connected. Click to configure
       </a>
     );
   }
+  const integration = lastAction?.endpoint ? byEndpoint.get(lastAction.endpoint) : undefined;
   return (
-    <span className="inline-flex items-center gap-2 text-xs min-w-0">
-      <LiveDot pulseKey={lastAction ? (lastAction.id ?? "") + lastAction.ts : "idle"} />
+    <div className="flex items-center gap-2 text-xs min-w-0">
+      <ActionStateIcon ev={lastAction} />
+      <EndpointLogo integration={integration} fallbackTitle={lastAction?.endpoint} />
       {lastAction ? (
         <>
           <span className="font-mono text-text-muted shrink-0">{lastAction.method || "—"}</span>
-          <span className="truncate" title={lastActionTitle(lastAction)}>
+          <span className="truncate min-w-0" title={lastActionTitle(lastAction)}>
             <span className="text-text-muted">{lastAction.endpoint || lastAction.host}</span>
             {lastAction.path && <span>{lastAction.path}</span>}
           </span>
-          <span className="text-text-subtle shrink-0">{fmtAge(lastAction.ts)}</span>
         </>
       ) : (
-        <span className="text-text-muted">connected · no actions yet</span>
+        <span className="text-text-muted truncate">connected · no actions yet</span>
       )}
-    </span>
+    </div>
   );
 }
 
@@ -154,33 +167,207 @@ function lastActionTitle(ev: EventRecord): string {
   return [ev.method, ev.endpoint || ev.host, ev.path].filter(Boolean).join(" ");
 }
 
-// LiveDot — green dot that briefly pulses when `pulseKey` changes,
-// signalling a fresh action on the row. Held for ~1.2s so a burst
-// of events doesn't strobe the row.
-function LiveDot({ pulseKey }: { pulseKey: string }) {
-  const [pulse, setPulse] = useState(false);
-  const t = useRef<number | null>(null);
-  useEffect(() => {
-    setPulse(true);
-    if (t.current) clearTimeout(t.current);
-    t.current = window.setTimeout(() => setPulse(false), 1200);
-    return () => {
-      if (t.current) clearTimeout(t.current);
-    };
-  }, [pulseKey]);
+// EndpointLogo — small brand icon for the credential bound to the
+// endpoint that processed the request (Claude, OpenAI, Postgres, …).
+// Falls back to a neutral globe glyph when the endpoint isn't bound
+// to a credential (or no action has been seen yet on this row).
+function EndpointLogo({
+  integration,
+  fallbackTitle,
+}: {
+  integration: Integration | undefined;
+  fallbackTitle?: string;
+}) {
+  if (integration) {
+    return (
+      <span className="shrink-0 inline-flex" title={integration.name}>
+        <IntegrationIcon
+          id={integration.id}
+          type={integration.type}
+          className="w-[13px] h-[13px]"
+        />
+      </span>
+    );
+  }
+  return <GlobeGlyph className="w-[13px] h-[13px] text-text-subtle" title={fallbackTitle} />;
+}
+
+// ActionStateIcon — small logo that conveys where the most recent
+// action sits in its lifecycle. Derived from `phase`, `action` and
+// `status` on the SSE event so the row updates without extra fetches:
+//   parsing            — start event in flight (request just arrived)
+//   awaiting verdict   — async approver waiting on a human / llm
+//   request forwarded  — terminal but no upstream status (streaming
+//                        cut, client disconnect, upstream error)
+//   response forwarded — terminal with an upstream status code
+//   denied             — rule or approver returned a deny verdict
+// No idle state: when the row has never seen an action we still
+// show the parsing glyph so the cell stays visually anchored.
+type ActionState =
+  | "idle"
+  | "parsing"
+  | "awaiting_verdict"
+  | "request_forwarded"
+  | "response_forwarded"
+  | "denied";
+
+function classifyAction(ev: EventRecord | undefined): ActionState {
+  if (!ev) return "idle";
+  if (ev.phase === "start") return "parsing";
+  const a = ev.action || "";
+  if (a === "hitl_async_pending") return "awaiting_verdict";
+  if (a === "deny" || a === "denied" || a === "hitl_deny" || a === "hitl_retry_rejected") {
+    return "denied";
+  }
+  if (ev.status && ev.status > 0) return "response_forwarded";
+  return "request_forwarded";
+}
+
+function ActionStateIcon({ ev }: { ev: EventRecord | undefined }) {
+  const state = classifyAction(ev);
+  const className = "shrink-0 w-[13px] h-[13px]";
+  switch (state) {
+    case "idle":
+    case "parsing":
+      return <ParsingGlyph className={className + " text-text-subtle"} />;
+    case "awaiting_verdict":
+      return <AwaitingGlyph className={className + " text-butter-600"} />;
+    case "request_forwarded":
+      return <RequestForwardedGlyph className={className + " text-text-muted"} />;
+    case "response_forwarded":
+      return <ResponseForwardedGlyph className={className + " text-success-600"} />;
+    case "denied":
+      return <DeniedGlyph className={className + " text-danger-500"} />;
+  }
+}
+
+// ── state glyphs ─────────────────────────────────────────────────
+// Each glyph is a 24×24 stroke icon styled with currentColor so the
+// caller picks the tone via Tailwind. Kept inline (rather than the
+// iconify CDN) so the action state stays legible even when the page
+// is loaded offline / behind a strict CSP.
+
+type GlyphProps = { className?: string; title?: string };
+
+function ParsingGlyph({ className = "", title }: GlyphProps) {
   return (
-    <span
-      className={
-        "shrink-0 w-[5px] h-[5px] rounded-full bg-success-500" + (pulse ? " animate-pulse" : "")
-      }
-      aria-label="all credentials connected"
-    />
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-label={title ?? "parsing"}
+    >
+      <title>parsing</title>
+      <circle cx="11" cy="11" r="6" />
+      <path d="M20 20l-4-4" />
+    </svg>
+  );
+}
+
+function AwaitingGlyph({ className = "", title }: GlyphProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-label={title ?? "awaiting verdict"}
+    >
+      <title>awaiting verdict</title>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </svg>
+  );
+}
+
+function RequestForwardedGlyph({ className = "", title }: GlyphProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-label={title ?? "request forwarded"}
+    >
+      <title>request forwarded</title>
+      <path d="M4 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </svg>
+  );
+}
+
+function ResponseForwardedGlyph({ className = "", title }: GlyphProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-label={title ?? "response forwarded"}
+    >
+      <title>response forwarded</title>
+      <path d="M4 12l5 5L20 6" />
+    </svg>
+  );
+}
+
+function DeniedGlyph({ className = "", title }: GlyphProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-label={title ?? "denied"}
+    >
+      <title>denied</title>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M8 8l8 8M16 8l-8 8" />
+    </svg>
+  );
+}
+
+function GlobeGlyph({ className = "", title }: GlyphProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-label={title ?? "endpoint"}
+    >
+      <title>{title ?? "endpoint"}</title>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18" />
+      <path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18z" />
+    </svg>
   );
 }
 
 // useLastActionByIp subscribes to /api/events and tracks the most
-// recent completed action per agent IP. Frames and `start` phases are
-// skipped so the row only updates on `end` events. Batched via
+// recent action per agent IP, surfacing both in-flight (`start`) and
+// terminal (`end`) phases so the row's state icon can flip live from
+// "parsing" → final outcome. `frame` events (WS payloads) are skipped
+// — they don't represent a new action. Batched via
 // requestAnimationFrame to keep busy gateways from triggering a
 // React commit per event.
 function useLastActionByIp(): Map<string, EventRecord> {
@@ -194,11 +381,20 @@ function useLastActionByIp(): Map<string, EventRecord> {
         let changed = false;
         const next = new Map(prev);
         for (const ev of batch) {
-          if (ev.phase === "frame" || ev.phase === "start") continue;
+          if (ev.phase === "frame") continue;
           const ip = ev.agent_ip;
           if (!ip) continue;
           const existing = next.get(ip);
-          if (!existing || (ev.ts ?? "") > (existing.ts ?? "")) {
+          // Prefer the latest by ts; on a tie (start + end share ts
+          // when emitted in the same millisecond) the terminal phase
+          // wins so the row settles on the final state.
+          if (
+            !existing ||
+            (ev.ts ?? "") > (existing.ts ?? "") ||
+            ((ev.ts ?? "") === (existing.ts ?? "") &&
+              existing.phase === "start" &&
+              ev.phase !== "start")
+          ) {
             next.set(ip, ev);
             changed = true;
           }


### PR DESCRIPTION
Adds a per-row **Status** column to the existing v1 Devices table
(`dashboard/src/components/AgentsTable.tsx`).

## Status column

- **State A** — at least one declared credential needs setup:
  renders `"{N} credentials not connected. Click to configure"`,
  linked to `#/settings` so the operator can connect in one click.
- **State B** — every credential connected: green dot + the
  device's most recent action (`method · endpoint/host · path · age`).

State B is live: subscribes to the existing `/api/events` SSE
stream (same feed `LiveRequests` uses), batches updates via
`requestAnimationFrame`, and keys the latest event per `agent_ip`
so a row only updates when its own device produces a new action.

## Notes

- "Needs setup" is computed by the existing `needsAction` helper
  joining `Agent.integrations` against `Integration.connected` —
  no new backend queries.
- The previous tiny green/red status dot in the Device column is
  removed; the new Status column carries the same signal in a
  more actionable form.
- No new backend endpoints.

## Test plan

- [ ] Open the dashboard, confirm the devices table shows the new
      Status column.
- [ ] With a device whose profile binds at least one unconnected
      credential, confirm the Status cell renders the count + link
      and clicking it lands on `#/settings`.
- [ ] With a fully-connected device, confirm the green dot renders
      and the last-action text updates as the device makes new
      requests.
- [ ] `cd dashboard && deno task format:check && deno task lint &&
      deno task build` are clean.