### PR TITLE
gateway: skip phantom-agent logging in wgRelay for unknown tailnet peers

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3170,30 +3170,49 @@ func (l *oneShotListener) Addr() net.Addr {
 // Emits a sink Event so transparently-relayed flows show up in the
 // dashboard request history alongside MITM traffic — without this,
 // ssh / git-over-ssh / arbitrary-port connections went silent.
+//
+// Analytics are gated on the peer being a known device. The tsnet
+// fallback handler catches every TCP forwarded through the gateway's
+// exit-node advertisement, which includes stray probes from every
+// other tailnet peer on the network. Without the gate, each new
+// probing tailnet IP mints a synthetic "agent" row in the dashboard
+// and the actions table fills up with thousands of phantom devices
+// that never appear in the device list. The dial still runs for
+// unknown peers (relay behavior unchanged); only the sink event is
+// suppressed.
 func (g *Gateway) wgRelay(c net.Conn, dstIP string, dstPort int) {
 	defer func() { _ = c.Close() }()
 	pip := peerIP(c)
 	profile := g.profileFor(pip)
 	agentPip := g.agentIPFor(c)
+	known := g.onboard == nil || g.onboard.HasDevice(pip) || g.onboard.HasDevice(agentPip)
 	host := fmt.Sprintf("%s:%d", dstIP, dstPort)
 	start := time.Now()
 	up, err := net.DialTimeout("tcp", net.JoinHostPort(dstIP, strconv.Itoa(dstPort)), 10*time.Second)
 	if err != nil {
-		g.sink.Emit(Event{
-			Mode: "relay", AgentIP: agentPip, Agent: profile,
-			Host: host, Action: "deny", Reason: err.Error(),
-			Ms: time.Since(start).Milliseconds(),
-		})
+		if known {
+			g.sink.Emit(Event{
+				Mode: "relay", AgentIP: agentPip, Agent: profile,
+				Host: host, Action: "deny", Reason: err.Error(),
+				Ms: time.Since(start).Milliseconds(),
+			})
+		}
 		return
 	}
 	defer func() { _ = up.Close() }()
-	rx, tx := pipeProgress(c, up, g.streamTracker(agentPip, host))
-	g.sink.Emit(Event{
-		Mode: "relay", AgentIP: agentPip, Agent: profile,
-		Host: host, Action: "allow",
-		In: rx, Out: tx,
-		Ms: time.Since(start).Milliseconds(),
-	})
+	var tracker func(rx, tx int64)
+	if known {
+		tracker = g.streamTracker(agentPip, host)
+	}
+	rx, tx := pipeProgress(c, up, tracker)
+	if known {
+		g.sink.Emit(Event{
+			Mode: "relay", AgentIP: agentPip, Agent: profile,
+			Host: host, Action: "allow",
+			In: rx, Out: tx,
+			Ms: time.Since(start).Milliseconds(),
+		})
+	}
 }
 
 // streamTracker returns a pipeProgress onTick callback that feeds the


### PR DESCRIPTION
* The tsnet fallback handler accepts every TCP forwarded through the
  gateway's exit-node advertisement (0.0.0.0/0, ::/0). Anything that
  doesn't match a port-specific case (:443 MITM, :5432 postgres,
  :53 DNS, VIPs, dashboard) falls through to `wgRelay`, which today
  unconditionally emits a sink event with the source peer's tailnet
  IP as `agent_ip` — including for tailnet peers that have nothing
  to do with this gateway.
* Symptom on a gateway with ~10 real agents: 1,600+ distinct
  `agent_ip` values in `actions`, including 1,500+ tailnet peers
  that never went through `/api/onboard/claim` and don't appear in
  the devices list. Most of the noise is relay-deny rows from peers
  dialing the gateway's own tailnet IP on :8443 — the dial fails
  (host network has no route to a tailnet IP) and each failed
  attempt mints a fresh phantom agent.
* Gate the `sink.Emit` and `streamTracker` calls on
  `g.onboard.HasDevice` for either the raw peer IP or its
  `agentIPFor` canonical alias. The dial itself still runs so relay
  behavior is unchanged for unknown peers; only the analytics side
  is suppressed.
* Join-time tsnet routes (claim → :443, `/api/peer/tsnet/register`
  → :8080, CA fetch → :8080, daemon DNS probe → :53) all match
  earlier cases in the fallback dispatch and never reach `wgRelay`,
  so a peer mid-join is unaffected.

Companion PR coming up to address the related IP-rotation case
(legit agents whose tailnet IP rotates and end up creating a fresh
phantom row each time).