### PR TITLE
endpoints: support `*.suffix` wildcards in hosts list

### DIFF
--- a/cmd/clawpatrol/dnsvip/dnsvip.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip.go
@@ -38,6 +38,7 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/hostmatch"
 )
 
 // hostResolver routes A/AAAA lookups for non-VIP names through the
@@ -105,8 +106,21 @@ type Allocator struct {
 	byV4      map[netip.Addr]*entry    // 10.78.x.y → entry
 	byV6      map[netip.Addr]*entry    // fd78::N → entry
 	endpoints map[string][]EndpointHit // hostname → hits
+	patterns  []patternBinding         // wildcard host bindings, longest suffix first
 	free      []uint32                 // recycled IDs
 	used      map[uint32]struct{}      // ID set, for fast in-use check
+}
+
+// patternBinding holds one wildcard host declaration plus the
+// EndpointHits that should fire when a DNS query (or post-allocation
+// VIP lookup) lands on a name matching Pattern. Patterns are kept in
+// declaration order at the slice level; RebuildFromPolicy sorts them
+// by descending length so the lazy-lookup walk returns the most
+// specific match first.
+type patternBinding struct {
+	Pattern string
+	Port    uint16
+	Hits    []EndpointHit
 }
 
 // New constructs an allocator and loads any existing state from the
