### PR TITLE
Drop the `clawpatrol login` subcommand

### DIFF
--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -266,7 +266,7 @@ func runEnv(args []string) {
 
 	caPath := filepath.Join(*caDir, "ca.crt")
 	if _, err := os.Stat(caPath); err != nil {
-		fmt.Fprintf(os.Stderr, "clawpatrol: ca not found at %s — run `clawpatrol login` first\n", caPath)
+		fmt.Fprintf(os.Stderr, "clawpatrol: ca not found at %s — run `clawpatrol join <gateway-url>` first\n", caPath)
 		os.Exit(2)
 	}
 	vars, err := envPushdownVars(caPath)

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2571,8 +2571,6 @@ func main() {
 	switch os.Args[1] {
 	case "gateway":
 		runGateway(os.Args[2:])
-	case "login":
-		runLogin(os.Args[2:])
 	case "join":
 		runJoin(os.Args[2:])
 	case "run":
@@ -2678,7 +2676,6 @@ usage:
                   --hostname NAME        device name to register (default: os.Hostname)
                   --profile NAME         suggest a profile for the approver
                   --whole-machine        bring up wg-quick (route all traffic)
-  clawpatrol login                       onboard this machine (tailscale path)
   clawpatrol run -- <cmd> [args...]      route one process tree through gateway
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -154,14 +154,43 @@ func runJoin(args []string) {
 		if gwHostFile != "" {
 			exitNode = gwHostFile
 		}
-		// -post-join: skip CA fetch/install + shell rc — already done
-		// by onboardViaDeviceFlow above.
-		loginArgs := []string{"-name", exitNode, "-ca-dir", *caOut, "-post-join"}
-		if *skipTrust {
-			loginArgs = append(loginArgs, "-no-trust")
+		if err := applyWholeMachineExitNode(exitNode); err != nil {
+			fail("%v", err)
 		}
-		runLogin(loginArgs)
 	}
+}
+
+// applyWholeMachineExitNode finishes the whole-machine Tailscale Linux
+// join: pins SSH + public-IP reply traffic to the direct path, flips
+// the system tailscaled's exit-node to the gateway, and points DNS at
+// the gateway (tsnet has no UDP fallback). CA fetch + trust install +
+// shell rc are handled earlier in the join flow.
+func applyWholeMachineExitNode(gwName string) error {
+	if err := exemptSSHFromExitNode(""); err != nil {
+		// Couldn't protect SSH — refuse to flip exit-node so we don't
+		// kill an in-flight admin session.
+		return fmt.Errorf("protect SSH from exit-node: %w", err)
+	}
+	if err := exemptPublicIPFromExitNode(); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ couldn't protect public IP inbound traffic: %v\n", err)
+	}
+	tscli, err := tailscaleBin()
+	if err != nil {
+		return fmt.Errorf("tailscale CLI not found: %w", err)
+	}
+	st, err := tailscaleStatus(tscli)
+	if err != nil {
+		return fmt.Errorf("tailscale status: %w", err)
+	}
+	peer := findPeerByName(st, gwName)
+	if peer == nil || len(peer.TailscaleIPs) == 0 {
+		return fmt.Errorf("no peer named %q on this tailnet", gwName)
+	}
+	if err := tsSet(tscli, "--exit-node="+gwName); err != nil {
+		return fmt.Errorf("tailscale set --exit-node=%s: %w", gwName, err)
+	}
+	pinDNSAtGatewayIfNeeded(peer.TailscaleIPs[0])
+	return nil
 }
 
 // joinSetup carries the post-join side-effect status so the caller
@@ -176,8 +205,8 @@ type joinSetup struct {
 }
 
 // isCaNotExposed returns true when the gateway deliberately did not expose
-// /ca.crt on its public path (Tailscale control mode). The CA will be
-// fetched securely over the tailnet by runLogin after Tailscale join.
+// /ca.crt on its public path (Tailscale control mode). The CA is then
+// fetched securely over the tailnet by onboardViaDeviceFlow.
 func isCaNotExposed(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "status 404")
 }
@@ -228,8 +257,9 @@ func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine bool) {
 		return
 	}
 	if _, err := os.Stat(s.caPath); err != nil {
-		// CA not fetched yet (Tailscale mode defers to runLogin). Skip
-		// trust install; runLogin will fetch + install from the tailnet.
+		// CA not fetched yet (Tailscale mode defers the fetch to the
+		// tailnet path inside onboardViaDeviceFlow). Skip trust install
+		// here; it lands once the CA arrives.
 		if wholeMachine {
 			installShellRC() //nolint:errcheck
 		}
@@ -287,117 +317,6 @@ func fetchCAHTTP(gateway, dst string) (string, error) {
 		return "", err
 	}
 	return fp, nil
-}
-
-func runLogin(args []string) {
-	fs := flag.NewFlagSet("login", flag.ExitOnError)
-	gwName := fs.String("name", "clawpatrol", "exit-node hostname to look for on the tailnet")
-	caOut := fs.String("ca-dir", defaultClawpatrolDir(), "where to store the fetched CA")
-	skipTrust := fs.Bool("no-trust", false, "fetch CA but skip system trust install (do it manually)")
-	skipExitNode := fs.Bool("no-exit-node", false, "skip setting tailscale exit-node (run manually later)")
-	postJoin := fs.Bool("post-join", false, "continuation of `clawpatrol join --whole-machine`: skip CA fetch/install + shell rc (already done by the join flow)")
-	_ = fs.Parse(args)
-
-	// Setting exit-node redirects ALL outbound traffic via the gateway,
-	// which kills an in-flight SSH session on Linux (reply packets to
-	// the client now route through tailnet → source IP changes mid-
-	// stream → client EOFs the handshake).
-	//
-	// Fix: install a policy-routing override BEFORE flipping exit-node
-	// so traffic destined for the SSH client keeps using the default
-	// table (= public interface). Reply packets stay direct, SSH
-	// survives, everything else routes via gateway as intended.
-	sshPinned := false
-	if !*skipExitNode && runtime.GOOS == "linux" {
-		if err := exemptSSHFromExitNode(""); err != nil {
-			fmt.Fprintf(os.Stderr, "⚠ couldn't protect SSH (will skip exit-node): %v\n", err)
-			*skipExitNode = true
-		} else {
-			sshPinned = true
-		}
-		if err := exemptPublicIPFromExitNode(); err != nil {
-			fmt.Fprintf(os.Stderr, "⚠ couldn't protect public IP inbound traffic: %v\n", err)
-		}
-	}
-
-	tscli, err := tailscaleBin()
-	if err != nil {
-		fail("tailscale CLI not found: %v\nis Tailscale installed and running?", err)
-	}
-
-	st, err := tailscaleStatus(tscli)
-	if err != nil {
-		fail("tailscale status: %v", err)
-	}
-	if st.Self == nil || len(st.Self.TailscaleIPs) == 0 {
-		fail("not logged into a tailnet (run: tailscale up)")
-	}
-	tailnetName := tailnetDisplayName(st)
-
-	peer := findPeerByName(st, *gwName)
-	if peer == nil {
-		fail("no peer named %q on this tailnet — is the gateway running and joined?", *gwName)
-	}
-
-	// Fetch CA BEFORE setting exit-node — once exit-node flips, an
-	// in-flight tailscaled reconfig can drop the request mid-flight.
-	// In -post-join the join flow already did this.
-	caPath := filepath.Join(*caOut, "ca.crt")
-	if !*postJoin {
-		if err := os.MkdirAll(*caOut, 0o700); err != nil {
-			fail("mkdir %s: %v", *caOut, err)
-		}
-		if err := fetchCA(peer.TailscaleIPs[0], caPath); err != nil {
-			fail("fetch CA: %v", err)
-		}
-	}
-
-	// On Linux, `tailscale set` requires sudo unless --operator=$USER
-	// was passed to `tailscale up`. tsSet handles either case.
-	//
-	if !*skipExitNode {
-		if err := tsSet(tscli, "--exit-node="+*gwName); err != nil {
-			fail("tailscale set --exit-node=%s: %v", *gwName, err)
-		}
-		// tsnet has no UDP fallback — outbound DNS from the client
-		// (e.g. resolv.conf nameserver 1.1.1.1) is silently dropped at
-		// the gateway's netstack. Hosts running systemd-resolved get
-		// away with it because their queries source-bind to a non-
-		// tailnet link; plain-resolv.conf hosts hang. Point DNS at the
-		// gateway's tsnet IP so queries hit serveTsnetDNSUDP instead.
-		// Skip when systemd-resolved is active.
-		pinDNSAtGatewayIfNeeded(peer.TailscaleIPs[0])
-	}
-
-	fmt.Println()
-	fmt.Printf("Connected to %s's tailnet.\n", tailnetName)
-	items := []string{fmt.Sprintf("Found exit node: %s (%s)", *gwName, peer.TailscaleIPs[0])}
-	if sshPinned {
-		items = append(items, "SSH (tcp/22) reply traffic pinned to direct route")
-	}
-	if !*postJoin {
-		caInstalled := false
-		caHint := ""
-		if *skipTrust {
-			caHint = manualTrustHint(caPath)
-		} else if err := installCATrust(caPath); err != nil {
-			caHint = manualTrustHint(caPath)
-		} else {
-			caInstalled = true
-		}
-		shellOK := installShellRC() == nil
-		items = append(items, setupSummaryItems(joinSetup{
-			caInstalled: caInstalled,
-			caPath:      caPath,
-			caHint:      caHint,
-			shellRC:     shellOK,
-		})...)
-	}
-	printTreeItems(items)
-	fmt.Println()
-	if !*postJoin {
-		fmt.Println("Installed! Try: claude")
-	}
 }
 
 // installShellRC appends `eval "$(clawpatrol env)"` to the user's shell
