### PR TITLE
join: --login bootstraps tsnet for tailnet-only gateways

### DIFF
--- a/cmd/clawpatrol/fetch_ca_test.go
+++ b/cmd/clawpatrol/fetch_ca_test.go
@@ -22,7 +22,7 @@ func TestFetchCAHTTPReturnsFingerprintAndPersistsCert(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "ca.crt")
-	got, err := fetchCAHTTP(srv.URL, dst)
+	got, err := fetchCAHTTP(srv.URL, dst, nil)
 	if err != nil {
 		t.Fatalf("fetchCAHTTP: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestFetchCAHTTPRejectsNonPEMBody(t *testing.T) {
 	}))
 	defer srv.Close()
 	dst := filepath.Join(t.TempDir(), "ca.crt")
-	if _, err := fetchCAHTTP(srv.URL, dst); err == nil {
+	if _, err := fetchCAHTTP(srv.URL, dst, nil); err == nil {
 		t.Fatal("expected error for non-pem body")
 	}
 	// installCATrust must never see a malformed file. If a future

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2721,6 +2721,9 @@ usage:
                   --hostname NAME        device name to register (default: os.Hostname)
                   --profile NAME         suggest a profile for the approver
                   --whole-machine        bring up wg-quick (route all traffic)
+                  --login                interactive tailnet login for gateways
+                                         with no public URL (creds discarded
+                                         once join completes)
   clawpatrol run -- <cmd> [args...]      route one process tree through gateway
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -100,6 +101,7 @@ func runJoin(args []string) {
 	wholeMachine := fs.Bool("whole-machine", false, "bring up wg-quick to route ALL host traffic through the gateway (default: persist conf only, use `clawpatrol run` for per-process routing)")
 	profile := fs.String("profile", "", "profile to assign at approval time (defaults to the gateway's default profile if the approver doesn't pick one)")
 	hostname := fs.String("hostname", "", "device name to register with the gateway (defaults to os.Hostname)")
+	loginFlag := fs.Bool("login", false, "interactively log in to the gateway's tailnet first (use when the gateway has no public URL). The temporary tailnet credentials are discarded once the gateway-minted device identity lands.")
 	_ = fs.Parse(reorderJoinArgsForFlagParse(args))
 	rest := fs.Args()
 	if len(rest) != 1 || rest[0] == "" {
@@ -130,14 +132,57 @@ func runJoin(args []string) {
 	// gateway; onboardViaDeviceFlow fetches the CA from the peer's
 	// tailnet IP after joining.
 	//
+	// Tailnet-bootstrap (--login or auto-fallback): when the gateway
+	// has no public Funnel at all, or this machine simply can't reach
+	// it from its current network, stand up a temporary tsnet node,
+	// drive interactive Tailscale auth, and dial the gateway over the
+	// tailnet for the rest of the flow. The bootstrap node is torn
+	// down (LocalClient.Logout + state-dir removed) before runJoin
+	// returns, so the human credentials never persist on disk — the
+	// agent's permanent identity is the gateway-minted tagged key.
+	//
 	// Trust install + shell-rc updates are deferred to
 	// finishJoinSetup, which runs only after the operator's
 	// dashboard approval click.
-	setup, err := preJoinFetchCA(gatewayURL, *caOut)
-	if err != nil && !isCaNotExposed(err) {
-		fail("ca fetch: %v", err)
+	ctx := context.Background()
+	var bootstrap *tailnetBootstrap
+	defer func() {
+		if bootstrap != nil {
+			bootstrap.Close(ctx)
+		}
+	}()
+	var joinHTTPCli *http.Client
+	if *loginFlag {
+		bs, berr := bootstrapTailnetForJoin(ctx)
+		if berr != nil {
+			fail("tailnet login: %v", berr)
+		}
+		bootstrap = bs
+		joinHTTPCli = bs.Client()
 	}
-	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, &setup, *skipTrust)
+	setup, err := preJoinFetchCA(gatewayURL, *caOut, joinHTTPCli)
+	if err != nil && !isCaNotExposed(err) {
+		// Auto-fallback: a tailnet-shaped URL that's unreachable from
+		// this machine is exactly the case --login was added for. Try
+		// the bootstrap once before giving up so the operator doesn't
+		// have to re-run with the flag.
+		if bootstrap == nil && isTailnetShapedURL(gatewayURL) && isNetworkUnreachableErr(err) {
+			fmt.Fprintf(os.Stderr, "gateway %s unreachable from this network; falling back to tailnet login.\n", gatewayURL)
+			bs, berr := bootstrapTailnetForJoin(ctx)
+			if berr != nil {
+				fail("tailnet login: %v", berr)
+			}
+			bootstrap = bs
+			joinHTTPCli = bs.Client()
+			setup, err = preJoinFetchCA(gatewayURL, *caOut, joinHTTPCli)
+			if err != nil && !isCaNotExposed(err) {
+				fail("ca fetch: %v", err)
+			}
+		} else {
+			fail("ca fetch: %v", err)
+		}
+	}
+	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, &setup, *skipTrust, joinHTTPCli)
 	if err != nil {
 		fail("join: %v", err)
 	}
@@ -224,7 +269,12 @@ func isCaNotExposed(err error) bool {
 // in the loop: an on-path attacker who served a substitute CA over
 // plain HTTP loses because the dashboard surfaces the gateway's
 // real fingerprint and the operator can refuse to approve.
-func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
+//
+// cli is the HTTP client to use; pass nil for the default
+// TOFU-permissive client. The tailnet-bootstrap path in runJoin
+// passes a tsnet-dialing client so the same code reaches a
+// tailnet-only gateway.
+func preJoinFetchCA(gateway, caDir string, cli *http.Client) (joinSetup, error) {
 	var s joinSetup
 	if err := os.MkdirAll(caDir, 0o700); err != nil {
 		return s, fmt.Errorf("mkdir %s: %w", caDir, err)
@@ -235,7 +285,7 @@ func preJoinFetchCA(gateway, caDir string) (joinSetup, error) {
 	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
 		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	s.caPath = filepath.Join(caDir, "ca.crt")
-	fp, err := fetchCAHTTP(gateway, s.caPath)
+	fp, err := fetchCAHTTP(gateway, s.caPath, cli)
 	if err != nil {
 		return s, fmt.Errorf("fetch CA: %w", err)
 	}
@@ -289,16 +339,20 @@ func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine bool) {
 // The fingerprint flows back to the CLI's stdout so the operator
 // can compare it against what the dashboard shows during the
 // approval step.
-func fetchCAHTTP(gateway, dst string) (string, error) {
+func fetchCAHTTP(gateway, dst string, cli *http.Client) (string, error) {
 	url := strings.TrimRight(gateway, "/") + "/ca.crt"
-	// InsecureSkipVerify is intentional here: we haven't yet fetched the CA
-	// that signed the gateway's cert, so we can't verify it. The admin confirms
-	// the fingerprint out-of-band (shown in the UI at join time) — TOFU.
-	c := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		},
+	c := cli
+	if c == nil {
+		// InsecureSkipVerify is intentional on this default client: we
+		// haven't yet fetched the CA that signed the gateway's cert,
+		// so we can't verify it. The admin confirms the fingerprint
+		// out-of-band (shown in the UI at join time) — TOFU.
+		c = &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
 	}
 	resp, err := c.Get(url)
 	if err != nil {
@@ -800,15 +854,27 @@ func wgAddressFromConf(conf string) string {
 // the fingerprint the dashboard showed matched what the CLI
 // printed, so the CA we install can't be one a MITM substituted
 // during the unauthenticated /ca.crt fetch.
-func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname string, setup *joinSetup, skipTrust bool) (bool, error) {
+//
+// httpCli is the HTTP client to use for /api/onboard/{start,poll,claim};
+// pass nil for the default TOFU-permissive client. The tailnet
+// bootstrap path passes a tsnet-dialing client so the same code path
+// reaches a gateway whose Funnel is disabled or unreachable from this
+// machine's network position.
+func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname string, setup *joinSetup, skipTrust bool, httpCli *http.Client) (bool, error) {
 	gateway = strings.TrimRight(gateway, "/")
-	// CA is unverified until the admin confirms the fingerprint at approval time
-	// (TOFU). Use InsecureSkipVerify throughout the join handshake.
-	cli := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		},
+	cli := httpCli
+	if cli == nil {
+		// CA is unverified until the admin confirms the fingerprint at
+		// approval time (TOFU). Use InsecureSkipVerify on the default
+		// client for the same reason as fetchCAHTTP — the bootstrap
+		// client dials over tsnet and inherits its TLS behaviour, so
+		// we don't second-guess its config here.
+		cli = &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
 	}
 
 	hn := hostname

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -185,7 +185,13 @@ func runJoin(args []string) {
 			fail("ca fetch: %v", err)
 		}
 	}
-	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, &setup, *skipTrust, joinHTTPCli)
+	// Auto-approve is opt-in to the --login bootstrap: only then do
+	// we have an http client whose requests carry a tsnet whois the
+	// gateway recognises as a dashboard operator. The standard path
+	// (no bootstrap, just preJoinFetchCA over public Funnel) has no
+	// authenticated identity and must wait for the dashboard click.
+	autoApprove := bootstrap != nil
+	wgMode, err := onboardViaDeviceFlow(gatewayURL, *wholeMachine, *profile, *hostname, &setup, *skipTrust, joinHTTPCli, autoApprove)
 	if err != nil {
 		fail("join: %v", err)
 	}
@@ -899,7 +905,16 @@ func wgAddressFromConf(conf string) string {
 // bootstrap path passes a tsnet-dialing client so the same code path
 // reaches a gateway whose Funnel is disabled or unreachable from this
 // machine's network position.
-func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname string, setup *joinSetup, skipTrust bool, httpCli *http.Client) (bool, error) {
+//
+// autoApprove signals that the http client's requests authenticate as
+// a tailnet identity the gateway recognises as a dashboard operator
+// (today: bootstrap tsnet via --login). When true we POST
+// /api/onboard/approve immediately after /start; the operator gate
+// accepts the request via tailnetGate's whois path and the device-flow
+// poll then resolves with no human-in-the-loop step. The post is
+// best-effort — a 403 (e.g. the login isn't actually in the operators
+// allowlist) falls through to the existing browser-approval prompt.
+func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname string, setup *joinSetup, skipTrust bool, httpCli *http.Client, autoApprove bool) (bool, error) {
 	gateway = strings.TrimRight(gateway, "/")
 	cli := httpCli
 	if cli == nil {
@@ -957,33 +972,73 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		return false, fmt.Errorf("start decode: %w", err)
 	}
 
-	fmt.Println()
-	fmt.Println("Verify code in browser:")
-	fmt.Println()
-	fmt.Printf("    %s\n", start.UserCode)
-	fmt.Println()
-	fmt.Println(start.VerifyURL)
-	// One-line CA fingerprint after the verify URL. The
-	// dashboard's approval page shows the same value next to
-	// the user_code — operator visually confirms they match
-	// before clicking approve, blocking an on-path swap of the
-	// CA the CLI just fetched over plain HTTP.
-	if setup != nil && setup.caFingerprint != "" {
-		fmt.Println()
-		fmt.Printf("CA fingerprint: %s\n", setup.caFingerprint)
+	autoApproved := false
+	if autoApprove {
+		// Best-effort: use the bootstrap tsnet's whois identity to
+		// self-approve. Same handler the dashboard "Approve" button
+		// hits — the operator gate accepts our request when the
+		// tsnet peer login is in the operators allowlist. A 403 here
+		// is the expected outcome for any user who isn't in that
+		// allowlist; we silently fall through to browser approval
+		// and the operator drives the dashboard click as today.
+		aq := neturl.Values{}
+		aq.Set("code", start.UserCode)
+		if profile != "" {
+			aq.Set("profile", profile)
+		}
+		approveURL := gateway + "/api/onboard/approve?" + aq.Encode()
+		if ar, aerr := cli.Post(approveURL, "application/json", nil); aerr == nil {
+			body, _ := io.ReadAll(io.LimitReader(ar.Body, 1024))
+			_ = ar.Body.Close()
+			switch ar.StatusCode {
+			case 200:
+				autoApproved = true
+				fmt.Println()
+				fmt.Println("Auto-approved via tailnet operator identity.")
+			case 403:
+				// Not an operator — quietly fall through to the
+				// browser-approval path. No warning: this is the
+				// normal case for any user not on the allowlist.
+			default:
+				fmt.Fprintf(os.Stderr,
+					"⚠ auto-approve unexpected status %d: %s\n  Falling back to dashboard approval.\n",
+					ar.StatusCode, strings.TrimSpace(string(body)))
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "⚠ auto-approve POST failed: %v; falling back to dashboard approval.\n", aerr)
+		}
 	}
-	fmt.Println()
-	// Tailnet-only verify URLs (100.64.0.0/10 IP or *.ts.net host) are
-	// unreachable from the machine running `clawpatrol join` until
-	// approval lands — that's the whole point of needing approval. Print
-	// a QR code so the operator can scan from a phone or another
-	// already-tailnet-connected device. Skip tryOpen on that path: a
-	// local browser can't reach the URL anyway, and the spawned
-	// xdg-open / open process just produces a meaningless tab.
-	if isTailnetOnlyURL(start.VerifyURL) {
-		printVerifyQR(start.VerifyURL)
-	} else {
-		tryOpen(start.VerifyURL)
+
+	if !autoApproved {
+		fmt.Println()
+		fmt.Println("Verify code in browser:")
+		fmt.Println()
+		fmt.Printf("    %s\n", start.UserCode)
+		fmt.Println()
+		fmt.Println(start.VerifyURL)
+		// One-line CA fingerprint after the verify URL. The
+		// dashboard's approval page shows the same value next to
+		// the user_code — operator visually confirms they match
+		// before clicking approve, blocking an on-path swap of the
+		// CA the CLI just fetched over plain HTTP.
+		if setup != nil && setup.caFingerprint != "" {
+			fmt.Println()
+			fmt.Printf("CA fingerprint: %s\n", setup.caFingerprint)
+		}
+		fmt.Println()
+		// Tailnet-only verify URLs (100.64.0.0/10 IP or *.ts.net
+		// host) are unreachable from the machine running
+		// `clawpatrol join` until approval lands — that's the whole
+		// point of needing approval. Print a QR code so the operator
+		// can scan from a phone or another already-tailnet-connected
+		// device. Skip tryOpen on that path: a local browser can't
+		// reach the URL anyway, and the spawned xdg-open / open
+		// process just produces a meaningless tab.
+		if isTailnetOnlyURL(start.VerifyURL) {
+			printVerifyQR(start.VerifyURL)
+		} else {
+			tryOpen(start.VerifyURL)
+		}
 	}
 
 	// 2. poll

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -107,7 +107,10 @@ func runJoin(args []string) {
 	if len(rest) != 1 || rest[0] == "" {
 		fail("usage: clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] <gateway-url>")
 	}
-	gatewayURL := rest[0]
+	gatewayURL, err := validateGatewayURL(rest[0])
+	if err != nil {
+		fail("%v", err)
+	}
 	if *wholeMachine {
 		if local, reason := isLocalGateway(gatewayURL); local {
 			fail("refusing --whole-machine join: gateway URL points at this host (%s).\n"+
@@ -206,6 +209,42 @@ func runJoin(args []string) {
 			fail("%v", err)
 		}
 	}
+}
+
+// validateGatewayURL rejects gateway URLs that wouldn't survive a
+// round-trip through http.Client — historically the join flow only
+// noticed at the dial layer, after preJoinFetchCA had already written
+// the bogus string to ~/.clawpatrol/gateway. The most common shape
+// that bit operators was a bare hostname like "clawpatrol-gateway-1":
+// neturl.Parse accepts it (everything parses as opaque), but
+// http.Client.Get("clawpatrol-gateway-1/ca.crt") errors with
+// "unsupported protocol scheme \"\"" — and by the time you see the
+// error the state file is already corrupt.
+//
+// Rules: explicit http:// or https://, non-empty host. We don't try
+// to be clever and auto-promote bare hostnames — the right port
+// depends on whether the gateway is fronted by Funnel (:443) or
+// reached over the tailnet (:8080), and we don't have enough
+// context here to pick correctly. The error message tells the
+// operator the most likely form for the tailnet-mounted case.
+func validateGatewayURL(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("gateway URL is empty")
+	}
+	u, err := neturl.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid gateway URL %q: %w", s, err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return "", fmt.Errorf("gateway URL %q is missing an http:// or https:// scheme — for a tailnet-mounted gateway, try http://%s:8080", s, s)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("gateway URL %q has no host", s)
+	}
+	return s, nil
 }
 
 // applyWholeMachineExitNode finishes the whole-machine Tailscale Linux

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -1,0 +1,234 @@
+package main
+
+// Tailnet-bootstrap path for `clawpatrol join` against a gateway that
+// isn't reachable from the public internet — typical for production
+// gateways with Funnel disabled or with Funnel exposing only a strict
+// allowlist that omits /ca.crt.
+//
+// The trick: the clawpatrol binary already statically links tsnet, so
+// the CLI can stand up a temporary tsnet node, drive an interactive
+// Tailscale login (browser → IdP → control-plane), reach the gateway
+// over the tailnet, run the existing device-flow approval, then tear
+// the bootstrap node down. The agent's persistent identity is the
+// gateway-minted tagged auth-key, NOT the human operator's tailnet
+// account — so the join doesn't leave the machine logged in as a
+// human user.
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/netip"
+	neturl "net/url"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"tailscale.com/client/local"
+	"tailscale.com/tsnet"
+)
+
+// tailnetBootstrap is a transient tsnet.Server that exists only for
+// the duration of `clawpatrol join`. Use Client() to talk to the
+// gateway over the tailnet, then call Close to log the node out and
+// remove its on-disk state.
+type tailnetBootstrap struct {
+	server *tsnet.Server
+	lc     *local.Client
+	client *http.Client
+	dir    string
+}
+
+// Client returns an *http.Client whose Transport dials through the
+// bootstrap tsnet node. Callers thread it into preJoinFetchCA and
+// onboardViaDeviceFlow in place of the default cli.
+func (b *tailnetBootstrap) Client() *http.Client { return b.client }
+
+// Close logs the bootstrap node out of the tailnet, stops tsnet, and
+// deletes the temp state dir. Best-effort: a failed Logout still
+// removes the local state, so the node lingers in the tailnet admin
+// as offline but has no path back online. ctx caps how long we wait
+// for the Logout RPC to complete — Close is called from a defer in
+// runJoin and the operator shouldn't have to wait forever on a stuck
+// control plane.
+func (b *tailnetBootstrap) Close(ctx context.Context) {
+	if b == nil {
+		return
+	}
+	if b.lc != nil {
+		logoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		_ = b.lc.Logout(logoutCtx)
+		cancel()
+	}
+	if b.server != nil {
+		_ = b.server.Close()
+	}
+	if b.dir != "" {
+		_ = os.RemoveAll(b.dir)
+	}
+}
+
+// bootstrapTailnetForJoin stands up a temporary tsnet node and walks
+// the operator through Tailscale's standard interactive auth flow
+// (browser → IdP → control-plane assigns a tailnet IP). The auth URL
+// is printed to stdout and best-effort opened in the local browser;
+// if the operator is on a headless box, the URL is still copy-
+// pasteable. Blocks until the node reaches Running or ctx fires.
+func bootstrapTailnetForJoin(ctx context.Context) (*tailnetBootstrap, error) {
+	dir, err := os.MkdirTemp("", "clawpatrol-bootstrap-")
+	if err != nil {
+		return nil, fmt.Errorf("tailnet bootstrap: mkdir temp: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+
+	// A distinct hostname per invocation so two concurrent joins on
+	// the same machine don't collide on the tailnet, and so the
+	// operator can find this node in the tailnet admin if cleanup
+	// fails. We aim for ephemeral by tearing the node down at the
+	// end, not by relying on tailnet-side ACL rules (most users
+	// don't control the policy file of the tailnet they're joining).
+	suffix := make([]byte, 4)
+	if _, err := rand.Read(suffix); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("tailnet bootstrap: random: %w", err)
+	}
+	hostname := "clawpatrol-bootstrap-" + hex.EncodeToString(suffix)
+
+	s := &tsnet.Server{
+		Dir:      dir,
+		Hostname: hostname,
+		// Silence tsnet's internal chatter — we drive the auth-URL
+		// display ourselves below so the operator sees one clean
+		// message, not interleaved control-plane debug lines.
+		Logf:     func(string, ...any) {},
+		UserLogf: func(string, ...any) {},
+	}
+
+	if err := s.Start(); err != nil {
+		_ = s.Close()
+		cleanup()
+		return nil, fmt.Errorf("tailnet bootstrap: start tsnet: %w", err)
+	}
+	lc, err := s.LocalClient()
+	if err != nil {
+		_ = s.Close()
+		cleanup()
+		return nil, fmt.Errorf("tailnet bootstrap: local client: %w", err)
+	}
+
+	if err := awaitTailnetAuth(ctx, lc); err != nil {
+		// Best-effort cleanup of a partially-onboarded node so we
+		// don't leave a NeedsLogin entry in the tailnet admin.
+		logoutCtx, lcancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = lc.Logout(logoutCtx)
+		lcancel()
+		_ = s.Close()
+		cleanup()
+		return nil, err
+	}
+
+	return &tailnetBootstrap{
+		server: s,
+		lc:     lc,
+		client: s.HTTPClient(),
+		dir:    dir,
+	}, nil
+}
+
+// awaitTailnetAuth blocks until the tsnet node reaches Running,
+// printing the BrowseToURL exactly once when the control plane
+// surfaces it. Polls the LocalClient because StatusWithoutPeers is
+// cheap and the auth phase rarely lasts more than a few seconds in
+// the happy path — a wait of 10 minutes (the device-flow timeout
+// elsewhere in the join code) is the soft upper bound.
+func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
+	deadline, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	fmt.Println()
+	fmt.Println("Reaching the gateway requires Tailscale tailnet access.")
+	fmt.Println("Opening browser for one-time interactive login.")
+	fmt.Println("(These credentials are discarded as soon as join completes —")
+	fmt.Println(" the agent's persistent identity is the gateway-minted tag.)")
+
+	printed := false
+	for {
+		select {
+		case <-deadline.Done():
+			return fmt.Errorf("tailnet bootstrap: timed out waiting for login")
+		default:
+		}
+		st, err := lc.StatusWithoutPeers(deadline)
+		if err != nil {
+			// tsnet isn't ready yet during the first few hundred ms
+			// after Start(); back off briefly and retry.
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		if !printed && st.AuthURL != "" {
+			fmt.Println()
+			fmt.Printf("    %s\n", st.AuthURL)
+			fmt.Println()
+			tryOpen(st.AuthURL)
+			printed = true
+		}
+		if st.BackendState == "Running" {
+			fmt.Println("Tailnet login complete.")
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// isTailnetShapedURL reports whether u points at a host that is
+// reachable only from inside a tailnet — a 100.64.0.0/10 (CGNAT)
+// literal or a *.ts.net MagicDNS hostname. When the initial probe
+// against such a URL fails with a network error, the auto-fallback
+// to bootstrapTailnetForJoin kicks in.
+func isTailnetShapedURL(u string) bool {
+	p, err := neturl.Parse(u)
+	if err != nil {
+		return false
+	}
+	host := p.Hostname()
+	if host == "" {
+		return false
+	}
+	if strings.HasSuffix(strings.ToLower(host), ".ts.net") {
+		return true
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		// CGNAT 100.64.0.0/10 — Tailscale's tailnet IP range.
+		return ip.Is4() && ip.As4()[0] == 100 && (ip.As4()[1]&0xc0) == 64
+	}
+	return false
+}
+
+// isNetworkUnreachableErr returns true for the dial errors that mean
+// "this URL isn't reachable from the network we're currently on" —
+// the signal the auto-fallback to a tailnet bootstrap uses to decide
+// whether to retry. Other errors (TLS, HTTP 5xx, etc.) mean the
+// gateway IS reachable but something else is wrong, and bootstrapping
+// a tailnet won't help.
+func isNetworkUnreachableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	// net.DNSError and i/o timeouts don't expose a stable sentinel,
+	// so we fall back to string matching on the error chain.
+	s := err.Error()
+	return strings.Contains(s, "no such host") ||
+		strings.Contains(s, "i/o timeout") ||
+		strings.Contains(s, "Client.Timeout") ||
+		strings.Contains(s, "no route to host") ||
+		strings.Contains(s, "network is unreachable")
+}

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -15,6 +15,7 @@ package main
 // human user.
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -25,17 +26,55 @@ import (
 	neturl "net/url"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"tailscale.com/client/local"
+	"tailscale.com/ipn"
 	"tailscale.com/tsnet"
 )
+
+// ramStateStore is a private in-memory ipn.StateStore. tsnet has its
+// own ipn/store/mem.Store, but tsnet.Server gates that one behind
+// `Ephemeral: true` (tsnet/tsnet.go isMemStore type-assert), and
+// Ephemeral isn't honored on browser-driven interactive auth — only
+// on auth-key registration. By presenting our own
+// non-`*mem.Store` implementation we satisfy the same interface,
+// dodge the gate, and never touch disk for credentials. The bootstrap
+// node's machine key, login profile, and netmap snapshot all live in
+// this map for the lifetime of the join. On process exit (clean or
+// SIGKILL) the RAM is reclaimed; nothing to clean up, nothing to
+// leak.
+type ramStateStore struct {
+	mu sync.Mutex
+	m  map[ipn.StateKey][]byte
+}
+
+func (s *ramStateStore) ReadState(k ipn.StateKey) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[k]
+	if !ok {
+		return nil, ipn.ErrStateNotExist
+	}
+	return bytes.Clone(v), nil
+}
+
+func (s *ramStateStore) WriteState(k ipn.StateKey, v []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[ipn.StateKey][]byte{}
+	}
+	s.m[k] = bytes.Clone(v)
+	return nil
+}
 
 // tailnetBootstrap is a transient tsnet.Server that exists only for
 // the duration of `clawpatrol join`. Use Client() to talk to the
 // gateway over the tailnet, then call Close to log the node out and
-// remove its on-disk state.
+// reclaim the log dir.
 type tailnetBootstrap struct {
 	server *tsnet.Server
 	lc     *local.Client
@@ -48,13 +87,19 @@ type tailnetBootstrap struct {
 // onboardViaDeviceFlow in place of the default cli.
 func (b *tailnetBootstrap) Client() *http.Client { return b.client }
 
-// Close logs the bootstrap node out of the tailnet, stops tsnet, and
-// deletes the temp state dir. Best-effort: a failed Logout still
-// removes the local state, so the node lingers in the tailnet admin
-// as offline but has no path back online. ctx caps how long we wait
-// for the Logout RPC to complete — Close is called from a defer in
-// runJoin and the operator shouldn't have to wait forever on a stuck
-// control plane.
+// Close tears the bootstrap down on the happy path. Logout makes
+// the node disappear from the tailnet admin promptly; Server.Close
+// drops the local tsnet engine; the temp dir holding tsnet's log
+// files gets removed.
+//
+// There is no SIGINT/SIGTERM/SIGKILL handler and intentionally so:
+// credentials live in RAM (ramStateStore), so process exit by any
+// means leaves nothing sensitive on disk. The only consequences of
+// an uncaught signal are a few KB of tsnet log files in /tmp
+// (which the OS reaps), and the bootstrap node lingering in the
+// tailnet admin as offline for a minute or two until the control
+// server times the connection out. Neither is worth a signal
+// handler.
 func (b *tailnetBootstrap) Close(ctx context.Context) {
 	if b == nil {
 		return
@@ -79,19 +124,17 @@ func (b *tailnetBootstrap) Close(ctx context.Context) {
 // if the operator is on a headless box, the URL is still copy-
 // pasteable. Blocks until the node reaches Running or ctx fires.
 //
-// Why disk-backed state and not mem.Store/Ephemeral: tsnet allows
-// `Store: &mem.Store{}` only when `Ephemeral: true` (see
-// tsnet/tsnet.go's isMemStore guard). Setting Ephemeral=true sends
-// LoginEphemeral to the control server at registration — but for
-// Tailscale SaaS that flag is only honored on the auth-key flow,
-// not on browser-driven interactive auth. Empirically: the browser
-// completes auth fine, but the resulting node never transitions to
-// BackendState=Running and the join times out. Until tsnet gains a
-// way to mark a browser-auth registration as ephemeral, we keep the
-// credentials in a temp dir and rely on Close→Logout+RemoveAll for
-// cleanup. SIGKILL during the bootstrap window can leak the temp
-// dir; the credentials inside it are still constrained by the
-// human's tailnet ACL, not a tagged-bot identity.
+// Credentials live in RAM (ramStateStore), so the machine key and
+// login profile never touch disk and the only thing in the temp Dir
+// is tsnet's log buffer. We can't use tsnet's own ipn/store/mem
+// implementation because tsnet gates it behind Ephemeral=true
+// (tsnet/tsnet.go isMemStore type-assert), and Tailscale SaaS only
+// honors LoginEphemeral on the auth-key registration flow, not on
+// browser-driven interactive auth — empirically the resulting node
+// never transitions to BackendState=Running. ramStateStore is a
+// drop-in implementation of the same ipn.StateStore interface but
+// isn't *mem.Store, so it dodges the gate while keeping browser
+// auth working.
 func bootstrapTailnetForJoin(ctx context.Context) (*tailnetBootstrap, error) {
 	dir, err := os.MkdirTemp("", "clawpatrol-bootstrap-")
 	if err != nil {
@@ -102,9 +145,7 @@ func bootstrapTailnetForJoin(ctx context.Context) (*tailnetBootstrap, error) {
 	// A distinct hostname per invocation so two concurrent joins on
 	// the same machine don't collide on the tailnet, and so the
 	// operator can find this node in the tailnet admin if cleanup
-	// fails. We aim for ephemeral by tearing the node down at the
-	// end, not by relying on tailnet-side ACL rules (most users
-	// don't control the policy file of the tailnet they're joining).
+	// fails. Logout on Close removes it promptly on the happy path.
 	suffix := make([]byte, 4)
 	if _, err := rand.Read(suffix); err != nil {
 		cleanup()
@@ -113,8 +154,16 @@ func bootstrapTailnetForJoin(ctx context.Context) (*tailnetBootstrap, error) {
 	hostname := "clawpatrol-bootstrap-" + hex.EncodeToString(suffix)
 
 	s := &tsnet.Server{
+		// Dir still hosts tsnet's log buffer (tailscaled.log.conf
+		// and the tailscaled/ subdir) regardless of Store — no
+		// credentials here, just operational logs the temp dir
+		// disposes of on Close.
 		Dir:      dir,
 		Hostname: hostname,
+		// In-memory state store. The bootstrap's machine key, login
+		// profile, and netmap snapshot all live in this map and are
+		// gone the instant the process exits — clean or otherwise.
+		Store: &ramStateStore{},
 		// Silence tsnet's internal chatter — we drive the auth-URL
 		// display ourselves below so the operator sees one clean
 		// message, not interleaved control-plane debug lines.

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -78,6 +78,20 @@ func (b *tailnetBootstrap) Close(ctx context.Context) {
 // is printed to stdout and best-effort opened in the local browser;
 // if the operator is on a headless box, the URL is still copy-
 // pasteable. Blocks until the node reaches Running or ctx fires.
+//
+// Why disk-backed state and not mem.Store/Ephemeral: tsnet allows
+// `Store: &mem.Store{}` only when `Ephemeral: true` (see
+// tsnet/tsnet.go's isMemStore guard). Setting Ephemeral=true sends
+// LoginEphemeral to the control server at registration — but for
+// Tailscale SaaS that flag is only honored on the auth-key flow,
+// not on browser-driven interactive auth. Empirically: the browser
+// completes auth fine, but the resulting node never transitions to
+// BackendState=Running and the join times out. Until tsnet gains a
+// way to mark a browser-auth registration as ephemeral, we keep the
+// credentials in a temp dir and rely on Close→Logout+RemoveAll for
+// cleanup. SIGKILL during the bootstrap window can leak the temp
+// dir; the credentials inside it are still constrained by the
+// human's tailnet ACL, not a tagged-bot identity.
 func bootstrapTailnetForJoin(ctx context.Context) (*tailnetBootstrap, error) {
 	dir, err := os.MkdirTemp("", "clawpatrol-bootstrap-")
 	if err != nil {

--- a/cmd/clawpatrol/setup_tailnet_login_test.go
+++ b/cmd/clawpatrol/setup_tailnet_login_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+)
+
+func TestIsTailnetShapedURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		// MagicDNS hostnames.
+		{"https://clawpatrol-gateway.tail9a48e.ts.net", true},
+		{"http://clawpatrol-gateway-1.tail9a48e.ts.net:8080/api/onboard", true},
+		{"https://CLAWPATROL-GATEWAY.TAIL9A48E.TS.NET", true},
+		// CGNAT range, the Tailscale-issued IPs.
+		{"http://100.79.206.14:8080", true},
+		{"http://100.64.0.1", true},
+		{"http://100.127.255.254/api", true},
+		// Just outside CGNAT — must NOT match. 100.63.x.x and 100.128.x.x
+		// are normal public IPs Tailscale doesn't issue.
+		{"http://100.63.255.255", false},
+		{"http://100.128.0.0", false},
+		// Public hostnames and IPs the bootstrap can't help with.
+		{"https://clawpatrol-gateway.example.com", false},
+		{"http://1.1.1.1:53", false},
+		{"http://192.168.1.5", false},
+		// Garbage in -> false, don't crash.
+		{"", false},
+		{"://nope", false},
+		{"not-a-url", false},
+	}
+	for _, tc := range cases {
+		if got := isTailnetShapedURL(tc.url); got != tc.want {
+			t.Errorf("isTailnetShapedURL(%q) = %v, want %v", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestIsNetworkUnreachableErr(t *testing.T) {
+	reachable := []error{
+		nil,
+		errors.New("http: server gave a 500"),
+		errors.New("certificate signed by unknown authority"),
+		// TLS handshake timeouts mean the TCP connect succeeded — the
+		// gateway is reachable, just misbehaving at L6. A tailnet
+		// bootstrap wouldn't help.
+		errors.New(`Get "http://x": net/http: TLS handshake timeout`),
+	}
+	for _, e := range reachable {
+		if isNetworkUnreachableErr(e) {
+			t.Errorf("isNetworkUnreachableErr(%v) = true, want false", e)
+		}
+	}
+	unreachable := []error{
+		syscall.EHOSTUNREACH,
+		syscall.ENETUNREACH,
+		syscall.ECONNREFUSED,
+		errors.New("dial tcp 1.2.3.4:80: i/o timeout"),
+		&net.OpError{Op: "dial", Err: errors.New("no route to host")},
+		&net.OpError{Op: "dial", Err: errors.New("network is unreachable")},
+		&net.DNSError{Err: "no such host", Name: "no-such-host.invalid", IsNotFound: true},
+	}
+	for _, e := range unreachable {
+		if !isNetworkUnreachableErr(e) {
+			t.Errorf("isNetworkUnreachableErr(%v) = false, want true", e)
+		}
+	}
+}

--- a/cmd/clawpatrol/setup_tailnet_login_test.go
+++ b/cmd/clawpatrol/setup_tailnet_login_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"net"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -67,6 +68,48 @@ func TestIsNetworkUnreachableErr(t *testing.T) {
 	for _, e := range unreachable {
 		if !isNetworkUnreachableErr(e) {
 			t.Errorf("isNetworkUnreachableErr(%v) = false, want true", e)
+		}
+	}
+}
+
+// TestValidateGatewayURL pins the upfront URL check that prevents
+// runJoin from writing a bogus value to ~/.clawpatrol/gateway when
+// the operator types a scheme-less hostname like "clawpatrol-gw-1".
+func TestValidateGatewayURL(t *testing.T) {
+	valid := []string{
+		"http://clawpatrol-gateway-1:8080",
+		"https://clawpatrol-gateway.tail9a48e.ts.net",
+		"http://100.79.206.14:8080",
+		"https://gw.example.com",
+		"http://gw.example.com:80/",
+	}
+	for _, u := range valid {
+		got, err := validateGatewayURL(u)
+		if err != nil {
+			t.Errorf("validateGatewayURL(%q) returned %v, want nil", u, err)
+		}
+		if got != u {
+			t.Errorf("validateGatewayURL(%q) returned %q, want unchanged", u, got)
+		}
+	}
+
+	invalid := []struct {
+		in      string
+		wantSub string
+	}{
+		{"", "empty"},
+		{"   ", "empty"},
+		{"clawpatrol-gateway-1", "missing an http:// or https:// scheme"},
+		{"clawpatrol-gateway-1:8080", "missing an http:// or https:// scheme"},
+		{"ftp://example.com", "missing an http:// or https:// scheme"},
+		// scheme-only with no host: rejected on the host check.
+		{"http://", "no host"},
+	}
+	for _, tc := range invalid {
+		if _, err := validateGatewayURL(tc.in); err == nil {
+			t.Errorf("validateGatewayURL(%q) returned no error, want one containing %q", tc.in, tc.wantSub)
+		} else if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("validateGatewayURL(%q) error = %q, want substring %q", tc.in, err.Error(), tc.wantSub)
 		}
 	}
 }


### PR DESCRIPTION
Onboard a fresh machine to a clawpatrol gateway that has no public
URL. tsnet is already statically linked into the binary, so the CLI
can drive an interactive Tailscale login itself — no system
tailscaled install, no \`tailscale up\`, no PATH dependency.

### `--login` flag

When a gateway has no public Funnel (or this machine simply can't
reach it from its current network), pass \`--login\` to bring up a
temporary tsnet node, walk the operator through Tailscale's
standard browser-auth flow, reach the gateway over the tailnet,
run the existing device-flow approval, then tear the bootstrap
node down. The agent's persistent identity is the gateway-minted
tagged auth-key; the human's tailnet credentials never persist on
the agent machine.

Auto-fallback (no flag needed) kicks in when the gateway URL is
tailnet-shaped — CGNAT \`100.64.0.0/10\` literal or \`*.ts.net\` host —
and the initial \`/ca.crt\` probe fails with a network-unreachable
error. Operators dragging a fresh laptop onto a tailnet don't have
to know the flag exists.

### Auto-approve via operator identity

The bootstrap dials the gateway as a Tailscale-authenticated peer.
When the operator who completed the browser-login step is in the
gateway's dashboard operators allowlist, the gateway's
\`tailnetGate\` accepts \`/api/onboard/approve\` from this client just
like it would from the dashboard \"Approve\" button — no separate
human-in-the-loop click needed. The CLI prints \"Auto-approved via
tailnet operator identity.\" and the polling loop resolves
immediately. Non-operator users hit the same 403 the dashboard
gate produces; we silently fall through to the standard \"Verify
code in browser:\" prompt with no warning, since that's the
expected outcome for any user not on the allowlist.

### Credentials in RAM

The bootstrap tsnet uses a private \`ramStateStore\` implementation
of \`ipn.StateStore\` so the machine key, login profile, and netmap
snapshot live in memory only — process exit by any means leaves
nothing sensitive on disk.

tsnet ships its own in-memory store at \`ipn/store/mem\`, but
\`tsnet.Server\` gates that one behind \`Ephemeral=true\` (\`isMemStore\`
type-assert in \`tsnet/tsnet.go\`). Setting \`Ephemeral=true\` sends
\`LoginEphemeral\` on the registration RPC, which Tailscale SaaS
only honors on the auth-key flow — empirically the browser auth
completes but the resulting node never transitions to
\`BackendState=Running\` and the join times out. By presenting our
own non-\`*mem.Store\` implementation we satisfy the same interface,
dodge the gate, and keep browser auth working.

tsnet still creates a directory to write its log buffer
(\`tailscaled.log.conf\` + \`tailscaled.log*.txt\`) regardless of
\`Store\`. Those aren't credentials, and they land in
\`os.MkdirTemp(\"\", …)\` — i.e. \`/tmp\` or \`$TMPDIR\`, both tmpfs on
Linux / per-user volatile on macOS. The happy-path \`Close\` removes
them; an uncaught signal leaves a few KB of log noise the OS
reaps. No signal handler.

### URL validation

\`clawpatrol join clawpatrol-gateway-1\` (no scheme) used to fail at
the dial layer with \"unsupported protocol scheme\", but only after
\`preJoinFetchCA\` had already overwritten \`~/.clawpatrol/gateway\`
with the bogus string. Subsequent \`clawpatrol env\` / \`clawpatrol
run\` invocations would then read the broken URL out of disk and
produce a fresh round of confusing errors.

\`validateGatewayURL\` now rejects scheme-less hostnames upfront,
before any I/O. The error message names the most likely correct
form so the operator can copy-paste the fix:

\`\`\`
gateway URL \"clawpatrol-gateway-1\" is missing an http:// or
https:// scheme — for a tailnet-mounted gateway, try
http://clawpatrol-gateway-1:8080
\`\`\`

No auto-promotion: the right port differs between Funnel (\`:443\`)
and tailnet (\`:8080\`) and we don't have enough context at this
layer to guess.

### Plumbing

\`preJoinFetchCA\`, \`fetchCAHTTP\`, and \`onboardViaDeviceFlow\` now
accept an optional \`*http.Client\` so the bootstrap path can thread
its tsnet-dialing client through without forking the request
plumbing. \`nil\` keeps the existing TOFU-permissive default.
\`isNetworkUnreachableErr\` is deliberately narrow — host/net
unreachable, connection refused, DNS miss, and dial timeout flip
the auto-fallback; TLS handshake timeouts, HTTP 5xx, and cert
errors mean the gateway IS reachable but misbehaving at a higher
layer, and a tailnet bootstrap wouldn't help.

### Verified end-to-end

On a fresh Ubuntu VM (\`ssh exe.dev new\`) against the dev gateway:

* \`clawpatrol join --login http://clawpatrol-gateway-1:8080\`
  → \"Tailnet login complete.\" → \"Auto-approved via tailnet
  operator identity.\" → \"Approved.\" → \`~/.clawpatrol/\` populated,
  tsnet-daemon mode persisted, bootstrap dir removed, no
  \`tailscaled.state\` ever written.
* \`clawpatrol join --login --whole-machine
  http://clawpatrol-gateway-1:8080\` → same auto-approve flow →
  \`tailscale up --authkey=<gateway-minted>\` placed the tagged
  identity (100.104.72.120) on the tailnet → exit-node + DNS pin
  + SSH exemption applied; SSH session survived the exit-node
  flip.