@@ -270,18 +284,32 @@ func (a *Allocator) makeEntry(id uint32, hostname string) *entry {
 // hostnames that disappeared have their pair freed back to the
 // free-list. The endpoint→hit map is rebuilt from scratch every
 // time. Persists on success.
+//
+// Wildcard hosts (`hosts = ["*.foo.com"]`) don't pre-allocate VIPs;
+// they install a pattern binding instead, and a lazy allocation
+// happens the first time intercepts() sees a DNS query that matches.
+// Lazy-allocated entries from previous policies survive a rebuild
+// when their hostname still matches some current pattern — that's
+// what keeps an agent's cached `s3.amazonaws.com → 10.78.0.5`
+// mapping valid across reloads.
 func (a *Allocator) RebuildFromPolicy(policy *config.CompiledPolicy) error {
 	if a == nil {
 		return nil
 	}
-	required := collectRequiredHosts(policy)
+	required, patterns := collectRequiredHosts(policy)
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// Free entries no longer required.
+	// Free entries that neither appear in the exact required set
+	// nor match any current wildcard pattern. Lazy entries from a
+	// previous policy whose pattern is gone are released back to
+	// the free-list here; surviving lazy entries keep their VIPs.
 	for hostname, e := range a.byName {
 		if _, keep := required[hostname]; keep {
+			continue
+		}
+		if matchPatternBindings(patterns, hostname) != nil {
 			continue
 		}
 		delete(a.byName, hostname)
@@ -290,10 +318,11 @@ func (a *Allocator) RebuildFromPolicy(policy *config.CompiledPolicy) error {
 		delete(a.used, e.ID)
 		a.free = append(a.free, e.ID)
 	}
-	// Allocate new ones in deterministic hostname order so persisted
-	// IDs match across machines that load the same policy from
-	// scratch (cosmetic — VIP order shouldn't be operator-visible
-	// except when comparing dnsvip.json across replicas).
+	// Allocate new exact entries in deterministic hostname order
+	// so persisted IDs match across machines that load the same
+	// policy from scratch (cosmetic — VIP order shouldn't be
+	// operator-visible except when comparing dnsvip.json across
+	// replicas).
 	var newHosts []string
 	for h := range required {
 		if _, exists := a.byName[h]; !exists {
@@ -307,66 +336,109 @@ func (a *Allocator) RebuildFromPolicy(policy *config.CompiledPolicy) error {
 		}
 	}
 
-	// Rebuild the endpoint→hits map.
+	// Rebuild the endpoint→hits map. For each VIP currently held
+	// (including surviving lazy entries) re-derive the hit list
+	// from whichever side of the policy claims the hostname now.
+	a.patterns = patterns
 	a.endpoints = map[string][]EndpointHit{}
 	for hostname, hits := range required {
 		a.endpoints[hostname] = hits
+	}
+	for hostname := range a.byName {
+		if _, ok := a.endpoints[hostname]; ok {
+			continue
+		}
+		if p := matchPatternBindings(patterns, hostname); p != nil {
+			a.endpoints[hostname] = p.Hits
+		}
 	}
 
 	return a.persistLocked()
 }
 
-// collectRequiredHosts walks the policy and returns the hostname →
-// []EndpointHit map for endpoints that opted into VIPs. Endpoints
-// must also be ConnRouters — that's where we get the host:port list
-// (the same one ConnIndex uses for direct-IP routing). A host string
-// without a port falls back to that protocol's default; SSH is the
-// only RequiresVIP plugin in v1 so the default is 22.
+// matchPatternBindings returns the most specific (longest pattern)
+// binding whose pattern matches hostname, or nil when none does.
+// Caller must hold whichever lock is appropriate (the patterns slice
+// is owned by Allocator.mu). patterns must already be sorted by
+// descending pattern length.
+func matchPatternBindings(patterns []patternBinding, hostname string) *patternBinding {
+	hostname = strings.ToLower(hostname)
+	for i := range patterns {
+		p := &patterns[i]
+		if hostmatch.MatchWildcard(p.Pattern, hostname) {
+			return p
+		}
+	}
+	return nil
+}
+
+// collectRequiredHosts walks the policy and returns two complementary
+// views of the VIP-needing host set:
+//
+//   - exact map: hostname → []EndpointHit, pre-allocated at rebuild
+//     time. Same shape and semantics the allocator has always had.
+//   - patterns: wildcard `*.suffix` bindings the allocator walks
+//     on-demand at DNS query time. No VIP exists yet for a pattern
+//     entry; the allocator lazy-allocates on first hit.
+//
+// Endpoints must opt into VIPs (RequiresVIP marker on the body OR
+// declare a tunnel — see CompiledEndpoint.RequiresVIP) and the
+// hostnames must come off the compiled Hosts list (the same source
+// ConnIndex consumes). A host string without a port falls back to
+// that protocol's default; SSH is the only RequiresVIP plugin in v1
+// so the default is 22.
 //
 // IP-literal entries are skipped: VIPs exist to recover hostname
 // identity from a TCP dst IP, but agents dialing an IP literal never
 // issue a DNS query, so allocating a VIP for one is wasted state. The
-// gateway's direct-IP dispatch path (consulting ConnIndex inside the
-// WG forwarder's default case) covers those entries instead.
-func collectRequiredHosts(policy *config.CompiledPolicy) map[string][]EndpointHit {
-	out := map[string][]EndpointHit{}
+// gateway's direct-IP dispatch path covers those entries instead.
+func collectRequiredHosts(policy *config.CompiledPolicy) (map[string][]EndpointHit, []patternBinding) {
+	exact := map[string][]EndpointHit{}
 	if policy == nil {
-		return out
+		return exact, nil
 	}
+	patternIdx := map[string]int{}
+	var patterns []patternBinding
 	for _, ep := range policy.Endpoints {
-		// CompiledEndpoint.RequiresVIP() OR's the body's marker
-		// with the "tunneled endpoint always needs a VIP" rule —
-		// tunneled upstream hostnames don't resolve in the agent's
-		// namespace, so VIP-routing is the only way the gateway
-		// recovers the endpoint at conn-accept.
 		if !ep.RequiresVIP() {
 			continue
 		}
-		// Use the compiled Hosts list (already populated via
-		// EndpointHosts()) — same source ConnIndex consumes.
 		for _, hp := range ep.Hosts {
-			host, portStr, err := net.SplitHostPort(hp)
-			if err != nil {
-				host = hp
-				portStr = ""
-			}
-			if host == "" {
+			host, portStr, err := hostmatch.SplitHostPort(hp)
+			if err != nil || host == "" {
 				continue
 			}
-			if net.ParseIP(host) != nil {
-				continue
-			}
-			var port = defaultPortFor(ep)
+			port := defaultPortFor(ep)
 			if portStr != "" {
 				var p uint16
 				if _, err := fmt.Sscanf(portStr, "%d", &p); err == nil {
 					port = p
 				}
 			}
-			out[host] = append(out[host], EndpointHit{Endpoint: ep, Port: port})
+			if hostmatch.IsWildcardHost(host) {
+				key := strings.ToLower(host)
+				idx, ok := patternIdx[key]
+				if !ok {
+					patternIdx[key] = len(patterns)
+					patterns = append(patterns, patternBinding{Pattern: key, Port: port})
+					idx = patternIdx[key]
+				}
+				patterns[idx].Hits = append(patterns[idx].Hits, EndpointHit{Endpoint: ep, Port: port})
+				continue
+			}
+			if net.ParseIP(host) != nil {
+				continue
+			}
+			exact[host] = append(exact[host], EndpointHit{Endpoint: ep, Port: port})
 		}
 	}
-	return out
+	sort.SliceStable(patterns, func(i, j int) bool {
+		if len(patterns[i].Pattern) != len(patterns[j].Pattern) {
+			return len(patterns[i].Pattern) > len(patterns[j].Pattern)
+		}
+		return patterns[i].Pattern < patterns[j].Pattern
+	})
+	return exact, patterns
 }
 
 // defaultPortFor returns the default port for a VIP-needing endpoint
@@ -575,11 +647,55 @@ func (a *Allocator) handleQuery(q *dns.Msg, dstIP string) *dns.Msg {
 	return resp
 }
 
+// intercepts reports whether hostname is bound to a VIP in this
+// allocator. Falls through to the wildcard pattern table on exact
+// miss and lazy-allocates a fresh VIP when a pattern claims the name
+// — the first DNS query for a `*.amazonaws.com` host pins it to a
+// stable VIP that persists across restarts (until the pattern leaves
+// policy).
 func (a *Allocator) intercepts(hostname string) bool {
+	hostname = strings.ToLower(hostname)
 	a.mu.RLock()
-	defer a.mu.RUnlock()
-	_, ok := a.byName[hostname]
-	return ok
+	if _, ok := a.byName[hostname]; ok {
+		a.mu.RUnlock()
+		return true
+	}
+	binding := matchPatternBindings(a.patterns, hostname)
+	a.mu.RUnlock()
+	if binding == nil {
+		return false
+	}
+	return a.lazyAllocateForPattern(hostname)
+}
+
+// lazyAllocateForPattern reserves a VIP for hostname under the write
+// lock. Returns true on success, false on pool exhaustion or DB
+// failure (the gateway logs the failure and the agent's DNS query
+// falls through to the upstream resolver — better than handing back a
+// half-built entry).
+func (a *Allocator) lazyAllocateForPattern(hostname string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	// Re-check under the write lock: a concurrent query might have
+	// already allocated this name.
+	if _, ok := a.byName[hostname]; ok {
+		return true
+	}
+	binding := matchPatternBindings(a.patterns, hostname)
+	if binding == nil {
+		return false
+	}
+	if _, err := a.allocateLocked(hostname); err != nil {
+		log.Printf("dnsvip: lazy-allocate %q: %v", hostname, err)
+		return false
+	}
+	a.endpoints[hostname] = binding.Hits
+	if err := a.persistLocked(); err != nil {
+		log.Printf("dnsvip: persist lazy %q: %v", hostname, err)
+		// State is still consistent in memory; persistence will
+		// retry on the next allocation.
+	}
+	return true
 }
 
 // forwardUpstream answers a query the VIP table didn't claim. For A

--- a/cmd/clawpatrol/dnsvip/dnsvip_test.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip_test.go
@@ -422,6 +422,145 @@ func TestForwardUpstreamNXDomainOnUnresolvable(t *testing.T) {
 	}
 }
 
+// TestWildcardLazyAllocation covers the wildcard host path: a policy
+// declares `*.amazonaws.com` and an agent's first DNS query for
+// `s3.amazonaws.com` triggers a fresh VIP allocation. Subsequent
+// queries hit the cached entry; a query for an unrelated name does
+// not allocate.
+func TestWildcardLazyAllocation(t *testing.T) {
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := fakePolicy(t, []string{"*.amazonaws.com:22"})
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	// Nothing pre-allocated for the wildcard.
+	if v4, _ := a.VIPsFor("s3.amazonaws.com"); v4.IsValid() {
+		t.Fatalf("wildcard pre-allocated VIP for s3.amazonaws.com: %v", v4)
+	}
+	// First DNS query triggers a lazy allocation.
+	q := new(dns.Msg)
+	q.SetQuestion("s3.amazonaws.com.", dns.TypeA)
+	resp := a.handleQuery(q, "")
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("handleQuery for wildcard match: resp=%+v", resp)
+	}
+	aRR, ok := resp.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected A record, got %T", resp.Answer[0])
+	}
+	v4, _ := a.VIPsFor("s3.amazonaws.com")
+	if !v4.IsValid() {
+		t.Fatalf("lazy allocation did not populate byName")
+	}
+	if !net.IP(v4.AsSlice()).Equal(aRR.A) {
+		t.Fatalf("answer A %v != allocated VIP %v", aRR.A, v4)
+	}
+	// LookupVIP must round-trip back to the originating endpoint.
+	host, hits := a.LookupVIP(v4.String())
+	if host != "s3.amazonaws.com" || len(hits) != 1 {
+		t.Fatalf("LookupVIP: host=%q hits=%v", host, hits)
+	}
+	if hits[0].Endpoint == nil || hits[0].Endpoint.Name != "epA" {
+		t.Fatalf("LookupVIP returned wrong endpoint: %+v", hits[0])
+	}
+
+	// Different hostname under the same pattern gets its own VIP.
+	q2 := new(dns.Msg)
+	q2.SetQuestion("dynamodb.us-east-1.amazonaws.com.", dns.TypeA)
+	resp2 := a.handleQuery(q2, "")
+	if resp2 == nil || len(resp2.Answer) != 1 {
+		t.Fatalf("second wildcard match: %+v", resp2)
+	}
+	v4Other, _ := a.VIPsFor("dynamodb.us-east-1.amazonaws.com")
+	if v4Other == v4 {
+		t.Fatalf("two distinct wildcard names got the same VIP: %v", v4)
+	}
+
+	// Bare suffix is NOT covered by `*.amazonaws.com`.
+	if a.intercepts("amazonaws.com") {
+		t.Fatalf("`amazonaws.com` should not be intercepted by `*.amazonaws.com`")
+	}
+}
+
+// TestWildcardVIPSurvivesReload pins the persistence contract: a
+// lazy-allocated VIP that still matches a wildcard in the new policy
+// keeps its IP, so an agent's cached DNS answer remains valid.
+func TestWildcardVIPSurvivesReload(t *testing.T) {
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := fakePolicy(t, []string{"*.amazonaws.com:22"})
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild 1: %v", err)
+	}
+	a.intercepts("s3.amazonaws.com") // triggers lazy allocation
+	v4Before, _ := a.VIPsFor("s3.amazonaws.com")
+	if !v4Before.IsValid() {
+		t.Fatalf("lazy allocate did not happen")
+	}
+
+	// Reload with the same pattern — VIP must survive.
+	if err := a.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild 2: %v", err)
+	}
+	v4After, _ := a.VIPsFor("s3.amazonaws.com")
+	if v4After != v4Before {
+		t.Fatalf("VIP drifted across reload: was %v now %v", v4Before, v4After)
+	}
+	// Endpoint→hits map must be re-populated from the pattern.
+	host, hits := a.LookupVIP(v4After.String())
+	if host != "s3.amazonaws.com" || len(hits) != 1 {
+		t.Fatalf("post-reload LookupVIP lost hits: host=%q hits=%v", host, hits)
+	}
+
+	// Persistence: a fresh allocator loaded from the same DB sees
+	// the lazy VIP and (after RebuildFromPolicy) reattaches hits.
+	b, err := New(db, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New 2: %v", err)
+	}
+	if err := b.RebuildFromPolicy(pol); err != nil {
+		t.Fatalf("Rebuild on fresh allocator: %v", err)
+	}
+	v4Restart, _ := b.VIPsFor("s3.amazonaws.com")
+	if v4Restart != v4Before {
+		t.Fatalf("VIP lost across restart: was %v now %v", v4Before, v4Restart)
+	}
+}
+
+// TestWildcardVIPFreedWhenPatternRemoved checks that a lazy entry
+// whose wildcard left policy is released, matching the eager-entry
+// reload semantics.
+func TestWildcardVIPFreedWhenPatternRemoved(t *testing.T) {
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := a.RebuildFromPolicy(fakePolicy(t, []string{"*.amazonaws.com:22"})); err != nil {
+		t.Fatalf("Rebuild 1: %v", err)
+	}
+	a.intercepts("s3.amazonaws.com")
+	if v4, _ := a.VIPsFor("s3.amazonaws.com"); !v4.IsValid() {
+		t.Fatalf("lazy allocate did not happen")
+	}
+
+	// Reload with a completely different pattern; the old entry
+	// must be freed.
+	if err := a.RebuildFromPolicy(fakePolicy(t, []string{"*.googleapis.com:22"})); err != nil {
+		t.Fatalf("Rebuild 2: %v", err)
+	}
+	if v4, _ := a.VIPsFor("s3.amazonaws.com"); v4.IsValid() {
+		t.Fatalf("entry should have been freed after pattern removed, still have %v", v4)
+	}
+}
+
 // TestForwardUpstreamRelaysOtherTypes confirms TXT (and by
 // extension SRV/MX/CAA/etc.) skips the synth path and goes through
 // relayUpstream. We send dstIP="" so the relay path returns

