### PR TITLE
fix: daemon refreshes env-pushdown without restart

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -54,12 +54,23 @@ const (
 	daemonIdleTimeout  = 5 * time.Minute
 	daemonHelloTimeout = 2 * time.Second
 
+	// envRefreshInterval bounds the latency between a gateway-side
+	// credential change (HCL reload, credential connect/disconnect)
+	// and that change becoming visible in the daemon's env-pushdown
+	// replies. A background goroutine refetches /api/env-pushdown at
+	// this cadence so `clawpatrol run -- env` invoked after a profile
+	// change picks up the new placeholders without a daemon restart.
+	// 2s keeps the steady-state load at ≤30 fetches/min while making
+	// a manual profile change visible inside one prompt.
+	envRefreshInterval = 2 * time.Second
+
 	// envCacheTTL bounds how stale a cached env-pushdown response can
-	// be before the next START / ENV call re-fetches it from the
-	// gateway. Trades off "profile changes propagate instantly" against
-	// "every bursty agent session hits the gateway". 30s keeps a fleet
-	// of short-lived `clawpatrol run` invocations to ≤2 fetches/min
-	// while making a manual profile change visible inside one prompt.
+	// be when the background refresh loop is delayed or failing
+	// (gateway briefly unreachable, dial in flight, etc.). On-demand
+	// START / ENV callers refetch past this age. Sized as a generous
+	// upper bound — the background loop normally keeps the cache
+	// fresh well below this — so a momentary fetch failure can't
+	// silently pin stale env state for the daemon's whole lifetime.
 	envCacheTTL        = 30 * time.Second
 	daemonSpawnTimeout = 30 * time.Second
 	daemonMagicLine    = "CLAWPATROL/1\n"
@@ -273,14 +284,26 @@ type daemon struct {
 	transport daemonTransport
 
 	// envVars + envFetchedAt cache the gateway's env-pushdown response.
-	// freshEnvVars refreshes when the cache is older than envCacheTTL,
-	// so a profile change on the gateway shows up to existing daemons
-	// within one TTL instead of requiring a daemon restart. Held under
-	// envMu (the JSON byte slice is shared with concurrent handle()
-	// goroutines that ship it to clients).
+	// A background goroutine (runEnvRefreshLoop) refreshes the cache
+	// every envRefreshInterval so credential changes on the gateway
+	// (operator connects a new credential, HCL reload pulls in a new
+	// credential block) propagate to existing daemons within one
+	// interval instead of requiring a daemon restart. freshEnvVars
+	// also refetches on-demand past envCacheTTL when the loop is
+	// delayed. Held under envMu (the JSON byte slice is shared with
+	// concurrent handle() goroutines that ship it to clients).
 	envMu        sync.Mutex
 	envVars      []byte
 	envFetchedAt time.Time
+
+	// envFetch is the fetcher the cache loop and freshEnvVars call to
+	// pull the latest env-pushdown JSON from the gateway. Injected so
+	// tests can stub the gateway round-trip; defaults to
+	// daemonFetchEnvPushdown when nil. envRefreshTick overrides the
+	// background loop's cadence — also for tests; zero means
+	// envRefreshInterval.
+	envFetch       func() []byte
+	envRefreshTick time.Duration
 
 	activeConns atomic.Int32
 
@@ -358,6 +381,12 @@ func runDaemon(_ []string) {
 	}
 
 	d.startIdleTimer()
+
+	// Start the background env-pushdown refresh loop. It owns the
+	// "credential changes propagate without restart" guarantee — see
+	// runEnvRefreshLoop. Runs for the life of the process; the daemon
+	// always exits via os.Exit (tryExit), which kills the goroutine.
+	go d.runEnvRefreshLoop()
 
 	// Main loop. After serve() returns the only valid events are:
 	//   - tryExit re-bound (sends on rebindCh) → loop, serve new listener.
@@ -539,15 +568,18 @@ func (d *daemon) handle(c net.Conn) {
 	}
 }
 
-// freshEnvVars returns the cached env-pushdown JSON if it was fetched
-// within the last envCacheTTL, otherwise re-fetches from the gateway
-// and updates the cache.
+// freshEnvVars returns the cached env-pushdown JSON, refetching from
+// the gateway only when the cache is older than envCacheTTL. The
+// background refresh loop (runEnvRefreshLoop) normally keeps the cache
+// fresh on a much shorter cadence; this on-demand path exists so the
+// first request after a stretched-out loop tick (or a stalled fetch)
+// still pulls a current snapshot.
 //
-// Why this exists: profile changes on the gateway (operator moves a
-// device from "default" → "divy" via the dashboard) need to be
-// reflected in the placeholders the daemon ships to clients. Without
-// the refresh the daemon serves whatever it cached at boot until
-// someone manually restarts it. envCacheTTL bounds the staleness.
+// Why this exists: profile changes on the gateway (operator connects
+// a new credential, HCL reload pulls in a new credential block) need
+// to be reflected in the placeholders the daemon ships to clients.
+// Without proactive refresh the daemon serves whatever it cached at
+// boot until someone manually restarts it.
 //
 // On gateway fetch error daemonFetchEnvPushdown already returns "[]"
 // (it can't distinguish "no vars declared" from "gateway down") — to
@@ -560,7 +592,7 @@ func (d *daemon) freshEnvVars() []byte {
 	if time.Since(d.envFetchedAt) < envCacheTTL && len(d.envVars) > 0 {
 		return d.envVars
 	}
-	fresh := daemonFetchEnvPushdown()
+	fresh := d.fetchEnv()
 	if isEmptyEnvList(fresh) && !isEmptyEnvList(d.envVars) {
 		// Probable transient gateway error — keep the last good list
 		// but don't bump envFetchedAt, so the next call retries.
@@ -569,6 +601,52 @@ func (d *daemon) freshEnvVars() []byte {
 	d.envVars = fresh
 	d.envFetchedAt = time.Now()
 	return d.envVars
+}
+
+// fetchEnv resolves the env-pushdown fetcher to use. Defaults to the
+// gateway-dialing daemonFetchEnvPushdown; tests inject a stub via the
+// envFetch field. Caller does NOT need to hold envMu — the function
+// value itself is immutable after daemon construction.
+func (d *daemon) fetchEnv() []byte {
+	if d.envFetch != nil {
+		return d.envFetch()
+	}
+	return daemonFetchEnvPushdown()
+}
+
+// runEnvRefreshLoop polls the gateway's /api/env-pushdown on a fixed
+// cadence and updates the cached JSON in place, so credential changes
+// (operator connects/disconnects, HCL reload) become visible to clients
+// without a daemon restart. Bounded to ≤30 fetches/min at the default
+// envRefreshInterval — bursty `clawpatrol run` invocations still serve
+// straight from the cache.
+//
+// Lifetime: runs for the life of the daemon process. The daemon exits
+// via os.Exit (tryExit), which terminates this goroutine implicitly;
+// there's no explicit stop channel.
+//
+// Mirrors freshEnvVars' transient-failure guard: if the gateway is
+// briefly unreachable (daemonFetchEnvPushdown returns "[]" on every
+// kind of failure), preserve the prior cache instead of clobbering it
+// with an empty list.
+func (d *daemon) runEnvRefreshLoop() {
+	interval := d.envRefreshTick
+	if interval == 0 {
+		interval = envRefreshInterval
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for range t.C {
+		fresh := d.fetchEnv()
+		d.envMu.Lock()
+		if isEmptyEnvList(fresh) && !isEmptyEnvList(d.envVars) {
+			d.envMu.Unlock()
+			continue
+		}
+		d.envVars = fresh
+		d.envFetchedAt = time.Now()
+		d.envMu.Unlock()
+	}
 }
 
 // isEmptyEnvList recognises the two encodings of "no push-down vars"

--- a/cmd/clawpatrol/daemon_linux_test.go
+++ b/cmd/clawpatrol/daemon_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -319,6 +320,122 @@ func TestDaemonEnvCommand_RoundTrip(t *testing.T) {
 				t.Errorf("env vars: got %+v, want %+v", got, tc.vars)
 			}
 		})
+	}
+}
+
+// TestDaemonEnvRefreshLoopPicksUpChanges verifies the background
+// env-pushdown refresh path: a credential change on the gateway side
+// (modelled here as the injected fetcher returning a new payload) is
+// reflected in the daemon's freshEnvVars output without restarting
+// the daemon — the regression check for cl-yi1e.
+//
+// Uses an injected fetcher so the test doesn't require a real
+// /api/env-pushdown HTTP round-trip; the unit under test is the
+// daemon's cache + refresh-loop wiring, not the HTTP plumbing
+// (which TestFetchEnvPushdownFromGateway already covers).
+func TestDaemonEnvRefreshLoopPicksUpChanges(t *testing.T) {
+	initial, err := json.Marshal([]pushdownEnvVar{
+		{Name: "GH_TOKEN", Value: "ghp_initial", PluginType: "github_oauth"},
+	})
+	if err != nil {
+		t.Fatalf("marshal initial: %v", err)
+	}
+	updated, err := json.Marshal([]pushdownEnvVar{
+		{Name: "GH_TOKEN", Value: "ghp_initial", PluginType: "github_oauth"},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sk-ant-new", PluginType: "anthropic_oauth_subscription"},
+	})
+	if err != nil {
+		t.Fatalf("marshal updated: %v", err)
+	}
+
+	var (
+		mu      sync.Mutex
+		current = initial
+		calls   int
+	)
+	fetch := func() []byte {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		out := make([]byte, len(current))
+		copy(out, current)
+		return out
+	}
+
+	d := &daemon{
+		envVars:        initial,
+		envFetchedAt:   time.Now(),
+		envFetch:       fetch,
+		envRefreshTick: 10 * time.Millisecond,
+	}
+	go d.runEnvRefreshLoop()
+
+	// Sanity check: cache starts on the initial payload.
+	if got := string(d.freshEnvVars()); got != string(initial) {
+		t.Fatalf("initial freshEnvVars = %q, want %q", got, string(initial))
+	}
+
+	// Simulate the operator connecting a new credential on the
+	// gateway: subsequent fetches now return the updated payload.
+	mu.Lock()
+	current = updated
+	mu.Unlock()
+
+	// Wait for the background loop to pick up the change. The loop
+	// runs at 10ms cadence, so a generous deadline avoids a flake on
+	// loaded CI hosts without sleeping needlessly on a fast one.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if string(d.freshEnvVars()) == string(updated) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("background refresh never picked up updated payload (calls=%d, last freshEnvVars=%q)",
+		calls, string(d.freshEnvVars()))
+}
+
+// TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty verifies the
+// fallback in runEnvRefreshLoop: a fetch that returns an empty list
+// (the sentinel daemonFetchEnvPushdown emits on every kind of fetch
+// failure) must NOT clobber a previously-known-good cache. Without
+// this guard a single 1s gateway blip would silently drop every
+// declared env var from the daemon's pushdown.
+func TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty(t *testing.T) {
+	good, err := json.Marshal([]pushdownEnvVar{
+		{Name: "GH_TOKEN", Value: "ghp_good"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var (
+		mu    sync.Mutex
+		empty = true
+	)
+	fetch := func() []byte {
+		mu.Lock()
+		defer mu.Unlock()
+		if empty {
+			return []byte("[]")
+		}
+		return good
+	}
+
+	d := &daemon{
+		envVars:        good,
+		envFetchedAt:   time.Now(),
+		envFetch:       fetch,
+		envRefreshTick: 10 * time.Millisecond,
+	}
+	go d.runEnvRefreshLoop()
+
+	// Let the loop tick several times under the empty-returning
+	// fetcher. The cache must hold the prior good value.
+	time.Sleep(80 * time.Millisecond)
+	if got := string(d.freshEnvVars()); got != string(good) {
+		t.Fatalf("after transient empty: freshEnvVars = %q, want %q (last good preserved)", got, string(good))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Linux daemon cached `/api/env-pushdown` for 30s and only re-fetched on TTL miss, so credentials added/connected on the gateway were invisible to existing daemons until the cache aged out (or the daemon was killed).
- Add a background goroutine (`runEnvRefreshLoop`) that refetches every 2s and updates the cache in place, so changes propagate to every existing session without a daemon restart.
- 30s on-demand TTL stays as a fallback when the loop is delayed or the gateway is briefly unreachable; transient-empty guard preserves the prior cache on fetch failure.

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .` clean
- [x] `go vet ./...`
- [x] New unit tests: `TestDaemonEnvRefreshLoopPicksUpChanges`, `TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty`