### PR TITLE
chore: switch releases from GH Pages to gh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -95,12 +89,9 @@ jobs:
   publish:
     needs: [build, macos-app]
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-
       - name: resolve tag
         id: tag
         run: |
@@ -115,38 +106,23 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: assemble site
+      - name: create checksums
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
-          mkdir -p site/releases/${TAG}
-          cp artifacts/clawpatrol-* site/releases/${TAG}/
-          # macOS .app for `clawpatrol run` per-process tunnel;
-          # install.sh picks this up on darwin in addition to the Go
-          # binary. download-artifact's merge-multiple flattens, so
-          # the file lands directly under artifacts/.
-          if [ -f artifacts/Clawpatrol.app.tar.gz ]; then
-            cp artifacts/Clawpatrol.app.tar.gz site/releases/${TAG}/
-          fi
-          (cd site/releases/${TAG} \
-            && sha256sum clawpatrol-* Clawpatrol.app.tar.gz 2>/dev/null > SHA256SUMS \
+          cd artifacts
+          (sha256sum clawpatrol-* Clawpatrol.app.tar.gz 2>/dev/null > SHA256SUMS \
             || sha256sum clawpatrol-* > SHA256SUMS)
-          # `latest` mirror
-          cp -r site/releases/${TAG} site/releases/latest
-          cp install.sh site/install.sh
-          # Public site index — just enough so curl + browser both work.
-          cat > site/index.html <<HTML
-          <!doctype html><meta charset=utf-8><title>clawpatrol releases</title>
-          <h1>clawpatrol</h1>
-          <p>Install: <code>curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh</code></p>
-          <p>Latest binaries: <a href="releases/latest/">releases/latest/</a></p>
-          <p>This tag: <a href="releases/${TAG}/">releases/${TAG}/</a></p>
-          HTML
 
-      - uses: actions/configure-pages@v5
-
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-      - id: deployment
-        uses: actions/deploy-pages@v4
+      - name: create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --generate-notes \
+            artifacts/clawpatrol-* \
+            artifacts/SHA256SUMS
+          if [ -f artifacts/Clawpatrol.app.tar.gz ]; then
+            gh release upload "${TAG}" artifacts/Clawpatrol.app.tar.gz
+          fi

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -96,7 +96,7 @@ Tailscale admin console — the ACL above is the whole prereq.
 
 ```bash
 # gateway VM — no public IP required, just outbound HTTPS
-curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
+curl -fsSL https://clawpatrol.dev/install.sh | sh
 
 cat > /opt/clawpatrol/gateway.hcl <<'EOF'
 gateway {
@@ -136,7 +136,7 @@ device on the tailnet once the gateway is up.
 ## Client setup
 
 ```bash
-curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
+curl -fsSL https://clawpatrol.dev/install.sh | sh
 clawpatrol join <gateway-url>   # prints a user_code; approve on the
                                 # dashboard from any trusted device
 # done — clawpatrol run claude (or gh/codex) just works

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -97,7 +97,7 @@ two sides talk over the loopback interface.
 
 ```bash
 # on the gateway VM (real public IP needed)
-curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
+curl -fsSL https://clawpatrol.dev/install.sh | sh
 
 cat > /opt/clawpatrol/gateway.hcl <<'EOF'
 gateway {
@@ -127,7 +127,7 @@ in `/opt/clawpatrol/oauth/`.
 ## Client setup
 
 ```bash
-curl -fsSL https://denoland.github.io/clawpatrol/install.sh | sh
+curl -fsSL https://clawpatrol.dev/install.sh | sh
 clawpatrol join http://your-gw.example.com:8080
 # approve at the displayed URL, done — claude/gh/codex just work
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
-# clawpatrol installer. Downloads a prebuilt binary from GitHub Pages
-# (https://denoland.github.io/clawpatrol) — source repo is private,
-# release artifacts are public via GH Pages. Falls back to source build
-# when CLAWPATROL_FROM_SOURCE=1 (requires `gh auth login` for the
-# private clone).
+# clawpatrol installer. Downloads a prebuilt binary from GitHub Releases.
+# Falls back to source build when CLAWPATROL_FROM_SOURCE=1 (requires Go).
 #
 # Usage:
 #   curl -fsSL https://clawpatrol.dev/install.sh | sh
@@ -11,16 +8,22 @@
 # Options (env vars):
 #   CLAWPATROL_VERSION       — release tag (default: latest)
 #   CLAWPATROL_PREFIX        — install dir (default: $HOME/.local/bin)
-#   CLAWPATROL_FROM_SOURCE   — 1 to build from source (gh CLI + Go required)
+#   CLAWPATROL_FROM_SOURCE   — 1 to build from source (Go required)
 #   CLAWPATROL_REF           — git ref when building from source (default: main)
 #
 # POSIX sh.
 
 set -eu
 
-BASE="https://denoland.github.io/clawpatrol"
+REPO="denoland/clawpatrol"
 VERSION="${CLAWPATROL_VERSION:-latest}"
 PREFIX="${CLAWPATROL_PREFIX:-$HOME/.local/bin}"
+
+if [ "$VERSION" = "latest" ]; then
+  BASE="https://github.com/${REPO}/releases/latest/download"
+else
+  BASE="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
 
 say()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
 fail() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
@@ -40,21 +43,17 @@ esac
 command -v curl >/dev/null 2>&1 || fail "curl required"
 mkdir -p "$PREFIX"
 
-# source-build branch (private repo — needs gh auth)
+# source-build branch
 if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
   REF="${CLAWPATROL_REF:-main}"
   command -v go  >/dev/null 2>&1 || fail "go toolchain required for source build"
   command -v git >/dev/null 2>&1 || fail "git required"
   SRC=$(mktemp -d)
   trap 'rm -rf "$SRC"' EXIT INT TERM
-  say "cloning denoland/clawpatrol@${REF}"
-  if command -v gh >/dev/null 2>&1; then
-    gh repo clone denoland/clawpatrol "$SRC" -- --depth 1 --branch "$REF" >/dev/null 2>&1 \
-      || gh repo clone denoland/clawpatrol "$SRC" -- --depth 1 >/dev/null 2>&1 \
-      || fail "gh repo clone failed (run \`gh auth login\` first?)"
-  else
-    fail "private repo — install gh and run \`gh auth login\`, or unset CLAWPATROL_FROM_SOURCE to download a binary"
-  fi
+  say "cloning ${REPO}@${REF}"
+  git clone --depth 1 --branch "$REF" "https://github.com/${REPO}.git" "$SRC" >/dev/null 2>&1 \
+    || git clone --depth 1 "https://github.com/${REPO}.git" "$SRC" >/dev/null 2>&1 \
+    || fail "git clone failed"
   if command -v deno >/dev/null 2>&1 && [ -d "$SRC/dashboard" ]; then
     say "building dashboard"
     ( cd "$SRC/dashboard" && deno install >/dev/null 2>&1 && deno task build >/dev/null 2>&1 ) \
@@ -73,14 +72,14 @@ if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
 fi
 
 # binary download (default)
-URL="${BASE}/releases/${VERSION}/clawpatrol-${OS}-${ARCH}"
+URL="${BASE}/clawpatrol-${OS}-${ARCH}"
 TMP=$(mktemp)
 trap 'rm -f "$TMP"' EXIT INT TERM
 say "downloading ${URL}"
 curl -fsSL -o "$TMP" "$URL" || fail "download failed (no release for ${OS}-${ARCH} at ${VERSION}?)"
 
 # optional sha256 verify
-SUMS=$(curl -fsSL "${BASE}/releases/${VERSION}/SHA256SUMS" 2>/dev/null || true)
+SUMS=$(curl -fsSL "${BASE}/SHA256SUMS" 2>/dev/null || true)
 if [ -n "$SUMS" ]; then
   EXPECTED=$(printf '%s\n' "$SUMS" | awk -v f="clawpatrol-${OS}-${ARCH}" '$2==f{print $1}')
   if [ -n "$EXPECTED" ]; then
@@ -116,7 +115,7 @@ echo
 # release as the Go binary, expanded to /Applications. Skip silently
 # if the artifact isn't present (older releases or unsigned dev runs).
 if [ "$OS" = "darwin" ]; then
-  APP_URL="${BASE}/releases/${VERSION}/Clawpatrol.app.tar.gz"
+  APP_URL="${BASE}/Clawpatrol.app.tar.gz"
   APP_TMP=$(mktemp -d)
   if curl -fsSL -o "$APP_TMP/app.tgz" "$APP_URL" 2>/dev/null; then
     say "installing Clawpatrol.app to /Applications"

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
-# clawpatrol installer. Downloads a prebuilt binary from GitHub Pages
-# (https://denoland.github.io/clawpatrol) — source repo is private,
-# release artifacts are public via GH Pages. Falls back to source build
-# when CLAWPATROL_FROM_SOURCE=1 (requires `gh auth login` for the
-# private clone).
+# clawpatrol installer. Downloads a prebuilt binary from GitHub Releases.
+# Falls back to source build when CLAWPATROL_FROM_SOURCE=1 (requires Go).
 #
 # Usage:
 #   curl -fsSL https://clawpatrol.dev/install.sh | sh
@@ -11,16 +8,22 @@
 # Options (env vars):
 #   CLAWPATROL_VERSION       — release tag (default: latest)
 #   CLAWPATROL_PREFIX        — install dir (default: $HOME/.local/bin)
-#   CLAWPATROL_FROM_SOURCE   — 1 to build from source (gh CLI + Go required)
+#   CLAWPATROL_FROM_SOURCE   — 1 to build from source (Go required)
 #   CLAWPATROL_REF           — git ref when building from source (default: main)
 #
 # POSIX sh.
 
 set -eu
 
-BASE="https://denoland.github.io/clawpatrol"
+REPO="denoland/clawpatrol"
 VERSION="${CLAWPATROL_VERSION:-latest}"
 PREFIX="${CLAWPATROL_PREFIX:-$HOME/.local/bin}"
+
+if [ "$VERSION" = "latest" ]; then
+  BASE="https://github.com/${REPO}/releases/latest/download"
+else
+  BASE="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
 
 say()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
 fail() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
@@ -40,21 +43,17 @@ esac
 command -v curl >/dev/null 2>&1 || fail "curl required"
 mkdir -p "$PREFIX"
 
-# source-build branch (private repo — needs gh auth)
+# source-build branch
 if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
   REF="${CLAWPATROL_REF:-main}"
   command -v go  >/dev/null 2>&1 || fail "go toolchain required for source build"
   command -v git >/dev/null 2>&1 || fail "git required"
   SRC=$(mktemp -d)
   trap 'rm -rf "$SRC"' EXIT INT TERM
-  say "cloning denoland/clawpatrol@${REF}"
-  if command -v gh >/dev/null 2>&1; then
-    gh repo clone denoland/clawpatrol "$SRC" -- --depth 1 --branch "$REF" >/dev/null 2>&1 \
-      || gh repo clone denoland/clawpatrol "$SRC" -- --depth 1 >/dev/null 2>&1 \
-      || fail "gh repo clone failed (run \`gh auth login\` first?)"
-  else
-    fail "private repo — install gh and run \`gh auth login\`, or unset CLAWPATROL_FROM_SOURCE to download a binary"
-  fi
+  say "cloning ${REPO}@${REF}"
+  git clone --depth 1 --branch "$REF" "https://github.com/${REPO}.git" "$SRC" >/dev/null 2>&1 \
+    || git clone --depth 1 "https://github.com/${REPO}.git" "$SRC" >/dev/null 2>&1 \
+    || fail "git clone failed"
   if command -v deno >/dev/null 2>&1 && [ -d "$SRC/dashboard" ]; then
     say "building dashboard"
     ( cd "$SRC/dashboard" && deno install >/dev/null 2>&1 && deno task build >/dev/null 2>&1 ) \
@@ -73,14 +72,14 @@ if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
 fi
 
 # binary download (default)
-URL="${BASE}/releases/${VERSION}/clawpatrol-${OS}-${ARCH}"
+URL="${BASE}/clawpatrol-${OS}-${ARCH}"
 TMP=$(mktemp)
 trap 'rm -f "$TMP"' EXIT INT TERM
 say "downloading ${URL}"
 curl -fsSL -o "$TMP" "$URL" || fail "download failed (no release for ${OS}-${ARCH} at ${VERSION}?)"
 
 # optional sha256 verify
-SUMS=$(curl -fsSL "${BASE}/releases/${VERSION}/SHA256SUMS" 2>/dev/null || true)
+SUMS=$(curl -fsSL "${BASE}/SHA256SUMS" 2>/dev/null || true)
 if [ -n "$SUMS" ]; then
   EXPECTED=$(printf '%s\n' "$SUMS" | awk -v f="clawpatrol-${OS}-${ARCH}" '$2==f{print $1}')
   if [ -n "$EXPECTED" ]; then
@@ -116,7 +115,7 @@ echo
 # release as the Go binary, expanded to /Applications. Skip silently
 # if the artifact isn't present (older releases or unsigned dev runs).
 if [ "$OS" = "darwin" ]; then
-  APP_URL="${BASE}/releases/${VERSION}/Clawpatrol.app.tar.gz"
+  APP_URL="${BASE}/Clawpatrol.app.tar.gz"
   APP_TMP=$(mktemp -d)
   if curl -fsSL -o "$APP_TMP/app.tgz" "$APP_URL" 2>/dev/null; then
     say "installing Clawpatrol.app to /Applications"


### PR DESCRIPTION
Clean reapply of #328 now that the repo is public. #328 was reverted in #342 because GH Releases were not reachable without auth at the time; that constraint is gone.

## Changes

- **`.github/workflows/release.yml`** — drop the `configure-pages` / `upload-pages-artifact` / `deploy-pages` steps and the `pages: write` / `id-token: write` permissions. The publish job now resolves the tag, downloads the matrix artifacts, generates `SHA256SUMS`, and calls `gh release create <tag> --generate-notes` with the binaries + `SHA256SUMS`. `Clawpatrol.app.tar.gz` is uploaded if the macos-app job produced one.
- **`install.sh`** + **`site/public/install.sh`** — `BASE` now points at `github.com/<repo>/releases/{latest,<tag>}/download/`. Source-build path drops the `gh auth login` / `gh repo clone` requirement and uses plain `git clone` over HTTPS now that the repo is public.
- **`doc/tailscale.md`** + **`doc/wireguard.md`** — `curl … denoland.github.io/clawpatrol/install.sh` → `curl … clawpatrol.dev/install.sh` (the same script, served straight off the site).

## Notes

Merge-time fixes from the original #328 (private-repo era): the source-build path now references `dashboard/` + Deno + `./cmd/clawpatrol` rather than the old `www/` + npm + repo-root layout that #328 was originally written against.

## Test plan
- [x] `install.sh` and `site/public/install.sh` are byte-identical.
- [x] No remaining `denoland.github.io/clawpatrol` references anywhere in tree.
- [ ] Manual: cut a test tag, watch the workflow create a release with all 4 binaries + macos-app + `SHA256SUMS`, then `curl -fsSL https://clawpatrol.dev/install.sh | sh` installs from the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)