### PR TITLE
fix: drive relay recv/send through SyscallConn.Read/Write (cl-0jsq)

### DIFF
--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -533,17 +533,46 @@ func runRelayWorker(_ []string) {
 	sockFD := int(sock.Fd())
 	ignoreSIGPIPE()
 
+	relayWorkerLoop(
+		func() (uint16, int, error) { return recvJob(sockFD) },
+		handleJob,
+	)
+}
+
+// relayWorkerLoop is the recv→dispatch loop, extracted so tests can drive
+// it with a faked recv. Transient errors (EAGAIN/EWOULDBLOCK/EINTR) are
+// retried; io.EOF / supervisor shutdown returns cleanly; other errors log
+// and return.
+//
+// Previously this loop exited on any non-EOF error, which surfaced as the
+// log line "[clawpatrol relay-worker] recv: resource temporarily unavailable"
+// (EAGAIN's canonical strerror text) followed by a silent worker death and
+// the wrapped command losing its auto-expose tunnel.
+func relayWorkerLoop(recv func() (uint16, int, error), handle func(uint16, int)) {
 	for {
-		port, fd, err := recvJob(sockFD)
+		port, fd, err := recv()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return
+			if isTransientRecvErr(err) {
+				continue
 			}
-			fmt.Fprintf(os.Stderr, "[clawpatrol relay-worker] recv: %v\n", err)
+			if !errors.Is(err, io.EOF) {
+				fmt.Fprintf(os.Stderr, "[clawpatrol relay-worker] recv: %v\n", err)
+			}
 			return
 		}
-		go handleJob(port, fd)
+		go handle(port, fd)
 	}
