### PR TITLE
feat: redesign HITLBar and add inline verdicts to live requests

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -374,16 +374,23 @@ func runDaemon(_ []string) {
 // wg.conf. Either way, the returned transport carries one network
 // identity shared by every `clawpatrol run` on this host.
 func daemonStartTransport() (daemonTransport, error) {
-	mode := strings.TrimSpace(readFileSilent(filepath.Join(defaultClawpatrolDir(), "mode")))
+	modeFile := filepath.Join(defaultClawpatrolDir(), "mode")
+	mode := strings.TrimSpace(readFileSilent(modeFile))
 	switch mode {
 	case "tailscale":
 		return startTsnetTransport()
-	case "wireguard", "":
-		// Empty mode = legacy WG join (older builds didn't write a
-		// marker file). Presence of wg.conf is the WG signal.
+	case "wireguard":
 		return startWGTransport()
+	case "":
+		// No mode file: either a legacy WG join (older builds didn't write
+		// the marker) or join never completed / wrote nothing (permission
+		// error on clawDir). Distinguish by checking for wg.conf.
+		if _, err := os.Stat(defaultRunConf()); err == nil {
+			return startWGTransport()
+		}
+		return nil, fmt.Errorf("no mode file at %s and no wg.conf — re-run `clawpatrol join`", modeFile)
 	default:
-		return nil, fmt.Errorf("unknown mode %q in %s/mode", mode, defaultClawpatrolDir())
+		return nil, fmt.Errorf("unknown mode %q in %s — re-run `clawpatrol join`", mode, modeFile)
 	}
 }
 

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -324,6 +324,15 @@ func preJoinFetchCA(gateway, caDir string, cli *http.Client) (joinSetup, error) 
 	if err := os.MkdirAll(caDir, 0o700); err != nil {
 		return s, fmt.Errorf("mkdir %s: %w", caDir, err)
 	}
+	// Preflight: fail fast if the directory isn't writable by the current
+	// user. A root-owned dir from a previous `docker run -v` will pass
+	// MkdirAll (dir already exists) but fail every subsequent WriteFile,
+	// causing join to report success while writing nothing.
+	probe := filepath.Join(caDir, ".write-probe")
+	if err := os.WriteFile(probe, nil, 0o600); err != nil {
+		return s, fmt.Errorf("config dir %s is not writable (owner mismatch?): %w", caDir, err)
+	}
+	_ = os.Remove(probe)
 	// Persist the dashboard URL before the CA fetch so subsequent
 	// `clawpatrol env` / `clawpatrol run` invocations work even when
 	// the CA fetch is deferred (Tailscale mode, 404 on /ca.crt).
@@ -1187,7 +1196,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				}
 			}
 		}
-		_ = os.WriteFile(filepath.Join(clawDir, "mode"), []byte("tailscale\n"), 0o600)
+		if err := os.WriteFile(filepath.Join(clawDir, "mode"), []byte("tailscale\n"), 0o600); err != nil {
+			return false, fmt.Errorf("write mode: %w", err)
+		}
 		// Persist the join-time --hostname so the per-host daemon
 		// registers under the operator-chosen name instead of
 		// os.Hostname() (which on most VMs is the system login, not
@@ -1198,7 +1209,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		if tailnetGWHost != "" {
 			_ = os.WriteFile(filepath.Join(clawDir, "tailnet-gateway"), []byte(tailnetGWHost+"\n"), 0o600)
 		}