@@ -1471,7 +1390,7 @@ func installTailscale() error {
 		if err := c.Run(); err != nil {
 			return fmt.Errorf("brew install: %w (or download manually from tailscale.com)", err)
 		}
-		fmt.Println("  launch Tailscale.app once, then re-run clawpatrol login")
+		fmt.Println("  launch Tailscale.app once, then re-run clawpatrol join")
 		return fmt.Errorf("manual app launch required")
 	case "linux":
 		c := exec.Command("sh", "-c", "curl -fsSL https://tailscale.com/install.sh | sh")

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -1,10 +1,10 @@
 # clawpatrol — Tailscale mode
 
 Tailscale as the primary control plane. The gateway joins your existing
-tailnet as an exit-node via an embedded **tsnet.Server**; devices already
-on the tailnet run `clawpatrol login` to pin it as their exit-node. No
-public UDP port, no WireGuard keypair management, no subnet allocation
-— Tailscale's control plane handles all of that.
+tailnet as an exit-node via an embedded **tsnet.Server**; devices onboard
+through the same `clawpatrol join <gateway-url>` device-flow that
+WireGuard mode uses. No public UDP port, no WireGuard keypair management,
+no subnet allocation — Tailscale's control plane handles all of that.
 
 ## How it works
 
@@ -13,14 +13,18 @@ public UDP port, no WireGuard keypair management, no subnet allocation
    `authkey` field or `$TS_AUTHKEY`. It joins the tailnet under the configured hostname
    (default: `clawpatrol-gateway`) and binds the MITM + dashboard on
    the resulting tailnet IP.
-2. When a device runs `clawpatrol login`, the dashboard mints a
-   single-use Tailscale auth key by exchanging OAuth client credentials
-   for a short-lived bearer token and calling the Tailscale key API
-   (`reusable: false`, `preauthorized: true`, 10-minute TTL).
-3. `clawpatrol login` calls `tailscale up --authkey=<key>` (installs
-   Tailscale if missing), installs a fwmark policy-route to keep SSH
-   alive, fetches the gateway CA, sets `--exit-node=clawpatrol-gateway`,
-   and writes the CA bundle to the system trust store.
+2. When a device runs `clawpatrol join <gateway-url>`, the dashboard
+   mints a single-use Tailscale auth key by exchanging OAuth client
+   credentials for a short-lived bearer token and calling the
+   Tailscale key API (`reusable: false`, `preauthorized: true`,
+   10-minute TTL) and ships it back over the device-flow poll.
+3. The per-process tsnet daemon picks up that auth key on first
+   `clawpatrol run` and joins the tailnet under the operator-chosen
+   hostname. With `--whole-machine` (Linux), the join flow also runs
+   `tailscale up --authkey=<key>`, installs a fwmark policy-route to
+   keep SSH alive, and sets `--exit-node=clawpatrol-gateway` on the
+   system tailscaled. The CA is fetched over the tailnet and
+   installed into the system trust store.
 4. All outbound traffic now exits through the gateway. The gateway
    intercepts at L4 — TCP/443 → SNI peek → MITM or splice, everything
    else forwarded via `wgRelay` / `relayUDP`. Tailscale handles NAT
@@ -33,8 +37,10 @@ public UDP port, no WireGuard keypair management, no subnet allocation
 
 - `clawpatrol gateway gateway.hcl` boots the tsnet node, no public
   ports needed — only outbound HTTPS to the Tailscale control plane.
-- `clawpatrol login` is one command on the device: join tailnet +
-  install CA + set exit-node. Subsequent re-runs are idempotent.
+- `clawpatrol join <gateway-url>` is one command on the device:
+  device-flow approval against the dashboard, then install CA +
+  (with `--whole-machine`) set the gateway as exit-node. Subsequent
+  re-runs are idempotent.
 - Agents (`claude`, `gh`, `codex`) run unmodified. `eval "$(clawpatrol
   env)"` exports placeholder tokens + CA bundle. HTTPS to
   `api.anthropic.com` routes through the exit-node, gateway intercepts,
@@ -57,7 +63,7 @@ public UDP port, no WireGuard keypair management, no subnet allocation
 | **Auth key source** | OAuth client_credentials → Tailscale API | Self-generated keypair |
 | **Device IP** | Assigned by Tailscale control plane | Allocated from `wg_subnet_cidr` |
 | **Dashboard auth** | Tailscale user identity (no proxy needed) | Falls back to `admin_email`; needs auth proxy for multi-user |
-| **Client command** | `clawpatrol login` | `clawpatrol join <gw-url>` |
+| **Client command** | `clawpatrol join <gw-url>` | `clawpatrol join <gw-url>` |
 | **State** | `state_dir` — tsnet machine key + ipn state in sqlite | `state_dir` — WG server key, peer map, sessions in sqlite |
 
 ## Required tailnet ACL
@@ -129,25 +135,17 @@ device on the tailnet once the gateway is up.
 
 ## Client setup
 
-Device must be on the tailnet first:
-
 ```bash
-# Install Tailscale (if not already): https://tailscale.com/download
-# Then:
-tailscale up   # join tailnet with your normal Tailscale credentials
-
 curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
-clawpatrol login           # finds clawpatrol-gateway on the tailnet
-                            # approve at the dashboard URL it prints
-# done — claude/gh/codex just work
+clawpatrol join <gateway-url>   # prints a user_code; approve on the
+                                # dashboard from any trusted device
+# done — clawpatrol run claude (or gh/codex) just works
 ```
 
-Options:
-
-```
---name string       exit-node hostname to find on the tailnet (default: clawpatrol-gateway)
---no-exit-node      skip setting exit-node (use if you only want the CA)
-```
+The gateway mints a single-use Tailscale auth key as part of the
+approval; the local tsnet daemon joins the tailnet on first
+`clawpatrol run`. Add `--whole-machine` to additionally install
+system Tailscale and pin the gateway as the host-wide exit-node.
 
 ## Tunnel plugin — reach internal tailnet services
 


### PR DESCRIPTION
`login` is the legacy tailscale-only onboarding command that predates
the device-flow approval flow in `clawpatrol join`. Run standalone, it
never gets a per-device api-token, never mints a per-device tailscale
auth key, and never registers the device with the gateway dashboard — so
the resulting setup is incomplete.

The only internal use was `runJoin` shelling out with `-post-join` to
finish the whole-machine Linux tailscale path (flip exit-node, exempt
SSH + public IP from the new default route, pin DNS at the gateway).
That work moves into a small `applyWholeMachineExitNode` helper called
inline from `runJoin`.

* Remove the `login` case from the CLI dispatch and the usage block.
* Delete `runLogin` and inline the post-join exit-node setup.
* Update the stale `clawpatrol login` references in `runEnv`'s error
  message, the tailscale install prompt, and `doc/tailscale.md` to point
  at `clawpatrol join` instead.