### PR TITLE
Show pending approvals on the device page

### DIFF
--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -8,6 +8,7 @@ import {
   type Integration,
 } from "../lib/api";
 import { fmtBytes } from "../lib/format";
+import { HITLBar } from "./HITLBar";
 import { IntegrationsCards } from "./IntegrationsCards";
 import { LiveRequests } from "./LiveRequests";
 import { DeviceIcon } from "./Logos";
@@ -204,6 +205,11 @@ export function DevicePage({
           </div>
         </div>
       </section>
+
+      {/* pending approvals awaiting a decision for this device — same
+          cards as the home page, scoped to this device's agent IP.
+          Renders nothing when there are none. */}
+      <HITLBar agentIP={a.ip} />
 
       {/* agents (sessions) running on this device */}
       <SessionsTable sessions={a.sessions ?? []} />

--- a/dashboard/src/components/HITLBar.tsx
+++ b/dashboard/src/components/HITLBar.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from "react";
 import { decideHITL, getHITLPending, type HITLPending, type HITLResolveResult } from "../lib/api";
 import { Button } from "./Button";
 
-export function HITLBar() {
+// agentIP, when set, scopes the bar to a single device's pending
+// approvals (used on the device page); unset shows every device's
+// (the home page).
+export function HITLBar({ agentIP }: { agentIP?: string } = {}) {
   const [pending, setPending] = useState<HITLPending[]>([]);
   const [justResolved, setJustResolved] = useState<HITLPending[]>([]);
   const [notice, setNotice] = useState("");
@@ -13,7 +16,7 @@ export function HITLBar() {
       try {
         const r = await getHITLPending();
         if (!cancelled) {
-          const incoming = r ?? [];
+          const incoming = (r ?? []).filter((p) => !agentIP || p.agent_ip === agentIP);
           // Detect >0 → 0 transition: briefly flash green "Approved" cards.
           setPending((prev) => {
             if (prev.length > 0 && incoming.length === 0) {
@@ -33,7 +36,7 @@ export function HITLBar() {
       cancelled = true;
       clearInterval(t);
     };
-  }, []);
+  }, [agentIP]);
 
   async function decide(id: string, allow: boolean, confirmMsg: string) {
     if (!confirm(confirmMsg)) return;


### PR DESCRIPTION
Fixes #597.

* Pending human-in-the-loop approvals only rendered on the home page.
* Add an optional `agentIP` prop to `HITLBar` that scopes the pending
  list to a single device (filtering on `agent_ip`, the same field
  the live-request stream filters on). With no `agentIP` the bar is
  unchanged — the home page still shows every device's approvals.
* Render a scoped `<HITLBar agentIP={a.ip} />` on the device page,
  above the sessions table. It renders nothing when the device has no
  pending approvals.