-		_ = os.WriteFile(filepath.Join(clawDir, "control-url"), []byte(tailnetControlURL+"\n"), 0o600)
+		if err := os.WriteFile(filepath.Join(clawDir, "control-url"), []byte(tailnetControlURL+"\n"), 0o600); err != nil {
+			return false, fmt.Errorf("write control-url: %w", err)
+		}
 		if gatewayIP != "" {
 			tailnetURL := fmt.Sprintf("http://%s:8080", gatewayIP)
 			_ = os.WriteFile(filepath.Join(clawDir, "tailnet-url"), []byte(tailnetURL+"\n"), 0o600)
@@ -1230,7 +1243,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			if err := os.MkdirAll(stateDir, 0o700); err != nil {
 				return false, fmt.Errorf("daemon state dir: %w", err)
 			}
-			_ = os.WriteFile(filepath.Join(stateDir, "auth-key"), []byte(authKey+"\n"), 0o600)
+			if err := os.WriteFile(filepath.Join(stateDir, "auth-key"), []byte(authKey+"\n"), 0o600); err != nil {
+				return false, fmt.Errorf("write auth-key: %w", err)
+			}
 		}
 		items := []string{"Joined (tsnet mode — persistent daemon node joins tailnet on first `clawpatrol run`)"}
 		items = append(items, setupSummaryItems(*setup)...)
@@ -1313,7 +1328,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	// Write mode marker files so `clawpatrol run` can detect Tailscale mode.
 	clawDir := filepath.Dir(setup.caPath)
-	_ = os.WriteFile(filepath.Join(clawDir, "mode"), []byte("tailscale\n"), 0o600)
+	if err := os.WriteFile(filepath.Join(clawDir, "mode"), []byte("tailscale\n"), 0o600); err != nil {
+		return false, fmt.Errorf("write mode: %w", err)
+	}
 	if hn != "" {
 		_ = os.WriteFile(filepath.Join(clawDir, "hostname"), []byte(hn+"\n"), 0o600)
 	}
@@ -1321,7 +1338,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		_ = os.WriteFile(filepath.Join(clawDir, "tailnet-gateway"), []byte(tailnetGWHost+"\n"), 0o600)
 	}
 	if tailnetControlURL != "" {
-		_ = os.WriteFile(filepath.Join(clawDir, "control-url"), []byte(tailnetControlURL+"\n"), 0o600)
+		if err := os.WriteFile(filepath.Join(clawDir, "control-url"), []byte(tailnetControlURL+"\n"), 0o600); err != nil {
+			return false, fmt.Errorf("write control-url: %w", err)
+		}
 	}
 
 	// Fetch CA from the gateway's tailnet IP now that we're on the tailnet.

--- a/dashboard/src/components/HITLBar.tsx
+++ b/dashboard/src/components/HITLBar.tsx
@@ -2,10 +2,9 @@ import { useEffect, useState } from "react";
 import { decideHITL, getHITLPending, type HITLPending, type HITLResolveResult } from "../lib/api";
 import { Button } from "./Button";
 
