### PR TITLE
Use "approve" verb consistently for HITL decisions in dashboard

### DIFF
--- a/dashboard/src/components/HITLBar.tsx
+++ b/dashboard/src/components/HITLBar.tsx
@@ -76,10 +76,13 @@ function PendingCard({
   const ep = item.endpoint || item.host;
   const sep = item.path && !item.path.startsWith("/") ? " " : "";
   const target = `${item.method} ${ep}${sep}${item.path}`;
+  // Verb matches the Slack "Approve" button and the "approved" status
+  // badge — the dashboard previously said "allow" here, which read as
+  // a different action from the same decision shown elsewhere.
   const approveLabel =
     item.approval_effect === "create_retry_grant" || item.operation_state === "pending_approval"
       ? "approve retry"
-      : "allow";
+      : "approve";
 
   return (
     <div className="border-l-4 border-butter-400 bg-canvas border-y border-r border-navy overflow-hidden">


### PR DESCRIPTION
Fixes #601.

* The dashboard pending-approval button was labelled "allow", while
  the Slack approval button says "Approve" and the resolved status
  badge says "approved". The same human-in-the-loop decision read as
  two different actions depending on the surface.
* Relabel the dashboard button to "approve" (the retry-grant variant
  already said "approve retry").
* Scope is the HITL decision verb only. The rule-verdict vocabulary
  (`allow` / `deny` in HCL and the rules panel) and the data-layer
  action strings are deliberately left unchanged.