### PR TITLE
test engine + downloaded actions: typed endpoint references (cl-kls0)

### DIFF
--- a/cmd/clawpatrol/action_file.go
+++ b/cmd/clawpatrol/action_file.go
@@ -215,7 +215,7 @@ func hasBinaryControlBytes(b []byte) bool {
 func MatchFromCompiledRule(cr *config.CompiledRule, ep *config.CompiledEndpoint) Match {
 	m := Match{}
 	if ep != nil {
-		m.Endpoint = ep.Name
+		m.Endpoint = endpointRef(ep)
 	}
 	if cr == nil {
 		m.Verdict = "allow"
@@ -240,11 +240,31 @@ func MatchFromCompiledRule(cr *config.CompiledRule, ep *config.CompiledEndpoint)
 // match.endpoint wins when set; otherwise action.host is scanned
 // against policy.Endpoints for a unique match. Ambiguous hosts
 // error with the candidate list.
+//
+// match.endpoint uses the typed form `endpoint-type.endpoint-name`
+// (e.g. `https.github`) — the same addressing model HCL rules use.
+// Bare names are rejected so the reference is unambiguous across
+// endpoint types.
 func (f *Fixture) ResolveEndpoint(policy *config.CompiledPolicy) (*config.CompiledEndpoint, error) {
 	if f.Match.Endpoint != "" {
-		ep := policy.Endpoints[f.Match.Endpoint]
+		typ, name, ok := splitEndpointRef(f.Match.Endpoint)
+		if !ok {
+			return nil, fmt.Errorf(
+				"match.endpoint %q must use typed form `endpoint-type.endpoint-name` (e.g. `https.github`)",
+				f.Match.Endpoint)
+		}
+		ep := policy.Endpoints[name]
 		if ep == nil {
 			return nil, fmt.Errorf("endpoint %q not in compiled policy", f.Match.Endpoint)
+		}
+		if ep.Plugin == nil || ep.Plugin.Type != typ {
+			got := ""
+			if ep.Plugin != nil {
+				got = ep.Plugin.Type
+			}
+			return nil, fmt.Errorf(
+				"match.endpoint %q: endpoint %q is type %q, not %q",
+				f.Match.Endpoint, name, got, typ)
 		}
 		return ep, nil
 	}
@@ -266,9 +286,34 @@ func (f *Fixture) ResolveEndpoint(policy *config.CompiledPolicy) (*config.Compil
 	}
 	names := make([]string, 0, len(matches))
 	for _, ep := range matches {
-		names = append(names, ep.Name)
+		names = append(names, endpointRef(ep))
 	}
 	return nil, fmt.Errorf("host %q is claimed by multiple endpoints %v; set `match.endpoint` to disambiguate", host, names)
+}
+
+// endpointRef formats a CompiledEndpoint as `endpoint-type.endpoint-name`
+// — the typed reference form fixtures and the runner use to address
+// endpoints unambiguously across endpoint types.
+func endpointRef(ep *config.CompiledEndpoint) string {
+	if ep == nil {
+		return ""
+	}
+	typ := ""
+	if ep.Plugin != nil {
+		typ = ep.Plugin.Type
+	}
+	return typ + "." + ep.Name
+}
+
+// splitEndpointRef parses a typed reference `type.name` into its
+// components. Returns ok=false if either side is empty or the dot
+// is missing.
+func splitEndpointRef(ref string) (typ, name string, ok bool) {
+	i := strings.IndexByte(ref, '.')
+	if i <= 0 || i == len(ref)-1 {
+		return "", "", false
+	}
+	return ref[:i], ref[i+1:], true
 }
 
 // endpointClaimsHost matches `host` and `host:port` forms either

--- a/cmd/clawpatrol/action_file_test.go
+++ b/cmd/clawpatrol/action_file_test.go
@@ -81,22 +81,22 @@ func TestFixtureUnmarshalRejections(t *testing.T) {
 }
 
 func TestMatchFromCompiledRule(t *testing.T) {
-	ep := &config.CompiledEndpoint{Name: "ep"}
+	ep := &config.CompiledEndpoint{Name: "ep", Plugin: &config.Plugin{Type: "https"}}
 	cases := []struct {
 		name string
 		cr   *config.CompiledRule
 		want Match
 	}{
-		{"nil-rule", nil, Match{Verdict: "allow", Endpoint: "ep"}},
+		{"nil-rule", nil, Match{Verdict: "allow", Endpoint: "https.ep"}},
 		{"explicit-allow",
 			&config.CompiledRule{Name: "r1", Outcome: config.Outcome{Verdict: "allow"}},
-			Match{Verdict: "allow", Rule: "r1", Endpoint: "ep"}},
+			Match{Verdict: "allow", Rule: "r1", Endpoint: "https.ep"}},
 		{"deny",
 			&config.CompiledRule{Name: "r2", Outcome: config.Outcome{Verdict: "deny", Reason: "no"}},
-			Match{Verdict: "deny", Rule: "r2", Endpoint: "ep", Reason: "no"}},
+			Match{Verdict: "deny", Rule: "r2", Endpoint: "https.ep", Reason: "no"}},
 		{"approve-chain",
 			&config.CompiledRule{Name: "r3", Outcome: config.Outcome{Approve: []config.ApproveStage{{}}}},
-			Match{Verdict: "approve", Rule: "r3", Endpoint: "ep"}},
+			Match{Verdict: "approve", Rule: "r3", Endpoint: "https.ep"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/clawpatrol/test_test.go
+++ b/cmd/clawpatrol/test_test.go
@@ -138,7 +138,7 @@ profile "default" { credentials = [bearer_token.a, bearer_token.b] }
 	})
 
 	t.Run("ambiguous host disambiguated by match.endpoint", func(t *testing.T) {
-		f := mk(t, `{"action":{"host":"api.example.com","http":{"path":"/x"}},"match":{"verdict":"allow","endpoint":"beta"}}`)
+		f := mk(t, `{"action":{"host":"api.example.com","http":{"path":"/x"}},"match":{"verdict":"allow","endpoint":"https.beta"}}`)
 		ep, err := f.ResolveEndpoint(policy)
 		if err != nil {
 			t.Fatal(err)
@@ -153,6 +153,22 @@ profile "default" { credentials = [bearer_token.a, bearer_token.b] }
 		_, err := f.ResolveEndpoint(policy)
 		if err == nil || !strings.Contains(err.Error(), "no endpoint claims") {
 			t.Fatalf("want unknown-host error, got %v", err)
+		}
+	})
+
+	t.Run("bare-name match.endpoint is rejected", func(t *testing.T) {
+		f := mk(t, `{"action":{"host":"solo.example.com","http":{"path":"/x"}},"match":{"verdict":"allow","endpoint":"beta"}}`)
+		_, err := f.ResolveEndpoint(policy)
+		if err == nil || !strings.Contains(err.Error(), "typed form") {
+			t.Fatalf("want typed-form error, got %v", err)
+		}
+	})
+
+	t.Run("wrong type prefix is rejected", func(t *testing.T) {
+		f := mk(t, `{"action":{"host":"solo.example.com","http":{"path":"/x"}},"match":{"verdict":"allow","endpoint":"postgres.beta"}}`)
+		_, err := f.ResolveEndpoint(policy)
+		if err == nil || !strings.Contains(err.Error(), "type") {
+			t.Fatalf("want type-mismatch error, got %v", err)
 		}
 	})
 }

--- a/cmd/clawpatrol/testdata/delete-issue.json
+++ b/cmd/clawpatrol/testdata/delete-issue.json
@@ -12,7 +12,7 @@
   "match": {
     "verdict":  "deny",
     "rule":     "github-writes",
-    "endpoint": "github",
+    "endpoint": "https.github",
     "reason":   "writes go through PR review"
   }
 }

--- a/cmd/clawpatrol/testdata/get-user.json
+++ b/cmd/clawpatrol/testdata/get-user.json
@@ -13,6 +13,6 @@
   "match": {
     "verdict":  "allow",
     "rule":     "github-reads",
-    "endpoint": "github"
+    "endpoint": "https.github"
   }
 }

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1540,6 +1540,10 @@ func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
 		http.Error(rw, fmt.Sprintf("event action %q is not exportable as a fixture", ev.Action), 400)
 		return
 	}