-// HITL pending-approvals table. Polls /api/hitl/pending — list is
-// short-lived (60s default), so SSE plumbing isn't worth it.
 export function HITLBar() {
   const [pending, setPending] = useState<HITLPending[]>([]);
+  const [justResolved, setJustResolved] = useState<HITLPending[]>([]);
   const [notice, setNotice] = useState("");
 
   useEffect(() => {
@@ -13,7 +12,17 @@ export function HITLBar() {
     async function tick() {
       try {
         const r = await getHITLPending();
-        if (!cancelled) setPending(r ?? []);
+        if (!cancelled) {
+          const incoming = r ?? [];
+          // Detect >0 → 0 transition: briefly flash green "Approved" cards.
+          setPending((prev) => {
+            if (prev.length > 0 && incoming.length === 0) {
+              setJustResolved(prev);
+              setTimeout(() => setJustResolved([]), 2500);
+            }
+            return incoming;
+          });
+        }
       } catch {
         /* ignore transient */
       }
@@ -38,169 +47,116 @@ export function HITLBar() {
     }
   }
 
-  if (pending.length === 0 && !notice) return null;
+  if (pending.length === 0 && justResolved.length === 0 && !notice) return null;
 
   return (
-    <div className="bg-canvas border-1.5 border-navy overflow-hidden">
-      <div className="px-4 py-2.5 text-xs font-mono uppercase tracking-wider text-navy font-bold flex items-center bg-navy-100 border-b border-navy">
-        <span>Pending approvals</span>
-        <span className="ml-2 text-rust-500 tabular-nums">● {pending.length}</span>
-      </div>
+    <div className="space-y-1.5">
       {notice && (
-        <div className="px-4 py-2 text-xs text-rust-700 bg-canvas-muted border-t border-rust-200">
+        <div className="px-4 py-2 text-xs text-rust-700 bg-canvas border-1.5 border-rust-200">
           {notice}
         </div>
       )}
-      {pending.length > 0 && (
-        <table className="w-full table-fixed border-collapse">
-          <colgroup>
-            <col style={{ width: 140 }} />
-            <col style={{ width: 60 }} />
-            <col />
-            <col style={{ width: 160 }} />
-          </colgroup>
-          <tbody>
-            {pending.map((p) => {
-              const ep = p.endpoint || p.host;
-              // HTTPS paths start with `/` and concatenate cleanly into
-              // a URL ("api.anthropic.com/v1/messages"). SQL / k8s
-              // paths don't start with `/`; insert a space so we get
-              // "users-db UPDATE ..." rather than "users-dbUPDATE ...".
-              const sep = p.path && !p.path.startsWith("/") ? " " : "";
-              const approval = hitlApprovalDisplay(p);
-              return (
-                <tr
-                  key={p.id}
-                  className="border-b border-canvas-muted last:border-b-0 hover:bg-canvas-muted"
-                >
-                  <Td className="text-xs text-text-muted tabular-nums truncate">{p.agent_ip}</Td>
-                  <Td className="font-mono text-xs uppercase font-semibold text-rust-700">
-                    {p.method}
-                  </Td>
-                  <Td>
-                    <span className="text-xs text-text truncate block" title={ep + sep + p.path}>
-                      <span className="text-text-muted">
-                        {ep}
-                        {sep}
-                      </span>
-                      <span>{p.path}</span>
-                    </span>
-                    {p.reason && (
-                      <div className="text-2xs text-text-muted truncate">{p.reason}</div>
-                    )}
-                    {approval && (
-                      <div className="mt-1 flex gap-2 text-2xs leading-snug text-text-muted">
-                        <span className="shrink-0 rounded-sm border border-navy-200 bg-navy-50 px-1.5 py-0.5 font-mono uppercase tracking-wide text-navy">
-                          {approval.label}
-                        </span>
-                        <span className="whitespace-pre-line">{approval.message}</span>
-                      </div>
-                    )}
-                  </Td>
-                  <Td className="text-right">
-                    <div className="flex gap-1.5 justify-end">
-                      <Button
-                        variant="outline"
-                        onClick={() =>
-                          decide(
-                            p.id,
-                            false,
-                            `Deny this request?\n\n${p.method} ${ep}${sep}${p.path}`,
-                          )
-                        }
-                      >
-                        deny
-                      </Button>
-                      <Button
-                        onClick={() => {
-                          const verb = approval?.approveLabel ?? "allow";
-                          const cap = verb.charAt(0).toUpperCase() + verb.slice(1);
-                          decide(
-                            p.id,
-                            true,
-                            `${cap} this request?\n\n${p.method} ${ep}${sep}${p.path}`,
-                          );
-                        }}
-                      >
-                        {approval?.approveLabel ?? "allow"}
-                      </Button>
-                    </div>
-                  </Td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+      {justResolved.map((r) => <ResolvedCard key={r.id} item={r} />)}
+      {pending.map((p) => (
+        <PendingCard key={p.id} item={p} onDecide={decide} />
+      ))}
+    </div>
+  );
+}
+
+function PendingCard({
+  item,
+  onDecide,
+}: {
+  item: HITLPending;
+  onDecide: (id: string, allow: boolean, msg: string) => void;
+}) {
+  const ep = item.endpoint || item.host;
+  const sep = item.path && !item.path.startsWith("/") ? " " : "";
+  const target = `${item.method} ${ep}${sep}${item.path}`;
+  const approveLabel =
+    item.approval_effect === "create_retry_grant" ||
+    item.operation_state === "pending_approval"
+      ? "approve retry"
+      : "allow";
+
+  return (
+    <div className="border-l-4 border-butter-400 bg-canvas border-y border-r border-navy overflow-hidden">
+      <div className="px-4 py-3 flex items-center gap-3 min-w-0">
+        {/* status badge */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className="w-2 h-2 rounded-full bg-butter-400 animate-pulse" />
+          <span className="font-mono text-2xs font-bold uppercase tracking-wider text-butter-700 whitespace-nowrap">
+            awaiting approval
+          </span>
+        </div>
+        {/* request */}
+        <span className="font-mono text-xs font-semibold text-text-muted shrink-0">
+          {item.method}
+        </span>
+        <span className="font-mono text-xs text-text truncate flex-1 min-w-0" title={target}>
+          {ep}
+          {sep}
+          {item.path}
+        </span>
+        {/* actions */}
+        <div className="flex gap-1.5 shrink-0">
+          <Button
+            variant="outline"
+            onClick={() => onDecide(item.id, false, `Deny this request?\n\n${target}`)}
+          >
+            deny
+          </Button>
+          <Button
+            onClick={() => {
+              const cap = approveLabel.charAt(0).toUpperCase() + approveLabel.slice(1);
+              onDecide(item.id, true, `${cap}?\n\n${target}`);
+            }}
+          >
+            {approveLabel}
+          </Button>
+        </div>
+      </div>
+      {(item.body_sample || item.ua || item.reason) && (
+        <div className="px-4 pb-2.5 pt-1.5 border-t border-canvas-muted space-y-0.5">
+          {item.body_sample && (
+            <div className="font-mono text-2xs text-text truncate">{item.body_sample}</div>
+          )}
+          <div className="text-2xs text-text-muted truncate">
+            {item.ua && (
+              <span>requested by <span className="font-mono text-text">{item.ua}</span></span>
+            )}
+            {item.ua && item.reason && <span className="mx-1.5">·</span>}
+            {item.reason && <span>{item.reason}</span>}
+          </div>
+        </div>
       )}
     </div>
   );
 }
 
-function hitlApprovalDisplay(
-  p: HITLPending,
-): { label: string; message: string; approveLabel: string } | null {
-  const effect = p.approval_effect;
-  const state = p.operation_state;
-  const message = (
-    p.approval_message || hitlApprovalFallbackMessage(state, effect, p.upstream_called)
-  ).trim();
-  if (!message && !state && !effect) return null;
-  if (effect === "create_retry_grant" || state === "pending_approval") {
-    return {
-      label: "retry grant",
-      message:
-        message || "Upstream has not been called. Approval allows one matching client retry.",
-      approveLabel: "approve retry",
-    };
-  }
-  if (p.upstream_called) {
-    return {
-      label: "upstream called",
-      message: message || "The approved request has been retried and forwarded upstream.",
-      approveLabel: "allow",
-    };
-  }
-  return {
-    label: state === "sync_waiting" ? "sync wait" : humanizeHITLState(state || "pending"),
-    message: message || "Approval sends this request upstream immediately while the client waits.",
-    approveLabel: "allow",
-  };
-}
-
-function hitlApprovalFallbackMessage(
-  state: HITLPending["operation_state"],
-  effect: HITLPending["approval_effect"],
-  upstreamCalled?: boolean,
-): string {
-  if (upstreamCalled) return "The approved request has been retried and forwarded upstream.";
-  if (effect === "create_retry_grant" || state === "pending_approval") {
-    return "Upstream has not been called. Approve will not send the request upstream now; it only allows one matching client retry.";
-  }
-  if (state === "approved_waiting_for_retry") {
-    return "Approved. Waiting for the client to retry the original request. Upstream has not been called yet.";
-  }
-  if (state === "denied" || state === "expired" || state === "client_disconnected") {
-    return "Upstream was not called.";
-  }
-  if (state === "sync_waiting" || effect === "execute_upstream") {
-    return "Approval sends this request upstream immediately while the client waits.";
-  }
-  return "";
-}
-
-function humanizeHITLState(state: string): string {
-  return state.replaceAll("_", " ");
+function ResolvedCard({ item }: { item: HITLPending }) {
+  const ep = item.endpoint || item.host;
+  const sep = item.path && !item.path.startsWith("/") ? " " : "";
+  return (
+    <div className="border-l-4 border-success-500 bg-canvas border-y border-r border-navy px-4 py-3 flex items-center gap-3 min-w-0">
+      <div className="flex items-center gap-1.5 shrink-0">
+        <span className="w-2 h-2 rounded-full bg-success-500" />
+        <span className="font-mono text-2xs font-bold uppercase tracking-wider text-success-700 whitespace-nowrap">
+          approved
+        </span>
+      </div>
+      <span className="font-mono text-xs font-semibold text-text-muted shrink-0">{item.method}</span>
+      <span className="font-mono text-xs text-text truncate flex-1 min-w-0">
+        {ep}
+        {sep}
+        {item.path}
+      </span>
+    </div>
+  );
 }
 
 function hitlDecisionNotice(result: HITLResolveResult): string {
   const detail = result.reason || result.state || "unknown";
   return `HITL request is no longer active: ${detail}`;
-}
-
-function Td({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return (
-    <td className={"px-3 sm:px-3.5 py-2.5 align-middle overflow-hidden " + className}>
-      {children}
-    </td>
-  );
 }

--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -207,6 +207,9 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
   const { verb, body } = rowDescriptors(ev, schema);
   const sep = body && !body.startsWith("/") ? " " : "";
   const hasFrames = (ev.frames?.length ?? 0) > 0;
+  const isDenied =
+    ev.action === "deny" || ev.action === "denied" || ev.action === "hitl_deny";
+  const isApproved = ev.action === "approved" || ev.action === "hitl_allow";
   return (
     <div className="border-b border-canvas-muted">
       <div
@@ -237,6 +240,26 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
           {inFlight ? "…" : ev.ms + "ms"}
         </span>
       </div>
+      {inFlight && ev.action === "hitl_pending" && (
+        <div className="px-4 pb-1.5 flex items-center gap-1.5 text-2xs font-mono text-butter-600">
+          <span className="w-1.5 h-1.5 rounded-full bg-butter-400 animate-pulse shrink-0" />
+          awaiting approval
+        </div>
+      )}
+      {isDenied && (
+        <div className="px-4 pb-1.5 flex items-center gap-1.5 text-2xs font-mono text-danger-600 min-w-0">
+          <span className="w-1.5 h-1.5 rounded-full bg-danger-500 shrink-0" />
+          <span className="font-semibold">denied</span>
+          {ev.rule && <span className="text-danger-400 shrink-0">· {ev.rule}</span>}
+          {ev.reason && <span className="text-text-subtle truncate">· {ev.reason}</span>}
+        </div>
+      )}
+      {isApproved && ev.approver_by && (
+        <div className="px-4 pb-1.5 flex items-center gap-1.5 text-2xs font-mono text-success-600">
+          <span className="w-1.5 h-1.5 rounded-full bg-success-500 shrink-0" />
+          approved by {ev.approver_by}
+        </div>
+      )}
       {hasFrames && (
         <div className="bg-canvas-muted border-t border-canvas-muted max-h-45 overflow-y-auto">
           {ev.frames!.map((f, i) => (


### PR DESCRIPTION
## Summary

- **HITLBar redesign**: replaces the dense table with one card per pending item. Each card reads left-to-right in ~2 s: `● AWAITING APPROVAL · METHOD · endpoint/path · [deny] [allow]`. Shows `body_sample` (query/SQL/command) and `ua` (requesting agent) when the gateway populates them. Flashes green "Approved" cards for 2.5 s when the pending list clears. Preserves `approveLabel` logic so retry-grant states still show "approve retry".
- **LiveRequests inline verdicts**: denied rows now show `denied · rule · reason` inline without needing to click through. Approved/hitl_allow rows show `approved by <actor>` inline.

## Test plan

- [ ] Trigger a real HITL request and confirm card layout renders correctly
- [ ] Trigger a retry-grant HITL and confirm button says "approve retry"
- [ ] Confirm denied events in live feed show rule + reason sub-row
- [ ] Confirm approved events show "approved by" sub-row