### PR TITLE
join: print QR code for tailnet-only verify URLs

### DIFF
--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	neturl "net/url"
 	"os"
 	"os/exec"
@@ -18,6 +19,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mdp/qrterminal/v3"
 )
 
 type tsStatus struct {
@@ -865,7 +868,18 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		fmt.Printf("CA fingerprint: %s\n", setup.caFingerprint)
 	}
 	fmt.Println()
-	tryOpen(start.VerifyURL)
+	// Tailnet-only verify URLs (100.64.0.0/10 IP or *.ts.net host) are
+	// unreachable from the machine running `clawpatrol join` until
+	// approval lands — that's the whole point of needing approval. Print
+	// a QR code so the operator can scan from a phone or another
+	// already-tailnet-connected device. Skip tryOpen on that path: a
+	// local browser can't reach the URL anyway, and the spawned
+	// xdg-open / open process just produces a meaningless tab.
+	if isTailnetOnlyURL(start.VerifyURL) {
+		printVerifyQR(start.VerifyURL)
+	} else {
+		tryOpen(start.VerifyURL)
+	}
 
 	// 2. poll
 	interval := time.Duration(start.Interval) * time.Second
@@ -1234,6 +1248,51 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	fmt.Println("Installed! Try: clawpatrol run -- claude")
 
 	return false, nil
