### PR TITLE
macos: auto-recover from stale tsnet state on auth-key reject

### DIFF
--- a/macos/netstack/wgnetstack.go
+++ b/macos/netstack/wgnetstack.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/netip"
@@ -802,6 +803,21 @@ var (
 	tsStarted bool
 )
 
+// isStaleStateErr matches tsnet.Server.Up errors that indicate the
+// persisted state in Dir is from an incompatible past (different
+// control plane, expired/revoked auth key tied to old node identity,
+// half-written tailscaled.state from a crashed prior init). Recovery
+// is to wipe the state dir and retry with the supplied fresh auth
+// key. Matches on the message Tailscale's control returns:
+// "backend: invalid key: API key XXXX not valid".
+func isStaleStateErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "invalid key") || strings.Contains(msg, "not valid")
+}
+
 // ts_netstack_init joins the tailnet with the given ephemeral auth key
 // and configures the gateway as the tsnet exit node so subsequent dials
 // route through it. Blocks until the tsnet node has a 100.x.x.x address
@@ -853,17 +869,38 @@ func ts_netstack_init(authKeyC, controlURLС, gwHostC, gwIPC, tokenC, hostnameC,
 		tsHostname = fmt.Sprintf("clawpatrol-ne-%d", os.Getpid())
 	}
 
-	s := &tsnet.Server{
-		Hostname:   tsHostname,
-		AuthKey:    authKey,
-		ControlURL: controlURL,
-		Dir:        stateDir,
-		Logf:       func(string, ...any) {},
+	newServer := func() *tsnet.Server {
+		return &tsnet.Server{
+			Hostname:   tsHostname,
+			AuthKey:    authKey,
+			ControlURL: controlURL,
+			Dir:        stateDir,
+			Logf:       func(string, ...any) {},
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
+
+	s := newServer()
 	upSt, err := s.Up(ctx)
+	// "invalid key" on first Up means the saved state in stateDir is
+	// stale (most commonly: upgrade from a build that wrote a half-
+	// initialised tailscaled.state, or the tailnet the saved node
+	// belongs to no longer accepts this auth key). Wipe stateDir and
+	// retry once with a clean slate so the fresh auth key actually
+	// gets consumed against the current control URL.
+	if err != nil && isStaleStateErr(err) {
+		_ = s.Close()
+		log.Printf("ts_netstack_init: stale state detected (%v); wiping %s and retrying", err, stateDir)
+		_ = os.RemoveAll(stateDir)
+		if mkErr := os.MkdirAll(stateDir, 0o700); mkErr != nil {
+			setErr(errBuf, errLen, "mkdir state dir after wipe: "+mkErr.Error())
+			return -1
+		}
+		s = newServer()
+		upSt, err = s.Up(ctx)
+	}
 	if err != nil {
 		_ = s.Close()
 		setErr(errBuf, errLen, "tsnet up: "+err.Error())


### PR DESCRIPTION
## Bug

Mac mini install of v0.2.1 (and presumably every other host that ran v0.2.0 first) can't bring up NE's tsnet. The fresh \`clawpatrol join\` mints a valid auth key, NE.startProxy fires \`ts_netstack_init\`, and Tailscale immediately rejects the key:

\`\`\`
ts_netstack_init: tsnet up: tsnet.Up: backend: invalid key: API key kgZXnD5TAr11CNTRL not valid
\`\`\`

Re-joining doesn't help — every fresh key gets the same rejection.

The only workaround is to manually \`sudo rm -rf "/var/root/Library/Application Support/clawpatrol"\` and re-join. After that the NE comes up cleanly and stays up.

## Root cause

#544 introduced a persistent state dir for tsnet. Upgrading from a build that wrote a half-initialised \`tailscaled.state\` into that path (v0.2.0 → v0.2.1 in the wild, but also any prior \`startProxy\` that died mid-Up) leaves stale state behind. \`tsnet.Server.Up\` reads the stale state, resumes against whatever control plane / node identity it names, and tries to validate the freshly-minted auth key against THAT identity. Control returns \"invalid key\". NE never reports a tsnet IP, every \`clawpatrol run\` lands in the default profile with no tunnel.

## Fix

If \`tsnet.Server.Up\` fails on the first attempt with an \"invalid key\" / \"not valid\" error, \`os.RemoveAll(stateDir)\` + recreate the dir + retry \`Up\` once with the supplied fresh auth key. Lets the upgrade path self-heal without operator sudo.

Subsequent restarts pick up the now-good saved identity and never hit the retry path — single-use key still consumed exactly once.

## Test plan
- [x] \`CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildmode=c-archive\` clean.
- [x] Full \`build-macos-app.sh\` produces signed-locally \`Clawpatrol.app\`.
- [x] Manual confirmation that wiping state dir + re-join is what unblocks on Mac mini (the workaround this PR automates).
- [ ] Install on the still-broken Mac mini, watch \`ts_netstack_init: stale state detected\` log line, then successful Up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)