### PR TITLE
fix: scope settings credential Profiles column to each profile's own list

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -715,26 +715,36 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 // column for profiles and one for endpoints so an operator can see
 // at a glance where a credential is in play.
 //
-// Profiles are matched strictly against each CompiledProfile's own
-// HCL-declared `credentials = [...]` list (plus the tunnel chain on
-// the profile's endpoints for tunnel-attached auth). Walking the
-// global endpoint→credentials list would leak sibling profiles
-// onto the row whenever two profiles share an endpoint — e.g. the
-// postgres `pg` endpoint carries both `pg-readonly` and `pg-writer`,
-// and profile "data" (declares only `pg-readonly`) must not appear
-// in `pg-writer`'s Profiles cell. Mirror of the device-page fix in
-// cl-lgwg / commit b0a3813.
+// Both columns read in the canonical "credentials bind endpoints"
+// direction:
 //
-// Endpoints stay on the global binding — that column is genuinely
-// "which endpoints declare this credential", profile-agnostic.
+//   - Endpoints: the credential's own `endpoint` / `endpoints`
+//     framework attr (via config.CredentialEndpointTargets), plus any
+//     endpoint whose tunnel chain attaches this credential.
+//   - Profiles: each CompiledProfile's own HCL-declared `credentials`
+//     list, plus the tunnel chain on the profile's endpoints for
+//     tunnel-attached auth.
+//
+// Walking the inverted CompiledEndpoint.Credentials list would leak
+// sibling profiles onto the Profiles column whenever two profiles
+// share an endpoint — e.g. the postgres `pg` endpoint carries both
+// `pg-readonly` and `pg-writer`, and profile "data" (declares only
+// `pg-readonly`) must not appear in `pg-writer`'s Profiles cell.
+// Mirror of the device-page fix in cl-lgwg / commit b0a3813.
 func credentialBindings(policy *config.CompiledPolicy, credName string) (profiles, endpoints []string) {
 	if policy == nil {
 		return nil, nil
 	}
 	epSet := map[string]bool{}
+	for _, n := range config.CredentialEndpointTargets(policy.Credentials[credName]) {
+		epSet[n] = true
+	}
 	for epName, ep := range policy.Endpoints {
-		if endpointBindsCredential(ep, credName) {
-			epSet[epName] = true
+		for tun := ep.Tunnel; tun != nil; tun = tun.Via {
+			if tun.Credential != nil && tun.Credential.Symbol != nil && tun.Credential.Symbol.Name == credName {
+				epSet[epName] = true
+				break
+			}
 		}
 	}
 	if len(epSet) > 0 {
@@ -778,23 +788,6 @@ func profileBindsCredential(prof *config.CompiledProfile, credName string) bool 
 			if tun.Credential != nil && tun.Credential.Symbol != nil && tun.Credential.Symbol.Name == credName {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func endpointBindsCredential(ep *config.CompiledEndpoint, credName string) bool {
-	if ep == nil {
-		return false
-	}
-	for _, cb := range ep.Credentials {
-		if cb != nil && cb.Symbol != nil && cb.Symbol.Name == credName {
-			return true
-		}
-	}
-	for tun := ep.Tunnel; tun != nil; tun = tun.Via {
-		if tun.Credential != nil && tun.Credential.Symbol.Name == credName {
-			return true
 		}
 	}
 	return false

--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -711,10 +711,22 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 }
 
 // credentialBindings reports every profile + endpoint that references
-// the named credential, walking endpoint.Credentials AND the chain of
-// tunnels the endpoint dials through. The dashboard's details table
-// renders one column for profiles and one for endpoints so an
-// operator can see at a glance where a credential is in play.
+// the named credential. The dashboard's details table renders one
+// column for profiles and one for endpoints so an operator can see
+// at a glance where a credential is in play.
+//
+// Profiles are matched strictly against each CompiledProfile's own
+// HCL-declared `credentials = [...]` list (plus the tunnel chain on
+// the profile's endpoints for tunnel-attached auth). Walking the
+// global endpoint→credentials list would leak sibling profiles
+// onto the row whenever two profiles share an endpoint — e.g. the
+// postgres `pg` endpoint carries both `pg-readonly` and `pg-writer`,
+// and profile "data" (declares only `pg-readonly`) must not appear
+// in `pg-writer`'s Profiles cell. Mirror of the device-page fix in
+// cl-lgwg / commit b0a3813.
+//
+// Endpoints stay on the global binding — that column is genuinely
+// "which endpoints declare this credential", profile-agnostic.
 func credentialBindings(policy *config.CompiledPolicy, credName string) (profiles, endpoints []string) {
 	if policy == nil {
 		return nil, nil
@@ -734,11 +746,8 @@ func credentialBindings(policy *config.CompiledPolicy, credName string) (profile
 	}
 	profSet := map[string]bool{}
 	for pname, prof := range policy.Profiles {
-		for epName, ep := range prof.Endpoints {
-			if epSet[epName] || endpointBindsCredential(ep, credName) {
-				profSet[pname] = true
-				break
-			}
+		if profileBindsCredential(prof, credName) {
+			profSet[pname] = true
 		}
 	}
 	if len(profSet) > 0 {
@@ -749,6 +758,29 @@ func credentialBindings(policy *config.CompiledPolicy, credName string) (profile
 		sort.Strings(profiles)
 	}
 	return profiles, endpoints
+}
+
+// profileBindsCredential reports whether the profile's own HCL list
+// declares the credential, or reaches it via a tunnel attached to one
+// of its endpoints. Mirrors credentialsInProfile's data sources so
+// the inverse rendering stays consistent with the per-device view.
+func profileBindsCredential(prof *config.CompiledProfile, credName string) bool {
+	if prof == nil {
+		return false
+	}
+	for _, ent := range prof.Credentials {
+		if ent != nil && ent.Symbol != nil && ent.Symbol.Name == credName {
+			return true
+		}
+	}
+	for _, ep := range prof.Endpoints {
+		for tun := ep.Tunnel; tun != nil; tun = tun.Via {
+			if tun.Credential != nil && tun.Credential.Symbol != nil && tun.Credential.Symbol.Name == credName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func endpointBindsCredential(ep *config.CompiledEndpoint, credName string) bool {

--- a/cmd/clawpatrol/credential_bindings_test.go
+++ b/cmd/clawpatrol/credential_bindings_test.go
@@ -80,14 +80,21 @@ rule "default-allow" {
 // "data" declares only pg-readonly and must appear under pg-readonly
 // only, not pg-writer.
 func TestCredentialBindingsDoesNotLeakSiblingProfiles(t *testing.T) {
-	readonly := &config.Entity{Symbol: &config.Symbol{Name: "pg-readonly"}}
-	writer := &config.Entity{Symbol: &config.Symbol{Name: "pg-writer"}}
+	pgTargets := config.FrameworkAttrs{
+		RefLists: map[string][]string{"endpoints": {"pg"}},
+	}
+	readonly := &config.Entity{Symbol: &config.Symbol{Name: "pg-readonly"}, Framework: pgTargets}
+	writer := &config.Entity{Symbol: &config.Symbol{Name: "pg-writer"}, Framework: pgTargets}
 	ep := &config.CompiledEndpoint{
 		Name:        "pg",
 		Credentials: []*config.Entity{readonly, writer},
 	}
 	policy := &config.CompiledPolicy{
 		Endpoints: map[string]*config.CompiledEndpoint{"pg": ep},
+		Credentials: map[string]*config.Entity{
+			"pg-readonly": readonly,
+			"pg-writer":   writer,
+		},
 		Profiles: map[string]*config.CompiledProfile{
 			"data": {
 				Credentials: []*config.Entity{readonly},

--- a/cmd/clawpatrol/credential_bindings_test.go
+++ b/cmd/clawpatrol/credential_bindings_test.go
@@ -71,6 +71,73 @@ rule "default-allow" {
 	}
 }
 
+// Settings-page Profiles column must NOT leak sibling profiles onto
+// a credential's row. Regression for cl-c38g (inverse of cl-lgwg):
+// credentialBindings previously walked the global endpoint→credentials
+// list to populate profiles, so any profile routing through a shared
+// endpoint claimed every credential bound to that endpoint. The
+// postgres "pg" endpoint binds both pg-readonly and pg-writer; profile
+// "data" declares only pg-readonly and must appear under pg-readonly
+// only, not pg-writer.
+func TestCredentialBindingsDoesNotLeakSiblingProfiles(t *testing.T) {
+	readonly := &config.Entity{Symbol: &config.Symbol{Name: "pg-readonly"}}
+	writer := &config.Entity{Symbol: &config.Symbol{Name: "pg-writer"}}
+	ep := &config.CompiledEndpoint{
+		Name:        "pg",
+		Credentials: []*config.Entity{readonly, writer},
+	}
+	policy := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{"pg": ep},
+		Profiles: map[string]*config.CompiledProfile{
+			"data": {
+				Credentials: []*config.Entity{readonly},
+				Endpoints:   map[string]*config.CompiledEndpoint{"pg": ep},
+			},
+			"platform": {
+				Credentials: []*config.Entity{writer},
+				Endpoints:   map[string]*config.CompiledEndpoint{"pg": ep},
+			},
+		},
+	}
+	roProfs, roEps := credentialBindings(policy, "pg-readonly")
+	if !sliceEq(roProfs, []string{"data"}) {
+		t.Errorf("pg-readonly profiles got %v want [data] (must not include platform)", roProfs)
+	}
+	if !sliceEq(roEps, []string{"pg"}) {
+		t.Errorf("pg-readonly endpoints got %v want [pg]", roEps)
+	}
+	wrProfs, wrEps := credentialBindings(policy, "pg-writer")
+	if !sliceEq(wrProfs, []string{"platform"}) {
+		t.Errorf("pg-writer profiles got %v want [platform] (must not include data)", wrProfs)
+	}
+	if !sliceEq(wrEps, []string{"pg"}) {
+		t.Errorf("pg-writer endpoints got %v want [pg]", wrEps)
+	}
+}
+
+// Tunnel-attached credentials must still surface on every profile
+// whose endpoint set reaches the tunnel — mirrors the tunnel walk
+// kept in credentialsInProfile after the cl-lgwg fix.
+func TestCredentialBindingsSurfacesTunnelAttachedCredentials(t *testing.T) {
+	tailnet := &config.Entity{Symbol: &config.Symbol{Name: "tailnet-auth"}}
+	ep := &config.CompiledEndpoint{
+		Name:   "internal_api",
+		Tunnel: &config.CompiledTunnel{Name: "corp", Credential: tailnet},
+	}
+	policy := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{"internal_api": ep},
+		Profiles: map[string]*config.CompiledProfile{
+			"eng": {
+				Endpoints: map[string]*config.CompiledEndpoint{"internal_api": ep},
+			},
+		},
+	}
+	profs, _ := credentialBindings(policy, "tailnet-auth")
+	if !sliceEq(profs, []string{"eng"}) {
+		t.Errorf("tailnet-auth profiles got %v want [eng] via tunnel walk", profs)
+	}
+}
+
 // TestCredentialConfigOperatorFields extracts the per-credential
 // operator-set HCL attrs back from the Emit hook. Postgres exposes
 // `user`; the dashboard's details table renders it as a column.

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -349,7 +349,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			}
 			profile.Credentials = append(profile.Credentials, credEnt)
 			merged := mergeDisambig(blockDisambiguators(credEnt), pr.Disambiguators[credName])
-			for _, epName := range credentialEndpointTargets(credEnt) {
+			for _, epName := range CredentialEndpointTargets(credEnt) {
 				ce, ok := cp.Endpoints[epName]
 				if !ok {
 					continue
@@ -413,11 +413,16 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	return cp, nil
 }
 
-// credentialEndpointTargets returns the endpoint names a credential
+// CredentialEndpointTargets returns the endpoint names a credential
 // binds. Reads either the singular `endpoint` framework attr or the
 // list-form `endpoints`; cross-credential validation has already
 // rejected the both-set case.
-func credentialEndpointTargets(ent *Entity) []string {
+//
+// This is the canonical "credentials bind endpoints" direction.
+// CompiledEndpoint.Credentials is the inverted index built from these
+// targets — callers asking "which endpoints does credential C declare?"
+// should use this function, not walk every endpoint's Credentials list.
+func CredentialEndpointTargets(ent *Entity) []string {
 	if ent == nil {
 		return nil
 	}
@@ -444,7 +449,7 @@ func attachCredentials(cp *CompiledPolicy, p *Policy) error {
 		if !ok {
 			return nil
 		}
-		targets := credentialEndpointTargets(ent)
+		targets := CredentialEndpointTargets(ent)
 		if len(targets) == 0 {
 			return nil
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1058,7 +1058,7 @@ func validateProfileDisambiguators(p *Policy, table *SymbolTable) hcl.Diagnostic
 				continue
 			}
 			members[credName] = true
-			memberEndpoints[credName] = credentialEndpointTargets(ent)
+			memberEndpoints[credName] = CredentialEndpointTargets(ent)
 			mergedDisambig[credName] = mergeDisambig(blockDisambiguators(ent), pr.Disambiguators[credName])
 
 			// Per-type field validity on the profile-inline side too.


### PR DESCRIPTION
## Summary

`credentialBindings` (cmd/clawpatrol/agents.go) populated the settings-page credentials table's **Profiles** cell by collecting every endpoint globally bound to the credential and then claiming any profile whose endpoint set intersected. That walks the global endpoint→credentials list — the inverse of the bug fixed in commit b0a3813 (#cl-lgwg) for the device page.

With the postgres `pg` endpoint binding both `pg-readonly` and `pg-writer`, profile `data` (declares only `pg-readonly`) showed up under `pg-writer`'s row on the settings credentials table, and vice versa.

Fix: match each profile against `CompiledProfile.Credentials` directly (the profile's HCL-declared list, populated by `Compile()` from `pr.Credentials`) and keep the tunnel-chain walk for tunnel-attached auth — same data sources as `credentialsInProfile`, so the per-credential view and the per-device view stay consistent. The **Endpoints** column is unchanged: it's genuinely the global endpoint→credentials projection.

Runtime dispatch (`ResolveCredential`) was already profile-scoped — re-ran the existing `TestResolveCredentialIsolatesProfilesSharingEndpoint` pin, still green.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `TestCredentialBindingsDoesNotLeakSiblingProfiles` — new, pins credential→profiles direction with the shared-endpoint repro
- [x] `TestCredentialBindingsSurfacesTunnelAttachedCredentials` — new, pins the tunnel-walk path
- [x] `TestCredentialBindings` — existing happy-path cases still pass
- [x] `TestResolveCredentialIsolatesProfilesSharingEndpoint` — re-run, runtime matcher still isolates profiles
- [x] `gofmt -l .` clean