+	// Stamp the typed reference (endpoint-type.endpoint-name) so the
+	// runner can route the fixture without ambiguity. ev.Endpoint is
+	// the bare DB-recorded name; the policy supplies the type.
+	m.Endpoint = endpointRef(ep)
 
 	fx := &Fixture{Match: m, Action: Action{PeerIP: ev.AgentIP}}
 	switch ep.Family {

--- a/cmd/clawpatrol/web_fixture_export_test.go
+++ b/cmd/clawpatrol/web_fixture_export_test.go
@@ -85,7 +85,7 @@ func TestExporterHTTPSHappyPath(t *testing.T) {
 	if f.Action.HTTP.Path != "/user" {
 		t.Errorf("path=%q want /user", f.Action.HTTP.Path)
 	}
-	want := Match{Verdict: "allow", Rule: "github-reads", Endpoint: "github"}
+	want := Match{Verdict: "allow", Rule: "github-reads", Endpoint: "https.github"}
 	if f.Match != want {
 		t.Errorf("match=%+v want %+v", f.Match, want)
 	}
@@ -138,8 +138,8 @@ profile "default" { credentials = [bearer_token.a, bearer_token.b] }
 	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
 		t.Fatal(err)
 	}
-	if f.Match.Endpoint != "beta" {
-		t.Errorf("expected match.endpoint=beta, got %q", f.Match.Endpoint)
+	if f.Match.Endpoint != "https.beta" {
+		t.Errorf("expected match.endpoint=https.beta, got %q", f.Match.Endpoint)
 	}
 }
 
@@ -428,7 +428,7 @@ profile "default" { credentials = [bearer_token.tok] }
 func TestRunnerRejectsPassthrough(t *testing.T) {
 	gw := gatewayWithPolicy(t, fixtureHCL)
 	body := `{"action":{"host":"api.github.com","http":{"method":"GET","path":"/x"}},` +
-		`"match":{"verdict":"passthrough","endpoint":"github"}}`
+		`"match":{"verdict":"passthrough","endpoint":"https.github"}}`
 	tmp := filepath.Join(t.TempDir(), "pt.json")
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {
 		t.Fatal(err)

--- a/site/doc/clawpatrol-test.md
+++ b/site/doc/clawpatrol-test.md
@@ -63,7 +63,7 @@ profile "default" { endpoints = [https.github] }
   "match": {
     "verdict":  "allow",
     "rule":     "github-reads",
-    "endpoint": "github"
+    "endpoint": "https.github"
   }
 }
 ```
@@ -82,8 +82,8 @@ from `"allow"` to `"deny"`. Re-run:
 ```
 $ clawpatrol test github.hcl fixtures/
 FAIL fixtures/get-user.json
-  want verdict="allow"      rule="github-reads"                 endpoint="github"
-  got  verdict="deny"       rule="github-reads"                 endpoint="github"
+  want verdict="allow"      rule="github-reads"                 endpoint="https.github"
+  got  verdict="deny"       rule="github-reads"                 endpoint="https.github"
 1 action(s) checked, 1 mismatch(es)
 $ echo $?
 1
@@ -176,7 +176,7 @@ facet’s vocabulary — the same fields your CEL rule conditions read.
   "match": {
     "verdict":  "deny",
     "rule":     "github-writes",
-    "endpoint": "github",
+    "endpoint": "https.github",
     "reason":   "writes go through PR review"
   }
 }
@@ -198,7 +198,7 @@ facet’s vocabulary — the same fields your CEL rule conditions read.
   "match": {
     "verdict":  "deny",
     "rule":     "no-secrets",
-    "endpoint": "k8s-dev"
+    "endpoint": "kubernetes.k8s-dev"
   }
 }
 ```
@@ -214,7 +214,7 @@ facet’s vocabulary — the same fields your CEL rule conditions read.
   "match": {
     "verdict":  "allow",
     "rule":     "pg-reads",
-    "endpoint": "pg-staging"
+    "endpoint": "postgres.pg-staging"
   }
 }
 ```
