### PR TITLE
ssh: fix BlobStore wiring + log per-channel intent

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -313,10 +313,15 @@ type Gateway struct {
 	certs    *CertCache
 	dialer   *net.Dialer
 	sink     *Sink
-	oauth    *OAuthRegistry
-	agents   *AgentRegistry
-	hitl     *HITLRegistry
-	onboard  *onboardRegistry
+	// blobs is the gateway-side plugin blob store (sqlite-backed).
+	// Used by endpoint plugins that need per-endpoint persistent
+	// bytes — SSH host keys today, future JWT signing keys.
+	// Exposed to plugins via ConnHandle.Blobs.
+	blobs   runtime.BlobStore
+	oauth   *OAuthRegistry
+	agents  *AgentRegistry
+	hitl    *HITLRegistry
+	onboard *onboardRegistry
 	// secrets hands credential plugins the secret bytes they inject
 	// at request time. gatewaySecretStore stacks the credential_secrets
 	// table (dashboard slots), OAuthRegistry (refreshed access tokens),
@@ -1447,6 +1452,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 		Profile:  profile,
 		PeerIP:   pip,
 		Secrets:  g.secrets,
+		Blobs:    g.blobs,
 		DialUpstream: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			// Plugin asks for ep.Hosts[0]:port; we bypass DNS by
 			// dialing the original upstream IP the WG forwarder
@@ -1601,6 +1607,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 		Profile:      profile,
 		PeerIP:       pip,
 		Secrets:      g.secrets,
+		Blobs:        g.blobs,
 		StateDir:     g.stateDir,
 		DstPort:      dstPort,
 		UpstreamHost: hostname,
@@ -2763,6 +2770,7 @@ func runGateway(args []string) {
 		certs:    certs,
 		dialer:   newUpstreamDialer(cfg.Resolver()),
 		sink:     sink,
+		blobs:    blobs,
 		oauth:    oauthReg,
 		agents:   NewAgentRegistry(),
 		hitl:     newHITLRegistry(sink),

--- a/internal/config/plugins/endpoints/ssh.go
+++ b/internal/config/plugins/endpoints/ssh.go
@@ -221,13 +221,16 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	}
 	defer func() { _ = clientConn.Close() }()
 
-	if ch.Emit != nil {
-		ch.Emit(runtime.ConnEvent{
-			Action:  "allow",
-			Verb:    "ssh",
-			Summary: fmt.Sprintf("%s@%s", agentUser, upstreamAddr),
-		})
+	emit := func(ev runtime.ConnEvent) {
+		if ch.Emit != nil {
+			ch.Emit(ev)
+		}
 	}
+	emit(runtime.ConnEvent{
+		Action:  "allow",
+		Verb:    "connect",
+		Summary: fmt.Sprintf("%s@%s", agentUser, upstreamAddr),
+	})
 
 	// Step 6: bidirectional pump. Two waitgroups — `dispatch` covers
 	// the four conn-level demuxers (channel + global-request feeds);
@@ -238,10 +241,15 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	// have drained, so a fast `ssh host echo hi` doesn't lose its
 	// final bytes when the upstream half tears down (visible as ~10%
 	// blank-output flake when running tests in tight succession).
+	//
+	// Only the agent→upstream channel pump gets the emit hook: we
+	// want to log user intent (exec / shell / subsystem / direct-tcpip
+	// target) and upstream replies (exit-status), not the rare
+	// upstream-originated X11 / forwarded-tcpip openings.
 	var dispatch, chans sync.WaitGroup
 	dispatch.Add(4)
-	go func() { defer dispatch.Done(); pumpChannels(clientConn, srvChans, &chans) }()
-	go func() { defer dispatch.Done(); pumpChannels(srvConn, clientChans, &chans) }()
+	go func() { defer dispatch.Done(); pumpChannels(clientConn, srvChans, &chans, emit) }()
+	go func() { defer dispatch.Done(); pumpChannels(srvConn, clientChans, &chans, nil) }()
 	go func() { defer dispatch.Done(); pumpGlobalReqs(clientConn, srvReqs) }()
 	go func() { defer dispatch.Done(); pumpGlobalReqs(srvConn, clientReqs) }()
 
@@ -390,8 +398,18 @@ func warnHostKeyOnce(endpointName string) {
 // and opens the same type on the other. Each successful pair runs
 // proxyChannel (tracked via wg so HandleConn can drain in-flight
 // channels before closing the SSH conns).
-func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel, wg *sync.WaitGroup) {
+//
+// emit is non-nil only for the agent→upstream direction; pumpChannels
+// uses it to log direct-tcpip targets at channel-open time and passes
+// it to proxyChannel for per-channel request logging (exec / shell /
+// subsystem / exit-status).
+func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel, wg *sync.WaitGroup, emit func(runtime.ConnEvent)) {
 	for newCh := range source {
+		if emit != nil {
+			if ev, ok := classifyChannelOpen(newCh); ok {
+				emit(ev)
+			}
+		}
 		targetCh, targetReqs, err := target.OpenChannel(newCh.ChannelType(), newCh.ExtraData())
 		if err != nil {
 			var ocErr *ssh.OpenChannelError
@@ -410,7 +428,7 @@ func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel, wg *sync.WaitGr
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			proxyChannel(sourceCh, sourceReqs, targetCh, targetReqs)
+			proxyChannel(sourceCh, sourceReqs, targetCh, targetReqs, emit)
 		}()
 	}
 }
@@ -434,7 +452,7 @@ func pumpChannels(target ssh.Conn, source <-chan ssh.NewChannel, wg *sync.WaitGr
 // intact — closing too eagerly would cut off in-flight reads on the
 // fast side and lose the last few bytes of output (~10% flake rate
 // in `ssh host echo X` stress tests).
-func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs <-chan *ssh.Request) {
+func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs <-chan *ssh.Request, emit func(runtime.ConnEvent)) {
 	// pumpDir copies both stdout and stderr from src to dst, then
 	// emits channel-eof. Combining the two before CloseWrite is
 	// required: stderr is just extended-data on the same channel,
@@ -451,9 +469,14 @@ func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs
 		inner.Wait()
 		_ = dst.CloseWrite()
 	}
-	forwardReqs := func(target ssh.Channel, source <-chan *ssh.Request, done chan<- struct{}) {
+	forwardReqs := func(target ssh.Channel, source <-chan *ssh.Request, classify func(*ssh.Request) (runtime.ConnEvent, bool), done chan<- struct{}) {
 		defer close(done)
 		for r := range source {
+			if classify != nil {
+				if ev, ok := classify(r); ok {
+					emit(ev)
+				}
+			}
 			ok, err := target.SendRequest(r.Type, r.WantReply, r.Payload)
 			if err != nil {
 				ok = false
@@ -464,14 +487,23 @@ func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs
 		}
 	}
 
+	// aReqs flow agent→upstream (exec / shell / subsystem); bReqs flow
+	// upstream→agent (exit-status / signal). Only classify when this
+	// proxyChannel was spawned by the agent-direction pump (emit set).
+	var classifyAgent, classifyUpstream func(*ssh.Request) (runtime.ConnEvent, bool)
+	if emit != nil {
+		classifyAgent = classifyAgentChannelReq
+		classifyUpstream = classifyUpstreamChannelReq
+	}
+
 	pumpA := make(chan struct{}) // upstream→agent data finished
 	pumpB := make(chan struct{}) // agent→upstream data finished
 	reqA := make(chan struct{})  // upstream→agent reqs finished
 	reqB := make(chan struct{})  // agent→upstream reqs finished
 	go pumpDir(a, b, pumpA)
 	go pumpDir(b, a, pumpB)
-	go forwardReqs(a, bReqs, reqA)
-	go forwardReqs(b, aReqs, reqB)
+	go forwardReqs(a, bReqs, classifyUpstream, reqA)
+	go forwardReqs(b, aReqs, classifyAgent, reqB)
 
 	// fromUpstream / fromAgent fire when a full direction
 	// (data + reqs) has drained — at that point its source channel
@@ -532,6 +564,92 @@ func isProxyDroppedGlobalReq(name string) bool {
 		return true
 	}
 	return false
+}
+
+// ── Per-channel request / channel-open classification (logging) ──────
+
+// SSH wire payload shapes we decode for logging only — never modify.
+// Field names match the RFC declaration order so ssh.Unmarshal walks
+// them correctly (it ignores struct tags and reads in order).
+type (
+	// RFC4254 §6.5.
+	execPayload struct{ Command string }
+	// RFC4254 §6.5.
+	subsystemPayload struct{ Name string }
+	// RFC4254 §6.10.
+	exitStatusPayload struct{ Status uint32 }
+	// RFC4254 §7.2 — payload of a `direct-tcpip` channel's ExtraData.
+	directTCPIPPayload struct {
+		DestHost   string
+		DestPort   uint32
+		OriginHost string
+		OriginPort uint32
+	}
+)
+
+// classifyChannelOpen turns an agent-originated channel-open into a
+// log event. Only `direct-tcpip` (port forwarding) carries a target
+// we can usefully surface; `session` opens are noise (the interesting
+// per-session intent rides on the following exec / shell / subsystem
+// channel-request, classified separately).
+func classifyChannelOpen(newCh ssh.NewChannel) (runtime.ConnEvent, bool) {
+	if newCh.ChannelType() != "direct-tcpip" {
+		return runtime.ConnEvent{}, false
+	}
+	var d directTCPIPPayload
+	if err := ssh.Unmarshal(newCh.ExtraData(), &d); err != nil {
+		return runtime.ConnEvent{}, false
+	}
+	return runtime.ConnEvent{
+		Action:  "allow",
+		Verb:    "forward",
+		Summary: fmt.Sprintf("→ %s:%d", d.DestHost, d.DestPort),
+	}, true
+}
+
+// classifyAgentChannelReq turns an agent→upstream channel request
+// into a log event. exec carries the full argv as a single string;
+// subsystem carries the subsystem name (e.g. "sftp"); shell carries
+// no payload (interactive session start). Other request types
+// (pty-req, env, window-change, signal, eow@openssh.com, ...) are
+// session-keepalive noise — drop them silently.
+func classifyAgentChannelReq(r *ssh.Request) (runtime.ConnEvent, bool) {
+	switch r.Type {
+	case "exec":
+		var p execPayload
+		if err := ssh.Unmarshal(r.Payload, &p); err != nil {
+			return runtime.ConnEvent{}, false
+		}
+		return runtime.ConnEvent{Action: "allow", Verb: "exec", Summary: p.Command}, true
+	case "shell":
+		return runtime.ConnEvent{Action: "allow", Verb: "shell", Summary: "interactive shell"}, true
+	case "subsystem":
+		var p subsystemPayload
+		if err := ssh.Unmarshal(r.Payload, &p); err != nil {
+			return runtime.ConnEvent{}, false
+		}
+		return runtime.ConnEvent{Action: "allow", Verb: "subsystem", Summary: p.Name}, true
+	}
+	return runtime.ConnEvent{}, false
+}
+
+// classifyUpstreamChannelReq turns an upstream→agent channel request
+// into a log event. The interesting one is exit-status — pairs an
+// earlier exec/shell event with its return code in the audit log.
+// signal / exit-signal are rare and not surfaced for now.
+func classifyUpstreamChannelReq(r *ssh.Request) (runtime.ConnEvent, bool) {
+	if r.Type != "exit-status" {
+		return runtime.ConnEvent{}, false
+	}
+	var p exitStatusPayload
+	if err := ssh.Unmarshal(r.Payload, &p); err != nil {
+		return runtime.ConnEvent{}, false
+	}
+	return runtime.ConnEvent{
+		Action:  "allow",
+		Verb:    "exit",
+		Summary: fmt.Sprintf("exit %d", p.Status),
+	}, true
 }
 
 // ── Host key persistence ──────────────────────────────────────────────

--- a/internal/config/plugins/endpoints/ssh_test.go
+++ b/internal/config/plugins/endpoints/ssh_test.go
@@ -3,6 +3,8 @@ package endpoints
 import (
 	"testing"
 
+	"golang.org/x/crypto/ssh"
+
 	"github.com/denoland/clawpatrol/internal/config"
 )
 
@@ -100,3 +102,127 @@ func TestPickSSHCredential(t *testing.T) {
 		})
 	}
 }
