### PR TITLE
sec: mint tsnet auth keys single-use (reusable=false)

### DIFF
--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -468,10 +468,13 @@ func (t *tailscaleOnboarder) MintKey(ctx context.Context, _ string, _ bool) (str
 }
 
 // mintTailscaleAuthKey calls Tailscale's OAuth + auth-key API to mint
-// a reusable auth key. ephemeral=true makes each registered node
-// auto-disappear on disconnect (used by per-process tsnet runs);
-// ephemeral=false keeps the node registered across reconnects (used
-// by whole-machine joins).
+// a single-use auth key. The Linux daemon (daemon_transport_tsnet_linux.go)
+// persists the tsnet node identity in $XDG_STATE_HOME/clawpatrol/tsnet/
+// after first boot — subsequent daemon respawns load the stored identity
+// and reconnect with no auth-key, so one key per machine is enough.
+// ephemeral=true makes each registered node auto-disappear on disconnect;
+// ephemeral=false keeps the node registered across reconnects (used by
+// daemon-mode and whole-machine joins).
 func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig, ephemeral bool) (string, error) {
 	clientID := resolveTemplate(ts.OAuthClientID)
 	clientSecret := resolveTemplate(ts.OAuthClientSecret)
@@ -532,7 +535,13 @@ func mintTailscaleAuthKey(ctx context.Context, ts JoinConfig, ephemeral bool) (s
 		"capabilities": map[string]any{
 			"devices": map[string]any{
 				"create": map[string]any{
-					"reusable":      true,
+					// Single-use: the daemon consumes it once at first
+					// boot, then leans on the persisted tsnet state for
+					// every subsequent reconnect. A stolen auth-key
+					// file is dead the moment the daemon registers, so
+					// off-box exfiltration shrinks to a race against
+					// the first daemon boot.
+					"reusable":      false,
 					"ephemeral":     ephemeral,
 					"preauthorized": true,
 					"tags":          tags,


### PR DESCRIPTION
## Summary

- Flip the Tailscale auth-key mint from \`reusable: true\` → \`reusable: false\` at \`cmd/clawpatrol/onboard.go\`. One-line behavior change + comment explaining why it's safe.

## Why this is safe

The Linux daemon (\`daemon_transport_tsnet_linux.go\`) calls \`tsnet.Server{AuthKey, Dir: \$XDG_STATE_HOME/clawpatrol/tsnet, …}\`. tsnet persists its node identity (machine key + node ID + login session) to that \`Dir\` on first boot. Subsequent daemon respawns load the stored identity and reconnect — same semantics as \`tailscale up\`, no key consumed on reconnect.

So the auth-key is only ever needed once. Making it single-use carries no cost for the legit flow.

| Lifecycle event | Old (reusable=true) | New (reusable=false) |
|---|---|---|
| First \`clawpatrol run\` after join | consume key | consume key |
| Daemon idle-exit + respawn 6 min later | reload state, ignore key | reload state, ignore key |
| Laptop reboot | reload state, ignore key | reload state, ignore key |
| Re-install / state wiped | re-run \`clawpatrol join\` | re-run \`clawpatrol join\` |
| Auth-key file copied off-box | spawns fresh \`tag:client\` node | dead string after first daemon boot |

## What this closes

The reusable + 90-day-expiry combo turned the auth-key file into a 90-day bearer. Any process on the host (agents, malware, anything running as the user) that read \`~/.local/state/clawpatrol/auth-key\` at month 2 could spin up a new tag:client tailnet node from anywhere. Single-use shrinks that window to "between mint and first daemon boot" — typically seconds for users who immediately run \`clawpatrol run\` after joining.

## What this does NOT close

The post-boot tsnet state dir (\`~/.local/state/clawpatrol/tsnet/\`) is now the bearer. File copy of that dir → \`tsnet.Server{Dir: stolen}\` on attacker hardware → resumes as the legit node. Same problem under a different filename, same shape as the WG-key-leak case. Real fix is either:
- Tag ACL clamp (\`tag:client → gateway:443\`) so stolen-state nodes can only reach the gateway anyway.
- Daemon-as-svc-user / setuid wrapper so state ownership ≠ agent UID. Matches \`tailscaled\`'s privilege model.

Tracked as follow-up.

## Test plan

- [x] \`go build\` / \`go vet\` / \`gofmt -l\` clean on darwin + linux
- [x] \`go test ./cmd/clawpatrol/\` passes
- [ ] Manual: fresh \`clawpatrol join\` against a test gateway → \`clawpatrol run echo ok\` → daemon respawn after 5min → \`clawpatrol run echo ok\` again (verifies daemon reconnects without re-mint)
- [ ] Manual: copy \`auth-key\` post-first-boot → attempt \`tsnet.Server{AuthKey: copy}\` elsewhere → expect 'key already used' from Tailscale

🤖 Generated with [Claude Code](https://claude.com/claude-code)