### PR TITLE
Linux self-forking daemon + exit-node routing, no more PROXY v1

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -66,7 +66,6 @@ func daemonControlSockPath() string { return filepath.Join(daemonRuntimeDir(), "
 func daemonSpawnLockPath() string   { return filepath.Join(daemonRuntimeDir(), "spawn.lock") }
 func daemonLogPath() string         { return filepath.Join(daemonRuntimeDir(), "daemon.log") }
 
-
 // daemonConnect returns a control connection to the per-host daemon,
 // spawning one if none is running. Safe to call from concurrent
 // `clawpatrol run` invocations.

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -25,18 +25,23 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"tailscale.com/tsnet"
 )
 
 const (
@@ -217,6 +222,15 @@ type daemon struct {
 	sockPath string
 	lockFile *os.File
 
+	// tsServer is the daemon's single tailnet identity, shared by every
+	// concurrent `clawpatrol run` session on this host. Set once at
+	// startup, never replaced. envVars is the cached env-pushdown
+	// response — clients pull it from us instead of dialing the gateway
+	// themselves (they're not on the tailnet; only we are).
+	tsServer *tsnet.Server
+	tsIP     netip.Addr
+	envVars  []byte // pre-serialized JSON for the FETCH path in handle()
+
 	activeConns atomic.Int32
 
 	mu        sync.Mutex
@@ -246,8 +260,27 @@ func runDaemon(_ []string) {
 
 	log.Printf("daemon pid=%d starting", os.Getpid())
 
-	// Bind first. Parent holds the spawn lock while we do this, so we
-	// can't race another daemon for the socket.
+	// Boot tsnet first. We don't bind the control socket until the
+	// daemon is fully usable — that way a parent reading "ready\n" can
+	// proceed straight to a session START without retries.
+	tsServer, tsIP, err := daemonStartTsnet(dir)
+	if err != nil {
+		log.Fatalf("daemon: tsnet: %v", err)
+	}
+
+	// Fetch the env-pushdown JSON once and cache it. Sessions get the
+	// same vars over their lifetime — refreshing per-session would
+	// stampede the gateway under bursty agent fleets.
+	envJSON := daemonFetchEnvPushdown(tsServer)
+
+	// Register this tsnet IP with the gateway so it maps to the host's
+	// device row (and therefore its profile). Best-effort: a failure
+	// only means traffic lands in the default profile until the next
+	// daemon restart.
+	daemonRegisterWithGateway(tsServer, tsIP)
+
+	// Bind the control socket last. Parent still holds spawn.lock at
+	// this point, so we can't race another daemon for the path.
 	_ = os.Remove(sockPath)
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -266,6 +299,9 @@ func runDaemon(_ []string) {
 		sockPath: sockPath,
 		listener: ln,
 		lockFile: lf,
+		tsServer: tsServer,
+		tsIP:     tsIP,
+		envVars:  envJSON,
 		rebindCh: make(chan struct{}),
 	}
 
@@ -327,9 +363,17 @@ func (d *daemon) serve() {
 	}
 }
 
-// handle services a single client conn: hello handshake, then block
-// until the client closes. The actual session protocol (TUN-fd via
-// SCM_RIGHTS, gVisor attach) is added in a follow-up commit.
+// handle services a single `clawpatrol run` session. After the
+// hello handshake the protocol is:
+//
+//	client → daemon:  "START\n"
+//	daemon → client:  "TSIP <ip>\n" "ENV <n>\n" <n bytes JSON>
+//	client → daemon:  SCM_RIGHTS carrying one TUN fd (payload byte 0)
+//	daemon → client:  "ATTACHED\n"
+//	client → daemon:  (control conn stays open; close = session end)
+//
+// On close the per-session gVisor stack tears down, the TUN fd is
+// released, and any in-flight conns through tsnet drain.
 func (d *daemon) handle(c net.Conn) {
 	defer func() {
 		_ = c.Close()
@@ -345,13 +389,183 @@ func (d *daemon) handle(c net.Conn) {
 		return
 	}
 
-	// Keep the conn alive until peer closes.
+	br := bufio.NewReader(c)
+	_ = c.SetReadDeadline(time.Now().Add(daemonHelloTimeout))
+	line, err := br.ReadString('\n')
+	if err != nil {
+		log.Printf("daemon: read command: %v", err)
+		return
+	}
+	if line != "START\n" {
+		log.Printf("daemon: unknown command %q", line)
+		return
+	}
+	_ = c.SetReadDeadline(time.Time{})
+
+	// 1. Tell the client our tsnet IP and ship the env-pushdown JSON.
+	if _, err := fmt.Fprintf(c, "TSIP %s\nENV %d\n", d.tsIP, len(d.envVars)); err != nil {
+		return
+	}
+	if _, err := c.Write(d.envVars); err != nil {
+		return
+	}
+
+	// 2. Receive the TUN fd via SCM_RIGHTS. *net.UnixConn → *os.File
+	// duplicates the underlying fd so the daemon owns its own
+	// reference; we close cFile when handle returns.
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		log.Printf("daemon: conn is not *net.UnixConn (got %T)", c)
+		return
+	}
+	cFile, err := uc.File()
+	if err != nil {
+		log.Printf("daemon: get conn fd: %v", err)
+		return
+	}
+	defer func() { _ = cFile.Close() }()
+
+	tunFd, err := recvFD(cFile)
+	if err != nil {
+		log.Printf("daemon: recv TUN fd: %v", err)
+		return
+	}
+	tunFile := os.NewFile(uintptr(tunFd), tunIfName)
+	defer func() { _ = tunFile.Close() }()
+
+	// 3. Build the per-session gVisor stack. Multiple sessions share
+	// the daemon's single tsnet.Server but each gets its own stack so
+	// a misbehaving session can't OOM a neighbor.
+	gvStack, gvEp, err := newTsnetRunStack(d.tsIP)
+	if err != nil {
+		log.Printf("daemon: gvisor stack: %v", err)
+		return
+	}
+	defer gvStack.Close()
+	startTunBridge(tunFile, gvEp, d.tsServer)
+	enableTsnetTCPForwarder(gvStack, d.tsServer)
+
+	// 4. Tell the client the bridge is up.
+	if _, err := io.WriteString(c, "ATTACHED\n"); err != nil {
+		return
+	}
+
+	// 5. Block until the client closes (signals session end). A read
+	// here either returns EOF on a clean close or an error on abort;
+	// either way we fall through to defers and tear down.
 	buf := make([]byte, 256)
 	for {
 		_ = c.SetReadDeadline(time.Now().Add(time.Hour))
 		if _, err := c.Read(buf); err != nil {
 			return
 		}
+	}
+}
+
+// daemonStartTsnet reads persisted join state (auth-key, control-url,
+// gateway-ip), starts a tsnet.Server, waits for it to come up, and
+// points its outbound dials at the gateway as an exit node. Returns
+// the started server and our assigned 100.x address.
+func daemonStartTsnet(runtimeDir string) (*tsnet.Server, netip.Addr, error) {
+	caDir := defaultClawpatrolDir()
+	authKey := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tsnet-auth-key")))
+	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "control-url")))
+	gwIPStr := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tailnet-gateway-ip")))
+	if authKey == "" {
+		return nil, netip.Addr{}, fmt.Errorf("missing tsnet-auth-key in %s (re-run `clawpatrol join`)", caDir)
+	}
+	if gwIPStr == "" {
+		return nil, netip.Addr{}, fmt.Errorf("missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", caDir)
+	}
+	gwIP, err := netip.ParseAddr(gwIPStr)
+	if err != nil {
+		return nil, netip.Addr{}, fmt.Errorf("parse tailnet-gateway-ip %q: %w", gwIPStr, err)
+	}
+
+	// State directory under XDG_RUNTIME_DIR is fine for now (Phase 4
+	// will move it to a persistent location alongside the auth key so
+	// the node identity survives daemon restarts; until the auth key
+	// itself is non-ephemeral, persisting state across restarts buys
+	// nothing).
+	stateDir := filepath.Join(runtimeDir, "tsnet")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, netip.Addr{}, fmt.Errorf("tsnet state dir: %w", err)
+	}
+
+	hn := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "hostname")))
+	if hn == "" {
+		hn, _ = os.Hostname()
+	}
+
+	s := &tsnet.Server{
+		Hostname:   hn,
+		AuthKey:    authKey,
+		ControlURL: controlURL,
+		Dir:        stateDir,
+		Ephemeral:  true,
+		Logf:       func(string, ...any) {},
+	}
+
+	log.Printf("daemon: joining tailnet as %q...", hn)
+	tsIP, err := waitTsnetUp(s)
+	if err != nil {
+		_ = s.Close()
+		return nil, netip.Addr{}, fmt.Errorf("waitTsnetUp: %w", err)
+	}
+	log.Printf("daemon: tailnet IP %s", tsIP)
+
+	if err := setGatewayExitNode(s, gwIP); err != nil {
+		_ = s.Close()
+		return nil, netip.Addr{}, fmt.Errorf("set exit-node %s: %w", gwIP, err)
+	}
+
+	// Let any code path that needs a tailnet-routed HTTP client (e.g.
+	// gatewayClient → /api/env-pushdown) reach 100.x via tsnet.
+	gatewayDialOverride = s.Dial
+
+	return s, tsIP, nil
+}
+
+// daemonFetchEnvPushdown asks the gateway for the env-pushdown vars
+// belonging to this host's profile. Returns a JSON byte slice that
+// handle() ships to each new session verbatim. Best-effort: on any
+// failure we cache an empty list and log; clients then run without
+// pushdown until the daemon restarts.
+func daemonFetchEnvPushdown(_ *tsnet.Server) []byte {
+	caDir := defaultClawpatrolDir()
+	vars, err := fetchEnvPushdownFromGateway(caDir)
+	if err != nil {
+		log.Printf("daemon: env-pushdown fetch: %v (continuing with empty set)", err)
+		vars = nil
+	}
+	if vars == nil {
+		vars = []pushdownEnvVar{}
+	}
+	out, err := json.Marshal(vars)
+	if err != nil {
+		log.Printf("daemon: env-pushdown marshal: %v", err)
+		return []byte("[]")
+	}
+	return out
+}
+
+// daemonRegisterWithGateway POSTs this daemon's tsnet IP to the
+// gateway's /api/peer/ephemeral/tsnet/register so it maps to the
+// host's device row (and therefore the host's profile). Best-effort.
+func daemonRegisterWithGateway(s *tsnet.Server, tsIP netip.Addr) {
+	caDir := defaultClawpatrolDir()
+	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tailnet-url")))
+	if gwURL == "" {
+		gwURL = strings.TrimSpace(readFileSilent(filepath.Join(caDir, "gateway")))
+	}
+	token := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "api-token")))
+	if gwURL == "" || token == "" {
+		log.Printf("daemon: register: missing gateway URL or api-token; skipping")
+		return
+	}
+	cli := tsnetHTTPClient(s, filepath.Join(caDir, "ca.crt"))
+	if err := registerEphemeralTsnetIP(cli, gwURL, token, tsIP.String()); err != nil {
+		log.Printf("daemon: register: %v (default profile until next restart)", err)
 	}
 }
 
@@ -433,6 +647,13 @@ func (d *daemon) tryExit() {
 	d.mu.Lock()
 	d.exited = true
 	d.mu.Unlock()
+
+	// Close tsnet politely so the control plane can mark this node
+	// offline immediately rather than aging it out. Best-effort: we're
+	// about to exit anyway.
+	if d.tsServer != nil {
+		_ = d.tsServer.Close()
+	}
 
 	log.Printf("daemon pid=%d clean exit", os.Getpid())
 	os.Exit(0)

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -232,6 +232,13 @@ type daemon struct {
 	tsIP     netip.Addr
 	envVars  []byte // pre-serialized JSON for the FETCH path in handle()
 
+	// bootWarning is a one-line message that the smoke-probe at startup
+	// generates when exit-node routing looks broken. Empty means clean
+	// boot. Sent on every session START so `clawpatrol run` can repeat
+	// it on stderr — operators shouldn't have to tail daemon.log to
+	// discover ACL misconfiguration.
+	bootWarning string
+
 	activeConns atomic.Int32
 
 	mu        sync.Mutex
@@ -263,7 +270,7 @@ func runDaemon(_ []string) {
 	// Boot tsnet first. We don't bind the control socket until the
 	// daemon is fully usable — that way a parent reading "ready\n" can
 	// proceed straight to a session START without retries.
-	tsServer, tsIP, err := daemonStartTsnet()
+	tsServer, tsIP, bootWarning, err := daemonStartTsnet()
 	if err != nil {
 		log.Fatalf("daemon: tsnet: %v", err)
 	}
@@ -296,13 +303,14 @@ func runDaemon(_ []string) {
 	}
 
 	d := &daemon{
-		sockPath: sockPath,
-		listener: ln,
-		lockFile: lf,
-		tsServer: tsServer,
-		tsIP:     tsIP,
-		envVars:  envJSON,
-		rebindCh: make(chan struct{}),
+		sockPath:    sockPath,
+		listener:    ln,
+		lockFile:    lf,
+		tsServer:    tsServer,
+		tsIP:        tsIP,
+		envVars:     envJSON,
+		bootWarning: bootWarning,
+		rebindCh:    make(chan struct{}),
 	}
 
 	// Signal ready on the inherited pipe (fd 3). Once this lands, the
@@ -402,12 +410,24 @@ func (d *daemon) handle(c net.Conn) {
 	}
 	_ = c.SetReadDeadline(time.Time{})
 
-	// 1. Tell the client our tsnet IP and ship the env-pushdown JSON.
+	// 1. Tell the client our tsnet IP, ship the env-pushdown JSON, and
+	// pass along any one-line warning the smoke-probe generated at
+	// daemon boot. The WARN frame is always emitted (n=0 when clean)
+	// so the protocol stays unambiguous — no peek-ahead on the client
+	// side.
 	if _, err := fmt.Fprintf(c, "TSIP %s\nENV %d\n", d.tsIP, len(d.envVars)); err != nil {
 		return
 	}
 	if _, err := c.Write(d.envVars); err != nil {
 		return
+	}
+	if _, err := fmt.Fprintf(c, "WARN %d\n", len(d.bootWarning)); err != nil {
+		return
+	}
+	if len(d.bootWarning) > 0 {
+		if _, err := io.WriteString(c, d.bootWarning); err != nil {
+			return
+		}
 	}
 
 	// 2. Receive the TUN fd via SCM_RIGHTS. *net.UnixConn → *os.File
@@ -466,21 +486,25 @@ func (d *daemon) handle(c net.Conn) {
 // gateway-ip), starts a tsnet.Server, waits for it to come up, and
 // points its outbound dials at the gateway as an exit node. Returns
 // the started server and our assigned 100.x address.
-func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
+// Returns the started server, its tailnet IP, and a non-empty warning
+// string when exit-node routing looks broken (so each `clawpatrol run`
+// can repeat it on stderr instead of leaving the operator to discover
+// it in daemon.log).
+func daemonStartTsnet() (*tsnet.Server, netip.Addr, string, error) {
 	caDir := defaultClawpatrolDir()
 	stateDir := daemonStateDir()
 	authKey := strings.TrimSpace(readFileSilent(filepath.Join(stateDir, "auth-key")))
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "control-url")))
 	gwIPStr := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tailnet-gateway-ip")))
 	if authKey == "" {
-		return nil, netip.Addr{}, fmt.Errorf("missing auth-key in %s (re-run `clawpatrol join`)", stateDir)
+		return nil, netip.Addr{}, "", fmt.Errorf("missing auth-key in %s (re-run `clawpatrol join`)", stateDir)
 	}
 	if gwIPStr == "" {
-		return nil, netip.Addr{}, fmt.Errorf("missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", caDir)
+		return nil, netip.Addr{}, "", fmt.Errorf("missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", caDir)
 	}
 	gwIP, err := netip.ParseAddr(gwIPStr)
 	if err != nil {
-		return nil, netip.Addr{}, fmt.Errorf("parse tailnet-gateway-ip %q: %w", gwIPStr, err)
+		return nil, netip.Addr{}, "", fmt.Errorf("parse tailnet-gateway-ip %q: %w", gwIPStr, err)
 	}
 
 	// Persistent state dir so the tsnet node keeps the same identity
@@ -490,7 +514,7 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	// instead of churning one per daemon lifetime.
 	tsnetDir := filepath.Join(stateDir, "tsnet")
 	if err := os.MkdirAll(tsnetDir, 0o700); err != nil {
-		return nil, netip.Addr{}, fmt.Errorf("tsnet state dir: %w", err)
+		return nil, netip.Addr{}, "", fmt.Errorf("tsnet state dir: %w", err)
 	}
 
 	hn := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "hostname")))
@@ -511,13 +535,13 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	tsIP, err := waitTsnetUp(s)
 	if err != nil {
 		_ = s.Close()
-		return nil, netip.Addr{}, fmt.Errorf("waitTsnetUp: %w", err)
+		return nil, netip.Addr{}, "", fmt.Errorf("waitTsnetUp: %w", err)
 	}
 	log.Printf("daemon: tailnet IP %s", tsIP)
 
 	if err := setGatewayExitNode(s, gwIP); err != nil {
 		_ = s.Close()
-		return nil, netip.Addr{}, fmt.Errorf("set exit-node %s: %w", gwIP, err)
+		return nil, netip.Addr{}, "", fmt.Errorf("set exit-node %s: %w", gwIP, err)
 	}
 
 	// Smoke-test exit-node routing. EditPrefs accepts ExitNodeIP
@@ -528,13 +552,15 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	// Probe by dialing the gateway's tailnet IP on port 53 — that
 	// port is bound by the gateway's tsnet DNS listener so a working
 	// path returns "connection established" within hundreds of ms.
+	var bootWarning string
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 8*time.Second)
 	if c, derr := s.Dial(probeCtx, "tcp", net.JoinHostPort(gwIP.String(), "53")); derr == nil {
 		_ = c.Close()
 	} else {
-		log.Printf("tsnet probe: gateway unreachable via exit-node routing — %v. "+
-			"Check autoApprovers.exitNode in your tailnet ACL (see doc/tailscale.md). "+
-			"Continuing; outbound traffic from clawpatrol run will fail until the ACL is fixed.", derr)
+		bootWarning = fmt.Sprintf("tsnet probe: gateway unreachable via exit-node routing (%v). "+
+			"Check autoApprovers.exitNode in your tailnet ACL — see doc/tailscale.md. "+
+			"Outbound traffic from `clawpatrol run` will fail until the ACL is fixed.", derr)
+		log.Printf("%s", bootWarning)
 	}
 	probeCancel()
 
@@ -542,7 +568,7 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	// gatewayClient → /api/env-pushdown) reach 100.x via tsnet.
 	gatewayDialOverride = s.Dial
 
-	return s, tsIP, nil
+	return s, tsIP, bootWarning, nil
 }
 
 // daemonFetchEnvPushdown asks the gateway for the env-pushdown vars

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -578,8 +578,10 @@ func daemonFetchEnvPushdown(_ *tsnet.Server) []byte {
 }
 
 // daemonRegisterWithGateway POSTs this daemon's tsnet IP to the
