### PR TITLE
dashboard: fix device-page crash + credential card legibility

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -186,11 +186,11 @@ func loadConfig(path string) (*config.Gateway, *config.CompiledPolicy, error) {
 // we re-sort by the Order slice (which buildSymbols populates in
 // declaration order) and filter to KindProfile entries.
 func orderedProfileNames(p *config.Policy) []string {
+	out := []string{}
 	if p == nil {
-		return nil
+		return out
 	}
 	seen := map[string]bool{}
-	var out []string
 	for _, name := range p.Order {
 		if seen[name] {
 			continue

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -1132,6 +1133,7 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 		"integrations": w.statusList(r),
 		"agents":       w.agentsList(),
 		"update":       currentUpdateBanner.Load(),
+		"config_file":  filepath.Base(w.g.cfgPath),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [whoami, setWhoami] = useState<Whoami | null>(null);
   const [update, setUpdate] = useState<UpdateBanner | null>(null);
+  const [configFile, setConfigFile] = useState<string>("gateway.hcl");
   const [connectId, setConnectId] = useState<string | null>(null);
   const [route, setRoute] = useState(parseRoute());
 
@@ -65,6 +66,7 @@ export default function App() {
       setAgents(s.agents || []);
       setWhoami(s.whoami);
       setUpdate(s.update ?? null);
+      if (s.config_file) setConfigFile(s.config_file);
     } catch {
       /* swallow */
     }
@@ -116,6 +118,7 @@ export default function App() {
           ip={route.ip}
           agents={agents}
           integrations={integrations}
+          configFile={configFile}
           onBack={() => navigate("")}
           onConnect={(id) => setConnectId(id)}
           onRefresh={refresh}

--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -44,7 +44,7 @@ export function DevicePage({
   const [profileCreds, setProfileCreds] = useState<Integration[] | null>(null);
   useEffect(() => {
     listProfiles()
-      .then(setProfiles)
+      .then((p) => setProfiles(p ?? []))
       .catch(() => setProfiles([]));
   }, []);
   const devProfile = a?.profile;
@@ -54,7 +54,7 @@ export function DevicePage({
       return;
     }
     getStatus(devProfile)
-      .then(setProfileCreds)
+      .then((c) => setProfileCreds(c ?? []))
       .catch(() => setProfileCreds(null));
     // Re-fetch whenever the parent's integrations list changes too —
     // OAuth modal calls onRefresh on success, which updates parent state
@@ -209,8 +209,27 @@ export function DevicePage({
       {/* live request stream filtered by this device */}
       <LiveRequests agentIP={a.ip} height="360px" />
 
-      {/* integrations management for this user */}
-      <IntegrationsCards list={allForUser} onConnect={onConnect} onRefresh={onRefresh} />
+      {/* credentials for this device's profile — header makes the
+          profile→credentials linkage explicit and points operators at
+          gateway.hcl since the dashboard is read-only for declarations. */}
+      <section className="bg-canvas-light border-1.5 border-navy">
+        <div className="flex items-center px-4 py-2.5 bg-navy-100 border-b border-navy gap-2">
+          <div className="font-mono text-xs uppercase tracking-wider text-navy font-bold">
+            Credentials
+          </div>
+          {a.profile && (
+            <span className="text-2xs text-navy/70">
+              for profile <span className="font-mono">{a.profile}</span>
+            </span>
+          )}
+          <span className="ml-auto text-2xs text-navy/70">
+            declared in <span className="font-mono">gateway.hcl</span>
+          </span>
+        </div>
+        <div className="p-3">
+          <IntegrationsCards list={allForUser} onConnect={onConnect} onRefresh={onRefresh} />
+        </div>
+      </section>
 
       {/* rules — per-device scope (with global rules layered in) */}
       <RulesPanel deviceIP={a.ip} profile={a.profile} />

--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -21,6 +21,7 @@ export function DevicePage({
   ip,
   agents,
   integrations,
+  configFile,
   onBack,
   onConnect,
   onRefresh,
@@ -28,6 +29,7 @@ export function DevicePage({
   ip: string;
   agents: Agent[];
   integrations: Integration[];
+  configFile: string;
   onBack: () => void;
   onConnect: (id: string) => void;
   onRefresh: () => void;
@@ -223,7 +225,7 @@ export function DevicePage({
             </span>
           )}
           <span className="ml-auto text-2xs text-navy/70">
-            declared in <span className="font-mono">gateway.hcl</span>
+            declared in <span className="font-mono">{configFile}</span>
           </span>
         </div>
         <div className="p-3">

--- a/dashboard/src/components/IntegrationsCards.tsx
+++ b/dashboard/src/components/IntegrationsCards.tsx
@@ -8,12 +8,11 @@ import { CredentialSecretsModal } from "./CredentialSecretsModal";
 import { IntegrationIcon } from "./Logos";
 import { Modal } from "./Modal";
 
-// Card header format: `<plugin display name> · <credential bare name>`.
-// The bare name (the operator's HCL block name) is always present so
-// two same-type cards can be told apart at a glance, and so the
-// subtitle slot below the header is free for per-type contextual
-// information (OAuth identity, "Not connected", etc.) instead of
-// repeating the block name.
+// Card layout: heading = bare HCL credential name (the unique
+// identifier two same-type cards differ by), subtitle = plugin label
+// plus optional context (OAuth identity, "not connected", etc.). The
+// icon already conveys the plugin type, so prefixing the heading
+// truncated the name itself — the part the operator actually needs.
 
 // Cap on visible cards before the overflow button appears. The N-th
 // slot is replaced by "+ K more" so the row width stays predictable
@@ -260,15 +259,16 @@ function Card({
           ? "paste secret"
           : "api key only";
   // Plugin display name (e.g. "GitHub", "Postgres"). Falls back to the
-  // raw HCL type key for unrecognised plugins rather than the bare
-  // credential name, which would produce `<name> · <name>` titles.
+  // raw HCL type key for unrecognised plugins.
   const label = credentialTypeLabel(i.type, i.type);
-  // Title is always `<displayName> · <name>` regardless of how many
-  // creds of this type are declared. The OAuth identity that used to
-  // suffix the title moves to the subtitle below.
-  const heading = `${label} · ${i.name}`;
-  const subtitle = contextualSubtitle(i, connected, hasSlots);
-  const title = [heading, `credential: ${i.id}`, `type: ${i.type}`, status].join("\n");
+  // Heading shows the bare HCL block name — that's the unique
+  // identifier two same-type cards differ by, and the icon already
+  // conveys the plugin type. The type label moves into the subtitle.
+  const heading = i.name;
+  const subtitle = contextualSubtitle(i, connected, hasSlots, label);
+  const title = [`${label} · ${i.name}`, `credential: ${i.id}`, `type: ${i.type}`, status].join(
+    "\n",
+  );
   return (
     <button
       disabled={!clickable && !connected}
@@ -302,17 +302,15 @@ function Card({
           )}
           <span
             className={
-              "w-[6px] h-[6px] rounded-full " + (connected ? "bg-success-500" : "bg-text-subtle")
+              "w-[9px] h-[9px] rounded-full " + (connected ? "bg-success-500" : "bg-danger-500")
             }
           />
         </span>
       </div>
       <div className="w-full min-w-0 space-y-0.5">
-        {subtitle && (
-          <div className="text-2xs text-text-muted truncate" title={subtitle}>
-            {subtitle}
-          </div>
-        )}
+        <div className="text-2xs text-text-muted truncate" title={subtitle}>
+          {subtitle}
+        </div>
         <div className="text-2xs text-text-subtle tabular-nums truncate" title={status}>
           {status}
         </div>
@@ -321,37 +319,38 @@ function Card({
   );
 }
 
-// contextualSubtitle returns the per-credential-type hint shown below
-// the card title. Sources are all non-secret fields already on the
-// IntegrationRow payload — no secret material (token prefixes, raw
-// password hashes, etc.) is rendered. Returns "" to mean "omit the
-// subtitle slot entirely" (compact card).
-function contextualSubtitle(i: Integration, connected: boolean, hasSlots: boolean): string {
+// contextualSubtitle returns the subtitle shown below the card
+// heading: always leads with the plugin label (since the heading no
+// longer carries it), followed by the OAuth identity or per-state
+// hint. Sources are all non-secret fields on the IntegrationRow
+// payload — no secret material is rendered.
+function contextualSubtitle(
+  i: Integration,
+  connected: boolean,
+  hasSlots: boolean,
+  label: string,
+): string {
+  // Plugin label always leads the subtitle now that the heading shows
+  // just the bare HCL name. OAuth identity (when present) follows.
+  const hint = subtitleHint(i, connected, hasSlots);
+  return hint ? `${label} · ${hint}` : label;
+}
+
+function subtitleHint(i: Integration, connected: boolean, hasSlots: boolean): string {
   if (connected) {
-    // OAuth flows persist the connected account identity (email /
-    // username / workspace name) on the credential at connect time —
-    // that's what `display_name` is. Surface it directly when present.
     if (i.display_name) return i.display_name;
-    // Manual / Tailscale / OAuth-without-identity: nothing useful to
-    // distinguish two same-type creds, fall back to a stable
-    // placeholder so the row still reads "configured".
-    if (hasSlots || i.has_tailscale_auth) return "Saved";
     return "";
   }
-  // Not connected: OAuth awaits an explicit user action. Tailscale's
-  // hint depends on whether tsnet is mid-auth — "Awaiting
-  // authentication" makes the click-to-open-URL flow legible to the
-  // operator, whereas "Not connected" reads as a dead-end.
   if (i.has_tailscale_auth) {
     const s = i.tailscale_auth?.state;
-    if (s === "needs_login" || s === "needs_machine_auth") return "Awaiting authentication";
-    if (s === "starting") return "Starting";
-    if (s === "stopped") return "Stopped";
-    if (s === "in_use_other_user") return "In use by another user";
-    return "Not connected";
+    if (s === "needs_login" || s === "needs_machine_auth") return "awaiting auth";
+    if (s === "starting") return "starting";
+    if (s === "stopped") return "stopped";
+    if (s === "in_use_other_user") return "in use by another user";
+    return "not connected";
   }
-  if (i.has_oauth) return "Not connected";
-  if (hasSlots) return "Not configured";
+  if (i.has_oauth) return "not connected";
+  if (hasSlots) return "not configured";
   return "";
 }
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -374,6 +374,10 @@ type StateResp = {
   integrations: Integration[];
   agents: Agent[];
   update?: UpdateBanner | null;
+  // Basename of the gateway config file (e.g. "gateway.hcl",
+  // "dev.hcl"). Surfaced in UI hints so operators see the actual
+  // running config name rather than a hardcoded string.
+  config_file?: string;
 };
 let lastStateTag = "";
 let lastState: StateResp | null = null;


### PR DESCRIPTION
## Summary

Four device-page fixes prompted by dashboard feedback:

- **Crash with no profiles.** `/api/profiles` returned JSON `null` when no profiles were declared (Go nil slice), which crashed the device page's profile picker with `Cannot read properties of null (reading 'length')`. `orderedProfileNames` now returns an empty slice.
- **Credential card truncation.** Heading was `<plugin> · <name>` — the prefix was eating the bare HCL name, which is the part that distinguishes two same-type cards. Heading is now the bare name; the type label moves to the subtitle, since the icon already conveys the plugin.
- **Faint status indicator.** Dot enlarged from 6→9px, and not-connected changes from grey to red so the two states are visually distinguishable.
- **Profile→credentials linkage.** Wrapped the credentials grid in a labeled section that surfaces the active profile and points at the actual running config file (`/api/state` now returns the basename, so `dev.hcl` / `prod.hcl` etc. render correctly instead of a hardcoded string).

## Test plan

- [ ] Open a device page on a config with no `profile` blocks — page renders instead of crashing.
- [ ] Open a device with a long-named credential (e.g. `codex_subscription`) — full name is visible in the card heading.
- [ ] Confirm green vs red status dots are easily distinguishable.
- [ ] Confirm the credentials section header reads "Credentials for profile `<name>` · declared in `<configfile>`".
- [ ] Rename your config from `gateway.hcl` to `dev.hcl` — section header reflects the rename after the next state poll.
