### PR TITLE
telemetry: track install.sh runs in D1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@
 #   CLAWPATROL_PREFIX        — install dir (default: $HOME/.local/bin)
 #   CLAWPATROL_FROM_SOURCE   — 1 to build from source (Go required)
 #   CLAWPATROL_REF           — git ref when building from source (default: main)
+#   CLAWPATROL_NO_TELEMETRY  — 1 to skip the anonymous install-event ping
 #
 # POSIX sh.
 
@@ -19,6 +20,33 @@ REPO="denoland/clawpatrol"
 VERSION="${CLAWPATROL_VERSION:-latest}"
 PREFIX="${CLAWPATROL_PREFIX:-$HOME/.local/bin}"
 
+# Anonymous install telemetry. Pings clawpatrol.dev with os/arch/
+# version and a generated per-run id so we can count installs and
+# debug failures. Opt out with CLAWPATROL_NO_TELEMETRY=1.
+TELEMETRY_URL="https://clawpatrol.dev/api/telemetry/v1/install"
+INSTALL_ID=""
+
+telemetry() {
+  [ "${CLAWPATROL_NO_TELEMETRY:-0}" = "1" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  if [ -z "$INSTALL_ID" ]; then
+    INSTALL_ID=$(
+      od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n' \
+        || date +%s%N 2>/dev/null \
+        || date +%s
+    )
+  fi
+  event="$1"
+  reason="${2:-}"
+  body=$(printf '{"install_id":"%s","event":"%s","os":"%s","arch":"%s","version":"%s","from_source":"%s","reason":"%s"}' \
+    "$INSTALL_ID" "$event" \
+    "${OS:-}" "${ARCH:-}" "$VERSION" \
+    "${CLAWPATROL_FROM_SOURCE:-0}" "$reason")
+  (curl -fsS --max-time 3 -X POST \
+     -H 'Content-Type: application/json' \
+     -d "$body" "$TELEMETRY_URL" >/dev/null 2>&1 || true) &
+}
+
 if [ "$VERSION" = "latest" ]; then
   BASE="https://github.com/${REPO}/releases/latest/download"
 else
@@ -26,7 +54,7 @@ else
 fi
 
 say()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
-fail() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+fail() { telemetry failed "$*"; printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
@@ -68,6 +96,7 @@ if [ "${CLAWPATROL_FROM_SOURCE:-0}" = "1" ]; then
   mv "$SRC/clawpatrol" "$PREFIX/clawpatrol"
   chmod +x "$PREFIX/clawpatrol"
   say "installed: $PREFIX/clawpatrol"
+  telemetry completed
   exit 0
 fi
 
@@ -132,4 +161,5 @@ if [ "$OS" = "darwin" ]; then
   rm -rf "$APP_TMP"
 fi
 
+telemetry completed
 echo "next: clawpatrol join <gateway-url>"

--- a/site/migrations/0003_create_installs.sql
+++ b/site/migrations/0003_create_installs.sql
@@ -1,0 +1,17 @@
+-- One row per `install.sh` invocation that pinged home. Append-only;
+-- install_id is generated client-side per script run, so duplicate
+-- events for the same id (retries from the same shell) collapse via
+-- INSERT OR REPLACE in the worker.
+CREATE TABLE installs (
+  install_id  TEXT PRIMARY KEY,
+  received_at INTEGER NOT NULL,
+  event       TEXT NOT NULL,   -- 'completed' | 'failed'
+  os          TEXT,
+  arch        TEXT,
+  version     TEXT,
+  from_source INTEGER,         -- 0 | 1
+  reason      TEXT             -- failure message, empty on completed
+);
+
+CREATE INDEX installs_received_at ON installs(received_at);
+CREATE INDEX installs_event       ON installs(event);

--- a/site/sql/telemetry/installs-7d.sql
+++ b/site/sql/telemetry/installs-7d.sql
@@ -1,0 +1,6 @@
+-- Install events in the last 7 days, split by outcome.
+SELECT event, COUNT(*) AS count
+FROM installs
+WHERE received_at > unixepoch() - 7 * 86400
+GROUP BY event
+ORDER BY count DESC;

--- a/site/sql/telemetry/installs-failures-7d.sql
+++ b/site/sql/telemetry/installs-failures-7d.sql
@@ -1,0 +1,11 @@
+-- Top failure reasons in the last 7 days. Useful for catching
+-- regressions in install.sh (unsupported arch, missing curl,
+-- sha256 mismatch, ...).
+SELECT
+  COALESCE(reason, '(unknown)') AS reason,
+  COUNT(*) AS count
+FROM installs
+WHERE received_at > unixepoch() - 7 * 86400
+  AND event = 'failed'
+GROUP BY reason
+ORDER BY count DESC, reason;

--- a/site/sql/telemetry/installs-platforms-7d.sql
+++ b/site/sql/telemetry/installs-platforms-7d.sql
@@ -1,0 +1,9 @@
+-- Successful installs in the last 7 days, broken down by os/arch.
+SELECT
+  COALESCE(os, '?') || '/' || COALESCE(arch, '?') AS platform,
+  COUNT(*) AS count
+FROM installs
+WHERE received_at > unixepoch() - 7 * 86400
+  AND event = 'completed'
+GROUP BY platform
+ORDER BY count DESC, platform;

--- a/site/worker/index.test.ts
+++ b/site/worker/index.test.ts
@@ -57,6 +57,49 @@ test("rejects oversized telemetry payloads from Content-Length before reading th
   assert.equal(calls.prepare, 0);
 });
 
+test("install ping inserts a row and 204s", async () => {
+  const { env: testEnv, calls } = env();
+  const body = JSON.stringify({
+    install_id: "abcd1234",
+    event: "completed",
+    os: "darwin",
+    arch: "arm64",
+    version: "latest",
+    from_source: "0",
+    reason: "",
+  });
+  const res = await worker.fetch(
+    new Request("https://clawpatrol.dev/api/telemetry/v1/install", {
+      method: "POST",
+      body,
+    }),
+    testEnv,
+  );
+
+  assert.equal(res.status, 204);
+  assert.equal(calls.prepare, 1);
+  const bound = calls.bind[0];
+  assert.equal(bound[0], "abcd1234");
+  assert.equal(bound[2], "completed");
+  assert.equal(bound[3], "darwin");
+  assert.equal(bound[4], "arm64");
+  assert.equal(bound[6], 0);
+});
+
+test("install ping rejects unknown event names", async () => {
+  const { env: testEnv, calls } = env();
+  const res = await worker.fetch(
+    new Request("https://clawpatrol.dev/api/telemetry/v1/install", {
+      method: "POST",
+      body: JSON.stringify({ install_id: "x", event: "bogus" }),
+    }),
+    testEnv,
+  );
+
+  assert.equal(res.status, 400);
+  assert.equal(calls.prepare, 0);
+});
+
 test("rejects payloads over the byte limit, not just the JavaScript string length", async () => {
   const { env: testEnv, calls } = env();
   globalThis.fetch = async () => {

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -27,6 +27,9 @@ export default {
     if (url.pathname === "/api/telemetry/v1/check") {
       return handleCheck(req, env);
     }
+    if (url.pathname === "/api/telemetry/v1/install") {
+      return handleInstall(req, env);
+    }
     return env.ASSETS.fetch(req);
   },
   async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
@@ -118,6 +121,68 @@ async function handleCheck(
     url: release.url,
     advisory: release.advisory,
   });
+}
+
+async function handleInstall(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response(null, { status: 405 });
+  }
+  const contentLength = req.headers.get("Content-Length");
+  if (contentLength !== null) {
+    const n = Number(contentLength);
+    if (Number.isFinite(n) && n > MAX_BODY_BYTES) {
+      return new Response(null, { status: 413 });
+    }
+  }
+
+  const text = await req.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const id = str(body.install_id);
+  const event = str(body.event);
+  if (!id || (event !== "completed" && event !== "failed")) {
+    return new Response(null, { status: 400 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const fromSource = body.from_source === "1" || body.from_source === 1 ? 1 : 0;
+  await env.TELEMETRY_DB.prepare(
+    `INSERT INTO installs (
+       install_id, received_at, event,
+       os, arch, version, from_source, reason
+     ) VALUES (?,?,?,?,?,?,?,?)
+     ON CONFLICT(install_id) DO UPDATE SET
+       received_at = excluded.received_at,
+       event       = excluded.event,
+       os          = excluded.os,
+       arch        = excluded.arch,
+       version     = excluded.version,
+       from_source = excluded.from_source,
+       reason      = excluded.reason`,
+  ).bind(
+    id,
+    now,
+    event,
+    str(body.os) || null,
+    str(body.arch) || null,
+    str(body.version) || null,
+    fromSource,
+    str(body.reason) || null,
+  ).run();
+
+  return new Response(null, { status: 204 });
 }
 
 type Release = {


### PR DESCRIPTION
## Summary

- Adds `POST /api/telemetry/v1/install` to the site worker and an `installs` D1 table. `install.sh` pings it on success and from `fail()` with the error message as `reason`, sending `{install_id, event, os, arch, version, from_source, reason}`.
- Closes the gap between pageview counts on `/install.sh` (Cloudflare Web Analytics) and the existing gateway-ping telemetry, which only sees installs that survive to actually run `clawpatrol run`. The new data answers "how many `curl ... | sh` invocations succeeded vs failed, and why."
- Three SQL queries land alongside the existing gateway ones (`installs-7d`, `installs-platforms-7d`, `installs-failures-7d`) so `npm run telemetry` surfaces install metrics out of the box.
- Opt-out via `CLAWPATROL_NO_TELEMETRY=1`. Curl runs backgrounded with `--max-time 3` so a flaky network cannot hang the install.

## Test plan

- [x] `cd site && npm test` — happy path and bad-event tests for the new route both pass alongside the existing size-limit tests.
- [ ] After merge: `cd site && npx wrangler d1 migrations apply TELEMETRY_DB --remote` to create the `installs` table.
- [ ] After merge: `cd site && npm run deploy` to ship the worker.
- [ ] Smoke test from a fresh VM: `curl -fsSL https://clawpatrol.dev/install.sh | sh`, then `cd site && npm run telemetry` and confirm a row in `installs-7d.sql` output.
- [ ] Confirm `CLAWPATROL_NO_TELEMETRY=1 sh install.sh` produces no `installs` row.