--- a/cmd/clawpatrol/gateway.example.hcl
+++ b/cmd/clawpatrol/gateway.example.hcl
@@ -92,6 +92,7 @@ credential "github_oauth"                 "github"        {}
 
 # Bearer tokens — opaque "Authorization: Bearer <token>".
 credential "bearer_token" "grafana-token" {}
+credential "bearer_token" "aws-token"     {}
 
 # Notion OAuth — workspace-scoped.
 credential "notion_oauth" "notion-oauth" {}
@@ -170,6 +171,18 @@ endpoint "https" "notion" {
 endpoint "https" "grafana" {
   hosts      = ["mygrafana.grafana.net"]
   credential = grafana-token
+}
+
+# HTTPS — wildcard hosts. A `*.<suffix>` entry matches any name that
+# ends in `.<suffix>` and has at least one character before that
+# suffix; `*.amazonaws.com` covers both `s3.amazonaws.com` and
+# `s3.us-east-1.amazonaws.com` but NOT the bare `amazonaws.com`.
+# Exact hosts always beat wildcards; among wildcards the longest
+# matching suffix wins (so `*.us-east-1.amazonaws.com` takes
+# precedence over `*.amazonaws.com` for east-1 names).
+endpoint "https" "aws" {
+  hosts      = ["*.amazonaws.com"]
+  credential = aws-token
 }
 
 # SSH — the wire protocol carries no SNI / Host header, so the
@@ -440,7 +453,7 @@ rule "k8s-default" {
 # fallback the dashboard assigns at approval time.
 
 profile "default" {
-  endpoints = [anthropic, openai-api, openai-chatgpt, github-api]
+  endpoints = [anthropic, openai-api, openai-chatgpt, github-api, aws]
 }
 
 profile "support" {

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denoland/clawpatrol/internal/config/hostmatch"
 	"github.com/denoland/clawpatrol/internal/config/match"
 )
 
@@ -51,13 +52,26 @@ type CompiledPolicy struct {
 // dispatch against. Endpoints map by name; HostIndex maps exact
 // declared hosts plus bare-host aliases for HTTPS-family default-port
 // declarations to the endpoint that owns them for fast SNI / authority
-// lookup. CompiledEndpoint.Hosts keeps the operator-declared strings
-// unchanged.
+// lookup. HostPatterns captures wildcard `*.suffix` declarations the
+// dispatcher walks when HostIndex misses. CompiledEndpoint.Hosts keeps
+// the operator-declared strings unchanged.
 type CompiledProfile struct {
 	Name            string
 	Endpoints       map[string]*CompiledEndpoint
 	HostIndex       map[string]*CompiledEndpoint
+	HostPatterns    []HostPattern
 	HITLAsyncGrants bool
+}
+
+// HostPattern is one wildcard host binding inside a CompiledProfile.
+// Pattern is the full lowercased `*.suffix` string; Endpoint is the
+// CompiledEndpoint that declared it. The dispatcher walks
+// HostPatterns when an exact HostIndex lookup misses; the slice is
+// pre-sorted at compile time so longer (more specific) suffixes are
+// tried first.
+type HostPattern struct {
+	Pattern  string
+	Endpoint *CompiledEndpoint
 }
 
 // CompiledEndpoint flattens an endpoint plus the rules that target it.
@@ -305,6 +319,22 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			// SNI on the wire) matches a config-declared host
 			// regardless of its casing.
 			for _, h := range ce.Hosts {
+				host, _, hpErr := hostmatch.SplitHostPort(h)
+				if hpErr != nil || host == "" {
+					continue
+				}
+				if hostmatch.IsWildcardHost(host) {
+					// Wildcard patterns route on the SNI/authority
+					// host alone (no port), so collapse port-qualified
+					// `*.foo.com:443` and bare `*.foo.com` to a single
+					// pattern keyed on the host portion. Duplicates
+					// from listing both forms are removed below.
+					profile.HostPatterns = append(profile.HostPatterns, HostPattern{
+						Pattern:  strings.ToLower(host),
+						Endpoint: ce,
+					})
+					continue
+				}
 				profile.HostIndex[strings.ToLower(h)] = ce
 			}
 		}
@@ -327,6 +357,11 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				}
 			}
 		}
