### PR TITLE
fix: exit clawpatrol run when relay-supervisor or relay-worker dies

### DIFF
--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -41,6 +41,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -195,6 +196,22 @@ func notifSendContinue(fd int, id uint64) error {
 //
 // On each listen() trap it inspects the agent's socket, opens a host-side
 // listener on the same port, and hands accepted connections to the worker.
+//
+// Two background loops run concurrently:
+//
+//   - The seccomp notify loop (the supervisor's primary job).
+//   - A worker-socket monitor: when the worker process dies, its end of
+//     the socketpair closes and recvmsg here returns EOF. That's the only
+//     way the supervisor (host netns, host pid space) can notice the
+//     worker (agent netns) has died — there's no Wait relationship.
+//
+// On clean shutdown the agent child exits, which sends Pdeathsig=SIGTERM
+// to the worker AND empties the seccomp filter's task list. Both loops
+// fire near-simultaneously: the seccomp loop returns via ENOENT, the
+// monitor returns via EOF. We give the seccomp loop a short grace window
+// — if it closes within that window the worker death is the expected
+// shutdown cascade and we exit 0; otherwise the worker died for some
+// other reason and we exit non-zero so the top parent can surface it.
 func runRelaySupervisor(_ []string) {
 	notifyFile := os.NewFile(3, "seccomp-notify")
 	workerSock := os.NewFile(4, "worker-sock")
@@ -208,6 +225,82 @@ func runRelaySupervisor(_ []string) {
 	// from the accept goroutines instead.
 	ignoreSIGPIPE()
 
+	type evtKind int
+	const (
+		evtSeccompClosed evtKind = iota
+		evtSeccompError
+		evtWorkerGone
+	)
+	type evt struct {
+		kind evtKind
+		err  error
+	}
+	ch := make(chan evt, 2)
+
+	go func() {
+		err := runRelaySupervisorNotifyLoop(notifyFD, workerFD)
+		if err == nil || errors.Is(err, unix.ENOENT) {
+			ch <- evt{kind: evtSeccompClosed}
+			return
+		}
+		ch <- evt{kind: evtSeccompError, err: err}
+	}()
+
+	go func() {
+		err := monitorWorkerSocket(workerFD)
+		ch <- evt{kind: evtWorkerGone, err: err}
+	}()
+
+	first := <-ch
+	switch first.kind {
+	case evtSeccompClosed:
+		// Clean shutdown — the seccomp filter has no remaining tasks
+		// because the agent child died. The worker is either already
+		// dead (Pdeathsig) or imminent; let the kernel reap it.
+		return
+	case evtSeccompError:
+		fmt.Fprintf(os.Stderr, "[clawpatrol relay] notif_recv: %v\n", first.err)
+		os.Exit(1)
+	}
+
+	// Worker died first. Wait briefly to see if the seccomp filter also
+	// closes (the expected cascade). The grace window is small because
+	// the cascade runs at kernel speed once the agent child exits.
+	select {
+	case second := <-ch:
+		if second.kind == evtSeccompClosed {
+			return
+		}
+		// Seccomp error or another worker event — unusual; fall through
+		// to the worker-died message.
+	case <-time.After(supervisorShutdownGrace):
+	}
+
+	// Real unexpected death. The last-stderr-line tee in the parent
+	// surfaces this message in `clawpatrol run`'s exit error.
+	if first.err != nil && !errors.Is(first.err, io.EOF) {
+		fmt.Fprintf(os.Stderr,
+			"[clawpatrol relay] relay-worker exited unexpectedly: %v\n",
+			first.err)
+	} else {
+		fmt.Fprintln(os.Stderr,
+			"[clawpatrol relay] relay-worker exited unexpectedly")
+	}
+	os.Exit(1)
+}
+
+// supervisorShutdownGrace is how long the worker-monitor goroutine waits
+// for the seccomp notify loop to also close before declaring the worker
+// death unexpected. Sized for the kernel's task-cleanup latency, not for
+// user-visible delays — the parent's `clawpatrol run` is blocked on its
+// own child.Wait while this runs.
+const supervisorShutdownGrace = 500 * time.Millisecond
+
+// runRelaySupervisorNotifyLoop is the supervisor's primary seccomp loop:
+// recv listen() traps, peek the agent socket, mirror on the host, hand
+// off accepts to the worker. Returns unix.ENOENT for the normal-shutdown
+// case (filter has no remaining tasks); other errors are propagated.
+func runRelaySupervisorNotifyLoop(notifyFD, workerFD int) error {
 	// SOCK_SEQPACKET is message-atomic so concurrent sendmsg don't need
 	// serialization for correctness, but a mutex lets us reason about
 	// retries on transient errors without races on the fd.
@@ -224,12 +317,7 @@ func runRelaySupervisor(_ []string) {
 	for {
 		n, err := notifRecv(notifyFD)
 		if err != nil {
-			// ENOENT = the filter has no remaining tasks. Normal shutdown.
-			if errors.Is(err, unix.ENOENT) {
-				return
-			}
-			fmt.Fprintf(os.Stderr, "[clawpatrol relay] notif_recv: %v\n", err)
-			return
+			return err
 		}
 
 		isListen := uint32(n.Data.NR) == listenNR
@@ -266,6 +354,36 @@ func runRelaySupervisor(_ []string) {
 		} else {
 			_ = notifSendContinue(notifyFD, n.ID)
 		}
+	}
+}
+
+// monitorWorkerSocket blocks reading from the worker end of the
+// supervisor↔worker socketpair. Supervisor → worker is the only
+// direction we send on that pair (port + SCM_RIGHTS fd); the worker
+// never writes back. So recvmsg returns:
+//
+//   - n=0 / io.EOF when the worker closes its end (process death).
+//   - a non-EINTR error otherwise.
+//
+// A read that actually returns bytes is a protocol violation — log it
+// and keep looping. We don't trust an arbitrary peer to behave but we
+// also don't want to declare the worker dead just because it sent
+// something.
+func monitorWorkerSocket(fd int) error {
+	buf := make([]byte, 64)
+	for {
+		n, _, _, _, err := unix.Recvmsg(fd, buf, nil, 0)
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return err
+		}
+		if n == 0 {
+			return io.EOF
+		}
+		fmt.Fprintf(os.Stderr,
+			"[clawpatrol relay] unexpected %d bytes from worker\n", n)
 	}
 }
 
@@ -671,9 +789,12 @@ func setupRelayInChild(parentSock *os.File) {
 
 // spawnRelaySupervisor re-execs self as `relay-supervisor`, passing the
 // seccomp notify fd and worker socket via ExtraFiles (fd 3 and fd 4).
-// Returns the started *exec.Cmd; the caller does not Wait — Pdeathsig
-// reaps the supervisor when the top parent exits.
-func spawnRelaySupervisor(notifyFile, workerSock *os.File) (*exec.Cmd, error) {
+// stderr is wired to the caller-provided writer (typically a
+// last-line-capturing tee in front of os.Stderr) so the parent can
+// surface the supervisor's final log line if it dies unexpectedly.
+// Returns the started *exec.Cmd; the caller is responsible for Wait —
+// see the run-side handling in run_linux.go for the death semantics.
+func spawnRelaySupervisor(notifyFile, workerSock *os.File, stderr io.Writer) (*exec.Cmd, error) {
 	self, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("self path: %w", err)
@@ -682,7 +803,7 @@ func spawnRelaySupervisor(notifyFile, workerSock *os.File) (*exec.Cmd, error) {
 	c.ExtraFiles = []*os.File{notifyFile, workerSock}
 	c.Stdin = nil
 	c.Stdout = nil
-	c.Stderr = os.Stderr
+	c.Stderr = stderr
 	c.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGTERM,
 	}

--- a/cmd/clawpatrol/relay_linux_test.go
+++ b/cmd/clawpatrol/relay_linux_test.go
@@ -3,10 +3,13 @@
 package main
 
 import (
+	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -122,6 +125,42 @@ func TestScanProcNetTcp(t *testing.T) {
 				t.Errorf("ip=%s, want %s", ip, tc.wantIP)
 			}
 		})
+	}
+}
+
+// TestMonitorWorkerSocketEOFOnPeerClose pins the death-detection contract:
+// when the worker process exits, its end of the supervisor↔worker
+// SOCK_SEQPACKET pair closes and monitorWorkerSocket must return io.EOF.
+// This is the only signal the supervisor (in the host pid space) gets
+// for a worker that lives across a netns boundary.
+func TestMonitorWorkerSocketEOFOnPeerClose(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX,
+		unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	supFD := fds[0]
+	workerFD := fds[1]
+	defer func() { _ = unix.Close(supFD) }()
+
+	done := make(chan error, 1)
+	go func() { done <- monitorWorkerSocket(supFD) }()
+
+	// Let the recvmsg take the call out of the goroutine scheduler.
+	time.Sleep(20 * time.Millisecond)
+
+	// Simulate worker death by closing its end of the pair.
+	if err := unix.Close(workerFD); err != nil {
+		t.Fatalf("close worker fd: %v", err)
+	}
+
+	select {
+	case got := <-done:
+		if !errors.Is(got, io.EOF) {
+			t.Fatalf("monitorWorkerSocket: got %v, want io.EOF", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorWorkerSocket did not return after peer close")
 	}
 }
 

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -52,6 +52,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -236,12 +237,15 @@ func runRun(args []string) {
 	// the supervisor in the host netns. Absence (--no-auto-expose,
 	// unsupported arch) is non-fatal.
 	var relaySup *exec.Cmd
+	var relayStderr *lastLineWriter
 	if autoExpose {
 		if relayFDs, err := recvFDs(pSock, 2); err == nil {
 			notifyFile := os.NewFile(uintptr(relayFDs[0]), "seccomp-notify")
 			supSock := os.NewFile(uintptr(relayFDs[1]), "relay-sup-sock")
-			if c, serr := spawnRelaySupervisor(notifyFile, supSock); serr != nil {
+			relayStderr = newLastLineWriter(os.Stderr)
+			if c, serr := spawnRelaySupervisor(notifyFile, supSock, relayStderr); serr != nil {
 				fmt.Fprintf(os.Stderr, "warning: auto-expose relay: %v (webhooks won't be reachable from host)\n", serr)
+				relayStderr = nil
 			} else {
 				relaySup = c
 			}
@@ -260,15 +264,77 @@ func runRun(args []string) {
 		}
 	}()
 
-	waitErr := child.Wait()
+	// Wait on the wrapped child and the relay supervisor concurrently.
+	// Either can finish first. Sequencing:
+	//
+	//   - Child exits first: SIGTERM the supervisor, drain its Wait.
+	//     If the supervisor reports an unexpected death anyway, we
+	//     surface it but the child's exit code wins.
+	//   - Supervisor exits first: the relay is gone, so subsequent
+	//     traffic from the wrapped child would silently fail. SIGTERM
+	//     the child (grace-period SIGKILL fallback), then exit non-zero
+	//     with the supervisor's last stderr line as the cause.
+	childDoneCh := make(chan error, 1)
+	go func() { childDoneCh <- child.Wait() }()
 
-	if relaySup != nil && relaySup.Process != nil {
-		_ = relaySup.Process.Signal(syscall.SIGTERM)
-		_, _ = relaySup.Process.Wait()
+	supExitCh := make(chan error, 1)
+	if relaySup != nil {
+		go func() { supExitCh <- relaySup.Wait() }()
+	}
+
+	var (
+		waitErr error
+		supDied bool
+		supErr  error
+	)
+
+	select {
+	case e := <-childDoneCh:
+		waitErr = e
+		if relaySup != nil && relaySup.Process != nil {
+			_ = relaySup.Process.Signal(syscall.SIGTERM)
+			select {
+			case <-supExitCh:
+			case <-time.After(2 * time.Second):
+				_ = relaySup.Process.Kill()
+				<-supExitCh
+			}
+		}
+	case se := <-supExitCh:
+		supDied = true
+		supErr = se
+		if child.Process != nil {
+			_ = child.Process.Signal(syscall.SIGTERM)
+		}
+		select {
+		case waitErr = <-childDoneCh:
+		case <-time.After(2 * time.Second):
+			_ = child.Process.Kill()
+			waitErr = <-childDoneCh
+		}
 	}
 
 	// Closing ctrl (via the deferred Close) tears the session down on
 	// the daemon side.
+
+	if supDied {
+		msg := "auto-expose relay died — exiting"
+		if supErr != nil {
+			msg = fmt.Sprintf("%s (%v)", msg, supErr)
+		}
+		if relayStderr != nil {
+			if last := relayStderr.LastLine(); last != "" {
+				msg = msg + ": " + last
+			}
+		}
+		fmt.Fprintf(os.Stderr, "clawpatrol: %s\n", msg)
+		code := 1
+		var ee *exec.ExitError
+		if errors.As(supErr, &ee) && ee.ExitCode() > 0 {
+			code = ee.ExitCode()
+		}
+		os.Exit(code)
+	}
 
 	if waitErr != nil {
 		var ee *exec.ExitError
@@ -277,6 +343,53 @@ func runRun(args []string) {
 		}
 		fail("wait: %v", waitErr)
 	}
+}
+
+// lastLineWriter wraps an io.Writer with a small ring buffer so the
+// "last log line" of a child process can be retrieved after it exits.
+// Used in front of os.Stderr when wiring up the relay supervisor: the
+// supervisor's normal stderr still streams to the user in real time,
+// and on death the parent can pluck the final line to surface as the
+// cause.
+//
+// The buffer is bounded; a runaway child can't OOM us. The "last line"
+// is the trailing non-empty run of bytes between newlines.
+type lastLineWriter struct {
+	mu  sync.Mutex
+	buf []byte
+	w   io.Writer
+}
+
+const lastLineMaxBytes = 4096
+
+func newLastLineWriter(w io.Writer) *lastLineWriter {
+	return &lastLineWriter{w: w}
+}
+
+func (l *lastLineWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	l.buf = append(l.buf, p...)
+	if len(l.buf) > lastLineMaxBytes {
+		l.buf = l.buf[len(l.buf)-lastLineMaxBytes:]
+	}
+	l.mu.Unlock()
+	if l.w == nil {
+		return len(p), nil
+	}
+	return l.w.Write(p)
+}
+
+// LastLine returns the last non-empty line in the captured buffer with
+// surrounding whitespace stripped. Returns "" if nothing readable was
+// captured.
+func (l *lastLineWriter) LastLine() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	s := strings.TrimRight(string(l.buf), "\r\n \t")
+	if i := strings.LastIndexAny(s, "\r\n"); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.TrimSpace(s)
 }
 
 // runRunChild executes inside the unshared user+net+mnt namespaces.

--- a/cmd/clawpatrol/run_linux_test.go
+++ b/cmd/clawpatrol/run_linux_test.go
@@ -3,9 +3,96 @@
 package main
 
 import (
+	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// TestLastLineWriter pins the contract used to surface the relay
+// supervisor's cause-of-death: the writer must (a) forward every byte
+// to the underlying sink (so live logs aren't suppressed), and (b)
+// expose the trailing non-empty line so the parent can quote it on
+// unexpected exit.
+func TestLastLineWriter(t *testing.T) {
+	cases := []struct {
+		name   string
+		writes []string
+		want   string
+	}{
+		{
+			name:   "single line no trailing newline",
+			writes: []string{"hello world"},
+			want:   "hello world",
+		},
+		{
+			name:   "two lines trailing newline",
+			writes: []string{"first\nsecond\n"},
+			want:   "second",
+		},
+		{
+			name:   "split writes",
+			writes: []string{"par", "tial\nsec", "ond line\n"},
+			want:   "second line",
+		},
+		{
+			name:   "trailing whitespace stripped",
+			writes: []string{"last line   \n\n\r\n"},
+			want:   "last line",
+		},
+		{
+			name:   "empty",
+			writes: nil,
+			want:   "",
+		},
+		{
+			name:   "only newlines",
+			writes: []string{"\n\n\n"},
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sink bytes.Buffer
+			lw := newLastLineWriter(&sink)
+			joined := strings.Join(tc.writes, "")
+			for _, w := range tc.writes {
+				n, err := lw.Write([]byte(w))
+				if err != nil {
+					t.Fatalf("Write: %v", err)
+				}
+				if n != len(w) {
+					t.Fatalf("Write n=%d, want %d", n, len(w))
+				}
+			}
+			if got := sink.String(); got != joined {
+				t.Errorf("sink got %q, want %q (writer must pass through every byte)", got, joined)
+			}
+			if got := lw.LastLine(); got != tc.want {
+				t.Errorf("LastLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLastLineWriterBounded ensures a long-running noisy child can't
+// drive the ring buffer unbounded.
+func TestLastLineWriterBounded(t *testing.T) {
+	lw := newLastLineWriter(nil)
+	// Write well over lastLineMaxBytes.
+	chunk := strings.Repeat("a", 1024)
+	for i := 0; i < 20; i++ {
+		if _, err := lw.Write([]byte(chunk + "\n")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if got := len(lw.buf); got > lastLineMaxBytes {
+		t.Fatalf("buf size %d exceeds bound %d", got, lastLineMaxBytes)
+	}
+	if got := lw.LastLine(); got == "" {
+		t.Fatal("LastLine empty after writes")
+	}
+}
 
 func TestSplitWGAddresses(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

- If `relay-supervisor` or `relay-worker` died, `clawpatrol run` kept executing the wrapped command with a dead relay — webhooks would silently fail. Now an unexpected death in either tears down the wrapped child and exits non-zero with the cause on stderr.
- Supervisor monitors the worker socketpair for EOF and coordinates with the seccomp notify loop's `ENOENT` shutdown via a 500ms grace, so the normal exit cascade (user cmd → agent child → worker via Pdeathsig) stays silent.
- Top parent waits on the wrapped child and the supervisor concurrently; if the supervisor dies first, it SIGTERM/SIGKILLs the wrapped child and surfaces the supervisor's last stderr line as the cause. Last-line capture uses a bounded (4 KB) ring-buffer tee in front of `os.Stderr` so live logs still stream in real time.

Closes cl-2qgj.

## Test plan

- [x] `go build ./cmd/clawpatrol/` and `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./cmd/clawpatrol/ -count=1` passes (full package)
- [x] `TestMonitorWorkerSocketEOFOnPeerClose` — real socketpair, close peer end, assert `io.EOF`
- [x] `TestLastLineWriter` — pass-through + last-line extraction across input shapes
- [x] `TestLastLineWriterBounded` — ring buffer stays bounded under noisy writes
- [ ] Manual integration: kill `relay-worker` mid-run, verify `clawpatrol run` exits non-zero, wrapped child gets terminated, stderr contains the worker-death cause (not exercised here — would require a daemon + namespaces harness this repo doesn't have)

🤖 Generated with [Claude Code](https://claude.com/claude-code)