### PR TITLE
fix: scope device credential cards to the profile's own declared list

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -818,6 +818,13 @@ func dashboardTailscaleState(label tailscaleproto.NodeStateLabel, hasPersistedSl
 // apiStatus and the device-page card render so per-device views only
 // show credentials the device's profile actually uses.
 //
+// Reads strictly from CompiledProfile.Credentials (the profile's own
+// HCL-declared list). Walking ep.Credentials would leak credentials
+// from *other* profiles that share the same endpoint — e.g. the
+// postgres `pg` endpoint carries both `pg-readonly` and `pg-writer`,
+// but profile "data" declares only `pg-readonly` and must not see
+// `pg-writer` on its card.
+//
 // Walking tunnel-attached credentials in addition to the profile's
 // own list lets the dashboard surface tunnel-bound auth (e.g. the
 // tailscale node-auth credential) on profiles whose endpoints reach
@@ -833,14 +840,14 @@ func credentialsInProfile(policy *config.CompiledPolicy, profile string) map[str
 		return map[string]bool{} // unknown profile → empty set, not nil
 	}
 	out := map[string]bool{}
-	for _, ep := range prof.Endpoints {
-		for _, ent := range ep.Credentials {
-			if ent != nil && ent.Symbol != nil {
-				out[ent.Symbol.Name] = true
-			}
+	for _, ent := range prof.Credentials {
+		if ent != nil && ent.Symbol != nil {
+			out[ent.Symbol.Name] = true
 		}
+	}
+	for _, ep := range prof.Endpoints {
 		for tun := ep.Tunnel; tun != nil; tun = tun.Via {
-			if tun.Credential != nil {
+			if tun.Credential != nil && tun.Credential.Symbol != nil {
 				out[tun.Credential.Symbol.Name] = true
 			}
 		}

--- a/cmd/clawpatrol/tailscale_dashboard_test.go
+++ b/cmd/clawpatrol/tailscale_dashboard_test.go
@@ -44,7 +44,8 @@ func TestCredentialsInProfileWalksTransitivelyViaTunnelChain(t *testing.T) {
 	policy := &config.CompiledPolicy{
 		Profiles: map[string]*config.CompiledProfile{
 			"default": {
-				Endpoints: map[string]*config.CompiledEndpoint{"grafana": ep},
+				Credentials: []*config.Entity{endpointCred},
+				Endpoints:   map[string]*config.CompiledEndpoint{"grafana": ep},
 			},
 		},
 	}
@@ -54,6 +55,47 @@ func TestCredentialsInProfileWalksTransitivelyViaTunnelChain(t *testing.T) {
 	}
 	if !got["grafana-bearer"] {
 		t.Errorf("expected endpoint credential in %v", got)
+	}
+}
+
+// Profiles that share an endpoint must NOT see each other's credentials.
+// Regression for cl-lgwg: the dashboard previously walked ep.Credentials
+// (the global endpoint→credentials list) and leaked credentials from
+// sibling profiles. The postgres "pg" endpoint binds both pg-readonly
+// and pg-writer; profile "data" declares only pg-readonly and must
+// see exactly that, not the writer credential bound to "platform".
+func TestCredentialsInProfileDoesNotLeakSiblingProfileCredentials(t *testing.T) {
+	readonly := &config.Entity{Symbol: &config.Symbol{Name: "pg-readonly"}}
+	writer := &config.Entity{Symbol: &config.Symbol{Name: "pg-writer"}}
+	ep := &config.CompiledEndpoint{
+		Name:        "pg",
+		Credentials: []*config.Entity{readonly, writer},
+	}
+	policy := &config.CompiledPolicy{
+		Profiles: map[string]*config.CompiledProfile{
+			"data": {
+				Credentials: []*config.Entity{readonly},
+				Endpoints:   map[string]*config.CompiledEndpoint{"pg": ep},
+			},
+			"platform": {
+				Credentials: []*config.Entity{writer},
+				Endpoints:   map[string]*config.CompiledEndpoint{"pg": ep},
+			},
+		},
+	}
+	data := credentialsInProfile(policy, "data")
+	if !data["pg-readonly"] {
+		t.Errorf("profile data: missing own credential pg-readonly in %v", data)
+	}
+	if data["pg-writer"] {
+		t.Errorf("profile data: leaked sibling credential pg-writer in %v", data)
+	}
+	platform := credentialsInProfile(policy, "platform")
+	if !platform["pg-writer"] {
+		t.Errorf("profile platform: missing own credential pg-writer in %v", platform)
+	}
+	if platform["pg-readonly"] {
+		t.Errorf("profile platform: leaked sibling credential pg-readonly in %v", platform)
 	}
 }
 

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -1079,6 +1079,60 @@ profile "default" { credentials = [bearer_token.test, bearer_token.prod, bearer_
 	})
 }
 
+// TestResolveCredentialIsolatesProfilesSharingEndpoint verifies that
+// two profiles binding distinct credentials to the same endpoint
+// dispatch to their own credential — the readonly profile must NEVER
+// receive the writer credential and vice versa. Regression for
+// cl-lgwg: the dashboard was leaking sibling-profile credentials onto
+// device cards; this test pins down that the runtime dispatch table
+// (CompiledProfile.EndpointCredentials) does NOT have the same flaw.
+func TestResolveCredentialIsolatesProfilesSharingEndpoint(t *testing.T) {
+	src := `
+endpoint "postgres" "pg" { host = "pg.example:5432" }
+credential "postgres_credential" "pg-readonly" {
+  endpoint = postgres.pg
+  user     = "agent_ro"
+}
+credential "postgres_credential" "pg-writer" {
+  endpoint = postgres.pg
+  user     = "agent_rw"
+}
+profile "data"     { credentials = [postgres_credential.pg-readonly] }
+profile "platform" { credentials = [postgres_credential.pg-writer] }
+`
+	cp := compileFixture(t, src)
+	ep := cp.Endpoints["pg"]
+
+	mkReq := func(user string) *match.Request {
+		return &match.Request{
+			Family: "sql",
+			User:   user,
+			Meta:   &sqlfacet.Meta{Statement: user + "\x00pw"},
+		}
+	}
+
+	got := runtime.ResolveCredential(cp, "data", ep, mkReq("agent_ro"))
+	if got == nil || got.Credential.Symbol.Name != "pg-readonly" {
+		t.Errorf("data profile / user=agent_ro → %+v, want pg-readonly", got)
+	}
+	// Data profile must NOT match writer credential even if the
+	// request happens to carry the writer's user — the writer
+	// credential isn't in the profile's dispatch table at all.
+	got = runtime.ResolveCredential(cp, "data", ep, mkReq("agent_rw"))
+	if got != nil && got.Credential.Symbol.Name == "pg-writer" {
+		t.Errorf("data profile / user=agent_rw resolved sibling writer credential: %+v", got)
+	}
+
+	got = runtime.ResolveCredential(cp, "platform", ep, mkReq("agent_rw"))
+	if got == nil || got.Credential.Symbol.Name != "pg-writer" {
+		t.Errorf("platform profile / user=agent_rw → %+v, want pg-writer", got)
+	}
+	got = runtime.ResolveCredential(cp, "platform", ep, mkReq("agent_ro"))
+	if got != nil && got.Credential.Symbol.Name == "pg-readonly" {
+		t.Errorf("platform profile / user=agent_ro resolved sibling readonly credential: %+v", got)
+	}
+}
+
 // containsAll returns true iff s contains every needle.
 func containsAll(s string, needles ...string) bool {
 	for _, n := range needles {


### PR DESCRIPTION


credentialsInProfile walked CompiledEndpoint.Credentials (the global endpoint→credentials list) for every endpoint reached by a profile, which leaks sibling-profile credentials onto a device's card whenever two profiles share an endpoint. With the postgres "pg" endpoint bound to both pg-readonly and pg-writer, every device on profile "data" (declares only pg-readonly) saw pg-writer too, and Agents.Integrations (used by the agents table's red "needs setup" dot) flagged credentials the device never actually uses.

Read CompiledProfile.Credentials directly — the profile's HCL-declared list, populated by Compile() from pr.Credentials. Keep walking ep.Tunnel.Via for tunnel-attached auth so tailscale node-auth and the like still surface on profiles whose endpoints route through a tunnel.

Runtime dispatch (ResolveCredential / EndpointCredentials) was already profile-scoped — pinned by a new TestResolveCredentialIsolatesProfilesSharingEndpoint test. Dashboard-only fix.