+		// Wildcard patterns: longest-suffix-wins, so sort by
+		// descending pattern length. Within equal length we sort
+		// alphabetically for determinism.
+		dedupePatterns(&profile.HostPatterns)
+		sortHostPatterns(profile.HostPatterns)
 		cp.Profiles[name] = profile
 	}
 
@@ -404,7 +439,56 @@ func bareHostAlias(ep *CompiledEndpoint, host string) (string, bool) {
 	if err != nil || bare == "" || port != "443" {
 		return "", false
 	}
+	// Wildcards go through HostPatterns, not HostIndex.
+	if strings.HasPrefix(bare, "*.") {
+		return "", false
+	}
 	return bare, true
+}
+
+// dedupePatterns removes duplicate (pattern, endpoint) entries that
+// arise when a profile binds the same wildcard via both bare and
+// port-qualified forms (e.g. `*.foo.com` and `*.foo.com:443`).
+func dedupePatterns(patterns *[]HostPattern) {
+	if len(*patterns) < 2 {
+		return
+	}
+	seen := make(map[string]struct{}, len(*patterns))
+	out := (*patterns)[:0]
+	for _, p := range *patterns {
+		key := p.Pattern + "\x00" + p.Endpoint.Name
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, p)
+	}
+	*patterns = out
+}
+
+// sortHostPatterns orders patterns so the dispatcher's linear scan
+// returns the longest (most specific) suffix first. Ties break
+// alphabetically for determinism.
+func sortHostPatterns(patterns []HostPattern) {
+	sort.SliceStable(patterns, func(i, j int) bool {
+		if len(patterns[i].Pattern) != len(patterns[j].Pattern) {
+			return len(patterns[i].Pattern) > len(patterns[j].Pattern)
+		}
+		return patterns[i].Pattern < patterns[j].Pattern
+	})
+}
+
+// MatchHostPattern is the matcher used at dispatch time. Returns the
+// first endpoint whose pattern matches hostname (patterns must already
+// be sorted by descending pattern length). Hostname must already be
+// lowercased; patterns are stored lowercased by Compile.
+func MatchHostPattern(patterns []HostPattern, hostname string) *CompiledEndpoint {
+	for _, p := range patterns {
+		if hostmatch.MatchWildcard(p.Pattern, hostname) {
+			return p.Endpoint
+		}
+	}
+	return nil
 }
 
 // hostExtractor / credentialExtractor are the small cross-cut readers

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -103,6 +103,108 @@ func TestCompile(t *testing.T) {
 	}
 }
 
