### PR TITLE
site: serve .txt with charset=utf-8

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -6,3 +6,9 @@
 /install.sh
   Cache-Control: no-cache, no-store, must-revalidate
   CDN-Cache-Control: no-store
+
+# CF serves .txt as `text/plain` with no charset, so browsers fall back
+# to Latin-1 and mangle the em dashes in llms.txt / llms-full.txt
+# (— → â€"). Pin UTF-8 explicitly.
+/*.txt
+  Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
## Summary

Cloudflare serves `.txt` assets with `Content-Type: text/plain` and no charset, so browsers fall back to Latin-1 and mangle the em dashes in `llms.txt` / `llms-full.txt` (`—` renders as `â€"`).

Verified live:

```
$ curl -sI -u :aruba 'https://clawpatrol.dev/llms.txt' | grep -i content-type
content-type: text/plain
```

Pin UTF-8 explicitly in `site/public/_headers`:

```
/*.txt
  Content-Type: text/plain; charset=utf-8
```

`_headers` is Cloudflare's per-route header config; it's already used in this repo to override `Cache-Control` on `/install.sh`. Wrangler ships the file as-is from the assets directory at deploy time.

## Test plan

- [ ] Redeploy via `wrangler deploy`.
- [ ] `curl -sI -u :aruba https://clawpatrol.dev/llms.txt | grep content-type` reports `text/plain; charset=utf-8`.
- [ ] Open `https://clawpatrol.dev/llms.txt` in a browser — em dashes render as `—`, not `â€"`.
