### PR TITLE
hitl: update Slack prompt on sync timeout

### DIFF
--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -213,6 +213,66 @@ func (g *Gateway) updateHITLOperationMessage(ctx context.Context, op HITLOperati
 	if credName == "" {
 		return
 	}
+	g.updateHITLMessageRef(ctx, policy, credName, runtime.HITLMessageUpdate{
+		MessageRef:     op.ApproverMessageRef,
+		OperationID:    op.ID,
+		State:          runtime.HITLOperationState(op.State),
+		Method:         op.Method,
+		Host:           op.Host,
+		Path:           op.RedactedPath,
+		Profile:        op.ProfileID,
+		UpstreamCalled: op.UpstreamCalled,
+		LastError:      op.LastError,
+	})
+}
+
+func (g *Gateway) updatePendingHITLMessage(ctx context.Context, pending runtime.HITLPending, ref string, result runtime.HITLResolveResult) {
+	if g == nil || ref == "" || len(pending.Approvers) == 0 {
+		return
+	}
+	policy := g.Policy()
+	if policy == nil {
+		return
+	}
+	approver := policy.Approvers[pending.Approvers[0]]
+	if approver == nil {
+		return
+	}
+	credName := ""
+	if h, ok := approver.Body.(runtime.HITLHumanCredentialer); ok {
+		credName = h.HumanApproverCredential()
+	}
+	if credName == "" {
+		return
+	}
+	state := runtime.HITLOperationStateDenied
+	switch result.State {
+	case runtime.HITLStateTimedOut:
+		state = runtime.HITLOperationStateExpired
+	case runtime.HITLStateClientDisconnected:
+		state = runtime.HITLOperationStateClientDisconnected
+	case runtime.HITLStateApproved:
+		state = runtime.HITLOperationStateExecutingUpstream
+	case runtime.HITLStateDenied:
+		state = runtime.HITLOperationStateDenied
+	}
+	g.updateHITLMessageRef(ctx, policy, credName, runtime.HITLMessageUpdate{
+		MessageRef:     ref,
+		OperationID:    pending.OperationID,
+		State:          state,
+		Method:         pending.Method,
+		Host:           pending.Host,
+		Path:           pending.Path,
+		Profile:        "",
+		UpstreamCalled: false,
+		LastError:      result.Reason,
+	})
+}
+
+func (g *Gateway) updateHITLMessageRef(ctx context.Context, policy *config.CompiledPolicy, credName string, update runtime.HITLMessageUpdate) {
+	if policy == nil || credName == "" {
+		return
+	}
 	cred := policy.Credentials[credName]
 	if cred == nil {
 		return
@@ -224,18 +284,12 @@ func (g *Gateway) updateHITLOperationMessage(ctx context.Context, op HITLOperati
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := updater.UpdateHITLMessage(ctx, g.secrets, runtime.HITLMessageUpdate{
-		MessageRef:     op.ApproverMessageRef,
-		OperationID:    op.ID,
-		State:          runtime.HITLOperationState(op.State),
-		Method:         op.Method,
-		Host:           op.Host,
-		Path:           op.RedactedPath,
-		Profile:        op.ProfileID,
-		UpstreamCalled: op.UpstreamCalled,
-		LastError:      op.LastError,
-	}); err != nil {
-		log.Printf("hitl async operation message update %s: %v", op.ID, err)
+	if err := updater.UpdateHITLMessage(ctx, g.secrets, update); err != nil {
+		if update.OperationID != "" {
+			log.Printf("hitl operation message update %s: %v", update.OperationID, err)
+		} else {
+			log.Printf("hitl pending message update: %v", err)
+		}
 	}
 }
 

--- a/cmd/clawpatrol/hitl_registry_test.go
+++ b/cmd/clawpatrol/hitl_registry_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -147,6 +148,79 @@ func TestHITLRegistryCancelRecordsClientDisconnected(t *testing.T) {
 	}
 	if !strings.Contains(stale.Reason, "upstream request was not sent") {
 		t.Fatalf("stale Reason = %q, want upstream-not-sent explanation", stale.Reason)
+	}
+}
+
+func TestHITLRegistryCancelUpdatesRecordedMessageRefs(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	var gotPending runtime.HITLPending
+	var gotRef string
+	var gotResult runtime.HITLResolveResult
+	updated := make(chan struct{}, 1)
+	registry.pendingMessageUpdater = func(_ context.Context, pending runtime.HITLPending, ref string, result runtime.HITLResolveResult) {
+		gotPending = pending
+		gotRef = ref
+		gotResult = result
+		updated <- struct{}{}
+	}
+	id, _ := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+	if err := registry.RecordMessageRef(context.Background(), id, `{"type":"slack","channel":"C123","ts":"1778764174.925659"}`); err != nil {
+		t.Fatalf("RecordMessageRef returned error: %v", err)
+	}
+
+	result := registry.Cancel(id, runtime.HITLStateTimedOut, "approver timed out; upstream request was not sent")
+	if !result.OK {
+		t.Fatalf("Cancel OK = false, want true: %#v", result)
+	}
+	select {
+	case <-updated:
+	case <-time.After(time.Second):
+		t.Fatal("Cancel did not update recorded message ref")
+	}
+	if gotPending.ID != id || gotPending.Host != "api.example.test" || gotPending.Method != "POST" || gotPending.Path != "/v1/write" {
+		t.Fatalf("updated pending = %#v", gotPending)
+	}
+	if gotRef == "" || !strings.Contains(gotRef, "1778764174.925659") {
+		t.Fatalf("updated ref = %q, want recorded Slack message ref", gotRef)
+	}
+	if gotResult.State != runtime.HITLStateTimedOut || !strings.Contains(gotResult.Reason, "upstream request was not sent") {
+		t.Fatalf("updated result = %#v", gotResult)
+	}
+}
+
+func TestHITLRegistryLateMessageRefUpdateUsesFreshContext(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	updated := make(chan error, 1)
+	registry.pendingMessageUpdater = func(ctx context.Context, _ runtime.HITLPending, _ string, _ runtime.HITLResolveResult) {
+		updated <- ctx.Err()
+	}
+	id, _ := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+	result := registry.Cancel(id, runtime.HITLStateTimedOut, "approver timed out; upstream request was not sent")
+	if !result.OK {
+		t.Fatalf("Cancel OK = false, want true: %#v", result)
+	}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := registry.RecordMessageRef(canceledCtx, id, `{"type":"slack","channel":"C123","ts":"1778764174.925659"}`); err != nil {
+		t.Fatalf("RecordMessageRef returned error: %v", err)
+	}
+	select {
+	case err := <-updated:
+		if err != nil {
+			t.Fatalf("late updater ctx err = %v, want live context", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late RecordMessageRef did not update terminal message")
 	}
 }
 

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2528,6 +2528,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			DashboardURL:              g.cfg.PublicURL,
 			Policy:                    policy,
 			MessageUpdateSink:         g.recordHITLOperationMessageRef,
+			PendingMessageUpdateSink:  g.hitl.RecordMessageRef,
 		}
 		v, err := ar.Approve(ctx, req)
 		// Stamp the entity name + plugin type on every verdict so the
@@ -2778,6 +2779,7 @@ func runGateway(args []string) {
 	log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
 	g.secrets = newGatewaySecretStore(db, oauthReg)
 	g.hitl.asyncGrantResolver = g.resolveAsyncHITLGrant
+	g.hitl.pendingMessageUpdater = g.updatePendingHITLMessage
 	g.tunnels = NewTunnelManager(g.secrets, stateDir)
 	registerOAuthCredentials(oauthReg, policy)
 	g.policy.Store(policy)

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -2479,11 +2479,13 @@ func wrapBodySampler(rc io.ReadCloser, s *sampler) io.ReadCloser {
 const hitlTerminalTTL = 30 * time.Minute
 
 type HITLRegistry struct {
-	mu                 sync.Mutex
-	pending            map[string]*pendingEntry
-	terminal           map[string]terminalHITLEntry
-	sink               *Sink // SSE fan-out for the dashboard
-	asyncGrantResolver func(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult
+	mu                    sync.Mutex
+	pending               map[string]*pendingEntry
+	terminal              map[string]terminalHITLEntry
+	messageRefs           map[string][]string
+	sink                  *Sink // SSE fan-out for the dashboard
+	asyncGrantResolver    func(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult
+	pendingMessageUpdater func(ctx context.Context, pending runtime.HITLPending, ref string, result runtime.HITLResolveResult)
 }
 
 type pendingEntry struct {
@@ -2493,14 +2495,16 @@ type pendingEntry struct {
 
 type terminalHITLEntry struct {
 	result    runtime.HITLResolveResult
+	pending   runtime.HITLPending
 	expiresAt time.Time
 }
 
 func newHITLRegistry(sink *Sink) *HITLRegistry {
 	return &HITLRegistry{
-		pending:  map[string]*pendingEntry{},
-		terminal: map[string]terminalHITLEntry{},
-		sink:     sink,
+		pending:     map[string]*pendingEntry{},
+		terminal:    map[string]terminalHITLEntry{},
+		messageRefs: map[string][]string{},
+		sink:        sink,
 	}
 }
 
@@ -2520,6 +2524,7 @@ func (r *HITLRegistry) Add(p runtime.HITLPending) (string, <-chan runtime.HITLDe
 	r.pruneTerminalLocked(time.Now())
 	r.pending[p.ID] = &pendingEntry{p: p, decision: ch}
 	delete(r.terminal, p.ID)
+	delete(r.messageRefs, p.ID)
 	r.mu.Unlock()
 	if r.sink != nil {
 		r.sink.Emit(Event{
@@ -2528,6 +2533,32 @@ func (r *HITLRegistry) Add(p runtime.HITLPending) (string, <-chan runtime.HITLDe
 		})
 	}
 	return p.ID, ch
+}
+
+func (r *HITLRegistry) RecordMessageRef(ctx context.Context, pendingID, ref string) error {
+	if strings.TrimSpace(pendingID) == "" || strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	var latePending runtime.HITLPending
+	var lateResult runtime.HITLResolveResult
+	var lateUpdater func(context.Context, runtime.HITLPending, string, runtime.HITLResolveResult)
+	r.mu.Lock()
+	r.pruneTerminalLocked(time.Now())
+	if _, ok := r.pending[pendingID]; ok {
+		r.messageRefs[pendingID] = append(r.messageRefs[pendingID], ref)
+		r.mu.Unlock()
+		return nil
+	}
+	if terminal, ok := r.terminal[pendingID]; ok && terminal.pending.ID != "" {
+		latePending = terminal.pending
+		lateResult = terminal.result
+		lateUpdater = r.pendingMessageUpdater
+	}
+	r.mu.Unlock()
+	if lateUpdater != nil {
+		go lateUpdater(context.Background(), latePending, ref, lateResult)
+	}
+	return nil
 }
 
 func (r *HITLRegistry) Discard(id string) {
@@ -2620,14 +2651,17 @@ func (r *HITLRegistry) DecideWithResult(id string, d runtime.HITLDecision) runti
 
 		result := resolver(e.p.OperationID, d)
 		r.mu.Lock()
-		r.terminal[id] = terminalHITLEntry{result: staleHITLResolveResult(result), expiresAt: now.Add(hitlTerminalTTL)}
+		r.terminal[id] = terminalHITLEntry{result: staleHITLResolveResult(result), pending: e.p, expiresAt: now.Add(hitlTerminalTTL)}
+		delete(r.messageRefs, id)
 		r.mu.Unlock()
 		return result
 	}
 	e.decision <- d
 	delete(r.pending, id)
+	delete(r.messageRefs, id)
 	r.terminal[id] = terminalHITLEntry{
 		result:    runtime.HITLResolveResult{OK: false, State: state, Reason: reason},
+		pending:   e.p,
 		expiresAt: now.Add(hitlTerminalTTL),
 	}
 	r.mu.Unlock()
@@ -2656,18 +2690,28 @@ func (r *HITLRegistry) Cancel(id string, state runtime.HITLState, reason string)
 func (r *HITLRegistry) resolve(id string, state runtime.HITLState, reason string) (*pendingEntry, runtime.HITLResolveResult) {
 	now := time.Now()
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.pruneTerminalLocked(now)
 	e := r.pending[id]
 	if e == nil {
 		if terminal, ok := r.terminal[id]; ok {
+			r.mu.Unlock()
 			return nil, terminal.result
 		}
+		r.mu.Unlock()
 		return nil, runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "unknown or expired HITL request"}
 	}
 	delete(r.pending, id)
 	terminal := runtime.HITLResolveResult{OK: false, State: state, Reason: reason}
-	r.terminal[id] = terminalHITLEntry{result: terminal, expiresAt: now.Add(hitlTerminalTTL)}
+	refs := append([]string(nil), r.messageRefs[id]...)
+	delete(r.messageRefs, id)
+	r.terminal[id] = terminalHITLEntry{result: terminal, pending: e.p, expiresAt: now.Add(hitlTerminalTTL)}
+	updater := r.pendingMessageUpdater
+	r.mu.Unlock()
+	if updater != nil {
+		for _, ref := range refs {
+			go updater(context.Background(), e.p, ref, terminal)
+		}
+	}
 	return e, runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
 }
 

--- a/internal/config/plugins/approvers/human.go
+++ b/internal/config/plugins/approvers/human.go
@@ -149,19 +149,20 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					msg = expandMessage(h.Message, req)
 				}
 				target := runtime.HITLTarget{
-					CredentialName:    h.Credential,
-					Channel:           h.Channel,
-					Interactive:       h.Interactive,
-					PendingID:         id,
-					DashboardURL:      req.DashboardURL,
-					ThreadTS:          req.ThreadTS,
-					OperationState:    pending.OperationState,
-					ApprovalEffect:    pending.ApprovalEffect,
-					UpstreamCalled:    pending.UpstreamCalled,
-					ApprovalMessage:   pending.ApprovalMessage,
-					Summary:           summary,
-					Message:           msg,
-					MessageUpdateSink: req.MessageUpdateSink,
+					CredentialName:           h.Credential,
+					Channel:                  h.Channel,
+					Interactive:              h.Interactive,
+					PendingID:                id,
+					DashboardURL:             req.DashboardURL,
+					ThreadTS:                 req.ThreadTS,
+					OperationState:           pending.OperationState,
+					ApprovalEffect:           pending.ApprovalEffect,
+					UpstreamCalled:           pending.UpstreamCalled,
+					ApprovalMessage:          pending.ApprovalMessage,
+					Summary:                  summary,
+					Message:                  msg,
+					MessageUpdateSink:        req.MessageUpdateSink,
+					PendingMessageUpdateSink: req.PendingMessageUpdateSink,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {

--- a/internal/config/plugins/credentials/slack.go
+++ b/internal/config/plugins/credentials/slack.go
@@ -211,10 +211,17 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 	if err != nil {
 		return err
 	}
-	if target.MessageUpdateSink != nil && req.AsyncOperationID != "" && posted.Channel != "" && posted.TS != "" {
+	if posted.Channel != "" && posted.TS != "" {
 		ref := encodeSlackMessageRef(slackMessageRef{Credential: target.CredentialName, Channel: posted.Channel, TS: posted.TS, PendingID: target.PendingID, Interactive: target.Interactive, Message: target.Message, Summary: target.Summary})
-		if err := target.MessageUpdateSink(ctx, req.AsyncOperationID, ref); err != nil {
-			log.Printf("slack notify: record HITL message ref for %s: %v", req.AsyncOperationID, err)
+		if target.MessageUpdateSink != nil && req.AsyncOperationID != "" {
+			if err := target.MessageUpdateSink(ctx, req.AsyncOperationID, ref); err != nil {
+				log.Printf("slack notify: record HITL message ref for %s: %v", req.AsyncOperationID, err)
+			}
+		}
+		if target.PendingMessageUpdateSink != nil && target.PendingID != "" {
+			if err := target.PendingMessageUpdateSink(ctx, target.PendingID, ref); err != nil {
+				log.Printf("slack notify: record pending HITL message ref for %s: %v", target.PendingID, err)
+			}
 		}
 	}
 	return nil
@@ -469,7 +476,7 @@ func slackOperationStatus(update runtime.HITLMessageUpdate) string {
 	case runtime.HITLOperationStateExpired:
 		return ":alarm_clock: HITL approval expired"
 	case runtime.HITLOperationStateClientDisconnected:
-		return ":warning: Original client disconnected before async polling handle was returned"
+		return ":warning: Original client disconnected before approval"
 	default:
 		return "HITL state: `" + string(update.State) + "`"
 	}

--- a/internal/config/plugins/credentials/slack_update_test.go
+++ b/internal/config/plugins/credentials/slack_update_test.go
@@ -68,6 +68,59 @@ func TestSlackNotifyHITLRecordsMessageRefForAsyncOperation(t *testing.T) {
 	}
 }
 
+func TestSlackNotifyHITLRecordsMessageRefForSyncPendingRequest(t *testing.T) {
+	var recordedPendingID, recordedRef string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1778764174.925659"}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackPostMessageURL
+	oldClient := slackHTTPClient
+	oldBackoff := slackNotifyRetryBackoff
+	slackPostMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	slackNotifyRetryBackoff = 0
+	defer func() {
+		slackPostMessageURL = oldURL
+		slackHTTPClient = oldClient
+		slackNotifyRetryBackoff = oldBackoff
+	}()
+
+	err := (&SlackTokens{}).NotifyHITL(context.Background(), runtime.ApproveRequest{
+		Secrets: testSecretStore{
+			"slack-approvals": {Extras: map[string]string{"bot": "xoxb-test"}},
+		},
+		Method: "POST",
+		Host:   "api.example.test",
+		Path:   "/v1/resources/update",
+	}, runtime.HITLTarget{
+		CredentialName: "slack-approvals",
+		Channel:        "C123",
+		PendingID:      "pending-123",
+		Interactive:    true,
+		PendingMessageUpdateSink: func(_ context.Context, pendingID, ref string) error {
+			recordedPendingID = pendingID
+			recordedRef = ref
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyHITL returned error: %v", err)
+	}
+	if recordedPendingID != "pending-123" {
+		t.Fatalf("recorded pending ID = %q", recordedPendingID)
+	}
+	ref, ok := decodeSlackMessageRef(recordedRef)
+	if !ok {
+		t.Fatalf("recorded ref did not decode: %q", recordedRef)
+	}
+	if ref.Credential != "slack-approvals" || ref.Channel != "C123" || ref.TS != "1778764174.925659" || ref.PendingID != "pending-123" || !ref.Interactive {
+		t.Fatalf("recorded ref = %#v", ref)
+	}
+}
+
 func TestSlackNotifyHITLRecordsMessageOverrideForUpdates(t *testing.T) {
 	var recordedRef string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -316,6 +316,11 @@ type HITLNotifier interface {
 // Implementations must not store tokens or other secrets in ref.
 type HITLMessageUpdateSink func(ctx context.Context, operationID, ref string) error
 
+// HITLPendingMessageUpdateSink records a channel-specific message reference
+// against a live synchronous pending HITL request. Implementations must not
+// store tokens or other secrets in ref.
+type HITLPendingMessageUpdateSink func(ctx context.Context, pendingID, ref string) error
+
 // HITLMessageUpdater is optionally implemented by notifier credentials that
 // can update an already-posted HITL prompt as the durable operation moves
 // through async states.
@@ -369,6 +374,9 @@ type HITLTarget struct {
 	// MessageUpdateSink records a notifier-specific, non-secret message ref
 	// for async HITL operation status updates.
 	MessageUpdateSink HITLMessageUpdateSink
+	// PendingMessageUpdateSink records a notifier-specific, non-secret
+	// message ref for synchronous pending HITL terminal updates.
+	PendingMessageUpdateSink HITLPendingMessageUpdateSink
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.
@@ -441,6 +449,10 @@ type ApproveRequest struct {
 	// MessageUpdateSink records channel message references for async HITL
 	// operation updates after notifiers successfully post prompts.
 	MessageUpdateSink HITLMessageUpdateSink
+	// PendingMessageUpdateSink records channel message references for live
+	// synchronous HITL prompts so terminal timeout/disconnect states can be
+	// reflected back to the original operator-facing message.
+	PendingMessageUpdateSink HITLPendingMessageUpdateSink
 }
 
 // ApproveVerdict is what an approver returns. "" Decision means the
@@ -654,7 +666,7 @@ func HITLApprovalMessage(state HITLOperationState, effect HITLApprovalEffect, up
 	case HITLOperationStateExpired:
 		return "Approval expired.\nUpstream was not called."
 	case HITLOperationStateClientDisconnected:
-		return "The original client connection closed before Claw Patrol could return an async polling handle.\nUpstream was not called.\nThis prompt is stale."
+		return "The original client connection closed before approval.\nUpstream was not called.\nThis prompt is stale."
 	}
 	if effect == HITLApprovalEffectCreateRetryGrant {
 		return "Upstream has not been called.\nApprove will not send the request upstream now.\nApprove will allow the client to retry the same request once."


### PR DESCRIPTION
## Summary
- Record Slack message refs for synchronous HITL pending requests, not only async HITL operations
- Update recorded Slack prompts when sync HITL reaches terminal timeout/client-disconnect states
- Add regressions for timeout update, late message-ref races, and sync pending Slack ref recording

## Test plan
- `go test ./cmd/clawpatrol -run 'TestHITLRegistryCancelUpdatesRecordedMessageRefs|TestHITLRegistryLateMessageRefUpdateUsesFreshContext|TestHITLRegistryCancelRecordsClientDisconnected|TestHITLRegistryCancelAfterDecisionKeepsApprovedTerminalState' -count=1`
- `go test ./internal/config/plugins/approvers ./internal/config/plugins/credentials ./cmd/clawpatrol`
- `go test ./...`
- `git diff --check`
- Static added-line security scan: no findings
- Independent review: previous context-cancellation finding fixed; follow-up review approved

## Notes
This keeps async HITL message updates intact while adding the synchronous path needed for first-launch transparent HITL UX: if the original sync request times out or disconnects, the Slack prompt no longer remains visually pending with stale buttons.