### PR TITLE
UI/UX pass

### DIFF
--- a/dashboard/login.html
+++ b/dashboard/login.html
@@ -8,14 +8,22 @@
     <style>
       /* ── Minimal subset of the dashboard's design tokens ─────────
          Only the values used on this page; mirrors dashboard/src/index.css.
-         IBM Plex Sans (variable) is the only family loaded here —
-         keeps the login bundle small. */
+         IBM Plex Sans (body) + Funnel Display (heading) loaded here —
+         keeps the login bundle small. Files are served from the
+         shared/fonts symlink under the dashboard's public/ root. */
       @font-face {
         font-family: "IBM Plex Sans";
         font-style: normal;
         font-weight: 100 700;
         font-display: swap;
         src: url("/fonts/ibm-plex-sans/IBMPlexSans-Variable--latin_basic.woff2") format("woff2");
+      }
+      @font-face {
+        font-family: "Funnel Display";
+        font-style: normal;
+        font-weight: 300 800;
+        font-display: swap;
+        src: url("/fonts/funnel-display/FunnelDisplay-Variable--latin_basic.woff2") format("woff2");
       }
 
       :root {
@@ -31,6 +39,7 @@
         --color-text-subtle: #82838c;
         --color-danger: #a83232;
         --font-sans: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+        --font-display: "Funnel Display", system-ui, sans-serif;
       }
 
       *,
