### PR TITLE
runtime: single-credential bindings ignore disambiguator filters

### DIFF
--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -237,8 +237,12 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 	}
 	cc := runtime.ResolveCredential(ch.Policy, ch.Profile, ch.Endpoint, credReq)
 	if cc == nil {
-		pgWriteError(ch.Conn, "no credential bound to postgres endpoint")
-		return fmt.Errorf("no credential")
+		msg := "no credential bound to postgres endpoint"
+		if hint := runtime.CredentialMismatchReason(ch.Policy, ch.Profile, ch.Endpoint, credReq); hint != "" {
+			msg = "no matching credential: " + hint
+		}
+		pgWriteError(ch.Conn, msg)
+		return fmt.Errorf("%s", msg)
 	}
 	// Plugin.Runtime is a typed-nil sentinel used for interface
 	// dispatch checks; the actual decoded HCL value is on Body.

--- a/internal/config/runtime/dispatch.go
+++ b/internal/config/runtime/dispatch.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/denoland/clawpatrol/internal/config"
@@ -179,8 +181,15 @@ func synthesizeUnparseableDeny(r *config.CompiledRule) *config.CompiledRule {
 // ties are impossible at runtime — but if one ever shows up we
 // return nil rather than silently mis-routing.
 //
-// Single-binding entries with an empty disambiguator map short-
-// circuit when they're the only entry: matches anything.
+// Single-entry bindings short-circuit unconditionally: with only one
+// credential on a (profile, endpoint), there's nothing to
+// disambiguate. The credential's body fields (postgres_credential's
+// `user`, clickhouse's `database`, etc.) still drive upstream auth,
+// but the agent doesn't need to mirror those values in its
+// StartupMessage / Hello to make the dispatch pick the credential.
+// Multi-entry endpoints still go through the disambiguator filter
+// below so placeholder-driven `pg_ro` / `pg_rw` patterns keep
+// working.
 //
 // Returns nil when the profile is unknown OR the profile binds no
 // credential to ep — the caller (endpoint plugin) decides whether to
@@ -193,7 +202,7 @@ func ResolveCredential(policy *config.CompiledPolicy, profile string, ep *config
 	if len(entries) == 0 {
 		return nil
 	}
-	if len(entries) == 1 && len(entries[0].Disambiguators) == 0 {
+	if len(entries) == 1 {
 		return entries[0]
 	}
 	// Placeholder detection: if any entry constrains "placeholder",
@@ -239,6 +248,73 @@ func ResolveCredential(policy *config.CompiledPolicy, profile string, ep *config
 		return nil
 	}
 	return best
+}
+
+// CredentialMismatchReason builds a one-line explanation of why
+// ResolveCredential just returned nil for (profile, ep, req) despite
+// the binding existing in policy. Useful for surfacing actionable
+// connection errors to agents (e.g. postgres' SCRAM error path) so
+// the operator sees "user 'none' doesn't match" instead of a flat
+// "no credential bound". Returns "" when the profile-endpoint pair
+// has no bound credentials at all — the caller falls back to its
+// generic "no credential" message in that case.
+func CredentialMismatchReason(policy *config.CompiledPolicy, profile string, ep *config.CompiledEndpoint, req *match.Request) string {
+	if ep == nil {
+		return ""
+	}
+	entries := profileCredentialsAt(policy, profile, ep.Name)
+	if len(entries) == 0 {
+		return ""
+	}
+	// Collect the distinct disambiguator values declared per field
+	// across all entries — that's the set of values the agent could
+	// have sent to make any one entry match.
+	expected := map[string]map[string]struct{}{}
+	for _, c := range entries {
+		for field, want := range c.Disambiguators {
+			if want == "" {
+				continue
+			}
+			set, ok := expected[field]
+			if !ok {
+				set = map[string]struct{}{}
+				expected[field] = set
+			}
+			set[want] = struct{}{}
+		}
+	}
+	if len(expected) == 0 {
+		return ""
+	}
+	fields := make([]string, 0, len(expected))
+	for f := range expected {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+	var parts []string
+	for _, field := range fields {
+		got := ""
+		if req != nil {
+			switch field {
+			case "user":
+				got = req.User
+			case "database":
+				got = req.Database
+			}
+		}
+		values := make([]string, 0, len(expected[field]))
+		for v := range expected[field] {
+			values = append(values, v)
+		}
+		sort.Strings(values)
+		valueList := strings.Join(values, ", ")
+		if got == "" {
+			parts = append(parts, fmt.Sprintf("%s missing (valid: %s)", field, valueList))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s=%q not in [%s]", field, got, valueList))
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 // disambiguatorMatches reports whether every constraint in the

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -3,6 +3,7 @@ package runtime_test
 import (
 	"encoding/base64"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/denoland/clawpatrol/internal/config"
@@ -725,6 +726,76 @@ func TestResolveCredentialSingular(t *testing.T) {
 	got := runtime.ResolveCredential(cp, "default", ep, &match.Request{Family: "http", Headers: http.Header{}})
 	if got == nil || got.Credential.Symbol.Name != "pat" {
 		t.Errorf("singular credential resolution wrong: %+v", got)
+	}
+}
+
+// TestResolveCredentialSingularIgnoresDisambiguators pins the behavior
+// that a single credential bound to (profile, endpoint) is returned
+// regardless of its disambiguator fields. The body's `user` /
+// `database` attrs still drive upstream auth (PostgresAuth() reads
+// them), but the agent's StartupMessage doesn't have to mirror them
+// to make the dispatcher pick the only credential present. Previously
+// the agent had to set PGUSER to the credential's upstream user or
+// the dispatcher returned nil and the connection failed with "no
+// credential bound" — a usability footgun on every single-credential
+// postgres endpoint.
+func TestResolveCredentialSingularIgnoresDisambiguators(t *testing.T) {
+	src := `
+endpoint "postgres" "ep" { host = "db.example.com:5432" }
+credential "postgres_credential" "only" {
+  endpoint = postgres.ep
+  user     = "iam-bot@project.iam"
+  database = "prod"
+}
+profile "default" { credentials = [postgres_credential.only] }
+`
+	cp := compileFixture(t, src)
+	ep := cp.Endpoints["ep"]
+	cases := []*match.Request{
+		{Family: "sql"},
+		{Family: "sql", User: "none", Database: "postgres"},
+		{Family: "sql", User: "iam-bot@project.iam", Database: "prod"},
+	}
+	for _, req := range cases {
+		got := runtime.ResolveCredential(cp, "default", ep, req)
+		if got == nil || got.Credential.Symbol.Name != "only" {
+			t.Errorf("req=%+v got %+v, want credential %q", req, got, "only")
+		}
+	}
+}
+
+// TestCredentialMismatchReason: when a multi-credential endpoint has
+// no matching entry for the agent's user/database, the helper builds
+// an actionable message that lists the disambiguator values the
+// operator could have supplied. Used by the postgres plugin's "no
+// credential bound" error path so the agent sees which user values
+// the endpoint actually accepts.
+func TestCredentialMismatchReason(t *testing.T) {
+	src := `
+endpoint "postgres" "ep" { host = "db.example.com:5432" }
+credential "postgres_credential" "ro" {
+  endpoint = postgres.ep
+  user     = "pg_ro"
+}
+credential "postgres_credential" "rw" {
+  endpoint = postgres.ep
+  user     = "pg_rw"
+}
+profile "default" { credentials = [postgres_credential.ro, postgres_credential.rw] }
+`
+	cp := compileFixture(t, src)
+	ep := cp.Endpoints["ep"]
+
+	if got := runtime.CredentialMismatchReason(cp, "default", ep, &match.Request{Family: "sql", User: "none"}); got == "" || !strings.Contains(got, `user="none"`) || !strings.Contains(got, "pg_ro") || !strings.Contains(got, "pg_rw") {
+		t.Errorf("missing-user reason should name agent value + alternatives, got %q", got)
+	}
+	if got := runtime.CredentialMismatchReason(cp, "default", ep, &match.Request{Family: "sql"}); got == "" || !strings.Contains(got, "missing") {
+		t.Errorf("empty-user reason should say missing, got %q", got)
+	}
+	// Profile with no bindings → empty (caller falls back to its own
+	// "no credential bound" wording).
+	if got := runtime.CredentialMismatchReason(cp, "no-such-profile", ep, &match.Request{Family: "sql"}); got != "" {
+		t.Errorf("no-binding case should return empty, got %q", got)
 	}
 }
 


### PR DESCRIPTION
* A credential bound 1:1 to a (profile, endpoint) pair has nothing
  to disambiguate, but \`ResolveCredential\`'s singular short-circuit
  only fired when the entry's \`Disambiguators\` map was empty —
  which on \`postgres_credential\` is essentially never, since every
  postgres credential declares a \`user\` value (the upstream
  identity to authenticate as) and that same value auto-becomes a
  \`Disambiguators[\"user\"]\` filter via
  \`PostgresCredential.CredentialDisambiguators()\`.
* As a result \`psql -U none\` against an endpoint with a single
  bound credential whose \`user\` was \`iam-bot@project.iam\` failed
  with \"no credential bound to postgres endpoint\" — even though
  there's only one credential the dispatcher could possibly
  return. Operators had to know the upstream IAM identity to make
  any connection succeed.
* Drop the empty-map condition from the singular short-circuit so
  any single-entry binding returns immediately. Multi-entry
  endpoints still go through the full disambiguator filter, so
  placeholder patterns (\`PH_pg_ro\` / \`PH_pg_rw\` etc.) keep
  working unchanged.
* Add \`CredentialMismatchReason\` to surface a useful error on the
  multi-entry no-match path. It walks the bound credentials,
  collects the disambiguator field/value sets the operator could
  have supplied, and formats them next to what the agent actually
  sent. The postgres plugin's \"no credential bound\" error path
  upgrades to e.g. \`no matching credential: user=\"none\" not in
  [pg_ro, pg_rw]\` when alternatives exist, so the next
  head-scratch is shorter.