### PR TITLE
site: snapshot telemetry counts daily for time-series tracking

### DIFF
--- a/site/migrations/0002_create_snapshots.sql
+++ b/site/migrations/0002_create_snapshots.sql
@@ -1,0 +1,14 @@
+-- Daily roll-ups of gateway telemetry. The `gateways` table only
+-- holds the latest ping per instance, so historical counts have to
+-- be snapshotted. Populated by the worker's scheduled() handler.
+--
+-- Tall shape: one row per (day, metric, bucket). New dimensions or
+-- new bucket values (a new OS/arch, a new transport) need no schema
+-- change. Active count uses bucket=''.
+CREATE TABLE telemetry_snapshots (
+  day    INTEGER NOT NULL,  -- yyyymmdd, UTC
+  metric TEXT    NOT NULL,  -- 'active' | 'transport' | 'platform' | 'version'
+  bucket TEXT    NOT NULL,  -- '' for 'active'
+  count  INTEGER NOT NULL,
+  PRIMARY KEY (day, metric, bucket)
+);

--- a/site/sql/snapshot.sql
+++ b/site/sql/snapshot.sql
@@ -1,0 +1,34 @@
+-- Write today's roll-up rows into telemetry_snapshots. Idempotent:
+-- rerunning the same UTC day overwrites that day's rows. The
+-- scheduled worker handler computes the same numbers via prepared
+-- statements; this file lets you seed or backfill manually with
+--   npx wrangler d1 execute TELEMETRY_DB --remote --file sql/snapshot.sql
+INSERT OR REPLACE INTO telemetry_snapshots (day, metric, bucket, count)
+SELECT CAST(strftime('%Y%m%d', 'now') AS INTEGER), 'active', '',
+       COUNT(*)
+  FROM gateways
+ WHERE last_seen > unixepoch() - 7 * 86400;
+
+INSERT OR REPLACE INTO telemetry_snapshots (day, metric, bucket, count)
+SELECT CAST(strftime('%Y%m%d', 'now') AS INTEGER), 'transport',
+       COALESCE(transport, '(unknown)'),
+       COUNT(*)
+  FROM gateways
+ WHERE last_seen > unixepoch() - 7 * 86400
+ GROUP BY transport;
+
+INSERT OR REPLACE INTO telemetry_snapshots (day, metric, bucket, count)
+SELECT CAST(strftime('%Y%m%d', 'now') AS INTEGER), 'platform',
+       COALESCE(os, '?') || '/' || COALESCE(arch, '?'),
+       COUNT(*)
+  FROM gateways
+ WHERE last_seen > unixepoch() - 7 * 86400
+ GROUP BY os, arch;
+
+INSERT OR REPLACE INTO telemetry_snapshots (day, metric, bucket, count)
+SELECT CAST(strftime('%Y%m%d', 'now') AS INTEGER), 'version',
+       version,
+       COUNT(*)
+  FROM gateways
+ WHERE last_seen > unixepoch() - 7 * 86400
+ GROUP BY version;

--- a/site/sql/telemetry/active-history.sql
+++ b/site/sql/telemetry/active-history.sql
@@ -1,0 +1,6 @@
+-- Active gateways per day, from snapshots written by the cron.
+SELECT day, count AS active_gateways
+  FROM telemetry_snapshots
+ WHERE metric = 'active'
+ ORDER BY day DESC
+ LIMIT 30;

--- a/site/sql/telemetry/platforms-history.sql
+++ b/site/sql/telemetry/platforms-history.sql
@@ -1,0 +1,6 @@
+-- OS/arch split per day from snapshots. Long form, most-recent first.
+SELECT day, bucket AS platform, count
+  FROM telemetry_snapshots
+ WHERE metric = 'platform'
+ ORDER BY day DESC, count DESC, platform
+ LIMIT 90;

--- a/site/sql/telemetry/transports-history.sql
+++ b/site/sql/telemetry/transports-history.sql
@@ -1,0 +1,7 @@
+-- Transport split per day. Long form so new buckets don't need
+-- a schema or query change. Most-recent first.
+SELECT day, bucket AS transport, count
+  FROM telemetry_snapshots
+ WHERE metric = 'transport'
+ ORDER BY day DESC, count DESC, transport
+ LIMIT 90;

--- a/site/sql/telemetry/versions-history.sql
+++ b/site/sql/telemetry/versions-history.sql
@@ -1,0 +1,6 @@
+-- Version split per day from snapshots. Long form, most-recent first.
+SELECT day, bucket AS version, count
+  FROM telemetry_snapshots
+ WHERE metric = 'version'
+ ORDER BY day DESC, count DESC, version
+ LIMIT 90;

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -1,11 +1,14 @@
 /// <reference types="@cloudflare/workers-types" />
