### PR TITLE
Replace demo image with live iframe

### DIFF
--- a/site/src/sections/DemoSection.tsx
+++ b/site/src/sections/DemoSection.tsx
@@ -25,15 +25,12 @@ export function DemoSection() {
         </p>
       </div>
 
-      <div class="max-w-4xl mx-auto px-6 sm:px-8 mb-12">
-        <a href={DEMO_URL} class="block group">
-          <img
-            src="/screenshots/demo-dashboard.png"
-            alt="Claw Patrol admin dashboard showing a device fleet and live request feed"
-            class="w-full block border border-navy
-              transition-opacity group-hover:opacity-90"
-          />
-        </a>
+      <div class="max-w-4xl mx-auto px-6 sm:px-8 mb-8">
+        <iframe
+          src="https://demo.clawpatrol.dev/"
+          className="h-128 w-full border-3 border-t-24 border-navy squircle-lg shadow-[4px_6px_0_0_var(--color-canvas-300)] border-navy"
+          width="100%"
+        ></iframe>
       </div>
 
       <div class="text-center">


### PR DESCRIPTION
Instead of having a static image of the dashboard, let's use a live iframe to show visitors the demo firsthand.

This keeps it in sync with any changes we might make, and users can still opt to click through to it.

<img width="1860" height="1790" alt="CleanShot 2026-05-22 at 15 22 54@2x" src="https://github.com/user-attachments/assets/d0b77598-769e-45fb-8da9-cbcef60599c8" />