-// gateway's /api/peer/ephemeral/tsnet/register so it maps to the
-// host's device row (and therefore the host's profile). Best-effort.
+// gateway's /api/peer/tsnet/register so it maps to the host's
+// device row (and therefore the host's profile). First call after
+// approval promotes the synthetic placeholder; subsequent calls are
+// no-ops on the server side. Best-effort.
 func daemonRegisterWithGateway(s *tsnet.Server, tsIP netip.Addr) {
 	caDir := defaultClawpatrolDir()
 	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tailnet-url")))
@@ -592,7 +594,7 @@ func daemonRegisterWithGateway(s *tsnet.Server, tsIP netip.Addr) {
 		return
 	}
 	cli := tsnetHTTPClient(s, filepath.Join(caDir, "ca.crt"))
-	if err := registerEphemeralTsnetIP(cli, gwURL, token, tsIP.String()); err != nil {
+	if err := registerTsnetPeer(cli, gwURL, token, tsIP.String()); err != nil {
 		log.Printf("daemon: register: %v (default profile until next restart)", err)
 	}
 }

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -66,6 +66,19 @@ func daemonControlSockPath() string { return filepath.Join(daemonRuntimeDir(), "
 func daemonSpawnLockPath() string   { return filepath.Join(daemonRuntimeDir(), "spawn.lock") }
 func daemonLogPath() string         { return filepath.Join(daemonRuntimeDir(), "daemon.log") }
 
+// daemonStateDir resolves the per-user **persistent** state directory.
+// Unlike daemonRuntimeDir, the contents survive logout — the tsnet
+// node identity lives here so the daemon registers as the same device
+// every time it boots. Prefer XDG_STATE_HOME; fall back to
+// ~/.local/state/clawpatrol when unset.
+func daemonStateDir() string {
+	if d := os.Getenv("XDG_STATE_HOME"); d != "" {
+		return filepath.Join(d, "clawpatrol")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state", "clawpatrol")
+}
+
 // daemonConnect returns a control connection to the per-host daemon,
 // spawning one if none is running. Safe to call from concurrent
 // `clawpatrol run` invocations.
@@ -251,8 +264,7 @@ type daemon struct {
 func runDaemon(_ []string) {
 	log.SetFlags(log.Lmicroseconds)
 
-	dir := daemonRuntimeDir()
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := os.MkdirAll(daemonRuntimeDir(), 0o700); err != nil {
 		log.Fatalf("daemon: mkdir runtime: %v", err)
 	}
 	sockPath := daemonControlSockPath()
@@ -263,7 +275,7 @@ func runDaemon(_ []string) {
 	// Boot tsnet first. We don't bind the control socket until the
 	// daemon is fully usable — that way a parent reading "ready\n" can
 	// proceed straight to a session START without retries.
-	tsServer, tsIP, err := daemonStartTsnet(dir)
+	tsServer, tsIP, err := daemonStartTsnet()
 	if err != nil {
 		log.Fatalf("daemon: tsnet: %v", err)
 	}
@@ -466,7 +478,7 @@ func (d *daemon) handle(c net.Conn) {
 // gateway-ip), starts a tsnet.Server, waits for it to come up, and
 // points its outbound dials at the gateway as an exit node. Returns
 // the started server and our assigned 100.x address.
-func daemonStartTsnet(runtimeDir string) (*tsnet.Server, netip.Addr, error) {
+func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	caDir := defaultClawpatrolDir()
 	authKey := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tsnet-auth-key")))
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "control-url")))
@@ -482,12 +494,12 @@ func daemonStartTsnet(runtimeDir string) (*tsnet.Server, netip.Addr, error) {
 		return nil, netip.Addr{}, fmt.Errorf("parse tailnet-gateway-ip %q: %w", gwIPStr, err)
 	}
 
-	// State directory under XDG_RUNTIME_DIR is fine for now (Phase 4
-	// will move it to a persistent location alongside the auth key so
-	// the node identity survives daemon restarts; until the auth key
-	// itself is non-ephemeral, persisting state across restarts buys
-	// nothing).
-	stateDir := filepath.Join(runtimeDir, "tsnet")
+	// Persistent state dir so the tsnet node keeps the same identity
+	// (and tailnet IP, when the control plane is cooperative) across
+	// idle-exit + respawn cycles. Auth keys are minted non-ephemeral,
+	// so a single device row shows up on the dashboard per host
+	// instead of churning one per daemon lifetime.
+	stateDir := filepath.Join(daemonStateDir(), "tsnet")
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return nil, netip.Addr{}, fmt.Errorf("tsnet state dir: %w", err)
 	}
@@ -502,7 +514,7 @@ func daemonStartTsnet(runtimeDir string) (*tsnet.Server, netip.Addr, error) {
 		AuthKey:    authKey,
 		ControlURL: controlURL,
 		Dir:        stateDir,
-		Ephemeral:  true,
+		Ephemeral:  false,
 		Logf:       func(string, ...any) {},
 	}
 

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -1,0 +1,460 @@
+//go:build linux
+
+package main
+
+// Per-host self-forking daemon. `clawpatrol run` connects to a Unix
+// socket; if no daemon is alive, it re-execs itself as `clawpatrol
+// daemon` (a hidden subcommand) and the new process binds the socket,
+// then idle-exits 5 minutes after the last client disconnects.
+//
+// The race-control protocol is the same one validated by the
+// ~/self-fork prototype: an exclusive flock around spawn, an
+// idle-timer that drops back to the lock before unlinking, a
+// mandatory hello() handshake on every client connect, and a
+// single-`os.Exit`-site invariant in the daemon. See the prototype's
+// README for the lost-race re-bind path and the two earlier
+// implementation bugs the test suite is designed to catch.
+//
+// For now the daemon's `handle()` only does the hello + holds the conn
+// open until the client closes. The session protocol (TUN-fd passing,
+// gVisor multiplexing over a shared tsnet.Server) is added in a
+// follow-up.
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	daemonIdleTimeout  = 5 * time.Minute
+	daemonHelloTimeout = 2 * time.Second
+	daemonSpawnTimeout = 30 * time.Second
+	daemonMagicLine    = "CLAWPATROL/1\n"
+)
+
+// daemonRuntimeDir resolves the per-user runtime directory holding the
+// daemon's coordination state (control socket, spawn lock, log). Prefer
+// XDG_RUNTIME_DIR (tmpfs, per-user, no NFS pitfalls); fall back to
+// /tmp/clawpatrol-<uid> when unset (containers, minimal images).
+func daemonRuntimeDir() string {
+	if d := os.Getenv("XDG_RUNTIME_DIR"); d != "" {
+		return filepath.Join(d, "clawpatrol")
+	}
+	return filepath.Join("/tmp", fmt.Sprintf("clawpatrol-%d", os.Getuid()))
+}
+
+func daemonControlSockPath() string { return filepath.Join(daemonRuntimeDir(), "control.sock") }
+func daemonSpawnLockPath() string   { return filepath.Join(daemonRuntimeDir(), "spawn.lock") }
+func daemonLogPath() string         { return filepath.Join(daemonRuntimeDir(), "daemon.log") }
+
+// daemonConnect returns a control connection to the per-host daemon,
+// spawning one if none is running. Safe to call from concurrent
+// `clawpatrol run` invocations.
+func daemonConnect() (net.Conn, error) {
+	dir := daemonRuntimeDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	sockPath := daemonControlSockPath()
+	lockPath := daemonSpawnLockPath()
+
+	// 1. Happy path: try to connect + hello without taking the spawn
+	// lock. If we land on a live daemon this returns immediately;
+	// the lock is reserved for the cold-start / dying-daemon case.
+	if c, ok := daemonDialAndHello(sockPath); ok {
+		return c, nil
+	}
+
+	// 2. Spawn-path: serialize via exclusive flock on spawn.lock so
+	// at most one client at a time tries to fork a daemon.
+	lf, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open spawn lock: %w", err)
+	}
+	defer func() { _ = lf.Close() }()
+	if err := syscall.Flock(int(lf.Fd()), syscall.LOCK_EX); err != nil {
+		return nil, fmt.Errorf("flock ex: %w", err)
+	}
+	// Lock released by lf.Close() above.
+
+	// 3. Re-check under the lock — someone may have spawned a daemon
+	// while we were blocked.
+	if c, ok := daemonDialAndHello(sockPath); ok {
+		return c, nil
+	}
+
+	// 4. Stale socket from a SIGKILL'd previous daemon? Remove it.
+	// bind() in the new daemon would otherwise EADDRINUSE.
+	_ = os.Remove(sockPath)
+
+	// 5. Re-exec self as `clawpatrol daemon`.
+	if err := daemonSpawn(dir); err != nil {
+		return nil, fmt.Errorf("spawn daemon: %w", err)
+	}
+
+	// 6. The daemon wrote "ready" before we got here so the socket is
+	// bound. Final dial must succeed.
+	if c, ok := daemonDialAndHello(sockPath); ok {
+		return c, nil
+	}
+	return nil, errors.New("post-spawn dial failed")
+}
+
+// daemonDialAndHello dials the control socket and runs the hello
+// handshake. Returns the conn on success; on any failure closes the
+// conn and returns nil + false. The caller distinguishes "no daemon"
+// from "daemon is dying" by retrying under the spawn lock.
+func daemonDialAndHello(sockPath string) (net.Conn, bool) {
+	c, err := net.DialTimeout("unix", sockPath, 200*time.Millisecond)
+	if err != nil {
+		return nil, false
+	}
+	if err := daemonHello(c); err != nil {
+		_ = c.Close()
+		return nil, false
+	}
+	return c, true
+}
+
+// daemonHello writes a magic line + a fresh nonce and expects the
+// daemon to echo the nonce. A mismatch (ECONNRESET because the
+// listener tore down between connect() and accept(), read timeout,
+// random garbage) lets the caller treat the daemon as gone.
+func daemonHello(c net.Conn) error {
+	_ = c.SetDeadline(time.Now().Add(daemonHelloTimeout))
+	defer func() { _ = c.SetDeadline(time.Time{}) }()
+
+	nonce := make([]byte, 8)
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
+	nonceLine := hex.EncodeToString(nonce) + "\n"
+	if _, err := io.WriteString(c, daemonMagicLine+nonceLine); err != nil {
+		return err
+	}
+	br := bufio.NewReader(c)
+	got, err := br.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if got != nonceLine {
+		return fmt.Errorf("hello mismatch: got %q want %q", got, nonceLine)
+	}
+	return nil
+}
+
+// daemonSpawn re-execs the current binary as `clawpatrol daemon`,
+// waits for it to write "ready\n" on the inherited pipe (fd 3), then
+// returns. The child detaches via Setsid and ignores SIGHUP.
+func daemonSpawn(dir string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = pr.Close() }()
+
+	logf, err := os.OpenFile(daemonLogPath(),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		_ = pw.Close()
+		return err
+	}
+	defer func() { _ = logf.Close() }()
+
+	cmd := exec.Command(self, "daemon")
+	cmd.Stdin = nil
+	cmd.Stdout = logf
+	cmd.Stderr = logf
+	cmd.ExtraFiles = []*os.File{pw} // becomes fd 3 in the child
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		_ = pw.Close()
+		return err
+	}
+	// Parent closes its write end so child death (without writing
+	// "ready") propagates back as EOF rather than hanging.
+	_ = pw.Close()
+	// Release the child to its own lifecycle. Without this the runtime
+	// keeps a SIGCHLD wait pending and the child reaps as a zombie when
+	// this process exits.
+	if err := cmd.Process.Release(); err != nil {
+		log.Printf("warn: release daemon: %v", err)
+	}
+
+	_ = pr.SetReadDeadline(time.Now().Add(daemonSpawnTimeout))
+	br := bufio.NewReader(pr)
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("daemon ready: %w (read %q)", err, line)
+	}
+	if line != "ready\n" {
+		return fmt.Errorf("daemon ready: unexpected %q", line)
+	}
+	return nil
+}
+
+// ----- daemon process -------------------------------------------------
+
+type daemon struct {
+	sockPath string
+	lockFile *os.File
+
+	activeConns atomic.Int32
+
+	mu        sync.Mutex
+	listener  net.Listener
+	idleTimer *time.Timer
+	exited    bool
+	// rebindCh: tryExit sends here after replacing d.listener on the
+	// lost-race recovery path. On the clean-exit path tryExit calls
+	// os.Exit instead; the main goroutine blocks on this channel and
+	// dies with the process.
+	rebindCh chan struct{}
+}
+
+// runDaemon is the entry point for the `clawpatrol daemon` subcommand.
+// Invoked exclusively by daemonSpawn — clients should never run this
+// directly. Returns only via os.Exit from tryExit (or log.Fatal on
+// fatal startup error).
+func runDaemon(_ []string) {
+	log.SetFlags(log.Lmicroseconds)
+
+	dir := daemonRuntimeDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		log.Fatalf("daemon: mkdir runtime: %v", err)
+	}
+	sockPath := daemonControlSockPath()
+	lockPath := daemonSpawnLockPath()
+
+	log.Printf("daemon pid=%d starting", os.Getpid())
+
+	// Bind first. Parent holds the spawn lock while we do this, so we
+	// can't race another daemon for the socket.
+	_ = os.Remove(sockPath)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		log.Fatalf("daemon: listen %s: %v", sockPath, err)
+	}
+	if err := os.Chmod(sockPath, 0o600); err != nil {
+		log.Printf("warn: chmod sock: %v", err)
+	}
+
+	lf, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		log.Fatalf("daemon: open spawn lock: %v", err)
+	}
+
+	d := &daemon{
+		sockPath: sockPath,
+		listener: ln,
+		lockFile: lf,
+		rebindCh: make(chan struct{}),
+	}
+
+	// Signal ready on the inherited pipe (fd 3). Once this lands, the
+	// parent unblocks and the spawn lock is released.
+	if ready := os.NewFile(3, "ready"); ready != nil {
+		_, _ = ready.WriteString("ready\n")
+		_ = ready.Close()
+	}
+
+	d.startIdleTimer()
+
+	// Main loop. After serve() returns the only valid events are:
+	//   - tryExit re-bound (sends on rebindCh) → loop, serve new listener.
+	//   - tryExit is exiting (calls os.Exit) → channel receive blocks
+	//     forever, process dies under us.
+	// Never busy-poll d.exited or d.listener — that's how the previous
+	// (pre-prototype) version of this code spun the CPU.
+	for {
+		d.serve()
+		<-d.rebindCh
+		log.Printf("daemon pid=%d serve loop: re-entering accept on new listener", os.Getpid())
+	}
+}
+
+func (d *daemon) startIdleTimer() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.exited {
+		return
+	}
+	if d.idleTimer != nil {
+		d.idleTimer.Stop()
+	}
+	d.idleTimer = time.AfterFunc(daemonIdleTimeout, d.tryExit)
+}
+
+func (d *daemon) cancelIdleTimer() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.idleTimer != nil {
+		d.idleTimer.Stop()
+	}
+}
+
+func (d *daemon) serve() {
+	d.mu.Lock()
+	ln := d.listener
+	d.mu.Unlock()
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			return // listener closed by tryExit
+		}
+		n := d.activeConns.Add(1)
+		d.cancelIdleTimer()
+		log.Printf("daemon: accept, active=%d", n)
+		go d.handle(c)
+	}
+}
+
+// handle services a single client conn: hello handshake, then block
+// until the client closes. The actual session protocol (TUN-fd via
+// SCM_RIGHTS, gVisor attach) is added in a follow-up commit.
+func (d *daemon) handle(c net.Conn) {
+	defer func() {
+		_ = c.Close()
+		n := d.activeConns.Add(-1)
+		log.Printf("daemon: close, active=%d", n)
+		if n == 0 {
+			d.startIdleTimer()
+		}
+	}()
+
+	if err := daemonHandshake(c); err != nil {
+		log.Printf("daemon: handshake: %v", err)
+		return
+	}
+
+	// Keep the conn alive until peer closes.
+	buf := make([]byte, 256)
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(time.Hour))
+		if _, err := c.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
+// daemonHandshake reads the client's "CLAWPATROL/1\n<nonce>\n" hello
+// and echoes the nonce. Any framing error closes the conn (the client
+// re-enters the spawn path on a hello failure).
+func daemonHandshake(c net.Conn) error {
+	_ = c.SetReadDeadline(time.Now().Add(daemonHelloTimeout))
+	defer func() { _ = c.SetReadDeadline(time.Time{}) }()
+
+	br := bufio.NewReader(c)
+	mag, err := br.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if mag != daemonMagicLine {
+		return fmt.Errorf("bad magic %q", mag)
+	}
+	nonce, err := br.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(c, nonce); err != nil {
+		return err
+	}
+	return nil
+}
+
+// tryExit is the race-sensitive bit. Step-by-step rationale lives in
+// the ~/self-fork README; the ordering here matches the prototype's
+// tested version. The single os.Exit site below is load-bearing:
+// allowing main goroutine to fall out of runDaemon after serve()
+// returns would skip whatever cleanup we add to this path.
+func (d *daemon) tryExit() {
+	if err := syscall.Flock(int(d.lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// A client is mid-spawn-check. Back off and rearm.
+		log.Printf("daemon: tryExit: lock contended (%v), rearming", err)
+		d.startIdleTimer()
+		return
+	}
+	// On any abort below we MUST release the lock and rearm. On the
+	// exit path we hold it through os.Exit (kernel releases at process
+	// death).
+
+	if n := d.activeConns.Load(); n > 0 {
+		log.Printf("daemon: tryExit: active=%d after lock; abort", n)
+		_ = syscall.Flock(int(d.lockFile.Fd()), syscall.LOCK_UN)
+		d.startIdleTimer()
+		return
+	}
+
+	log.Printf("daemon: tryExit: unlinking socket")
+	if err := os.Remove(d.sockPath); err != nil && !os.IsNotExist(err) {
+		log.Printf("warn: unlink: %v", err)
+	}
+	_ = d.listener.Close()
+
+	if n := d.activeConns.Load(); n > 0 {
+		// Lost the race: a conn was accepted between our last check
+		// and listener.Close(). Re-bind and keep serving. Do NOT spawn
+		// a fresh serve goroutine — the main loop's <-d.rebindCh will
+		// pick this up.
+		log.Printf("daemon: tryExit: lost race (active=%d); re-binding", n)
+		ln, err := net.Listen("unix", d.sockPath)
+		if err != nil {
+			log.Printf("FATAL: re-bind after lost race: %v", err)
+			os.Exit(1)
+		}
+		_ = os.Chmod(d.sockPath, 0o600)
+		d.mu.Lock()
+		d.listener = ln
+		d.mu.Unlock()
+		_ = syscall.Flock(int(d.lockFile.Fd()), syscall.LOCK_UN)
+		d.startIdleTimer()
+		d.rebindCh <- struct{}{}
+		return
+	}
+
+	d.mu.Lock()
+	d.exited = true
+	d.mu.Unlock()
+
+	log.Printf("daemon pid=%d clean exit", os.Getpid())
+	os.Exit(0)
+}
+
+// daemonConnectContext is a thin context-aware wrapper used by callers
+// that want to bound the total connect-or-spawn time. tsnet boot is
+// the slow part; daemonSpawnTimeout already covers it.
+func daemonConnectContext(ctx context.Context) (net.Conn, error) {
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := daemonConnect()
+		ch <- res{c, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.c, r.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -66,18 +66,6 @@ func daemonControlSockPath() string { return filepath.Join(daemonRuntimeDir(), "
 func daemonSpawnLockPath() string   { return filepath.Join(daemonRuntimeDir(), "spawn.lock") }
 func daemonLogPath() string         { return filepath.Join(daemonRuntimeDir(), "daemon.log") }
 
-// daemonStateDir resolves the per-user **persistent** state directory.
-// Unlike daemonRuntimeDir, the contents survive logout — the tsnet
-// node identity lives here so the daemon registers as the same device
-// every time it boots. Prefer XDG_STATE_HOME; fall back to
-// ~/.local/state/clawpatrol when unset.
-func daemonStateDir() string {
-	if d := os.Getenv("XDG_STATE_HOME"); d != "" {
-		return filepath.Join(d, "clawpatrol")
-	}
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "state", "clawpatrol")
-}
 
 // daemonConnect returns a control connection to the per-host daemon,
 // spawning one if none is running. Safe to call from concurrent
@@ -480,11 +468,12 @@ func (d *daemon) handle(c net.Conn) {
 // the started server and our assigned 100.x address.
 func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	caDir := defaultClawpatrolDir()
-	authKey := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tsnet-auth-key")))
+	stateDir := daemonStateDir()
+	authKey := strings.TrimSpace(readFileSilent(filepath.Join(stateDir, "auth-key")))
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "control-url")))
 	gwIPStr := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tailnet-gateway-ip")))
 	if authKey == "" {
-		return nil, netip.Addr{}, fmt.Errorf("missing tsnet-auth-key in %s (re-run `clawpatrol join`)", caDir)
+		return nil, netip.Addr{}, fmt.Errorf("missing auth-key in %s (re-run `clawpatrol join`)", stateDir)
 	}
 	if gwIPStr == "" {
 		return nil, netip.Addr{}, fmt.Errorf("missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", caDir)
@@ -499,8 +488,8 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 	// idle-exit + respawn cycles. Auth keys are minted non-ephemeral,
 	// so a single device row shows up on the dashboard per host
 	// instead of churning one per daemon lifetime.
-	stateDir := filepath.Join(daemonStateDir(), "tsnet")
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+	tsnetDir := filepath.Join(stateDir, "tsnet")
+	if err := os.MkdirAll(tsnetDir, 0o700); err != nil {
 		return nil, netip.Addr{}, fmt.Errorf("tsnet state dir: %w", err)
 	}
 
@@ -513,7 +502,7 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 		Hostname:   hn,
 		AuthKey:    authKey,
 		ControlURL: controlURL,
-		Dir:        stateDir,
+		Dir:        tsnetDir,
 		Ephemeral:  false,
 		Logf:       func(string, ...any) {},
 	}

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -412,40 +412,23 @@ func (d *daemon) handle(c net.Conn) {
 
 	// 1. Tell the client our tsnet IP, ship the env-pushdown JSON, and
 	// pass along any one-line warning the smoke-probe generated at
-	// daemon boot. The WARN frame is always emitted (n=0 when clean)
-	// so the protocol stays unambiguous — no peek-ahead on the client
-	// side.
-	if _, err := fmt.Fprintf(c, "TSIP %s\nENV %d\n", d.tsIP, len(d.envVars)); err != nil {
+	// daemon boot.
+	if err := daemonWriteStartReply(c, d.tsIP, d.envVars, d.bootWarning); err != nil {
 		return
-	}
-	if _, err := c.Write(d.envVars); err != nil {
-		return
-	}
-	if _, err := fmt.Fprintf(c, "WARN %d\n", len(d.bootWarning)); err != nil {
-		return
-	}
-	if len(d.bootWarning) > 0 {
-		if _, err := io.WriteString(c, d.bootWarning); err != nil {
-			return
-		}
 	}
 
-	// 2. Receive the TUN fd via SCM_RIGHTS. *net.UnixConn → *os.File
-	// duplicates the underlying fd so the daemon owns its own
-	// reference; we close cFile when handle returns.
+	// 2. Receive the TUN fd via SCM_RIGHTS using the *net.UnixConn's
+	// native ReadMsgUnix path. Going through .File() + unix.Recvmsg
+	// would dup the underlying fd, which on Linux clears O_NONBLOCK
+	// on the shared file description and leaves the conn deadlocked
+	// for subsequent reads — see sendFDUnixConn for the same
+	// reasoning on the client side.
 	uc, ok := c.(*net.UnixConn)
 	if !ok {
 		log.Printf("daemon: conn is not *net.UnixConn (got %T)", c)
 		return
 	}
-	cFile, err := uc.File()
-	if err != nil {
-		log.Printf("daemon: get conn fd: %v", err)
-		return
-	}
-	defer func() { _ = cFile.Close() }()
-
-	tunFd, err := recvFD(cFile)
+	tunFd, err := recvFDUnixConn(uc)
 	if err != nil {
 		log.Printf("daemon: recv TUN fd: %v", err)
 		return
@@ -612,6 +595,29 @@ func daemonRegisterWithGateway(s *tsnet.Server, tsIP netip.Addr) {
 	if err := registerEphemeralTsnetIP(cli, gwURL, token, tsIP.String()); err != nil {
 		log.Printf("daemon: register: %v (default profile until next restart)", err)
 	}
+}
+
+// daemonWriteStartReply writes the TSIP / ENV / WARN frames that the
+// daemon emits in response to a session START. Pure framing — does
+// not touch tsServer or the gVisor stack, so it's testable in
+// isolation. The WARN frame is always emitted (n=0 when clean) so
+// the client's parser never has to peek ahead.
+func daemonWriteStartReply(w io.Writer, tsIP netip.Addr, envVars []byte, warning string) error {
+	if _, err := fmt.Fprintf(w, "TSIP %s\nENV %d\n", tsIP, len(envVars)); err != nil {
+		return err
+	}
+	if _, err := w.Write(envVars); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "WARN %d\n", len(warning)); err != nil {
+		return err
+	}
+	if len(warning) > 0 {
+		if _, err := io.WriteString(w, warning); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // daemonHandshake reads the client's "CLAWPATROL/1\n<nonce>\n" hello

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -4,21 +4,21 @@ package main
 
 // Per-host self-forking daemon. `clawpatrol run` connects to a Unix
 // socket; if no daemon is alive, it re-execs itself as `clawpatrol
-// daemon` (a hidden subcommand) and the new process binds the socket,
-// then idle-exits 5 minutes after the last client disconnects.
+// daemon-internal` (a hidden subcommand) and the new process binds
+// the socket, then idle-exits 5 minutes after the last client
+// disconnects.
 //
-// The race-control protocol is the same one validated by the
-// ~/self-fork prototype: an exclusive flock around spawn, an
-// idle-timer that drops back to the lock before unlinking, a
-// mandatory hello() handshake on every client connect, and a
-// single-`os.Exit`-site invariant in the daemon. See the prototype's
-// README for the lost-race re-bind path and the two earlier
-// implementation bugs the test suite is designed to catch.
-//
-// For now the daemon's `handle()` only does the hello + holds the conn
-// open until the client closes. The session protocol (TUN-fd passing,
-// gVisor multiplexing over a shared tsnet.Server) is added in a
-// follow-up.
+// Race-control protocol:
+//   - exclusive flock on spawn.lock serializes the connect-or-spawn
+//     path across concurrent clients.
+//   - mandatory hello() handshake on every client connect rejects
+//     conns landing on a daemon that's mid-teardown.
+//   - the idle-exit goroutine drops back to the lock before unlinking
+//     the socket; a "lost race" recovery path re-binds a fresh
+//     listener when an accept slips in between recheck and close.
+//   - single os.Exit site invariant: the main goroutine never returns
+//     from runDaemon on its own, so cleanup placed on the exit path
+//     cannot be skipped.
 
 import (
 	"bufio"
@@ -106,7 +106,7 @@ func daemonConnect() (net.Conn, error) {
 	// bind() in the new daemon would otherwise EADDRINUSE.
 	_ = os.Remove(sockPath)
 
-	// 5. Re-exec self as `clawpatrol daemon`.
+	// 5. Re-exec self as `clawpatrol daemon-internal`.
 	if err := daemonSpawn(dir); err != nil {
 		return nil, fmt.Errorf("spawn daemon: %w", err)
 	}
@@ -162,9 +162,10 @@ func daemonHello(c net.Conn) error {
 	return nil
 }
 
-// daemonSpawn re-execs the current binary as `clawpatrol daemon`,
-// waits for it to write "ready\n" on the inherited pipe (fd 3), then
-// returns. The child detaches via Setsid and ignores SIGHUP.
+// daemonSpawn re-execs the current binary as `clawpatrol
+// daemon-internal`, waits for it to write "ready\n" on the inherited
+// pipe (fd 3), then returns. The child detaches via Setsid and
+// ignores SIGHUP.
 func daemonSpawn(dir string) error {
 	self, err := os.Executable()
 	if err != nil {
@@ -184,7 +185,7 @@ func daemonSpawn(dir string) error {
 	}
 	defer func() { _ = logf.Close() }()
 
-	cmd := exec.Command(self, "daemon")
+	cmd := exec.Command(self, "daemon-internal")
 	cmd.Stdin = nil
 	cmd.Stdout = logf
 	cmd.Stderr = logf
@@ -244,10 +245,10 @@ type daemon struct {
 	rebindCh chan struct{}
 }
 
-// runDaemon is the entry point for the `clawpatrol daemon` subcommand.
-// Invoked exclusively by daemonSpawn — clients should never run this
-// directly. Returns only via os.Exit from tryExit (or log.Fatal on
-// fatal startup error).
+// runDaemon is the entry point for the `clawpatrol daemon-internal`
+// subcommand. Invoked exclusively by daemonSpawn — clients should
+// never run this directly. Returns only via os.Exit from tryExit (or
+// log.Fatal on fatal startup error).
 func runDaemon(_ []string) {
 	log.SetFlags(log.Lmicroseconds)
 
@@ -612,11 +613,13 @@ func daemonHandshake(c net.Conn) error {
 	return nil
 }
 
-// tryExit is the race-sensitive bit. Step-by-step rationale lives in
-// the ~/self-fork README; the ordering here matches the prototype's
-// tested version. The single os.Exit site below is load-bearing:
-// allowing main goroutine to fall out of runDaemon after serve()
-// returns would skip whatever cleanup we add to this path.
+// tryExit is the race-sensitive bit. The ordering — lock, recheck,
+// unlink, close, recheck, exit-or-rebind — is what makes concurrent
+// connect-or-spawn safe; see the file-header comment for the protocol
+// and the inline comments below for each step's rationale. The
+// single os.Exit site here is load-bearing: allowing the main
+// goroutine to fall out of runDaemon after serve() returns would skip
+// whatever cleanup we add to this path.
 func (d *daemon) tryExit() {
 	if err := syscall.Flock(int(d.lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		// A client is mid-spawn-check. Back off and rearm.

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -519,6 +519,24 @@ func daemonStartTsnet() (*tsnet.Server, netip.Addr, error) {
 		return nil, netip.Addr{}, fmt.Errorf("set exit-node %s: %w", gwIP, err)
 	}
 
+	// Smoke-test exit-node routing. EditPrefs accepts ExitNodeIP
+	// unconditionally, but actual routing requires the tailnet ACL to
+	// auto-approve the gateway as an exit node for our tag (see
+	// doc/tailscale.md → "Required tailnet ACL"). Without that, every
+	// dial silently times out instead of returning a useful error.
+	// Probe by dialing the gateway's tailnet IP on port 53 — that
+	// port is bound by the gateway's tsnet DNS listener so a working
+	// path returns "connection established" within hundreds of ms.
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	if c, derr := s.Dial(probeCtx, "tcp", net.JoinHostPort(gwIP.String(), "53")); derr == nil {
+		_ = c.Close()
+	} else {
+		log.Printf("tsnet probe: gateway unreachable via exit-node routing — %v. "+
+			"Check autoApprovers.exitNode in your tailnet ACL (see doc/tailscale.md). "+
+			"Continuing; outbound traffic from clawpatrol run will fail until the ACL is fixed.", derr)
+	}
+	probeCancel()
+
 	// Let any code path that needs a tailnet-routed HTTP client (e.g.
 	// gatewayClient → /api/env-pushdown) reach 100.x via tsnet.
 	gatewayDialOverride = s.Dial

--- a/cmd/clawpatrol/daemon_linux_test.go
+++ b/cmd/clawpatrol/daemon_linux_test.go
@@ -1,0 +1,278 @@
+//go:build linux
+
+package main
+
+// In-memory round-trip of the daemon's control protocol. Does not
+// boot tsnet, does not build a gVisor stack — exercises only the
+// wire format and the SCM_RIGHTS fd hand-off. A real Unix
+// socketpair is used (not net.Pipe) because the daemon
+// type-asserts the conn to *net.UnixConn for the SCM_RIGHTS recv,
+// and File() on a non-Unix conn would not return a usable fd.
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// socketpairConns returns two ends of an AF_UNIX SOCK_STREAM
+// socketpair as *net.UnixConn. The underlying fds are owned by the
+// returned conns; closing them releases the fds.
+func socketpairConns(t *testing.T) (a, b *net.UnixConn) {
+	t.Helper()
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	fa := os.NewFile(uintptr(fds[0]), "sp-a")
+	fb := os.NewFile(uintptr(fds[1]), "sp-b")
+	defer func() { _ = fa.Close() }()
+	defer func() { _ = fb.Close() }()
+	ca, err := net.FileConn(fa)
+	if err != nil {
+		t.Fatalf("FileConn a: %v", err)
+	}
+	cb, err := net.FileConn(fb)
+	if err != nil {
+		_ = ca.Close()
+		t.Fatalf("FileConn b: %v", err)
+	}
+	uc1, ok1 := ca.(*net.UnixConn)
+	uc2, ok2 := cb.(*net.UnixConn)
+	if !ok1 || !ok2 {
+		_ = ca.Close()
+		_ = cb.Close()
+		t.Fatalf("expected *net.UnixConn, got %T / %T", ca, cb)
+	}
+	return uc1, uc2
+}
+
+// TestDaemonProtocolRoundTrip drives the full session-start protocol
+// end-to-end over a real Unix socketpair: hello handshake, START
+// command, TSIP/ENV/WARN reply, SCM_RIGHTS TUN-fd hand-off, ATTACHED
+// reply. Verifies the client-side parser reconstructs every value
+// the daemon-side encoder ships, and that a real fd flows through
+// SCM_RIGHTS in both directions.
+//
+// Covers cases:
+//   - non-empty env-pushdown payload
+//   - non-empty boot warning (the load-bearing case for the new WARN
+//     frame — empty would still pass even with the WARN line missing)
+//   - real fd round-trip (writes a sentinel byte through the recv'd
+//     fd and reads it back on the original to confirm).
+func TestDaemonProtocolRoundTrip(t *testing.T) {
+	daemonSide, clientSide := socketpairConns(t)
+	defer func() { _ = daemonSide.Close() }()
+	defer func() { _ = clientSide.Close() }()
+
+	wantTsIP := netip.MustParseAddr("100.64.0.7")
+	envVarsIn := []pushdownEnvVar{
+		{Name: "SSL_CERT_FILE", Value: "/home/u/.clawpatrol/ca.crt"},
+		{Name: "GH_TOKEN", Value: "ghp_placeholder", Description: "github"},
+	}
+	envJSON, err := json.Marshal(envVarsIn)
+	if err != nil {
+		t.Fatalf("marshal env: %v", err)
+	}
+	wantWarning := "tsnet probe: gateway unreachable via exit-node routing (i/o timeout). " +
+		"Check autoApprovers.exitNode in your tailnet ACL."
+
+	// A pair of socketpair'd fds for the SCM_RIGHTS round-trip
+	// payload. The daemon side recvs one end; the client keeps the
+	// other to write a sentinel byte we can read on the recv'd end.
+	fdPair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("fd-payload socketpair: %v", err)
+	}
+	clientKeeps := os.NewFile(uintptr(fdPair[0]), "payload-a")
+	defer func() { _ = clientKeeps.Close() }()
+	defer unix.Close(fdPair[1])
+
+	// --- daemon side --------------------------------------------------
+	type daemonResult struct {
+		recvFd   int
+		attached bool
+		err      error
+	}
+	dCh := make(chan daemonResult, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		res := daemonResult{recvFd: -1}
+		defer func() { dCh <- res }()
+
+		if err := daemonHandshake(daemonSide); err != nil {
+			res.err = err
+			return
+		}
+		br := bufio.NewReader(daemonSide)
+		cmd, err := br.ReadString('\n')
+		if err != nil {
+			res.err = err
+			return
+		}
+		if cmd != "START\n" {
+			res.err = io.ErrUnexpectedEOF
+			return
+		}
+		if err := daemonWriteStartReply(daemonSide, wantTsIP, envJSON, wantWarning); err != nil {
+			res.err = err
+			return
+		}
+		recvFd, err := recvFDUnixConn(daemonSide)
+		if err != nil {
+			res.err = err
+			return
+		}
+		res.recvFd = recvFd
+		if _, err := io.WriteString(daemonSide, "ATTACHED\n"); err != nil {
+			res.err = err
+			return
+		}
+		res.attached = true
+	}()
+
+	// --- client side --------------------------------------------------
+	if err := daemonHello(clientSide); err != nil {
+		t.Fatalf("client daemonHello: %v", err)
+	}
+	// daemonClientStartSession writes "START\n" itself — do not write
+	// it here too. An extra START would sit in the kernel buffer until
+	// some later read; if that read happens to be the recvmsg waiting
+	// for SCM_RIGHTS, Linux truncates at the byte-before-ancillary and
+	// the FD never gets delivered.
+	br, gotTsIP, gotEnv, gotWarning, err := daemonClientStartSession(clientSide)
+	if err != nil {
+		t.Fatalf("daemonClientStartSession: %v", err)
+	}
+	if gotTsIP != wantTsIP {
+		t.Errorf("tsIP: got %v, want %v", gotTsIP, wantTsIP)
+	}
+	if gotWarning != wantWarning {
+		t.Errorf("warning: got %q\nwant %q", gotWarning, wantWarning)
+	}
+	if !envVarsEqual(gotEnv, envVarsIn) {
+		t.Errorf("env vars: got %+v, want %+v", gotEnv, envVarsIn)
+	}
+	if err := sendFDUnixConn(clientSide, fdPair[1]); err != nil {
+		t.Fatalf("client sendFD: %v", err)
+	}
+	// Pull the daemon's result FIRST so a daemon-side error surfaces
+	// as a clear failure message, instead of the client timing out
+	// reading ATTACHED that the daemon never wrote.
+	wg.Wait()
+	res := <-dCh
+	if res.err != nil {
+		t.Fatalf("daemon side: %v", res.err)
+	}
+	if !res.attached {
+		t.Fatalf("daemon never wrote ATTACHED")
+	}
+	if err := daemonClientWaitAttached(clientSide, br); err != nil {
+		t.Fatalf("client wait ATTACHED: %v", err)
+	}
+
+	// Smoke-verify the SCM_RIGHTS fd actually points at the same
+	// socketpair: write a sentinel through the daemon's recv'd fd,
+	// read it on the client's retained end.
+	defer unix.Close(res.recvFd)
+	if _, err := unix.Write(res.recvFd, []byte{0xAB}); err != nil {
+		t.Fatalf("write to recv'd fd: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := unix.Read(int(clientKeeps.Fd()), buf); err != nil {
+		t.Fatalf("read sentinel on client end: %v", err)
+	}
+	if buf[0] != 0xAB {
+		t.Fatalf("sentinel mismatch: got %#x, want 0xAB", buf[0])
+	}
+}
+
+// TestDaemonProtocol_EmptyWarning covers the n=0 WARN frame: the
+// daemon still emits "WARN 0\n" with no body, the client parses it,
+// and the empty warning is returned without spurious bytes.
+func TestDaemonProtocol_EmptyWarning(t *testing.T) {
+	daemonSide, clientSide := socketpairConns(t)
+	defer func() { _ = daemonSide.Close() }()
+	defer func() { _ = clientSide.Close() }()
+
+	go func() {
+		_ = daemonHandshake(daemonSide)
+		br := bufio.NewReader(daemonSide)
+		_, _ = br.ReadString('\n') // "START\n"
+		_ = daemonWriteStartReply(daemonSide, netip.MustParseAddr("100.64.0.1"), []byte("[]"), "")
+	}()
+
+	if err := daemonHello(clientSide); err != nil {
+		t.Fatalf("client hello: %v", err)
+	}
+	// START is written by daemonClientStartSession itself.
+	_, _, _, gotWarning, err := daemonClientStartSession(clientSide)
+	if err != nil {
+		t.Fatalf("startSession: %v", err)
+	}
+	if gotWarning != "" {
+		t.Errorf("warning: got %q, want empty", gotWarning)
+	}
+}
+
+// TestDaemonClientParse_Malformed feeds the client parser
+// hand-rolled byte streams that violate the protocol, and checks
+// each variant returns a non-nil error rather than a misinterpreted
+// value.
+func TestDaemonClientParse_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"missing TSIP prefix", "WAT 100.64.0.1\nENV 0\nWARN 0\n"},
+		{"bad TSIP value", "TSIP not-an-ip\nENV 0\nWARN 0\n"},
+		{"missing ENV prefix", "TSIP 100.64.0.1\nVNE 0\nWARN 0\n"},
+		{"non-numeric ENV length", "TSIP 100.64.0.1\nENV xyz\nWARN 0\n"},
+		{"oversized ENV length", "TSIP 100.64.0.1\nENV 9999999999\nWARN 0\n"},
+		{"missing WARN frame", "TSIP 100.64.0.1\nENV 0\n"},
+		{"oversized WARN length", "TSIP 100.64.0.1\nENV 0\nWARN 99999\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			daemonSide, clientSide := socketpairConns(t)
+			defer func() { _ = daemonSide.Close() }()
+			defer func() { _ = clientSide.Close() }()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, _ = io.WriteString(daemonSide, tc.body)
+				_ = daemonSide.Close()
+			}()
+			_, _, _, _, err := daemonClientStartSession(clientSide)
+			<-done // join the writer so we never leak goroutines or fds
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func envVarsEqual(a, b []pushdownEnvVar) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// silence "imported and not used" if strings happens to drop out.
+var _ = strings.HasPrefix

--- a/cmd/clawpatrol/daemon_other.go
+++ b/cmd/clawpatrol/daemon_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package main
+
+// The self-forking daemon is Linux-only. macOS has the NE provider
+// (which already serves the equivalent role); other platforms aren't
+// supported for `clawpatrol run`. Stubs let the `daemon` subcommand
+// compile cross-platform — it just refuses to run.
+
+func runDaemon(_ []string) {
+	fail("clawpatrol daemon: linux only")
+}

--- a/cmd/clawpatrol/daemon_other.go
+++ b/cmd/clawpatrol/daemon_other.go
@@ -8,5 +8,5 @@ package main
 // compile cross-platform — it just refuses to run.
 
 func runDaemon(_ []string) {
-	fail("clawpatrol daemon: linux only")
+	fail("clawpatrol daemon-internal: linux only")
 }

--- a/cmd/clawpatrol/ephemeral_peer.go
+++ b/cmd/clawpatrol/ephemeral_peer.go
@@ -1,25 +1,23 @@
 package main
 
-// Peer registration handlers for `clawpatrol run`:
+// WG-mode ephemeral peer add/remove handlers for `clawpatrol run`.
+// Each invocation gets its own WireGuard keypair and IP (POST
+// /api/peer/ephemeral, DELETE on exit) so concurrent runs on the
+// same host don't fight over a single WG session.
 //
-//   WG mode: each invocation gets its own WireGuard keypair and IP
-//   (POST /api/peer/ephemeral, DELETE on exit) so concurrent runs on
-//   the same host don't fight over a single WG session.
+// The Tailscale-mode "peer registration" path used to live here too
+// but tsnet now has one persistent daemon per host (cmd/clawpatrol
+// daemon-internal) — the daemon does promotion-only registration
+// against /api/peer/tsnet/register handled in onboard.go.
 //
-//   Tailscale mode: tsnet keeps a stable per-machine identity across
-//   runs (POST /api/peer/ephemeral/tsnet/register binds the tailnet
-//   IP to the parent device's profile). The "ephemeral" in the path
-//   is historical — the registration is persistent.
-//
-// Both endpoints authenticate via the per-peer Bearer token minted
-// during `clawpatrol join` and stored hashed in peer_api_tokens.
+// Endpoints authenticate via the per-peer Bearer token minted during
+// `clawpatrol join` and stored hashed in peer_api_tokens.
 
 import (
 	"fmt"
 	"net"
 	"net/http"
 	"net/netip"
-	"strings"
 	"sync"
 )
 
@@ -126,70 +124,6 @@ func (w *webMux) apiAddEphemeralPeer(rw http.ResponseWriter, r *http.Request) {
 	w.g.onboard.setEphemeralProfile(ip, parentIP, profile)
 	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
 	writeJSON(rw, map[string]string{"ip": ip, "ip6": ip6})
-}
-
-// apiRegisterEphemeralTsnetIP handles POST /api/peer/ephemeral/tsnet/register.
-// Called by `clawpatrol run` right after the ephemeral tsnet node joins.
-//
-// First run from a machine promotes its tailnet IP to the device's
-// stable parent: the synthetic `tsnet-<hostname>` placeholder created
-// at approve time is replaced by a real devices row keyed on the
-// 100.x IP. Subsequent concurrent runs attribute their (different)
-// ephemeral IPs to the same parent via ephemeralParentByIP — exactly
-// the WG-mode ephemeralPeer model.
-func (w *webMux) apiRegisterEphemeralTsnetIP(rw http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(rw, "POST", http.StatusMethodNotAllowed)
-		return
-	}
-	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
-	parentIP := peerIPForAPIToken(w.g.db, token)
-	if parentIP == "" {
-		http.Error(rw, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	tsnetIP := r.URL.Query().Get("ip")
-	if tsnetIP == "" {
-		http.Error(rw, "missing ip", http.StatusBadRequest)
-		return
-	}
-	if _, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(tsnetIP, "1")); err != nil {
-		http.Error(rw, "invalid ip", http.StatusBadRequest)
-		return
-	}
-	if w.g.onboard == nil {
-		rw.WriteHeader(http.StatusNoContent)
-		return
-	}
-	profile := w.g.onboard.ProfileForIP(parentIP)
-	hostname := strings.TrimSpace(r.URL.Query().Get("hostname"))
-	// First-run promotion: synthetic parent → real tailnet IP. Repoint
-	// the api-token and clean up the placeholder row so the dashboard
-	// surfaces a single device keyed on the actual 100.x address.
-	if strings.HasPrefix(parentIP, "tsnet-") {
-		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
-		_, _ = w.g.db.Exec("DELETE FROM devices WHERE id=?", parentIP)
-		w.g.onboard.ForgetIP(parentIP)
-		if w.g.agents != nil {
-			w.g.agents.Delete(parentIP)
-		}
-		if profile != "" {
-			w.g.onboard.AssignProfile(tsnetIP, profile)
-		}
-		if hostname != "" {
-			w.g.onboard.SetHostname(tsnetIP, hostname)
-		}
-		if w.g.agents != nil {
-			w.g.agents.Seed(tsnetIP)
-		}
-	} else {
-		// Subsequent concurrent run — attribute to the existing parent.
-		w.g.onboard.setEphemeralProfile(tsnetIP, parentIP, profile)
-	}
-	// Map the ephemeral run's IPv6 ULA too — tsnet traffic frequently
-	// arrives on fd7a:115c:a1e0::/48 rather than the 100.x.
-	w.g.seedTsnetIPv6Alias(tsnetIP)
-	rw.WriteHeader(http.StatusNoContent)
 }
 
 // apiRemoveEphemeralPeer handles DELETE /api/peer/ephemeral?pubkey=<hex>.

--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -78,8 +78,26 @@ var envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
 // callers surface the error so the operator knows their agents
 // won't get the placeholder tokens.
 func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
-	var out []pushdownEnvVar
-	for _, k := range []string{
+	out := caPathPushdownVars(caPath)
+	vars, err := envPushdownGatewayFetcher(filepath.Dir(caPath))
+	if err != nil {
+		return out, err
+	}
+	return append(out, vars...), nil
+}
+
+// caPathPushdownVars returns the CA-bundle env vars every wrapped
+// agent needs (SSL_CERT_FILE, NODE_EXTRA_CA_CERTS, etc.), each
+// pointing at caPath. These are client-side — the gateway doesn't
+// know the client's filesystem layout, so they are never returned
+// by /api/env-pushdown.
+//
+// Exposed within the package so the Linux daemon-routed path
+// (`clawpatrol run` → daemon control socket) can combine these
+// with the gateway-fetched vars the daemon ships back, instead
+// of re-implementing the list.
+func caPathPushdownVars(caPath string) []pushdownEnvVar {
+	keys := []string{
 		"SSL_CERT_FILE",
 		"NODE_EXTRA_CA_CERTS",
 		"REQUESTS_CA_BUNDLE",
@@ -87,14 +105,12 @@ func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
 		"GIT_SSL_CAINFO",
 		"DENO_CERT",
 		"PIP_CERT",
-	} {
+	}
+	out := make([]pushdownEnvVar, 0, len(keys))
+	for _, k := range keys {
 		out = append(out, pushdownEnvVar{Name: k, Value: caPath})
 	}
-	vars, err := envPushdownGatewayFetcher(filepath.Dir(caPath))
-	if err != nil {
-		return out, err
-	}
-	return append(out, vars...), nil
+	return out
 }
 
 // gatewayDialOverride lets callers (e.g. clawpatrol run in tsnet mode)

--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -55,6 +56,15 @@ type pushdownEnvVar struct {
 	PluginType  string
 }
 
+// envPushdownGatewayFetcher resolves the gateway's declared
+// push-down vars. Defaults to dialing /api/env-pushdown directly
+// (works on Linux per-process tsnet, where the parent CLI hosts
+// the tsnet.Server itself via gatewayDialOverride). Platform-
+// specific run modes that have no tailnet route from the parent
+// process — macOS NE most notably — override this with a fetcher
+// that asks the network extension to make the call instead.
+var envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
+
 // envPushdownVars returns every var the operator's CLI environment
 // needs: CA-bundle vars (which point at a path on the *client's*
 // disk so the client owns them) plus the gateway's declared
@@ -80,7 +90,7 @@ func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
 	} {
 		out = append(out, pushdownEnvVar{Name: k, Value: caPath})
 	}
-	vars, err := fetchEnvPushdownFromGateway(filepath.Dir(caPath))
+	vars, err := envPushdownGatewayFetcher(filepath.Dir(caPath))
 	if err != nil {
 		return out, err
 	}
@@ -152,6 +162,22 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("fetch %s: status %d", url, resp.StatusCode)
 	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	vars, err := parseEnvPushdownJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", url, err)
+	}
+	return vars, nil
+}
+
+// parseEnvPushdownJSON decodes the wire format returned by
+// /api/env-pushdown into the CLI's internal pushdownEnvVar shape.
+// Shared between the direct HTTP fetcher and the macOS variant
+// that hops through the NE's session socket.
+func parseEnvPushdownJSON(raw []byte) ([]pushdownEnvVar, error) {
 	var body struct {
 		Vars []struct {
 			Name        string `json:"name"`
@@ -160,8 +186,8 @@ func fetchEnvPushdownFromGateway(caDir string) ([]pushdownEnvVar, error) {
 			PluginType  string `json:"plugin_type"`
 		} `json:"vars"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil, fmt.Errorf("decode %s: %w", url, err)
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
 	}
 	out := make([]pushdownEnvVar, 0, len(body.Vars))
 	for _, v := range body.Vars {

--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -272,8 +272,19 @@ func applyEnvPushdown(caDir string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "clawpatrol: %v — agent will run without placeholder push-down\n", err)
 	}
+	applyEnvPushdownVars(vars)
+}
+
+// applyEnvPushdownVars sets env vars from an already-fetched list,
+// honoring CLAWPATROL_NO_ENV and never clobbering values the operator
+// set deliberately. Used by `clawpatrol run` which now receives the
+// vars from the daemon over its control socket instead of dialing the
+// gateway directly.
+func applyEnvPushdownVars(vars []pushdownEnvVar) {
+	if os.Getenv("CLAWPATROL_NO_ENV") == "1" {
+		return
+	}
 	for _, ev := range vars {
-		// Don't clobber values the operator already set deliberately.
 		if os.Getenv(ev.Name) != "" {
 			continue
 		}

--- a/cmd/clawpatrol/integrations_test.go
+++ b/cmd/clawpatrol/integrations_test.go
@@ -113,6 +113,10 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 // vars (client-side) plus the server-supplied ones in a single
 // flat list.
 func TestEnvPushdownVarsServerDriven(t *testing.T) {
+	prev := envPushdownGatewayFetcher
+	envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
+	t.Cleanup(func() { envPushdownGatewayFetcher = prev })
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"vars": []map[string]string{{"name": "CODEX_ACCESS_TOKEN", "value": "from-server"}},
@@ -152,6 +156,15 @@ func TestEnvPushdownVarsServerDriven(t *testing.T) {
 // (so TLS verification keeps working) but surface the error so the
 // caller can warn the operator.
 func TestEnvPushdownVarsErrorReturnsCAOnly(t *testing.T) {
+	// Pin the gateway fetcher to the direct-HTTP path — on darwin the
+	// init() in run_tsnet_darwin.go rewires this to the NE session
+	// socket, which would dial /tmp/clawpatrol.sock and return whatever
+	// the host's running NE happens to have to say, instead of the
+	// gateway-URL-missing error this test exercises.
+	prev := envPushdownGatewayFetcher
+	envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
+	t.Cleanup(func() { envPushdownGatewayFetcher = prev })
+
 	dir := t.TempDir()
 	caPath := filepath.Join(dir, "ca.crt")
 	_ = os.WriteFile(caPath, []byte("dummy"), 0o644)

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2577,6 +2577,10 @@ func main() {
 		runJoin(os.Args[2:])
 	case "run":
 		runRun(os.Args[2:])
+	case "daemon":
+		// internal: re-exec'd by `clawpatrol run` (Linux only) to host
+		// the per-user tsnet daemon. Hidden from usage().
+		runDaemon(os.Args[2:])
 	case "relay-supervisor":
 		// internal: re-exec'd by `clawpatrol run` to host the auto-expose
 		// supervisor in the host netns. Hidden from usage.

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2577,9 +2577,11 @@ func main() {
 		runJoin(os.Args[2:])
 	case "run":
 		runRun(os.Args[2:])
-	case "daemon":
+	case "daemon-internal":
 		// internal: re-exec'd by `clawpatrol run` (Linux only) to host
-		// the per-user tsnet daemon. Hidden from usage().
+		// the per-user tsnet daemon. Hidden from usage(); name carries
+		// the -internal suffix so it doesn't read like a user-facing
+		// command if it leaks into help text or shell history.
 		runDaemon(os.Args[2:])
 	case "relay-supervisor":
 		// internal: re-exec'd by `clawpatrol run` to host the auto-expose

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3087,9 +3087,13 @@ func runGateway(args []string) {
 			continue
 		}
 		go func(c net.Conn) {
-			// WireGuard-mode loopback listener: only used for local
-			// debugging. Treat every connection as a direct dashboard
-			// hit, no PROXY framing.
+			// WireGuard-mode loopback listener. MITM traffic in WG mode
+			// flows through the promiscuous wg forwarder above; what
+			// arrives here is direct host-local hits at the dashboard
+			// (a separate UID on the same host running an agent or an
+			// admin tool, an SSH-forwarded port, etc.). No PROXY
+			// framing in this mode — terminate TLS, serve the
+			// dashboard mux.
 			g.serveTSNetDirect(c, tsnetDashMux)
 		}(c)
 	}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2919,14 +2919,14 @@ func runGateway(args []string) {
 	if err != nil {
 		log.Fatalf("listen: %v", err)
 	}
-	log.Printf("gateway listening on %s, %d endpoints across %d profiles",
-		ln.Addr(), len(policy.Endpoints), len(policy.Profiles))
+	if ln != nil {
+		log.Printf("gateway listening on %s, %d endpoints across %d profiles",
+			ln.Addr(), len(policy.Endpoints), len(policy.Profiles))
+	} else {
+		log.Printf("gateway listening on tsnet (exit-node routed), %d endpoints across %d profiles",
+			len(policy.Endpoints), len(policy.Profiles))
+	}
 
-	// In Tailscale mode, `clawpatrol run` clients prepend a HAProxy PROXY v1
-	// header carrying the original 4-tuple so we can dispatch by dst port/IP
-	// exactly like the WG promiscuous forwarder. Peek the first bytes: if the
-	// connection starts with "PROXY " use full dispatch; otherwise it is a
-	// direct admin/dashboard connection.
 	if tsnetServer != nil && cfg.Funnel && cfg.PublicURL == "" {
 		// Auto-derive public_url from the tsnet cert domain so that
 		// join responses, HITL status links, and OAuth redirect URIs use
@@ -3067,6 +3067,13 @@ func runGateway(args []string) {
 			}, true
 		})
 	}
+	if ln == nil {
+		// Tailscale mode: nothing more to accept here. All client TCP
+		// arrives via the tsnet fallback handler above; UDP/53 via the
+		// dnsvip listener; HTTPS/info via the Funnel + tsnet info
+		// listeners. Block forever so runGateway doesn't return.
+		select {}
+	}
 	for {
 		c, err := ln.Accept()
 		if err != nil {
@@ -3074,70 +3081,13 @@ func runGateway(args []string) {
 			continue
 		}
 		go func(c net.Conn) {
-			dstIP, dstPort, conn, err := readProxyHeader(c)
-			if err != nil {
-				_ = c.Close()
-				return
-			}
-			if dstPort == 0 {
-				// No PROXY header — direct connection (admin dashboard, curl, join).
-				g.serveTSNetDirect(conn, tsnetDashMux)
-				return
-			}
-			switch {
-			case dstPort == 443:
-				g.handle(conn, dstIP)
-			case dstPort == 5432:
-				g.handlePostgresConn(conn, dstIP)
-			case dstPort == 53:
-				g.handleDNSTCPConn(conn, dstIP)
-			case g.dnsvip.IsVIP(dstIP):
-				g.handleVIPConn(conn, dstIP, dstPort)
-			case tsnetDashPort != 0 && int(dstPort) == tsnetDashPort:
-				_ = http.Serve(&oneShotListener{c: conn}, tsnetDashMux)
-			default:
-				if g.tryDirectIPConn(conn, dstIP, dstPort) {
-					return
-				}
-				g.wgRelay(conn, dstIP, int(dstPort))
-			}
+			// WireGuard-mode loopback listener: only used for local
+			// debugging. Treat every connection as a direct dashboard
+			// hit, no PROXY framing.
+			g.serveTSNetDirect(c, tsnetDashMux)
 		}(c)
 	}
 }
-
-// readProxyHeader peeks at c for a HAProxy PROXY v1 line.
-// If "PROXY TCP4 srcIP dstIP srcPort dstPort\r\n" is present it is consumed
-// and the original dst IP/port returned. If absent, dstPort==0 and the conn
-// is returned with all peeked bytes still readable.
-func readProxyHeader(c net.Conn) (dstIP string, dstPort uint16, conn net.Conn, _ error) {
-	br := bufio.NewReaderSize(c, 128)
-	hdr, err := br.Peek(5)
-	bc := &bufferedConn{Reader: br, Conn: c}
-	if err != nil || string(hdr) != "PROXY" {
-		return "", 0, bc, nil
-	}
-	line, err := br.ReadString('\n')
-	if err != nil {
-		return "", 0, nil, fmt.Errorf("proxy header read: %w", err)
-	}
-	// "PROXY TCP4 srcIP dstIP srcPort dstPort\r\n"
-	fields := strings.Fields(strings.TrimRight(line, "\r\n"))
-	if len(fields) != 6 {
-		return "", 0, nil, fmt.Errorf("malformed proxy header: %q", line)
-	}
-	port, err := strconv.ParseUint(fields[5], 10, 16)
-	if err != nil {
-		return "", 0, nil, fmt.Errorf("proxy header port: %w", err)
-	}
-	return fields[3], uint16(port), bc, nil
-}
-
-type bufferedConn struct {
-	*bufio.Reader
-	net.Conn
-}
-
-func (b *bufferedConn) Read(p []byte) (int, error) { return b.Reader.Read(p) }
 
 func serveHTTPLogged(name, addr string, handler http.Handler) {
 	if err := http.ListenAndServe(addr, handler); err != nil {

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -898,16 +897,6 @@ func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 		resp["control_url"] = w.ts.ControlURL
 		if w.g != nil && w.g.tailscaleIP != "" {
 			resp["gateway_ip"] = w.g.tailscaleIP
-		}
-		// Tailscale Funnel owns :443 on the tsnet node, so cfg.Listen
-		// for the agent listener is usually :8443. Communicate it so
-		// `clawpatrol run` dials the right port.
-		if w.g != nil {
-			_, port, _ := net.SplitHostPort(w.g.cfg.Listen)
-			if port == "" {
-				port = "443"
-			}
-			resp["gateway_port"] = port
 		}
 		// CA cert delivered over the approved Funnel/onboard channel —
 		// the gateway's /ca.crt is intentionally not exposed publicly

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"sync"
@@ -844,6 +845,70 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 		resp["api_token"] = token
 	}
 	writeJSON(rw, resp)
+}
+
+// apiPeerTsnetRegister is the daemon's one-shot self-registration on
+// first boot after `clawpatrol join`: the api-token minted at approve
+// time is bound to a synthetic "tsnet-<host>" placeholder; the daemon
+// now has its real tailnet IP and asks the gateway to rebind the
+// token + create the real devices row. Subsequent calls (later daemon
+// boots, gateway restarts) reach the no-op branch — the token's
+// peer_ip is already the real IP, nothing to do.
+//
+// Auth: bearer api-token in the Authorization header. The path is
+// /api/peer/tsnet/register — no "ephemeral" in the name because the
+// daemon model has one persistent peer per host, not a pool of
+// short-lived ones.
+func (w *webMux) apiPeerTsnetRegister(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	parentIP := peerIPForAPIToken(w.g.db, token)
+	if parentIP == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	tsnetIP := strings.TrimSpace(r.URL.Query().Get("ip"))
+	if tsnetIP == "" {
+		http.Error(rw, "missing ip", http.StatusBadRequest)
+		return
+	}
+	if ip, err := netip.ParseAddr(tsnetIP); err != nil || !ip.IsValid() {
+		http.Error(rw, "invalid ip", http.StatusBadRequest)
+		return
+	}
+	if w.g.onboard == nil {
+		rw.WriteHeader(http.StatusNoContent)
+		return
+	}
+	hostname := strings.TrimSpace(r.URL.Query().Get("hostname"))
+	if strings.HasPrefix(parentIP, "tsnet-") {
+		// First call — promote the synthetic placeholder to a real
+		// devices row keyed on the tailnet IP. Rebind the api-token,
+		// drop the placeholder from in-memory state, copy across the
+		// profile picked at approve time.
+		profile := w.g.onboard.ProfileForIP(parentIP)
+		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
+		w.g.onboard.ForgetIP(parentIP)
+		if w.g.agents != nil {
+			w.g.agents.Delete(parentIP)
+		}
+		if profile != "" {
+			w.g.onboard.AssignProfile(tsnetIP, profile)
+		}
+		if hostname != "" {
+			w.g.onboard.SetHostname(tsnetIP, hostname)
+		}
+		if w.g.agents != nil {
+			w.g.agents.Seed(tsnetIP)
+		}
+	}
+	// Map the daemon's IPv6 ULA too — tsnet traffic from this peer
+	// frequently arrives on fd7a:115c:a1e0::/48 rather than the 100.x.
+	w.g.seedTsnetIPv6Alias(tsnetIP)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // apiOnboardPoll is hit by the CLI to retrieve the auth key once

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -487,12 +487,13 @@ func newOnboarder(ts JoinConfig) Onboarder {
 
 type tailscaleOnboarder struct{ ts JoinConfig }
 
-func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string, wholeMachine bool) (string, string, string, error) {
-	// Per-process tsnet (default): ephemeral=true so each `clawpatrol run`
-	// gets a fresh node that auto-cleans on exit (matches macOS NE +
-	// WG-mode ephemeralPeer). Whole-machine: ephemeral=false so the
-	// system tailscale node persists across reboots.
-	k, err := mintTailscaleAuthKey(ctx, t.ts, !wholeMachine)
+func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string, _ bool) (string, string, string, error) {
+	// One persistent (non-ephemeral) auth key per device. The Linux
+	// daemon (cmd/clawpatrol daemon) holds one stable tsnet identity
+	// shared across every `clawpatrol run` on the host, so the
+	// per-process ephemeral model is gone. Whole-machine joins on
+	// Linux also want a persistent node so the host survives reboots.
+	k, err := mintTailscaleAuthKey(ctx, t.ts, false)
 	return k, "", "", err
 }
 

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -489,7 +489,7 @@ type tailscaleOnboarder struct{ ts JoinConfig }
 
 func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string, _ bool) (string, string, string, error) {
 	// One persistent (non-ephemeral) auth key per device. The Linux
-	// daemon (cmd/clawpatrol daemon) holds one stable tsnet identity
+	// daemon (cmd/clawpatrol daemon_linux.go) holds one stable tsnet identity
 	// shared across every `clawpatrol run` on the host, so the
 	// per-process ephemeral model is gone. Whole-machine joins on
 	// Linux also want a persistent node so the host survives reboots.

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -601,6 +601,49 @@ func sendFD(s *os.File, fd int) error {
 	return unix.Sendmsg(int(s.Fd()), []byte{0}, rights, nil, 0)
 }
 
+// sendFDUnixConn ships one fd via SCM_RIGHTS over a *net.UnixConn,
+// using the WriteMsgUnix path instead of .File() + Sendmsg. The
+// dup-based path silently switches the underlying file description
+// to blocking mode (Linux shares O_NONBLOCK across dups), which
+// strands the runtime poller on subsequent reads of the same conn.
+// Use this when the SCM_RIGHTS exchange happens on a long-lived
+// control conn that the caller keeps reading from afterwards.
+func sendFDUnixConn(c *net.UnixConn, fd int) error {
+	rights := unix.UnixRights(fd)
+	_, _, err := c.WriteMsgUnix([]byte{0}, rights, nil)
+	return err
+}
+
+// recvFDUnixConn is the counterpart to sendFDUnixConn — reads one fd
+// out of one SCM_RIGHTS message off c. Same rationale: avoids the
+// .File() dup and keeps the conn usable for follow-up reads.
+func recvFDUnixConn(c *net.UnixConn) (int, error) {
+	buf := make([]byte, 1)
+	oob := make([]byte, unix.CmsgSpace(4))
+	n, oobn, flags, _, err := c.ReadMsgUnix(buf, oob)
+	if err != nil {
+		return -1, err
+	}
+	if flags&unix.MSG_CTRUNC != 0 {
+		return -1, fmt.Errorf("recvFDUnixConn: ancillary truncated (oobn=%d, n=%d)", oobn, n)
+	}
+	cmsgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return -1, err
+	}
+	for _, cmsg := range cmsgs {
+		fds, err := unix.ParseUnixRights(&cmsg)
+		if err != nil || len(fds) == 0 {
+			continue
+		}
+		for _, x := range fds[1:] {
+			_ = unix.Close(x)
+		}
+		return fds[0], nil
+	}
+	return -1, fmt.Errorf("no SCM_RIGHTS fd (oobn=%d, n=%d, flags=%#x)", oobn, n, flags)
+}
+
 func recvFD(s *os.File) (int, error) {
 	fds, err := recvFDs(s, 1)
 	if err != nil {

--- a/cmd/clawpatrol/run_tsnet_common.go
+++ b/cmd/clawpatrol/run_tsnet_common.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"tailscale.com/ipn"
 	"tailscale.com/tsnet"
 )
 
@@ -58,6 +59,28 @@ func tsnetHTTPClient(ts *tsnet.Server, caPath string) *http.Client {
 			TLSClientConfig: &tls.Config{RootCAs: roots},
 		},
 	}
+}
+
+// setGatewayExitNode points this tsnet node at the gateway as its exit
+// node. Once set, every outbound dial on s (tcp + udp) is routed via
+// the gateway, where it lands in the gateway's RegisterFallbackTCPHandler
+// / DNS UDP listener — same dispatch as whole-machine clients. The
+// gateway-side already auto-advertises 0.0.0.0/0 + ::/0 (see
+// advertiseExitRoutes), so this only needs the operator's tailnet
+// ACL to auto-approve exit-node usage for the client's tag.
+func setGatewayExitNode(s *tsnet.Server, gatewayIP netip.Addr) error {
+	if !gatewayIP.IsValid() {
+		return fmt.Errorf("setGatewayExitNode: invalid gateway IP")
+	}
+	lc, err := s.LocalClient()
+	if err != nil {
+		return err
+	}
+	_, err = lc.EditPrefs(context.Background(), &ipn.MaskedPrefs{
+		ExitNodeIPSet: true,
+		Prefs:         ipn.Prefs{ExitNodeIP: gatewayIP},
+	})
+	return err
 }
 
 // waitTsnetUp starts the tsnet.Server and blocks until the node is Running

--- a/cmd/clawpatrol/run_tsnet_common.go
+++ b/cmd/clawpatrol/run_tsnet_common.go
@@ -116,11 +116,13 @@ func waitTsnetUp(s *tsnet.Server) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("no tailnet IPs assigned")
 }
 
-// registerEphemeralTsnetIP tells the gateway which 100.x.x.x tailnet IP this
-// `clawpatrol run` invocation got, so the gateway maps it to the parent
-// device's profile for credential dispatch and seeds a real device row
-// (one per machine, not per run). Called over tsnet (tailnet-only endpoint).
-func registerEphemeralTsnetIP(client *http.Client, gwURL, token, tsIP string) error {
+// registerTsnetPeer tells the gateway which 100.x.x.x tailnet IP this
+// daemon is using, so it can promote the synthetic "tsnet-<host>"
+// placeholder bound to the api-token at approve time into a real
+// devices row keyed on the tailnet IP. Idempotent: subsequent calls
+// (later daemon boots) see the token already pointing at a real IP
+// and hit the gateway's no-op branch.
+func registerTsnetPeer(client *http.Client, gwURL, token, tsIP string) error {
 	// Prefer the operator-supplied --hostname from `clawpatrol join`
 	// (persisted to <ca-dir>/hostname). Fall back to os.Hostname() for
 	// older joins that didn't write the file.
@@ -128,7 +130,7 @@ func registerEphemeralTsnetIP(client *http.Client, gwURL, token, tsIP string) er
 	if hn == "" {
 		hn, _ = os.Hostname()
 	}
-	u := gwURL + "/api/peer/ephemeral/tsnet/register?ip=" + tsIP
+	u := gwURL + "/api/peer/tsnet/register?ip=" + tsIP
 	if hn != "" {
 		u += "&hostname=" + hn
 	}

--- a/cmd/clawpatrol/run_tsnet_darwin.go
+++ b/cmd/clawpatrol/run_tsnet_darwin.go
@@ -22,12 +22,15 @@ package main
 //  6. Register session PID via session IPC, then `Clawpatrol run -- <cmd>`.
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -101,6 +104,11 @@ func runRunTsnet(args []string) {
 	if tsIP == "" {
 		fmt.Fprintln(os.Stderr, "warning: NE never reported tsnet IP — run will land in the default profile")
 	}
+	// env-pushdown is on a tailnet-only endpoint that the parent CLI
+	// (host network) can't reach. Hop through the NE's session socket
+	// — the NE has tsnet up with the gateway as exit-node and is the
+	// one process on this Mac that can dial 100.x.
+	envPushdownGatewayFetcher = fetchEnvPushdownViaNESessionSock
 	applyEnvPushdown(dir)
 
 	cleanup := registerSession()
@@ -160,4 +168,52 @@ func queryTsnetIP() string {
 		return strings.TrimSpace(after)
 	}
 	return ""
+}
+
+// fetchEnvPushdownViaNESessionSock asks the NE to fetch the
+// gateway's /api/env-pushdown over tsnet on the parent's behalf
+// and ships the raw JSON back over the session socket. Wire
+// format: client sends "getenv\n"; ext replies "env <len>\n"
+// followed by <len> raw JSON bytes (or "err\n" on failure).
+// The length-prefix is binary-safe so the JSON body is delivered
+// verbatim regardless of its content.
+//
+// caDir is unused — the auth token and gateway hostname live in
+// the extension's providerConfiguration, which the CLI cannot
+// (and should not) read on macOS. The signature matches
+// envPushdownGatewayFetcher so it slots into envPushdownVars.
+func fetchEnvPushdownViaNESessionSock(caDir string) ([]pushdownEnvVar, error) {
+	_ = caDir
+	d := net.Dialer{Timeout: 2 * time.Second}
+	c, err := d.Dial("unix", sessionSockPath)
+	if err != nil {
+		return nil, fmt.Errorf("dial NE session socket %s: %w", sessionSockPath, err)
+	}
+	defer func() { _ = c.Close() }()
+	_ = c.SetDeadline(time.Now().Add(20 * time.Second))
+	if _, err := c.Write([]byte("getenv\n")); err != nil {
+		return nil, fmt.Errorf("write getenv: %w", err)
+	}
+	rd := bufio.NewReader(c)
+	header, err := rd.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("read env header: %w", err)
+	}
+	header = strings.TrimRight(header, "\n")
+	if header == "err" {
+		return nil, fmt.Errorf("NE refused getenv (no tsnet config or HTTP fetch failed)")
+	}
+	rest, ok := strings.CutPrefix(header, "env ")
+	if !ok {
+		return nil, fmt.Errorf("unexpected getenv reply: %q", header)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(rest))
+	if err != nil || n < 0 || n > 1<<20 {
+		return nil, fmt.Errorf("invalid env length: %q", rest)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(rd, body); err != nil {
+		return nil, fmt.Errorf("read env body (%d bytes): %w", n, err)
+	}
+	return parseEnvPushdownJSON(body)
 }

--- a/cmd/clawpatrol/run_tsnet_darwin.go
+++ b/cmd/clawpatrol/run_tsnet_darwin.go
@@ -7,14 +7,16 @@ package main
 // Uses the same NETransparentProxy system extension as WireGuard mode, but
 // with a tsnet.Server as the transport instead of WireGuard + gVisor.
 // The extension intercepts all TCP/UDP flows from the child process tree
-// via PPID-walk, and routes them through the gateway over the tailnet using
-// ts_netstack_tcp_connect (tsnet.Dial + HAProxy PROXY v1 header).
+// via PPID-walk, and routes them through the gateway over the tailnet by
+// setting the gateway as the tsnet exit node (ts_netstack_init configures
+// ExitNodeIP); ts_netstack_tcp_connect then dials the original dst, which
+// tsnet routes via the gateway, where it lands in RegisterFallbackTCPHandler.
 //
 // Flow:
 //  1. Mint ephemeral tsnet auth key from gateway.
 //  2. `Clawpatrol install` — ensure NE system extension is loaded.
-//  3. `Clawpatrol start-tsnet <authKey> <controlURL> <gwHost> <gwPort>`
-//     — NE calls ts_netstack_init: joins tailnet, blocks until Running.
+//  3. `Clawpatrol start-tsnet <authKey> <controlURL> <gwHost> <gwIP>`
+//     — NE calls ts_netstack_init: joins tailnet + sets ExitNodeIP=gwIP.
 //  4. Poll session socket for `gettsip` → receive 100.x.x.x of NE node.
 //  5. Register that IP with gateway (profile dispatch mapping).
 //  6. Register session PID via session IPC, then `Clawpatrol run -- <cmd>`.
@@ -43,6 +45,7 @@ func runRunTsnet(args []string) {
 
 	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway")))
 	gwHost := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway")))
+	gwIP := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway-ip")))
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "control-url")))
 	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
 	// tsnet auth key is intentionally NOT read from disk. On macOS the
@@ -58,11 +61,8 @@ func runRunTsnet(args []string) {
 	if gwURL == "" || token == "" {
 		fail("tsnet run: missing gateway url or api-token in %s", dir)
 	}
-	// Gateway agent port persisted at join (Tailscale Funnel owns :443,
-	// so this is typically :8443).
-	gwPort := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway-port")))
-	if gwPort == "" {
-		gwPort = "443"
+	if gwIP == "" {
+		fail("tsnet run: missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", dir)
 	}
 
 	// Ensure system extension is loaded.
@@ -82,7 +82,7 @@ func runRunTsnet(args []string) {
 	hn, _ := os.Hostname()
 	fmt.Fprintln(os.Stderr, "clawpatrol: joining tailnet via NE...")
 	{
-		c := exec.Command(macHelperPath, "start-tsnet", "", controlURL, gwHost, gwPort, token, hn)
+		c := exec.Command(macHelperPath, "start-tsnet", "", controlURL, gwHost, gwIP, token, hn)
 		c.Stdout, c.Stderr = os.Stdout, os.Stderr
 		if err := c.Run(); err != nil {
 			var ee *exec.ExitError

--- a/cmd/clawpatrol/run_tsnet_darwin.go
+++ b/cmd/clawpatrol/run_tsnet_darwin.go
@@ -35,6 +35,16 @@ import (
 	"time"
 )
 
+func init() {
+	// macOS has no tailnet route from the parent CLI — only the NE
+	// does. Route every gateway-tailnet HTTP call (env-pushdown, the
+	// one such call from the parent) through the NE for both
+	// `clawpatrol run` and the `clawpatrol env` shell-rc shim that
+	// fires on every new terminal. Silent skip when the NE isn't
+	// running keeps shell startup quiet between joins / after reboot.
+	envPushdownGatewayFetcher = fetchEnvPushdownViaNESessionSock
+}
+
 func runRunTsnet(args []string) {
 	warnIfOnGatewayHost()
 
@@ -105,10 +115,9 @@ func runRunTsnet(args []string) {
 		fmt.Fprintln(os.Stderr, "warning: NE never reported tsnet IP — run will land in the default profile")
 	}
 	// env-pushdown is on a tailnet-only endpoint that the parent CLI
-	// (host network) can't reach. Hop through the NE's session socket
-	// — the NE has tsnet up with the gateway as exit-node and is the
-	// one process on this Mac that can dial 100.x.
-	envPushdownGatewayFetcher = fetchEnvPushdownViaNESessionSock
+	// (host network) can't reach. The init() above already pointed
+	// envPushdownGatewayFetcher at the NE session-socket fetcher;
+	// applyEnvPushdown will use it.
 	applyEnvPushdown(dir)
 
 	cleanup := registerSession()

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -2,34 +2,31 @@
 
 package main
 
-// `clawpatrol run` in Tailscale mode. Spins up an ephemeral tsnet.Server
-// per invocation — fresh node identity each time, auto-removed on
-// disconnect by Tailscale (ephemeral=true). Mirrors macOS NE
-// (macos/netstack/wgnetstack.go) + WG-mode ephemeralPeer flow so
-// concurrent `clawpatrol run` invocations on one machine don't fight
-// over a shared state lock.
-//
-// The auth key persisted at join is reusable + ephemeral=true, so each
-// run consumes the same key but spawns a distinct tailnet node.
+// `clawpatrol run` in Tailscale mode. The parent process is a thin
+// client to the per-host `clawpatrol daemon` (see daemon_linux.go),
+// which owns one tsnet.Server shared across every concurrent run.
 //
 // Flow:
-//  1. Read persisted reusable+ephemeral auth_key from ~/.clawpatrol/.
-//  2. tsnet.Server{Ephemeral: true, Dir: MkdirTemp(...)} joins the
-//     gateway's tailnet under a fresh hostname.
-//  3. EditPrefs(ExitNodeIP=gateway) so every outbound dial from this
-//     tsnet node is routed via the gateway. Original dst is recovered
-//     server-side by RegisterFallbackTCPHandler — no PROXY-header
-//     smuggling required.
-//  4. Register the new tailnet IP with the gateway — register handler
-//     attributes traffic back to the parent device via
-//     ephemeralParentByIP so the dashboard shows ONE row per machine.
-//  5. Child in a new user+net+mnt ns creates the TUN, sends fd via
-//     SCM_RIGHTS.
-//  6. gVisor TCP forwarder dials the original destination via tsnet
-//     (which is exit-node-routed through the gateway).
+//  1. Connect to (or spawn) the daemon via its Unix control socket.
+//  2. Ask it to START a session — the daemon replies with its tsnet
+//     IP and the env-pushdown JSON. Both are applied locally before
+//     the child execs.
+//  3. Child in a new user+net+mnt ns creates the TUN, sends fd via
+//     SCM_RIGHTS to the parent.
+//  4. Parent forwards that TUN fd to the daemon (again via
+//     SCM_RIGHTS) on the same control conn.
+//  5. Daemon attaches the TUN to a per-session gVisor stack and TCP
+//     forwarder; replies ATTACHED.
+//  6. Parent signals the child; child brings up its tun + execs the
+//     agent. The agent's outbound traffic flows TUN → daemon's
+//     gVisor → daemon's tsnet (exit-node-routed through the gateway).
+//  7. On child exit the parent closes the control conn; the daemon
+//     tears down the session.
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -83,86 +80,25 @@ func runRunTsnet(args []string) {
 
 	checkUserNS()
 
-	dir := defaultClawpatrolDir()
-	// applyEnvPushdown moved to after tsnet join — env-pushdown is
-	// tailnet-only, can't be fetched until we're on the tailnet.
-
-	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway")))
-	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "control-url")))
-	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
-	authKey := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tsnet-auth-key")))
-	gwIPStr := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway-ip")))
-	if gwURL == "" || token == "" {
-		fail("tsnet run: missing gateway url or api-token in %s", dir)
-	}
-	if authKey == "" {
-		fail("tsnet run: missing tsnet-auth-key in %s (re-run `clawpatrol join`)", dir)
-	}
-	if gwIPStr == "" {
-		fail("tsnet run: missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", dir)
-	}
-	gwIP, err := netip.ParseAddr(gwIPStr)
+	// 1. Open a control conn to the per-host daemon, spawning one if
+	// none is alive. Hello handshake happens inside daemonConnect.
+	ctrl, err := daemonConnect()
 	if err != nil {
-		fail("tsnet run: tailnet-gateway-ip %q: %v", gwIPStr, err)
+		fail("daemon connect: %v", err)
 	}
+	defer func() { _ = ctrl.Close() }()
 
-	// 2. Spin up an ephemeral tsnet.Server per invocation. tmpdir state
-	// + Ephemeral:true means each run is a fresh tailnet node, freed
-	// automatically when this process exits. Concurrent runs on the same
-	// host don't collide on tsnet's exclusive state lock.
-	stateDir, err := os.MkdirTemp("", "clawpatrol-tsnet-*")
+	// 2. Ask for a session. Daemon replies with its tsnet IP plus the
+	// cached env-pushdown JSON. Apply both locally before forking.
+	tsIP, envVars, err := daemonClientStartSession(ctrl)
 	if err != nil {
-		fail("tsnet state dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(stateDir) }()
-	hn := fmt.Sprintf("clawpatrol-run-%d", os.Getpid())
-	tsServer := &tsnet.Server{
-		Hostname:   hn,
-		AuthKey:    authKey,
-		ControlURL: controlURL,
-		Dir:        stateDir,
-		Ephemeral:  true,
-		Logf:       func(string, ...any) {},
-	}
-	defer func() { _ = tsServer.Close() }()
-
-	// Wait for tsnet Running — get our 100.x.x.x address.
-	fmt.Fprintln(os.Stderr, "clawpatrol: joining tailnet...")
-	tsIP, err := waitTsnetUp(tsServer)
-	if err != nil {
-		fail("tsnet join: %v", err)
+		fail("daemon START: %v", err)
 	}
 	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
+	applyEnvPushdownVars(envVars)
 
-	// Route every outbound dial on this tsnet node through the gateway
-	// as an exit node. The gateway picks the traffic up via
-	// RegisterFallbackTCPHandler (TCP) and its tsnet :53 UDP listener
-	// (DNS), recovering the original dst from tsnet's exit-node
-	// machinery rather than a smuggled PROXY-v1 header.
-	if err := setGatewayExitNode(tsServer, gwIP); err != nil {
-		fail("tsnet set exit-node %s: %v", gwIP, err)
-	}
-
-	// Peer-API calls (register, env-pushdown) are tailnet-only — dial via
-	// tsnet so requests reach the gateway's 100.x address from the parent
-	// process (which is on host network, not tailnet).
-	tailnetAPI := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-url")))
-	if tailnetAPI == "" {
-		tailnetAPI = gwURL
-	}
-	tsClient := tsnetHTTPClient(tsServer, filepath.Join(dir, "ca.crt"))
-	gatewayDialOverride = tsServer.Dial
-
-	// Register ephemeral tsnet IP with gateway so profile dispatch uses
-	// the right credentials (same as ephemeral WG peer registration).
-	if rerr := registerEphemeralTsnetIP(tsClient, tailnetAPI, token, tsIP.String()); rerr != nil {
-		fmt.Fprintf(os.Stderr, "warning: tsnet profile registration: %v (will use default profile)\n", rerr)
-	}
-
-	// Fetch env-pushdown now that we're on the tailnet.
-	applyEnvPushdown(dir)
-
-	// 3. IPC channels: TUN fd handoff + wg-up pipe (same plumbing as WG mode).
+	// 3. IPC channels for the child: TUN fd handoff + wg-up pipe
+	// (same plumbing as WG mode).
 	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
 		fail("socketpair: %v", err)
@@ -221,21 +157,34 @@ func runRunTsnet(args []string) {
 		_ = child.Process.Kill()
 		fail("recv tun fd: %v", err)
 	}
-	tunFile := os.NewFile(uintptr(tunFd), tunIfName)
 
-	// 6. Build gVisor stack on the TUN fd.
-	gvStack, gvEp, err := newTsnetRunStack(tsIP)
+	// 6. Hand the TUN fd off to the daemon. .File() dups the underlying
+	// fd so we keep ctrl usable for the ATTACHED reply + the
+	// session-close idle keep-alive; close the duped fd as soon as
+	// SCM_RIGHTS goes out.
+	uc, ok := ctrl.(*net.UnixConn)
+	if !ok {
+		_ = child.Process.Kill()
+		fail("control conn: unexpected type %T", ctrl)
+	}
+	ctrlFile, err := uc.File()
 	if err != nil {
 		_ = child.Process.Kill()
-		fail("gvisor stack: %v", err)
+		fail("control conn file: %v", err)
 	}
-	defer gvStack.Close()
-	startTunBridge(tunFile, gvEp, tsServer)
+	if err := sendFD(ctrlFile, tunFd); err != nil {
+		_ = ctrlFile.Close()
+		_ = child.Process.Kill()
+		fail("send tun fd to daemon: %v", err)
+	}
+	_ = ctrlFile.Close()
+	_ = unix.Close(tunFd)
 
-	// 7. TCP forwarder: every connection → tsnet (exit-node-routed
-	// through the gateway). The gateway recovers the original dst via
-	// its RegisterFallbackTCPHandler.
-	enableTsnetTCPForwarder(gvStack, tsServer)
+	// 7. Wait for ATTACHED.
+	if err := daemonClientWaitAttached(ctrl); err != nil {
+		_ = child.Process.Kill()
+		fail("daemon ATTACHED: %v", err)
+	}
 
 	// 8. Signal child: bridge is up.
 	_, _ = wgUpW.Write([]byte{1})
@@ -274,6 +223,9 @@ func runRunTsnet(args []string) {
 		_, _ = relaySup.Process.Wait()
 	}
 
+	// Closing ctrl (via the deferred Close) tears the session down on
+	// the daemon side.
+
 	if waitErr != nil {
 		var ee *exec.ExitError
 		if errors.As(waitErr, &ee) {
@@ -281,6 +233,67 @@ func runRunTsnet(args []string) {
 		}
 		fail("wait: %v", waitErr)
 	}
+}
+
+// daemonClientStartSession sends "START\n" on ctrl and parses the
+// daemon's reply (tsnet IP + env-pushdown JSON length + JSON body).
+func daemonClientStartSession(ctrl net.Conn) (netip.Addr, []pushdownEnvVar, error) {
+	if _, err := io.WriteString(ctrl, "START\n"); err != nil {
+		return netip.Addr{}, nil, err
+	}
+	br := bufio.NewReader(ctrl)
+	tsipLine, err := br.ReadString('\n')
+	if err != nil {
+		return netip.Addr{}, nil, fmt.Errorf("read TSIP: %w", err)
+	}
+	tsipLine = strings.TrimRight(tsipLine, "\r\n")
+	if !strings.HasPrefix(tsipLine, "TSIP ") {
+		return netip.Addr{}, nil, fmt.Errorf("expected TSIP, got %q", tsipLine)
+	}
+	tsIP, err := netip.ParseAddr(strings.TrimSpace(tsipLine[len("TSIP "):]))
+	if err != nil {
+		return netip.Addr{}, nil, fmt.Errorf("parse TSIP: %w", err)
+	}
+	envLine, err := br.ReadString('\n')
+	if err != nil {
+		return netip.Addr{}, nil, fmt.Errorf("read ENV: %w", err)
+	}
+	envLine = strings.TrimRight(envLine, "\r\n")
+	if !strings.HasPrefix(envLine, "ENV ") {
+		return netip.Addr{}, nil, fmt.Errorf("expected ENV, got %q", envLine)
+	}
+	var n int
+	if _, err := fmt.Sscanf(envLine[len("ENV "):], "%d", &n); err != nil {
+		return netip.Addr{}, nil, fmt.Errorf("parse ENV length: %w", err)
+	}
+	if n < 0 || n > 1<<20 {
+		return netip.Addr{}, nil, fmt.Errorf("ENV length %d out of range", n)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(br, body); err != nil {
+		return netip.Addr{}, nil, fmt.Errorf("read ENV body: %w", err)
+	}
+	var vars []pushdownEnvVar
+	if n > 0 {
+		if err := json.Unmarshal(body, &vars); err != nil {
+			return netip.Addr{}, nil, fmt.Errorf("decode ENV body: %w", err)
+		}
+	}
+	return tsIP, vars, nil
+}
+
+func daemonClientWaitAttached(ctrl net.Conn) error {
+	_ = ctrl.SetReadDeadline(time.Now().Add(5 * time.Second))
+	defer func() { _ = ctrl.SetReadDeadline(time.Time{}) }()
+	br := bufio.NewReader(ctrl)
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if strings.TrimRight(line, "\r\n") != "ATTACHED" {
+		return fmt.Errorf("expected ATTACHED, got %q", line)
+	}
+	return nil
 }
 
 // runRunTsnetChild runs inside the new user+net+mnt namespace.

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -100,7 +101,19 @@ func runRunTsnet(args []string) {
 		fmt.Fprintf(os.Stderr, "clawpatrol: daemon: %s\n", daemonWarn)
 	}
 	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
-	applyEnvPushdownVars(envVars)
+
+	// envVars from the daemon are only the gateway-fetched
+	// push-down vars — the daemon doesn't know the client's
+	// filesystem layout, so the CA-bundle vars (SSL_CERT_FILE,
+	// NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE,
+	// GIT_SSL_CAINFO, DENO_CERT, PIP_CERT) have to be added here.
+	// Without these, the wrapped agent's HTTPS client (python
+	// requests, node fetch, etc.) skips our MITM CA, sees the
+	// gateway's mint as untrusted, and either fails the handshake
+	// or falls back to its own bundle (which doesn't have our CA).
+	caPath := filepath.Join(defaultClawpatrolDir(), "ca.crt")
+	allVars := append(caPathPushdownVars(caPath), envVars...)
+	applyEnvPushdownVars(allVars)
 
 	// 3. IPC channels for the child: TUN fd handoff + wg-up pipe
 	// (same plumbing as WG mode).

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -36,7 +36,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -346,30 +345,12 @@ func runRunTsnetChild() {
 		_ = bindResolv("nameserver 1.1.1.1\nnameserver 8.8.8.8\n")
 	}
 
-	// Mask ~/.clawpatrol/ from the agent's view. The dir holds two
-	// parent-only bearer secrets — tsnet-auth-key (lets any process
-	// join the tailnet under tag:client) and api-token (gates the
-	// gateway peer API). The agent never needs either: parent already
-	// fetched env-pushdown and registered the ephemeral peer before
-	// fork. Only ca.crt is required downstream (NODE_EXTRA_CA_CERTS /
-	// REQUESTS_CA_BUNDLE / SSL_CERT_FILE all point at it), so we
-	// re-create it inside an empty tmpfs that overlays the real dir
-	// for this mnt ns only — the parent's view is untouched.
-	//
-	// Effect: an agent inside `clawpatrol run` can read its own env
-	// vars and ca.crt but cannot exfiltrate the tsnet auth key to
-	// another machine. The host-side bearer is bound to "code running
-	// on this physical machine," not "anyone who copies the file."
-	clawDir := defaultClawpatrolDir()
-	caBytes, _ := os.ReadFile(filepath.Join(clawDir, "ca.crt"))
-	if err := unix.Mount("tmpfs", clawDir, "tmpfs", 0, "mode=0755"); err != nil {
-		fail("mask clawpatrol dir: %v", err)
-	}
-	if len(caBytes) > 0 {
-		if err := os.WriteFile(filepath.Join(clawDir, "ca.crt"), caBytes, 0o644); err != nil {
-			fail("rewrite ca.crt in masked dir: %v", err)
-		}
-	}
+	// The agent runs as the same uid as the parent and can therefore
+	// read anything the parent can; the daemon owns the tsnet auth
+	// key (stored under $XDG_STATE_HOME/clawpatrol/) and never hands
+	// it back. PR_SET_DUMPABLE in the parent still closes the
+	// ptrace_scope=0 /proc memory bypass; nothing else is hidden from
+	// the agent at this layer.
 
 	autoExpose := os.Getenv(runNoAutoExposeEnv) != "1"
 	if autoExpose {

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -163,26 +163,21 @@ func runRunTsnet(args []string) {
 		fail("recv tun fd: %v", err)
 	}
 
-	// 6. Hand the TUN fd off to the daemon. .File() dups the underlying
-	// fd so we keep ctrl usable for the ATTACHED reply + the
-	// session-close idle keep-alive; close the duped fd as soon as
-	// SCM_RIGHTS goes out.
+	// 6. Hand the TUN fd off to the daemon over the control conn via
+	// WriteMsgUnix. Going through .File() + unix.Sendmsg would dup
+	// the fd, and on Linux that clears O_NONBLOCK on the underlying
+	// file description (shared across dups) — leaving the conn in
+	// blocking mode and stranding the runtime poller on the next
+	// read. WriteMsgUnix handles SCM_RIGHTS natively, no dup.
 	uc, ok := ctrl.(*net.UnixConn)
 	if !ok {
 		_ = child.Process.Kill()
 		fail("control conn: unexpected type %T", ctrl)
 	}
-	ctrlFile, err := uc.File()
-	if err != nil {
-		_ = child.Process.Kill()
-		fail("control conn file: %v", err)
-	}
-	if err := sendFD(ctrlFile, tunFd); err != nil {
-		_ = ctrlFile.Close()
+	if err := sendFDUnixConn(uc, tunFd); err != nil {
 		_ = child.Process.Kill()
 		fail("send tun fd to daemon: %v", err)
 	}
-	_ = ctrlFile.Close()
 	_ = unix.Close(tunFd)
 
 	// 7. Wait for ATTACHED.

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -87,11 +87,17 @@ func runRunTsnet(args []string) {
 	}
 	defer func() { _ = ctrl.Close() }()
 
-	// 2. Ask for a session. Daemon replies with its tsnet IP plus the
-	// cached env-pushdown JSON. Apply both locally before forking.
-	tsIP, envVars, err := daemonClientStartSession(ctrl)
+	// 2. Ask for a session. Daemon replies with its tsnet IP, the
+	// cached env-pushdown JSON, and (when applicable) a one-line
+	// boot warning the smoke-probe generated — surface that on
+	// stderr so operators see the message without tailing the
+	// daemon log.
+	br, tsIP, envVars, daemonWarn, err := daemonClientStartSession(ctrl)
 	if err != nil {
 		fail("daemon START: %v", err)
+	}
+	if daemonWarn != "" {
+		fmt.Fprintf(os.Stderr, "clawpatrol: daemon: %s\n", daemonWarn)
 	}
 	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
 	applyEnvPushdownVars(envVars)
@@ -180,7 +186,7 @@ func runRunTsnet(args []string) {
 	_ = unix.Close(tunFd)
 
 	// 7. Wait for ATTACHED.
-	if err := daemonClientWaitAttached(ctrl); err != nil {
+	if err := daemonClientWaitAttached(ctrl, br); err != nil {
 		_ = child.Process.Kill()
 		fail("daemon ATTACHED: %v", err)
 	}
@@ -235,56 +241,82 @@ func runRunTsnet(args []string) {
 }
 
 // daemonClientStartSession sends "START\n" on ctrl and parses the
-// daemon's reply (tsnet IP + env-pushdown JSON length + JSON body).
-func daemonClientStartSession(ctrl net.Conn) (netip.Addr, []pushdownEnvVar, error) {
+// daemon's reply: TSIP line, ENV length + JSON body, WARN length +
+// optional text. The single bufio.Reader is returned to the caller
+// so subsequent reads (e.g. ATTACHED) share the same buffer — using
+// a fresh bufio.Reader for later reads would lose any bytes that
+// got pulled into this one's buffer during the WARN read.
+func daemonClientStartSession(ctrl net.Conn) (*bufio.Reader, netip.Addr, []pushdownEnvVar, string, error) {
 	if _, err := io.WriteString(ctrl, "START\n"); err != nil {
-		return netip.Addr{}, nil, err
+		return nil, netip.Addr{}, nil, "", err
 	}
 	br := bufio.NewReader(ctrl)
 	tsipLine, err := br.ReadString('\n')
 	if err != nil {
-		return netip.Addr{}, nil, fmt.Errorf("read TSIP: %w", err)
+		return nil, netip.Addr{}, nil, "", fmt.Errorf("read TSIP: %w", err)
 	}
 	tsipLine = strings.TrimRight(tsipLine, "\r\n")
 	if !strings.HasPrefix(tsipLine, "TSIP ") {
-		return netip.Addr{}, nil, fmt.Errorf("expected TSIP, got %q", tsipLine)
+		return nil, netip.Addr{}, nil, "", fmt.Errorf("expected TSIP, got %q", tsipLine)
 	}
 	tsIP, err := netip.ParseAddr(strings.TrimSpace(tsipLine[len("TSIP "):]))
 	if err != nil {
-		return netip.Addr{}, nil, fmt.Errorf("parse TSIP: %w", err)
+		return nil, netip.Addr{}, nil, "", fmt.Errorf("parse TSIP: %w", err)
 	}
-	envLine, err := br.ReadString('\n')
+	envLen, err := readLenPrefixed(br, "ENV", 1<<20)
 	if err != nil {
-		return netip.Addr{}, nil, fmt.Errorf("read ENV: %w", err)
+		return nil, netip.Addr{}, nil, "", err
 	}
-	envLine = strings.TrimRight(envLine, "\r\n")
-	if !strings.HasPrefix(envLine, "ENV ") {
-		return netip.Addr{}, nil, fmt.Errorf("expected ENV, got %q", envLine)
-	}
-	var n int
-	if _, err := fmt.Sscanf(envLine[len("ENV "):], "%d", &n); err != nil {
-		return netip.Addr{}, nil, fmt.Errorf("parse ENV length: %w", err)
-	}
-	if n < 0 || n > 1<<20 {
-		return netip.Addr{}, nil, fmt.Errorf("ENV length %d out of range", n)
-	}
-	body := make([]byte, n)
-	if _, err := io.ReadFull(br, body); err != nil {
-		return netip.Addr{}, nil, fmt.Errorf("read ENV body: %w", err)
+	envBody := make([]byte, envLen)
+	if _, err := io.ReadFull(br, envBody); err != nil {
+		return nil, netip.Addr{}, nil, "", fmt.Errorf("read ENV body: %w", err)
 	}
 	var vars []pushdownEnvVar
-	if n > 0 {
-		if err := json.Unmarshal(body, &vars); err != nil {
-			return netip.Addr{}, nil, fmt.Errorf("decode ENV body: %w", err)
+	if envLen > 0 {
+		if err := json.Unmarshal(envBody, &vars); err != nil {
+			return nil, netip.Addr{}, nil, "", fmt.Errorf("decode ENV body: %w", err)
 		}
 	}
-	return tsIP, vars, nil
+	warnLen, err := readLenPrefixed(br, "WARN", 4096)
+	if err != nil {
+		return nil, netip.Addr{}, nil, "", err
+	}
+	var warning string
+	if warnLen > 0 {
+		buf := make([]byte, warnLen)
+		if _, err := io.ReadFull(br, buf); err != nil {
+			return nil, netip.Addr{}, nil, "", fmt.Errorf("read WARN body: %w", err)
+		}
+		warning = string(buf)
+	}
+	return br, tsIP, vars, warning, nil
 }
 
-func daemonClientWaitAttached(ctrl net.Conn) error {
+// readLenPrefixed reads a "<tag> <n>\n" line and returns n. Errors
+// when the tag doesn't match or n is outside [0, maxLen].
+func readLenPrefixed(br *bufio.Reader, tag string, maxLen int) (int, error) {
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", tag, err)
+	}
+	line = strings.TrimRight(line, "\r\n")
+	prefix := tag + " "
+	if !strings.HasPrefix(line, prefix) {
+		return 0, fmt.Errorf("expected %s, got %q", tag, line)
+	}
+	var n int
+	if _, err := fmt.Sscanf(line[len(prefix):], "%d", &n); err != nil {
+		return 0, fmt.Errorf("parse %s length: %w", tag, err)
+	}
+	if n < 0 || n > maxLen {
+		return 0, fmt.Errorf("%s length %d out of range", tag, n)
+	}
+	return n, nil
+}
+
+func daemonClientWaitAttached(ctrl net.Conn, br *bufio.Reader) error {
 	_ = ctrl.SetReadDeadline(time.Now().Add(5 * time.Second))
 	defer func() { _ = ctrl.SetReadDeadline(time.Time{}) }()
-	br := bufio.NewReader(ctrl)
 	line, err := br.ReadString('\n')
 	if err != nil {
 		return err

--- a/cmd/clawpatrol/run_tsnet_linux.go
+++ b/cmd/clawpatrol/run_tsnet_linux.go
@@ -16,15 +16,17 @@ package main
 //  1. Read persisted reusable+ephemeral auth_key from ~/.clawpatrol/.
 //  2. tsnet.Server{Ephemeral: true, Dir: MkdirTemp(...)} joins the
 //     gateway's tailnet under a fresh hostname.
-//  3. Register the new tailnet IP with the gateway — register handler
+//  3. EditPrefs(ExitNodeIP=gateway) so every outbound dial from this
+//     tsnet node is routed via the gateway. Original dst is recovered
+//     server-side by RegisterFallbackTCPHandler — no PROXY-header
+//     smuggling required.
+//  4. Register the new tailnet IP with the gateway — register handler
 //     attributes traffic back to the parent device via
 //     ephemeralParentByIP so the dashboard shows ONE row per machine.
-//  4. Child in a new user+net+mnt ns creates the TUN, sends fd via
+//  5. Child in a new user+net+mnt ns creates the TUN, sends fd via
 //     SCM_RIGHTS.
-//  5. gVisor TCP forwarder dials gateway via tsnet + HAProxy PROXY v1
-//     header carrying original src/dst/ports.
-//  6. Gateway recovers original dst from the PROXY header and
-//     dispatches like WireGuard / exit-node paths.
+//  6. gVisor TCP forwarder dials the original destination via tsnet
+//     (which is exit-node-routed through the gateway).
 
 import (
 	"context"
@@ -86,24 +88,22 @@ func runRunTsnet(args []string) {
 	// tailnet-only, can't be fetched until we're on the tailnet.
 
 	gwURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway")))
-	gwHost := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway")))
 	controlURL := strings.TrimSpace(readFileSilent(filepath.Join(dir, "control-url")))
 	token := strings.TrimSpace(readFileSilent(filepath.Join(dir, "api-token")))
 	authKey := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tsnet-auth-key")))
-	if gwHost == "" {
-		gwHost = "clawpatrol-gateway"
-	}
+	gwIPStr := strings.TrimSpace(readFileSilent(filepath.Join(dir, "tailnet-gateway-ip")))
 	if gwURL == "" || token == "" {
 		fail("tsnet run: missing gateway url or api-token in %s", dir)
 	}
 	if authKey == "" {
 		fail("tsnet run: missing tsnet-auth-key in %s (re-run `clawpatrol join`)", dir)
 	}
-	// Gateway agent port (where the MITM listener lives). Tsnet Funnel
-	// owns :443, so the listener is typically :8443. Persisted at join.
-	gwPort := strings.TrimSpace(readFileSilent(filepath.Join(dir, "gateway-port")))
-	if gwPort == "" {
-		gwPort = "443"
+	if gwIPStr == "" {
+		fail("tsnet run: missing tailnet-gateway-ip in %s (re-run `clawpatrol join`)", dir)
+	}
+	gwIP, err := netip.ParseAddr(gwIPStr)
+	if err != nil {
+		fail("tsnet run: tailnet-gateway-ip %q: %v", gwIPStr, err)
 	}
 
 	// 2. Spin up an ephemeral tsnet.Server per invocation. tmpdir state
@@ -133,6 +133,15 @@ func runRunTsnet(args []string) {
 		fail("tsnet join: %v", err)
 	}
 	_ = os.Setenv("CLAWPATROL_TS_ADDR", tsIP.String())
+
+	// Route every outbound dial on this tsnet node through the gateway
+	// as an exit node. The gateway picks the traffic up via
+	// RegisterFallbackTCPHandler (TCP) and its tsnet :53 UDP listener
+	// (DNS), recovering the original dst from tsnet's exit-node
+	// machinery rather than a smuggled PROXY-v1 header.
+	if err := setGatewayExitNode(tsServer, gwIP); err != nil {
+		fail("tsnet set exit-node %s: %v", gwIP, err)
+	}
 
 	// Peer-API calls (register, env-pushdown) are tailnet-only — dial via
 	// tsnet so requests reach the gateway's 100.x address from the parent
@@ -223,10 +232,10 @@ func runRunTsnet(args []string) {
 	defer gvStack.Close()
 	startTunBridge(tunFile, gvEp, tsServer)
 
-	// 7. TCP forwarder: every connection → tsnet → gateway.
-	// We forward to gwHost:originalPort so the gateway can route by port
-	// (port 443 → HTTPS MITM; other ports forwarded if gateway listens).
-	enableTsnetTCPForwarder(gvStack, tsServer, gwHost, gwPort)
+	// 7. TCP forwarder: every connection → tsnet (exit-node-routed
+	// through the gateway). The gateway recovers the original dst via
+	// its RegisterFallbackTCPHandler.
+	enableTsnetTCPForwarder(gvStack, tsServer)
 
 	// 8. Signal child: bridge is up.
 	_, _ = wgUpW.Write([]byte{1})
@@ -594,26 +603,15 @@ func ipv4Checksum(b []byte) uint16 {
 }
 
 // enableTsnetTCPForwarder installs a promiscuous TCP forwarder on s.
-// Every connection dials the gateway via tsnet and prepends a HAProxy
-// PROXY v1 header carrying the original 4-tuple. The gateway recovers
-// the original dst from the PROXY header and dispatches via the same
-// path as WireGuard and whole-machine exit-node clients.
-//
-// Why PROXY (vs. relying on tsnet exit-node routing): using the gateway
-// as a tsnet exit node would work but requires the operator to enable
-// the gateway's advertised exit-route in the Tailscale admin console
-// for every client tag — extra config we don't want to require.
-// Peer-to-peer dial + PROXY header keeps the setup self-contained.
-func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost, gwPort string) {
-	gwAddr := net.JoinHostPort(gwHost, gwPort)
+// Every connection dials the original destination via tsnet. The
+// tsnet node has been configured with ExitNodeIP=<gateway> upstream,
+// so this dial transparently routes through the gateway, where it
+// lands in RegisterFallbackTCPHandler with the original dst intact.
+func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server) {
 	fwd := tcp.NewForwarder(s, 1<<20, 16384, func(req *tcp.ForwarderRequest) {
 		id := req.ID()
-		// Format IPs via .String() — tcpip.Address used with %s prints
-		// the raw bytes (binary garbage), making the PROXY header
-		// unparseable. String() returns dotted-decimal for IPv4.
-		proxyHdr := fmt.Sprintf("PROXY TCP4 %s %s %d %d\r\n",
-			id.RemoteAddress.String(), id.LocalAddress.String(),
-			id.RemotePort, id.LocalPort)
+		dstAddr := net.JoinHostPort(id.LocalAddress.String(),
+			fmt.Sprintf("%d", id.LocalPort))
 
 		var wq waiter.Queue
 		ep, err := req.CreateEndpoint(&wq)
@@ -626,14 +624,11 @@ func enableTsnetTCPForwarder(s *stack.Stack, ts *tsnet.Server, gwHost, gwPort st
 		go func() {
 			defer func() { _ = local.Close() }()
 			ctx := context.Background()
-			remote, err := ts.Dial(ctx, "tcp", gwAddr)
+			remote, err := ts.Dial(ctx, "tcp", dstAddr)
 			if err != nil {
 				return
 			}
 			defer func() { _ = remote.Close() }()
-			if _, err := io.WriteString(remote, proxyHdr); err != nil {
-				return
-			}
 			tsnetBiRelay(local, remote)
 		}()
 	})

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -216,14 +216,23 @@ func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
 // only after the operator's dashboard approval has confirmed the
 // CA fingerprint matches — so the CA we install can't be one
 // substituted by an on-path attacker at fetch time.
-func finishJoinSetup(s *joinSetup, skipTrust bool) {
+//
+// installShellRC fires only in --whole-machine mode. In
+// per-process mode every agent picks up CA + push-down vars
+// through `clawpatrol run`, so the shell-rc shim is dead weight
+// — and worse, the `clawpatrol env` it eval's on every new
+// terminal would dial the gateway's tailnet IP, which the
+// parent shell can't reach (only the NE can).
+func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine bool) {
 	if s.caPath == "" {
 		return
 	}
 	if _, err := os.Stat(s.caPath); err != nil {
 		// CA not fetched yet (Tailscale mode defers to runLogin). Skip
 		// trust install; runLogin will fetch + install from the tailnet.
-		installShellRC() //nolint:errcheck
+		if wholeMachine {
+			installShellRC() //nolint:errcheck
+		}
 		return
 	}
 	if !skipTrust {
@@ -235,8 +244,10 @@ func finishJoinSetup(s *joinSetup, skipTrust bool) {
 	} else {
 		s.caHint = manualTrustHint(s.caPath)
 	}
-	if err := installShellRC(); err == nil {
-		s.shellRC = true
+	if wholeMachine {
+		if err := installShellRC(); err == nil {
+			s.shellRC = true
+		}
 	}
 }
 
@@ -991,7 +1002,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	// into the system trust store. Doing this earlier would
 	// have meant trusting a CA the operator hadn't vouched
 	// for, which is exactly the on-path attack we're closing.
-	finishJoinSetup(setup, skipTrust)
+	finishJoinSetup(setup, skipTrust, wholeMachine)
 	// Persist the per-peer bearer the gateway minted alongside the
 	// wg conf. Lives next to ca.crt — same dir the env-pushdown
 	// fetcher reads. Best-effort; missing file means env-pushdown
@@ -1285,8 +1296,10 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			}
 		}
 	}
-	if err := installShellRC(); err == nil {
-		setup.shellRC = true
+	if wholeMachine {
+		if err := installShellRC(); err == nil {
+			setup.shellRC = true
+		}
 	}
 
 	items := []string{"Joined tailnet as " + tailIP}

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -720,6 +720,21 @@ func defaultClawpatrolDir() string {
 	return filepath.Join(home, ".clawpatrol")
 }
 
+// daemonStateDir returns the per-user **persistent** directory for
+// daemon-only state (auth-key, future daemon-private files). XDG
+// spec: $XDG_STATE_HOME/clawpatrol, fall back to
+// ~/.local/state/clawpatrol when unset. Separate from
+// defaultClawpatrolDir so that the agent-visible ~/.clawpatrol/
+// directory only holds files the agent legitimately needs (ca.crt,
+// mode marker, etc.).
+func daemonStateDir() string {
+	if d := os.Getenv("XDG_STATE_HOME"); d != "" {
+		return filepath.Join(d, "clawpatrol")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state", "clawpatrol")
+}
+
 // readFileSilent reads a file and returns its contents as a string,
 // or empty on any error.
 func readFileSilent(path string) string {
@@ -1117,18 +1132,13 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		//
 		// macOS: hand the key directly to the NE extension via
 		// NETransparentProxyManager's providerConfiguration (system-
-		// owned VPN preferences storage). The user-side CLI does not
-		// keep a copy on disk, so an agent inside `clawpatrol run`
-		// cannot read it back from $HOME. Subsequent runs invoke
-		// `start-tsnet` with an empty authKey arg; the container app
-		// reads the stored value from existing preferences.
+		// owned VPN preferences storage). The user-side CLI never
+		// holds the bearer on disk.
 		//
-		// Linux: parent process reads the file at each `clawpatrol run`
-		// and spins up its own tsnet.Server. The child mnt namespace
-		// overlays an empty tmpfs on ~/.clawpatrol/ before exec'ing
-		// the agent (see run_tsnet_linux.go), so the agent still can't
-		// read the key — same machine-binding property as macOS, just
-		// enforced by mount-ns isolation instead of NE storage.
+		// Linux: write to the daemon's persistent state directory
+		// (separate from ~/.clawpatrol, which holds agent-visible
+		// files like ca.crt). The clawpatrol daemon is the sole
+		// reader.
 		if runtime.GOOS == "darwin" {
 			c := exec.Command(macHelperPath, "start-tsnet",
 				authKey, tailnetControlURL, tailnetGWHost, gatewayIP, apiToken, hn)
@@ -1137,7 +1147,11 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				return false, fmt.Errorf("macHelper start-tsnet: %w", err)
 			}
 		} else {
-			_ = os.WriteFile(filepath.Join(clawDir, "tsnet-auth-key"), []byte(authKey+"\n"), 0o600)
+			stateDir := daemonStateDir()
+			if err := os.MkdirAll(stateDir, 0o700); err != nil {
+				return false, fmt.Errorf("daemon state dir: %w", err)
+			}
+			_ = os.WriteFile(filepath.Join(stateDir, "auth-key"), []byte(authKey+"\n"), 0o600)
 		}
 		items := []string{"Joined (tsnet mode — ephemeral node joins tailnet at run time)"}
 		items = append(items, setupSummaryItems(*setup)...)

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -940,7 +940,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	stopSpin := startSpinner("Waiting for approval")
 	authKey, loginServer, apiToken := "", "", ""
-	var tailnetGWHost, tailnetControlURL, gatewayIP, gatewayPort, caPEM string
+	var tailnetGWHost, tailnetControlURL, gatewayIP, caPEM string
 	for time.Now().Before(deadline) {
 		time.Sleep(interval)
 		pr, err := cli.Post(gateway+"/api/onboard/poll?device_code="+start.DeviceCode, "application/json", nil)
@@ -957,7 +957,6 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			tailnetGWHost = pv["gateway_host"]
 			tailnetControlURL = pv["control_url"]
 			gatewayIP = pv["gateway_ip"]
-			gatewayPort = pv["gateway_port"]
 			caPEM = pv["ca_pem"]
 			break
 		}
@@ -1109,6 +1108,10 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		if gatewayIP != "" {
 			tailnetURL := fmt.Sprintf("http://%s:8080", gatewayIP)
 			_ = os.WriteFile(filepath.Join(clawDir, "tailnet-url"), []byte(tailnetURL+"\n"), 0o600)
+			// Used by `clawpatrol run` to set the gateway as its tsnet
+			// exit node so the gateway sees the original dst via
+			// RegisterFallbackTCPHandler (no PROXY-header smuggling).
+			_ = os.WriteFile(filepath.Join(clawDir, "tailnet-gateway-ip"), []byte(gatewayIP+"\n"), 0o600)
 		}
 		// tsnet auth-key persistence — platform split.
 		//
@@ -1128,16 +1131,13 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		// enforced by mount-ns isolation instead of NE storage.
 		if runtime.GOOS == "darwin" {
 			c := exec.Command(macHelperPath, "start-tsnet",
-				authKey, tailnetControlURL, tailnetGWHost, gatewayPort, apiToken, hn)
+				authKey, tailnetControlURL, tailnetGWHost, gatewayIP, apiToken, hn)
 			c.Stdout, c.Stderr = os.Stdout, os.Stderr
 			if err := c.Run(); err != nil {
 				return false, fmt.Errorf("macHelper start-tsnet: %w", err)
 			}
 		} else {
 			_ = os.WriteFile(filepath.Join(clawDir, "tsnet-auth-key"), []byte(authKey+"\n"), 0o600)
-		}
-		if gatewayPort != "" {
-			_ = os.WriteFile(filepath.Join(clawDir, "gateway-port"), []byte(gatewayPort+"\n"), 0o600)
 		}
 		items := []string{"Joined (tsnet mode — ephemeral node joins tailnet at run time)"}
 		items = append(items, setupSummaryItems(*setup)...)
@@ -1253,6 +1253,8 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				// is the gateway's InfoListen (plain HTTP on the tailnet).
 				tailnetURL := fmt.Sprintf("http://%s:8080", peer.TailscaleIPs[0])
 				_ = os.WriteFile(filepath.Join(clawDir, "tailnet-url"), []byte(tailnetURL+"\n"), 0o600)
+				_ = os.WriteFile(filepath.Join(clawDir, "tailnet-gateway-ip"),
+					[]byte(peer.TailscaleIPs[0]+"\n"), 0o600)
 				if _, serr := os.Stat(setup.caPath); serr != nil {
 					if ferr := fetchCA(peer.TailscaleIPs[0], setup.caPath); ferr == nil {
 						if !skipTrust {

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -62,8 +62,9 @@ func gatewayTsnetDir(stateDir string) (string, error) {
 //
 // Tailscale control mode: always uses an embedded tsnet.Server.
 // Requires authkey in HCL or TS_AUTHKEY env (no system tailscaled
-// needed). Returns the *tsnet.Server so the caller can register a
-// fallback TCP handler for whole-machine exit-node traffic.
+// needed). Returns the *tsnet.Server. All MITM traffic from tsnet
+// clients is intercepted via RegisterFallbackTCPHandler (set up by
+// runGateway), so we don't open a tailnet :443 listener here.
 //
 // WireGuard mode: returns nil server and a loopback TCP listener.
 func openListener(cfg *config.Gateway, stateDir string) (*tsnet.Server, net.Listener, error) {
@@ -103,19 +104,19 @@ func openListener(cfg *config.Gateway, stateDir string) (*tsnet.Server, net.List
 		ControlURL: cfg.ControlURL,
 		Dir:        dir,
 	}
-	_, portStr, _ := net.SplitHostPort(cfg.Listen)
-	if portStr == "" {
-		portStr = "443"
-	}
-	ln, err := s.Listen("tcp", ":"+portStr)
+	// Bring tsnet up. We don't need a tailnet TCP listener — exit-node
+	// routing delivers client conns straight to RegisterFallbackTCPHandler.
+	// Listen on a throwaway port to drive s.Up() since tsnet has no other
+	// public bring-up API and never exposes this listener to callers.
+	bringUp, err := s.Listen("tcp", ":0")
 	if err != nil {
 		return nil, nil, err
 	}
-	// Advertise exit routes so whole-machine clients can use this node
-	// as a Tailscale exit node. s.Up() completed inside s.Listen(), so
-	// LocalClient is available. Async to avoid blocking runGateway.
+	_ = bringUp.Close()
+	// Advertise exit routes so whole-machine and per-process tsnet
+	// clients can use this node as a Tailscale exit node.
 	go advertiseExitRoutes(s)
-	return s, ln, nil
+	return s, nil, nil
 }
 
 // startFunnelListener opens a Tailscale Funnel listener on :443 (internet

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -255,7 +255,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/ephemeral", Auth: authSelfAuthenticating, Handler: w.apiEphemeralPeer},
-		{Method: http.MethodPost, Path: "/api/peer/ephemeral/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiRegisterEphemeralTsnetIP},
+		{Method: http.MethodPost, Path: "/api/peer/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiPeerTsnetRegister},
 		// /__login is the auth point itself — it MUST be reachable
 		// without a credential. The handler dispatches on r.Method
 		// (GET renders the form, POST validates + mints a session
@@ -614,11 +614,23 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 			http.Error(rw, "tailnet access required — onboard via `clawpatrol join <gateway>`", http.StatusForbidden)
 			return
 		}
+		// Tagged-device whois (e.g. tag:client onboarded peers) returns
+		// "tagged-devices" rather than a user email. These callers are
+		// agents, not operators — they must never reach operator-class
+		// routes (/api/onboard/approve, /api/onboard/lookup) or the
+		// authDashboard routes. See issue #509: without this check, an
+		// attacker who got a copy of the persisted client auth key could
+		// join the tailnet as a fresh tag:client device, hit
+		// /api/onboard/approve with any policy profile, and mint a new
+		// auth key bound to it.
+		if isTaggedDeviceLogin(login) {
+			http.Error(rw, "operator-class routes are not available to tagged-device peers — set the dashboard password or sign in as an operator-tagged tailnet user", http.StatusForbidden)
+			return
+		}
 		// authDashboard routes require an explicit allowlist match.
 		// Without this check, any whois-attributable tailnet peer
-		// (including a tagged agent that managed to acquire a user
-		// login somehow) would inherit operator powers — exactly
-		// the threat the password gate above is closing.
+		// would inherit operator powers — exactly the threat the
+		// password gate above is closing.
 		if w.authRequirementForPath(r.URL.Path) == authDashboard {
 			if !config.MatchDashboardOperator(login, w.g.cfg.DashboardOperators) {
 				http.Error(rw, "dashboard operator allowlist did not match — set the dashboard password or add this login to dashboard_operators", http.StatusForbidden)
@@ -628,6 +640,16 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 		principal := principal{Kind: principalTailnet, Owner: login, User: login, Device: device, Host: displayHost}
 		next.ServeHTTP(rw, r.WithContext(contextWithPrincipal(r.Context(), principal)))
 	})
+}
+
+// isTaggedDeviceLogin reports whether a tsnet whois login string
+// belongs to a tagged device rather than a human-identified user.
+// Tailscale returns "tagged-devices" for the canonical case; nodes
+// associated with a specific tag (older tailnets, custom ACL) come
+// back as "tagged-<tagname>". Neither form should pass an operator
+// gate: the bearer is the tag, not a person.
+func isTaggedDeviceLogin(login string) bool {
+	return login == "tagged-devices" || strings.HasPrefix(login, "tagged-")
 }
 
 // mountCredentialWebhooks walks every credential whose body

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -614,26 +614,25 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 			http.Error(rw, "tailnet access required — onboard via `clawpatrol join <gateway>`", http.StatusForbidden)
 			return
 		}
-		// Tagged-device whois (e.g. tag:client onboarded peers) returns
-		// "tagged-devices" rather than a user email. These callers are
-		// agents, not operators — they must never reach operator-class
-		// routes (/api/onboard/approve, /api/onboard/lookup) or the
-		// authDashboard routes. See issue #509: without this check, an
-		// attacker who got a copy of the persisted client auth key could
-		// join the tailnet as a fresh tag:client device, hit
-		// /api/onboard/approve with any policy profile, and mint a new
-		// auth key bound to it.
-		if isTaggedDeviceLogin(login) {
-			http.Error(rw, "operator-class routes are not available to tagged-device peers — set the dashboard password or sign in as an operator-tagged tailnet user", http.StatusForbidden)
-			return
-		}
-		// authDashboard routes require an explicit allowlist match.
-		// Without this check, any whois-attributable tailnet peer
-		// would inherit operator powers — exactly the threat the
-		// password gate above is closing.
-		if w.authRequirementForPath(r.URL.Path) == authDashboard {
+		// Operator-class routes — approving onboarding devices, looking
+		// up pending user_codes, reading the dashboard via tailnet
+		// identity — must require an explicit dashboard_operators
+		// allowlist match for the tailnet identity path. Previously
+		// authTailnetOperator and authDashboardOrTailnetOperator
+		// accepted any non-empty whois, which let tag:client peers
+		// (whois == "tagged-devices") call /api/onboard/approve and
+		// mint fresh auth keys bound to arbitrary profiles — see
+		// issue #509. MatchDashboardOperator only accepts "user@domain"
+		// or "*@domain" entries, so "tagged-devices" and "tagged-*"
+		// stubs fail closed by construction.
+		//
+		// The dashboard-password path is unaffected: requests carrying
+		// a valid cp_session cookie have their principal injected by
+		// dashboardAuthGate upstream and short-circuit this gate at
+		// the principalFromContext check above.
+		if needsOperatorGate(w.authRequirementForPath(r.URL.Path)) {
 			if !config.MatchDashboardOperator(login, w.g.cfg.DashboardOperators) {
-				http.Error(rw, "dashboard operator allowlist did not match — set the dashboard password or add this login to dashboard_operators", http.StatusForbidden)
+				http.Error(rw, "operator routes require a dashboard password session or a tailnet login matching dashboard_operators", http.StatusForbidden)
 				return
 			}
 		}
@@ -642,14 +641,19 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 	})
 }
 
-// isTaggedDeviceLogin reports whether a tsnet whois login string
-// belongs to a tagged device rather than a human-identified user.
-// Tailscale returns "tagged-devices" for the canonical case; nodes
-// associated with a specific tag (older tailnets, custom ACL) come
-// back as "tagged-<tagname>". Neither form should pass an operator
-// gate: the bearer is the tag, not a person.
-func isTaggedDeviceLogin(login string) bool {
-	return login == "tagged-devices" || strings.HasPrefix(login, "tagged-")
+// needsOperatorGate reports whether req requires the caller to be an
+// operator — either a dashboard-password session or a tailnet login
+// matching dashboard_operators. Every non-public, non-self-auth
+// route is operator-class in the daemon-model gateway, because all
+// of them either expose internal state or accept profile-affecting
+// writes. The dashboard-password path is handled separately by
+// dashboardAuthGate; this only applies on the tailnet-identity path.
+func needsOperatorGate(req authRequirement) bool {
+	switch req {
+	case authDashboard, authTailnetOperator, authDashboardOrTailnetOperator:
+		return true
+	}
+	return false
 }
 
 // mountCredentialWebhooks walks every credential whose body

--- a/cmd/clawpatrol/web_auth_test.go
+++ b/cmd/clawpatrol/web_auth_test.go
@@ -276,8 +276,19 @@ func TestOnboardApproveWithDashboardPasswordInTailscaleModeDoesNotRequireTailnet
 	}
 }
 
-func TestOnboardApproveWithTailnetPrincipalInTailscaleModeDoesNotRequireDashboardPassword(t *testing.T) {
+// A tailnet operator whose login matches dashboard_operators can
+// reach /api/onboard/approve without a dashboard password — that's
+// the entire point of the operator allowlist. Reaching the handler
+// shows up as a 404 because the code "NOPE" doesn't exist.
+//
+// Pre-#509 these tests didn't configure DashboardOperators at all
+// and still expected the request to pass; that loose behavior let
+// any tailnet member (including tag:client whois "tagged-devices")
+// approve onboards. The fix requires an explicit allowlist match
+// on operator-class routes; the test config now reflects that.
+func TestOnboardApproveWithTailnetPrincipalInTailscaleModeReachesHandler(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
+	w.g.cfg.DashboardOperators = []string{"*@example.com"}
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -294,8 +305,9 @@ func TestOnboardApproveWithTailnetPrincipalInTailscaleModeDoesNotRequireDashboar
 	}
 }
 
-func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeDoesNotRequireDashboardPassword(t *testing.T) {
+func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeReachesHandler(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "")
+	w.g.cfg.DashboardOperators = []string{"*@example.com"}
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -309,6 +321,33 @@ func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeDoesNotRequireD
 	}
 	if !strings.Contains(rr.Body.String(), "unknown or expired code") {
 		t.Fatalf("body = %q, want onboard handler error", rr.Body.String())
+	}
+}
+
+// Counterpart to the previous two tests: a tailnet identity that
+// *doesn't* match dashboard_operators must be rejected on
+// /api/onboard/approve even though Tailscale control mode is
+// active. This is the #509 case — without this check, tag:client
+// peers (whois resolves to "tagged-devices") could approve their
+// own onboards.
+func TestOnboardApproveRejectsTailnetPrincipalNotInOperators(t *testing.T) {
+	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
+	w.g.cfg.DashboardOperators = []string{"*@example.com"}
+	h := w.handler()
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	// "tagged-devices" is the tsnet whois reply for a tag:client
+	// peer with no human identity attached.
+	req.Header.Set("Tailscale-User-Login", "tagged-devices")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body = %q", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "operator routes require") {
+		t.Fatalf("body = %q, want operator-gate error", rr.Body.String())
 	}
 }
 

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -60,6 +60,32 @@ public UDP port, no WireGuard keypair management, no subnet allocation
 | **Client command** | `clawpatrol login` | `clawpatrol join <gw-url>` |
 | **State** | `state_dir` — tsnet machine key + ipn state in sqlite | `state_dir` — WG server key, peer map, sessions in sqlite |
 
+## Required tailnet ACL
+
+Client traffic flows through the gateway by treating it as the
+client's tsnet **exit node**. The client side sets
+`ExitNodeIP=<gateway>` automatically; for that to actually route,
+the tailnet ACL must **auto-approve the gateway as an exit node
+for the client tag**. Without it, the pref is accepted locally
+but every outbound dial silently times out.
+
+Add to your tailnet ACL JSON:
+
+```jsonc
+{
+  "autoApprovers": {
+    "exitNode": ["tag:client"]    // must match tailscale_tags below
+  },
+  "tagOwners": {
+    "tag:client": ["autogroup:admin"]
+  }
+}
+```
+
+The gateway already advertises `0.0.0.0/0` + `::/0` via
+`advertiseExitRoutes`, so no operator action is needed in the
+Tailscale admin console — the ACL above is the whole prereq.
+
 ## Operator setup
 
 ```bash

--- a/macos/Clawpatrol/main.swift
+++ b/macos/Clawpatrol/main.swift
@@ -182,16 +182,21 @@ func saveProxyProfileAndExit(wholeMachine: Bool, explicit: Bool) {
         let proto = NETunnelProviderProtocol()
         proto.providerBundleIdentifier = extBundleID
         proto.serverAddress = "clawpatrol-gateway"
-        // Preserve any wg-conf already saved on the existing profile.
-        var wgConf = ""
+        // Carry forward every key from the existing providerConfiguration —
+        // wg-conf for WG mode, plus tsnet-auth-key / tsnet-control-url /
+        // tsnet-gateway-host / tsnet-gateway-ip / tsnet-api-token /
+        // tsnet-hostname for tailscale mode. `install` only owns `mode`;
+        // every other key flows in from `start` / `start-tsnet` and must
+        // survive a re-run of `install` (which `clawpatrol run` issues on
+        // every invocation to make sure the sysext is loaded).
+        var cfg: [String: Any] = [:]
         if let existingProto = existing?.protocolConfiguration as? NETunnelProviderProtocol,
-           let prevConf = existingProto.providerConfiguration?["wg-conf"] as? String {
-            wgConf = prevConf
+           let existingCfg = existingProto.providerConfiguration {
+            for (k, v) in existingCfg { cfg[k] = v }
         }
-        proto.providerConfiguration = [
-            "wg-conf": wgConf,
-            "mode": resolvedMode,
-        ]
+        if cfg["wg-conf"] == nil { cfg["wg-conf"] = "" }
+        cfg["mode"] = resolvedMode
+        proto.providerConfiguration = cfg
         manager.protocolConfiguration = proto
         manager.localizedDescription = proxyProfileName
         manager.isEnabled = true
@@ -207,7 +212,8 @@ func saveProxyProfileAndExit(wholeMachine: Bool, explicit: Bool) {
             let modeChanged = (prevMode ?? "") != resolvedMode
             let running = manager.connection.status == .connected
                 || manager.connection.status == .connecting
-            if modeChanged && running && !wgConf.isEmpty {
+            let hasWGConf = !((cfg["wg-conf"] as? String) ?? "").isEmpty
+            if modeChanged && running && hasWGConf {
                 reloadTunnelAndExit(manager: manager, label: resolvedMode)
             } else {
                 exit(0)

--- a/macos/Clawpatrol/main.swift
+++ b/macos/Clawpatrol/main.swift
@@ -41,14 +41,14 @@ case "start":
     guard CommandLine.arguments.count >= 3 else { usage() }
     startProxy(confPath: CommandLine.arguments[2])
 case "start-tsnet":
-    // args: authKey controlURL gwHost gwPort [token hostname]
+    // args: authKey controlURL gwHost gwIP [token hostname]
     guard CommandLine.arguments.count >= 6 else { usage() }
     let token = CommandLine.arguments.count >= 7 ? CommandLine.arguments[6] : ""
     let hostname = CommandLine.arguments.count >= 8 ? CommandLine.arguments[7] : ""
     startTsnetProxy(authKey: CommandLine.arguments[2],
                     controlURL: CommandLine.arguments[3],
                     gwHost: CommandLine.arguments[4],
-                    gwPort: CommandLine.arguments[5],
+                    gwIP: CommandLine.arguments[5],
                     token: token,
                     hostname: hostname)
 case "stop": stopProxy()
@@ -290,7 +290,7 @@ func startProxy(confPath: String) {
     }
 }
 
-func startTsnetProxy(authKey: String, controlURL: String, gwHost: String, gwPort: String, token: String, hostname: String) {
+func startTsnetProxy(authKey: String, controlURL: String, gwHost: String, gwIP: String, token: String, hostname: String) {
     NETransparentProxyManager.loadAllFromPreferences { managers, err in
         if let err = err { fail("loadAll: \(err)") }
         let existing = managers?.first(where: { $0.localizedDescription == proxyProfileName })
@@ -320,7 +320,7 @@ func startTsnetProxy(authKey: String, controlURL: String, gwHost: String, gwPort
             "tsnet-auth-key": resolvedAuthKey,
             "tsnet-control-url": controlURL,
             "tsnet-gateway-host": gwHost,
-            "tsnet-gateway-port": gwPort,
+            "tsnet-gateway-ip": gwIP,
             "tsnet-api-token": token,
             "tsnet-hostname": hostname,
         ]

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -94,6 +94,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                             userInfo: [NSLocalizedDescriptionKey: "tsnet: \(msg)"]))
                         return
                     }
+                    setTsnetIPCConfig(gwHost: gwHost, token: token)
                     startSessionListener()
                     startSessionReaper()
                     self.applyNetworkSettings(completionHandler: completionHandler)
@@ -507,6 +508,28 @@ private func pidFromAuditToken(_ data: Data) -> pid_t? {
 // a local authz concern only the host's user controls anyway.
 let sessionSockPath = "/tmp/clawpatrol.sock"
 
+// tsnet-mode gateway hostname + per-peer api token. Mirror of the
+// providerConfiguration values, captured at startProxy time so the
+// session-IPC `getenv` handler (a free function) can pass them to
+// ts_netstack_fetch_env_pushdown without reaching into the provider
+// instance. Empty in WG mode.
+private var tsnetGwHostForIPC: String = ""
+private var tsnetApiTokenForIPC: String = ""
+private let tsnetIPCConfigLock = NSLock()
+
+private func setTsnetIPCConfig(gwHost: String, token: String) {
+    tsnetIPCConfigLock.lock()
+    tsnetGwHostForIPC = gwHost
+    tsnetApiTokenForIPC = token
+    tsnetIPCConfigLock.unlock()
+}
+
+private func tsnetIPCConfig() -> (gwHost: String, token: String) {
+    tsnetIPCConfigLock.lock()
+    defer { tsnetIPCConfigLock.unlock() }
+    return (tsnetGwHostForIPC, tsnetApiTokenForIPC)
+}
+
 private var sessionPidsSet: Set<pid_t> = []
 private let sessionPidsLock = NSLock()
 
@@ -632,6 +655,46 @@ private func serviceSessionClient(_ fd: Int32) {
                     ts_netstack_get_ip(p.baseAddress, Int32(p.count))
                 }
                 reply = rc == 0 ? "tsip \(String(cString: ipBuf))\n" : "err\n"
+            } else if parts.count == 1 && parts[0] == "getenv" {
+                // env-pushdown fetch routed through the extension's tsnet
+                // stack — the parent CLI has no tailnet route to the
+                // gateway's 100.x address and the /api/env-pushdown
+                // endpoint isn't Funnel-exposed. Wire format is
+                // length-prefixed: header "env <N>\n" followed by N raw
+                // bytes of JSON (binary-safe regardless of the body).
+                let cfg = tsnetIPCConfig()
+                if cfg.gwHost.isEmpty || cfg.token.isEmpty {
+                    reply = "err\n"
+                } else {
+                    let cap = 256 * 1024
+                    var body = [CChar](repeating: 0, count: cap)
+                    let n = cfg.gwHost.withCString { ghC in
+                        cfg.token.withCString { tkC in
+                            body.withUnsafeMutableBufferPointer { p in
+                                ts_netstack_fetch_env_pushdown(
+                                    UnsafeMutablePointer(mutating: ghC),
+                                    UnsafeMutablePointer(mutating: tkC),
+                                    p.baseAddress, Int32(p.count))
+                            }
+                        }
+                    }
+                    if n < 0 {
+                        reply = "err\n"
+                    } else {
+                        let header = "env \(n)\n"
+                        _ = header.withCString { cs in
+                            Darwin.write(fd, cs, strlen(cs))
+                        }
+                        _ = body.withUnsafeBufferPointer { p in
+                            p.baseAddress!.withMemoryRebound(
+                                to: UInt8.self, capacity: Int(n)
+                            ) { q in
+                                Darwin.write(fd, q, Int(n))
+                            }
+                        }
+                        reply = "" // body already written; skip the std write below
+                    }
+                }
             } else if parts.count == 2, let pid = pid_t(parts[1]) {
                 switch parts[0] {
                 case "register":   sessionRegister(pid);   reply = "ok\n"

--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -55,7 +55,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             guard let authKey = cfg["tsnet-auth-key"] as? String, !authKey.isEmpty,
                   let controlURL = cfg["tsnet-control-url"] as? String,
                   let gwHost = cfg["tsnet-gateway-host"] as? String, !gwHost.isEmpty,
-                  let gwPort = cfg["tsnet-gateway-port"] as? String, !gwPort.isEmpty else {
+                  let gwIP = cfg["tsnet-gateway-ip"] as? String, !gwIP.isEmpty else {
                 completionHandler(NSError(domain: "clawpatrol", code: 1,
                     userInfo: [NSLocalizedDescriptionKey: "missing tsnet config fields"]))
                 return
@@ -68,14 +68,14 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 let rc = authKey.withCString { akC in
                     controlURL.withCString { cuC in
                         gwHost.withCString { ghC in
-                            gwPort.withCString { gpC in
+                            gwIP.withCString { gipC in
                                 token.withCString { tkC in
                                     hostname.withCString { hnC in
                                         errBuf.withUnsafeMutableBufferPointer { ebuf in
                                             ts_netstack_init(UnsafeMutablePointer(mutating: akC),
                                                              UnsafeMutablePointer(mutating: cuC),
                                                              UnsafeMutablePointer(mutating: ghC),
-                                                             UnsafeMutablePointer(mutating: gpC),
+                                                             UnsafeMutablePointer(mutating: gipC),
                                                              UnsafeMutablePointer(mutating: tkC),
                                                              UnsafeMutablePointer(mutating: hnC),
                                                              ebuf.baseAddress, Int32(ebuf.count))

--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -1027,6 +1027,56 @@ func ts_netstack_udp_connect(hostC *C.char, port C.int, errBuf *C.char, errLen C
 	return C.int64_t(id)
 }
 
+// ts_netstack_fetch_env_pushdown GETs the gateway's tailnet-only
+// /api/env-pushdown endpoint via tsnet so the parent CLI (which is on
+// the host network and has no tailnet route) can reach 100.x through
+// the extension. The raw JSON body is copied into outBuf NUL-terminated;
+// returns the body length, or -1 on any error.
+//
+//export ts_netstack_fetch_env_pushdown
+func ts_netstack_fetch_env_pushdown(gwHostC, tokenC, outBuf *C.char, outBufCap C.int) C.int {
+	tsMu.Lock()
+	s := tsServer
+	tsMu.Unlock()
+	if s == nil {
+		return -1
+	}
+	gwHost := C.GoString(gwHostC)
+	token := C.GoString(tokenC)
+	if gwHost == "" || token == "" {
+		return -1
+	}
+	client := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: &http.Transport{DialContext: s.Dial},
+	}
+	u := "http://" + gwHost + ":8080/api/env-pushdown"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return -1
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return -1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		return -1
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return -1
+	}
+	if outBufCap <= 0 || len(body) >= int(outBufCap) {
+		return -1
+	}
+	dst := unsafe.Slice((*byte)(unsafe.Pointer(outBuf)), int(outBufCap))
+	copy(dst, body)
+	dst[len(body)] = 0
+	return C.int(len(body))
+}
+
 // ts_netstack_close shuts down the tsnet server.
 //
 //export ts_netstack_close

--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -894,22 +894,22 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwIPC, tokenC, hostnameC,
 	// network and can't dial gateway tailnet IPs directly; tsnet
 	// (running here) IS on the tailnet.
 	if token != "" && ip4 != "" {
-		go registerEphemeralOverTsnet(s, gwHost, token, ip4, hostname)
+		go registerTsnetPeerFromNE(s, gwHost, token, ip4, hostname)
 	}
 	return 0
 }
 
-// registerEphemeralOverTsnet POSTs to the gateway's tailnet-only
-// /api/peer/ephemeral/tsnet/register endpoint using tsnet.Server.Dial
-// so the call reaches a 100.x tailnet IP that the parent process
-// (host network) cannot. Best-effort: on failure the run still works
-// but lands in the gateway's default profile.
-func registerEphemeralOverTsnet(s *tsnet.Server, gwHost, token, tsIP, hostname string) {
+// registerTsnetPeerFromNE POSTs to the gateway's /api/peer/tsnet/register
+// endpoint using tsnet.Server.Dial so the call reaches a 100.x tailnet IP
+// that the parent process (host network) cannot. First call after
+// approval promotes the synthetic placeholder; subsequent calls (NE
+// reboots, gateway restarts) are server-side no-ops. Best-effort.
+func registerTsnetPeerFromNE(s *tsnet.Server, gwHost, token, tsIP, hostname string) {
 	client := &http.Client{
 		Timeout:   15 * time.Second,
 		Transport: &http.Transport{DialContext: s.Dial},
 	}
-	u := "http://" + gwHost + ":8080/api/peer/ephemeral/tsnet/register?ip=" + tsIP
+	u := "http://" + gwHost + ":8080/api/peer/tsnet/register?ip=" + tsIP
 	if hostname != "" {
 		u += "&hostname=" + url.QueryEscape(hostname)
 	}

--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -42,6 +42,7 @@ import (
 	"time"
 	"unsafe"
 
+	"tailscale.com/ipn"
 	"tailscale.com/tsnet"
 
 	"golang.zx2c4.com/wireguard/conn"
@@ -784,30 +785,30 @@ func raiseFDLimit() {
 //
 // Flow:
 //   Provider.swift (tsnet mode)
-//     bridgeTCP flow → ts_netstack_tcp_connect(ip, port)
-//       → tsServer.Dial(gwAddr)
-//       → write HAProxy PROXY v1 header with original dstIP:dstPort
-//       → gateway dispatches to target
+//     ts_netstack_init joins the tailnet and sets ExitNodeIP=<gateway>.
+//     bridgeTCP flow → ts_netstack_tcp_connect(dstIP, dstPort)
+//       → tsServer.Dial("dstIP:dstPort")
+//       → tsnet exit-node-routes the dial through the gateway, which
+//         picks it up in RegisterFallbackTCPHandler with the original
+//         dst intact.
 //
-// The PROXY header carries (tsNodeIP, dstIP, 0, dstPort); srcPort is
-// 0 because the NE intercept layer doesn't expose the original local
-// port. Gateway routing uses dstIP:dstPort only.
+// No PROXY-v1 framing: the gateway sees original dst directly via
+// tsnet's exit-node machinery.
 
 var (
 	tsServer  *tsnet.Server
-	tsGwAddr  string
 	tsNodeIP  string
 	tsMu      sync.Mutex
 	tsStarted bool
 )
 
 // ts_netstack_init joins the tailnet with the given ephemeral auth key
-// and records the gateway address for ts_netstack_tcp_connect. Blocks
-// until the tsnet node has a 100.x.x.x address (≤90s). Returns 0 on
-// success, -1 on failure.
+// and configures the gateway as the tsnet exit node so subsequent dials
+// route through it. Blocks until the tsnet node has a 100.x.x.x address
+// (≤90s). Returns 0 on success, -1 on failure.
 //
 //export ts_netstack_init
-func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, tokenC, hostnameC, errBuf *C.char, errLen C.int) C.int {
+func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwIPC, tokenC, hostnameC, errBuf *C.char, errLen C.int) C.int {
 	tsMu.Lock()
 	defer tsMu.Unlock()
 	if tsStarted {
@@ -817,9 +818,15 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, tokenC, hostname
 	authKey := C.GoString(authKeyC)
 	controlURL := C.GoString(controlURLС)
 	gwHost := C.GoString(gwHostC)
-	gwPort := C.GoString(gwPortC)
+	gwIPStr := C.GoString(gwIPC)
 	token := C.GoString(tokenC)
 	hostname := C.GoString(hostnameC)
+
+	gwIP, err := netip.ParseAddr(gwIPStr)
+	if err != nil || !gwIP.IsValid() {
+		setErr(errBuf, errLen, "invalid gateway IP: "+gwIPStr)
+		return -1
+	}
 
 	stateDir, err := os.MkdirTemp("", "clawpatrol-tsnet-ne-*")
 	if err != nil {
@@ -846,6 +853,26 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, tokenC, hostname
 		return -1
 	}
 
+	// Configure gateway as exit node. Every outbound dial from this
+	// tsnet node — TCP and UDP — will be routed through the gateway,
+	// where the original dst lands in RegisterFallbackTCPHandler.
+	lc, err := s.LocalClient()
+	if err != nil {
+		_ = s.Close()
+		_ = os.RemoveAll(stateDir)
+		setErr(errBuf, errLen, "local client: "+err.Error())
+		return -1
+	}
+	if _, err := lc.EditPrefs(ctx, &ipn.MaskedPrefs{
+		ExitNodeIPSet: true,
+		Prefs:         ipn.Prefs{ExitNodeIP: gwIP},
+	}); err != nil {
+		_ = s.Close()
+		_ = os.RemoveAll(stateDir)
+		setErr(errBuf, errLen, "set exit-node: "+err.Error())
+		return -1
+	}
+
 	var ip4 string
 	for _, ip := range upSt.Self.TailscaleIPs {
 		if ip.Is4() {
@@ -858,7 +885,6 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwPortC, tokenC, hostname
 	}
 
 	tsServer = s
-	tsGwAddr = net.JoinHostPort(gwHost, gwPort)
 	tsNodeIP = ip4
 	tsStarted = true
 
@@ -915,16 +941,16 @@ func ts_netstack_get_ip(outBuf *C.char, outLen C.int) C.int {
 	return 0
 }
 
-// ts_netstack_tcp_connect dials dstHost:dstPort via the gateway over
-// tsnet (PROXY v1 header carries the original destination). Returns a
-// positive connection ID for use with wg_netstack_send/recv/close_conn.
+// ts_netstack_tcp_connect dials dstHost:dstPort via tsnet. The tsnet
+// node has the gateway set as its exit node (see ts_netstack_init), so
+// this dial transparently routes through the gateway, which sees the
+// original dst via RegisterFallbackTCPHandler. Returns a positive
+// connection ID for use with wg_netstack_send/recv/close_conn.
 //
 //export ts_netstack_tcp_connect
 func ts_netstack_tcp_connect(hostC *C.char, port C.int, timeoutMs C.int, errBuf *C.char, errLen C.int) C.int64_t {
 	tsMu.Lock()
 	s := tsServer
-	gwAddr := tsGwAddr
-	srcIP := tsNodeIP
 	tsMu.Unlock()
 	if s == nil {
 		setErr(errBuf, errLen, "ts_netstack not initialized")
@@ -937,15 +963,10 @@ func ts_netstack_tcp_connect(hostC *C.char, port C.int, timeoutMs C.int, errBuf 
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMs)*time.Millisecond)
 		defer cancel()
 	}
-	conn, err := s.Dial(ctx, "tcp", gwAddr)
+	dstAddr := net.JoinHostPort(host, fmt.Sprintf("%d", int(port)))
+	conn, err := s.Dial(ctx, "tcp", dstAddr)
 	if err != nil {
 		setErr(errBuf, errLen, "tsnet dial: "+err.Error())
-		return -1
-	}
-	proxyHdr := fmt.Sprintf("PROXY TCP4 %s %s 0 %d\r\n", srcIP, host, int(port))
-	if _, err := io.WriteString(conn, proxyHdr); err != nil {
-		_ = conn.Close()
-		setErr(errBuf, errLen, "proxy hdr: "+err.Error())
 		return -1
 	}
 	id := nextConnID.Add(1)
@@ -1017,7 +1038,6 @@ func ts_netstack_close() {
 		tsServer = nil
 	}
 	tsStarted = false
-	tsGwAddr = ""
 	tsNodeIP = ""
 }
 

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -34,6 +34,34 @@ non-tailnet devices reach the gateway over Tailscale Funnel.
 Devices onboard with `clawpatrol login` instead of `clawpatrol
 join`; see [CLI reference](/docs/cli/) for the Tailscale variant.
 
+#### Required tailnet ACL
+
+The gateway routes client traffic by acting as their **Tailscale
+exit node**. Clients call `EditPrefs(ExitNodeIP=<gateway>)` once
+they join; routing only works if the tailnet ACL **auto-approves
+the gateway as an exit node** for the client tag. Without this,
+clients set the pref locally but every outbound dial silently
+times out — the gateway never sees the traffic.
+
+In your tailnet's ACL JSON, add (or extend) `autoApprovers`:
+
+```jsonc
+{
+  "autoApprovers": {
+    "exitNode": ["tag:clawpatrol"]   // matches tailscale_tags above
+  },
+  "tagOwners": {
+    "tag:clawpatrol": ["autogroup:admin"]
+  }
+}
+```
+
+The tag must be the one you set in `tailscale_tags` on the
+gateway config. If you skip this step, the daemon logs a
+`tsnet probe: gateway unreachable via exit-node routing — check
+autoApprovers.exitNode in your tailnet ACL` warning on first
+boot, and every `clawpatrol run` hangs at "joining tailnet".
+
 ### WireGuard endpoint
 
 The default WireGuard listener is `0.0.0.0:51820`. Clients dial


### PR DESCRIPTION
* Tailscale-mode `clawpatrol run` on Linux now goes through a per-host
  self-forking daemon (a hidden `clawpatrol daemon-internal` subcommand)
  instead of spinning up a fresh `tsnet.Server` per invocation. The
  daemon owns one persistent tsnet identity, shared across every
  concurrent `clawpatrol run` via a Unix control socket + SCM_RIGHTS
  TUN-fd hand-off + per-session gVisor stack. Idle-exits 5 minutes after
  the last client disconnects; race-control protocol is the validated
  spawn-lock + lost-race-rebind shape with a single os.Exit site.
* Drops the HAProxy PROXY-v1 wire format in both directions. Clients
  (Linux daemon, macOS NE) set `ExitNodeIP=<gateway>` via `EditPrefs`;
  outbound dials route through the gateway as a tsnet exit node and land
  in the existing `RegisterFallbackTCPHandler` with the original dst
  intact. Gateway no longer opens a tsnet `:443` listener.
* One persistent, non-ephemeral auth key per device. The
  `/api/onboard/poll` response now always returns a non-ephemeral
  Tailscale key. The daemon registers itself once via
  `/api/peer/tsnet/register` (replaces
  `/api/peer/ephemeral/tsnet/register`); subsequent calls are no-ops on
  the server side.
* Daemon-only state (auth key, tsnet node identity) moves to
  `\$XDG_STATE_HOME/clawpatrol/`. The agent-visible files (ca.crt, mode
  marker, api-token, gateway URLs) stay in `~/.clawpatrol/`. The
  mnt-namespace tmpfs mask in `runRunTsnetChild` is deleted — it was
  hiding the auth-key file from the agent, which now lives elsewhere
  entirely. `PR_SET_DUMPABLE=0` on the parent stays.
* All tsnet-side ephemeral-peer machinery is gone:
  `apiRegisterEphemeralTsnetIP`, the synthetic `tsnet-<host>`
  placeholder's repeat-register path, `setEphemeralProfile` calls on the
  tsnet code path, the ephemeral_peers in-memory replay for tsnet. This
  was the root cause of a profile-switch bug where the dashboard
  appeared to accept a profile change but reverted on read (in-memory
  ephemeral entry masked the device row). WG-mode ephemeral peers remain
  — see #516 for the follow-up.
* Security: tightens `tailnetGate` so operator-class routes
  (`/api/onboard/approve`, `/api/onboard/lookup`, authDashboard,
  authDashboardOrTailnetOperator) require an explicit
  `dashboard_operators` allowlist match on the tailnet-identity path.
  Previously any tailnet member could approve, including `tag:client`
  peers whose whois resolves to `tagged-devices`. Fixes #509.
  Dashboard-password sessions are unaffected.
* macOS NE: `gwPort` -> `gwIP` rename across the start-tsnet helper +
  `ts_netstack_init` cgo export + Provider.swift, matching the
  exit-node-routed flow. The NE preserves unrelated
  providerConfiguration keys on subsequent `Clawpatrol install` calls so
  the auth key persists across per-process `clawpatrol run` invocations.
  env-pushdown HTTP on macOS now hops through the NE's tsnet stack via a
  new `getenv` session-IPC verb — the parent CLI on macOS has no tailnet
  route, so a direct fetch would always time out.
* `clawpatrol run` on Linux pushes the seven CA-bundle env vars
  (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`,
  `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`, `PIP_CERT`) to the
  wrapped agent alongside the gateway-pushed placeholder credentials.
  Without these, agents that respect e.g. `REQUESTS_CA_BUNDLE` bypassed
  the MITM CA.
* `clawpatrol join` only installs the `eval \"\$(clawpatrol env)\"`
  shell-rc shim in `--whole-machine` mode. In per-process mode
  `clawpatrol run` already passes the env vars to the child; the shim
  was dead weight and was printing context-deadline timeouts in every
  new terminal on tailnet-only hosts.

## ACL prerequisite

The deployer's Tailscale ACL must auto-approve the gateway as an exit
node for the client tag. Add to the ACL JSON:

```jsonc
{
  \"autoApprovers\": {
    \"exitNode\": [\"tag:client\"]
  }
}
```

(matching whatever tag is configured in `tailscale_tags` on the
gateway). Without this every outbound dial from `clawpatrol run` times
out. The daemon smoke-probes exit-node routing at startup and forwards
the warning text to `clawpatrol run`'s stderr on the next session, so
the operator sees the cause in the terminal rather than having to tail
`daemon.log`.

## Verified end-to-end on Linux against the live deno.co
## tsnet gateway

* `clawpatrol join https://clawpatrol.deno.co`
* operator-allowlist approve via `/api/onboard/approve` with
  `profile=avocet2`
* daemon spawn, tsnet join, exit-node routing
* `clawpatrol run -- curl https://api.github.com`: HTTP 200, cert chain
  is `CN=api.github.com / issuer=clawpatrol gateway CA` (MITM verified).
  curl with `--cacert ~/.clawpatrol/ca.crt` and system trust bypassed
  also succeeds, proving the only path is via the gateway's CA.
* Profile switch round-trip via `/api/agents/profile` (avocet2 ->
  default -> avocet2) persists to `devices.profile` each time — the
  previous symptom (dashboard click "took" in the UI but reverted on
  next read) is gone.

## Follow-ups left out of this PR

* #515 — Tailscale-only join approval URL: print a QR code instead of
  unconditionally trying to open a local browser.
* #516 — Apply the same daemon-model unification to WG mode (drop
  per-process ephemeral WG peers + the rest of the setEphemeralProfile
  machinery on the server). This PR leaves WG mode untouched.