### PR TITLE
fix: decouple tailscale credential status from tunnel liveness (cl-eh83)

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -599,15 +599,18 @@ type IntegrationRow struct {
 
 // TailscaleAuthStatusUI is the dashboard-facing slice of a
 // tailscale-node-auth credential's live state. Connected reflects
-// whether tsnet's BackendState is Running — not merely whether
-// identity bytes have been persisted, which can happen mid-auth
-// before the tailnet join completes. State carries the underlying
-// label so the card can distinguish "awaiting authentication" from
-// "starting" from "stopped". PendingURL is the live Tailscale login
-// URL emitted by tsnet during NeedsLogin — the dashboard's "Connect"
-// button redirects to it. Endpoint paths are surfaced so the
-// dashboard renders the connect flow without hard-coding the route
-// layout.
+// tailnet-auth validity, not tunnel liveness: a credential whose
+// OAuth-issued node identity is persisted and has not been observed
+// to fail (NeedsLogin / NeedsMachAuth / InUseOtherUser) reads as
+// connected even when the tunnel is idle and tsnet is torn down.
+// State carries the underlying live BackendState label (or a
+// hasPersistedSlots-aware fallback) so the card can distinguish
+// "awaiting authentication" from "starting" from "stopped" from
+// "running" — that's the tunnel signal, separate from the credential
+// signal. PendingURL is the live Tailscale login URL emitted by
+// tsnet during NeedsLogin — the dashboard's "Connect" button
+// redirects to it. Endpoint paths are surfaced so the dashboard
+// renders the connect flow without hard-coding the route layout.
 type TailscaleAuthStatusUI struct {
 	Connected bool                          `json:"connected"`
 	State     tailscaleproto.NodeStateLabel `json:"state"`
@@ -686,16 +689,11 @@ func (w *webMux) statusList(r *http.Request) []IntegrationRow {
 			row.HasTailscaleAuth = true
 			present, _ := credentialSlotPresence(w.g.db, name)
 			label := tailscaleproto.DefaultStates.Get(name)
-			// Connected reads strictly from the live BackendState:
-			// persisted slots prove auth completed *at some point*, not
-			// that the node is currently joined. A gateway restart sees
-			// slots but Starting/NeedsLogin until tsnet finishes its
-			// boot — surfacing "connected" in that window misled the
-			// operator into thinking traffic could flow.
+			hasSlots := len(present) > 0
 			row.TailscaleAuth = &TailscaleAuthStatusUI{
-				Connected:     label == tailscaleproto.NodeStateRunning,
-				State:         dashboardTailscaleState(label, len(present) > 0),
-				HasState:      len(present) > 0,
+				Connected:     tailscaleCredentialAuthValid(label, hasSlots),
+				State:         dashboardTailscaleState(label, hasSlots),
+				HasState:      hasSlots,
 				PendingURL:    tailscaleproto.Default.Get(name),
 				ConnectURL:    "/api/tailscale/connect?id=" + name,
 				StatusURL:     "/api/tailscale/status?id=" + name,
@@ -790,6 +788,42 @@ func credentialConfig(ent *config.Entity, name string) map[string]string {
 		out[n] = strings.TrimSpace(raw)
 	}
 	return out
+}
+
+// tailscaleCredentialAuthValid reports whether a tailscale-node-auth
+// credential should be rendered as "connected" in the dashboard. It
+// is a function of credential auth state alone, not tunnel liveness:
+// tunnels open lazily and close on idle, and the credential's OAuth
+// grant remains valid across those cycles. A fresh auth attempt
+// against the tailnet only fails if the operator (or a tailnet admin)
+// has revoked the grant or invalidated the node — which surfaces as
+// tsnet entering NeedsLogin / NeedsMachineAuth / InUseOtherUser. As
+// long as the watcher hasn't observed one of those auth-trouble
+// states, persisted credential_secrets stand as proof that the OAuth
+// flow succeeded and the node identity is accepted.
+//
+// Two paths read as connected:
+//   - tsnet is currently Running for this credential (live join, the
+//     strongest possible signal);
+//   - persisted node-identity slots exist and the live state is not
+//     one of the explicit auth-trouble labels (cached last-known-good,
+//     the spec for an idle tunnel).
+//
+// Everything else reads as not-connected, including no-persisted-
+// slots-and-not-Running (operator has never completed the auth) and
+// any of the auth-trouble labels (the tailnet itself reported the
+// credential is no longer good, so cached slots are stale).
+func tailscaleCredentialAuthValid(label tailscaleproto.NodeStateLabel, hasPersistedSlots bool) bool {
+	if label == tailscaleproto.NodeStateRunning {
+		return true
+	}
+	switch label {
+	case tailscaleproto.NodeStateNeedsLogin,
+		tailscaleproto.NodeStateNeedsMachAuth,
+		tailscaleproto.NodeStateInUseOtherUser:
+		return false
+	}
+	return hasPersistedSlots
 }
 
 // dashboardTailscaleState narrows the live BackendState for the

--- a/cmd/clawpatrol/tailscale_dashboard.go
+++ b/cmd/clawpatrol/tailscale_dashboard.go
@@ -60,8 +60,12 @@ type tailscaleAuthResponse struct {
 //
 // Three response states:
 //
-//   - "connected": node state already lives in credential_secrets;
-//     the operator doesn't need to click Connect.
+//   - "connected": credential auth is valid — either tsnet is live-
+//     Running for this credential, or persisted node identity is
+//     present and the watcher has not observed an auth-trouble state
+//     (NeedsLogin / NeedsMachAuth / InUseOtherUser). Tunnel may still
+//     be torn down (idle) — that's a tunnel signal, not a credential
+//     signal. Operator has nothing to click.
 //   - "pending": tsnet has a live login URL ready — the dashboard
 //     redirects the browser to it.
 //   - "awaiting_url": the credential exists but tsnet hasn't emitted a
@@ -95,15 +99,16 @@ func (w *webMux) apiTailscaleConnect(rw http.ResponseWriter, r *http.Request) {
 	resp := tailscaleAuthResponse{ID: id}
 	label := tailscaleproto.DefaultStates.Get(id)
 	resp.State = label
-	switch label {
-	case tailscaleproto.NodeStateRunning:
-		// Live tsnet has joined the tailnet — no operator click
-		// needed. Persisted slots alone (the previous "connected"
-		// gate) are not enough: they can exist while tsnet is still
-		// Starting or even in NeedsLogin after a state reset.
+	present, _ := credentialSlotPresence(w.g.db, id)
+	hasSlots := len(present) > 0
+	if tailscaleCredentialAuthValid(label, hasSlots) {
+		// Either tsnet is live-Running, or persisted node identity is
+		// still good (idle tunnel — auth doesn't get invalidated by
+		// the tunnel cycling). Either way the operator has nothing to
+		// click; reporting "connected" matches the /api/state row.
 		resp.Connected = true
 		resp.Status = "connected"
-	default:
+	} else {
 		if u := tailscaleproto.Default.Get(id); u != "" {
 			resp.AuthURL = u
 			resp.PendingURL = u

--- a/cmd/clawpatrol/tailscale_dashboard_test.go
+++ b/cmd/clawpatrol/tailscale_dashboard_test.go
@@ -210,12 +210,31 @@ func TestDashboardTailscaleStateRespectsLive(t *testing.T) {
 		want      tailscaleproto.NodeStateLabel
 		connected bool
 	}{
+		// Live Running: always connected. State label is the live one.
 		{"running with slots", tailscaleproto.NodeStateRunning, true, tailscaleproto.NodeStateRunning, true},
 		{"running no slots", tailscaleproto.NodeStateRunning, false, tailscaleproto.NodeStateRunning, true},
-		{"starting overrides slots", tailscaleproto.NodeStateStarting, true, tailscaleproto.NodeStateStarting, false},
+
+		// Starting with persisted identity: not yet joined, but auth is
+		// good (cached). Credential reads as connected; state surfaces
+		// the live "starting" so the tunnel signal is still visible.
+		{"starting with slots", tailscaleproto.NodeStateStarting, true, tailscaleproto.NodeStateStarting, true},
+		{"starting no slots", tailscaleproto.NodeStateStarting, false, tailscaleproto.NodeStateStarting, false},
+
+		// NeedsLogin is the tailnet actively rejecting the persisted
+		// identity — cached slots are stale, credential is not valid.
 		{"needs login with slots", tailscaleproto.NodeStateNeedsLogin, true, tailscaleproto.NodeStateNeedsLogin, false},
-		{"unknown with slots maps to stopped", tailscaleproto.NodeStateUnknown, true, tailscaleproto.NodeStateStopped, false},
+		{"needs login no slots", tailscaleproto.NodeStateNeedsLogin, false, tailscaleproto.NodeStateNeedsLogin, false},
+		{"needs machine auth with slots", tailscaleproto.NodeStateNeedsMachAuth, true, tailscaleproto.NodeStateNeedsMachAuth, false},
+		{"in use other user with slots", tailscaleproto.NodeStateInUseOtherUser, true, tailscaleproto.NodeStateInUseOtherUser, false},
+
+		// Idle / torn-down tunnel: tsnet was Close()'d so DefaultStates
+		// is cleared (Unknown). Auth is still valid via persisted slots
+		// — this is the bug-fix case (cl-eh83). State label flips to
+		// "stopped" to keep the tunnel signal honest.
+		{"unknown with slots → connected (idle tunnel)", tailscaleproto.NodeStateUnknown, true, tailscaleproto.NodeStateStopped, true},
 		{"unknown no slots stays unknown", tailscaleproto.NodeStateUnknown, false, tailscaleproto.NodeStateUnknown, false},
+		{"stopped with slots → connected", tailscaleproto.NodeStateStopped, true, tailscaleproto.NodeStateStopped, true},
+		{"stopped no slots → not connected", tailscaleproto.NodeStateStopped, false, tailscaleproto.NodeStateStopped, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -223,8 +242,8 @@ func TestDashboardTailscaleStateRespectsLive(t *testing.T) {
 			if got != tc.want {
 				t.Fatalf("dashboardTailscaleState(%q, slots=%v) = %q, want %q", tc.label, tc.slots, got, tc.want)
 			}
-			if connected := tc.label == tailscaleproto.NodeStateRunning; connected != tc.connected {
-				t.Fatalf("connected = %v, want %v", connected, tc.connected)
+			if connected := tailscaleCredentialAuthValid(tc.label, tc.slots); connected != tc.connected {
+				t.Fatalf("tailscaleCredentialAuthValid(%q, slots=%v) = %v, want %v", tc.label, tc.slots, connected, tc.connected)
 			}
 		})
 	}
@@ -300,6 +319,58 @@ func TestApiTailscaleConnectRunningStateMarksConnected(t *testing.T) {
 	}
 	if resp.State != tailscaleproto.NodeStateRunning {
 		t.Fatalf("response.State = %q, want running", resp.State)
+	}
+}
+
+// Regression for cl-eh83: when a tailscale tunnel closes due to
+// inactivity it calls DefaultStates.Set(name, NodeStateUnknown) — the
+// pre-fix /api/tailscale/connect handler keyed strictly off the live
+// BackendState and reported the credential as not-connected (status
+// "awaiting_url" or attempting to force-acquire a tunnel just to mint
+// a URL). The OAuth grant and persisted node identity are still
+// valid; the tunnel cycling is a separate concern. The handler must
+// fall through to the persisted-slots signal and report "connected".
+func TestApiTailscaleConnectIdleTunnelWithPersistedAuthReadsConnected(t *testing.T) {
+	const credName = "idle-cred"
+	defer tailscaleproto.DefaultStates.Set(credName, tailscaleproto.NodeStateUnknown)
+	// Simulate the tunnel having been Close()'d on idle: DefaultStates
+	// has the entry cleared, no parked URL.
+	tailscaleproto.DefaultStates.Set(credName, tailscaleproto.NodeStateUnknown)
+	tailscaleproto.Default.Set(credName, "")
+
+	db := newSessionTestDB(t)
+	// Persisted node identity from a prior successful auth. The exact
+	// slot name doesn't matter for credentialSlotPresence — any row is
+	// the "auth succeeded at some point" signal.
+	if err := setCredentialSlot(db, credName, "_machinekey", "stub-machine-key-bytes"); err != nil {
+		t.Fatalf("setCredentialSlot: %v", err)
+	}
+
+	g := &Gateway{db: db}
+	credEnt := &config.Entity{
+		Plugin: &config.Plugin{Type: "tailscale_credential"},
+		Body:   stubTailscaleCred{},
+	}
+	g.policy.Store(&config.CompiledPolicy{
+		Credentials: map[string]*config.Entity{credName: credEnt},
+	})
+	w := &webMux{g: g}
+
+	r := httptest.NewRequest(http.MethodPost, "/api/tailscale/connect?id="+credName, nil)
+	rw := httptest.NewRecorder()
+	w.apiTailscaleConnect(rw, r)
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %q, want 200", rw.Code, rw.Body.String())
+	}
+	var resp tailscaleAuthResponse
+	if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Connected || resp.Status != "connected" {
+		t.Fatalf("response = %+v, want Connected=true Status=connected (idle tunnel must not flip credential to disconnected)", resp)
+	}
+	if resp.AuthURL != "" || resp.PendingURL != "" {
+		t.Fatalf("response.AuthURL/PendingURL = %q/%q, want empty (no operator action required)", resp.AuthURL, resp.PendingURL)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The dashboard credential card surfaced **disconnected** whenever a tailscale tunnel closed on idle, because `Connected` was wired strictly to the live `ipn.State` (cleared to `NodeStateUnknown` in `tailscaleTunnelConn.Close()`).
- The OAuth-issued node identity is independent of any single tunnel's lifecycle — tunnels close on idle and re-open on demand. The credential should reflect tailnet-auth state, not tunnel state.
- New `tailscaleCredentialAuthValid(label, hasPersistedSlots)` returns true when tsnet is `Running` *or* when persisted credential_secrets exist and the watcher hasn't observed an auth-trouble state (`NeedsLogin` / `NeedsMachAuth` / `InUseOtherUser`). `dashboardTailscaleState` still surfaces the live tunnel label so the tunnel signal stays visible separately.
- Applied at both the `/api/state` row builder (`statusList`) and the `/api/tailscale/connect` (and `/status` alias) handler, so polling an idle credential returns `connected` instead of force-acquiring a tunnel to mint an auth URL.

Closes cl-eh83.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] New: `TestApiTailscaleConnectIdleTunnelWithPersistedAuthReadsConnected` pins idle-tunnel + persisted slots → Connected=true at the handler
- [x] Updated: `TestDashboardTailscaleStateRespectsLive` cases now cover the auth-vs-tunnel split (idle/stopped + slots → connected; NeedsLogin/NeedsMachAuth/InUseOtherUser + slots → not connected)
- [ ] Manual: trigger a tunnel through a tailscale credential, let it idle out, verify dashboard card still shows green