### PR TITLE
gateway: catch-all UDP/53 interception in tsnet exit-node mode

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3093,6 +3093,13 @@ func runGateway(args []string) {
 				log.Printf("tsnet: dnsvip UDP listener on %s:53", g.tailscaleIP)
 				serveTsnetDNSUDP(pc, g.dnsvip)
 			}()
+			// Layer a UDP/53 catch-all onto tsnet's underlying netstack so
+			// exit-node clients whose system resolver targets a public IP
+			// (8.8.8.8, 1.1.1.1) still reach dnsvip — the IP-bound listener
+			// above only catches packets aimed at the gateway's own tailnet
+			// IP. tsnet has no public UDP fallback hook, so this reaches
+			// through Sys().Netstack (see installTsnetUDPDNSCatchAll).
+			g.installTsnetUDPDNSCatchAll(tsnetServer)
 		}
 		// Intercept all TCP forwarded through this exit node (whole-machine
 		// clients). dst is the original internet destination — same dispatch

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -37,9 +37,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"tailscale.com/ipn"
 	"tailscale.com/tsnet"
+	"tailscale.com/types/nettype"
+	"tailscale.com/wgengine/netstack"
 
 	"github.com/denoland/clawpatrol/internal/config"
 )
@@ -234,5 +237,88 @@ func advertiseExitRoutes(s *tsnet.Server) {
 		log.Printf("tsnet: advertise exit routes: %v", err)
 	} else {
 		log.Printf("tsnet: advertised exit routes (0.0.0.0/0, ::/0)")
+	}
+}
+
+// installTsnetUDPDNSCatchAll layers a catch-all UDP/53 interceptor
+// onto tsnet's internal netstack so DNS queries from exit-node
+// clients reach the gateway's dnsvip regardless of which resolver IP
+// the client points at (8.8.8.8, 1.1.1.1, the tailnet's MagicDNS,
+// anything). Without this, an exit-node client whose system resolver
+// targets 8.8.8.8 has its UDP/53 packets forwarded by tsnet's
+// netstack out to the real 8.8.8.8 — which can't resolve internal
+// hostnames (e.g. clickhouse-o11y, *.denosr-staging.internal) and
+// won't allocate the VIPs that endpoint dispatch relies on.
+//
+// tsnet exposes RegisterFallbackTCPHandler for catch-all TCP but
+// has no UDP equivalent (ListenPacket requires a concrete bind IP).
+// The hook we need is GetUDPHandlerForFlow on the underlying
+// *netstack.Impl, reachable via tsnet.Server.Sys().Netstack. The
+// Sys() doc warns "not a stable API" — pinned via go.mod; revisit if
+// the field disappears on a Tailscale upgrade.
+//
+// Must be called after the tsnet.Server has been started (Start()
+// triggered by an earlier Listen/ListenPacket); only then is the
+// netstack subsystem registered.
+func (g *Gateway) installTsnetUDPDNSCatchAll(s *tsnet.Server) {
+	if g.dnsvip == nil || s == nil {
+		return
+	}
+	sys := s.Sys()
+	if sys == nil {
+		log.Printf("tsnet: UDP/53 catch-all skipped — Sys() returned nil")
+		return
+	}
+	impl, ok := sys.Netstack.GetOK()
+	if !ok {
+		log.Printf("tsnet: UDP/53 catch-all skipped — netstack subsystem not registered yet")
+		return
+	}
+	ns, ok := impl.(*netstack.Impl)
+	if !ok {
+		log.Printf("tsnet: UDP/53 catch-all skipped — Sys().Netstack is %T not *netstack.Impl", impl)
+		return
+	}
+	orig := ns.GetUDPHandlerForFlow
+	ns.GetUDPHandlerForFlow = func(src, dst netip.AddrPort) (func(nettype.ConnPacketConn), bool) {
+		if dst.Port() == 53 {
+			return g.serveTsnetUDPDNSFlow, true
+		}
+		if orig != nil {
+			return orig(src, dst)
+		}
+		return nil, false
+	}
+	log.Printf("tsnet: UDP/53 catch-all installed (any-dst → dnsvip)")
+}
+
+// serveTsnetUDPDNSFlow handles one UDP/53 flow from an exit-node
+// client. tsnet calls this per-flow with a connected packet conn
+// already bound to the (src, dst) tuple — Read/Write talk to the
+// single peer, no addr juggling required. dnsvip.HandlePacket
+// generates the response (VIP allocation for endpoint hostnames,
+// upstream lookup otherwise). The loop covers the few resolvers
+// that reuse the socket for follow-up queries; idle flows time
+// out and close so we don't leak goroutines.
+func (g *Gateway) serveTsnetUDPDNSFlow(c nettype.ConnPacketConn) {
+	defer func() { _ = c.Close() }()
+	if g.dnsvip == nil {
+		return
+	}
+	buf := make([]byte, 65535)
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(10 * time.Second))
+		n, err := c.Read(buf)
+		if err != nil {
+			return
+		}
+		resp := g.dnsvip.HandlePacket(buf[:n], "")
+		if len(resp) == 0 {
+			continue
+		}
+		_ = c.SetWriteDeadline(time.Now().Add(2 * time.Second))
+		if _, err := c.Write(resp); err != nil {
+			return
+		}
 	}
 }


### PR DESCRIPTION
* TCP/53 to any destination is already caught by the tsnet
  fallback handler (\`case dstPort == 53\` in
  \`RegisterFallbackTCPHandler\`), but UDP has no equivalent. The
  existing IP-bound listener (\`tsnetServer.ListenPacket(\"udp\",
  g.tailscaleIP+\":53\")\`) only catches packets aimed at the
  gateway's own tailnet IP.
* Exit-node clients whose system resolver targets a public IP
  (8.8.8.8, 1.1.1.1, MagicDNS, anything that isn't the gateway)
  have their UDP/53 forwarded by tsnet's netstack out to the
  real resolver, which can't resolve internal hostnames like
  \`clickhouse-o11y\` or \`*.denosr-staging.internal\` — and even
  when the public resolver knows the name, dnsvip never sees the
  query so the follow-up TCP connection doesn't land on a VIP
  the gateway dispatches.
* Layer a catch-all on top of \`*netstack.Impl.GetUDPHandlerForFlow\`,
  reached via \`tsnet.Server.Sys().Netstack\`. The Sys() API is
  documented as "not a stable API" upstream so the access is
  pinned via go.mod and guarded with type-assert + nil checks —
  a Tailscale upgrade that renames or removes the subsystem
  logs and no-ops rather than crashing.
* The IP-bound listener stays as a defensive fallback; both paths
  invoke \`dnsvip.HandlePacket\`, so the catch-all just adds
  coverage for everything outside the gateway's own IP.

Only relevant in tsnet mode (the exit-node path). WG mode's
promiscuous netstack already catches all UDP regardless of dst.