### PR TITLE
fix: wait for daemon transport readiness before exec'ing wrapped command

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -91,10 +91,27 @@ type daemonTransport interface {
 	// Each `clawpatrol run` repeats it on stderr so configuration
 	// issues surface without tailing daemon.log.
 	BootWarning() string
+	// WaitReady blocks until the transport can actually carry user
+	// traffic — wg: a handshake has completed; tsnet: exit-node
+	// routing is up (the gateway is reachable on the tailnet). The
+	// daemon calls this once per session, after the TUN handoff and
+	// before signalling ATTACHED, so the wrapped child never execs
+	// into a tunnel that silently drops its first packets. Returns
+	// nil immediately on the warm path once readiness has been
+	// observed at least once this daemon lifetime. Returns ctx.Err()
+	// (wrapped) on timeout.
+	WaitReady(ctx context.Context) error
 	// Close tears down the transport. Best-effort — the daemon is
 	// about to exit.
 	Close() error
 }
+
+// daemonReadyTimeout caps how long a session START waits for the
+// transport to become usable before failing with READYERR. The wg
+// boot wait is itself 10s and tsnet's is 8s; this is the worst-case
+// for a daemon that survived boot in a "warned" state and is now
+// catching up on a delayed handshake/probe.
+const daemonReadyTimeout = 30 * time.Second
 
 // daemonRuntimeDir resolves the directory holding the daemon's
 // coordination state (control socket, spawn lock, log). It MUST be a
