### PR TITLE
fix: restore wildcard hosts + small regressions from #368 squash

### DIFF
--- a/cmd/clawpatrol/gateway.example.hcl
+++ b/cmd/clawpatrol/gateway.example.hcl
@@ -107,6 +107,17 @@ endpoint "https" "slack" {
 endpoint "https" "notion"  { hosts = ["api.notion.com", "mcp.notion.com"] }
 endpoint "https" "grafana" { hosts = ["mygrafana.grafana.net"] }
 
+# HTTPS — wildcard hosts. A `*.<suffix>` entry matches any name that
+# ends in `.<suffix>` and has at least one character before that
+# suffix; `*.amazonaws.com` covers both `s3.amazonaws.com` and
+# `s3.us-east-1.amazonaws.com` but NOT the bare `amazonaws.com`.
+# Exact hosts always beat wildcards; among wildcards the longest
+# matching suffix wins (so `*.us-east-1.amazonaws.com` takes
+# precedence over `*.amazonaws.com` for east-1 names).
+endpoint "https" "aws" {
+  hosts = ["*.amazonaws.com"]
+}
+
 # SSH — the wire protocol carries no SNI / Host header, so the
 # gateway runs a DNS server inside the WG tunnel and answers A/AAAA
 # queries for SSH-able hostnames with virtual IPs from 10.78.0.0/16
@@ -194,6 +205,9 @@ credential "github_oauth" "github" {
 # Bearer tokens — opaque "Authorization: Bearer <token>".
 credential "bearer_token" "grafana" {
   endpoint = https.grafana
+}
+credential "bearer_token" "aws" {
+  endpoint = https.aws
 }
 
 # Notion OAuth — workspace-scoped.
@@ -446,7 +460,7 @@ rule "k8s-default" {
 # fallback the dashboard assigns at approval time.
 
 profile "default" {
-  credentials = [anthropic_oauth_subscription.claude, openai_codex_oauth.codex, github_oauth.github]
+  credentials = [anthropic_oauth_subscription.claude, openai_codex_oauth.codex, github_oauth.github, bearer_token.aws]
 }
 
 profile "support" {

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denoland/clawpatrol/internal/config/hostmatch"
 	"github.com/denoland/clawpatrol/internal/config/match"
 )
 
@@ -51,8 +52,9 @@ type CompiledPolicy struct {
 // dispatch against. Endpoints map by name; HostIndex maps exact
 // declared hosts plus bare-host aliases for HTTPS-family default-port
 // declarations to the endpoint that owns them for fast SNI / authority
-// lookup. CompiledEndpoint.Hosts keeps the operator-declared strings
-// unchanged.
+// lookup. HostPatterns captures wildcard `*.suffix` declarations the
+// dispatcher walks when HostIndex misses. CompiledEndpoint.Hosts keeps
+// the operator-declared strings unchanged.
 //
 // Endpoint membership is the transitive closure
 // profile → credentials → endpoints: a profile names credentials, and
@@ -74,8 +76,20 @@ type CompiledProfile struct {
 	Credentials         []*Entity
 	Endpoints           map[string]*CompiledEndpoint
 	HostIndex           map[string]*CompiledEndpoint
+	HostPatterns        []HostPattern
 	EndpointCredentials map[string][]*CompiledCredential
 	HITLAsyncGrants     bool
+}
+
+// HostPattern is one wildcard host binding inside a CompiledProfile.
+// Pattern is the full lowercased `*.suffix` string; Endpoint is the
+// CompiledEndpoint that declared it. The dispatcher walks
+// HostPatterns when an exact HostIndex lookup misses; the slice is
+// pre-sorted at compile time so longer (more specific) suffixes are
+// tried first.
+type HostPattern struct {
+	Pattern  string
+	Endpoint *CompiledEndpoint
 }
 
 // CompiledEndpoint flattens an endpoint plus the rules that target it.
@@ -344,6 +358,22 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				// SNI on the wire) matches a config-declared host
 				// regardless of its casing.
 				for _, h := range ce.Hosts {
+					host, _, hpErr := hostmatch.SplitHostPort(h)
+					if hpErr != nil || host == "" {
+						continue
+					}
+					if hostmatch.IsWildcardHost(host) {
+						// Wildcard patterns route on the SNI/authority
+						// host alone (no port), so collapse port-qualified
+						// `*.foo.com:443` and bare `*.foo.com` to a single
+						// pattern keyed on the host portion. Duplicates
+						// from listing both forms are removed below.
+						profile.HostPatterns = append(profile.HostPatterns, HostPattern{
+							Pattern:  strings.ToLower(host),
+							Endpoint: ce,
+						})
+						continue
+					}
 					profile.HostIndex[strings.ToLower(h)] = ce
 				}
 				profile.EndpointCredentials[epName] = append(
@@ -370,6 +400,11 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				}
 			}
 		}
+		// Wildcard patterns: longest-suffix-wins, so sort by
+		// descending pattern length. Within equal length we sort
+		// alphabetically for determinism.
+		dedupePatterns(&profile.HostPatterns)
+		sortHostPatterns(profile.HostPatterns)
 		cp.Profiles[name] = profile
 	}
 
@@ -521,7 +556,56 @@ func bareHostAlias(ep *CompiledEndpoint, host string) (string, bool) {
 	if err != nil || bare == "" || port != "443" {
 		return "", false
 	}
+	// Wildcards go through HostPatterns, not HostIndex.
+	if strings.HasPrefix(bare, "*.") {
+		return "", false
+	}
 	return bare, true
+}
+
+// dedupePatterns removes duplicate (pattern, endpoint) entries that
+// arise when a profile binds the same wildcard via both bare and
+// port-qualified forms (e.g. `*.foo.com` and `*.foo.com:443`).
+func dedupePatterns(patterns *[]HostPattern) {
+	if len(*patterns) < 2 {
+		return
+	}
+	seen := make(map[string]struct{}, len(*patterns))
+	out := (*patterns)[:0]
+	for _, p := range *patterns {
+		key := p.Pattern + "\x00" + p.Endpoint.Name
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, p)
+	}
+	*patterns = out
+}
+
+// sortHostPatterns orders patterns so the dispatcher's linear scan
+// returns the longest (most specific) suffix first. Ties break
+// alphabetically for determinism.
+func sortHostPatterns(patterns []HostPattern) {
+	sort.SliceStable(patterns, func(i, j int) bool {
+		if len(patterns[i].Pattern) != len(patterns[j].Pattern) {
+			return len(patterns[i].Pattern) > len(patterns[j].Pattern)
+		}
+		return patterns[i].Pattern < patterns[j].Pattern
+	})
+}
+
+// MatchHostPattern is the matcher used at dispatch time. Returns the
+// first endpoint whose pattern matches hostname (patterns must already
+// be sorted by descending pattern length). Hostname must already be
+// lowercased; patterns are stored lowercased by Compile.
+func MatchHostPattern(patterns []HostPattern, hostname string) *CompiledEndpoint {
+	for _, p := range patterns {
+		if hostmatch.MatchWildcard(p.Pattern, hostname) {
+			return p.Endpoint
+		}
+	}
+	return nil
 }
 
 // extractHosts mirrors the per-type hosts field via interface dispatch.

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -103,6 +103,113 @@ func TestCompile(t *testing.T) {
 	}
 }
 
