### PR TITLE
Show endpoint hostname instead of VIP in dashboard for tunneled postgres

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1492,8 +1492,10 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 	// the connection to an unrelated database (e.g. an RDS hostname
 	// silently terminating on a Cloud SQL tunnel).
 	var ep *config.CompiledEndpoint
+	var hostname string
 	if g.dnsvip != nil {
-		if _, hits := g.dnsvip.LookupVIP(dstIP); len(hits) > 0 {
+		if hn, hits := g.dnsvip.LookupVIP(dstIP); len(hits) > 0 {
+			hostname = hn
 			cand := make([]*config.CompiledEndpoint, 0, len(hits))
 			for _, h := range hits {
 				if h.Endpoint != nil {
@@ -1524,6 +1526,14 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 	}
 
 	upstreamAddr := dstIP + ":5432"
+	// Event Host carries the agent-dialed hostname when the dst is a
+	// dnsvip VIP (tunneled endpoint), else the raw dst IP. Without
+	// this the dashboard shows the synthetic VIP (e.g. fdXX::N) and
+	// the operator can't tell which database the connection hits.
+	eventHost := hostname
+	if eventHost == "" {
+		eventHost = dstIP
+	}
 	ch := &runtime.ConnHandle{
 		Conn:     c,
 		Endpoint: ep,
@@ -1548,7 +1558,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 				return
 			}
 			g.sink.Emit(Event{
-				Mode: "pg", Family: ep.Family, Host: dstIP, AgentIP: agentPip,
+				Mode: "pg", Family: ep.Family, Host: eventHost, AgentIP: agentPip,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,
@@ -1560,7 +1570,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {
 			return g.runApproveChain(context.Background(), req.Stages, runApproveCtx{
-				AgentIP: agentPip, Host: dstIP, Method: req.Verb, Path: req.Summary,
+				AgentIP: agentPip, Host: eventHost, Method: req.Verb, Path: req.Summary,
 				Reason:   ifNotEmpty(req.Rule, func(r *config.CompiledRule) string { return r.Outcome.Reason }),
 				Endpoint: ep, Rule: req.Rule, Profile: profile,
 			})


### PR DESCRIPTION
Fixes #599.

* `handlePostgresConn` emitted dashboard events with `Host` set to the
  raw destination IP. For tunneled postgres endpoints the dst is a
  synthetic dnsvip VIP (e.g. an `fd`-prefixed address), so the
  live-request row showed the VIP and the operator could not tell
  which database the connection was talking to.
* The hostname is already resolved by `dnsvip.LookupVIP` in that
  function but was discarded. Capture it and use it as the event
  `Host`, falling back to the dst IP for direct-IP (non-VIP)
  connections.
* Same value is now passed into the approval-chain context, so HITL
  prompts for tunneled postgres also show the hostname.
* Mirrors the `eventHost` handling `dispatchConnEndpoint` already uses
  for `clickhouse_native`.