### PR TITLE
human_approver: per-request channel override via X-HITL-Channel

### DIFF
--- a/cmd/clawpatrol/hitl_channel_header_test.go
+++ b/cmd/clawpatrol/hitl_channel_header_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+// sanitizeSlackChannelHeader gates the X-HITL-Channel header before
+// it's threaded into the approver request. The header is
+// agent-controlled, so anything that doesn't shape like a Slack
+// channel ID must be dropped — otherwise an attacker-shaped value
+// could land in chat.postMessage verbatim.
+func TestSanitizeSlackChannelHeader(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Public + private channels accepted.
+		{"C0AH1SJGHAP", "C0AH1SJGHAP"},
+		{"C03P8NG2Q06", "C03P8NG2Q06"},
+		{"GABC12345", "GABC12345"}, // private channel / mpim
+		// Whitespace trimmed.
+		{"  C0AH1SJGHAP  ", "C0AH1SJGHAP"},
+
+		// Empty in, empty out — caller falls back to static block field.
+		{"", ""},
+
+		// DMs and user IDs rejected — not valid HITL destinations.
+		{"D12345678", ""},
+		{"U12345678", ""},
+
+		// Too short / too long.
+		{"C123", ""},
+		{"C" + repeat("A", 25), ""},
+
+		// Wrong shape — lowercase, punctuation, injection attempts.
+		{"c0ah1sjghap", ""},
+		{"C0AH1S JGHAP", ""},
+		{"C0AH1S\nJGHAP", ""},
+		{"C0AH1S;DROP", ""},
+		{"<a>C0AH1SJGHAP", ""},
+	}
+	for _, c := range cases {
+		got := sanitizeSlackChannelHeader(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeSlackChannelHeader(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func repeat(s string, n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		out += s
+	}
+	return out
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2095,6 +2095,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				AgentIP: agentAddr, Host: host, Method: req.Method, Path: req.URL.RequestURI(),
 				UA: req.Header.Get("User-Agent"), BodySample: string(matchBody), Reason: cr.Outcome.Reason,
 				ThreadTS: req.Header.Get("X-HITL-Thread-TS"),
+				Channel:  sanitizeSlackChannelHeader(req.Header.Get("X-HITL-Channel")),
 				Endpoint: ep, Rule: cr, Profile: profile, Request: mreq,
 				AsyncOperationID: asyncOp.ID, AsyncPendingOnSyncTimeout: asyncOp.ID != "", AsyncSyncWaitTimeout: asyncSyncWait,
 			})
@@ -2199,6 +2200,7 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 				"Cf-Worker", "Cf-Ray", "Cf-Ew-Via", "Cf-Connecting-Ip", "Cdn-Loop",
 				"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "Via",
 				"X-HITL-Thread-TS",
+				"X-HITL-Channel",
 			} {
 				req.Header.Del(h)
 			}
@@ -2512,6 +2514,7 @@ type runApproveCtx struct {
 	BodySample                string
 	Reason                    string
 	ThreadTS                  string
+	Channel                   string
 	Endpoint                  *config.CompiledEndpoint
 	Rule                      *config.CompiledRule
 	Profile                   string
@@ -2566,6 +2569,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			BodySample:                c.BodySample,
 			Reason:                    c.Reason,
 			ThreadTS:                  c.ThreadTS,
+			Channel:                   c.Channel,
 			AsyncOperationID:          c.AsyncOperationID,
 			AsyncPendingOnSyncTimeout: c.AsyncPendingOnSyncTimeout,
 			Pool:                      g.hitl,
@@ -2602,6 +2606,37 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 }
 
 // ifNotEmpty returns f(v) when v != nil, else "".
+// sanitizeSlackChannelHeader validates the X-HITL-Channel header
+// before it's threaded into the approver request. A misformed value
+// would either be silently ignored downstream or, worse, posted
+// verbatim to chat.postMessage with attacker-controlled bytes — so
+// reject anything that doesn't shape like a Slack channel ID. Public
+// channels (C…), private channels (G…), and multi-party DMs (G…) all
+// share the same syntactic class. DMs (D…) and user IDs (U…) are
+// not valid HITL destinations and are rejected too.
+//
+// Empty input returns empty (caller falls back to the approver's
+// static `channel` block field).
+func sanitizeSlackChannelHeader(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if len(s) < 9 || len(s) > 24 {
+		return ""
+	}
+	if s[0] != 'C' && s[0] != 'G' {
+		return ""
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+			return ""
+		}
+	}
+	return s
+}
+
 func ifNotEmpty(r *config.CompiledRule, f func(*config.CompiledRule) string) string {
 	if r == nil {
 		return ""

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2630,7 +2630,7 @@ func sanitizeSlackChannelHeader(s string) string {
 	}
 	for i := 1; i < len(s); i++ {
 		c := s[i]
-		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
 			return ""
 		}
 	}

--- a/internal/config/plugins/approvers/human.go
+++ b/internal/config/plugins/approvers/human.go
@@ -148,7 +148,15 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 		}
 	}
 
