### PR TITLE
Restore sync HITL Slack terminal updates

### DIFF
--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -239,6 +239,70 @@ func (g *Gateway) updateHITLOperationMessage(ctx context.Context, op HITLOperati
 	}
 }
 
+func (g *Gateway) updatePendingHITLMessage(ctx context.Context, pending runtime.HITLPending, ref string, result runtime.HITLResolveResult) {
+	if g == nil || ref == "" {
+		return
+	}
+	policy := g.Policy()
+	if policy == nil {
+		return
+	}
+	credName := ""
+	for _, approverName := range pending.Approvers {
+		approver := policy.Approvers[approverName]
+		if approver == nil {
+			continue
+		}
+		if h, ok := approver.Body.(runtime.HITLHumanCredentialer); ok {
+			credName = h.HumanApproverCredential()
+			if credName != "" {
+				break
+			}
+		}
+	}
+	if credName == "" {
+		return
+	}
+	cred := policy.Credentials[credName]
+	if cred == nil {
+		return
+	}
+	updater, ok := cred.Body.(runtime.HITLMessageUpdater)
+	if !ok {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	state := runtime.HITLOperationStateExpired
+	switch result.State {
+	case runtime.HITLStateClientDisconnected:
+		state = runtime.HITLOperationStateClientDisconnected
+	case runtime.HITLStateApproved:
+		state = runtime.HITLOperationStateApprovedWaitingForRetry
+	case runtime.HITLStateDenied:
+		state = runtime.HITLOperationStateDenied
+	case runtime.HITLStateTimedOut:
+		state = runtime.HITLOperationStateExpired
+	}
+	path := pending.Path
+	if path == "" {
+		path = pending.Endpoint
+	}
+	if err := updater.UpdateHITLMessage(ctx, g.secrets, runtime.HITLMessageUpdate{
+		MessageRef:     ref,
+		OperationID:    pending.OperationID,
+		State:          state,
+		Method:         pending.Method,
+		Host:           pending.Host,
+		Path:           path,
+		UpstreamCalled: pending.UpstreamCalled,
+		LastError:      result.Reason,
+	}); err != nil {
+		log.Printf("hitl pending message update %s: %v", pending.ID, err)
+	}
+}
+
 func (g *Gateway) resolveAsyncHITLGrant(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult {
 	if g == nil || g.db == nil {
 		return runtime.HITLResolveResult{OK: false, State: runtime.HITLStateUnknown, Reason: "async HITL operation store is unavailable"}

--- a/cmd/clawpatrol/hitl_registry_test.go
+++ b/cmd/clawpatrol/hitl_registry_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,8 +10,37 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denoland/clawpatrol/internal/config"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
+
+type captureApproveRequestApprover struct {
+	got chan runtime.ApproveRequest
+}
+
+func (a captureApproveRequestApprover) Approve(_ context.Context, req runtime.ApproveRequest) (runtime.ApproveVerdict, error) {
+	a.got <- req
+	return runtime.ApproveVerdict{Decision: "allow"}, nil
+}
+
+func TestGatewayRunApproveChainWiresPendingMessageUpdateSink(t *testing.T) {
+	approver := captureApproveRequestApprover{got: make(chan runtime.ApproveRequest, 1)}
+	g := &Gateway{cfg: &config.Gateway{}, hitl: newHITLRegistry(nil)}
+	g.policy.Store(&config.CompiledPolicy{Approvers: map[string]*config.Entity{"ops": {Body: approver}}})
+
+	verdict := g.runApproveChain(context.Background(), []config.ApproveStage{{Name: "ops"}}, runApproveCtx{Host: "api.example.test", Method: "POST", Path: "/v1/write"})
+	if verdict.Decision != "allow" {
+		t.Fatalf("runApproveChain verdict = %#v, want allow", verdict)
+	}
+	select {
+	case req := <-approver.got:
+		if req.PendingMessageUpdateSink == nil {
+			t.Fatal("ApproveRequest PendingMessageUpdateSink is nil; sync HITL Slack prompts cannot record terminal-update message refs")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("approver was not invoked")
+	}
+}
 
 func TestHITLRegistryAsyncPendingApprovalCreatesRetryGrantInsteadOfSendingChannelDecision(t *testing.T) {
 	registry := newHITLRegistry(nil)
@@ -147,6 +177,77 @@ func TestHITLRegistryCancelRecordsClientDisconnected(t *testing.T) {
 	}
 	if !strings.Contains(stale.Reason, "upstream request was not sent") {
 		t.Fatalf("stale Reason = %q, want upstream-not-sent explanation", stale.Reason)
+	}
+}
+
+func TestHITLRegistryCancelUpdatesRecordedMessageRefs(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	var gotPending runtime.HITLPending
+	var gotRef string
+	var gotResult runtime.HITLResolveResult
+	updated := make(chan struct{}, 1)
+	registry.pendingMessageUpdater = func(_ context.Context, pending runtime.HITLPending, ref string, result runtime.HITLResolveResult) {
+		gotPending = pending
+		gotRef = ref
+		gotResult = result
+		updated <- struct{}{}
+	}
+	id, _ := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+	if err := registry.RecordMessageRef(context.Background(), id, `{"type":"slack","channel":"C123","ts":"1778764174.925659"}`); err != nil {
+		t.Fatalf("RecordMessageRef returned error: %v", err)
+	}
+
+	result := registry.Cancel(id, runtime.HITLStateTimedOut, "approver timed out; upstream request was not sent")
+	if !result.OK {
+		t.Fatalf("Cancel OK = false, want true: %#v", result)
+	}
+	select {
+	case <-updated:
+	case <-time.After(time.Second):
+		t.Fatal("Cancel did not update recorded message ref")
+	}
+	if gotPending.ID != id || gotPending.Host != "api.example.test" || gotPending.Method != "POST" || gotPending.Path != "/v1/write" {
+		t.Fatalf("updated pending = %#v, want original sync HITL request", gotPending)
+	}
+	if gotRef == "" || !strings.Contains(gotRef, "1778764174.925659") {
+		t.Fatalf("updated ref = %q, want recorded Slack message ref", gotRef)
+	}
+	if gotResult.State != runtime.HITLStateTimedOut || !strings.Contains(gotResult.Reason, "upstream request was not sent") {
+		t.Fatalf("updated result = %#v, want timed-out upstream-not-sent terminal result", gotResult)
+	}
+}
+
+func TestHITLRegistryLateMessageRefUpdateUsesFreshContext(t *testing.T) {
+	registry := newHITLRegistry(nil)
+	updated := make(chan error, 1)
+	registry.pendingMessageUpdater = func(ctx context.Context, _ runtime.HITLPending, _ string, _ runtime.HITLResolveResult) {
+		updated <- ctx.Err()
+	}
+	id, _ := registry.Add(runtime.HITLPending{
+		Host:      "api.example.test",
+		Method:    "POST",
+		Path:      "/v1/write",
+		CreatedAt: time.Now(),
+	})
+	registry.Cancel(id, runtime.HITLStateTimedOut, "approver timed out; upstream request was not sent")
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := registry.RecordMessageRef(canceledCtx, id, `{"type":"slack","channel":"C123","ts":"1778764174.925659"}`); err != nil {
+		t.Fatalf("RecordMessageRef returned error: %v", err)
+	}
+	select {
+	case err := <-updated:
+		if err != nil {
+			t.Fatalf("late updater ctx err = %v, want live context", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late RecordMessageRef did not update terminal message")
 	}
 }
 

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2528,6 +2528,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			DashboardURL:              g.cfg.PublicURL,
 			Policy:                    policy,
 			MessageUpdateSink:         g.recordHITLOperationMessageRef,
+			PendingMessageUpdateSink:  g.hitl.RecordMessageRef,
 		}
 		v, err := ar.Approve(ctx, req)
 		// Stamp the entity name + plugin type on every verdict so the
@@ -2778,6 +2779,7 @@ func runGateway(args []string) {
 	log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
 	g.secrets = newGatewaySecretStore(db, oauthReg)
 	g.hitl.asyncGrantResolver = g.resolveAsyncHITLGrant
+	g.hitl.pendingMessageUpdater = g.updatePendingHITLMessage
 	g.tunnels = NewTunnelManager(g.secrets, stateDir)
 	registerOAuthCredentials(oauthReg, policy)
 	g.policy.Store(policy)

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -2483,20 +2483,24 @@ func wrapBodySampler(rc io.ReadCloser, s *sampler) io.ReadCloser {
 const hitlTerminalTTL = 30 * time.Minute
 
 type HITLRegistry struct {
-	mu                 sync.Mutex
-	pending            map[string]*pendingEntry
-	terminal           map[string]terminalHITLEntry
-	sink               *Sink // SSE fan-out for the dashboard
-	asyncGrantResolver func(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult
+	mu                    sync.Mutex
+	pending               map[string]*pendingEntry
+	terminal              map[string]terminalHITLEntry
+	sink                  *Sink // SSE fan-out for the dashboard
+	asyncGrantResolver    func(operationID string, d runtime.HITLDecision) runtime.HITLResolveResult
+	pendingMessageUpdater func(ctx context.Context, pending runtime.HITLPending, ref string, result runtime.HITLResolveResult)
 }
 
 type pendingEntry struct {
-	p        runtime.HITLPending
-	decision chan runtime.HITLDecision
+	p           runtime.HITLPending
+	decision    chan runtime.HITLDecision
+	messageRefs []string
 }
 
 type terminalHITLEntry struct {
 	result    runtime.HITLResolveResult
+	pending   runtime.HITLPending
+	refs      []string
 	expiresAt time.Time
 }
 
@@ -2653,7 +2657,10 @@ func (r *HITLRegistry) Cancel(id string, state runtime.HITLState, reason string)
 	if strings.TrimSpace(reason) == "" {
 		reason = string(state)
 	}
-	_, result := r.resolve(id, state, reason)
+	e, result := r.resolve(id, state, reason)
+	if e != nil && result.OK {
+		r.updateRecordedMessageRefs(context.Background(), e.p, e.messageRefs, result)
+	}
 	return result
 }
 
@@ -2671,8 +2678,54 @@ func (r *HITLRegistry) resolve(id string, state runtime.HITLState, reason string
 	}
 	delete(r.pending, id)
 	terminal := runtime.HITLResolveResult{OK: false, State: state, Reason: reason}
-	r.terminal[id] = terminalHITLEntry{result: terminal, expiresAt: now.Add(hitlTerminalTTL)}
+	r.terminal[id] = terminalHITLEntry{result: terminal, pending: e.p, refs: append([]string(nil), e.messageRefs...), expiresAt: now.Add(hitlTerminalTTL)}
 	return e, runtime.HITLResolveResult{OK: true, State: state, Reason: reason}
+}
+
+// RecordMessageRef records the channel-specific message id for a pending sync
+// HITL prompt so terminal states (timeout/client disconnect) can proactively
+// update the original Slack message. If the request already reached a terminal
+// state before the notifier returned, use a fresh context to update immediately:
+// the caller's request context is often canceled by then.
+func (r *HITLRegistry) RecordMessageRef(_ context.Context, pendingID, ref string) error {
+	if strings.TrimSpace(pendingID) == "" || strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	var pending runtime.HITLPending
+	var result runtime.HITLResolveResult
+	var shouldUpdate bool
+	now := time.Now()
+	r.mu.Lock()
+	r.pruneTerminalLocked(now)
+	if e := r.pending[pendingID]; e != nil {
+		e.messageRefs = append(e.messageRefs, ref)
+		r.mu.Unlock()
+		return nil
+	}
+	if terminal, ok := r.terminal[pendingID]; ok {
+		terminal.refs = append(terminal.refs, ref)
+		r.terminal[pendingID] = terminal
+		pending = terminal.pending
+		result = terminal.result
+		shouldUpdate = true
+	}
+	r.mu.Unlock()
+	if shouldUpdate {
+		r.updateRecordedMessageRefs(context.Background(), pending, []string{ref}, result)
+	}
+	return nil
+}
+
+func (r *HITLRegistry) updateRecordedMessageRefs(ctx context.Context, pending runtime.HITLPending, refs []string, result runtime.HITLResolveResult) {
+	if r == nil || r.pendingMessageUpdater == nil {
+		return
+	}
+	for _, ref := range refs {
+		if strings.TrimSpace(ref) == "" {
+			continue
+		}
+		r.pendingMessageUpdater(ctx, pending, ref, result)
+	}
 }
 
 func (r *HITLRegistry) pruneTerminalLocked(now time.Time) {

--- a/internal/config/plugins/approvers/human.go
+++ b/internal/config/plugins/approvers/human.go
@@ -149,19 +149,20 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 					msg = expandMessage(h.Message, req)
 				}
 				target := runtime.HITLTarget{
-					CredentialName:    h.Credential,
-					Channel:           h.Channel,
-					Interactive:       h.Interactive,
-					PendingID:         id,
-					DashboardURL:      req.DashboardURL,
-					ThreadTS:          req.ThreadTS,
-					OperationState:    pending.OperationState,
-					ApprovalEffect:    pending.ApprovalEffect,
-					UpstreamCalled:    pending.UpstreamCalled,
-					ApprovalMessage:   pending.ApprovalMessage,
-					Summary:           summary,
-					Message:           msg,
-					MessageUpdateSink: req.MessageUpdateSink,
+					CredentialName:           h.Credential,
+					Channel:                  h.Channel,
+					Interactive:              h.Interactive,
+					PendingID:                id,
+					DashboardURL:             req.DashboardURL,
+					ThreadTS:                 req.ThreadTS,
+					OperationState:           pending.OperationState,
+					ApprovalEffect:           pending.ApprovalEffect,
+					UpstreamCalled:           pending.UpstreamCalled,
+					ApprovalMessage:          pending.ApprovalMessage,
+					Summary:                  summary,
+					Message:                  msg,
+					MessageUpdateSink:        req.MessageUpdateSink,
+					PendingMessageUpdateSink: req.PendingMessageUpdateSink,
 				}
 				go func() {
 					if err := notifier.NotifyHITL(ctx, req, target); err != nil {

--- a/internal/config/plugins/approvers/human_test.go
+++ b/internal/config/plugins/approvers/human_test.go
@@ -90,6 +90,15 @@ func (p *captureHITLPool) wasDiscarded() bool {
 	return p.discarded
 }
 
+type captureNotifier struct {
+	notified chan runtime.HITLTarget
+}
+
+func (n *captureNotifier) NotifyHITL(_ context.Context, _ runtime.ApproveRequest, target runtime.HITLTarget) error {
+	n.notified <- target
+	return nil
+}
+
 func TestHumanApproverAsyncSyncWaitTimeoutLeavesPromptPendingForRetryGrant(t *testing.T) {
 	pool := newCaptureHITLPool()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
@@ -156,6 +165,47 @@ func TestHumanApproverPendingIncludesSyncApprovalGuidance(t *testing.T) {
 	}
 	if !strings.Contains(pending.ApprovalMessage, "send this request upstream immediately") {
 		t.Fatalf("ApprovalMessage = %q, want immediate upstream guidance", pending.ApprovalMessage)
+	}
+}
+
+func TestHumanApproverForwardsPendingMessageUpdateSinkToNotifier(t *testing.T) {
+	pool := newCaptureHITLPool()
+	notifier := &captureNotifier{notified: make(chan runtime.HITLTarget, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	sink := runtime.HITLPendingMessageUpdateSink(func(context.Context, string, string) error { return nil })
+	go func() {
+		_, err := (&HumanApprover{Credential: "slack", Channel: "C123", Timeout: 60}).Approve(ctx, runtime.ApproveRequest{
+			Pool:                     pool,
+			Policy:                   &config.CompiledPolicy{Credentials: map[string]*config.Entity{"slack": {Body: notifier}}},
+			ApproverName:             "ops",
+			Method:                   "POST",
+			Host:                     "api.example.test",
+			Path:                     "/v1/write",
+			PendingMessageUpdateSink: sink,
+		})
+		done <- err
+	}()
+
+	select {
+	case target := <-notifier.notified:
+		if target.PendingID != pool.id {
+			t.Fatalf("target PendingID = %q, want %q", target.PendingID, pool.id)
+		}
+		if target.PendingMessageUpdateSink == nil {
+			t.Fatal("target PendingMessageUpdateSink is nil; sync HITL Slack prompts cannot record message refs")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not notify credential")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Approve error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not return after context cancellation")
 	}
 }
 

--- a/internal/config/plugins/credentials/slack.go
+++ b/internal/config/plugins/credentials/slack.go
@@ -211,10 +211,17 @@ func (s *SlackTokens) NotifyHITL(ctx context.Context, req runtime.ApproveRequest
 	if err != nil {
 		return err
 	}
-	if target.MessageUpdateSink != nil && req.AsyncOperationID != "" && posted.Channel != "" && posted.TS != "" {
+	if posted.Channel != "" && posted.TS != "" {
 		ref := encodeSlackMessageRef(slackMessageRef{Credential: target.CredentialName, Channel: posted.Channel, TS: posted.TS, PendingID: target.PendingID, Interactive: target.Interactive, Message: target.Message, Summary: target.Summary})
-		if err := target.MessageUpdateSink(ctx, req.AsyncOperationID, ref); err != nil {
-			log.Printf("slack notify: record HITL message ref for %s: %v", req.AsyncOperationID, err)
+		if target.MessageUpdateSink != nil && req.AsyncOperationID != "" {
+			if err := target.MessageUpdateSink(ctx, req.AsyncOperationID, ref); err != nil {
+				log.Printf("slack notify: record HITL message ref for %s: %v", req.AsyncOperationID, err)
+			}
+		}
+		if target.PendingMessageUpdateSink != nil && target.PendingID != "" {
+			if err := target.PendingMessageUpdateSink(ctx, target.PendingID, ref); err != nil {
+				log.Printf("slack notify: record pending HITL message ref for %s: %v", target.PendingID, err)
+			}
 		}
 	}
 	return nil

--- a/internal/config/plugins/credentials/slack_update_test.go
+++ b/internal/config/plugins/credentials/slack_update_test.go
@@ -11,6 +11,62 @@ import (
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
+func TestSlackNotifyHITLRecordsMessageRefForSyncPendingRequest(t *testing.T) {
+	var recordedPendingID, recordedRef string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer xoxb-test" {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1778764174.925659"}`))
+	}))
+	defer server.Close()
+
+	oldURL := slackPostMessageURL
+	oldClient := slackHTTPClient
+	oldBackoff := slackNotifyRetryBackoff
+	slackPostMessageURL = server.URL
+	slackHTTPClient = server.Client()
+	slackNotifyRetryBackoff = 0
+	defer func() {
+		slackPostMessageURL = oldURL
+		slackHTTPClient = oldClient
+		slackNotifyRetryBackoff = oldBackoff
+	}()
+
+	err := (&SlackTokens{}).NotifyHITL(context.Background(), runtime.ApproveRequest{
+		Secrets: testSecretStore{
+			"slack-approvals": {Extras: map[string]string{"bot": "xoxb-test"}},
+		},
+		Method: "POST",
+		Host:   "api.example.test",
+		Path:   "/v1/resources/update",
+	}, runtime.HITLTarget{
+		CredentialName: "slack-approvals",
+		Channel:        "C123",
+		PendingID:      "pending-123",
+		Interactive:    true,
+		PendingMessageUpdateSink: func(_ context.Context, pendingID, ref string) error {
+			recordedPendingID = pendingID
+			recordedRef = ref
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyHITL returned error: %v", err)
+	}
+	if recordedPendingID != "pending-123" {
+		t.Fatalf("recorded pending ID = %q", recordedPendingID)
+	}
+	ref, ok := decodeSlackMessageRef(recordedRef)
+	if !ok {
+		t.Fatalf("recorded ref did not decode: %q", recordedRef)
+	}
+	if ref.Credential != "slack-approvals" || ref.Channel != "C123" || ref.TS != "1778764174.925659" || ref.PendingID != "pending-123" || !ref.Interactive {
+		t.Fatalf("recorded ref = %#v", ref)
+	}
+}
+
 func TestSlackNotifyHITLRecordsMessageRefForAsyncOperation(t *testing.T) {
 	var recordedOperationID, recordedRef string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -316,6 +316,11 @@ type HITLNotifier interface {
 // Implementations must not store tokens or other secrets in ref.
 type HITLMessageUpdateSink func(ctx context.Context, operationID, ref string) error
 
+// HITLPendingMessageUpdateSink records a channel-specific message reference
+// against a live synchronous pending HITL request. Implementations must not
+// store tokens or other secrets in ref.
+type HITLPendingMessageUpdateSink func(ctx context.Context, pendingID, ref string) error
+
 // HITLMessageUpdater is optionally implemented by notifier credentials that
 // can update an already-posted HITL prompt as the durable operation moves
 // through async states.
@@ -369,6 +374,9 @@ type HITLTarget struct {
 	// MessageUpdateSink records a notifier-specific, non-secret message ref
 	// for async HITL operation status updates.
 	MessageUpdateSink HITLMessageUpdateSink
+	// PendingMessageUpdateSink records a notifier-specific, non-secret
+	// message ref for synchronous pending HITL terminal updates.
+	PendingMessageUpdateSink HITLPendingMessageUpdateSink
 }
 
 // ApproverRuntime evaluates one stage of an approve = [...] chain.
@@ -441,6 +449,10 @@ type ApproveRequest struct {
 	// MessageUpdateSink records channel message references for async HITL
 	// operation updates after notifiers successfully post prompts.
 	MessageUpdateSink HITLMessageUpdateSink
+	// PendingMessageUpdateSink records channel message references for live
+	// synchronous HITL prompts so terminal timeout/disconnect states can be
+	// reflected back to the original operator-facing message.
+	PendingMessageUpdateSink HITLPendingMessageUpdateSink
 }
 
 // ApproveVerdict is what an approver returns. "" Decision means the


### PR DESCRIPTION
## Summary

Restores the sync HITL Slack terminal-update plumbing that was lost during the credential → endpoint → profile inversion work.

The sync flow now records Slack message refs for live pending HITL prompts, and the HITL registry proactively updates those recorded messages when the original request reaches a terminal state such as timeout or client disconnect.

## What changed

- Reintroduced `PendingMessageUpdateSink` through the runtime request/target types.
- Wires gateway → human approver → Slack notifier so sync pending prompts can record their Slack `channel`/`ts` message refs.
- Stores recorded message refs on `HITLRegistry` pending entries.
- On `Cancel` (timeout/client disconnect), updates every recorded prompt to the terminal state.
- Handles the race where Slack `chat.postMessage` returns after the request context is canceled by updating late refs with a fresh background context.

## Regression coverage

Adds tests that should fail if this gets dropped again:

- gateway `runApproveChain` must populate `ApproveRequest.PendingMessageUpdateSink`.
- human approver must forward `PendingMessageUpdateSink` to notifier targets.
- Slack notifier must record message refs for sync pending requests, not only async operations.
- HITL registry must update recorded refs on timeout/client-disconnect cancellation.
- late message-ref recording must use a fresh context instead of the canceled request context.

## Verification

- `go test ./cmd/clawpatrol ./internal/config/plugins/credentials ./internal/config/plugins/approvers -count=1`
- `go test ./...`
- `test -z "$(gofmt -l .)"`
- `git diff --check`
