### PR TITLE
site: keep inline <code> atomic on line wrap

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -224,6 +224,15 @@
   }
 }
 
+/* Inline `<code>` (excluding fenced `<pre><code>`) wraps as a single
+   atomic unit: a long token like `clawpatrol_native_endpoint` jumps to
+   the next line whole rather than splitting mid-identifier. `inline-block`
+   makes the element opaque to the line-breaker; if it then overflows
+   the line on its own, that's preferable to a mid-token break. */
+:not(pre) > code {
+  display: inline-block;
+}
+
 /* Docs-specific styles live in /src/docs.css and are imported at the
    top of this file. They ship with the main CSS bundle but are scoped
    to `.docs-content`, so they only paint inside the docs page wrapper. */


### PR DESCRIPTION
## Summary

Long inline `<code>` (e.g. `` `clawpatrol_native_endpoint` ``) was splitting
mid-identifier when it landed near the end of a line — both on the landing
page and the rendered docs. The fix is a single global rule in
`site/src/index.css`:

```css
:not(pre) > code {
  display: inline-block;
}
```

**Option A** from the task description. `inline-block` makes each `<code>`
opaque to the line-breaker, so the whole token wraps to the next line as a
unit; if it then overflows the remaining width on its own, that's the
preferable trade-off vs. a mid-token break. Scoped with `:not(pre) >` so
fenced code blocks (`<pre><code>`) are untouched — their existing
`overflow-x: auto` scrolling behavior is unchanged.

Picked over B/C because:

- **B** (`word-break: keep-all; overflow-wrap: normal`) is finicky and
  doesn't reliably keep multi-segment identifiers like
  `clawpatrol_native_endpoint` together across browsers.
- **C** (`white-space: nowrap`) is too blunt — multi-word inline code
  would refuse to wrap at all, risking horizontal overflow at the page
  level rather than just the token.

The rule lives at the top level of `index.css`, so it covers both surfaces
in one shot — landing components (`site/src/sections/*.tsx`) and docs
(rendered through `marked` and styled via `.docs-content` in `docs.css`,
which inherits this rule from the outer scope).

## Test plan

- [ ] `npm run build` from `site/` succeeds; the rule appears in the
      output bundle (`code{display:inline-block}` in `dist/assets/*.css`).
- [ ] Landing page: a paragraph containing a long inline `<code>` near
      the line edge wraps the code to the next line whole.
- [ ] Docs page with the same shape behaves the same.
- [ ] Fenced code blocks (`<pre><code>…`) render and scroll identically
      to before.