### PR TITLE
gateway: coalesce IP-rotated tsnet peers onto their existing device row

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -404,29 +404,69 @@ func (g *Gateway) profileFor(peerIP string) string {
 		if p := g.onboard.ProfileForIP(peerIP); p != "" {
 			return p
 		}
-		// Lazy IPv6 → IPv4 resolution: whole-machine tsnet traffic
-		// often arrives on the peer's fd7a:115c:a1e0::/48 ULA. If the
-		// onboard table only has the IPv4 entry (peers registered
-		// before seedTsnetIPv6Alias existed), resolve via tsnet WhoIs
-		// once and stamp the alias.
-		if g.tsnetLC != nil && strings.HasPrefix(peerIP, "fd7a:") {
-			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-			defer cancel()
-			if w, err := g.tsnetLC.WhoIs(ctx, net.JoinHostPort(peerIP, "0")); err == nil && w != nil && w.Node != nil {
-				for _, addr := range w.Node.Addresses {
-					ip := addr.Addr()
-					if !ip.Is4() {
-						continue
-					}
-					if p := g.onboard.ProfileForIP(ip.String()); p != "" {
-						g.onboard.RegisterIPAlias(peerIP, ip.String())
-						return p
-					}
+		// Lazy alias resolution via tsnet WhoIs. Two cases this catches:
+		//
+		//   1. Same Tailscale node, different address family — whole-
+		//      machine tsnet traffic arrives on the peer's IPv6 ULA
+		//      (fd7a:115c:a1e0::/48) but only the IPv4 is registered.
+		//   2. Same logical host, new Tailscale node — the host rejoined
+		//      the tailnet and got a fresh 100.x; without coalescing the
+		//      dashboard sprouts a phantom row per rejoin.
+		//
+		// ClaimAliasResolve guards against re-running WhoIs per packet
+		// for peers that have no matching device.
+		if g.tsnetLC != nil && g.onboard.ClaimAliasResolve(peerIP, 5*time.Minute) {
+			if canonical := g.resolveTsnetAlias(peerIP); canonical != "" {
+				if p := g.onboard.ProfileForIP(canonical); p != "" {
+					return p
 				}
 			}
 		}
 	}
 	return defaultProfileName(g.cfg.Policy)
+}
+
+// resolveTsnetAlias does a one-shot tsnet WhoIs for peerIP and, on a
+// match, registers an alias from peerIP onto the existing device IP.
+// Returns the canonical device IP on success, or "" when no match is
+// found. Both passes (address-match and hostname-match) only consider
+// IPs that already have a devices row, so an unknown tailnet peer with
+// no devices entry can never accidentally absorb traffic from another
+// peer.
+//
+// Hostname matches require exactly one devices row with that name (see
+// UniqueIPForHostname) so ephemeral pools that share a hostname — e.g.
+// the clawpatrol-run-* nodes Tailscale auto-suffixes on collision — are
+// never collapsed into one another.
+func (g *Gateway) resolveTsnetAlias(peerIP string) string {
+	if g.tsnetLC == nil || g.onboard == nil || peerIP == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	w, err := g.tsnetLC.WhoIs(ctx, net.JoinHostPort(peerIP, "0"))
+	if err != nil || w == nil || w.Node == nil {
+		return ""
+	}
+	for _, addr := range w.Node.Addresses {
+		ip := addr.Addr().String()
+		if ip == peerIP {
+			continue
+		}
+		if g.onboard.HasDevice(ip) {
+			g.onboard.RegisterIPAlias(peerIP, ip)
+			return ip
+		}
+	}
+	hostname := w.Node.ComputedName
+	if hostname == "" && w.Node.Hostinfo.Valid() {
+		hostname = w.Node.Hostinfo.Hostname()
+	}
+	if canonical := g.onboard.UniqueIPForHostname(hostname); canonical != "" && canonical != peerIP {
+		g.onboard.RegisterIPAlias(peerIP, canonical)
+		return canonical
+	}
+	return ""
 }
 
 // seedTsnetIPv6Alias resolves peerIP (IPv4) to the peer's IPv6 ULA via
@@ -465,10 +505,19 @@ func (g *Gateway) seedTsnetIPv6Alias(peerIP string) {
 // under a single device in the dashboard.
 func (g *Gateway) agentIPFor(c net.Conn) string {
 	ip := peerIP(c)
-	if g.onboard != nil {
-		return g.onboard.AgentIPFor(ip)
+	if g.onboard == nil {
+		return ip
 	}
-	return ip
+	// Mirror the lazy WhoIs lookup in profileFor here so callers that
+	// reach agentIPFor without first going through profileFor (e.g. the
+	// LLM-session bookkeeping paths) still benefit from alias resolution.
+	// Both functions use the same ClaimAliasResolve guard, so the WhoIs
+	// runs at most once per peer per 5-minute window regardless of which
+	// one is called first.
+	if g.tsnetLC != nil && g.onboard.ClaimAliasResolve(ip, 5*time.Minute) {
+		g.resolveTsnetAlias(ip)
+	}
+	return g.onboard.AgentIPFor(ip)
 }
 
 // defaultProfileName returns the profile a freshly-onboarded peer

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -82,7 +82,12 @@ type onboardRegistry struct {
 	extV6ByIP        map[string]string
 	canonicalByAlias map[string]string // alias IP → canonical device IP (e.g. fd7a:115c:a1e0::… → 100.x.x.x)
 	knownDeviceIPs   map[string]bool   // all IPs present in devices table
-	db               *sql.DB
+	// resolveTriedAt caches the last time we asked tsnet WhoIs whether an
+	// unknown peer IP corresponds to a known device. Without it, traffic
+	// from any IP that genuinely has no devices-table mapping would
+	// trigger a WhoIs lookup per packet.
+	resolveTriedAt map[string]time.Time
+	db             *sql.DB
 }
 
 func newOnboardRegistry() *onboardRegistry {
@@ -96,6 +101,7 @@ func newOnboardRegistry() *onboardRegistry {
 		extV6ByIP:        map[string]string{},
 		canonicalByAlias: map[string]string{},
 		knownDeviceIPs:   map[string]bool{},
+		resolveTriedAt:   map[string]time.Time{},
 	}
 }
 
@@ -360,6 +366,60 @@ func (r *onboardRegistry) IPForHostname(owner, hostname string) string {
 		return ip
 	}
 	return ""
+}
+
+// UniqueIPForHostname returns a device IP iff exactly one devices row has
+// this hostname. Used to coalesce a tailnet peer that has rejoined under
+// a fresh tailnet IP back onto its existing device row. Returns "" on
+// collisions so we never silently merge two distinct hosts that happen
+// to share a hostname (e.g. ephemeral clawpatrol-run nodes that all
+// register as "clawpatrol-run").
+func (r *onboardRegistry) UniqueIPForHostname(hostname string) string {
+	if hostname == "" {
+		return ""
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	found := ""
+	for ip, hn := range r.hostnameByIP {
+		if hn != hostname {
+			continue
+		}
+		if !r.knownDeviceIPs[ip] {
+			continue
+		}
+		if found != "" && found != ip {
+			return ""
+		}
+		found = ip
+	}
+	return found
+}
+
+// ClaimAliasResolve returns true if we should run a WhoIs lookup for ip
+// to try to map it onto a known device, and false if a recent attempt
+// already settled the question (positive or negative). The first caller
+// in a `within` window wins; subsequent callers skip the lookup so a
+// peer with no matching device doesn't trigger one WhoIs round-trip per
+// packet. Stamping the time inside the same critical section makes the
+// check-and-claim atomic across concurrent callers.
+func (r *onboardRegistry) ClaimAliasResolve(ip string, within time.Duration) bool {
+	if ip == "" {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.knownDeviceIPs[ip] {
+		return false
+	}
+	if _, ok := r.canonicalByAlias[ip]; ok {
+		return false
+	}
+	if t, ok := r.resolveTriedAt[ip]; ok && time.Since(t) < within {
+		return false
+	}
+	r.resolveTriedAt[ip] = time.Now()
+	return true
 }
 
 func (r *onboardRegistry) ForgetIP(ip string) {

--- a/cmd/clawpatrol/onboard_alias_test.go
+++ b/cmd/clawpatrol/onboard_alias_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUniqueIPForHostname(t *testing.T) {
+	r := newOnboardRegistry()
+	r.knownDeviceIPs["100.1.1.1"] = true
+	r.hostnameByIP["100.1.1.1"] = "avocet2"
+
+	if got := r.UniqueIPForHostname("avocet2"); got != "100.1.1.1" {
+		t.Fatalf("single-match: got %q, want %q", got, "100.1.1.1")
+	}
+	if got := r.UniqueIPForHostname("unknown-host"); got != "" {
+		t.Fatalf("no-match: got %q, want empty", got)
+	}
+	if got := r.UniqueIPForHostname(""); got != "" {
+		t.Fatalf("empty hostname: got %q, want empty", got)
+	}
+
+	// Second device with same hostname → collision, must refuse.
+	r.knownDeviceIPs["100.2.2.2"] = true
+	r.hostnameByIP["100.2.2.2"] = "avocet2"
+	if got := r.UniqueIPForHostname("avocet2"); got != "" {
+		t.Fatalf("collision: got %q, want empty", got)
+	}
+
+	// Hostname entry without a corresponding devices row (e.g. an
+	// in-memory tsnet placeholder) must not satisfy a unique match —
+	// otherwise UniqueIPForHostname would point traffic at a placeholder
+	// ID that isn't actually a device.
+	r2 := newOnboardRegistry()
+	r2.hostnameByIP["tsnet-foo"] = "foo"
+	if got := r2.UniqueIPForHostname("foo"); got != "" {
+		t.Fatalf("placeholder-only hostname: got %q, want empty", got)
+	}
+}
+
+func TestClaimAliasResolve(t *testing.T) {
+	r := newOnboardRegistry()
+
+	// First call for an unknown IP claims the resolution slot.
+	if !r.ClaimAliasResolve("100.9.9.9", time.Minute) {
+		t.Fatal("first claim should succeed")
+	}
+	// Second call within the window must be denied (negative cache).
+	if r.ClaimAliasResolve("100.9.9.9", time.Minute) {
+		t.Fatal("second claim within window should be denied")
+	}
+	// Backdating the trie entry past the window re-opens the slot.
+	r.resolveTriedAt["100.9.9.9"] = time.Now().Add(-2 * time.Minute)
+	if !r.ClaimAliasResolve("100.9.9.9", time.Minute) {
+		t.Fatal("expired claim should re-open")
+	}
+
+	// Known devices and registered aliases never trigger a WhoIs lookup.
+	r.knownDeviceIPs["100.1.1.1"] = true
+	if r.ClaimAliasResolve("100.1.1.1", time.Minute) {
+		t.Fatal("known device must not claim")
+	}
+	r.canonicalByAlias["100.5.5.5"] = "100.1.1.1"
+	if r.ClaimAliasResolve("100.5.5.5", time.Minute) {
+		t.Fatal("aliased IP must not claim")
+	}
+
+	// Empty IP is rejected so a missing-source-address bug never spams
+	// WhoIs lookups for the empty string.
+	if r.ClaimAliasResolve("", time.Minute) {
+		t.Fatal("empty ip must not claim")
+	}
+}


### PR DESCRIPTION
* When a tailnet host rejoins (e.g. clean reinstall, fresh tagged
  auth key), Tailscale issues a new node identity with a new 100.x
  while the old devices row stays put. `profileFor` / `agentIPFor`
  treated the new IP as a brand-new peer, creating a phantom agent
  row in the dashboard analytics that never appeared in the device
  list because the new IP never went through `/api/onboard/claim`.
  On the production gateway this surfaced as 1,000+ "agent IPs"
  against ~10 real devices.
* The existing fd7a:: lazy WhoIs lookup already handled one variant
  of this (same Tailscale node, IPv6 ULA vs IPv4 alias). Drop the
  fd7a-prefix guard so the lookup runs for any unknown IP, and add
  a second pass that matches the WhoIs hostname against
  `devices.name` when the address pass turns up nothing.
* Hostname matches require exactly one devices row with that name
  (`UniqueIPForHostname`) so the merge can never collapse two
  distinct hosts that happen to share a hostname — a real risk for
  the clawpatrol-run-* ephemeral pool that Tailscale auto-suffixes
  on collision.
* `ClaimAliasResolve` is a per-IP, time-bounded negative cache so
  traffic from a peer that genuinely has no matching device doesn't
  trigger a WhoIs on every connection. The first caller within the
  5-minute window claims the slot; subsequent callers skip the
  lookup and the WhoIs runs at most once per peer regardless of
  which entry point (profileFor vs agentIPFor) sees the connection
  first.
* `resolveTsnetAlias` only ever registers aliases onto IPs that
  already have a devices row, so an unknown peer mid-join cannot
  displace another peer's identity. Stacks with #556 — that PR
  stops minting phantom rows for peers with no devices entry at
  all; this PR keeps real agents that have rotated their tailnet
  IP attached to the right device row.

Verified safe for the join flow: claim → :443 MITM,
`/api/peer/tsnet/register` → :8080 dashboard mux, CA fetch → :8080,
daemon DNS probe → :53 — none of these paths require the peer to
be known by `profileFor`/`agentIPFor`, and the resolver only ever
remaps onto IPs that are already in the devices table, so a peer
mid-join (no devices row yet) is unaffected.