### PR TITLE
fix: update Slack copy for sync HITL disconnects

### DIFF
--- a/internal/config/plugins/credentials/slack.go
+++ b/internal/config/plugins/credentials/slack.go
@@ -476,7 +476,7 @@ func slackOperationStatus(update runtime.HITLMessageUpdate) string {
 	case runtime.HITLOperationStateExpired:
 		return ":alarm_clock: HITL approval expired"
 	case runtime.HITLOperationStateClientDisconnected:
-		return ":warning: Original client disconnected before async polling handle was returned"
+		return ":warning: Original client disconnected before approval. The upstream request was not sent."
 	default:
 		return "HITL state: `" + string(update.State) + "`"
 	}

--- a/internal/config/plugins/credentials/slack_update_test.go
+++ b/internal/config/plugins/credentials/slack_update_test.go
@@ -281,6 +281,24 @@ func TestSlackUpdateHITLMessageRetriesTransientChatUpdateFailure(t *testing.T) {
 	}
 }
 
+func TestSlackUpdateHITLMessageClientDisconnectedCopyMatchesSyncHITL(t *testing.T) {
+	blocks := slackHITLUpdateBlocks(runtime.HITLMessageUpdate{
+		State:          runtime.HITLOperationStateClientDisconnected,
+		Method:         "POST",
+		Host:           "api.example.test",
+		Path:           "/v1/resources/update",
+		UpstreamCalled: false,
+	}, slackMessageRef{Credential: "slack-approvals", Channel: "C123", TS: "1778764174.925659"})
+	buf, _ := json.Marshal(blocks)
+	text := string(buf)
+	if !strings.Contains(text, "Original client disconnected before approval") || !strings.Contains(text, "upstream request was not sent") {
+		t.Fatalf("client-disconnected update blocks = %s, want sync HITL upstream-not-sent copy", text)
+	}
+	if strings.Contains(text, "async polling handle") {
+		t.Fatalf("client-disconnected update kept async-only wording: %s", text)
+	}
+}
+
 func TestSlackUpdateHITLMessageRedactsSensitiveLastError(t *testing.T) {
 	blocks := slackHITLUpdateBlocks(runtime.HITLMessageUpdate{
 		State:     runtime.HITLOperationStateUpstreamFailed,

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -666,7 +666,7 @@ func HITLApprovalMessage(state HITLOperationState, effect HITLApprovalEffect, up
 	case HITLOperationStateExpired:
 		return "Approval expired.\nUpstream was not called."
 	case HITLOperationStateClientDisconnected:
-		return "The original client connection closed before Claw Patrol could return an async polling handle.\nUpstream was not called.\nThis prompt is stale."
+		return "The original client disconnected before approval completed.\nUpstream was not called.\nThis prompt is stale."
 	}
 	if effect == HITLApprovalEffectCreateRetryGrant {
 		return "Upstream has not been called.\nApprove will not send the request upstream now.\nApprove will allow the client to retry the same request once."


### PR DESCRIPTION
## Summary
- Update the Slack terminal copy for sync HITL client disconnects so it no longer mentions an async polling handle.
- Make the runtime guidance say the original client disconnected before approval completed.
- Add coverage that the Slack update uses the sync HITL wording and does not regress to the async polling-handle copy.

## Test plan
- `git diff --check`
- `go test ./internal/config/runtime ./internal/config/plugins/credentials -run 'TestSlackUpdateHITLMessage(ClientDisconnectedCopyMatchesSyncHITL|UsesChatUpdate)|TestSlackNotifyHITLRecordsMessageRefForSyncPendingRequest'`
- `go test ./cmd/clawpatrol ./internal/config/plugins/approvers ./internal/config/plugins/credentials -run 'TestHITLRegistryCancelUpdatesRecordedMessageRefs|TestHITLRegistryLateMessageRefUpdateUsesFreshContext|TestHumanApprover|TestSlackNotifyHITLRecordsMessageRefForSyncPendingRequest|TestSlackUpdateHITLMessage(ClientDisconnectedCopyMatchesSyncHITL|UsesChatUpdate)'`

Split out from #494 so the sync HITL public-docs PR remains docs-only.
