### PR TITLE
fix: populate ConnHandle.Blobs in conn dispatch (unblocks SSH)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -313,10 +313,15 @@ type Gateway struct {
 	certs    *CertCache
 	dialer   *net.Dialer
 	sink     *Sink
-	oauth    *OAuthRegistry
-	agents   *AgentRegistry
-	hitl     *HITLRegistry
-	onboard  *onboardRegistry
+	// blobs is the gateway-side plugin blob store (sqlite-backed).
+	// Used by endpoint plugins that need per-endpoint persistent
+	// bytes — SSH host keys today, future JWT signing keys.
+	// Exposed to plugins via ConnHandle.Blobs.
+	blobs   runtime.BlobStore
+	oauth   *OAuthRegistry
+	agents  *AgentRegistry
+	hitl    *HITLRegistry
+	onboard *onboardRegistry
 	// secrets hands credential plugins the secret bytes they inject
 	// at request time. gatewaySecretStore stacks the credential_secrets
 	// table (dashboard slots), OAuthRegistry (refreshed access tokens),
@@ -1447,6 +1452,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 		Profile:  profile,
 		PeerIP:   pip,
 		Secrets:  g.secrets,
+		Blobs:    g.blobs,
 		DialUpstream: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			// Plugin asks for ep.Hosts[0]:port; we bypass DNS by
 			// dialing the original upstream IP the WG forwarder
@@ -1601,6 +1607,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 		Profile:      profile,
 		PeerIP:       pip,
 		Secrets:      g.secrets,
+		Blobs:        g.blobs,
 		StateDir:     g.stateDir,
 		DstPort:      dstPort,
 		UpstreamHost: hostname,
@@ -2763,6 +2770,7 @@ func runGateway(args []string) {
 		certs:    certs,
 		dialer:   newUpstreamDialer(cfg.Resolver()),
 		sink:     sink,
+		blobs:    blobs,
 		oauth:    oauthReg,
 		agents:   NewAgentRegistry(),
 		hitl:     newHITLRegistry(sink),


### PR DESCRIPTION
## Summary
SSH connections through the gateway have been failing with a TCP reset mid-kex (\`kex_exchange_identification: read: Connection reset by peer\`) since at least #455. The gateway log shows the cause:

\`\`\`
ssh direct 65.20.66.139:22: ssh runtime needs a BlobStore to persist host keys
\`\`\`

\`ssh.HandleConn\` rejects \`ConnHandle\`s whose \`Blobs\` is nil — it needs the BlobStore to load / mint the per-endpoint host key. Both ConnHandle construction sites in \`main.go\` left \`Blobs\` unset:
- the postgres-only path (\`g.handlePGConn\`, line 1448),
- the generic \`dispatchConnEndpoint\` shared by VIP + direct-IP paths (line 1602).

This stores the gateway's BlobStore on the \`Gateway\` struct (next to \`sink\`) and wires it through both sites. Postgres doesn't currently use it, but the field is documented as the API for plugin persistence so future endpoints don't trip the same wire.

## Test plan
- [x] \`go build ./...\` + \`go test ./...\` green.
- [x] \`gofmt -l .\` clean.
- [ ] Deploy to clawpatrol-gateway and confirm \`ssh user@orchid\` reaches the upstream banner instead of getting RST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)