### PR TITLE
home: sort devices by activity, bucketed to the hour

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AgentsTable } from "./components/AgentsTable";
+import { AgentsTable, sortAgents } from "./components/AgentsTable";
 import { AnalyticsPage } from "./components/AnalyticsPage";
 import { ConnectModal } from "./components/ConnectModal";
 import { DevicePage } from "./components/DevicePage";
@@ -153,8 +153,9 @@ export default function App() {
 }
 
 // HomeAgents shows the first N agents on the home page with a link
-// to the full devices list when there's more. Sorted by IP (matching
-// AgentsTable's own sort) so truncation is stable across renders.
+// to the full devices list when there's more. Sorted by activity
+// (last_at, bucketed to the hour) so the most-recently-active devices
+// surface but the order doesn't churn on every ping.
 const HOME_AGENTS_LIMIT = 10;
 function HomeAgents({
   agents,
@@ -165,13 +166,18 @@ function HomeAgents({
   integrations: Integration[];
   onSelect: (ip: string) => void;
 }) {
-  const sorted = [...agents].sort((a, b) => a.ip.localeCompare(b.ip));
+  const sorted = sortAgents(agents, "activity");
   const shown = sorted.slice(0, HOME_AGENTS_LIMIT);
   const overflow = sorted.length - shown.length;
   return (
     <section className="bg-canvas border-1.5 border-navy overflow-hidden">
       <div className="overflow-x-auto">
-        <AgentsTable agents={shown} integrations={integrations} onSelect={onSelect} />
+        <AgentsTable
+          agents={shown}
+          integrations={integrations}
+          onSelect={onSelect}
+          sortBy="activity"
+        />
       </div>
       {overflow > 0 && (
         <a

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -9,14 +9,19 @@ export function AgentsTable({
   agents,
   integrations,
   onSelect,
+  sortBy = "ip",
 }: {
   agents: Agent[];
   integrations?: Integration[];
   onSelect?: (ip: string) => void;
+  // "ip": ascending IP — stable, default.
+  // "activity": most-recently-active first, bucketed to the hour so
+  // ordering doesn't reshuffle on every ping. IP tiebreak.
+  sortBy?: "ip" | "activity";
 }) {
   const byId = new Map<string, Integration>();
   for (const i of integrations ?? []) byId.set(i.id, i);
-  const stable = [...(agents ?? [])].sort((a, b) => a.ip.localeCompare(b.ip));
+  const stable = sortAgents(agents ?? [], sortBy);
   return (
     <table className="w-full table-fixed border-collapse" style={{ minWidth: 650 }}>
       <colgroup>
@@ -100,6 +105,23 @@ export function AgentsTable({
       </tbody>
     </table>
   );
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export function sortAgents(agents: Agent[], by: "ip" | "activity"): Agent[] {
+  const out = [...agents];
+  if (by === "ip") {
+    out.sort((a, b) => a.ip.localeCompare(b.ip));
+    return out;
+  }
+  out.sort((a, b) => {
+    const ba = Math.floor((Date.parse(a.last_at) || 0) / HOUR_MS);
+    const bb = Math.floor((Date.parse(b.last_at) || 0) / HOUR_MS);
+    if (ba !== bb) return bb - ba;
+    return a.ip.localeCompare(b.ip);
+  });
+  return out;
 }
 
 // needsAction returns true when a declared credential is missing its


### PR DESCRIPTION
## Summary
- Home page's top-10 device list now sorts by most-recently-active (`last_at`) instead of IP, so the devices people care about surface first.
- To keep order from churning on every ping, `last_at` is bucketed to 1-hour windows (desc), with IP as the tiebreak.
- Implemented as a `sortBy: "ip" | "activity"` prop on `AgentsTable`; `DevicesPage` keeps the existing IP order.

## Test plan
- [ ] Open home — top 10 devices ordered by activity, stable across renders within the hour.
- [ ] Open /devices — still alphabetical by IP.
- [ ] With <10 devices, no "…and N more" link.
- [ ] With >10 devices, overflow link reflects the activity-sorted slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)