### PR TITLE
Mint Tailscale auth keys as single-use

### DIFF
--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -468,10 +468,17 @@ func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string, _ bool) (str
 }
 
 // mintTailscaleAuthKey calls Tailscale's OAuth + auth-key API to mint
-// a reusable auth key. ephemeral=true makes each registered node
+// a single-use auth key. ephemeral=true makes the registered node
 // auto-disappear on disconnect (used by per-process tsnet runs);
 // ephemeral=false keeps the node registered across reconnects (used
-// by whole-machine joins).
+// by whole-machine joins and the per-host daemon).
+//
+// The key is non-reusable: it authenticates exactly one node
+// registration, then becomes inert. Daemon respawns and reboots reuse
+// the persisted tsnet state dir (no key needed — tsnet ignores the
+// AuthKey field once the local state is past NeedsLogin). Limits the
+// blast radius if the on-disk auth-key file leaks: an attacker can
+// register at most one extra tailnet node before the key is burned.
 func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig, ephemeral bool) (string, error) {
 	clientID := resolveTemplate(ts.OAuthClientID)
 	clientSecret := resolveTemplate(ts.OAuthClientSecret)
@@ -532,7 +539,7 @@ func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig, ephemeral bool) (s
 		"capabilities": map[string]any{
 			"devices": map[string]any{
 				"create": map[string]any{
-					"reusable":      true,
+					"reusable":      false,
 					"ephemeral":     ephemeral,
 					"preauthorized": true,
 					"tags":          tags,


### PR DESCRIPTION
* Flip `reusable: true` -> `false` in `mintTailscaleAuthKey`. The
  on-disk auth-key file (`\$XDG_STATE_HOME/clawpatrol/auth-key` on
  Linux, NE `providerConfiguration` on macOS) is consumed exactly
  once on first daemon bring-up and becomes inert thereafter.
* Daemon idle-exit + respawn and host reboots both keep working
  without re-joining: the persisted tsnet state dir
  (`\$XDG_STATE_HOME/clawpatrol/tsnet/`) carries the node identity
  across restarts. tsnet's \`Start()\` ignores \`AuthKey\` when local
  state is past \`NeedsLogin\` (tsnet.go in v1.98 logs \"Authkey is
  set; but state is %v. Ignoring authkey.\" and proceeds with the
  cached identity), so a burned key on respawn is a no-op.
* Limits the blast radius if the auth-key file leaks: an attacker
  can register at most one extra tailnet node before the key is
  burned, instead of arbitrarily many over the 90-day expiry
  window.

Existing operator workflow if the daemon state is lost (manual
\`rm -rf ~/.local/state/clawpatrol/tsnet\`, fresh install on a host
that already joined, etc.) is unchanged: \`clawpatrol join\` again
to mint a new key.