+// TestCompileWildcardHosts verifies that wildcard hosts are accepted,
+// land in HostPatterns (not HostIndex), and that malformed wildcards
+// or within-endpoint duplicates are rejected at load time.
+func TestCompileWildcardHosts(t *testing.T) {
+	src := `
+credential "bearer_token" "tok" {}
+endpoint "https" "aws" {
+  hosts      = ["*.amazonaws.com", "*.us-east-1.amazonaws.com:443"]
+  credential = tok
+}
+profile "p" { endpoints = [aws] }
+`
+	gw, diags := config.LoadBytes([]byte(src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	prof := cp.Profiles["p"]
+	if prof == nil {
+		t.Fatalf("missing profile p")
+	}
+	if got := len(prof.HostPatterns); got != 2 {
+		t.Fatalf("HostPatterns count = %d, want 2 (entries: %+v)", got, prof.HostPatterns)
+	}
+	// Longest first: *.us-east-1.amazonaws.com before *.amazonaws.com.
+	if prof.HostPatterns[0].Pattern != "*.us-east-1.amazonaws.com" {
+		t.Errorf("HostPatterns[0]=%q, want *.us-east-1.amazonaws.com", prof.HostPatterns[0].Pattern)
+	}
+	if prof.HostPatterns[1].Pattern != "*.amazonaws.com" {
+		t.Errorf("HostPatterns[1]=%q, want *.amazonaws.com", prof.HostPatterns[1].Pattern)
+	}
+	// Wildcards must not leak into HostIndex.
+	for k := range prof.HostIndex {
+		if strings.HasPrefix(k, "*.") {
+			t.Errorf("HostIndex leaked wildcard %q", k)
+		}
+	}
+}
+
+func TestCompileRejectsBadHosts(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "malformed wildcard - empty suffix",
+			src: `
+credential "bearer_token" "tok" {}
+endpoint "https" "bad" {
+  hosts = ["*."]
+  credential = tok
+}
+profile "p" { endpoints = [bad] }
+`,
+		},
+		{
+			name: "wildcard with bare TLD",
+			src: `
+credential "bearer_token" "tok" {}
+endpoint "https" "bad" {
+  hosts = ["*.com"]
+  credential = tok
+}
+profile "p" { endpoints = [bad] }
+`,
+		},
+		{
+			name: "wildcard not at leftmost label",
+			src: `
+credential "bearer_token" "tok" {}
+endpoint "https" "bad" {
+  hosts = ["api.*.foo.com"]
+  credential = tok
+}
+profile "p" { endpoints = [bad] }
+`,
+		},
+		{
+			name: "duplicate hosts",
+			src: `
+credential "bearer_token" "tok" {}
+endpoint "https" "bad" {
+  hosts = ["api.foo.com", "api.foo.com"]
+  credential = tok
+}
+profile "p" { endpoints = [bad] }
+`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, diags := config.LoadBytes([]byte(c.src), "in.hcl")
+			if !diags.HasErrors() {
+				t.Fatalf("load accepted bad hosts; want diagnostic")
+			}
+		})
+	}
+}
+
 // TestCompilePrioritySort verifies that rules with mixed priorities
 // land in descending priority order, matching the v14 first-match-
 // wins evaluation. Tied priorities preserve declaration order.