+
+// classifyAgentChannelReq covers the per-channel requests an agent
+// can send: exec carries argv as one string, shell is empty,
+// subsystem carries the subsystem name, anything else (pty-req,
+// env, window-change, signal, ...) is dropped silently.
+func TestClassifyAgentChannelReq(t *testing.T) {
+	cases := []struct {
+		name        string
+		reqType     string
+		payload     []byte
+		wantOK      bool
+		wantVerb    string
+		wantSummary string
+	}{
+		{
+			name:        "exec",
+			reqType:     "exec",
+			payload:     ssh.Marshal(execPayload{Command: "ls -la /etc"}),
+			wantOK:      true,
+			wantVerb:    "exec",
+			wantSummary: "ls -la /etc",
+		},
+		{
+			name:        "shell",
+			reqType:     "shell",
+			payload:     nil,
+			wantOK:      true,
+			wantVerb:    "shell",
+			wantSummary: "interactive shell",
+		},
+		{
+			name:        "subsystem sftp",
+			reqType:     "subsystem",
+			payload:     ssh.Marshal(subsystemPayload{Name: "sftp"}),
+			wantOK:      true,
+			wantVerb:    "subsystem",
+			wantSummary: "sftp",
+		},
+		{name: "pty-req dropped", reqType: "pty-req", payload: nil, wantOK: false},
+		{name: "env dropped", reqType: "env", payload: nil, wantOK: false},
+		{name: "window-change dropped", reqType: "window-change", payload: nil, wantOK: false},
+		{name: "exec with malformed payload", reqType: "exec", payload: []byte{0xff}, wantOK: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev, ok := classifyAgentChannelReq(&ssh.Request{Type: c.reqType, Payload: c.payload})
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v; want %v", ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if ev.Verb != c.wantVerb {
+				t.Errorf("verb = %q; want %q", ev.Verb, c.wantVerb)
+			}
+			if ev.Summary != c.wantSummary {
+				t.Errorf("summary = %q; want %q", ev.Summary, c.wantSummary)
+			}
+		})
+	}
+}
+
+// classifyUpstreamChannelReq surfaces exit-status only.
+func TestClassifyUpstreamChannelReq(t *testing.T) {
+	t.Run("exit-status", func(t *testing.T) {
+		ev, ok := classifyUpstreamChannelReq(&ssh.Request{
+			Type:    "exit-status",
+			Payload: ssh.Marshal(exitStatusPayload{Status: 127}),
+		})
+		if !ok {
+			t.Fatal("expected event for exit-status")
+		}
+		if ev.Verb != "exit" || ev.Summary != "exit 127" {
+			t.Errorf("got verb=%q summary=%q; want verb=exit summary=\"exit 127\"", ev.Verb, ev.Summary)
+		}
+	})
+	t.Run("signal dropped", func(t *testing.T) {
+		if _, ok := classifyUpstreamChannelReq(&ssh.Request{Type: "signal"}); ok {
+			t.Fatal("expected signal to be dropped")
+		}
+	})
+}
+
+// classifyChannelOpen surfaces direct-tcpip targets; session opens
+// (the common case for interactive logins / exec) are dropped — the
+// interesting intent rides on the following channel-request.
+func TestClassifyChannelOpen(t *testing.T) {
+	t.Run("direct-tcpip", func(t *testing.T) {
+		nc := fakeNewChannel{
+			ty: "direct-tcpip",
+			extra: ssh.Marshal(directTCPIPPayload{
+				DestHost: "db.internal", DestPort: 5432,
+				OriginHost: "127.0.0.1", OriginPort: 54321,
+			}),
+		}
+		ev, ok := classifyChannelOpen(nc)
+		if !ok {
+			t.Fatal("expected event for direct-tcpip")
+		}
+		if ev.Verb != "forward" || ev.Summary != "→ db.internal:5432" {
+			t.Errorf("got verb=%q summary=%q; want verb=forward summary=\"→ db.internal:5432\"", ev.Verb, ev.Summary)
+		}
+	})
+	t.Run("session dropped", func(t *testing.T) {
+		if _, ok := classifyChannelOpen(fakeNewChannel{ty: "session"}); ok {
+			t.Fatal("expected session open to be dropped")
+		}
+	})
+}
+
+// fakeNewChannel is the minimum ssh.NewChannel surface
+// classifyChannelOpen reads — type and ExtraData. Accept / Reject
+// aren't exercised by the classifier.
+type fakeNewChannel struct {
+	ty    string
+	extra []byte
+}
+
+func (f fakeNewChannel) Accept() (ssh.Channel, <-chan *ssh.Request, error) {
+	return nil, nil, nil
+}
+func (f fakeNewChannel) Reject(ssh.RejectionReason, string) error { return nil }
+func (f fakeNewChannel) ChannelType() string                      { return f.ty }
+func (f fakeNewChannel) ExtraData() []byte                        { return f.extra }