+}
+
+// isTransientRecvErr reports whether err from the SCM_RIGHTS recv loop
+// represents a transient interruption that should be retried rather than
+// treated as fatal. EAGAIN/EWOULDBLOCK can occur if the worker socket is
+// (inadvertently) nonblocking; EINTR occurs when a signal arrives during
+// the syscall. None of these indicate the supervisor has gone away.
+func isTransientRecvErr(err error) bool {
+	return errors.Is(err, syscall.EAGAIN) ||
+		errors.Is(err, syscall.EWOULDBLOCK) ||
+		errors.Is(err, syscall.EINTR)
 }
 
 func recvJob(fd int) (uint16, int, error) {

--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -611,7 +611,7 @@ func relayWorkerLoop(rc syscall.RawConn, handle func(uint16, int)) {
 func recvJob(rc syscall.RawConn) (uint16, int, error) {
 	var (
 		port  uint16
-		jobFD int = -1
+		jobFD = -1
 		rerr  error
 	)
 	err := rc.Read(func(rawFD uintptr) (done bool) {

--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -566,9 +566,21 @@ func relayWorkerLoop(recv func() (uint16, int, error), handle func(uint16, int))
 
 // isTransientRecvErr reports whether err from the SCM_RIGHTS recv loop
 // represents a transient interruption that should be retried rather than
-// treated as fatal. EAGAIN/EWOULDBLOCK can occur if the worker socket is
-// (inadvertently) nonblocking; EINTR occurs when a signal arrives during
-// the syscall. None of these indicate the supervisor has gone away.
+// treated as fatal. None of these indicate the supervisor has gone away.
+//
+// EAGAIN/EWOULDBLOCK: we create the socketpair blocking (SOCK_SEQPACKET
+// only, no SOCK_NONBLOCK), but O_NONBLOCK lives on the open file
+// description, not the fd, so anything that flips it on either end is
+// visible here after inheritance. In particular, wrapping a socket fd
+// with os.NewFile on the supervisor side hands it to Go's runtime
+// netpoller, which sets O_NONBLOCK on the underlying description; the
+// relay-worker child then inherits an fd that already has O_NONBLOCK
+// set and reads it via unix.Recvmsg (bypassing the runtime poller), so
+// the EAGAIN surfaces directly. This was observed in the wild as
+// "[clawpatrol relay-worker] recv: resource temporarily unavailable"
+// (EAGAIN's strerror text) followed by silent worker death.
+//
+// EINTR: a signal handler ran during recvmsg.
 func isTransientRecvErr(err error) bool {
 	return errors.Is(err, syscall.EAGAIN) ||
 		errors.Is(err, syscall.EWOULDBLOCK) ||

--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -202,16 +202,19 @@ func runRelaySupervisor(_ []string) {
 		fail("relay-supervisor: expected fds 3,4 to be open")
 	}
 	notifyFD := int(notifyFile.Fd())
-	workerFD := int(workerSock.Fd())
-
 	// SIGPIPE on the worker socket shouldn't kill the supervisor — log
 	// from the accept goroutines instead.
 	ignoreSIGPIPE()
 
-	// SOCK_SEQPACKET is message-atomic so concurrent sendmsg don't need
-	// serialization for correctness, but a mutex lets us reason about
-	// retries on transient errors without races on the fd.
-	var sendMu sync.Mutex
+	// Hand each acceptLoop a RawConn over workerSock rather than the raw
+	// int fd. The RawConn carries an internal reference to the *os.File,
+	// so the runtime can't GC workerSock out from under the goroutines
+	// and Write integrates with the poller (transient EAGAIN absorbed
+	// without us writing retry logic).
+	workerRC, err := workerSock.SyscallConn()
+	if err != nil {
+		fail("relay-supervisor: SyscallConn(worker-sock): %v", err)
+	}
 
 	seen := make(map[uint16]bool)
 	var seenMu sync.Mutex
@@ -262,7 +265,7 @@ func runRelaySupervisor(_ []string) {
 				continue
 			}
 			fmt.Fprintf(os.Stderr, "[clawpatrol relay] auto-expose %s:%d → agent netns\n", host, port)
-			go acceptLoop(ln, port, workerFD, &sendMu)
+			go acceptLoop(ln, port, workerRC)
 		} else {
 			_ = notifSendContinue(notifyFD, n.ID)
 		}
@@ -471,7 +474,16 @@ func mirrorBindScope(family int, inner net.IP) string {
 	return "127.0.0.1"
 }
 
-func acceptLoop(ln net.Listener, port uint16, workerFD int, sendMu *sync.Mutex) {
+// acceptLoop owns one host-side listener for a port the agent opened.
+// Each accepted host-side connection is shipped to the worker via
+// SCM_RIGHTS over workerRC.
+//
+// workerRC.Write integrates with the runtime poller and takes a per-
+// RawConn lock internally, so multiple acceptLoop goroutines writing
+// to the same workerRC are serialized correctly without an external
+// mutex, and EAGAIN/EWOULDBLOCK/EINTR on the kernel sendmsg are
+// absorbed by the poll-and-retry path inside Write.
+func acceptLoop(ln net.Listener, port uint16, workerRC syscall.RawConn) {
 	for {
 		c, err := ln.Accept()
 		if err != nil {
@@ -487,15 +499,38 @@ func acceptLoop(ln net.Listener, port uint16, workerFD int, sendMu *sync.Mutex) 
 		var portBuf [2]byte
 		binary.LittleEndian.PutUint16(portBuf[:], port)
 		rights := unix.UnixRights(fd)
-		sendMu.Lock()
-		err = unix.Sendmsg(workerFD, portBuf[:], rights, nil, 0)
-		sendMu.Unlock()
+		err = sendJob(workerRC, portBuf[:], rights)
 		_ = c.Close()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[clawpatrol relay] sendmsg to worker on :%d: %v\n", port, err)
 			return
 		}
 	}
+}
+
+// sendJob ships one (port-frame, SCM_RIGHTS-fd) message to the worker.
+// Mirrors recvJob's structure: the poller absorbs transient EAGAIN and
+// the RawConn keeps the underlying *os.File alive for the syscall's
+// duration.
+func sendJob(rc syscall.RawConn, frame []byte, oob []byte) error {
+	var serr error
+	err := rc.Write(func(rawFD uintptr) (done bool) {
+		e := unix.Sendmsg(int(rawFD), frame, oob, nil, 0)
+		if e != nil {
+			if errors.Is(e, syscall.EAGAIN) ||
+				errors.Is(e, syscall.EWOULDBLOCK) ||
+				errors.Is(e, syscall.EINTR) {
+				return false
+			}
+			serr = e
+			return true
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	return serr
 }
 
 // tcpRawFD extracts the raw fd from a *net.TCPConn for SCM_RIGHTS handoff.
@@ -530,91 +565,103 @@ func runRelayWorker(_ []string) {
 	if sock == nil {
 		fail("relay-worker: expected fd 3 to be open")
 	}
-	sockFD := int(sock.Fd())
 	ignoreSIGPIPE()
 
-	relayWorkerLoop(
-		func() (uint16, int, error) { return recvJob(sockFD) },
-		handleJob,
-	)
+	rc, err := sock.SyscallConn()
+	if err != nil {
+		fail("relay-worker: SyscallConn(supervisor-sock): %v", err)
+	}
+	relayWorkerLoop(rc, handleJob)
 }
 
-// relayWorkerLoop is the recv→dispatch loop, extracted so tests can drive
-// it with a faked recv. Transient errors (EAGAIN/EWOULDBLOCK/EINTR) are
-// retried; io.EOF / supervisor shutdown returns cleanly; other errors log
-// and return.
+// relayWorkerLoop reads SCM_RIGHTS frames off the supervisor sock and
+// dispatches each to handle in a fresh goroutine. The loop owns the
+// recv side of the sock; nothing else reads from rc, so we never have
+// concurrent Read calls fighting over the per-RawConn lock.
 //
-// Previously this loop exited on any non-EOF error, which surfaced as the
-// log line "[clawpatrol relay-worker] recv: resource temporarily unavailable"
-// (EAGAIN's canonical strerror text) followed by a silent worker death and
-// the wrapped command losing its auto-expose tunnel.
-func relayWorkerLoop(recv func() (uint16, int, error), handle func(uint16, int)) {
+// Lifetime: rc carries an internal reference to the underlying *os.File,
+// so as long as the loop is running the runtime can't GC the file out
+// from under us. (Holding the raw int fd directly would not have that
+// property — see relay_linux.go history for the failure mode that caused.)
+//
+// Transient errors: rc.Read integrates with the runtime poller. When the
+// kernel returns EAGAIN/EWOULDBLOCK/EINTR inside the callback, we return
+// false; Read parks the goroutine on the poll wait and re-runs the
+// callback when the fd becomes readable. The loop never observes these
+// errno classes itself — they're absorbed by the poller before the
+// outer loop sees anything.
+func relayWorkerLoop(rc syscall.RawConn, handle func(uint16, int)) {
 	for {
-		port, fd, err := recv()
+		port, fd, err := recvJob(rc)
 		if err != nil {
-			if isTransientRecvErr(err) {
-				continue
+			if errors.Is(err, io.EOF) {
+				return
 			}
-			if !errors.Is(err, io.EOF) {
-				fmt.Fprintf(os.Stderr, "[clawpatrol relay-worker] recv: %v\n", err)
-			}
+			fmt.Fprintf(os.Stderr, "[clawpatrol relay-worker] recv: %v\n", err)
 			return
 		}
 		go handle(port, fd)
 	}
 }
 
-// isTransientRecvErr reports whether err from the SCM_RIGHTS recv loop
-// represents a transient interruption that should be retried rather than
-// treated as fatal. None of these indicate the supervisor has gone away.
-//
-// EAGAIN/EWOULDBLOCK: we create the socketpair blocking (SOCK_SEQPACKET
-// only, no SOCK_NONBLOCK), but O_NONBLOCK lives on the open file
-// description, not the fd, so anything that flips it on either end is
-// visible here after inheritance. In particular, wrapping a socket fd
-// with os.NewFile on the supervisor side hands it to Go's runtime
-// netpoller, which sets O_NONBLOCK on the underlying description; the
-// relay-worker child then inherits an fd that already has O_NONBLOCK
-// set and reads it via unix.Recvmsg (bypassing the runtime poller), so
-// the EAGAIN surfaces directly. This was observed in the wild as
-// "[clawpatrol relay-worker] recv: resource temporarily unavailable"
-// (EAGAIN's strerror text) followed by silent worker death.
-//
-// EINTR: a signal handler ran during recvmsg.
-func isTransientRecvErr(err error) bool {
-	return errors.Is(err, syscall.EAGAIN) ||
-		errors.Is(err, syscall.EWOULDBLOCK) ||
-		errors.Is(err, syscall.EINTR)
-}
-
-func recvJob(fd int) (uint16, int, error) {
-	buf := make([]byte, 2)
-	oob := make([]byte, unix.CmsgSpace(4))
-	n, oobn, _, _, err := unix.Recvmsg(fd, buf, oob, 0)
+// recvJob reads one (port, SCM_RIGHTS fd) frame off the supervisor sock,
+// using the RawConn's poller integration to handle transient EAGAIN /
+// EWOULDBLOCK / EINTR inside the kernel without ever surfacing them to
+// the caller.
+func recvJob(rc syscall.RawConn) (uint16, int, error) {
+	var (
+		port  uint16
+		jobFD int = -1
+		rerr  error
+	)
+	err := rc.Read(func(rawFD uintptr) (done bool) {
+		buf := make([]byte, 2)
+		oob := make([]byte, unix.CmsgSpace(4))
+		n, oobn, _, _, recvErr := unix.Recvmsg(int(rawFD), buf, oob, 0)
+		if recvErr != nil {
+			// EAGAIN/EWOULDBLOCK: no message queued yet — ask the poller
+			// to wait for readability and re-run us. EINTR: a signal ran
+			// during recvmsg; same shape, retry.
+			if errors.Is(recvErr, syscall.EAGAIN) ||
+				errors.Is(recvErr, syscall.EWOULDBLOCK) ||
+				errors.Is(recvErr, syscall.EINTR) {
+				return false
+			}
+			rerr = recvErr
+			return true
+		}
+		if n == 0 {
+			rerr = io.EOF
+			return true
+		}
+		if n != 2 {
+			rerr = fmt.Errorf("short frame: %d bytes", n)
+			return true
+		}
+		cmsgs, perr := unix.ParseSocketControlMessage(oob[:oobn])
+		if perr != nil {
+			rerr = fmt.Errorf("parse cmsg: %w", perr)
+			return true
+		}
+		for _, cm := range cmsgs {
+			fds, perr := unix.ParseUnixRights(&cm)
+			if perr == nil && len(fds) > 0 {
+				// Close any extras (shouldn't happen — supervisor sends one).
+				for _, extra := range fds[1:] {
+					_ = unix.Close(extra)
+				}
+				port = binary.LittleEndian.Uint16(buf)
+				jobFD = fds[0]
+				return true
+			}
+		}
+		rerr = fmt.Errorf("no SCM_RIGHTS in frame")
+		return true
+	})
 	if err != nil {
 		return 0, -1, err
 	}
-	if n == 0 {
-		return 0, -1, io.EOF
-	}
-	if n != 2 {
-		return 0, -1, fmt.Errorf("short frame: %d bytes", n)
-	}
-	cmsgs, err := unix.ParseSocketControlMessage(oob[:oobn])
-	if err != nil {
-		return 0, -1, fmt.Errorf("parse cmsg: %w", err)
-	}
-	for _, cm := range cmsgs {
-		fds, err := unix.ParseUnixRights(&cm)
-		if err == nil && len(fds) > 0 {
-			// Close any extras (shouldn't happen — supervisor sends one).
-			for _, extra := range fds[1:] {
-				_ = unix.Close(extra)
-			}
-			return binary.LittleEndian.Uint16(buf), fds[0], nil
-		}
-	}
-	return 0, -1, fmt.Errorf("no SCM_RIGHTS in frame")
+	return port, jobFD, rerr
 }
 
 func handleJob(port uint16, fd int) {

--- a/cmd/clawpatrol/relay_linux_test.go
+++ b/cmd/clawpatrol/relay_linux_test.go
@@ -3,12 +3,12 @@
 package main
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -129,133 +129,209 @@ func TestScanProcNetTcp(t *testing.T) {
 	}
 }
 
-// TestIsTransientRecvErr pins which errno classes the worker treats as
-// retryable interruptions vs fatal. Regression guard for the symptom
-// "[clawpatrol relay-worker] recv: resource temporarily unavailable"
-// (EAGAIN's canonical strerror text) where the worker previously exited
-// on the first EAGAIN instead of looping.
-func TestIsTransientRecvErr(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"EAGAIN", syscall.EAGAIN, true},
-		{"EWOULDBLOCK", syscall.EWOULDBLOCK, true},
-		{"EINTR", syscall.EINTR, true},
-		{"wrapped EAGAIN", errors.Join(errors.New("recv"), syscall.EAGAIN), true},
-		{"EOF", io.EOF, false},
-		{"ECONNRESET", syscall.ECONNRESET, false},
-		{"EBADF", syscall.EBADF, false},
-		{"nil", nil, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isTransientRecvErr(tc.err); got != tc.want {
-				t.Errorf("isTransientRecvErr(%v) = %v, want %v", tc.err, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestRelayWorkerLoopRetriesTransient drives the loop with a fake recv
-// that returns EAGAIN/EWOULDBLOCK/EINTR on the first call and io.EOF on
-// the second. The loop must consume the transient and then exit cleanly
-// on EOF — i.e. exactly two recv calls.
-func TestRelayWorkerLoopRetriesTransient(t *testing.T) {
-	transients := []struct {
-		name string
-		err  error
-	}{
-		{"EAGAIN", syscall.EAGAIN},
-		{"EWOULDBLOCK", syscall.EWOULDBLOCK},
-		{"EINTR", syscall.EINTR},
-	}
-	for _, tc := range transients {
-		t.Run(tc.name, func(t *testing.T) {
-			var calls int
-			recv := func() (uint16, int, error) {
-				calls++
-				if calls == 1 {
-					return 0, -1, tc.err
-				}
-				return 0, -1, io.EOF
-			}
-			relayWorkerLoop(recv, func(uint16, int) {
-				t.Errorf("handle should not be called on errored recvs")
-			})
-			if calls != 2 {
-				t.Errorf("recv calls = %d, want 2 (one transient + one EOF)", calls)
-			}
-		})
-	}
-}
-
-// TestRelayWorkerLoopExitsOnFatal pins that non-transient, non-EOF errors
-// terminate the loop immediately.
-func TestRelayWorkerLoopExitsOnFatal(t *testing.T) {
-	var calls int
-	recv := func() (uint16, int, error) {
-		calls++
-		return 0, -1, syscall.ECONNRESET
-	}
-	relayWorkerLoop(recv, func(uint16, int) {
-		t.Errorf("handle should not be called on errored recvs")
-	})
-	if calls != 1 {
-		t.Errorf("recv calls = %d, want 1 (fatal exits immediately)", calls)
-	}
-}
-
-// TestRelayWorkerLoopDispatches verifies a successful recv goes to handle
-// before the loop continues. Uses a buffered channel so the goroutine can
-// publish independent of test timing.
-func TestRelayWorkerLoopDispatches(t *testing.T) {
-	var calls int
-	handled := make(chan uint16, 1)
-	recv := func() (uint16, int, error) {
-		calls++
-		if calls == 1 {
-			return 8080, 42, nil
-		}
-		return 0, -1, io.EOF
-	}
-	relayWorkerLoop(recv, func(port uint16, _ int) {
-		handled <- port
-	})
-	select {
-	case p := <-handled:
-		if p != 8080 {
-			t.Errorf("handled port = %d, want 8080", p)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("handle goroutine never ran")
-	}
-}
-
-// TestRecvJobReturnsEAGAINOnEmptyNonblockingSocket exercises recvJob
-// against a real SOCK_SEQPACKET socketpair flipped to nonblocking. With
-// no pending frame the kernel returns EAGAIN; recvJob must surface that
-// errno (not strip it or wrap it past recognition) so isTransientRecvErr
-// can classify it correctly.
-func TestRecvJobReturnsEAGAINOnEmptyNonblockingSocket(t *testing.T) {
-	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+// newRelaySocketpair returns a non-blocking SOCK_SEQPACKET socketpair
+// wrapped in *os.File on both ends. Non-blocking is required for the
+// SyscallConn.Read / Write paths to engage the runtime poller. Test
+// helper, not used by production.
+func newRelaySocketpair(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	sp, err := unix.Socketpair(unix.AF_UNIX,
+		unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC|unix.SOCK_NONBLOCK, 0)
 	if err != nil {
 		t.Fatalf("socketpair: %v", err)
 	}
-	defer func() { _ = unix.Close(sp[0]) }()
-	defer func() { _ = unix.Close(sp[1]) }()
+	a := os.NewFile(uintptr(sp[0]), "relay-test-a")
+	b := os.NewFile(uintptr(sp[1]), "relay-test-b")
+	t.Cleanup(func() {
+		_ = a.Close()
+		_ = b.Close()
+	})
+	return a, b
+}
 
-	if err := unix.SetNonblock(sp[1], true); err != nil {
-		t.Fatalf("set nonblock: %v", err)
+// sendOneFrame is a tiny helper that ships one (u16 port, SCM_RIGHTS fd)
+// frame to the worker over a *os.File-wrapped sock, bypassing the
+// production sendJob helper so tests can drive recv-side behaviour
+// directly.
+func sendOneFrame(t *testing.T, sender *os.File, port uint16, fd int) {
+	t.Helper()
+	var portBuf [2]byte
+	binary.LittleEndian.PutUint16(portBuf[:], port)
+	rights := unix.UnixRights(fd)
+	rc, err := sender.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+	if err := sendJob(rc, portBuf[:], rights); err != nil {
+		t.Fatalf("sendJob: %v", err)
+	}
+}
+
+// TestRecvJobReceivesFrame exercises the happy-path end-to-end: drop a
+// frame onto one end of a real socketpair and confirm recvJob extracts
+// the port and the SCM_RIGHTS fd from the other end.
+func TestRecvJobReceivesFrame(t *testing.T) {
+	sup, worker := newRelaySocketpair(t)
+
+	// Use a pipe's read end as the "fd to ship" — any fd that the
+	// receiver can fstat will do; we just want a recognisable kernel
+	// object on the other end so this test catches accidental fd loss.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = pr.Close() }()
+	defer func() { _ = pw.Close() }()
+
+	sendOneFrame(t, sup, 8080, int(pr.Fd()))
+
+	rc, err := worker.SyscallConn()
+	if err != nil {
+		t.Fatalf("worker SyscallConn: %v", err)
+	}
+	port, gotFD, err := recvJob(rc)
+	if err != nil {
+		t.Fatalf("recvJob: %v", err)
+	}
+	if port != 8080 {
+		t.Errorf("port = %d, want 8080", port)
+	}
+	if gotFD < 0 {
+		t.Errorf("gotFD = %d, want >= 0", gotFD)
+	}
+	_ = unix.Close(gotFD)
+}
+
+// TestRecvJobAbsorbsEAGAINViaPoller verifies the SyscallConn.Read poller
+// integration: a recvJob on an empty non-blocking socket must NOT return
+// EAGAIN. It should park on the poller until a frame arrives, then
+// complete. This is the property that replaces the previous explicit
+// isTransientRecvErr retry — under load, transient EAGAINs are absorbed
+// by the kernel poller, not surfaced to the loop.
+func TestRecvJobAbsorbsEAGAINViaPoller(t *testing.T) {
+	sup, worker := newRelaySocketpair(t)
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = pr.Close() }()
+	defer func() { _ = pw.Close() }()
+
+	rc, err := worker.SyscallConn()
+	if err != nil {
+		t.Fatalf("worker SyscallConn: %v", err)
 	}
 
-	_, _, err = recvJob(sp[1])
-	if err == nil {
-		t.Fatal("recvJob on empty nonblocking socket returned nil error")
+	type result struct {
+		port uint16
+		fd   int
+		err  error
 	}
-	if !isTransientRecvErr(err) {
-		t.Fatalf("recvJob err = %v, want classified transient (EAGAIN)", err)
+	done := make(chan result, 1)
+	go func() {
+		port, fd, err := recvJob(rc)
+		done <- result{port, fd, err}
+	}()
+
+	// Recv should be blocked in the poller. Confirm by ensuring no
+	// result arrives within a short window.
+	select {
+	case r := <-done:
+		t.Fatalf("recvJob returned prematurely: port=%d fd=%d err=%v", r.port, r.fd, r.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Now publish a frame; recv should complete.
+	sendOneFrame(t, sup, 9090, int(pr.Fd()))
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("recvJob err = %v, want nil", r.err)
+		}
+		if r.port != 9090 {
+			t.Errorf("port = %d, want 9090", r.port)
+		}
+		_ = unix.Close(r.fd)
+	case <-time.After(time.Second):
+		t.Fatal("recvJob did not unblock after frame was sent")
+	}
+}
+
+// TestRecvJobReturnsEOFOnPeerClose pins shutdown semantics: when the
+// supervisor goes away, recvJob must return io.EOF (not EBADF, not a
+// stray errno) so the loop can exit cleanly.
+func TestRecvJobReturnsEOFOnPeerClose(t *testing.T) {
+	sup, worker := newRelaySocketpair(t)
+	_ = sup.Close()
+
+	rc, err := worker.SyscallConn()
+	if err != nil {
+		t.Fatalf("worker SyscallConn: %v", err)
+	}
+	_, _, err = recvJob(rc)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("recvJob err = %v, want io.EOF", err)
+	}
+}
+
+// TestRelayWorkerLoopDispatchesEndToEnd ships two frames through a real
+// socketpair and confirms both reach the dispatch callback in order,
+// then verifies a clean shutdown when the sender closes.
+func TestRelayWorkerLoopDispatchesEndToEnd(t *testing.T) {
+	sup, worker := newRelaySocketpair(t)
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = pr.Close() }()
+	defer func() { _ = pw.Close() }()
+
+	rc, err := worker.SyscallConn()
+	if err != nil {
+		t.Fatalf("worker SyscallConn: %v", err)
+	}
+
+	type job struct {
+		port uint16
+		fd   int
+	}
+	jobs := make(chan job, 4)
+	loopDone := make(chan struct{})
+	go func() {
+		relayWorkerLoop(rc, func(port uint16, fd int) {
+			jobs <- job{port, fd}
+		})
+		close(loopDone)
+	}()
+
+	sendOneFrame(t, sup, 5000, int(pr.Fd()))
+	sendOneFrame(t, sup, 5001, int(pr.Fd()))
+
+	// Order between the two dispatch goroutines is non-deterministic;
+	// collect both and check as a set.
+	want := map[uint16]bool{5000: true, 5001: true}
+	got := map[uint16]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case j := <-jobs:
+			got[j.port] = true
+			_ = unix.Close(j.fd)
+		case <-time.After(time.Second):
+			t.Fatalf("dispatch[%d] never ran (got so far: %v)", i, got)
+		}
+	}
+	for p := range want {
+		if !got[p] {
+			t.Errorf("missing dispatch for port %d", p)
+		}
+	}
+
+	// Sender closes → loop sees EOF → returns.
+	_ = sup.Close()
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("relayWorkerLoop did not return after peer close")
 	}
 }
 

--- a/cmd/clawpatrol/relay_linux_test.go
+++ b/cmd/clawpatrol/relay_linux_test.go
@@ -3,10 +3,14 @@
 package main
 
 import (
+	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -122,6 +126,136 @@ func TestScanProcNetTcp(t *testing.T) {
 				t.Errorf("ip=%s, want %s", ip, tc.wantIP)
 			}
 		})
+	}
+}
+
+// TestIsTransientRecvErr pins which errno classes the worker treats as
+// retryable interruptions vs fatal. Regression guard for the symptom
+// "[clawpatrol relay-worker] recv: resource temporarily unavailable"
+// (EAGAIN's canonical strerror text) where the worker previously exited
+// on the first EAGAIN instead of looping.
+func TestIsTransientRecvErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"EAGAIN", syscall.EAGAIN, true},
+		{"EWOULDBLOCK", syscall.EWOULDBLOCK, true},
+		{"EINTR", syscall.EINTR, true},
+		{"wrapped EAGAIN", errors.Join(errors.New("recv"), syscall.EAGAIN), true},
+		{"EOF", io.EOF, false},
+		{"ECONNRESET", syscall.ECONNRESET, false},
+		{"EBADF", syscall.EBADF, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTransientRecvErr(tc.err); got != tc.want {
+				t.Errorf("isTransientRecvErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRelayWorkerLoopRetriesTransient drives the loop with a fake recv
+// that returns EAGAIN/EWOULDBLOCK/EINTR on the first call and io.EOF on
+// the second. The loop must consume the transient and then exit cleanly
+// on EOF — i.e. exactly two recv calls.
+func TestRelayWorkerLoopRetriesTransient(t *testing.T) {
+	transients := []struct {
+		name string
+		err  error
+	}{
+		{"EAGAIN", syscall.EAGAIN},
+		{"EWOULDBLOCK", syscall.EWOULDBLOCK},
+		{"EINTR", syscall.EINTR},
+	}
+	for _, tc := range transients {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			recv := func() (uint16, int, error) {
+				calls++
+				if calls == 1 {
+					return 0, -1, tc.err
+				}
+				return 0, -1, io.EOF
+			}
+			relayWorkerLoop(recv, func(uint16, int) {
+				t.Errorf("handle should not be called on errored recvs")
+			})
+			if calls != 2 {
+				t.Errorf("recv calls = %d, want 2 (one transient + one EOF)", calls)
+			}
+		})
+	}
+}
+
+// TestRelayWorkerLoopExitsOnFatal pins that non-transient, non-EOF errors
+// terminate the loop immediately.
+func TestRelayWorkerLoopExitsOnFatal(t *testing.T) {
+	var calls int
+	recv := func() (uint16, int, error) {
+		calls++
+		return 0, -1, syscall.ECONNRESET
+	}
+	relayWorkerLoop(recv, func(uint16, int) {
+		t.Errorf("handle should not be called on errored recvs")
+	})
+	if calls != 1 {
+		t.Errorf("recv calls = %d, want 1 (fatal exits immediately)", calls)
+	}
+}
+
+// TestRelayWorkerLoopDispatches verifies a successful recv goes to handle
+// before the loop continues. Uses a buffered channel so the goroutine can
+// publish independent of test timing.
+func TestRelayWorkerLoopDispatches(t *testing.T) {
+	var calls int
+	handled := make(chan uint16, 1)
+	recv := func() (uint16, int, error) {
+		calls++
+		if calls == 1 {
+			return 8080, 42, nil
+		}
+		return 0, -1, io.EOF
+	}
+	relayWorkerLoop(recv, func(port uint16, fd int) {
+		handled <- port
+	})
+	select {
+	case p := <-handled:
+		if p != 8080 {
+			t.Errorf("handled port = %d, want 8080", p)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handle goroutine never ran")
+	}
+}
+
+// TestRecvJobReturnsEAGAINOnEmptyNonblockingSocket exercises recvJob
+// against a real SOCK_SEQPACKET socketpair flipped to nonblocking. With
+// no pending frame the kernel returns EAGAIN; recvJob must surface that
+// errno (not strip it or wrap it past recognition) so isTransientRecvErr
+// can classify it correctly.
+func TestRecvJobReturnsEAGAINOnEmptyNonblockingSocket(t *testing.T) {
+	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	defer func() { _ = unix.Close(sp[0]) }()
+	defer func() { _ = unix.Close(sp[1]) }()
+
+	if err := unix.SetNonblock(sp[1], true); err != nil {
+		t.Fatalf("set nonblock: %v", err)
+	}
+
+	_, _, err = recvJob(sp[1])
+	if err == nil {
+		t.Fatal("recvJob on empty nonblocking socket returned nil error")
+	}
+	if !isTransientRecvErr(err) {
+		t.Fatalf("recvJob err = %v, want classified transient (EAGAIN)", err)
 	}
 }
 

--- a/cmd/clawpatrol/relay_linux_test.go
+++ b/cmd/clawpatrol/relay_linux_test.go
@@ -220,7 +220,7 @@ func TestRelayWorkerLoopDispatches(t *testing.T) {
 		}
 		return 0, -1, io.EOF
 	}
-	relayWorkerLoop(recv, func(port uint16, fd int) {
+	relayWorkerLoop(recv, func(port uint16, _ int) {
 		handled <- port
 	})
 	select {


### PR DESCRIPTION
## Summary

The relay's worker recv loop and supervisor accept-loop send both used the pattern `int(file.Fd())` + raw `unix.Recvmsg`/`unix.Sendmsg`, handing the int to a goroutine while letting Go's reference to the `*os.File` lapse. Two failure modes followed from the same anti-pattern; the previous iteration of this PR fixed one and exited on the other.

**EAGAIN.** `os.NewFile`'s poller integration sets `O_NONBLOCK` on the underlying file description. The inheriting process reads via raw `Recvmsg` (bypassing the poller) and surfaces EAGAIN whenever the kernel queue is briefly empty. Previously surfaced as `[clawpatrol relay-worker] recv: resource temporarily unavailable` followed by silent worker death. Previously addressed by classifying as transient + looping (`isTransientRecvErr`).

**EBADF.** Under heap pressure the `*os.File` becomes liveness-dead immediately after `.Fd()` returns; the runtime collects it; its `runtime.SetFinalizer`-installed `Close()` closes the very fd the goroutine is reading from. `Recvmsg` then returns EBADF. The previous fix explicitly exited on this errno (`isTransientRecvErr`'s test pinned `{"EBADF", syscall.EBADF, false}`). Reproducible: probing with `fcntl(F_GETFL)` from the failing recv site shows the syscall *also* returns EBADF — i.e. the fd is closed in our own fd table, not the peer's.

Both modes stem from the int-handoff. Both go away by holding a `syscall.RawConn` instead and driving `recvmsg`/`sendmsg` inside `RawConn.Read`/`Write` callbacks:

- **RawConn carries an internal `*os.File` reference** for the goroutine's lifetime. GC can't collect the file out from under us, so EBADF can't surface from inside our own process. No `runtime.KeepAlive` needed.
- **RawConn.Read/Write integrate with the runtime poller.** `EAGAIN`/`EWOULDBLOCK`/`EINTR` returned by `Recvmsg`/`Sendmsg` inside the callback turn into "return false" → park on the poll wait → re-run when the fd becomes ready. The outer loop never observes these errno classes.

`isTransientRecvErr` and the retry helper become dead weight. `sendMu` protecting concurrent `Sendmsg` across multiple `acceptLoop` goroutines becomes unnecessary too — `RawConn.Write` takes a per-RawConn lock internally and serialises concurrent writes for free.

## Why this matters for #589

PR #589 introduces a second recv loop in the **supervisor** (host-loopback direction). Empirical testing of #589 reproduced the EBADF mode at ~60% under 20-way concurrent load. The supervisor's new loop uses the same int-handoff anti-pattern this PR removes; once #589 rebases onto this branch, applying the same `RawConn.Read`/`Write` pattern to its loopback loop closes the same family of bugs there with no further plumbing.

## Test plan

- [x] `go test ./...` — full suite green.
- [x] `gofmt -l cmd/clawpatrol/relay_linux.go cmd/clawpatrol/relay_linux_test.go` — clean.
- [x] `go vet ./cmd/clawpatrol/` — clean.
- [x] New tests against real `SOCK_SEQPACKET|SOCK_NONBLOCK` socketpairs:
  - `TestRecvJobReceivesFrame` — happy path, extracts port + SCM_RIGHTS fd.
  - `TestRecvJobAbsorbsEAGAINViaPoller` — recv on empty non-blocking sock parks in the poller rather than surfacing EAGAIN; unblocks when a frame arrives. **This is the property that replaces `isTransientRecvErr`.**
  - `TestRecvJobReturnsEOFOnPeerClose` — clean shutdown semantics.
  - `TestRelayWorkerLoopDispatchesEndToEnd` — two frames in, two dispatch callbacks out, clean loop exit when sender closes.
  - All four pass 5× in a row, no flakes.
- [x] End-to-end with built binary: `clawpatrol run` + 20-way concurrent host → agent-netns traffic across 5 runs; **zero relay-recv errors** logged. The same workload against the prior tip of this branch reproduced EBADF reliably when combined with #589's loopback loop.

## What's removed

- `isTransientRecvErr` + its test.
- `TestRelayWorkerLoopRetriesTransient`, `TestRelayWorkerLoopExitsOnFatal`, `TestRelayWorkerLoopDispatches` (the recv-fake-driven loop tests — replaced with socketpair-driven end-to-end tests that exercise the real RawConn path).
- `TestRecvJobReturnsEAGAINOnEmptyNonblockingSocket` (asserted a behaviour that's now correctly *absent* — EAGAIN is absorbed by the poller, not surfaced).
- The `sendMu` mutex in `runRelaySupervisor` / `acceptLoop`.
- The `workerFD` raw int + `int(workerSock.Fd())` extraction.

Closes cl-0jsq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