-// Cloudflare Worker for clawpatrol.dev. Two responsibilities:
+// Cloudflare Worker for clawpatrol.dev. Three responsibilities:
 //
 //   1. Serve the static landing site (env.ASSETS, built into ./dist
 //      by `npm run build`).
 //   2. Accept telemetry pings from clawpatrol gateways at
 //      POST /api/telemetry/v1/check, upsert into D1, and return the
 //      latest GitHub release as the update-checker response.
+//   3. Daily cron (see wrangler.jsonc) that rolls up the `gateways`
+//      table into `telemetry_snapshots` so we can track counts over
+//      time. The live table only holds the latest ping per instance.
 //
 // Contract for what's stored: doc/telemetry.md.
 
@@ -25,6 +28,9 @@ export default {
       return handleCheck(req, env);
     }
     return env.ASSETS.fetch(req);
+  },
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    await snapshotDaily(env);
   },
 };
 
@@ -147,6 +153,69 @@ function parseAdvisory(
   const firstPara = m[2].split(/\n\s*\n/)[0].trim();
   if (!firstPara) return null;
   return { level: m[1].toLowerCase(), message: firstPara };
+}
+
+// Roll up the last 7 days of `gateways` into one row per
+// (day, metric, bucket). Idempotent: rerunning the same day
+// overwrites that day's rows via INSERT OR REPLACE.
+async function snapshotDaily(env: Env): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  const cutoff = now - 7 * 86400;
+  const day = yyyymmdd(new Date(now * 1000));
+  const db = env.TELEMETRY_DB;
+
+  const active = await db.prepare(
+    `SELECT COUNT(*) AS count FROM gateways WHERE last_seen > ?`,
+  ).bind(cutoff).first<{ count: number }>();
+
+  const transports = await db.prepare(
+    `SELECT COALESCE(transport, '(unknown)') AS bucket,
+            COUNT(*) AS count
+       FROM gateways
+      WHERE last_seen > ?
+      GROUP BY bucket`,
+  ).bind(cutoff).all<{ bucket: string; count: number }>();
+
+  const platforms = await db.prepare(
+    `SELECT COALESCE(os, '?') || '/' || COALESCE(arch, '?') AS bucket,
+            COUNT(*) AS count
+       FROM gateways
+      WHERE last_seen > ?
+      GROUP BY bucket`,
+  ).bind(cutoff).all<{ bucket: string; count: number }>();
+
+  const versions = await db.prepare(
+    `SELECT version AS bucket, COUNT(*) AS count
+       FROM gateways
+      WHERE last_seen > ?
+      GROUP BY bucket`,
+  ).bind(cutoff).all<{ bucket: string; count: number }>();
+
+  const rows: Array<[number, string, string, number]> = [
+    [day, "active", "", active?.count ?? 0],
+  ];
+  for (const r of transports.results) {
+    rows.push([day, "transport", r.bucket, r.count]);
+  }
+  for (const r of platforms.results) {
+    rows.push([day, "platform", r.bucket, r.count]);
+  }
+  for (const r of versions.results) {
+    rows.push([day, "version", r.bucket, r.count]);
+  }
+
+  const insert = db.prepare(
+    `INSERT OR REPLACE INTO telemetry_snapshots
+       (day, metric, bucket, count) VALUES (?, ?, ?, ?)`,
+  );
+  await db.batch(rows.map((r) => insert.bind(...r)));
+}
+
+function yyyymmdd(d: Date): number {
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth() + 1;
+  const dd = d.getUTCDate();
+  return y * 10000 + m * 100 + dd;
 }
 
 function str(v: unknown): string {

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -7,6 +7,9 @@
 		"binding": "ASSETS",
 		"run_worker_first": true
 	},
+	"triggers": {
+		"crons": ["5 0 * * *"]
+	},
 	"d1_databases": [
 		{
 			"binding": "TELEMETRY_DB",


### PR DESCRIPTION
## Summary

- `gateways` only stores one row per instance (upserted on every ping), so historical active-count, transport mix, OS/arch, and version trends are unrecoverable from it. Adds a tall `telemetry_snapshots(day, metric, bucket, count)` table that gets written daily.
- Worker `scheduled()` handler + new `5 0 * * *` UTC cron in `wrangler.jsonc` runs the same four queries as the `sql/telemetry/*-7d.sql` views and INSERT-OR-REPLACEs the rows for today.
- `sql/snapshot.sql` mirrors the cron's logic in pure SQL for manual seed / backfill via `wrangler d1 execute --file`. Already applied + seeded on remote.
- `sql/telemetry/*-history.sql` show up automatically in `npm run telemetry` so the snapshots are readable.

No backfill of pre-existing days is possible (the raw data isn't there). Table starts empty and fills forward.

## Test plan

- [x] `0002_create_snapshots.sql` applied to remote D1
- [x] `wrangler d1 execute --file sql/snapshot.sql --remote` populated today's rows (16, matching the live `-7d` counts)
- [x] `npm run telemetry` prints both live and history sections cleanly
- [x] `npm test` (worker tests) passes
- [ ] After deploy: confirm the cron fires at 00:05 UTC and writes the next day's rows
