### PR TITLE
dashboard: copy buttons work over plain HTTP

### DIFF
--- a/dashboard/src/components/AddDeviceModal.tsx
+++ b/dashboard/src/components/AddDeviceModal.tsx
@@ -28,11 +28,30 @@ export function AddDeviceModal({
 
 function Step({ n, label, cmd }: { n: number; label: string; cmd: string }) {
   const [copied, setCopied] = useState(false);
-  function copy() {
-    navigator.clipboard.writeText(cmd).then(() => {
+  async function copy() {
+    const flash = () => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    });
+    };
+    try {
+      await navigator.clipboard.writeText(cmd);
+      flash();
+      return;
+    } catch {
+      // Fall through to the legacy path below. Reasons writeText can
+      // throw: non-secure context, page not focused, browser policy.
+    }
+    const ta = document.createElement("textarea");
+    ta.value = cmd;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      if (document.execCommand("copy")) flash();
+    } finally {
+      document.body.removeChild(ta);
+    }
   }
   return (
     <div className="space-y-1">


### PR DESCRIPTION
## Summary

<img width="563" height="315" alt="Screenshot 2026-05-19 at 8 35 00 AM" src="https://github.com/user-attachments/assets/0623cfc7-0837-49cb-9904-91c251c01ec7" />

Copy buttons in the "Add Device" modal silently do nothing over plain HTTP. `navigator.clipboard` is `undefined` in non-secure browser contexts, and the prod dashboard is served over HTTP (e.g. `http://clawpatrol-gateway-1:8080` on the tailnet). The old code:

```ts
navigator.clipboard.writeText(cmd).then(() => { ... })
```

throws synchronously with `Cannot read properties of undefined (reading 'writeText')` before any feedback runs.

## Fix

Try the modern API first, fall through to the `document.execCommand('copy')` shim on either path failure. Both paths trigger the same flash so the operator sees confirmation regardless of context.

```
HTTPS / localhost  →  navigator.clipboard.writeText (preferred)
HTTP / other       →  textarea + execCommand("copy")  (legacy fallback)
```

22 insertions, 3 deletions in `dashboard/src/components/AddDeviceModal.tsx`.

## Repro before this PR
1. Open the dashboard at `http://clawpatrol-gateway-1:8080` (or any non-secure context)
2. Click "Add device" in the header
3. Click any "copy" button
4. Browser console shows `TypeError: Cannot read properties of undefined (reading 'writeText')`; clipboard is untouched, button doesn't flash

## After this PR
Same flow; button flashes "copied"; the command is on the clipboard.

## Test plan
- [x] dashboard `npm run build` clean
- [ ] manual: HTTPS / localhost path (modern API)
- [ ] manual: HTTP non-localhost path (legacy fallback)
- [ ] CI green
