### PR TITLE
dashboard: copy-to-clipboard buttons on action detail page (cl-ik9t)

### DIFF
--- a/dashboard/src/components/CopyButton.tsx
+++ b/dashboard/src/components/CopyButton.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import { copyText } from "../lib/clipboard";
+
+// CopyButton is the small icon button rendered in section headers
+// on the request detail page. `text` is resolved lazily so callers
+// can avoid serialising large bodies until the user clicks. Feedback
+// is a check icon that replaces the clipboard glyph for ~1.5s after
+// a successful copy; failure flashes red briefly with the error in
+// the tooltip.
+export function CopyButton({
+  text,
+  label,
+  disabled,
+}: {
+  text: () => string;
+  label: string;
+  disabled?: boolean;
+}) {
+  const [state, setState] = useState<"idle" | "copied" | "error">("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const flash = (next: "copied" | "error") => {
+    if (timer.current) clearTimeout(timer.current);
+    setState(next);
+    timer.current = setTimeout(() => setState("idle"), 1500);
+  };
+
+  const title =
+    state === "copied"
+      ? `Copied ${label}`
+      : state === "error"
+        ? `Failed to copy ${label}`
+        : `Copy ${label}`;
+
+  return (
+    <button
+      type="button"
+      // Section is a <details><summary>; without stopPropagation
+      // the click would also toggle the section collapse.
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (disabled) return;
+        copyText(text()).then((ok) => flash(ok ? "copied" : "error"));
+      }}
+      disabled={disabled}
+      aria-label={title}
+      title={title}
+      className={
+        "inline-flex items-center justify-center w-6 h-6 cursor-pointer " +
+        "text-text-muted hover:text-text " +
+        "disabled:cursor-not-allowed disabled:text-text-subtle disabled:hover:text-text-subtle " +
+        (state === "error" ? "text-danger-500 hover:text-danger-500 " : "") +
+        (state === "copied" ? "text-success-600 hover:text-success-600 " : "")
+      }
+    >
+      {state === "copied" ? <CheckIcon /> : <ClipboardIcon />}
+    </button>
+  );
+}
+
+function ClipboardIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="10" height="11" rx="1" />
+      <path d="M5 15V5a1 1 0 0 1 1-1h10" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m5 12 5 5L20 7" />
+    </svg>
+  );
+}

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -6,9 +6,11 @@ import {
   type EventRecord,
   type FacetSchema,
 } from "../lib/api";
+import { headersToJSON } from "../lib/clipboard";
 import { formatFacetValue, useFacets } from "../lib/facets";
 import { fmtDateTime } from "../lib/format";
 import { Button } from "./Button";
+import { CopyButton } from "./CopyButton";
 import { Main } from "./Main";
 import { PageTitle, type Crumb } from "./PageTitle";
 import { Tag } from "./Tag";
@@ -161,22 +163,38 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
             </Section>
           )}
           {hasReqH && (
-            <Section title="Request headers">
+            <Section
+              title="Request headers"
+              action={
+                <CopyButton label="request headers" text={() => headersToJSON(ev.req_headers!)} />
+              }
+            >
               <Headers obj={ev.req_headers!} />
             </Section>
           )}
           {hasReq && (
-            <Section title="Request body">
+            <Section
+              title="Request body"
+              action={<CopyButton label="request body" text={() => ev.req_body!} />}
+            >
               <HttpBody text={ev.req_body!} />
             </Section>
           )}
           {hasRespH && (
-            <Section title="Response headers">
+            <Section
+              title="Response headers"
+              action={
+                <CopyButton label="response headers" text={() => headersToJSON(ev.resp_headers!)} />
+              }
+            >
               <Headers obj={ev.resp_headers!} />
             </Section>
           )}
           {hasResp && (
-            <Section title={`Response body${status ? ` (${status})` : ""}`}>
+            <Section
+              title={`Response body${status ? ` (${status})` : ""}`}
+              action={<CopyButton label="response body" text={() => ev.resp_body!} />}
+            >
               <HttpBody text={ev.resp_body!} />
             </Section>
           )}
