### PR TITLE
daemon: fetch env-pushdown per session instead of polling

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -53,25 +53,6 @@ import (
 const (
 	daemonIdleTimeout  = 5 * time.Minute
 	daemonHelloTimeout = 2 * time.Second
-
-	// envRefreshInterval bounds the latency between a gateway-side
-	// credential change (HCL reload, credential connect/disconnect)
-	// and that change becoming visible in the daemon's env-pushdown
-	// replies. A background goroutine refetches /api/env-pushdown at
-	// this cadence so `clawpatrol run -- env` invoked after a profile
-	// change picks up the new placeholders without a daemon restart.
-	// 2s keeps the steady-state load at ≤30 fetches/min while making
-	// a manual profile change visible inside one prompt.
-	envRefreshInterval = 2 * time.Second
-
-	// envCacheTTL bounds how stale a cached env-pushdown response can
-	// be when the background refresh loop is delayed or failing
-	// (gateway briefly unreachable, dial in flight, etc.). On-demand
-	// START / ENV callers refetch past this age. Sized as a generous
-	// upper bound — the background loop normally keeps the cache
-	// fresh well below this — so a momentary fetch failure can't
-	// silently pin stale env state for the daemon's whole lifetime.
-	envCacheTTL        = 30 * time.Second
 	daemonSpawnTimeout = 30 * time.Second
 	daemonMagicLine    = "CLAWPATROL/1\n"
 )
@@ -283,27 +264,25 @@ type daemon struct {
 	// never replaced.
 	transport daemonTransport
 
-	// envVars + envFetchedAt cache the gateway's env-pushdown response.
-	// A background goroutine (runEnvRefreshLoop) refreshes the cache
-	// every envRefreshInterval so credential changes on the gateway
-	// (operator connects a new credential, HCL reload pulls in a new
-	// credential block) propagate to existing daemons within one
-	// interval instead of requiring a daemon restart. freshEnvVars
-	// also refetches on-demand past envCacheTTL when the loop is
-	// delayed. Held under envMu (the JSON byte slice is shared with
-	// concurrent handle() goroutines that ship it to clients).
-	envMu        sync.Mutex
-	envVars      []byte
-	envFetchedAt time.Time
+	// lastGoodEnv holds the most recent non-empty env-pushdown response
+	// observed during this daemon's lifetime. freshEnvVars hits the
+	// gateway on every call so a credential change made on the
+	// dashboard (operator connects a credential, HCL reload pulls in a
+	// new credential block) is visible to the very next `clawpatrol
+	// run` — issue #546. lastGoodEnv only kicks in when a fetch comes
+	// back empty AND a previous fetch was non-empty, to ride out
+	// transient gateway errors (daemonFetchEnvPushdown returns the "[]"
+	// sentinel on any failure and can't distinguish that from "no vars
+	// declared"). Held under envMu — concurrent handle() goroutines
+	// share the JSON byte slice.
+	envMu       sync.Mutex
+	lastGoodEnv []byte
 
-	// envFetch is the fetcher the cache loop and freshEnvVars call to
-	// pull the latest env-pushdown JSON from the gateway. Injected so
-	// tests can stub the gateway round-trip; defaults to
-	// daemonFetchEnvPushdown when nil. envRefreshTick overrides the
-	// background loop's cadence — also for tests; zero means
-	// envRefreshInterval.
-	envFetch       func() []byte
-	envRefreshTick time.Duration
+	// envFetch is the fetcher freshEnvVars calls to pull the latest
+	// env-pushdown JSON from the gateway. Injected so tests can stub
+	// the gateway round-trip; defaults to daemonFetchEnvPushdown when
+	// nil.
+	envFetch func() []byte
 
 	activeConns atomic.Int32
 
@@ -342,11 +321,6 @@ func runDaemon(_ []string) {
 		log.Fatalf("daemon: transport: %v", err)
 	}
 
-	// Pre-warm the env-pushdown cache so the first START reply doesn't
-	// pay the round-trip. Subsequent calls go through freshEnvVars,
-	// which re-fetches whenever the cache is older than envCacheTTL.
-	envJSON := daemonFetchEnvPushdown()
-
 	// Bind the control socket last. Parent still holds spawn.lock at
 	// this point, so we can't race another daemon for the path.
 	_ = os.Remove(sockPath)
@@ -364,13 +338,11 @@ func runDaemon(_ []string) {
 	}
 
 	d := &daemon{
-		sockPath:     sockPath,
-		listener:     ln,
-		lockFile:     lf,
-		transport:    transport,
-		envVars:      envJSON,
-		envFetchedAt: time.Now(),
-		rebindCh:     make(chan struct{}),
+		sockPath:  sockPath,
+		listener:  ln,
+		lockFile:  lf,
+		transport: transport,
+		rebindCh:  make(chan struct{}),
 	}
 
 	// Signal ready on the inherited pipe (fd 3). Once this lands, the
@@ -381,12 +353,6 @@ func runDaemon(_ []string) {
 	}
 
 	d.startIdleTimer()
-
-	// Start the background env-pushdown refresh loop. It owns the
-	// "credential changes propagate without restart" guarantee — see
-	// runEnvRefreshLoop. Runs for the life of the process; the daemon
-	// always exits via os.Exit (tryExit), which kills the goroutine.
-	go d.runEnvRefreshLoop()
 
 	// Main loop. After serve() returns the only valid events are:
 	//   - tryExit re-bound (sends on rebindCh) → loop, serve new listener.
@@ -568,85 +534,41 @@ func (d *daemon) handle(c net.Conn) {
 	}
 }
 
-// freshEnvVars returns the cached env-pushdown JSON, refetching from
-// the gateway only when the cache is older than envCacheTTL. The
-// background refresh loop (runEnvRefreshLoop) normally keeps the cache
-// fresh on a much shorter cadence; this on-demand path exists so the
-// first request after a stretched-out loop tick (or a stalled fetch)
-// still pulls a current snapshot.
+// freshEnvVars fetches the env-pushdown JSON from the gateway on
+// every call so a credential change made on the dashboard (operator
+// connects a credential, HCL reload pulls in a new credential block)
+// is visible to the next `clawpatrol run` without a daemon restart
+// (#546). The gateway lives on-tailnet so the round-trip is sub-50ms;
+// agent sessions are not noticeably slower, and an idle daemon
+// generates no traffic.
 //
-// Why this exists: profile changes on the gateway (operator connects
-// a new credential, HCL reload pulls in a new credential block) need
-// to be reflected in the placeholders the daemon ships to clients.
-// Without proactive refresh the daemon serves whatever it cached at
-// boot until someone manually restarts it.
-//
-// On gateway fetch error daemonFetchEnvPushdown already returns "[]"
-// (it can't distinguish "no vars declared" from "gateway down") — to
-// avoid silently dropping the previously-known-good list on a
-// transient gateway blip, fall back to the prior cache when the
-// fetch comes back empty AND the prior cache was non-empty.
+// daemonFetchEnvPushdown returns the "[]" sentinel on any fetch
+// failure and can't distinguish that from "no vars declared". If a
+// fetch comes back empty and we previously observed a non-empty list
+// in this daemon's lifetime, serve that last-known-good list rather
+// than silently dropping pushdown vars on a transient blip.
 func (d *daemon) freshEnvVars() []byte {
+	fresh := d.fetchEnv()
 	d.envMu.Lock()
 	defer d.envMu.Unlock()
-	if time.Since(d.envFetchedAt) < envCacheTTL && len(d.envVars) > 0 {
-		return d.envVars
+	if isEmptyEnvList(fresh) && !isEmptyEnvList(d.lastGoodEnv) {
+		return d.lastGoodEnv
 	}
-	fresh := d.fetchEnv()
-	if isEmptyEnvList(fresh) && !isEmptyEnvList(d.envVars) {
-		// Probable transient gateway error — keep the last good list
-		// but don't bump envFetchedAt, so the next call retries.
-		return d.envVars
+	if !isEmptyEnvList(fresh) {
+		d.lastGoodEnv = fresh
 	}
-	d.envVars = fresh
-	d.envFetchedAt = time.Now()
-	return d.envVars
+	return fresh
 }
 
 // fetchEnv resolves the env-pushdown fetcher to use. Defaults to the
 // gateway-dialing daemonFetchEnvPushdown; tests inject a stub via the
-// envFetch field. Caller does NOT need to hold envMu — the function
-// value itself is immutable after daemon construction.
+// envFetch field. The function value itself is immutable after daemon
+// construction, so no envMu required.
 func (d *daemon) fetchEnv() []byte {
 	if d.envFetch != nil {
 		return d.envFetch()
 	}
 	return daemonFetchEnvPushdown()
-}
-
-// runEnvRefreshLoop polls the gateway's /api/env-pushdown on a fixed
-// cadence and updates the cached JSON in place, so credential changes
-// (operator connects/disconnects, HCL reload) become visible to clients
-// without a daemon restart. Bounded to ≤30 fetches/min at the default
-// envRefreshInterval — bursty `clawpatrol run` invocations still serve
-// straight from the cache.
-//
-// Lifetime: runs for the life of the daemon process. The daemon exits
-// via os.Exit (tryExit), which terminates this goroutine implicitly;
-// there's no explicit stop channel.
-//
-// Mirrors freshEnvVars' transient-failure guard: if the gateway is
-// briefly unreachable (daemonFetchEnvPushdown returns "[]" on every
-// kind of failure), preserve the prior cache instead of clobbering it
-// with an empty list.
-func (d *daemon) runEnvRefreshLoop() {
-	interval := d.envRefreshTick
-	if interval == 0 {
-		interval = envRefreshInterval
-	}
-	t := time.NewTicker(interval)
-	defer t.Stop()
-	for range t.C {
-		fresh := d.fetchEnv()
-		d.envMu.Lock()
-		if isEmptyEnvList(fresh) && !isEmptyEnvList(d.envVars) {
-			d.envMu.Unlock()
-			continue
-		}
-		d.envVars = fresh
-		d.envFetchedAt = time.Now()
-		d.envMu.Unlock()
-	}
 }
 
 // isEmptyEnvList recognises the two encodings of "no push-down vars"

--- a/cmd/clawpatrol/daemon_linux_test.go
+++ b/cmd/clawpatrol/daemon_linux_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -323,17 +322,17 @@ func TestDaemonEnvCommand_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestDaemonEnvRefreshLoopPicksUpChanges verifies the background
-// env-pushdown refresh path: a credential change on the gateway side
-// (modelled here as the injected fetcher returning a new payload) is
-// reflected in the daemon's freshEnvVars output without restarting
-// the daemon — the regression check for cl-yi1e.
+// TestDaemonFreshEnvVarsPicksUpChanges verifies that freshEnvVars
+// hits the gateway on every call: a credential change on the gateway
+// side (modelled here as the injected fetcher returning a new payload)
+// is reflected in the very next freshEnvVars call without restarting
+// the daemon — regression check for #546.
 //
 // Uses an injected fetcher so the test doesn't require a real
 // /api/env-pushdown HTTP round-trip; the unit under test is the
-// daemon's cache + refresh-loop wiring, not the HTTP plumbing
-// (which TestFetchEnvPushdownFromGateway already covers).
-func TestDaemonEnvRefreshLoopPicksUpChanges(t *testing.T) {
+// daemon's per-call fetch wiring, not the HTTP plumbing (which
+// TestFetchEnvPushdownFromGateway already covers).
+func TestDaemonFreshEnvVarsPicksUpChanges(t *testing.T) {
 	initial, err := json.Marshal([]pushdownEnvVar{
 		{Name: "GH_TOKEN", Value: "ghp_initial", PluginType: "github_oauth"},
 	})
@@ -362,47 +361,38 @@ func TestDaemonEnvRefreshLoopPicksUpChanges(t *testing.T) {
 		return out
 	}
 
-	d := &daemon{
-		envVars:        initial,
-		envFetchedAt:   time.Now(),
-		envFetch:       fetch,
-		envRefreshTick: 10 * time.Millisecond,
-	}
-	go d.runEnvRefreshLoop()
+	d := &daemon{envFetch: fetch}
 
-	// Sanity check: cache starts on the initial payload.
 	if got := string(d.freshEnvVars()); got != string(initial) {
 		t.Fatalf("initial freshEnvVars = %q, want %q", got, string(initial))
 	}
+	if calls != 1 {
+		t.Fatalf("after one freshEnvVars: calls = %d, want 1", calls)
+	}
 
 	// Simulate the operator connecting a new credential on the
-	// gateway: subsequent fetches now return the updated payload.
+	// gateway: subsequent fetches now return the updated payload. The
+	// very next freshEnvVars must reflect it — no cache, no waiting
+	// for a background tick.
 	mu.Lock()
 	current = updated
 	mu.Unlock()
 
-	// Wait for the background loop to pick up the change. The loop
-	// runs at 10ms cadence, so a generous deadline avoids a flake on
-	// loaded CI hosts without sleeping needlessly on a fast one.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if string(d.freshEnvVars()) == string(updated) {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	if got := string(d.freshEnvVars()); got != string(updated) {
+		t.Fatalf("after gateway update: freshEnvVars = %q, want %q", got, string(updated))
 	}
-
-	t.Fatalf("background refresh never picked up updated payload (calls=%d, last freshEnvVars=%q)",
-		calls, string(d.freshEnvVars()))
+	if calls != 2 {
+		t.Fatalf("after two freshEnvVars: calls = %d, want 2 (every call must fetch)", calls)
+	}
 }
 
-// TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty verifies the
-// fallback in runEnvRefreshLoop: a fetch that returns an empty list
-// (the sentinel daemonFetchEnvPushdown emits on every kind of fetch
-// failure) must NOT clobber a previously-known-good cache. Without
-// this guard a single 1s gateway blip would silently drop every
-// declared env var from the daemon's pushdown.
-func TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty(t *testing.T) {
+// TestDaemonFreshEnvVarsKeepsLastGoodOnTransientEmpty verifies the
+// transient-failure guard in freshEnvVars: a fetch that returns an
+// empty list (the sentinel daemonFetchEnvPushdown emits on every kind
+// of fetch failure) must NOT clobber a previously-observed non-empty
+// list. Without this guard a single gateway blip would silently drop
+// every declared env var from the daemon's pushdown for one session.
+func TestDaemonFreshEnvVarsKeepsLastGoodOnTransientEmpty(t *testing.T) {
 	good, err := json.Marshal([]pushdownEnvVar{
 		{Name: "GH_TOKEN", Value: "ghp_good"},
 	})
@@ -412,7 +402,7 @@ func TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty(t *testing.T) {
 
 	var (
 		mu    sync.Mutex
-		empty = true
+		empty bool
 	)
 	fetch := func() []byte {
 		mu.Lock()
@@ -423,19 +413,20 @@ func TestDaemonEnvRefreshLoopKeepsLastGoodOnTransientEmpty(t *testing.T) {
 		return good
 	}
 
-	d := &daemon{
-		envVars:        good,
-		envFetchedAt:   time.Now(),
-		envFetch:       fetch,
-		envRefreshTick: 10 * time.Millisecond,
-	}
-	go d.runEnvRefreshLoop()
+	d := &daemon{envFetch: fetch}
 
-	// Let the loop tick several times under the empty-returning
-	// fetcher. The cache must hold the prior good value.
-	time.Sleep(80 * time.Millisecond)
+	// First call: real payload — populates lastGoodEnv.
 	if got := string(d.freshEnvVars()); got != string(good) {
-		t.Fatalf("after transient empty: freshEnvVars = %q, want %q (last good preserved)", got, string(good))
+		t.Fatalf("initial freshEnvVars = %q, want %q", got, string(good))
+	}
+
+	// Gateway "goes down" — fetcher now returns the empty sentinel.
+	// freshEnvVars must serve the prior good list.
+	mu.Lock()
+	empty = true
+	mu.Unlock()
+	if got := string(d.freshEnvVars()); got != string(good) {
+		t.Fatalf("during transient empty: freshEnvVars = %q, want %q (last good preserved)", got, string(good))
 	}
 }
 


### PR DESCRIPTION
Replaces the background-polling cache from #549 with a per-call fetch.
Both approaches fix #546; this trades the opposite knob.

* Per-call fetch matches the macOS NE path (`Provider.swift`'s `getenv`
  IPC re-fetches on every `clawpatrol run`), so Linux and macOS no
  longer diverge on freshness semantics.
* An idle daemon now makes zero gateway calls. The previous background
  poller fired every 2s for the daemon's full ≤5 min idle lifetime
  regardless of session activity.
* Each `clawpatrol run` pays one extra round-trip; the gateway lives
  on-tailnet so it's sub-50ms — no noticeable session latency.
* Transient-failure guard preserved in smaller form: `lastGoodEnv`
  (replaces `envVars` + `envFetchedAt`) holds the most recent non-empty
  observation and is served when a fetch returns the `[]` sentinel while
  a real list was previously observed. Same semantics as the old guard
  in `runEnvRefreshLoop` / `freshEnvVars`, just no TTL.
* Drops `envCacheTTL`, `envRefreshInterval`, `envRefreshTick`, the
  startup pre-warm fetch, and `runEnvRefreshLoop` entirely.
* Tests reworked: the two cl-yi1e tests are rewritten against the
  per-call `freshEnvVars` (one for "picks up changes immediately and
  calls the fetcher every time", one for the last-good fallback). No
  more `time.Sleep` / deadline polling in the test loop.