--- a/internal/config/hostmatch/hostmatch.go
+++ b/internal/config/hostmatch/hostmatch.go
@@ -1,0 +1,162 @@
+// Package hostmatch parses and matches the host entries that appear
+// in an endpoint's `hosts = [...]` list. Entries may be exact
+// `api.foo.com`, port-qualified `api.foo.com:443`, IP literals
+// `10.0.0.5`, IPv6 literals `[fd00::1]:22`, or wildcard suffixes
+// `*.foo.com` (optionally port-qualified).
+//
+// Wildcards take the form `*.<suffix>`: a single `*` at the leftmost
+// label, immediately followed by `.`, followed by a non-empty
+// hostname containing no further metacharacters. `*.foo.com` matches
+// any name that ends in `.foo.com` and has at least one character
+// before that suffix — both `s3.foo.com` and `s3.us-east-1.foo.com`
+// match, but the bare `foo.com` does not. Single-label restriction
+// (RFC 6125 TLS cert wildcards) is deliberately NOT applied: the
+// matching here is for endpoint routing, not certificate validation,
+// and the operator use case (e.g. `*.amazonaws.com`) needs to span
+// multiple label depths.
+package hostmatch
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IsWildcardHost reports whether the host portion of entry is a
+// wildcard pattern. entry may carry a `:port` suffix.
+func IsWildcardHost(entry string) bool {
+	host, _, err := SplitHostPort(entry)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(host, "*.")
+}
+
+// SplitHostPort separates a `host[:port]` entry into its parts. For
+// bare hosts it returns port="". Unlike net.SplitHostPort it does
+// NOT error on the bare-host case — the caller (an endpoint's hosts
+// list) routinely accepts both forms.
+//
+// Wildcard hosts like `*.foo.com` pass through unchanged in the
+// host return; `*.foo.com:443` separates as host=`*.foo.com`,
+// port=`443`.
+func SplitHostPort(entry string) (host, port string, err error) {
+	if entry == "" {
+		return "", "", fmt.Errorf("empty host entry")
+	}
+	// Bracketed IPv6 with port: [::1]:22.
+	if strings.HasPrefix(entry, "[") {
+		h, p, splitErr := net.SplitHostPort(entry)
+		if splitErr != nil {
+			return "", "", splitErr
+		}
+		return h, p, nil
+	}
+	// Count colons: zero means bare host, exactly one means host:port,
+	// more than one means an unbracketed IPv6 literal (caller intent
+	// unclear — let net.SplitHostPort error out).
+	switch strings.Count(entry, ":") {
+	case 0:
+		return entry, "", nil
+	case 1:
+		h, p, splitErr := net.SplitHostPort(entry)
+		if splitErr != nil {
+			return "", "", splitErr
+		}
+		return h, p, nil
+	default:
+		// Likely an unbracketed IPv6 literal without port. Treat the
+		// whole string as the host. (Bare IPv6 hosts in HCL are
+		// uncommon — the well-formed shape is [::1] — but we don't
+		// want to reject them outright.)
+		return entry, "", nil
+	}
+}
+
+// ValidateHost checks that entry is a syntactically valid host entry.
+// Accepts exact hostnames, IP literals, port-qualified forms, and
+// `*.<suffix>` wildcards. Returns an error explaining what's wrong
+// when entry doesn't fit any of those.
+func ValidateHost(entry string) error {
+	host, port, err := SplitHostPort(entry)
+	if err != nil {
+		return err
+	}
+	if host == "" {
+		return fmt.Errorf("missing host portion")
+	}
+	if strings.HasSuffix(entry, ":") && port == "" {
+		return fmt.Errorf("trailing colon with no port: %q", entry)
+	}
+	if port != "" {
+		if !isNumericPort(port) {
+			return fmt.Errorf("invalid port %q", port)
+		}
+	}
+	if strings.HasPrefix(host, "*.") {
+		return validateWildcardSuffix(host)
+	}
+	if strings.ContainsRune(host, '*') {
+		return fmt.Errorf("%q: `*` only allowed as leftmost label (use `*.<suffix>`)", host)
+	}
+	// Otherwise: exact hostname or IP. We don't enforce DNS-label
+	// rules (clawpatrol has historically accepted any non-empty
+	// string, and operators occasionally use synthetic names that
+	// don't pass strict DNS validation).
+	return nil
+}
+
+func validateWildcardSuffix(host string) error {
+	suffix := host[2:] // strip "*."
+	if suffix == "" {
+		return fmt.Errorf("%q: wildcard suffix is empty", host)
+	}
+	if strings.ContainsRune(suffix, '*') {
+		return fmt.Errorf("%q: only one `*` allowed", host)
+	}
+	if strings.HasPrefix(suffix, ".") || strings.HasSuffix(suffix, ".") {
+		return fmt.Errorf("%q: wildcard suffix must not start or end with `.`", host)
+	}
+	if strings.Contains(suffix, "..") {
+		return fmt.Errorf("%q: empty label in wildcard suffix", host)
+	}
+	if net.ParseIP(suffix) != nil {
+		return fmt.Errorf("%q: wildcard suffix must not be an IP literal", host)
+	}
+	if !strings.Contains(suffix, ".") {
+		// Refuse single-label suffixes like `*.com` — too broad to
+		// be a routing target. Operators who really want this can
+		// list specific TLDs.
+		return fmt.Errorf("%q: wildcard suffix must contain at least one `.` (refuse to match a whole TLD)", host)
+	}
+	return nil
+}
+
+func isNumericPort(p string) bool {
+	if p == "" || len(p) > 5 {
+		return false
+	}
+	n := 0
+	for _, r := range p {
+		if r < '0' || r > '9' {
+			return false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n >= 1 && n <= 65535
+}
+
+// MatchWildcard reports whether the lowercased hostname matches the
+// wildcard pattern. pattern must be a validated `*.<suffix>` form;
+// hostname must be a bare host (no port). Both should already be
+// lowercased — this function does no case folding.
+func MatchWildcard(pattern, hostname string) bool {
+	if !strings.HasPrefix(pattern, "*.") {
+		return false
+	}
+	suffix := pattern[1:] // e.g. ".foo.com"
+	if len(hostname) <= len(suffix) {
+		return false
+	}
+	return strings.HasSuffix(hostname, suffix)
+}

--- a/internal/config/hostmatch/hostmatch_test.go
+++ b/internal/config/hostmatch/hostmatch_test.go
@@ -1,0 +1,116 @@
+package hostmatch
+
+import "testing"
+
+func TestIsWildcardHost(t *testing.T) {
+	cases := []struct {
+		entry string
+		want  bool
+	}{
+		{"api.foo.com", false},
+		{"api.foo.com:443", false},
+		{"*.foo.com", true},
+		{"*.foo.com:443", true},
+		{"10.0.0.1", false},
+		{"[fd00::1]:22", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsWildcardHost(c.entry); got != c.want {
+			t.Errorf("IsWildcardHost(%q) = %v, want %v", c.entry, got, c.want)
+		}
+	}
+}
+
+func TestSplitHostPort(t *testing.T) {
+	cases := []struct {
+		entry, host, port string
+		wantErr           bool
+	}{
+		{"api.foo.com", "api.foo.com", "", false},
+		{"api.foo.com:443", "api.foo.com", "443", false},
+		{"*.foo.com:443", "*.foo.com", "443", false},
+		{"[fd00::1]:22", "fd00::1", "22", false},
+		{"fd00::1", "fd00::1", "", false},
+		{"10.0.0.5", "10.0.0.5", "", false},
+		{"10.0.0.5:5432", "10.0.0.5", "5432", false},
+		{"", "", "", true},
+		{":443", "", "", false}, // net.SplitHostPort accepts this; not our concern
+	}
+	for _, c := range cases {
+		host, port, err := SplitHostPort(c.entry)
+		if (err != nil) != c.wantErr {
+			t.Errorf("SplitHostPort(%q) err = %v, wantErr %v", c.entry, err, c.wantErr)
+			continue
+		}
+		if c.wantErr {
+			continue
+		}
+		if c.entry == ":443" {
+			continue // documented as net.SplitHostPort's behavior; not part of our contract
+		}
+		if host != c.host || port != c.port {
+			t.Errorf("SplitHostPort(%q) = (%q, %q), want (%q, %q)", c.entry, host, port, c.host, c.port)
+		}
+	}
+}
+
+func TestValidateHost(t *testing.T) {
+	good := []string{
+		"api.foo.com",
+		"api.foo.com:443",
+		"*.foo.com",
+		"*.foo.com:443",
+		"*.us-east-1.amazonaws.com",
+		"10.0.0.1",
+		"10.0.0.1:5432",
+		"[fd00::1]:22",
+	}
+	for _, g := range good {
+		if err := ValidateHost(g); err != nil {
+			t.Errorf("ValidateHost(%q) errored: %v", g, err)
+		}
+	}
+	bad := []string{
+		"",
+		"*",
+		"*foo.com",
+		"foo.*.com",
+		"*.*.com",
+		"**.com",
+		"*.",
+		"*.com",      // single-label suffix
+		"*.foo.com:", // empty port
+		"*.foo.com:0",
+		"*.foo.com:999999",
+		"*.foo..com",
+	}
+	for _, b := range bad {
+		if err := ValidateHost(b); err == nil {
+			t.Errorf("ValidateHost(%q) accepted, want error", b)
+		}
+	}
+}
+
+func TestMatchWildcard(t *testing.T) {
+	cases := []struct {
+		pattern, hostname string
+		want              bool
+	}{
+		{"*.foo.com", "api.foo.com", true},
+		{"*.foo.com", "a.b.c.foo.com", true},
+		{"*.foo.com", "foo.com", false},
+		{"*.foo.com", "notfoo.com", false},
+		{"*.foo.com", "x.notfoo.com", false},
+		{"*.foo.com", "foo.com.evil.example", false},
+		{"*.foo.com", "FOO.foo.com", true}, // both already lowercased per contract; we don't case-fold
+		{"*.amazonaws.com", "s3.us-east-1.amazonaws.com", true},
+		{"*.amazonaws.com", "amazonaws.com", false},
+		{"api.foo.com", "api.foo.com", false}, // not a wildcard pattern
+	}
+	for _, c := range cases {
+		if got := MatchWildcard(c.pattern, c.hostname); got != c.want {
+			t.Errorf("MatchWildcard(%q, %q) = %v, want %v", c.pattern, c.hostname, got, c.want)
+		}
+	}
+}

--- a/internal/config/plugins/endpoints/kubernetes.go
+++ b/internal/config/plugins/endpoints/kubernetes.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
@@ -89,14 +90,24 @@ func (e *KubernetesEndpoint) ConfigureUpstreamTLS(cfg *tls.Config) error {
 	return nil
 }
 
+// validateKubernetesEndpoint catches malformed host / server entries
+// before the compile pass turns them into a routing table. Kubernetes
+// endpoints can declare either `hosts = [...]` (managed clusters) or
+// `server = "..."` (self-hosted); EndpointHosts() returns whichever
+// is set, so the shared validateHosts check covers both shapes.
+func validateKubernetesEndpoint(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
+	return validateHosts(d, name, ctx.Block.DefRange)
+}
+
 func init() {
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "kubernetes",
-		Family: "k8s",
-		New:    func() any { return &KubernetesEndpoint{} },
-		Refs:   singularRef,
-		Build:  passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "kubernetes",
+		Family:   "k8s",
+		New:      func() any { return &KubernetesEndpoint{} },
+		Refs:     singularRef,
+		Validate: validateKubernetesEndpoint,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*KubernetesEndpoint)
 			if len(e.Hosts) > 0 {

--- a/internal/config/plugins/endpoints/util.go
+++ b/internal/config/plugins/endpoints/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/hostmatch"
 )
 
 // CredentialEntry is one row inside an endpoint's credentials list.
@@ -278,13 +279,63 @@ func credentialEntrySignature(e CredentialEntry) string {
 	return e.Placeholder + "\x00" + strings.Join(dbs, "\x00")
 }
 
+// validateHosts checks the host strings the plugin body exposes via
+// EndpointHosts(). It rejects malformed entries (bad ports,
+// malformed wildcards) and within-endpoint duplicates. Endpoint
+// plugins whose hosts come from a single field (postgres' Host,
+// kubernetes' Server) also pass through here — EndpointHosts
+// returns a one-element slice for them, so the same validation
+// applies.
+func validateHosts(d any, name string, defRange hcl.Range) hcl.Diagnostics {
+	hosts := extractHostsAny(d)
+	if len(hosts) == 0 {
+		return nil
+	}
+	var diags hcl.Diagnostics
+	seen := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		if err := hostmatch.ValidateHost(h); err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Malformed host on endpoint %q", name),
+				Detail:   fmt.Sprintf("hosts entry %q: %v", h, err),
+				Subject:  &defRange,
+			})
+			continue
+		}
+		key := strings.ToLower(h)
+		if _, dup := seen[key]; dup {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Duplicate host on endpoint %q", name),
+				Detail:   fmt.Sprintf("hosts entry %q appears more than once", h),
+				Subject:  &defRange,
+			})
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	return diags
+}
+
+// extractHostsAny mirrors compile.extractHosts but lives in this
+// package so the Validate hooks can call it without dragging the
+// internal compile pass in.
+func extractHostsAny(body any) []string {
+	if h, ok := body.(interface{ EndpointHosts() []string }); ok {
+		return h.EndpointHosts()
+	}
+	return nil
+}
+
 // multiCredValidate is the shared Validate hook for endpoint plugins
 // that accept both binding shapes. Validates the exclusivity invariant,
 // parses the list, cross-checks each entry's credential against the
 // symbol table, then stashes the parsed entries on the typed struct