@@ -395,11 +413,20 @@ function Facets({ rows }: { rows: Array<{ name: string; label: string; value: st
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+  action,
+}: {
+  title: string;
+  children: React.ReactNode;
+  action?: React.ReactNode;
+}) {
   return (
     <details open>
-      <summary className="cursor-pointer px-4 py-2.5 text-xs font-mono uppercase tracking-wider font-bold text-navy bg-navy-100 border-b border-navy hover:text-text select-none">
-        {title}
+      <summary className="cursor-pointer flex items-center gap-2 px-4 py-1.5 text-xs font-mono uppercase tracking-wider font-bold text-navy bg-navy-100 border-b border-navy hover:text-text select-none">
+        <span>{title}</span>
+        {action && <span className="ml-auto">{action}</span>}
       </summary>
       <div>{children}</div>
     </details>

--- a/dashboard/src/lib/clipboard.test.ts
+++ b/dashboard/src/lib/clipboard.test.ts
@@ -1,0 +1,87 @@
+/// <reference lib="deno.ns" />
+import { headersToJSON } from "./clipboard";
+
+Deno.test("headersToJSON: single-value headers serialise as strings", () => {
+  const out = headersToJSON({
+    "content-type": "application/json",
+    "x-request-id": "abc123",
+  });
+  const parsed = JSON.parse(out);
+  if (parsed["content-type"] !== "application/json") {
+    throw new Error(
+      `expected content-type as string, got ${JSON.stringify(parsed["content-type"])}`,
+    );
+  }
+  if (parsed["x-request-id"] !== "abc123") {
+    throw new Error(
+      `expected x-request-id as string, got ${JSON.stringify(parsed["x-request-id"])}`,
+    );
+  }
+});
+
+Deno.test("headersToJSON: multi-value headers serialise as arrays", () => {
+  const out = headersToJSON({
+    "set-cookie": ["a=1; Path=/", "b=2; Secure"],
+  });
+  const parsed = JSON.parse(out);
+  if (!Array.isArray(parsed["set-cookie"])) {
+    throw new Error(`expected set-cookie as array, got ${typeof parsed["set-cookie"]}`);
+  }
+  if (parsed["set-cookie"].length !== 2) {
+    throw new Error(`expected 2 cookies, got ${parsed["set-cookie"].length}`);
+  }
+  if (parsed["set-cookie"][0] !== "a=1; Path=/" || parsed["set-cookie"][1] !== "b=2; Secure") {
+    throw new Error(`unexpected values: ${JSON.stringify(parsed["set-cookie"])}`);
+  }
+});
+
+Deno.test("headersToJSON: empty header map produces empty object", () => {
+  const out = headersToJSON({});
+  if (out !== "{}") {
+    throw new Error(`expected '{}', got ${JSON.stringify(out)}`);
+  }
+});
+
+Deno.test("headersToJSON: empty header value preserved", () => {
+  const out = headersToJSON({ "x-empty": "" });
+  const parsed = JSON.parse(out);
+  if (parsed["x-empty"] !== "") {
+    throw new Error(`expected empty string, got ${JSON.stringify(parsed["x-empty"])}`);
+  }
+});
+
+Deno.test("headersToJSON: single-element array collapses to string", () => {
+  const out = headersToJSON({ "x-once": ["only"] });
+  const parsed = JSON.parse(out);
+  if (parsed["x-once"] !== "only") {
+    throw new Error(
+      `expected single-element array to collapse to string, got ${JSON.stringify(parsed["x-once"])}`,
+    );
+  }
+});
+
+Deno.test("headersToJSON: special characters are JSON-escaped", () => {
+  const out = headersToJSON({
+    "x-quote": 'he said "hi"',
+    "x-backslash": "a\\b",
+    "x-newline": "line1\nline2",
+    "x-tab": "a\tb",
+    "x-unicode": "café 漢字 🚀",
+  });
+  const parsed = JSON.parse(out);
+  if (parsed["x-quote"] !== 'he said "hi"') throw new Error("quote round-trip failed");
+  if (parsed["x-backslash"] !== "a\\b") throw new Error("backslash round-trip failed");
+  if (parsed["x-newline"] !== "line1\nline2") throw new Error("newline round-trip failed");
+  if (parsed["x-tab"] !== "a\tb") throw new Error("tab round-trip failed");
+  if (parsed["x-unicode"] !== "café 漢字 🚀") throw new Error("unicode round-trip failed");
+});
+
+Deno.test("headersToJSON: output is pretty-printed with 2-space indent", () => {
+  const out = headersToJSON({ a: "1", b: "2" });
+  if (!out.includes("\n")) {
+    throw new Error("expected newlines in pretty-printed output");
+  }
+  if (!out.includes('  "a"')) {
+    throw new Error(`expected 2-space indent, got: ${out}`);
+  }
+});

--- a/dashboard/src/lib/clipboard.ts
+++ b/dashboard/src/lib/clipboard.ts
@@ -1,0 +1,32 @@
+/// <reference lib="dom" />
+
+// headersToJSON serialises a header map as a pretty-printed JSON
+// object string. Single-value entries serialise as plain strings;
+// array entries serialise as JSON arrays of strings, preserving
+// multi-value headers verbatim. Key order is the input's insertion
+// order — matches the dashboard's on-screen rendering.
+export function headersToJSON(headers: Record<string, string | string[]>): string {
+  const obj: Record<string, string | string[]> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (Array.isArray(v)) {
+      obj[k] = v.length === 1 ? v[0] : v.slice();
+    } else {
+      obj[k] = v;
+    }
+  }
+  return JSON.stringify(obj, null, 2);
+}
+
+// copyText writes text to the system clipboard. Returns true on
+// success, false otherwise (insecure context, denied permission,
+// or no Clipboard API). Callers use the return value to decide
+// whether to flash a confirmation indicator.
+export async function copyText(text: string): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -15,5 +15,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary

- Adds a copy-to-clipboard icon button to the four content sections (request headers, request body, response headers, response body) on the V1 dashboard's action detail page.
- Headers copy as pretty-printed JSON with arrays for multi-value entries; bodies copy verbatim. Buttons are hidden when the section has no content (consistent with the existing pattern of hiding the section entirely).
- Brief checkmark confirmation replaces the icon for ~1.5s after a successful copy; failure flashes red with the error in the tooltip.
- New \`headersToJSON\` helper in \`dashboard/src/lib/clipboard.ts\` with deno-runnable unit tests covering single/multi value, empty maps, special characters, and pretty-printing. Test files are excluded from the \`tsc\` build via \`tsconfig\`.

Closes cl-ik9t.

## Test plan

- [x] \`deno test --sloppy-imports src/lib/clipboard.test.ts\` — 7/7 pass
- [x] \`make fmt-check\` clean
- [x] \`deno task lint\` clean
- [x] \`deno task build\` succeeds
- [x] \`go test ./...\` passes
- [ ] Manual: load action detail page, click each copy button on request/response sections, paste and verify content matches what's rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)