### PR TITLE
fix: route clawpatrol env through the daemon in tsnet mode

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -446,11 +446,27 @@ func (d *daemon) handle(c net.Conn) {
 		log.Printf("daemon: read command: %v", err)
 		return
 	}
-	if line != "START\n" {
+	_ = c.SetReadDeadline(time.Time{})
+
+	switch line {
+	case "START\n":
+		// fall through below
+	case "ENV\n":
+		// Lightweight query: ship the cached env-pushdown JSON and
+		// return. No TUN handoff, no per-session gVisor stack —
+		// `clawpatrol env` is a one-shot read, not a wrapped child.
+		// Without this branch the env subcommand has no tailnet
+		// route to the gateway from its own process (the daemon's
+		// tsnet.Server is process-local), and the direct fetch
+		// silently times out in tsnet-only deployments.
+		if err := daemonWriteEnvReply(c, d.envVars); err != nil {
+			log.Printf("daemon: ENV reply: %v", err)
+		}
+		return
+	default:
 		log.Printf("daemon: unknown command %q", line)
 		return
 	}
-	_ = c.SetReadDeadline(time.Time{})
 
 	// 1. Tell the client our underlay IP, ship the env-pushdown JSON,
 	// and pass along any one-line warning the transport's boot probe
@@ -528,6 +544,21 @@ func daemonFetchEnvPushdown() []byte {
 		return []byte("[]")
 	}
 	return out
+}
+
+// daemonWriteEnvReply writes a single "ENV <n>\n<n bytes>" frame —
+// the cached env-pushdown JSON. Used by the lightweight ENV control
+// command (no session, no TUN handoff).
+func daemonWriteEnvReply(w io.Writer, envVars []byte) error {
+	if _, err := fmt.Fprintf(w, "ENV %d\n", len(envVars)); err != nil {
+		return err
+	}
+	if len(envVars) > 0 {
+		if _, err := w.Write(envVars); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // daemonWriteStartReply writes the ADDR / ENV / WARN frames that the

--- a/cmd/clawpatrol/daemon_linux_test.go
+++ b/cmd/clawpatrol/daemon_linux_test.go
@@ -262,6 +262,66 @@ func TestDaemonClientParse_Malformed(t *testing.T) {
 	}
 }
 
+// TestDaemonEnvCommand_RoundTrip drives daemonWriteEnvReply through
+// daemonClientFetchEnv over a socketpair: the daemon's lightweight
+// ENV command (no session / TUN / gvisor) reads back as the same
+// pushdownEnvVar slice the daemon cached.
+func TestDaemonEnvCommand_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		vars []pushdownEnvVar
+	}{
+		{"empty list", nil},
+		{
+			"two vars",
+			[]pushdownEnvVar{
+				{Name: "OPENAI_API_KEY", Value: "<placeholder>", Description: "OpenAI", PluginType: "openai"},
+				{Name: "ANTHROPIC_API_KEY", Value: "<placeholder>", Description: "Anthropic"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(tc.vars)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if tc.vars == nil {
+				body = nil // exercise the n=0 branch
+			}
+			daemonSide, clientSide := socketpairConns(t)
+			defer func() { _ = daemonSide.Close() }()
+			defer func() { _ = clientSide.Close() }()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				br := bufio.NewReader(daemonSide)
+				cmd, err := br.ReadString('\n')
+				if err != nil {
+					t.Errorf("daemon read cmd: %v", err)
+					return
+				}
+				if cmd != "ENV\n" {
+					t.Errorf("daemon got cmd %q, want %q", cmd, "ENV\n")
+					return
+				}
+				if err := daemonWriteEnvReply(daemonSide, body); err != nil {
+					t.Errorf("daemonWriteEnvReply: %v", err)
+				}
+				_ = daemonSide.Close()
+			}()
+			got, err := daemonClientFetchEnv(clientSide)
+			<-done
+			if err != nil {
+				t.Fatalf("daemonClientFetchEnv: %v", err)
+			}
+			if !envVarsEqual(got, tc.vars) {
+				t.Errorf("env vars: got %+v, want %+v", got, tc.vars)
+			}
+		})
+	}
+}
+
 func envVarsEqual(a, b []pushdownEnvVar) bool {
 	if len(a) != len(b) {
 		return false

--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -65,6 +65,18 @@ type pushdownEnvVar struct {
 // that asks the network extension to make the call instead.
 var envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
 
+// envPushdownDaemonFetcher is the Linux-only "ask the local
+// daemon for its cached env-pushdown JSON" path. Wired up from
+// run_linux.go's init() so this file can stay platform-agnostic.
+// Nil on platforms with no per-host daemon (macOS, the gateway
+// itself); runEnv then skips straight to the direct HTTP fetcher.
+//
+// Reason this exists: in tsnet-only deployments the CLI process
+// invoking `clawpatrol env` has no tailnet route to the gateway's
+// 100.x address — that route lives inside the daemon's tsnet.Server.
+// Without a daemon hop the direct fetch silently times out.
+var envPushdownDaemonFetcher func() ([]pushdownEnvVar, error)
+
 // envPushdownVars returns every var the operator's CLI environment
 // needs: CA-bundle vars (which point at a path on the *client's*
 // disk so the client owns them) plus the gateway's declared
@@ -79,6 +91,16 @@ var envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
 // won't get the placeholder tokens.
 func envPushdownVars(caPath string) ([]pushdownEnvVar, error) {
 	out := caPathPushdownVars(caPath)
+	// Prefer the daemon-cached set when available — it's the only
+	// path that works in tsnet-only mode (the CLI process has no
+	// tailnet route of its own). Falls back to a direct fetch on any
+	// daemon error: daemon unreachable, hello mismatch, or an old
+	// daemon that doesn't understand the ENV command (replies EOF).
+	if envPushdownDaemonFetcher != nil {
+		if vars, err := envPushdownDaemonFetcher(); err == nil {
+			return append(out, vars...), nil
+		}
+	}
 	vars, err := envPushdownGatewayFetcher(filepath.Dir(caPath))
 	if err != nil {
 		return out, err

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -363,6 +363,51 @@ func runRunChild() {
 
 // --- daemon client protocol ------------------------------------------
 
+// daemonClientFetchEnv sends "ENV\n" on ctrl and parses the daemon's
+// single "ENV <n>\n<n bytes>" reply. Used by `clawpatrol env` so the
+// env subcommand can fetch the gateway-declared push-down vars even
+// in tsnet-only deployments, where the env process has no host-side
+// tailnet route and the in-process gatewayDialOverride is unset
+// (that's set by the daemon's own tsnet boot, not by the CLI's).
+func daemonClientFetchEnv(ctrl net.Conn) ([]pushdownEnvVar, error) {
+	if _, err := io.WriteString(ctrl, "ENV\n"); err != nil {
+		return nil, err
+	}
+	br := bufio.NewReader(ctrl)
+	envLen, err := readLenPrefixed(br, "ENV", 1<<20)
+	if err != nil {
+		return nil, err
+	}
+	if envLen == 0 {
+		return nil, nil
+	}
+	body := make([]byte, envLen)
+	if _, err := io.ReadFull(br, body); err != nil {
+		return nil, fmt.Errorf("read ENV body: %w", err)
+	}
+	var vars []pushdownEnvVar
+	if err := json.Unmarshal(body, &vars); err != nil {
+		return nil, fmt.Errorf("decode ENV body: %w", err)
+	}
+	return vars, nil
+}
+
+// envPushdownDaemonFetcher hooks runEnv (in integrations.go) into the
+// Linux-only daemon path. It dials the per-host daemon, asks for the
+// cached env-pushdown JSON via the lightweight ENV command, and
+// returns it. nil on platforms with no daemon; runEnv then falls back
+// to the direct HTTP fetch.
+func init() {
+	envPushdownDaemonFetcher = func() ([]pushdownEnvVar, error) {
+		ctrl, err := daemonConnect()
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = ctrl.Close() }()
+		return daemonClientFetchEnv(ctrl)
+	}
+}
+
 // daemonClientStartSession sends "START\n" on ctrl and parses the
 // daemon's reply: ADDR line, ENV length + JSON body, WARN length +
 // optional text. The single bufio.Reader is returned to the caller


### PR DESCRIPTION
## Bug

\`clawpatrol env\` silently emits only the CA-bundle vars in tsnet-only deployments, never the gateway's declared push-down list. The wrapped agent ends up without OpenAI / Anthropic / Slack / Notion / … placeholders, so every upstream auth fails:

\`\`\`
$ runuser -u orchid clawpatrol env
clawpatrol: fetch http://100.79.206.14:8080/api/env-pushdown:
  Get "http://100.79.206.14:8080/api/env-pushdown":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
export SSL_CERT_FILE="/home/orchid/.clawpatrol/ca.crt"
…
\`\`\`

## Root cause

\`integrations.go:120\` \`gatewayDialOverride\` is a **process-local** var, set only inside the daemon when its tsnet boots (\`daemon_transport_tsnet_linux.go:121\`). A separate \`clawpatrol env\` process has nil override → uses the default \`http.Transport.DialContext\` → tries to reach \`100.79.206.14:8080\` over the host network. In WG mode the host had a tunnel route (worked). In tsnet-only mode there's no tunnel on the host — only the daemon has tsnet → timeout.

## Fix

Add a lightweight \`ENV\\n\` control command to the per-host daemon (\`daemon_linux.go\` \`handle\`) that returns just the cached env-pushdown JSON — no TUN handoff, no per-session gVisor stack. \`runEnv\` (\`integrations.go\`) tries that hook first via a Linux-only \`envPushdownDaemonFetcher\` plumbed in from \`run_linux.go\`'s \`init()\`, and falls back to the direct HTTP fetcher when:
- no daemon is running (other platforms / fresh install),
- the daemon is an old build that doesn't understand ENV (replies EOF → daemon protocol logs \"unknown command\" + closes; client sees error and falls back).

The same daemon already has the JSON cached for the \`START\` reply, so this is a pure framing change — no extra gateway round-trip per \`clawpatrol env\` invocation.

## Out of scope
- \`clawpatrol run claude\` timeouts are separate — that path always goes through the daemon (\`run_linux.go:118\`). If it's also failing, the most likely cause is the daemon's tsnet exit-node probe failing because the tailnet ACL doesn't auto-approve the gateway as exit-node for the new agent's tag — see \`daemon_transport_tsnet_linux.go:112\` and \`doc/tailscale.md\`'s \"Required tailnet ACL\". Verifying that needs the orchid daemon log.

## Test plan
- [x] \`go build ./...\` + \`GOOS=linux go build ./cmd/clawpatrol\` + \`gofmt -l .\` clean.
- [x] New \`TestDaemonEnvCommand_RoundTrip\` covers the framing (empty list + non-empty list) over a socketpair.
- [ ] Manual on orchid: rebuild + replace \`/usr/local/bin/clawpatrol\`, run \`runuser -u orchid clawpatrol env\`, confirm the placeholders ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)