### PR TITLE
docs: surface control-mode coupling in dashboard bind sectione

### DIFF
--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -41,9 +41,12 @@ export function DevicePage({
   // Per-profile credential list — server-filters to only the
   // credentials referenced by endpoints in this device's profile,
   // so a "writer" device doesn't see the readonly's pg-cred and vice
-  // versa. Falls back to the parent's full list for the no-profile
-  // case (legacy single-tenant configs).
-  const [profileCreds, setProfileCreds] = useState<Integration[] | null>(null);
+  // versa. No fallback to the parent's full list: a device with no
+  // profile (or whose profile uses zero credentials) can't actually
+  // use any credential, so the card row should be empty rather than
+  // mirror the system-wide view from the settings page.
+  const [profileCreds, setProfileCreds] = useState<Integration[]>([]);
+  const [credsLoading, setCredsLoading] = useState(false);
   useEffect(() => {
     listProfiles()
       .then((p) => setProfiles(p ?? []))
@@ -52,12 +55,15 @@ export function DevicePage({
   const devProfile = a?.profile;
   useEffect(() => {
     if (!devProfile) {
-      setProfileCreds(null);
+      setProfileCreds([]);
+      setCredsLoading(false);
       return;
     }
+    setCredsLoading(true);
     getStatus(devProfile)
       .then((c) => setProfileCreds(c ?? []))
-      .catch(() => setProfileCreds(null));
+      .catch(() => setProfileCreds([]))
+      .finally(() => setCredsLoading(false));
     // Re-fetch whenever the parent's integrations list changes too —
     // OAuth modal calls onRefresh on success, which updates parent state
     // but otherwise this effect would stay stale and the card wouldn't
@@ -82,7 +88,6 @@ export function DevicePage({
 
   const dev = a;
   const total = dev.bytes_in + dev.bytes_out;
-  const allForUser = profileCreds ?? integrations;
 
   async function remove() {
     if (
@@ -239,7 +244,17 @@ export function DevicePage({
           </span>
         </div>
         <div className="p-3">
-          <IntegrationsCards list={allForUser} onConnect={onConnect} onRefresh={onRefresh} />
+          {credsLoading ? (
+            <div className="px-2 py-6 text-center text-xs text-text-subtle">loading…</div>
+          ) : profileCreds.length === 0 ? (
+            <div className="px-2 py-6 text-center text-xs text-text-subtle">
+              {devProfile
+                ? `no credentials bound to profile ${devProfile}`
+                : "no profile assigned — this device cannot use any credential"}
+            </div>
+          ) : (
+            <IntegrationsCards list={profileCreds} onConnect={onConnect} onRefresh={onRefresh} />
+          )}
         </div>
       </section>
 

--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -41,12 +41,9 @@ export function DevicePage({
   // Per-profile credential list — server-filters to only the
   // credentials referenced by endpoints in this device's profile,
   // so a "writer" device doesn't see the readonly's pg-cred and vice
-  // versa. No fallback to the parent's full list: a device with no
-  // profile (or whose profile uses zero credentials) can't actually
-  // use any credential, so the card row should be empty rather than
-  // mirror the system-wide view from the settings page.
-  const [profileCreds, setProfileCreds] = useState<Integration[]>([]);
-  const [credsLoading, setCredsLoading] = useState(false);
+  // versa. Falls back to the parent's full list for the no-profile
+  // case (legacy single-tenant configs).
+  const [profileCreds, setProfileCreds] = useState<Integration[] | null>(null);
   useEffect(() => {
     listProfiles()
       .then((p) => setProfiles(p ?? []))
@@ -55,15 +52,12 @@ export function DevicePage({
   const devProfile = a?.profile;
   useEffect(() => {
     if (!devProfile) {
-      setProfileCreds([]);
-      setCredsLoading(false);
+      setProfileCreds(null);
       return;
     }
-    setCredsLoading(true);
     getStatus(devProfile)
       .then((c) => setProfileCreds(c ?? []))
-      .catch(() => setProfileCreds([]))
-      .finally(() => setCredsLoading(false));
+      .catch(() => setProfileCreds(null));
     // Re-fetch whenever the parent's integrations list changes too —
     // OAuth modal calls onRefresh on success, which updates parent state
     // but otherwise this effect would stay stale and the card wouldn't
@@ -88,6 +82,7 @@ export function DevicePage({
 
   const dev = a;
   const total = dev.bytes_in + dev.bytes_out;
+  const allForUser = profileCreds ?? integrations;
 
   async function remove() {
     if (
@@ -244,17 +239,7 @@ export function DevicePage({
           </span>
         </div>
         <div className="p-3">
-          {credsLoading ? (
-            <div className="px-2 py-6 text-center text-xs text-text-subtle">loading…</div>
-          ) : profileCreds.length === 0 ? (
-            <div className="px-2 py-6 text-center text-xs text-text-subtle">
-              {devProfile
-                ? `no credentials bound to profile ${devProfile}`
-                : "no profile assigned — this device cannot use any credential"}
-            </div>
-          ) : (
-            <IntegrationsCards list={profileCreds} onConnect={onConnect} onRefresh={onRefresh} />
-          )}
+          <IntegrationsCards list={allForUser} onConnect={onConnect} onRefresh={onRefresh} />
         </div>
       </section>
 

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -114,8 +114,8 @@ tailnet IP at the info port, so tailnet peers reach
   is the only thing between those other interfaces and the
   dashboard.
 
-Operators can be allowlisted by tailnet identity so they skip the
-root-password prompt:
+Operators can be allowlisted by tailnet identity email so they skip
+the root-password prompt:
 
 ```hcl
 dashboard_operators = [

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -103,9 +103,16 @@ tailnet IP at the info port, so tailnet peers reach
   loopback-only. Operators reach the dashboard over the tailnet
   using the tsnet IP; SSH tunnel is the out-of-band fallback when
   the tailnet is the thing that's broken.
-- **`0.0.0.0:8080`** — possible but rarely useful. Funnel does not
-  expose the dashboard (see below), so a public host bind only
-  matters when the gateway sits behind an external auth proxy.
+- **`0.0.0.0:8080`** — also exposes the dashboard on every other
+  network interface of the host (LAN, and the public IP if the host
+  has one), on top of the always-on tailnet listener. Tailnet peers
+  don't need this — they already reach the dashboard through the
+  tsnet IP — so the only reason to bind `0.0.0.0` is to let
+  something off the tailnet reach the dashboard. Do this only when
+  the gateway sits behind an external auth proxy (Cloudflare Access,
+  oauth2-proxy) doing its own SSO first; otherwise the root password
+  is the only thing between those other interfaces and the
+  dashboard.
 
 Operators can be allowlisted by tailnet identity so they skip the
 root-password prompt:

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -63,30 +63,72 @@ clawpatrol gateway --reset-dashboard-password gateway.hcl
 
 ### Where to bind the dashboard
 
-Restricting where the dashboard is reachable on the network is
-an additional defence-in-depth layer on top of the password.
-Pick the shape that matches your access model:
+`info_listen` is the dashboard's host-side HTTP bind. The shapes
+that make sense for it — and the auth shortcuts available on top
+of the root password — depend on the control plane mode, because
+each mode automatically exposes the dashboard on its own overlay
+network as well.
 
-- **Loopback (`127.0.0.1:8080`)** — the default in the example.
-  Reach the dashboard via SSH tunnel
+#### In WireGuard mode
+
+The in-tunnel forwarder routes any connection to the info port on
+the gateway's WG IP to the dashboard, so joined devices reach
+`http://<gateway-wg-ip>:8080` with nothing extra configured.
+`info_listen` only controls who can reach the dashboard from
+**outside** the tunnel:
+
+- **`127.0.0.1:8080`** (the example default) — only loopback.
+  Operators who haven't joined as a device themselves reach the
+  dashboard via SSH tunnel
   (`ssh -L 8080:127.0.0.1:8080 gateway-host`) or a local reverse
   proxy.
-- **Tailnet / VPN IP (`100.x.x.x:8080`)** — only devices already
-  on your tailnet or WireGuard subnet can reach it. List each
-  operator's Tailscale account email in `dashboard_operators` to
-  let them in without typing the password:
+- **`0.0.0.0:8080`** — anyone with network reach to the host sees a
+  login page. The root password is the only thing between the
+  internet and the dashboard, so only do this when the gateway is
+  fronted by an auth proxy (Cloudflare Access, oauth2-proxy) that
+  does its own SSO first.
 
-  ```hcl
-  dashboard_operators = [
-    "alice@example.com",
-    "bob@example.com",
-  ]
-  ```
+`dashboard_operators` is ignored in WireGuard mode — there is no
+tailnet whois identity to match against, so the root password is the
+only auth.
 
-  Tagged devices (agents) never match the allowlist.
-- **Public (`0.0.0.0:8080`)** — works, but everyone on the
-  internet sees a login page. Front it with an auth proxy
-  (Cloudflare Access, oauth2-proxy) if you really need it.
+#### In Tailscale mode
+
+The embedded tsnet node always serves the dashboard on the gateway's
+tailnet IP at the info port, so tailnet peers reach
+`http://<gateway-tailnet-ip>:8080` with no extra configuration.
+`info_listen` controls the host-side bind:
+
+- **`127.0.0.1:8080`** (recommended) — keeps the host socket
+  loopback-only. Operators reach the dashboard over the tailnet
+  using the tsnet IP; SSH tunnel is the out-of-band fallback when
+  the tailnet is the thing that's broken.
+- **`0.0.0.0:8080`** — possible but rarely useful. Funnel does not
+  expose the dashboard (see below), so a public host bind only
+  matters when the gateway sits behind an external auth proxy.
+
+Operators can be allowlisted by tailnet identity so they skip the
+root-password prompt:
+
+```hcl
+dashboard_operators = [
+  "alice@example.com",
+  "*@example.com",
+]
+```
+
+Each entry is matched against the requesting peer's tsnet whois
+login on every dashboard request. Tagged devices (your agents) have
+a tag-name login, not a user email, so they never match a wildcard
+entry — agent peers can never inherit operator powers through this
+path.
+
+`funnel = true` exposes a small allowlist of public-bootstrap routes
+(`/api/onboard/{start,poll,claim}`, `/api/cred/*`,
+`/api/hitl/operations/*/status`) on `<node>.ts.net:443` so off-tailnet
+devices can join and OAuth callbacks can land. **The dashboard itself
+is not Funnel-reachable** — Funnel does not replace the tailnet (or
+SSH) path for operator access.
 
 ## Run under systemd
 


### PR DESCRIPTION
Restructure 'Where to bind the dashboard' under WireGuard and Tailscale headings to make explicit which bind shapes are valid for each control mode, and how each mode automatically exposes the dashboard on its overlay network (WG forwarder vs tsnet info listener). Note that dashboard_operators is ignored in WireGuard mode and that Funnel does not expose the dashboard.