### PR TITLE
dashboard: prefix logo src with import.meta.env.BASE_URL

### DIFF
--- a/dashboard/src/components/Header.tsx
+++ b/dashboard/src/components/Header.tsx
@@ -30,7 +30,11 @@ export function Header({
     <header className="bg-transparent">
       <div className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-4 flex items-center gap-4">
         <a href="#/" aria-label="Home" className="shrink-0">
-          <img src="/claw-patrol-logo.svg" alt="Claw Patrol" className="h-6 sm:h-8 w-auto" />
+          <img
+            src={import.meta.env.BASE_URL + "claw-patrol-logo.svg"}
+            alt="Claw Patrol"
+            className="h-6 sm:h-8 w-auto"
+          />
         </a>
         <nav className="ml-auto flex items-center gap-2">
           <a

--- a/dashboard/src/vite-env.d.ts
+++ b/dashboard/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- Replace hardcoded `src="/claw-patrol-logo.svg"` in `Header.tsx` with `import.meta.env.BASE_URL + "claw-patrol-logo.svg"` so the logo loads when the SPA is built with a non-root Vite `--base` (e.g. for the gh-pages demo deploy at `/clawpatrol-demo/`).

## Test plan
- [ ] Default root build: logo still loads at `/claw-patrol-logo.svg`.
- [ ] Subpath build (`vite build --base=/clawpatrol-demo/`): logo loads at `/clawpatrol-demo/claw-patrol-logo.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)