### PR TITLE
fix: move PR_SET_DUMPABLE=0 to after child.Start

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -68,20 +68,6 @@ func runRun(args []string) {
 
 	warnIfOnGatewayHost()
 
-	// Mark this parent process non-dumpable BEFORE we read any tsnet
-	// auth-key bytes into memory. PR_SET_DUMPABLE=0 causes
-	// /proc/<pid>/{mem,root,fd,maps} to become root-owned, so a same-
-	// uid agent (forked under us) cannot ptrace or follow
-	// /proc/<parent_pid>/root back to the host mnt namespace to
-	// bypass the child-side tmpfs overlay. Without this, a system
-	// with kernel.yama.ptrace_scope=0 leaks the key. The child
-	// inherits DUMPABLE=0 across fork but the eventual non-suid
-	// execve into the agent resets it to 1 (kernel rule), so debug
-	// tooling inside the agent still works.
-	if err := hideParentFromAgent(); err != nil {
-		fail("PR_SET_DUMPABLE: %v", err)
-	}
-
 	// Check for Tailscale mode — uses ephemeral tsnet instead of WireGuard.
 	if mode := strings.TrimSpace(readFileSilent(filepath.Join(defaultClawpatrolDir(), "mode"))); mode == "tailscale" {
 		runRunTsnet(args)
@@ -178,6 +164,17 @@ func runRun(args []string) {
 			fail("clone: %v\n  hint: run as your normal user — clawpatrol run uses unprivileged user namespaces which root cannot enter on this distro", err)
 		}
 		fail("clone: %v\n  hint: this distro may have unprivileged user namespaces disabled.\n  enable: sudo sysctl -w kernel.unprivileged_userns_clone=1", err)
+	}
+	// Now that the child has been cloned (which AppArmor's
+	// restrict-unprivileged-userns hook would deny if the parent were
+	// already non-dumpable), lock the parent down. Closes the
+	// /proc/<parent_pid>/{root,mem} bypass on ptrace_scope=0 systems.
+	// The child hasn't exec'd the agent yet — it's blocked on
+	// wgUpR waiting for our signal — so there's no window for the
+	// agent to read parent state before this prctl lands.
+	if err := hideParentFromAgent(); err != nil {
+		_ = child.Process.Kill()
+		fail("PR_SET_DUMPABLE: %v", err)
 	}
 	_ = cSock.Close()
 	_ = wgUpR.Close()

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -192,6 +192,17 @@ func runRunTsnet(args []string) {
 		}
 		fail("clone: %v\n  hint: this distro may have unprivileged user namespaces disabled.\n  enable: sudo sysctl -w kernel.unprivileged_userns_clone=1", err)
 	}
+	// Now that the child has been cloned (which AppArmor's
+	// restrict-unprivileged-userns hook would deny if the parent were
+	// already non-dumpable), lock the parent down. Closes the
+	// /proc/<parent_pid>/{root,mem} bypass on ptrace_scope=0 systems.
+	// The child hasn't exec'd the agent yet — it's blocked on wgUpR
+	// waiting for our signal — so there's no window for the agent to
+	// read parent state before this prctl lands.
+	if err := hideParentFromAgent(); err != nil {
+		_ = child.Process.Kill()
+		fail("PR_SET_DUMPABLE: %v", err)
+	}
 	_ = cSock.Close()
 	_ = wgUpR.Close()
 


### PR DESCRIPTION
## Summary

- Move \`prctl(PR_SET_DUMPABLE, 0)\` from the top of \`runRun\` to immediately after \`child.Start()\` in both WG (\`run_linux.go\`) and tsnet (\`run_tsnet_linux.go\`) paths.
- Kill the child if the prctl fails so a partial setup doesn't linger.

## Why

Calling prctl before the unprivileged user-namespace clone makes AppArmor's \`restrict-unprivileged-userns\` hook reject the clone with EACCES on Ubuntu 24.04+. Reported in the wild:

\`\`\`
clawpatrol: joining tailnet...
2026/05/20 17:46:32 LocalBackend state is NeedsLogin; running StartLoginInteractive...
2026/05/20 17:46:37 AuthLoop: state is Running; done
clawpatrol: clone: fork/exec /home/exedev/.local/bin/clawpatrol: permission denied
  hint: this distro may have unprivileged user namespaces disabled.
\`\`\`

## Why this is still safe

The child is blocked on \`wgUpR\` immediately after fork, waiting for the parent's go-signal. It cannot have exec'd the agent yet — that happens later in \`runRunChild\` / \`runRunTsnetChild\`, after the child has finished its own setup. Parent races to call \`hideParentFromAgent\` before writing \`wgUpW\`, which is the only signal that lets the child progress to exec. So the prctl lands before any hostile code in the new ns can observe parent state.

## Test plan

- [ ] gofmt clean, go build darwin + linux, go vet ✓ verified locally
- [ ] go test ./cmd/clawpatrol/ passes ✓
- [ ] On Ubuntu 24.04 host with AppArmor restrict-unprivileged-userns: \`clawpatrol run claude\` no longer fails with "permission denied"
- [ ] On a \`kernel.yama.ptrace_scope=0\` host: \`/proc/<parent_pid>/root\` from inside the agent still returns Permission denied (DUMPABLE=0 is effective by the time agent runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)