### PR TITLE
home: show 10 devices instead of 5

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -155,7 +155,7 @@ export default function App() {
 // HomeAgents shows the first N agents on the home page with a link
 // to the full devices list when there's more. Sorted by IP (matching
 // AgentsTable's own sort) so truncation is stable across renders.
-const HOME_AGENTS_LIMIT = 5;
+const HOME_AGENTS_LIMIT = 10;
 function HomeAgents({
   agents,
   integrations,


### PR DESCRIPTION
## Summary
- Bump `HOME_AGENTS_LIMIT` from 5 to 10 on the home page devices list.

## Test plan
- [ ] Load the dashboard home page with >5 devices and confirm 10 rows render before the "…and N more" overflow link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)