@@ -72,9 +81,9 @@
       }
 
       h1 {
-        font-family: var(--font-sans);
-        font-size: 24px;
-        font-weight: 700;
+        font-family: var(--font-display);
+        font-size: 32px;
+        font-weight: 400;
         margin: 0 0 16px;
         color: var(--color-text);
         line-height: 1.1;

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { AccountPage } from "./components/AccountPage";
 import { AgentsTable, sortAgents } from "./components/AgentsTable";
 import { AnalyticsPage } from "./components/AnalyticsPage";
 import { ConnectModal } from "./components/ConnectModal";
@@ -9,7 +10,7 @@ import { HITLBar } from "./components/HITLBar";
 import { LiveRequests } from "./components/LiveRequests";
 import { Main } from "./components/Main";
 import { OnboardPage } from "./components/OnboardPage";
-import { AccountPage } from "./components/AccountPage";
+import { PageTitle } from "./components/PageTitle";
 import { RequestDetailPage } from "./components/RequestDetailPage";
 import { SettingsPage } from "./components/SettingsPage";
 import { getState, type Agent, type Integration, type UpdateBanner, type Whoami } from "./lib/api";
@@ -92,11 +93,12 @@ export default function App() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-canvas-muted">
+    <div className="flex flex-col min-h-screen bg-canvas">
       <UpdateNotice update={update} />
       <Header whoami={whoami} currentRoute={route.name} />
       {route.name === "main" ? (
         <Main>
+          <PageTitle trail={[{ label: "Live overview" }]} />
           <HomeAgents
             agents={agents}
             integrations={integrations}
@@ -203,7 +205,7 @@ function UpdateNotice({ update }: { update: UpdateBanner | null }) {
   );
   if (dismissed) return null;
   return (
-    <div className="bg-butter-200 border-b border-butter-300 px-4 sm:px-4 py-2 md:py-3 text-xs text-text flex items-center justify-between gap-3">
+    <div className="bg-butter-100 border-b border-butter-300 px-4 sm:px-4 py-2 text-xs text-text flex items-center justify-between gap-3">
       <div className="flex-1">
         <span className="font-semibold">Claw Patrol {update.latest}</span>
         {" available — "}
@@ -222,10 +224,11 @@ function UpdateNotice({ update }: { update: UpdateBanner | null }) {
           localStorage.setItem(dismissKey, "1");
           setDismissed(true);
         }}
-        className="text-butter-900 hover:text-text text-lg leading-none px-1"
+        className="text-butter-900 hover:text-text text-lg leading-none px-1 cursor-pointer hover:bg-butter-300 squircle-md p-1 pb-1.5 pt-0.5 aspect-square h-6 transition-colors"
         title="dismiss"
       >
-        &times;
+        <span aria-hidden="true">&times;</span>
+        <span className="sr-only">Dismiss</span>
       </button>
     </div>
   );

--- a/dashboard/src/components/AccountPage.tsx
+++ b/dashboard/src/components/AccountPage.tsx
@@ -9,7 +9,7 @@ import { PageTitle } from "./PageTitle";
 export function AccountPage({ whoami }: { whoami: Whoami | null }) {
   return (
     <Main>
-      <PageTitle trail={[{ label: "Claw Patrol", href: "#/" }, { label: "account" }]} />
+      <PageTitle trail={[{ label: "Account" }]} />
       <section className="bg-canvas border-1.5 border-navy p-4 space-y-4">
         {whoami?.user ? <Identity whoami={whoami} /> : <NotLoggedIn />}
       </section>

--- a/dashboard/src/components/AddDeviceModal.tsx
+++ b/dashboard/src/components/AddDeviceModal.tsx
@@ -56,7 +56,7 @@ function Step({ n, label, cmd }: { n: number; label: string; cmd: string }) {
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-2">
-        <span className="w-[16px] h-[16px] rounded-full border-navy border bg-navy-100 text-2xs font-semibold font-mono flex items-center justify-center shrink-0">
+        <span className="w-6 h-6 squircle-md bg-navy-100 text-xs font-semibold font-mono flex items-center justify-center shrink-0">
           {n}
         </span>
         <span className="text-sm text-text-muted font-sans">{label}</span>

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -146,7 +146,7 @@ function Th({ children, className = "" }: { children: React.ReactNode; className
   return (
     <th
       className={
-        "px-3 sm:px-[14px] py-[9px] text-left text-xs font-mono uppercase tracking-wider text-navy font-bold " +
+        "px-3 sm:px-3.5 py-2.5 text-left text-xs font-mono uppercase tracking-wider text-navy font-bold " +
         className
       }
     >
@@ -165,10 +165,7 @@ function Td({
   title?: string;
 }) {
   return (
-    <td
-      className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className}
-      {...rest}
-    >
+    <td className={"px-3 sm:px-3.5 py-2.5 align-middle overflow-hidden " + className} {...rest}>
       {children}
     </td>
   );

--- a/dashboard/src/components/AnalyticsPage.tsx
+++ b/dashboard/src/components/AnalyticsPage.tsx
@@ -152,15 +152,15 @@ export function AnalyticsPage({ ip, agents }: { ip?: string; agents: Agent[] }) 
     return { n: totalCount, avg, p99, errPct, devices };
   })();
 
-  const trail: Crumb[] = [{ label: "Claw Patrol", href: "#/" }];
+  const trail: Crumb[] = [];
   if (deviceName) {
-    trail.push({ label: "devices", href: "#/devices" });
+    trail.push({ label: "Devices", href: "#/devices" });
     trail.push({
       label: deviceName,
       href: `#/device/${encodeURIComponent(ip!)}`,
     });
   }
-  trail.push({ label: "analytics" });
+  trail.push({ label: "Analytics" });
 
   return (
     <Main>
@@ -506,7 +506,7 @@ function LatencyChart({
           <Toggle options={["log", "linear"] as Scale[]} value={scale} onChange={setScale} />
         </div>
       </header>
-      <div ref={ref} className="p-4 min-h-[320px]" />
+      <div ref={ref} className="p-4 min-h-80" />
     </section>
   );
 }
@@ -583,7 +583,7 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
 
   const hdr = (label: string, field: "count" | "p99Ms") => (
     <th
-      className="px-3 sm:px-[14px] py-[9px] text-right text-xs font-mono font-bold uppercase tracking-wider text-navy cursor-pointer hover:text-navy-700 select-none"
+      className="px-3 sm:px-3.5 py-2.5 text-right text-xs font-mono font-bold uppercase tracking-wider text-navy cursor-pointer hover:text-navy-700 select-none"
       onClick={() => setSortBy(field)}
     >
       {label}
@@ -596,12 +596,12 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
       <table className="w-full text-xs">
         <colgroup>
           <col />
-          <col className="w-[120px]" />
-          <col className="w-[80px]" />
+          <col className="w-30" />
+          <col className="w-20" />
         </colgroup>
         <thead className="bg-navy-100 border-b border-navy">
           <tr>
-            <th className="px-3 sm:px-[14px] py-[9px] text-left text-xs font-mono uppercase tracking-wider text-navy font-bold">
+            <th className="px-3 sm:px-3.5 py-2.5 text-left text-xs font-mono uppercase tracking-wider text-navy font-bold">
               Top routes
             </th>
             {hdr("Reqs", "count")}
@@ -617,13 +617,13 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
                 className="border-b border-canvas-muted hover:bg-canvas-muted transition-colors"
               >
                 <td
-                  className="px-3 sm:px-[14px] py-[9px] font-mono align-middle break-all"
+                  className="px-3 sm:px-3.5 py-2.5 font-mono align-middle break-all"
                   title={`${d.method} ${d.host}${d.path}`}
                 >
                   <span className="text-text-subtle">{d.method}</span> {d.host}
                   <span className="text-text-muted">{d.path}</span>
                 </td>
-                <td className="px-3 sm:px-[14px] py-[9px] text-right whitespace-nowrap align-middle">
+                <td className="px-3 sm:px-3.5 py-2.5 text-right whitespace-nowrap align-middle">
                   <div className="flex items-center justify-end gap-1.5">
                     <div className="w-12 h-1.5 bg-canvas-muted rounded-full">
                       <div
@@ -634,7 +634,7 @@ function TopRoutes({ events }: { events: EventRecord[] }) {
                     <span className="w-8 text-right tabular-nums">{d.count}</span>
                   </div>
                 </td>
-                <td className="px-3 sm:px-[14px] py-[9px] text-right text-text-muted tabular-nums align-middle">
+                <td className="px-3 sm:px-3.5 py-2.5 text-right text-text-muted tabular-nums align-middle">
                   {fmtMs(d.p99Ms)}
                 </td>
               </tr>

--- a/dashboard/src/components/ConnectModal.tsx
+++ b/dashboard/src/components/ConnectModal.tsx
@@ -171,7 +171,7 @@ export function ConnectModal({
                   {extras.size > 0 ? `${extras.size} selected` : "optional"}
                 </span>
               </summary>
-              <div className="max-h-[300px] overflow-y-auto p-2 space-y-3 border-t border-canvas-300">
+              <div className="max-h-75 overflow-y-auto p-2 space-y-3 border-t border-canvas-300">
                 {optionalGroups.map((g) => (
                   <div key={g.title}>
                     <div className="font-mono text-2xs uppercase tracking-wider text-text-subtle mb-1">
@@ -263,7 +263,7 @@ export function ConnectModal({
                 autoFocus
               />
               {err && <div className="text-xs text-rust-700 mt-2 break-all">{err}</div>}
-              <div className="flex gap-2 mt-3 justify-end">
+              <div className="flex gap-2 mt-8 justify-end">
                 <Button variant="outline" onClick={onClose}>
                   cancel
                 </Button>

--- a/dashboard/src/components/CredentialSecretsModal.tsx
+++ b/dashboard/src/components/CredentialSecretsModal.tsx
@@ -100,7 +100,7 @@ export function CredentialSecretsModal({
         ))}
         {err && <div className="text-xs text-danger-500">{err}</div>}
       </div>
-      <div className="flex justify-end gap-2 px-4 py-3 border-t border-navy">
+      <div className="flex justify-end gap-2 px-4 py-3">
         <Button variant="outline" onClick={onClose}>
           Cancel
         </Button>

--- a/dashboard/src/components/CredentialsTypeGrid.tsx
+++ b/dashboard/src/components/CredentialsTypeGrid.tsx
@@ -346,7 +346,7 @@ function DetailsPanel({
         </div>
         <button
           onClick={onClose}
-          className="text-text-subtle hover:text-text text-sm leading-none px-1"
+          className="text-text text-sm leading-none px-1 cursor-pointer"
           title="fold"
         >
           ✕

--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -66,13 +66,7 @@ export function DevicePage({
   if (!a) {
     return (
       <Main>
-        <PageTitle
-          trail={[
-            { label: "Claw Patrol", href: "#/" },
-            { label: "devices", href: "#/devices" },
-            { label: ip },
-          ]}
-        />
+        <PageTitle trail={[{ label: "Devices", href: "#/devices" }, { label: ip }]} />
         <div className="bg-canvas border-1.5 border-navy px-5 py-8 text-center text-xs text-text-subtle">
           no agent with ip {ip}
         </div>
@@ -103,11 +97,7 @@ export function DevicePage({
   return (
     <Main>
       <PageTitle
-        trail={[
-          { label: "Claw Patrol", href: "#/" },
-          { label: "devices", href: "#/devices" },
-          { label: dev.hostname || dev.ip },
-        ]}
+        trail={[{ label: "Devices", href: "#/devices" }, { label: dev.hostname || dev.ip }]}
         actions={
           <>
             <ProfilePicker
@@ -132,7 +122,7 @@ export function DevicePage({
             <a
               href={`#/analytics/${encodeURIComponent(ip)}`}
               title="analytics"
-              className="w-[36px] h-[36px] rounded-full border-1.5 border-navy text-text-muted flex items-center justify-center hover:text-text transition-colors"
+              className="w-8 h-8 squircle-md flex items-center justify-center hover:bg-navy-100 transition-colors"
             >
               <svg
                 width="16"
@@ -152,7 +142,7 @@ export function DevicePage({
               type="button"
               onClick={remove}
               title="forget this device"
-              className="w-[36px] h-[36px] rounded-full border-1.5 border-navy text-text-muted flex items-center justify-center hover:border-danger-500 hover:text-danger-500 transition-colors"
+              className="w-8 h-8 squircle-md flex items-center justify-center hover:bg-danger-400 transition-colors cursor-pointer"
             >
               <svg
                 width="16"
@@ -283,7 +273,7 @@ function ProfilePicker({
         aria-expanded={open}
         title={`profile: ${current || "—"}`}
         className={
-          "inline-flex items-center justify-between gap-2 min-w-[160px] " +
+          "inline-flex items-center justify-between gap-2 min-w-40 " +
           "pl-2.5 pr-1.5 py-1 border-1.5 border-navy bg-canvas text-sm text-text " +
           "hover:bg-canvas-muted transition-colors disabled:opacity-50 " +
           "disabled:cursor-not-allowed"
@@ -308,7 +298,7 @@ function ProfilePicker({
         </svg>
       </button>
       {open && (
-        <div className="absolute right-0 top-[calc(100%+6px)] z-20 min-w-[200px] bg-canvas border-1.5 border-navy shadow-lg py-1">
+        <div className="absolute right-0 top-[calc(100%+0.375rem)] z-20 min-w-50 bg-canvas border-1.5 border-navy shadow-lg py-1">
           <div className="font-mono px-3 py-1.5 text-2xs uppercase tracking-wider text-text border-b border-canvas-muted">
             choose profile
           </div>

--- a/dashboard/src/components/DevicesPage.tsx
+++ b/dashboard/src/components/DevicesPage.tsx
@@ -21,7 +21,7 @@ export function DevicesPage({
   return (
     <Main>
       <PageTitle
-        trail={[{ label: "Claw Patrol", href: "#/" }, { label: "devices" }]}
+        trail={[{ label: "Devices" }]}
         actions={
           <Button variant="normal" size="sm" onClick={() => setShowAdd(true)}>
             Add device

--- a/dashboard/src/components/HITLBar.tsx
+++ b/dashboard/src/components/HITLBar.tsx
@@ -26,7 +26,8 @@ export function HITLBar() {
     };
   }, []);
 
-  async function decide(id: string, allow: boolean) {
+  async function decide(id: string, allow: boolean, confirmMsg: string) {
+    if (!confirm(confirmMsg)) return;
     setNotice("");
     setPending((p) => p.filter((x) => x.id !== id));
     try {
@@ -98,10 +99,29 @@ export function HITLBar() {
                   </Td>
                   <Td className="text-right">
                     <div className="flex gap-1.5 justify-end">
-                      <Button variant="outline" onClick={() => decide(p.id, false)}>
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          decide(
+                            p.id,
+                            false,
+                            `Deny this request?\n\n${p.method} ${ep}${sep}${p.path}`,
+                          )
+                        }
+                      >
                         deny
                       </Button>
-                      <Button onClick={() => decide(p.id, true)}>
+                      <Button
+                        onClick={() => {
+                          const verb = approval?.approveLabel ?? "allow";
+                          const cap = verb.charAt(0).toUpperCase() + verb.slice(1);
+                          decide(
+                            p.id,
+                            true,
+                            `${cap} this request?\n\n${p.method} ${ep}${sep}${p.path}`,
+                          );
+                        }}
+                      >
                         {approval?.approveLabel ?? "allow"}
                       </Button>
                     </div>
@@ -179,7 +199,7 @@ function hitlDecisionNotice(result: HITLResolveResult): string {
 
 function Td({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
-    <td className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className}>
+    <td className={"px-3 sm:px-3.5 py-2.5 align-middle overflow-hidden " + className}>
       {children}
     </td>
   );

--- a/dashboard/src/components/Header.tsx
+++ b/dashboard/src/components/Header.tsx
@@ -17,65 +17,72 @@ export function Header({
   whoami: Whoami | null;
   currentRoute?: string;
 }) {
-  const navBase =
-    "group relative w-[36px] h-[36px] rounded-full border-1.5 border-navy text-navy flex items-center justify-center bg-canvas hover:bg-canvas-muted transition-colors";
-  const navActive = "bg-navy-100";
   // Single-device pages are part of the Devices section, so the nav
   // button stays lit when drilling into a device.
   const devicesActive = currentRoute === "devices" || currentRoute === "device";
-  const analyticsActive = currentRoute === "analytics";
-  const settingsActive = currentRoute === "settings";
-  const accountActive = currentRoute === "account";
   return (
-    <header className="bg-transparent">
-      <div className="mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-4 flex items-center gap-4">
+    <header className="border-b-1.5 border-b-canvas-muted">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 py-3 flex items-center gap-4">
         <a href="#/" aria-label="Home" className="shrink-0">
           <img
             src={import.meta.env.BASE_URL + "claw-patrol-logo.svg"}
             alt="Claw Patrol"
-            className="h-6 sm:h-8 w-auto"
+            className="h-8 w-auto hidden xs:block"
+          />
+          <img
+            src={import.meta.env.BASE_URL + "claw-patrol-icon.svg"}
+            alt="Claw Patrol"
+            className="h-8 w-auto xs:hidden"
           />
         </a>
-        <nav className="ml-auto flex items-center gap-2">
-          <a
-            href="#/devices"
-            className={`${navBase} ${devicesActive ? navActive : ""}`}
-            aria-current={devicesActive ? "page" : undefined}
-            aria-label="Devices"
-          >
+        <nav className="ml-auto flex items-center gap-1">
+          <NavLink href="#/devices" label="Devices" active={devicesActive}>
             <DesktopNavIcon />
-            <NavTooltip>Devices</NavTooltip>
-          </a>
-          <a
-            href="#/analytics"
-            className={`${navBase} ${analyticsActive ? navActive : ""}`}
-            aria-current={analyticsActive ? "page" : undefined}
-            aria-label="Analytics"
-          >
+          </NavLink>
+          <NavLink href="#/analytics" label="Analytics" active={currentRoute === "analytics"}>
             <Icon paths={["M3 3v18h18", "m7 16 4-8 4 4 4-6"]} />
-            <NavTooltip>Analytics</NavTooltip>
-          </a>
-          <a
-            href="#/settings"
-            className={`${navBase} ${settingsActive ? navActive : ""}`}
-            aria-current={settingsActive ? "page" : undefined}
-            aria-label="Settings"
-          >
+          </NavLink>
+          <NavLink href="#/settings" label="Settings" active={currentRoute === "settings"}>
             <SettingsIcon />
-            <NavTooltip>Settings</NavTooltip>
-          </a>
-          <a
-            href="#/account"
-            className={`${navBase} ${accountActive ? navActive : ""}`}
-            aria-current={accountActive ? "page" : undefined}
-            aria-label="Account"
-          >
+          </NavLink>
+          <NavLink href="#/account" label="Account" active={currentRoute === "account"}>
             <AccountIcon />
-            <NavTooltip>Account</NavTooltip>
-          </a>
+          </NavLink>
         </nav>
       </div>
     </header>
+  );
+}
+
+// NavLink couples the aria-label and the tooltip text so they can't
+// drift apart. If a future link needs them to differ, split it back
+// into two props (label + tooltip) rather than reaching into the
+// className soup at the call site.
+function NavLink({
+  href,
+  label,
+  active,
+  children,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+  children: ReactNode;
+}) {
+  const NAV_BASE =
+    "group relative w-9 h-9 squircle-md border-navy-100 text-navy flex items-center justify-center hover:bg-navy-100 transition-colors";
+  const NAV_ACTIVE = "bg-navy-100";
+
+  return (
+    <a
+      href={href}
+      className={`${NAV_BASE} ${active ? NAV_ACTIVE : ""}`}
+      aria-current={active ? "page" : undefined}
+      aria-label={label}
+    >
+      {children}
+      <NavTooltip>{label}</NavTooltip>
+    </a>
   );
 }
 
@@ -90,7 +97,7 @@ function NavTooltip({ children }: { children: ReactNode }) {
       className={
         "pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 " +
         "px-2 py-1 bg-navy text-canvas text-2xs font-mono uppercase tracking-wider " +
-        "max-w-[220px] text-center leading-snug font-bold z-10 " +
+        "max-w-[14rem] text-center leading-snug font-bold z-10 " +
         "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 " +
         "transition-opacity duration-100"
       }

--- a/dashboard/src/components/IntegrationsCards.tsx
+++ b/dashboard/src/components/IntegrationsCards.tsx
@@ -294,7 +294,7 @@ function Card({
                 e.stopPropagation();
                 onDisconnect();
               }}
-              className="opacity-0 group-hover:opacity-100 text-xs leading-none text-text-subtle hover:text-danger-500 transition-opacity cursor-pointer"
+              className="opacity-0 group-hover:opacity-100 text-xs leading-none text-text hover:text-danger-500 transition-opacity cursor-pointer"
               title={connected ? "disconnect" : "reset stored identity"}
             >
               ✕

--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -3,7 +3,9 @@ import { type EventRecord, type FacetSchema } from "../lib/api";
 import { formatFacetValue, useFacets } from "../lib/facets";
 import { fmtTime } from "../lib/format";
 
-type RowState = EventRecord & { frames?: { direction: string; frame: string; ts: string }[] };
+type RowState = EventRecord & {
+  frames?: { direction: string; frame: string; ts: string }[];
+};
 
 export function LiveRequests({
   agentIP,
@@ -115,7 +117,11 @@ function mergeEvent(prev: RowState[], ev: EventRecord, max: number): RowState[] 
             ...r,
             frames: [
               ...(r.frames ?? []),
-              { direction: ev.direction ?? "", frame: ev.frame ?? "", ts: ev.ts },
+              {
+                direction: ev.direction ?? "",
+                frame: ev.frame ?? "",
+                ts: ev.ts,
+              },
             ],
           }
         : r,
@@ -215,11 +221,11 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
         <span className="text-2xs tabular-nums text-text-subtle shrink-0">{time}</span>
         <ModeIcon mode={ev.mode} />
         {verb && (
-          <span className="font-mono text-2xs uppercase font-semibold text-text-muted shrink-0 w-[44px]">
+          <span className="font-mono text-2xs uppercase font-semibold text-text-muted shrink-0 w-11">
             {verb}
           </span>
         )}
-        <span className={"text-xs tabular-nums shrink-0 w-[36px] " + statusColor}>
+        <span className={"text-xs tabular-nums shrink-0 w-9 " + statusColor}>
           {inFlight ? <InFlightSpinner /> : status || "—"}
         </span>
         <span className="text-xs text-text truncate flex-1 min-w-0" title={ev.host + sep + body}>
@@ -232,10 +238,10 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
         </span>
       </div>
       {hasFrames && (
-        <div className="bg-canvas-muted border-t border-canvas-muted max-h-[180px] overflow-y-auto">
+        <div className="bg-canvas-muted border-t border-canvas-muted max-h-45 overflow-y-auto">
           {ev.frames!.map((f, i) => (
             <div key={i} className="px-4 py-1 flex items-start gap-2 text-2xs font-mono">
-              <span className="text-text-subtle shrink-0 w-[24px]">{f.direction}</span>
+              <span className="text-text-subtle shrink-0 w-6">{f.direction}</span>
               <span className="text-text-muted truncate" title={f.frame}>
                 {f.frame}
               </span>

--- a/dashboard/src/components/Main.tsx
+++ b/dashboard/src/components/Main.tsx
@@ -8,6 +8,6 @@ import type { ReactNode } from "react";
 // that lets a single child sit centered in the remaining viewport
 // (see OnboardPage).
 export function Main({ children, centered }: { children: ReactNode; centered?: boolean }) {
-  const base = "flex-1 mx-auto w-full max-w-[1100px] px-4 sm:px-6 py-4 sm:py-6";
+  const base = "flex-1 mx-auto w-full max-w-7xl px-4 sm:px-6 py-6 pb-16";
   return <main className={`${base} ${centered ? "flex flex-col" : "space-y-4"}`}>{children}</main>;
 }

--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -72,7 +72,7 @@ export function Modal({
         (className ?? "")
       }
     >
-      <div className="flex items-center px-4 py-3 bg-navy-100 border-b border-navy">
+      <div className="flex items-center px-4 py-2 bg-navy-100 border-b border-navy">
         <div>
           <h2
             id={titleId}
@@ -90,7 +90,7 @@ export function Modal({
           type="button"
           onClick={onClose}
           aria-label="Close"
-          className="ml-auto text-2xl leading-none px-2 aspect-square py-1 pt-0.5 text-navy hover:text-text cursor-pointer"
+          className="ml-auto text-2xl squircle-md leading-none px-2 aspect-square py-1 pt-0.5 text-navy hover:bg-navy-200 transition-colors cursor-pointer"
         >
           <span aria-hidden="true">✕</span>
           <span className="sr-only">Close modal</span>

--- a/dashboard/src/components/OnboardPage.tsx
+++ b/dashboard/src/components/OnboardPage.tsx
@@ -39,10 +39,10 @@ export function OnboardPage({ code }: { code: string }) {
 
   return (
     <Main centered>
-      <PageTitle trail={[{ label: "Claw Patrol", href: "#/" }, { label: "add device" }]} />
+      <PageTitle trail={[{ label: "Add device" }]} />
 
       <div className="flex-1 flex items-center justify-center py-8">
-        <div className="w-full max-w-[480px] space-y-5">
+        <div className="w-full max-w-[30rem] space-y-5">
           {!info && !err && <div className="text-xs text-text-muted">loading…</div>}
           {err && <div className="text-xs text-danger-500">{err}</div>}
 
@@ -62,11 +62,11 @@ export function OnboardPage({ code }: { code: string }) {
               </div>
 
               {info.ca_fingerprint && (
-                <details className="text-[11px] text-[#737373]">
+                <details className="text-[0.6875rem] text-[#737373]">
                   <summary className="cursor-pointer hover:text-[#171717]">
                     CA fingerprint — should match `CA fingerprint:` line on the CLI
                   </summary>
-                  <div className="font-mono text-[10px] mt-1 break-all text-[#525252] select-all">
+                  <div className="font-mono text-2xs mt-1 break-all text-[#525252] select-all">
                     {info.ca_fingerprint}
                   </div>
                 </details>

--- a/dashboard/src/components/PageTitle.tsx
+++ b/dashboard/src/components/PageTitle.tsx
@@ -1,45 +1,55 @@
 import type { ReactNode } from "react";
 
-// PageTitle renders a consistent breadcrumb + optional contextual
-// actions strip below the global Header on inner routes. The home
-// page doesn't render this; every other route does.
+// PageTitle renders the page hero: a display-font heading for the
+// current page (the last crumb in `trail`), an optional breadcrumb
+// row below for any ancestor crumbs, and a right-aligned `actions`
+// slot for page-specific affordances (filter chips, profile pickers,
+// delete buttons, etc.).
 //
-// `trail` is the list of breadcrumb segments. The last one is the
-// current page (rendered without a link); the rest get rendered as
-// links if `href` is provided, plain text otherwise.
-//
-// `actions` are page-specific affordances (filter chip, profile
-// picker, delete button, etc.) that live on the same row as the
-// breadcrumb, right-aligned.
+// `trail` is the navigation path. The last item becomes the heading;
+// the rest render as breadcrumb links above the home logo. The
+// global Header already provides the "back to home" affordance, so
+// there is no synthetic root crumb — callers pass only the page's
+// own path.
 export type Crumb = {
   label: ReactNode;
   href?: string;
 };
 
 export function PageTitle({ trail, actions }: { trail: Crumb[]; actions?: ReactNode }) {
+  if (trail.length === 0) return null;
+  const heading = trail[trail.length - 1];
+  const crumbs = trail.slice(0, -1);
   return (
-    <div className="flex items-center justify-between gap-3 flex-wrap">
-      <nav aria-label="Breadcrumb" className="flex items-baseline gap-1.5 text-sm">
-        {trail.map((c, i) => {
-          const isLast = i === trail.length - 1;
-          return (
-            <span key={i} className="flex items-baseline gap-1.5">
-              {c.href && !isLast ? (
-                <a
-                  href={c.href}
-                  className="text-text-muted underline underline-offset-2 hover:text-text"
-                >
-                  {c.label}
-                </a>
-              ) : (
-                <span className="text-text-muted">{c.label}</span>
-              )}
-              {!isLast && <span className="text-text-muted">/</span>}
-            </span>
-          );
-        })}
-      </nav>
-      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    <div className="flex flex-col gap-2 mb-6">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h1 className="font-display text-2xl sm:text-3xl text-text leading-none">
+          {heading.label}
+        </h1>
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      </div>
+      {crumbs.length > 0 && (
+        <nav aria-label="Breadcrumb" className="flex items-baseline gap-1.5 text-sm">
+          {crumbs.map((c, i) => {
+            const isLast = i === crumbs.length - 1;
+            return (
+              <span key={i} className="flex items-baseline gap-1.5">
+                {c.href ? (
+                  <a
+                    href={c.href}
+                    className="text-text-muted underline underline-offset-2 hover:text-text"
+                  >
+                    {c.label}
+                  </a>
+                ) : (
+                  <span className="text-text-muted">{c.label}</span>
+                )}
+                {!isLast && <span className="text-text-muted">/</span>}
+              </span>
+            );
+          })}
+        </nav>
+      )}
     </div>
   );
 }

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
-  getAction,
   downloadActionFixture,
+  getAction,
   type Agent,
   type EventRecord,
   type FacetSchema,
@@ -84,7 +84,10 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
   // full breakdown lives in SQLDetail below.
   const isSQL = ev.family === "sql" || ev.mode === "pg" || ev.mode === "clickhouse_native";
   const header = isSQL
-    ? { verb: ((ev.facets?.verb as string | undefined) ?? ev.method ?? "").toUpperCase(), body: "" }
+    ? {
+        verb: ((ev.facets?.verb as string | undefined) ?? ev.method ?? "").toUpperCase(),
+        body: "",
+      }
     : headerFromFacets(ev, schema);
   const { verb, body } = header;
   const fullUrl = ev.host + (body && !body.startsWith("/") ? " " : "") + body;
@@ -247,7 +250,10 @@ function SQLDetail({ ev }: { ev: EventRecord }) {
   if (verb) facets.push({ label: "Verb", value: verb });
   if (tables.length > 0) facets.push({ label: "Tables", value: tables.join(", ") });
   if (functions.length > 0) {
-    facets.push({ label: "Functions", value: functions.map((s) => s.toUpperCase()).join(", ") });
+    facets.push({
+      label: "Functions",
+      value: functions.map((s) => s.toUpperCase()).join(", "),
+    });
   }
   return (
     <div className="bg-canvas border-1.5 border-navy divide-y divide-canvas-dark">
@@ -291,10 +297,13 @@ function Shell({
   agentName?: string;
   requestId?: string;
 }) {
-  const trail: Crumb[] = [{ label: "Claw Patrol", href: "#/" }];
+  const trail: Crumb[] = [];
   if (agentIP) {
-    trail.push({ label: "devices", href: "#/devices" });
-    trail.push({ label: agentName || agentIP, href: `#/device/${encodeURIComponent(agentIP)}` });
+    trail.push({ label: "Devices", href: "#/devices" });
+    trail.push({
+      label: agentName || agentIP,
+      href: `#/device/${encodeURIComponent(agentIP)}`,
+    });
   }
   if (requestId) {
     trail.push({
@@ -692,7 +701,7 @@ function Collapsible({
   }
   if (!open) {
     return (
-      <button onClick={() => setOpen(true)} className="text-text-subtle hover:text-text-muted">
+      <button onClick={() => setOpen(true)} className="text-text cursor-pointer">
         {bracket[0]} <span className="text-navy-500">{count} items</span> {bracket[1]}
       </button>
     );

--- a/dashboard/src/components/RulesPanel.tsx
+++ b/dashboard/src/components/RulesPanel.tsx
@@ -123,7 +123,7 @@ function RuleRow({ rule: r }: { rule: RuleSummary }) {
         </div>
       </div>
       <div className="flex flex-col items-end gap-0.5 shrink-0">
-        <span className="text-xs text-text-subtle truncate max-w-[160px]" title={r.name}>
+        <span className="text-xs text-text-subtle truncate max-w-[10rem]" title={r.name}>
           {r.name}
         </span>
         {(r.priority ?? 0) !== 0 && (

--- a/dashboard/src/components/SessionsTable.tsx
+++ b/dashboard/src/components/SessionsTable.tsx
@@ -121,7 +121,7 @@ function Th({ children, className = "" }: { children: React.ReactNode; className
   return (
     <th
       className={
-        "px-3 sm:px-[14px] py-[9px] text-left text-xs font-mono uppercase tracking-wider text-navy font-bold " +
+        "px-3 sm:px-3.5 py-2.5 text-left text-xs font-mono uppercase tracking-wider text-navy font-bold " +
         className
       }
     >
@@ -140,10 +140,7 @@ function Td({
   title?: string;
 }) {
   return (
-    <td
-      className={"px-3 sm:px-[14px] py-[9px] align-middle overflow-hidden " + className}
-      {...rest}
-    >
+    <td className={"px-3 sm:px-3.5 py-2.5 align-middle overflow-hidden " + className} {...rest}>
       {children}
     </td>
   );

--- a/dashboard/src/components/SettingsPage.tsx
+++ b/dashboard/src/components/SettingsPage.tsx
@@ -21,7 +21,7 @@ export function SettingsPage({
 }) {
   return (
     <Main>
-      <PageTitle trail={[{ label: "Claw Patrol", href: "#/" }, { label: "settings" }]} />
+      <PageTitle trail={[{ label: "Settings" }]} />
 
       <section className="space-y-3">
         <h2 className="font-mono text-xs uppercase tracking-wider text-navy font-bold">

--- a/dashboard/src/components/Tag.tsx
+++ b/dashboard/src/components/Tag.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from "react";
 export type Tone = "success" | "danger" | "warning" | "info" | "neutral";
 
 const tones: Record<Tone, string> = {
-  success: "bg-success-50 border-success-200 text-success-800",
+  success: "bg-success-100 border-success-200 text-success-800",
   danger: "bg-danger-50 border-danger-200 text-danger-800",
-  warning: "bg-butter-100 border-butter-200 text-butter-800",
+  warning: "bg-butter-200 border-butter-400 text-butter-800",
   info: "bg-navy-50 border-navy-200 text-navy-800",
   neutral: "bg-canvas-muted border-canvas-dark text-text-muted",
 };

--- a/shared/tokens.css
+++ b/shared/tokens.css
@@ -144,7 +144,7 @@
      AA Large (3:1) on light surfaces. */
   --color-text: #2c2e35;
   --color-text-muted: #62656d;
-  --color-text-subtle: #82838c;
+  --color-text-subtle: #7a7b85;
 
   --font-display: "Funnel Display", system-ui, sans-serif;
   --font-sans: "IBM Plex Sans", system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
Tightening up visuals and some UI/UX details across the dashboard.

- Add confirmation to HITL allow/deny buttons
- Add a PageTitle component to every top-level page
- Lighten background and make some other color and style adjustments
- Allow dashboard to grow wider where space allows
- Improved nav and button styling; unify button styling
- Tighten up modals
- Adjust some color design tokens for legibility
- Responsive/mobile improvements