### PR TITLE
dashboard: rename user 'profile' page to 'account'

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -9,7 +9,7 @@ import { HITLBar } from "./components/HITLBar";
 import { LiveRequests } from "./components/LiveRequests";
 import { Main } from "./components/Main";
 import { OnboardPage } from "./components/OnboardPage";
-import { ProfilePage } from "./components/ProfilePage";
+import { AccountPage } from "./components/AccountPage";
 import { RequestDetailPage } from "./components/RequestDetailPage";
 import { SettingsPage } from "./components/SettingsPage";
 import { getState, type Agent, type Integration, type UpdateBanner, type Whoami } from "./lib/api";
@@ -22,7 +22,7 @@ type Route =
   | { name: "onboard"; code: string }
   | { name: "request"; id: string }
   | { name: "settings" }
-  | { name: "profile" };
+  | { name: "account" };
 
 function parseRoute(): Route {
   const raw = window.location.hash;
@@ -37,7 +37,7 @@ function parseRoute(): Route {
   if (r) return { name: "request", id: decodeURIComponent(r[1]) };
   if (h === "#/settings") return { name: "settings" };
   if (h === "#/devices") return { name: "devices" };
-  if (h === "#/profile") return { name: "profile" };
+  if (h === "#/account") return { name: "account" };
   if (h === "#/analytics") return { name: "analytics" };
   const a = h.match(/^#\/analytics\/([^/]+)$/);
   if (a) return { name: "analytics", ip: decodeURIComponent(a[1]) };
@@ -124,8 +124,8 @@ export default function App() {
           onConnect={(id) => setConnectId(id)}
           onRefresh={refresh}
         />
-      ) : route.name === "profile" ? (
-        <ProfilePage whoami={whoami} />
+      ) : route.name === "account" ? (
+        <AccountPage whoami={whoami} />
       ) : (
         <DevicePage
           ip={route.ip}

--- a/dashboard/src/components/AccountPage.tsx
+++ b/dashboard/src/components/AccountPage.tsx
@@ -3,13 +3,13 @@ import { Button } from "./Button";
 import { Main } from "./Main";
 import { PageTitle } from "./PageTitle";
 
-// ProfilePage shows the currently authenticated principal (moved
+// AccountPage shows the currently authenticated principal (moved
 // here from the global Header) and the only account-level action
 // the dashboard supports: logging out.
-export function ProfilePage({ whoami }: { whoami: Whoami | null }) {
+export function AccountPage({ whoami }: { whoami: Whoami | null }) {
   return (
     <Main>
-      <PageTitle trail={[{ label: "Claw Patrol", href: "#/" }, { label: "profile" }]} />
+      <PageTitle trail={[{ label: "Claw Patrol", href: "#/" }, { label: "account" }]} />
       <section className="bg-canvas border-1.5 border-navy p-4 space-y-4">
         {whoami?.user ? <Identity whoami={whoami} /> : <NotLoggedIn />}
       </section>

--- a/dashboard/src/components/Header.tsx
+++ b/dashboard/src/components/Header.tsx
@@ -4,11 +4,11 @@ import type { Whoami } from "../lib/api";
 // Global header — rendered above every route. Logo links home; the
 // nav cluster on the right is four circular icon buttons for the
 // dashboard's top-level sections (devices, analytics, settings,
-// profile). Identity + log-out moved to the profile page.
+// account). Identity + log-out moved to the account page.
 //
 // `whoami` is still accepted (currently unused) so consumers don't
 // need to thread route-specific data through; future header
-// affordances (e.g. an unread indicator on the profile button) can
+// affordances (e.g. an unread indicator on the account button) can
 // read it without a signature change.
 export function Header({
   whoami: _whoami,
@@ -25,7 +25,7 @@ export function Header({
   const devicesActive = currentRoute === "devices" || currentRoute === "device";
   const analyticsActive = currentRoute === "analytics";
   const settingsActive = currentRoute === "settings";
-  const profileActive = currentRoute === "profile";
+  const accountActive = currentRoute === "account";
   return (
     <header className="bg-transparent">
       <div className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-4 flex items-center gap-4">
@@ -65,13 +65,13 @@ export function Header({
             <NavTooltip>Settings</NavTooltip>
           </a>
           <a
-            href="#/profile"
-            className={`${navBase} ${profileActive ? navActive : ""}`}
-            aria-current={profileActive ? "page" : undefined}
-            aria-label="Profile"
+            href="#/account"
+            className={`${navBase} ${accountActive ? navActive : ""}`}
+            aria-current={accountActive ? "page" : undefined}
+            aria-label="Account"
           >
-            <ProfileIcon />
-            <NavTooltip>Profile</NavTooltip>
+            <AccountIcon />
+            <NavTooltip>Account</NavTooltip>
           </a>
         </nav>
       </div>
@@ -139,9 +139,9 @@ function SettingsIcon() {
   );
 }
 
-// ProfileIcon is a stroked head-and-shoulders glyph matching the
+// AccountIcon is a stroked head-and-shoulders glyph matching the
 // outline style of the Analytics chart and Settings cog icons.
-function ProfileIcon() {
+function AccountIcon() {
   return (
     <svg
       width="18"


### PR DESCRIPTION
## Summary
- Renames the V1 dashboard's user/identity page from 'profile' to 'account' (cl-33ra)
- Updates: header nav button label/tooltip/aria-label, hash route (`#/profile` → `#/account`), breadcrumb, component (`ProfilePage` → `AccountPage`, `ProfileIcon` → `AccountIcon`)
- HCL/runtime 'profile' concept (CompiledProfile, ProfilePicker, device profile bindings) is intentionally untouched — separate domain concept

## Test plan
- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run build` (tsc + vite) clean
- [x] `gofmt -l .` clean
- [x] No remaining refs to `ProfilePage` / `#/profile` / `profileActive` / `ProfileIcon` in dashboard/src/