+// TestCompileWildcardHosts verifies that wildcard hosts are accepted,
+// land in HostPatterns (not HostIndex), and that malformed wildcards
+// or within-endpoint duplicates are rejected at load time.
+func TestCompileWildcardHosts(t *testing.T) {
+	src := `
+endpoint "https" "aws" {
+  hosts = ["*.amazonaws.com", "*.us-east-1.amazonaws.com:443"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.aws
+}
+profile "p" { credentials = [bearer_token.tok] }
+`
+	gw, diags := config.LoadBytes([]byte(src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	prof := cp.Profiles["p"]
+	if prof == nil {
+		t.Fatalf("missing profile p")
+	}
+	if got := len(prof.HostPatterns); got != 2 {
+		t.Fatalf("HostPatterns count = %d, want 2 (entries: %+v)", got, prof.HostPatterns)
+	}
+	// Longest first: *.us-east-1.amazonaws.com before *.amazonaws.com.
+	if prof.HostPatterns[0].Pattern != "*.us-east-1.amazonaws.com" {
+		t.Errorf("HostPatterns[0]=%q, want *.us-east-1.amazonaws.com", prof.HostPatterns[0].Pattern)
+	}
+	if prof.HostPatterns[1].Pattern != "*.amazonaws.com" {
+		t.Errorf("HostPatterns[1]=%q, want *.amazonaws.com", prof.HostPatterns[1].Pattern)
+	}
+	// Wildcards must not leak into HostIndex.
+	for k := range prof.HostIndex {
+		if strings.HasPrefix(k, "*.") {
+			t.Errorf("HostIndex leaked wildcard %q", k)
+		}
+	}
+}
+
+func TestCompileRejectsBadHosts(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "malformed wildcard - empty suffix",
+			src: `
+endpoint "https" "bad" {
+  hosts = ["*."]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.bad
+}
+profile "p" { credentials = [bearer_token.tok] }
+`,
+		},
+		{
+			name: "wildcard with bare TLD",
+			src: `
+endpoint "https" "bad" {
+  hosts = ["*.com"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.bad
+}
+profile "p" { credentials = [bearer_token.tok] }
+`,
+		},
+		{
+			name: "wildcard not at leftmost label",
+			src: `
+endpoint "https" "bad" {
+  hosts = ["api.*.foo.com"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.bad
+}
+profile "p" { credentials = [bearer_token.tok] }
+`,
+		},
+		{
+			name: "duplicate hosts",
+			src: `
+endpoint "https" "bad" {
+  hosts = ["api.foo.com", "api.foo.com"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.bad
+}
+profile "p" { credentials = [bearer_token.tok] }
+`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, diags := config.LoadBytes([]byte(c.src), "in.hcl")
+			if !diags.HasErrors() {
+				t.Fatalf("load accepted bad hosts; want diagnostic")
+			}
+		})
+	}
+}
+
 // TestCompilePrioritySort verifies that rules with mixed priorities
 // land in descending priority order, matching the v14 first-match-
 // wins evaluation. Tied priorities preserve declaration order.

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -203,12 +203,6 @@ var frameworkAttrsByKind = map[Kind][]FrameworkAttrSpec{
 	},
 }
 