### PR DESCRIPTION
Two SSH changes that landed together because the second one isn't testable without the first.

## 1. Fix: SSH was wholly broken (regression since #455)

\`ssh.HandleConn\` rejects \`ConnHandle\`s whose \`Blobs\` is nil — it needs the BlobStore to load / mint the per-endpoint host key. Both ConnHandle construction sites in \`main.go\` left \`Blobs\` unset:
- postgres-only path (\`g.handlePGConn\`, line 1448),
- generic \`dispatchConnEndpoint\` shared by VIP + direct-IP paths (line 1602).

Result: every SSH connection died with \`ssh runtime needs a BlobStore to persist host keys\` before the gateway could send a banner — agent saw a TCP RST mid-kex (\`kex_exchange_identification: read: Connection reset by peer\`).

Fix: store the BlobStore on \`Gateway\` (next to \`sink\`) and wire it through both ConnHandle build sites.

## 2. Feat: log per-channel intent and direct-tcpip targets

SSH used to emit a single \`ssh connect\` event per session and nothing else — every exec, shell, sftp, and port-forward inside the session was invisible to the audit log. This wires the agent→upstream channel pump and request stream into the existing \`ConnHandle.Emit\` plumbing.

What gets logged now:
- **\`forward → host:port\`** when an agent opens a \`direct-tcpip\` channel (parsed from the channel ExtraData per RFC4254 §7.2).
- **\`exec\`** — the full command argv. Matches the no-redaction precedent of \`kubectl exec\` storing argv in \`extra\`.
- **\`shell\`** — interactive session start.
- **\`subsystem\`** — subsystem name (catches \`sftp\`).
- **\`exit N\`** — upstream's \`exit-status\` reply, pairs with the earlier exec/shell.

Connection-level verb tightened from \`ssh\` → \`connect\` so per-channel verbs read consistently against it.

## Out of scope
- No \`ssh\` facet for CEL rules — matcher still doesn't see SSH-shaped fields. Adding \`ssh.command\` / \`ssh.user\` / \`ssh.forward_host\` is a follow-up.
- No byte counts per channel.
- No credential-secret redaction over exec commands (future: hook \`redactCredentialSample\` over the exec command body, same as HTTPS request bodies).
- Dashboard / fixture rendering of the SSH family falls back to the generic \`Method\` / \`Path\` columns.

## Test plan
- [x] \`go test ./...\` — all packages pass, including new unit tests for the three classifiers (\`classifyAgentChannelReq\`, \`classifyUpstreamChannelReq\`, \`classifyChannelOpen\`) and the existing \`pickSSHCredential\` suite.
- [x] \`gofmt -l .\` clean.
- [ ] Manual: \`ssh user@host echo hi\` against a clawpatrol-fronted SSH endpoint reaches the upstream banner (verifies #1) and produces \`connect\`, \`exec\`, \`exit\` rows (verifies #2).
- [ ] Manual: \`ssh -L 5432:db.internal:5432 user@host\` produces a \`forward → db.internal:5432\` row.
- [ ] Manual: \`sftp user@host\` produces a \`subsystem\` row with \`sftp\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)