-	if h.Channel != "" && h.Credential != "" && req.Policy != nil {
+	// Per-request channel override: req.Channel (populated from the
+	// X-HITL-Channel header at the gateway and validated there) wins
+	// over the block's static h.Channel. Empty req.Channel falls back
+	// to h.Channel — keeps existing configs working unchanged.
+	channel := h.Channel
+	if req.Channel != "" {
+		channel = req.Channel
+	}
+	if channel != "" && h.Credential != "" && req.Policy != nil {
 		ent, ok := req.Policy.Credentials[h.Credential]
 		if ok {
 			if notifier, ok := ent.Body.(runtime.HITLNotifier); ok {
@@ -158,7 +166,7 @@ func (h *HumanApprover) Approve(ctx context.Context, req runtime.ApproveRequest)
 				}
 				target := runtime.HITLTarget{
 					CredentialName:           h.Credential,
-					Channel:                  h.Channel,
+					Channel:                  channel,
 					Interactive:              h.Interactive,
 					PendingID:                id,
 					DashboardURL:             req.DashboardURL,

--- a/internal/config/plugins/approvers/human_test.go
+++ b/internal/config/plugins/approvers/human_test.go
@@ -209,6 +209,75 @@ func TestHumanApproverForwardsPendingMessageUpdateSinkToNotifier(t *testing.T) {
 	}
 }
 
+// Per-request Channel (populated from X-HITL-Channel) wins over the
+// static h.Channel so a single approver block can route to whichever
+// channel the originating session came from. Empty req.Channel must
+// fall back to the static value (covered by the existing
+// ForwardsPendingMessageUpdateSink test, which leaves Channel zero
+// and asserts notification still happens against h.Channel).
+func TestHumanApproverRequestChannelOverridesBlockChannel(t *testing.T) {
+	pool := newCaptureHITLPool()
+	notifier := &captureNotifier{notified: make(chan runtime.HITLTarget, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := (&HumanApprover{Credential: "slack", Channel: "C-STATIC", Timeout: 60}).Approve(ctx, runtime.ApproveRequest{
+			Pool:         pool,
+			Policy:       &config.CompiledPolicy{Credentials: map[string]*config.Entity{"slack": {Body: notifier}}},
+			ApproverName: "ops",
+			Method:       "POST",
+			Host:         "api.example.test",
+			Path:         "/v1/write",
+			Channel:      "C0AH1SJGHAP",
+		})
+		done <- err
+	}()
+	select {
+	case target := <-notifier.notified:
+		if target.Channel != "C0AH1SJGHAP" {
+			t.Fatalf("target.Channel = %q, want override %q", target.Channel, "C0AH1SJGHAP")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not notify credential")
+	}
+	cancel()
+	<-done
+}
+
+// A static-channel approver with an empty req.Channel must still
+// notify against its block-declared channel — req.Channel="" is the
+// signal to fall back, not a deny-by-omission.
+func TestHumanApproverEmptyRequestChannelFallsBackToBlockChannel(t *testing.T) {
+	pool := newCaptureHITLPool()
+	notifier := &captureNotifier{notified: make(chan runtime.HITLTarget, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := (&HumanApprover{Credential: "slack", Channel: "C-STATIC", Timeout: 60}).Approve(ctx, runtime.ApproveRequest{
+			Pool:         pool,
+			Policy:       &config.CompiledPolicy{Credentials: map[string]*config.Entity{"slack": {Body: notifier}}},
+			ApproverName: "ops",
+			Method:       "POST",
+			Host:         "api.example.test",
+			Path:         "/v1/write",
+			// Channel intentionally left zero
+		})
+		done <- err
+	}()
+	select {
+	case target := <-notifier.notified:
+		if target.Channel != "C-STATIC" {
+			t.Fatalf("target.Channel = %q, want fallback %q", target.Channel, "C-STATIC")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human approver did not notify credential")
+	}
+	cancel()
+	<-done
+}
+
 func TestHumanApproverTimeoutRecordsTimedOutTerminalState(t *testing.T) {
 	pool := newCaptureHITLPool()
 	done := make(chan struct {

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -427,6 +427,15 @@ type ApproveRequest struct {
 	// prompt as a reply in this Slack thread rather than top-level.
 	// Populated from the X-HITL-Thread-TS request header.
 	ThreadTS string
+	// Channel, when set, overrides the human_approver block's static
+	// `channel` field at notification time — used by agents that
+	// investigate incidents across multiple Slack channels and want
+	// the approval prompt to land in the originating thread's channel
+	// rather than a fixed one. Populated from the X-HITL-Channel
+	// request header. Validated as a Slack channel ID
+	// (`^C[A-Z0-9]+$`) at the read site; invalid values are dropped
+	// so the static fallback wins.
+	Channel string
 	// AsyncOperationID binds the prompt to a durable async operation.
 	// If AsyncPendingOnSyncTimeout is true and ctx hits DeadlineExceeded,
 	// human_approver leaves the prompt pending and returns async_pending.


### PR DESCRIPTION
## Summary

`human_approver` blocks today hard-code a single destination channel. An agent that investigates incidents across multiple Slack channels needs the approval prompt to land in whichever channel the originating session came from — which today requires N approver blocks and N rules with header-routing CEL on each rule.

This adds the same per-request override that `ThreadTS` already has, just for channel. When the inbound request carries `X-HITL-Channel: <id>`, the validated value replaces `h.Channel` at notification time. Empty/invalid header → fall back to the static block field, so existing configs are unchanged.

## Why mirror ThreadTS rather than add a CEL facet

The full-CEL approach (CEL-evaluable `channel` reading a `slack.session.channel` facet) was the first design considered — but `ThreadTS` already plumbs an identical per-request value via the `X-HITL-Thread-TS` header, validated and dispatched the same way. Reusing that shape:

- ~150 LOC instead of ~500
- No new facet, no grammar / parser changes, no doc burden on the operator
- Behaves intuitively next to `ThreadTS` (same source, same lifetime, same fallback story)
- Composes with `ThreadTS` cleanly: a request can pin both the channel AND the thread

The trade-off is the value is set by whoever proxies the request (today: the agent's own openclaw, mirroring how it sets `X-HITL-Thread-TS`), not declaratively in HCL.

## Plumbing

- `ApproveRequest.Channel` field, doc'd alongside `ThreadTS` (`internal/config/runtime/runtime.go`)
- `runApproveCtx.Channel` + read from `req.Header.Get(\"X-HITL-Channel\")` at the HTTP entry point + plumbed through `runApproveChain` into `ApproveRequest` (`cmd/clawpatrol/main.go`)
- `sanitizeSlackChannelHeader` validates: shape `^[CG][A-Z0-9]{8,23}$`, length-bounded, whitespace-trimmed. DMs (D…) and user IDs (U…) rejected — not valid HITL destinations. Lowercase / punctuation / injection shapes dropped to empty (caller falls back to static channel)
- `X-HITL-Channel` added to the upstream-strip list alongside `X-HITL-Thread-TS` so it never leaks to the real upstream
- `HumanApprover.Approve` prefers `req.Channel` over `h.Channel` for `HITLTarget.Channel`; falls back when empty

## Test plan

- [x] `go build ./...` clean
- [x] New: `TestSanitizeSlackChannelHeader` — public/private accepts, DM/user/lowercase/injection rejects, length bounds, whitespace trim
- [x] New: `TestHumanApproverRequestChannelOverridesBlockChannel` — `req.Channel != \"\"` wins over `h.Channel = \"C-STATIC\"`
- [x] New: `TestHumanApproverEmptyRequestChannelFallsBackToBlockChannel` — `req.Channel == \"\"` keeps existing behavior
- [x] Full `internal/config/plugins/approvers` + `cmd/clawpatrol` suites pass (~28s)
- [x] `gofmt -l .` clean

## Caller-side rollout (separate from this PR)

The agent / openclaw will start emitting `X-HITL-Channel: <slack channel id>` on outbound HTTP requests originating from a given Slack session. Once shipped, a single `human_approver \"incident-response\" {}` block can route prompts to whichever channel triggered the agent — no per-channel approver duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)