@@ -576,6 +593,20 @@ func (d *daemon) handle(c net.Conn) {
 	tunFile := os.NewFile(uintptr(tunFd), tunIfName)
 	defer func() { _ = tunFile.Close() }()
 
+	// 2.5. Block until the transport can actually carry traffic. Warm
+	// path is a single atomic load; cold path waits for the handshake
+	// / exit-node probe. On timeout we ship a READYERR frame so the
+	// wrapper fails with a clear message instead of exec'ing the
+	// child into a tunnel that silently drops its first packets.
+	rctx, rcancel := context.WithTimeout(context.Background(), daemonReadyTimeout)
+	rerr := d.transport.WaitReady(rctx)
+	rcancel()
+	if rerr != nil {
+		log.Printf("daemon: WaitReady: %v", rerr)
+		_ = daemonWriteReadyErr(c, rerr.Error())
+		return
+	}
+
 	// 3. Build the per-session gVisor stack. Multiple sessions share
 	// the daemon's single transport but each gets its own stack so a
 	// misbehaving session can't OOM a neighbor.
@@ -712,6 +743,24 @@ func daemonWriteStartReply(w io.Writer, addr netip.Addr, envVars []byte, warning
 	}
 	if len(warning) > 0 {
 		if _, err := io.WriteString(w, warning); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// daemonWriteReadyErr writes the "READYERR <n>\n<n bytes>" frame the
+// daemon sends in place of "ATTACHED\n" when WaitReady fails. The
+// frame is length-prefixed so the client parser never has to peek
+// ahead, and the body carries the underlying error text so the user
+// sees why their tunnel isn't ready (handshake timeout, exit-node
+// ACL missing, etc).
+func daemonWriteReadyErr(w io.Writer, msg string) error {
+	if _, err := fmt.Fprintf(w, "READYERR %d\n", len(msg)); err != nil {
+		return err
+	}
+	if len(msg) > 0 {
+		if _, err := io.WriteString(w, msg); err != nil {
 			return err
 		}
 	}

--- a/cmd/clawpatrol/daemon_ready_linux_test.go
+++ b/cmd/clawpatrol/daemon_ready_linux_test.go
@@ -1,0 +1,309 @@
+//go:build linux
+
+package main
+
+// WaitReady-pathway tests: the bare polling loops behind each
+// transport's WaitReady, plus the ATTACHED-or-READYERR wire format
+// exchanged with the wrapper, and one daemon.handle round-trip that
+// proves READYERR is what reaches the client when WaitReady fails.
+// The polling loops are split out so the ready-check logic is
+// exercisable without booting tsnet or wireguard-go.
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestWGConfigHasHandshake covers the parser that converts
+// wireguard-go's IpcGet blob into a "handshake done?" boolean. The
+// daemon's wg WaitReady polls this on every tick, so a regression
+// here (handshake never detected, or false positive on the zero
+// line) directly translates to either an infinite wait or a wrapper
+// that exec's into a tunnel that hasn't actually carried a packet.
+func TestWGConfigHasHandshake(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"absent line", "private_key=abc\npublic_key=def\n", false},
+		{"explicit zero", "public_key=def\nlast_handshake_time_sec=0\n", false},
+		{"non-zero", "public_key=def\nlast_handshake_time_sec=1734200000\nlast_handshake_time_nsec=0\n", true},
+		{"trailing junk after value tolerated", "last_handshake_time_sec=42 garbage\n", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wgConfigHasHandshake(tc.cfg); got != tc.want {
+				t.Fatalf("wgConfigHasHandshake(%q) = %v, want %v", tc.cfg, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPollWGReady_ColdToReady mimics the cold-start case: the first
+// few IpcGet returns carry no handshake, then one does. pollWGReady
+// must keep polling instead of returning early, and must stop the
+// instant the handshake appears.
+func TestPollWGReady_ColdToReady(t *testing.T) {
+	var calls atomic.Int32
+	getCfg := func() (string, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			return "public_key=def\nlast_handshake_time_sec=0\n", nil
+		}
+		return "public_key=def\nlast_handshake_time_sec=1734200000\n", nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := pollWGReady(ctx, getCfg, 5*time.Millisecond); err != nil {
+		t.Fatalf("pollWGReady cold→ready: %v", err)
+	}
+	if d := time.Since(start); d > time.Second {
+		t.Fatalf("pollWGReady cold→ready took %v, want < 1s", d)
+	}
+	if n := calls.Load(); n < 3 {
+		t.Fatalf("calls = %d, want ≥ 3", n)
+	}
+}
+
+// TestPollWGReady_WarmIsImmediate is the no-measurable-delay
+// invariant for the warm path: if IpcGet reports handshake done on
+// the very first read, pollWGReady must return without ever
+// scheduling its tick.
+func TestPollWGReady_WarmIsImmediate(t *testing.T) {
+	var calls atomic.Int32
+	getCfg := func() (string, error) {
+		calls.Add(1)
+		return "last_handshake_time_sec=1734200000\n", nil
+	}
+	// A huge interval would expose a regression where the loop
+	// sleeps unconditionally on the first iteration.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := pollWGReady(ctx, getCfg, time.Hour); err != nil {
+		t.Fatalf("pollWGReady warm: %v", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("warm path: calls = %d, want 1 (no polling required)", n)
+	}
+}
+
+// TestPollWGReady_Timeout: handshake never lands, ctx expires →
+// pollWGReady returns ctx.Err. The caller wraps that into the
+// user-visible "wg handshake not established" message.
+func TestPollWGReady_Timeout(t *testing.T) {
+	getCfg := func() (string, error) {
+		return "last_handshake_time_sec=0\n", nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	err := pollWGReady(ctx, getCfg, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want DeadlineExceeded", err)
+	}
+}
+
+// TestPollTsnetReady_ColdToReady: the dial probe fails until the
+// exit-node ACL catches up, then succeeds. pollTsnetReady must keep
+// retrying without burning the entire budget on one hung dial.
+func TestPollTsnetReady_ColdToReady(t *testing.T) {
+	var calls atomic.Int32
+	dial := func(_ context.Context) error {
+		n := calls.Add(1)
+		if n < 3 {
+			return errors.New("no route")
+		}
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := pollTsnetReady(ctx, dial, 50*time.Millisecond, 5*time.Millisecond); err != nil {
+		t.Fatalf("pollTsnetReady cold→ready: %v", err)
+	}
+	if d := time.Since(start); d > time.Second {
+		t.Fatalf("pollTsnetReady cold→ready took %v, want < 1s", d)
+	}
+	if n := calls.Load(); n < 3 {
+		t.Fatalf("calls = %d, want ≥ 3", n)
+	}
+}
+
+// TestPollTsnetReady_WarmIsImmediate: a dial that succeeds on the
+// first try must not schedule any sleeps. Same no-measurable-delay
+// invariant as the wg warm case.
+func TestPollTsnetReady_WarmIsImmediate(t *testing.T) {
+	var calls atomic.Int32
+	dial := func(_ context.Context) error {
+		calls.Add(1)
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := pollTsnetReady(ctx, dial, time.Hour, time.Hour); err != nil {
+		t.Fatalf("pollTsnetReady warm: %v", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("warm path: calls = %d, want 1", n)
+	}
+}
+
+// TestPollTsnetReady_Timeout: dials never succeed, ctx expires → we
+// surface DeadlineExceeded so the wrapper can fail with a useful
+// error instead of hanging.
+func TestPollTsnetReady_Timeout(t *testing.T) {
+	dial := func(ctx context.Context) error {
+		// Honor the per-probe ctx so the test runs at the configured
+		// pace instead of the kernel's dial timeout.
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+	err := pollTsnetReady(ctx, dial, 30*time.Millisecond, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want DeadlineExceeded", err)
+	}
+}
+
+// TestDaemonReadyErr_ClientParses round-trips a READYERR frame
+// through the wire format: daemon writes it, the client parser
+// surfaces the body as the error text. The wrapper relies on the
+// body being preserved verbatim so the operator sees the actual
+// failure (e.g. "wg handshake not established: context deadline
+// exceeded") instead of a parser-stage error.
+func TestDaemonReadyErr_ClientParses(t *testing.T) {
+	daemonSide, clientSide := socketpairConns(t)
+	defer func() { _ = daemonSide.Close() }()
+	defer func() { _ = clientSide.Close() }()
+
+	msg := "wg handshake not established: context deadline exceeded"
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := daemonWriteReadyErr(daemonSide, msg); err != nil {
+			t.Errorf("daemonWriteReadyErr: %v", err)
+		}
+	}()
+
+	br := bufio.NewReader(clientSide)
+	err := daemonClientWaitAttached(clientSide, br)
+	wg.Wait()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), msg) {
+		t.Fatalf("err = %q, want it to contain %q", err.Error(), msg)
+	}
+}
+
+// TestDaemonReadyErr_EmptyBody covers the n=0 edge: the daemon
+// writes the framing but no body. Client must still return an
+// error (no ATTACHED arrived) without trying to read zero bytes
+// off the conn.
+func TestDaemonReadyErr_EmptyBody(t *testing.T) {
+	daemonSide, clientSide := socketpairConns(t)
+	defer func() { _ = daemonSide.Close() }()
+	defer func() { _ = clientSide.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := daemonWriteReadyErr(daemonSide, ""); err != nil {
+			t.Errorf("daemonWriteReadyErr: %v", err)
+		}
+	}()
+
+	br := bufio.NewReader(clientSide)
+	err := daemonClientWaitAttached(clientSide, br)
+	wg.Wait()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("err = %q, want it to mention 'not ready'", err.Error())
+	}
+}
+
+// readyErrTransport is a fakeTransport whose WaitReady fails — a wg
+// device that never handshakes, or a tsnet node whose exit-node
+// probe keeps timing out.
+type readyErrTransport struct {
+	fakeTransport
+	err error
+}
+
+func (t *readyErrTransport) WaitReady(context.Context) error { return t.err }
+
+// TestDaemonHandle_ReadyErrBeforeAttached drives daemon.handle end to
+// end over a socketpair — hello, START, TUN-fd handoff — with a
+// transport whose WaitReady fails. The client must get READYERR
+// carrying the transport's error text rather than ATTACHED, an EOF,
+// or a parse error, since that text is what `clawpatrol run` prints.
+func TestDaemonHandle_ReadyErrBeforeAttached(t *testing.T) {
+	daemonSide, clientSide := socketpairConns(t)
+	defer func() { _ = daemonSide.Close() }()
+	defer func() { _ = clientSide.Close() }()
+
+	want := "wg handshake not established: context deadline exceeded"
+	d := &daemon{
+		transport: &readyErrTransport{err: errors.New(want)},
+		envFetch:  func() []byte { return []byte("[]") },
+		// handle's close path arms the idle timer once the last
+		// session leaves; exited short-circuits that so tryExit can
+		// never os.Exit the test binary.
+		exited: true,
+	}
+	d.activeConns.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handle(daemonSide)
+	}()
+
+	if err := daemonHello(clientSide); err != nil {
+		t.Fatalf("hello: %v", err)
+	}
+	br, _, _, _, err := daemonClientStartSession(clientSide)
+	if err != nil {
+		t.Fatalf("START: %v", err)
+	}
+	// Any fd stands in for the TUN: handle only receives and closes it
+	// before WaitReady runs.
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	defer func() { _ = unix.Close(fds[1]) }()
+	if err := sendFDUnixConn(clientSide, fds[0]); err != nil {
+		t.Fatalf("send fd: %v", err)
+	}
+	_ = unix.Close(fds[0])
+
+	err = daemonClientWaitAttached(clientSide, br)
+	<-done
+	if err == nil {
+		t.Fatal("expected READYERR, got ATTACHED")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %q, want it to contain %q", err, want)
+	}
+}

--- a/cmd/clawpatrol/daemon_session_linux_test.go
+++ b/cmd/clawpatrol/daemon_session_linux_test.go
@@ -47,9 +47,10 @@ func (f *fakeTransport) Dial(_ context.Context, network, addr string) (net.Conn,
 	f.mu.Unlock()
 	return f.dial(network, addr)
 }
-func (f *fakeTransport) LocalAddr() netip.Addr { return netip.MustParseAddr("100.64.0.5") }
-func (f *fakeTransport) BootWarning() string   { return "" }
-func (f *fakeTransport) Close() error          { return nil }
+func (f *fakeTransport) LocalAddr() netip.Addr           { return netip.MustParseAddr("100.64.0.5") }
+func (f *fakeTransport) BootWarning() string             { return "" }
+func (f *fakeTransport) WaitReady(context.Context) error { return nil }
+func (f *fakeTransport) Close() error                    { return nil }
 
 func (f *fakeTransport) dialedAddrs() []string {
 	f.mu.Lock()

--- a/cmd/clawpatrol/daemon_transport_tsnet_linux.go
+++ b/cmd/clawpatrol/daemon_transport_tsnet_linux.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"tailscale.com/tsnet"
@@ -26,7 +27,15 @@ import (
 type tsnetTransport struct {
 	s           *tsnet.Server
 	localAddr   netip.Addr
+	gwIP        netip.Addr
 	bootWarning string
+	// ready caches the first observed successful exit-node probe so
+	// warm-path WaitReady is a single atomic load. Set on boot if the
+	// startup probe succeeded; set by WaitReady on the first cold-path
+	// success. Never flips back — once routing has worked, the
+	// "we've never been usable" distinction the wrapper cares about
+	// is permanently resolved for this daemon lifetime.
+	ready atomic.Bool
 }
 
 func (t *tsnetTransport) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -36,6 +45,55 @@ func (t *tsnetTransport) Dial(ctx context.Context, network, addr string) (net.Co
 func (t *tsnetTransport) LocalAddr() netip.Addr { return t.localAddr }
 func (t *tsnetTransport) BootWarning() string   { return t.bootWarning }
 func (t *tsnetTransport) Close() error          { return t.s.Close() }
+
+// WaitReady blocks until a probe dial to the gateway's tailnet IP on
+// port 53 succeeds (proving exit-node routing is up), or ctx expires.
+// Warm-path returns nil on the first atomic load. Cold-path is the
+// fallback for boots where the startup probe failed: we keep retrying
+// until the operator's tailnet ACL catches up or the timeout fires.
+func (t *tsnetTransport) WaitReady(ctx context.Context) error {
+	if t.ready.Load() {
+		return nil
+	}
+	dial := func(ctx context.Context) error {
+		c, err := t.s.Dial(ctx, "tcp", net.JoinHostPort(t.gwIP.String(), "53"))
+		if err != nil {
+			return err
+		}
+		_ = c.Close()
+		return nil
+	}
+	if err := pollTsnetReady(ctx, dial, tsnetReadyDialTimeout, tsnetReadyPollInterval); err != nil {
+		return fmt.Errorf("tsnet exit-node probe failed: %w", err)
+	}
+	t.ready.Store(true)
+	return nil
+}
+
+const (
+	tsnetReadyDialTimeout  = 2 * time.Second
+	tsnetReadyPollInterval = 200 * time.Millisecond
+)
+
+// pollTsnetReady runs dial in a loop until it returns nil or ctx is
+// done. Each call gets its own dialTimeout-bounded child ctx so a
+// hung exit-node hop can't consume the entire wait budget on one try.
+// Split out so the polling loop is testable without booting tsnet.
+func pollTsnetReady(ctx context.Context, dial func(context.Context) error, dialTimeout, interval time.Duration) error {
+	for {
+		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		err := dial(probeCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
 
 // startTsnetTransport reads persisted join state (auth-key, control-url,
 // gateway-ip), starts a tsnet.Server, waits for it to come up, points
@@ -104,14 +162,18 @@ func startTsnetTransport() (daemonTransport, error) {
 	// Probe by dialing the gateway's tailnet IP on port 53 — that
 	// port is bound by the gateway's tsnet DNS listener so a working
 	// path returns "connection established" within hundreds of ms.
-	var bootWarning string
+	var (
+		bootWarning string
+		bootReady   bool
+	)
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 8*time.Second)
 	if c, derr := s.Dial(probeCtx, "tcp", net.JoinHostPort(gwIP.String(), "53")); derr == nil {
 		_ = c.Close()
+		bootReady = true
 	} else {
 		bootWarning = fmt.Sprintf("tsnet probe: gateway unreachable via exit-node routing (%v). "+
 			"Check autoApprovers.exitNode in your tailnet ACL — see doc/tailscale.md. "+
-			"Outbound traffic from `clawpatrol run` will fail until the ACL is fixed.", derr)
+			"Each `clawpatrol run` waits up to %s for routing before failing.", derr, daemonReadyTimeout)
 		log.Printf("%s", bootWarning)
 	}
 	probeCancel()
@@ -126,7 +188,11 @@ func startTsnetTransport() (daemonTransport, error) {
 	// daemon restart.
 	daemonRegisterTsnetPeer(s, tsIP)
 
-	return &tsnetTransport{s: s, localAddr: tsIP, bootWarning: bootWarning}, nil
+	t := &tsnetTransport{s: s, localAddr: tsIP, gwIP: gwIP, bootWarning: bootWarning}
+	if bootReady {
+		t.ready.Store(true)
+	}
+	return t, nil
 }
 
 // daemonRegisterTsnetPeer POSTs this daemon's tsnet IP to the

--- a/cmd/clawpatrol/daemon_transport_wg_linux.go
+++ b/cmd/clawpatrol/daemon_transport_wg_linux.go
@@ -23,6 +23,7 @@ import (
 	"net/netip"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.zx2c4.com/wireguard/device"
@@ -55,10 +56,70 @@ type wgTransport struct {
 	tun         *wgClientTun
 	localAddr   netip.Addr
 	bootWarning string
+	// ready caches the first observed "handshake done" so warm-path
+	// WaitReady is a single atomic load. Once true, never flips back —
+	// a later rekey or peer roam doesn't invalidate the daemon-wide
+	// "we've talked to the peer at least once" signal that distinguishes
+	// "cold" from "warm" for the wrapped child.
+	ready atomic.Bool
 }
 
 func (t *wgTransport) LocalAddr() netip.Addr { return t.localAddr }
 func (t *wgTransport) BootWarning() string   { return t.bootWarning }
+
+// WaitReady blocks until wireguard-go reports a completed handshake,
+// or ctx expires. Warm-path: returns nil immediately once a handshake
+// has been observed at least once this daemon lifetime. Cold-path:
+// polls IpcGet every wgReadyPollInterval until last_handshake_time_sec
+// becomes non-zero.
+func (t *wgTransport) WaitReady(ctx context.Context) error {
+	if t.ready.Load() {
+		return nil
+	}
+	if err := pollWGReady(ctx, t.dev.IpcGet, wgReadyPollInterval); err != nil {
+		return fmt.Errorf("wg handshake not established: %w", err)
+	}
+	t.ready.Store(true)
+	return nil
+}
+
+const wgReadyPollInterval = 50 * time.Millisecond
+
+// pollWGReady polls getCfg (wireguard-go's IpcGet output) every
+// interval until the peer's last_handshake_time_sec line is non-zero,
+// or ctx is done. Split out so the polling loop is testable without
+// instantiating a real wireguard-go device.
+func pollWGReady(ctx context.Context, getCfg func() (string, error), interval time.Duration) error {
+	for {
+		if cfg, err := getCfg(); err == nil && wgConfigHasHandshake(cfg) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// wgConfigHasHandshake reports whether the IpcGet config blob carries
+// a "last_handshake_time_sec=N" line with N > 0. wireguard-go writes
+// the line as soon as the first handshake completes; absence (or 0)
+// means we haven't talked to the peer yet.
+func wgConfigHasHandshake(cfg string) bool {
+	for _, line := range strings.Split(cfg, "\n") {
+		rest, ok := strings.CutPrefix(line, "last_handshake_time_sec=")
+		if !ok {
+			continue
+		}
+		var sec int64
+		_, _ = fmt.Sscanf(rest, "%d", &sec)
+		if sec > 0 {
+			return true
+		}
+	}
+	return false
+}
 
 func (t *wgTransport) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
 	host, portStr, err := net.SplitHostPort(addr)
@@ -158,26 +219,32 @@ func startWGTransport() (daemonTransport, error) {
 	// Wait for the first handshake so the first user flow doesn't race.
 	// 10s is generous — under normal conditions the keepalive-driven
 	// initiation completes well under one second. Treat a timeout as a
-	// boot warning rather than a hard failure: traffic will still flow
-	// once the peer eventually responds (could be a packet-loss spike
-	// or DNS hiccup at startup).
+	// boot warning rather than a hard failure: per-session WaitReady
+	// picks up where this left off, so a delayed peer response still
+	// blocks the wrapper rather than letting the child exec into a
+	// dropping tunnel.
 	bootWarning := ""
-	if !waitWGHandshake(dev, 10*time.Second) {
-		bootWarning = "wg probe: no handshake from gateway within 10s. " +
-			"Outbound traffic from `clawpatrol run` may stall until the " +
-			"peer responds. Check the gateway endpoint and the host's " +
-			"egress UDP/51820 path."
+	bootReady := waitWGHandshake(dev, 10*time.Second)
+	if !bootReady {
+		bootWarning = fmt.Sprintf("wg probe: no handshake from gateway within 10s. "+
+			"Each `clawpatrol run` waits up to %s for the peer before failing. "+
+			"Check the gateway endpoint and the host's egress UDP/51820 path.",
+			daemonReadyTimeout)
 		log.Printf("%s", bootWarning)
 	} else {
 		log.Printf("daemon: wg handshake established")
 	}
 
-	return &wgTransport{
+	t := &wgTransport{
 		dev:         dev,
 		tun:         tun,
 		localAddr:   clientIP,
 		bootWarning: bootWarning,
-	}, nil
+	}
+	if bootReady {
+		t.ready.Store(true)
+	}
+	return t, nil
 }
 
 // buildDaemonWGIpc renders the wireguard-go IpcSet payload from a
@@ -212,24 +279,9 @@ func base64DecodeToHex(b64 string) (string, error) {
 // waitWGHandshake polls IpcGet for last_handshake_time_sec until it
 // becomes non-zero or timeout. Returns true on success.
 func waitWGHandshake(d *device.Device, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for {
-		if cfg, err := d.IpcGet(); err == nil {
-			for _, line := range strings.Split(cfg, "\n") {
-				if strings.HasPrefix(line, "last_handshake_time_sec=") {
-					var sec int64
-					_, _ = fmt.Sscanf(line, "last_handshake_time_sec=%d", &sec)
-					if sec > 0 {
-						return true
-					}
-				}
-			}
-		}
-		if time.Now().After(deadline) {
-			return false
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return pollWGReady(ctx, d.IpcGet, wgReadyPollInterval) == nil
 }
 
 // --- client-side wg-go tun adapter ----------------------------------

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -615,17 +615,51 @@ func readLenPrefixed(br *bufio.Reader, tag string, maxLen int) (int, error) {
 	return n, nil
 }
 
+// daemonClientWaitAttached blocks on the daemon's post-handoff reply.
+// Two valid frames:
+//   - "ATTACHED\n" — gVisor stack is wired up AND the transport's
+//     WaitReady fired green, so the child can exec into a working
+//     tunnel right away.
+//   - "READYERR <n>\n<n bytes>" — the daemon couldn't confirm
+//     transport readiness within daemonReadyTimeout (handshake
+//     stalled, exit-node ACL missing, etc). We surface the body as
+//     the error so `clawpatrol run` exits with the actual reason
+//     instead of "expected ATTACHED, got ..." gibberish.
+//
+// The deadline is daemonReadyTimeout + buffer so the wrapper's read
+// outlasts the daemon's own WaitReady budget; a bare 5s window (the
+// pre-WaitReady value) would expire before the daemon could even
+// report the timeout.
 func daemonClientWaitAttached(ctrl net.Conn, br *bufio.Reader) error {
-	_ = ctrl.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_ = ctrl.SetReadDeadline(time.Now().Add(daemonReadyTimeout + 5*time.Second))
 	defer func() { _ = ctrl.SetReadDeadline(time.Time{}) }()
 	line, err := br.ReadString('\n')
 	if err != nil {
 		return err
 	}
-	if strings.TrimRight(line, "\r\n") != "ATTACHED" {
+	line = strings.TrimRight(line, "\r\n")
+	switch {
+	case line == "ATTACHED":
+		return nil
+	case strings.HasPrefix(line, "READYERR "):
+		var n int
+		if _, err := fmt.Sscanf(line[len("READYERR "):], "%d", &n); err != nil {
+			return fmt.Errorf("parse READYERR length: %w", err)
+		}
+		if n < 0 || n > 4096 {
+			return fmt.Errorf("READYERR length %d out of range", n)
+		}
+		if n == 0 {
+			return fmt.Errorf("daemon transport not ready")
+		}
+		body := make([]byte, n)
+		if _, err := io.ReadFull(br, body); err != nil {
+			return fmt.Errorf("read READYERR body: %w", err)
+		}
+		return fmt.Errorf("daemon transport not ready: %s", string(body))
+	default:
 		return fmt.Errorf("expected ATTACHED, got %q", line)
 	}
-	return nil
 }
 
 // --- capability manipulation -------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `WaitReady(ctx)` to the `daemonTransport` interface; wg polls wireguard-go's `last_handshake_time_sec`, tsnet re-runs the gateway:53 exit-node probe. Both cache the first observed success in an atomic so warm-path callers pay one atomic load.
- The daemon's session handler runs `WaitReady` between the TUN handoff and the ATTACHED reply with a 30s timeout; on failure it ships a new `READYERR <n>\n<body>` frame so the wrapper exits with the actual reason instead of a misleading "expected ATTACHED, got ..." parse error.
- Client's ATTACHED read deadline grows from 5s → 35s to outlast the daemon's own readiness budget; parser now handles both `ATTACHED` and `READYERR`.

Closes cl-lmuk.

## Test plan
- [x] Cold start: `pollWGReady` / `pollTsnetReady` keep retrying until a stubbed `getCfg`/`dial` flips to ready, then return without blowing the budget.
- [x] Warm start: both pollers return after a single call with no sleeps (huge interval, short ctx — would expose any unconditional pre-sleep).
- [x] Timeout: pollers return `context.DeadlineExceeded`; daemon writes `READYERR`; client parser surfaces the body verbatim as the returned error.
- [x] `READYERR` with empty body: client still returns a "not ready" error rather than reading zero bytes.
- [x] `go test ./...` clean, `gofmt -l .` clean, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)