-// FrameworkAttrsFor returns the framework attr specs declared for
-// kind, or nil if none.
-func FrameworkAttrsFor(kind Kind) []FrameworkAttrSpec {
-	return frameworkAttrsByKind[kind]
-}
-
 // RefSpec declares a field on a decoded plugin struct that holds a
 // bare-name reference (or a list of them) into the symbol table.
 type RefSpec struct {

--- a/internal/config/plugins/endpoints/clickhouse_https.go
+++ b/internal/config/plugins/endpoints/clickhouse_https.go
@@ -91,12 +91,13 @@ func ClickhouseHTTPSDatabaseFromRequest(req *http.Request) string {
 func init() {
 	var _ runtime.PlaceholderDetector = ClickhouseHTTPSEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "clickhouse_https",
-		Family:  "sql",
-		New:     func() any { return &ClickhouseHTTPSEndpoint{} },
-		Runtime: ClickhouseHTTPSEndpointRuntime{},
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "clickhouse_https",
+		Family:   "sql",
+		New:      func() any { return &ClickhouseHTTPSEndpoint{} },
+		Runtime:  ClickhouseHTTPSEndpointRuntime{},
+		Validate: hostsValidate,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*ClickhouseHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/internal/config/plugins/endpoints/clickhouse_native.go
+++ b/internal/config/plugins/endpoints/clickhouse_native.go
@@ -179,9 +179,10 @@ func init() {
 // so without tls there's nothing for it to do.
 func validateClickhouseNativeEndpoint(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
 	var diags hcl.Diagnostics
+	diags = append(diags, validateHosts(d, name, ctx.Block.DefRange)...)
 	e, ok := d.(*ClickhouseNativeEndpoint)
 	if !ok {
-		return nil
+		return diags
 	}
 	if e.AcceptInvalidCertificate && !e.TLS {
 		diags = append(diags, &hcl.Diagnostic{

--- a/internal/config/plugins/endpoints/https.go
+++ b/internal/config/plugins/endpoints/https.go
@@ -64,12 +64,13 @@ func basicAuthPayload(authz string) string {
 func init() {
 	var _ runtime.PlaceholderDetector = HTTPSEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "https",
-		Family:  "http",
-		New:     func() any { return &HTTPSEndpoint{} },
-		Runtime: HTTPSEndpointRuntime{},
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "https",
+		Family:   "http",
+		New:      func() any { return &HTTPSEndpoint{} },
+		Runtime:  HTTPSEndpointRuntime{},
+		Validate: hostsValidate,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*HTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/internal/config/plugins/endpoints/kubernetes.go
+++ b/internal/config/plugins/endpoints/kubernetes.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
@@ -92,13 +93,23 @@ func (e *KubernetesEndpoint) ConfigureUpstreamTLS(cfg *tls.Config) error {
 	return nil
 }
 
+// validateKubernetesEndpoint catches malformed host / server entries
+// before the compile pass turns them into a routing table. Kubernetes
+// endpoints can declare either `hosts = [...]` (managed clusters) or
+// `server = "..."` (self-hosted); EndpointHosts() returns whichever
+// is set, so the shared validateHosts check covers both shapes.
+func validateKubernetesEndpoint(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
+	return validateHosts(d, name, ctx.Block.DefRange)
+}
+
 func init() {
 	config.Register(&config.Plugin{
-		Kind:   config.KindEndpoint,
-		Type:   "kubernetes",
-		Family: "k8s",
-		New:    func() any { return &KubernetesEndpoint{} },
-		Build:  passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "kubernetes",
+		Family:   "k8s",
+		New:      func() any { return &KubernetesEndpoint{} },
+		Validate: validateKubernetesEndpoint,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*KubernetesEndpoint)
 			if len(e.Hosts) > 0 {

--- a/internal/config/plugins/endpoints/openai_codex_https.go
+++ b/internal/config/plugins/endpoints/openai_codex_https.go
@@ -147,12 +147,13 @@ func init() {
 	var _ runtime.PlaceholderDetector = OpenAICodexHTTPSEndpointRuntime{}
 	var _ runtime.HTTPSyntheticResponder = OpenAICodexHTTPSEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "openai_codex_https",
-		Family:  "http",
-		New:     func() any { return &OpenAICodexHTTPSEndpoint{} },
-		Runtime: OpenAICodexHTTPSEndpointRuntime{},
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "openai_codex_https",
+		Family:   "http",
+		New:      func() any { return &OpenAICodexHTTPSEndpoint{} },
+		Runtime:  OpenAICodexHTTPSEndpointRuntime{},
+		Validate: hostsValidate,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*OpenAICodexHTTPSEndpoint)
 			b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))

--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -140,12 +140,13 @@ func init() {
 	var _ runtime.PlaceholderDetector = PostgresEndpointRuntime{}
 	var _ runtime.SQLParser = PostgresEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "postgres",
-		Family:  "sql",
-		New:     func() any { return &PostgresEndpoint{} },
-		Runtime: PostgresEndpointRuntime{},
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "postgres",
+		Family:   "sql",
+		New:      func() any { return &PostgresEndpoint{} },
+		Runtime:  PostgresEndpointRuntime{},
+		Validate: hostsValidate,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*PostgresEndpoint)
 			b.SetAttributeValue("host", cty.StringVal(e.Host))

--- a/internal/config/plugins/endpoints/ssh.go
+++ b/internal/config/plugins/endpoints/ssh.go
@@ -97,12 +97,13 @@ type SSHEndpointRuntime struct {
 func init() {
 	rt := &SSHEndpointRuntime{}
 	config.Register(&config.Plugin{
-		Kind:    config.KindEndpoint,
-		Type:    "ssh",
-		Family:  "ssh",
-		New:     func() any { return &SSHEndpoint{} },
-		Runtime: rt,
-		Build:   passthroughBuild,
+		Kind:     config.KindEndpoint,
+		Type:     "ssh",
+		Family:   "ssh",
+		New:      func() any { return &SSHEndpoint{} },
+		Runtime:  rt,
+		Validate: hostsValidate,
+		Build:    passthroughBuild,
 		Emit: func(body any, _ string, b *hclwrite.Body) {
 			e := body.(*SSHEndpoint)
 			if len(e.Hosts) > 0 {

--- a/internal/config/plugins/endpoints/util.go
+++ b/internal/config/plugins/endpoints/util.go
@@ -15,13 +15,75 @@
 package endpoints
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/hostmatch"
 )
 
 // passthroughBuild is the Build hook for endpoint plugins that don't
 // derive any record beyond their decoded body.
 func passthroughBuild(d any, _ string, _ *config.BuildCtx) (any, hcl.Diagnostics) {
 	return d, nil
+}
+
+// validateHosts checks the host strings the plugin body exposes via
+// EndpointHosts(). It rejects malformed entries (bad ports,
+// malformed wildcards) and within-endpoint duplicates. Endpoint
+// plugins whose hosts come from a single field (postgres' Host,
+// kubernetes' Server) also pass through here — EndpointHosts
+// returns a one-element slice for them, so the same validation
+// applies.
+func validateHosts(d any, name string, defRange hcl.Range) hcl.Diagnostics {
+	hosts := extractHostsAny(d)
+	if len(hosts) == 0 {
+		return nil
+	}
+	var diags hcl.Diagnostics
+	seen := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		if err := hostmatch.ValidateHost(h); err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Malformed host on endpoint %q", name),
+				Detail:   fmt.Sprintf("hosts entry %q: %v", h, err),
+				Subject:  &defRange,
+			})
+			continue
+		}
+		key := strings.ToLower(h)
+		if _, dup := seen[key]; dup {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Duplicate host on endpoint %q", name),
+				Detail:   fmt.Sprintf("hosts entry %q appears more than once", h),
+				Subject:  &defRange,
+			})
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	return diags
+}
+
+// extractHostsAny mirrors compile.extractHosts but lives in this
+// package so the Validate hooks can call it without dragging the
+// internal compile pass in.
+func extractHostsAny(body any) []string {
+	if h, ok := body.(interface{ EndpointHosts() []string }); ok {
+		return h.EndpointHosts()
+	}
+	return nil
+}
+
+// hostsValidate is the Validate hook every endpoint plugin uses to
+// catch malformed / duplicate `hosts = [...]` entries at config-load
+// time. Registered as Plugin.Validate on every endpoint type;
+// per-plugin Validate hooks that need to layer additional checks on
+// top should chain to validateHosts explicitly.
+func hostsValidate(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
+	return validateHosts(d, name, ctx.Block.DefRange)
 }

--- a/internal/config/runtime/dispatch.go
+++ b/internal/config/runtime/dispatch.go
@@ -13,9 +13,13 @@ import (
 // so a TLS SNI value like "api.example.com" can match an endpoint
 // declared as "api.example.com:443" without a runtime scan. DNS
 // hostnames are case-insensitive; the lookup key is lowercased to
-// match the lowercase keys Compile inserts. Returns nil when the
-// profile doesn't bind any matching endpoint — the caller then
-// applies the defaults.unknown_host policy.
+// match the lowercase keys Compile inserts.
+//
+// When the exact lookup misses we walk HostPatterns — the profile's
+// wildcard declarations (`hosts = ["*.foo.com"]`) — in
+// longest-suffix-first order. Exact matches always win over wildcards
+// for the same name. Returns nil when nothing matches; the caller
+// then applies the defaults.unknown_host policy.
 func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.CompiledEndpoint {
 	if policy == nil {
 		return nil
@@ -26,9 +30,17 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 		// Single-tenant fallback: if no peer-to-profile mapping is
 		// established, walk every profile and return the first match.
 		// Matches main.go's existing profileFor behavior when only
-		// one profile exists.
+		// one profile exists. Exact matches are tried across all
+		// profiles before falling back to wildcards so a profile that
+		// declared the exact host wins over a different profile's
+		// wildcard.
 		for _, p := range policy.Profiles {
 			if ep := p.HostIndex[host]; ep != nil {
+				return ep
+			}
+		}
+		for _, p := range policy.Profiles {
+			if ep := config.MatchHostPattern(p.HostPatterns, host); ep != nil {
 				return ep
 			}
 		}
@@ -37,7 +49,7 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 	if ep := prof.HostIndex[host]; ep != nil {
 		return ep
 	}
-	return nil
+	return config.MatchHostPattern(prof.HostPatterns, host)
 }
 
 // MatchRequest walks an endpoint's priority-sorted rule list and

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -213,6 +213,117 @@ profile "default" { credentials = [bearer_token.api-tok, postgres_credential.db-
 	}
 }
 
+func TestHostEndpointWildcardMatches(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "aws-ep" {
+  hosts = ["*.amazonaws.com"]
+}
+credential "bearer_token" "aws-tok" {
+  endpoint = https.aws-ep
+}
+profile "default" { credentials = [bearer_token.aws-tok] }
+`)
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"s3.amazonaws.com", "aws-ep"},
+		{"dynamodb.us-east-1.amazonaws.com", "aws-ep"},
+		{"AB.AMAZONAWS.COM", "aws-ep"},
+		{"amazonaws.com", ""},
+		{"notamazonaws.com", ""},
+		{"foo.bar", ""},
+	}
+	for _, c := range cases {
+		got := runtime.HostEndpoint(cp, "default", c.host)
+		gotName := ""
+		if got != nil {
+			gotName = got.Name
+		}
+		if gotName != c.want {
+			t.Errorf("HostEndpoint(%q) = %q, want %q", c.host, gotName, c.want)
+		}
+	}
+}
+
+func TestHostEndpointExactBeatsWildcard(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "aws-ep" {
+  hosts = ["*.amazonaws.com"]
+}
+endpoint "https" "s3-ep" {
+  hosts = ["s3.amazonaws.com"]
+}
+credential "bearer_token" "aws-tok" {
+  endpoint = https.aws-ep
+}
+credential "bearer_token" "s3-tok" {
+  endpoint = https.s3-ep
+}
+profile "default" { credentials = [bearer_token.aws-tok, bearer_token.s3-tok] }
+`)
+	if got := runtime.HostEndpoint(cp, "default", "s3.amazonaws.com"); got == nil || got.Name != "s3-ep" {
+		t.Fatalf("exact host should beat wildcard: got %+v, want s3-ep", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "dynamodb.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("uncovered subdomain should fall to wildcard: got %+v, want aws-ep", got)
+	}
+}
+
+func TestHostEndpointLongestWildcardWins(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "east-ep" {
+  hosts = ["*.us-east-1.amazonaws.com"]
+}
+endpoint "https" "aws-ep" {
+  hosts = ["*.amazonaws.com"]
+}
+credential "bearer_token" "east-tok" {
+  endpoint = https.east-ep
+}
+credential "bearer_token" "aws-tok" {
+  endpoint = https.aws-ep
+}
+profile "default" { credentials = [bearer_token.aws-tok, bearer_token.east-tok] }
+`)
+	if got := runtime.HostEndpoint(cp, "default", "s3.us-east-1.amazonaws.com"); got == nil || got.Name != "east-ep" {
+		t.Fatalf("longest suffix should win: got %+v, want east-ep", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "s3.us-west-2.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("shorter pattern picks up the rest: got %+v, want aws-ep", got)
+	}
+}
+
+func TestHostEndpointWildcardWithPortAlias(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "aws-ep" {
+  hosts = ["*.amazonaws.com:443"]
+}
+credential "bearer_token" "aws-tok" {
+  endpoint = https.aws-ep
+}
+profile "default" { credentials = [bearer_token.aws-tok] }
+`)
+	if got := runtime.HostEndpoint(cp, "default", "s3.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("port-qualified wildcard should match bare SNI: got %+v, want aws-ep", got)
+	}
+}
+
+func TestHostEndpointWildcardSingleTenantFallback(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "aws-ep" {
+  hosts = ["*.amazonaws.com"]
+}
+credential "bearer_token" "aws-tok" {
+  endpoint = https.aws-ep
+}
+profile "tenant" { credentials = [bearer_token.aws-tok] }
+`)
+	if got := runtime.HostEndpoint(cp, "missing-profile", "s3.amazonaws.com"); got == nil || got.Name != "aws-ep" {
+		t.Fatalf("fallback scan should find wildcard match across profiles: got %+v, want aws-ep", got)
+	}
+}
+
 // TestMatchRequest exercises priority-ordered first-match-wins
 // dispatch and the default catch-all (priority -100).
 func TestMatchRequest(t *testing.T) {

--- a/site/doc/glossary.md
+++ b/site/doc/glossary.md
@@ -15,7 +15,7 @@ it talks to. Operators describe the system with [endpoints](#endpoint),
 
 The Claw Patrol daemon. It loads config, hosts the operator UI, applies
 policy, injects real credentials, and forwards allowed traffic upstream.
-See [Architecture](/docs/architecture/) for the gateway's position in a
+See [Architecture](/docs/architecture/) for the gateway’s position in a
 deployment.
 
 ### Agent
@@ -45,7 +45,7 @@ nothing more. The unit a [rule](#rule) attaches to. See
 
 A typed handle to a secret for one or more [endpoints](#endpoint). The
 config block describes where the secret should be injected; the secret
-bytes stay in the gateway's [secret store](#secret-store). See
+bytes stay in the gateway’s [secret store](#secret-store). See
 [Config Reference](/docs/config-reference/) for credential schemas.
 
 ### Action
@@ -53,7 +53,7 @@ bytes stay in the gateway's [secret store](#secret-store). See
 One unit of agent work the gateway sees and applies policy to — one
 HTTP call, one SQL query, one `kubectl` invocation, one SSH command.
 Each action targets an [endpoint](#endpoint), is gated by the matching
-[rule](#rule)'s [outcome](#outcome), and surfaces in the dashboard's
+[rule](#rule)'s [outcome](#outcome), and surfaces in the dashboard’s
 live request feed. "Action" is the operator-visible concept of "the
 thing the agent did."
 
@@ -61,7 +61,7 @@ thing the agent did."
 
 One policy decision targeting one or more [endpoints](#endpoint). A
 rule has a CEL [`condition`](#cel-condition) string that matches against
-the [facets](#facet) of the rule's protocol family (inferred from its
+the [facets](#facet) of the rule’s protocol family (inferred from its
 endpoints), an optional `credential` predicate, and an [outcome](#outcome)
 — either a literal `verdict` or an `approve = [...]` chain. See
 [Rules](/docs/rules/) for family-specific matching and examples.
@@ -77,8 +77,8 @@ Kubernetes resource. Each protocol family exposes its own facets. See
 
 The boolean expression a [rule](#rule)'s `condition = "..."` field
 carries. CEL ([Common Expression Language](https://github.com/google/cel-spec))
-is evaluated against the [facets](#facet) of the rule's inferred family.
-An absent or empty `condition` matches every request the rule's
+is evaluated against the [facets](#facet) of the rule’s inferred family.
+An absent or empty `condition` matches every request the rule’s
 endpoints see.
 
 ### Approver
@@ -106,14 +106,14 @@ new config block types and the behavior behind them. See
 
 The decision a matched [rule](#rule) carries: `verdict = "allow"`,
 `verdict = "deny"`, or `approve = [...]` (an ordered list of
-[approver](#approver) stages). On allow, the credential plugin's
+[approver](#approver) stages). On allow, the credential plugin’s
 runtime stamps the secret onto the forwarded request.
 
 ### Placeholder
 
 A magic string an [agent](#agent) embeds in the auth slot when its
 [profile](#profile) wields more than one [credential](#credential) at
-the same [endpoint](#endpoint). The profile's credentials list mixes
+the same [endpoint](#endpoint). The profile’s credentials list mixes
 bare-name entries with inline `{ placeholder = "PH_...", credential =
 name }` objects that name the discriminator for each ambiguous
 credential; the gateway looks at the incoming request, picks the
@@ -130,7 +130,7 @@ variables, keyed by `CLAWPATROL_SECRET_<UPPER_NAME>` (with
 
 ### MitM
 
-"Man-in-the-middle" — the gateway's TLS interception strategy. It
+"Man-in-the-middle" — the gateway’s TLS interception strategy. It
 allows the gateway to inspect and authorize encrypted protocol traffic
 before forwarding it upstream. See
 [Architecture › MitM TLS Interception](/docs/architecture/#mitm-tls-interception).
@@ -165,5 +165,5 @@ for exact fields, types, and examples.
 
 <!-- Implementation-level vocabulary (Plugin, Runtime, the
 HTTP/Postgres/TLS/Conn runtime interfaces, ConnIndex, the WG
-promiscuous forwarder, etc.) lives in the repo's internal
+promiscuous forwarder, etc.) lives in the repo’s internal
 doc/code-vocabulary.md, not here. -->


### PR DESCRIPTION
PR #368 landed as a squash-merge whose base predated three other PRs
that had touched files #368 also modified. The squash silently used
#368's view of those files and overwrote main's content, undoing parts
of #485 (wildcards), #478 (dead-code cleanup), and #488 (style pass).

This restores them.

## What got undone

| PR | What was lost |
|---|---|
| **#485** (`*.suffix` wildcards) | All `HostPattern` / `hostmatch.IsWildcardHost` / `MatchHostPattern` integration in `compile.go`, `runtime/dispatch.go`, `endpoints/util.go`. The `hostmatch` package itself stayed (`dnsvip.go` depends on it), but request-time dispatch + config-load validation no longer consulted it. Wildcard endpoints declared in HCL parsed but never matched at runtime. |
| **#478** (cleanup unused funcs) | `config.FrameworkAttrsFor` came back. No call sites remain. |
| **#488** (style pass) | Typographic apostrophes in `site/doc/glossary.md` reverted to ASCII straight quotes. The other two files #488 touched survived. |

## What this fixes

* Re-applies the wildcard integration from #485, adapted to the post-inversion grammar:
  - `CompiledProfile.HostPatterns` + `dedupePatterns` / `sortHostPatterns` / `MatchHostPattern` in `internal/config/compile.go`.
  - `runtime.HostEndpoint` falls through to `HostPatterns` on exact-host miss; the single-tenant fallback also walks wildcards.
  - `endpoints/util.go` exposes `validateHosts` / `hostsValidate` so every endpoint plugin's `Validate` hook catches malformed wildcards and within-endpoint duplicates at load time. Wired into every endpoint plugin (`https`, `ssh`, `kubernetes`, `postgres`, `clickhouse_https`, `openai_codex_https`); `clickhouse_native` already had a `Validate` so I chained `validateHosts` from it.
* Restores the `*.amazonaws.com` example in `gateway.example.hcl` in the new grammar.
* Translates the existing wildcard tests (`TestCompileWildcardHosts`, `TestCompileRejectsBadHosts`, `TestHostEndpointWildcard*`) to the credential→endpoint inverted shape.
* Drops `config.FrameworkAttrsFor` again.
* Re-applies typographic apostrophes in `site/doc/glossary.md`.

## Verification

* `go test ./...` clean — including `TestCompileWildcardHosts`, `TestCompileRejectsBadHosts`, and all `TestHostEndpointWildcard*` cases that were quietly absent on main.
* `go vet ./...`, `gofmt -l .` clean.