-// via setCredentialEntries.
+// via setCredentialEntries. Also validates the endpoint's hosts list.
 func multiCredValidate(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
 	var diags hcl.Diagnostics
+	diags = append(diags, validateHosts(d, name, ctx.Block.DefRange)...)
 	diags = append(diags, validateBinding(d, "endpoint", name, ctx.Block.DefRange)...)
 	hcr, ok := d.(hasCredentialsRaw)
 	if !ok {

--- a/internal/config/runtime/dispatch.go
+++ b/internal/config/runtime/dispatch.go
@@ -13,9 +13,13 @@ import (
 // so a TLS SNI value like "api.example.com" can match an endpoint
 // declared as "api.example.com:443" without a runtime scan. DNS
 // hostnames are case-insensitive; the lookup key is lowercased to
-// match the lowercase keys Compile inserts. Returns nil when the
-// profile doesn't bind any matching endpoint — the caller then
-// applies the defaults.unknown_host policy.
+// match the lowercase keys Compile inserts.
+//
+// When the exact lookup misses we walk HostPatterns — the profile's
+// wildcard declarations (`hosts = ["*.foo.com"]`) — in
+// longest-suffix-first order. Exact matches always win over wildcards
+// for the same name. Returns nil when nothing matches; the caller
+// then applies the defaults.unknown_host policy.
 func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.CompiledEndpoint {
 	if policy == nil {
 		return nil
@@ -26,9 +30,17 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 		// Single-tenant fallback: if no peer-to-profile mapping is
 		// established, walk every profile and return the first match.
 		// Matches main.go's existing profileFor behavior when only
-		// one profile exists.
+		// one profile exists. Exact matches are tried across all
+		// profiles before falling back to wildcards so a profile that
+		// declared the exact host wins over a different profile's
+		// wildcard.
 		for _, p := range policy.Profiles {
 			if ep := p.HostIndex[host]; ep != nil {
+				return ep
+			}
+		}
+		for _, p := range policy.Profiles {
+			if ep := config.MatchHostPattern(p.HostPatterns, host); ep != nil {
 				return ep
 			}
 		}
@@ -37,7 +49,7 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 	if ep := prof.HostIndex[host]; ep != nil {
 		return ep
 	}
-	return nil
+	return config.MatchHostPattern(prof.HostPatterns, host)
 }
 
 // MatchRequest walks an endpoint's priority-sorted rule list and

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -203,6 +203,110 @@ profile "default" { endpoints = [api, db] }
 	}
 }
 
+func TestHostEndpointWildcardMatches(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "aws-tok" {}
+endpoint "https" "aws-ep" {
+  hosts      = ["*.amazonaws.com"]
+  credential = aws-tok
+}
+profile "default" { endpoints = [aws-ep] }
+`)
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"s3.amazonaws.com", "aws-ep"},
+		{"dynamodb.us-east-1.amazonaws.com", "aws-ep"},
+		{"AB.AMAZONAWS.COM", "aws-ep"},
+		{"amazonaws.com", ""},
+		{"notamazonaws.com", ""},
+		{"foo.bar", ""},
+	}
+	for _, c := range cases {
+		got := runtime.HostEndpoint(cp, "default", c.host)
+		gotName := ""
+		if got != nil {
+			gotName = got.Name
+		}
+		if gotName != c.want {
+			t.Errorf("HostEndpoint(%q) = %q, want %q", c.host, gotName, c.want)
+		}
+	}
+}
+
+func TestHostEndpointExactBeatsWildcard(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "aws-tok" {}
+credential "bearer_token" "s3-tok"  {}
+endpoint "https" "aws-ep" {
+  hosts      = ["*.amazonaws.com"]
+  credential = aws-tok
+}
+endpoint "https" "s3-ep" {
+  hosts      = ["s3.amazonaws.com"]
+  credential = s3-tok
+}
+profile "default" { endpoints = [aws-ep, s3-ep] }
+`)
+	if got := runtime.HostEndpoint(cp, "default", "s3.amazonaws.com"); got == nil || got.Name != "s3-ep" {
+		t.Fatalf("exact host should beat wildcard: got %+v, want s3-ep", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "dynamodb.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("uncovered subdomain should fall to wildcard: got %+v, want aws-ep", got)
+	}
+}
+
+func TestHostEndpointLongestWildcardWins(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "aws-tok"  {}
+credential "bearer_token" "east-tok" {}
+endpoint "https" "east-ep" {
+  hosts      = ["*.us-east-1.amazonaws.com"]
+  credential = east-tok
+}
+endpoint "https" "aws-ep" {
+  hosts      = ["*.amazonaws.com"]
+  credential = aws-tok
+}
+profile "default" { endpoints = [aws-ep, east-ep] }
+`)
+	if got := runtime.HostEndpoint(cp, "default", "s3.us-east-1.amazonaws.com"); got == nil || got.Name != "east-ep" {
+		t.Fatalf("longest suffix should win: got %+v, want east-ep", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "s3.us-west-2.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("shorter pattern picks up the rest: got %+v, want aws-ep", got)
+	}
+}
+
+func TestHostEndpointWildcardWithPortAlias(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "aws-tok" {}
+endpoint "https" "aws-ep" {
+  hosts      = ["*.amazonaws.com:443"]
+  credential = aws-tok
+}
+profile "default" { endpoints = [aws-ep] }
+`)
+	if got := runtime.HostEndpoint(cp, "default", "s3.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("port-qualified wildcard should match bare SNI: got %+v, want aws-ep", got)
+	}
+}
+
+func TestHostEndpointWildcardSingleTenantFallback(t *testing.T) {
+	cp := compileFixture(t, `
+credential "bearer_token" "aws-tok" {}
+endpoint "https" "aws-ep" {
+  hosts      = ["*.amazonaws.com"]
+  credential = aws-tok
+}
+profile "tenant" { endpoints = [aws-ep] }
+`)
+	if got := runtime.HostEndpoint(cp, "missing-profile", "s3.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("fallback scan should find wildcard match across profiles: got %+v, want aws-ep", got)
+	}
+}
+
 // TestMatchRequest exercises priority-ordered first-match-wins
 // dispatch and the default catch-all (priority -100).
 func TestMatchRequest(t *testing.T) {


### PR DESCRIPTION
* new `internal/config/hostmatch` package with `*.<suffix>` parser
  + matcher. validates entries at load time and rejects malformed
  patterns (`*foo.com`, `*.com`, `api.*.foo`) and within-endpoint
  duplicates
* `CompiledProfile` grows `HostPatterns`; wildcards split off from
  `HostIndex` at compile time, deduped, and sorted longest-suffix-
  first so the dispatcher returns the most specific match
* `runtime.HostEndpoint` falls through to `HostPatterns` on exact
  miss; exact hosts always win, and single-tenant fallback walks
  exact across every profile before wildcards
* DNS-VIP lazy-allocates VIPs the first time a query matches a
  wildcard pattern. Lazy entries persist across restarts and survive
  policy reloads when some current pattern still covers the name;
  the endpoint->hits map is re-derived on rebuild
* example: new `*.amazonaws.com` HTTPS endpoint demonstrating the
  syntax + matching rules

`*.amazonaws.com` matches `s3.amazonaws.com` and
`s3.us-east-1.amazonaws.com` (any subdomain depth) but NOT the bare
`amazonaws.com`. More-specific wildcards beat less-specific ones, so
`*.us-east-1.amazonaws.com` takes precedence over `*.amazonaws.com`
for east-1 names; an exact host beats any wildcard.