@@ -239,7 +239,7 @@ agent through different rule sets — set `match.endpoint` explicitly:
   "match": {
     "verdict":  "approve",
     "rule":     "anthropic-default",
-    "endpoint": "anthropic-agent-A"
+    "endpoint": "https.anthropic-agent-A"
   }
 }
 ```
@@ -262,8 +262,12 @@ by multiple endpoints [anthropic-agent-A anthropic-agent-B]; set
   it; pin to a terminal verdict or drop the fixture.
 - `rule` — name of the rule that fired. Empty when no rule matched
   and the endpoint default was used.
-- `endpoint` — optional. When set, pins dispatch and asserts the
-  matched endpoint on replay (see "Shared hosts" above).
+- `endpoint` — optional. Typed reference of the form
+  `endpoint-type.endpoint-name` (e.g. `https.github`,
+  `postgres.pg-staging`) — the same addressing model HCL rules use.
+  When set, pins dispatch and asserts the matched endpoint on replay
+  (see "Shared hosts" above). Bare names are rejected because they
+  collide across endpoint types.
 - `reason` — informational only; the runner doesn’t compare it.
 
 `approve` is terminal: a rule routing to an approver chain records


### PR DESCRIPTION
`match.endpoint` in test-engine fixtures and `clawpatrol`-exported downloaded actions now use the typed form `endpoint-type.endpoint-name` (e.g. `https.github`), matching the addressing model HCL rules already use. Bare names are rejected at resolve time so references are unambiguous across endpoint types.

- ResolveEndpoint parses `type.name`, looks up by name, and verifies the endpoint's plugin type matches.
- MatchFromCompiledRule and writeActionFixture emit the typed form.
- Ambiguous-host disambiguation lists typed refs so the operator can copy the right value into `match.endpoint`.
- testdata fixtures and the site/doc/clawpatrol-test.md examples updated; new tests cover bare-name rejection and wrong-type prefix.