### PR TITLE
cli: link to the example config in gateway help

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2698,7 +2698,10 @@ flags:
                                   then start. The next dashboard request will
                                   re-run first-run setup.
 
-Start from examples/gateway.example.hcl in the repo, or see the HCL reference:
+Start from the example config:
+  https://github.com/denoland/clawpatrol/blob/main/examples/gateway.example.hcl
+
+HCL reference:
   https://clawpatrol.dev/docs/config-reference`
 
 func runGateway(args []string) {


### PR DESCRIPTION
## Summary
`clawpatrol gateway` (no args / `-h`) ended with:

```
Start from examples/gateway.example.hcl in the repo, or see the HCL reference:
  https://clawpatrol.dev/docs/config-reference
```

"in the repo" is a dead breadcrumb for anyone who installed via `curl | sh` and isn't sitting in a clone. Replace with the canonical GitHub URL so the link is clickable from the terminal:

```
Start from the example config:
  https://github.com/denoland/clawpatrol/blob/main/examples/gateway.example.hcl

HCL reference:
  https://clawpatrol.dev/docs/config-reference
```

## Test plan
- [x] `go build ./cmd/clawpatrol`
- [x] `go run ./cmd/clawpatrol gateway` shows the new help text