+}
+
+// isTailnetOnlyURL reports whether u's host is reachable only from
+// inside a Tailscale tailnet: a 100.64.0.0/10 CGNAT address (the
+// range Tailscale carves nodes out of) or a name ending in `.ts.net`
+// (the MagicDNS suffix). Invalid URLs return false so the caller
+// falls back to the regular `tryOpen` path.
+func isTailnetOnlyURL(u string) bool {
+	p, err := neturl.Parse(u)
+	if err != nil || p == nil {
+		return false
+	}
+	host := p.Hostname()
+	if host == "" {
+		return false
+	}
+	if strings.HasSuffix(strings.ToLower(host), ".ts.net") {
+		return true
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return ip.Is4() && tailscaleCGNAT.Contains(ip)
+	}
+	return false
+}
+
+// tailscaleCGNAT is 100.64.0.0/10 — Tailscale's CGNAT range. Anything
+// inside it is unreachable except from a tailnet member.
+var tailscaleCGNAT = netip.MustParsePrefix("100.64.0.0/10")
+
+// printVerifyQR writes a terminal QR code encoding url to stdout.
+// Used when the verify URL is tailnet-only — the operator scans with a
+// phone or another already-onboarded device that can actually reach
+// the gateway.
+func printVerifyQR(url string) {
+	fmt.Println("Tailnet-only URL — scan from a device with tailnet access:")
+	fmt.Println()
+	cfg := qrterminal.Config{
+		Level:     qrterminal.M,
+		Writer:    os.Stdout,
+		BlackChar: qrterminal.BLACK,
+		WhiteChar: qrterminal.WHITE,
+		QuietZone: 1,
+	}
+	qrterminal.GenerateWithConfig(url, cfg)
+	fmt.Println()
 }
 
 func tryOpen(u string) {

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -1281,17 +1281,15 @@ var tailscaleCGNAT = netip.MustParsePrefix("100.64.0.0/10")
 // Used when the verify URL is tailnet-only — the operator scans with a
 // phone or another already-onboarded device that can actually reach
 // the gateway.
+//
+// GenerateHalfBlock packs two QR rows per terminal line via the
+// ▀ / ▄ / █ / space unicode chars. Half the vertical space of the
+// ANSI-colored block-per-cell variant, and renders cleanly when the
+// operator pipes the join output to a file or pastes it into chat.
 func printVerifyQR(url string) {
 	fmt.Println("Tailnet-only URL — scan from a device with tailnet access:")
 	fmt.Println()
-	cfg := qrterminal.Config{
-		Level:     qrterminal.M,
-		Writer:    os.Stdout,
-		BlackChar: qrterminal.BLACK,
-		WhiteChar: qrterminal.WHITE,
-		QuietZone: 1,
-	}
-	qrterminal.GenerateWithConfig(url, cfg)
+	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
 	fmt.Println()
 }
 

--- a/cmd/clawpatrol/setup_test.go
+++ b/cmd/clawpatrol/setup_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+// isTailnetOnlyURL gates the join-time decision to print a QR code
+// (true) vs spawn a local browser (false). Tailnet-only = 100.64/10
+// CGNAT IP or *.ts.net MagicDNS host. Anything else — public DNS, RFC
+// 1918, loopback — falls through to the regular tryOpen path.
+func TestIsTailnetOnlyURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"100.x cgnat ip", "http://100.79.206.14:8080/#/onboard/ABCD-1234", true},
+		{"100.64.0.1 lower bound", "http://100.64.0.1/", true},
+		{"100.127.255.254 upper bound", "http://100.127.255.254/", true},
+		{"100.128.x outside cgnat", "http://100.128.0.1/", false},
+		{"100.63.x outside cgnat", "http://100.63.255.255/", false},
+		{".ts.net magicdns", "https://clawpatrol-gateway.tail9a48e.ts.net/#/onboard/X", true},
+		{".TS.NET case-insensitive", "https://gw.TAIL9A48E.TS.NET/", true},
+		{"public dns", "https://gw.example.com/", false},
+		{"loopback ip", "http://127.0.0.1:8080/", false},
+		{"rfc1918 ip", "http://10.0.0.5/", false},
+		{"empty url", "", false},
+		{"garbage url", "::not-a-url::", false},
+		{"missing host", "http:///path", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isTailnetOnlyURL(c.url); got != c.want {
+				t.Errorf("isTailnetOnlyURL(%q) = %v; want %v", c.url, got, c.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -82,10 +82,11 @@ require (
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect
+	github.com/mdp/qrterminal/v3 v3.2.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
@@ -129,4 +130,5 @@ require (
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
+	rsc.io/qr v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -209,6 +211,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
+github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
+github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
 github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
@@ -469,6 +473,8 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 tailscale.com v1.96.5 h1:gNkfA/KSZAl6jCH9cj8urq00HRWItDDTtGsyATI89jA=


### PR DESCRIPTION
Closes #515.

## Problem

When the gateway runs in tsnet-only mode the onboarding flow returns a verify URL on a tailnet-only address:

```
Verify code in browser:

    ZXVE-6777

http://100.79.206.14:8080/#/onboard/ZXVE-6777
```

The machine running `clawpatrol join` is by definition not on the tailnet yet — it's joining — so the local browser `xdg-open`/`open` spawns lands on a URL it can never reach. The operator is left squinting at the printed line and re-typing it on their phone.

## Fix

Detect tailnet-only verify URLs and render the URL as a terminal QR code instead of trying to open it locally. Operator scans from a phone or another already-onboarded device that *can* reach the gateway.

"Tailnet-only" = host in 100.64.0.0/10 (Tailscale's CGNAT range) **or** ending in `.ts.net` (MagicDNS). Public-DNS / RFC1918 / loopback verify URLs keep the existing `tryOpen` behaviour.

QR rendered via `qrterminal.GenerateHalfBlock` — two QR rows per terminal line, no ANSI colour, scans cleanly from any modern monospace font. New dep: `github.com/mdp/qrterminal/v3`.

## Sample output

Real captured output for `http://100.79.206.14:8080/#/onboard/ZXVE-6777`:

```
Verify code in browser:

    ZXVE-6777

http://100.79.206.14:8080/#/onboard/ZXVE-6777

Tailnet-only URL — scan from a device with tailnet access:

█████████████████████████████████████████
█████████████████████████████████████████
████ ▄▄▄▄▄ █▀▄▀▄ ▀▄ ▀▀█ ▄█   █ ▄▄▄▄▄ ████
████ █   █ ██▄▄ ▀▀█▄█▀█▄▄▀██ █ █   █ ████
████ █▄▄▄█ █▄  ▄█▄▀██ ███▄   █ █▄▄▄█ ████
████▄▄▄▄▄▄▄█▄█▄▀▄▀▄█ ▀▄█ ▀▄█ █▄▄▄▄▄▄▄████
████ █▄█▄█▄██▄▀ ▄▄█▄ ▄ ▄█▄ ███▀▀▄██▄▀████
████▄ ▄▄█▄▄█▀████▄██▀▄█▀ ▄██▀  ▄▀█▄▄▄████
████ ▄█▀▄█▄▀▄█ ▄▀██ █▀█▀█▀███ ▄▄▄ ██ ████
████ ▀▄▄█▀▄▀▀    █▀▀█▀▄▀█ ▄█▀█▄▀ ██ ▄████
████ █▀█▀█▄▄ ██▀█▀██▄  ██  ███ ▀███▀▀████
████ █ ▄▀▀▄▀██▀▄█  ██▀ ▀█▀ █ ▄▄▄▀█▄▄ ████
██████▀▄▀▄▄▄▀▄  ▀▀█▀ █ ▀ ▀ ▄█▀ ▄▄▄█ ▀████
████▄▀▀ █▀▄▄█ █▀  █▄ ▀▄▄ ▀▄█ ▀▄▀▀▀▄▄▄████
████▄█▄▄▄▄▄█▀▄ ▀   ▄▄▄ ▄█▄ ▀ ▄▄▄ ▀█ ▀████
████ ▄▄▄▄▄ ███  ▀ ▄█▀▄██ ▄█  █▄█ ▀▄  ████
████ █   █ █▄  █▄██ █▀█ █▀█▀▄ ▄  ▄▀▀ ████
████ █▄▄▄█ █▄ ▀ █▀▄▀█▀▄▀█ ██ ▄▀▀ ▄█▀▄████
████▄▄▄▄▄▄▄█▄█▄█▄███▄▄▄█▄▄▄█▄▄▄██▄▄▄▄████
█████████████████████████████████████████
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
```

Scanned with iPhone camera → opens `http://100.79.206.14:8080/#/onboard/ZXVE-6777` directly.

## Test plan
- [x] `go build ./...` + `GOOS=linux go build ./cmd/clawpatrol` + `gofmt -l .` clean.
- [x] New `TestIsTailnetOnlyURL` covers cgnat boundaries, magicdns, public DNS, RFC1918, loopback, garbage URLs.
- [x] Manual capture above scans correctly on an iPhone camera.
- [ ] Manual: `clawpatrol join https://gw.public-host.example` keeps the existing browser-open behaviour, no QR printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)