### PR TITLE
Block requests like this

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -1047,7 +1047,7 @@ func (w *webMux) apiAgentProfile(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "missing ip or profile", 400)
 		return
 	}
-	names := orderedProfileNames(w.g.cfg.Policy)
+	names := orderedProfileNames(w.g.cfg.Load().Policy)
 	known := false
 	for _, n := range names {
 		if n == profile {
@@ -1066,7 +1066,7 @@ func (w *webMux) apiAgentProfile(rw http.ResponseWriter, r *http.Request) {
 // apiProfiles lists declared profile names so the dashboard can
 // render a profile picker per device.
 func (w *webMux) apiProfiles(rw http.ResponseWriter, _ *http.Request) {
-	writeJSON(rw, orderedProfileNames(w.g.cfg.Policy))
+	writeJSON(rw, orderedProfileNames(w.g.cfg.Load().Policy))
 }
 
 // RuleSummary is the JSON shape the dashboard renders for each rule.

--- a/cmd/clawpatrol/credential_match_test.go
+++ b/cmd/clawpatrol/credential_match_test.go
@@ -151,7 +151,6 @@ func newCredentialMatchHarness(t *testing.T, policyHCL string) *credentialMatchH
 
 	certs, _ := inMemoryCertCache(t)
 	g := &Gateway{
-		cfg:     gw,
 		db:      db,
 		certs:   certs,
 		sink:    sink,
@@ -159,6 +158,7 @@ func newCredentialMatchHarness(t *testing.T, policyHCL string) *credentialMatchH
 		secrets: newGatewaySecretStore(db, nil),
 		onboard: newOnboardRegistry(),
 	}
+	g.cfg.Store(gw)
 	g.policy.Store(policy)
 	g.transports.Store(ep, transport)
 

--- a/cmd/clawpatrol/hitl_async_e2e_test.go
+++ b/cmd/clawpatrol/hitl_async_e2e_test.go
@@ -219,7 +219,6 @@ profile "default" {
 	certs, _ := inMemoryCertCache(t)
 	registry := newHITLRegistry(sink)
 	g := &Gateway{
-		cfg:     gw,
 		db:      db,
 		certs:   certs,
 		sink:    sink,
@@ -227,6 +226,7 @@ profile "default" {
 		secrets: newGatewaySecretStore(db, nil),
 		onboard: newOnboardRegistry(),
 	}
+	g.cfg.Store(gw)
 	registry.asyncGrantResolver = g.resolveAsyncHITLGrant
 	g.policy.Store(policy)
 	g.transports.Store(ep, transport)

--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -74,8 +74,11 @@ func (g *Gateway) asyncHumanApproverFor(stages []config.ApproveStage) (string, h
 }
 
 func (g *Gateway) maybeStartAsyncHITLOperation(ctx context.Context, in hitlAsyncOperationInput) (hitlAsyncOperationStart, bool, error) {
+	if g == nil || g.db == nil || in.HTTPRequest == nil || in.Endpoint == nil || in.Rule == nil || in.Approver == nil {
+		return hitlAsyncOperationStart{}, false, nil
+	}
 	cfg := g.cfg.Load()
-	if g == nil || g.db == nil || cfg == nil || cfg.PublicURL() == "" || in.HTTPRequest == nil || in.Endpoint == nil || in.Rule == nil || in.Approver == nil {
+	if cfg == nil || cfg.PublicURL() == "" {
 		return hitlAsyncOperationStart{}, false, nil
 	}
 	if in.ProfileID == "" || in.PrincipalID == "" || in.ApproverID == "" || in.MatchReq == nil {

--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -74,7 +74,8 @@ func (g *Gateway) asyncHumanApproverFor(stages []config.ApproveStage) (string, h
 }
 
 func (g *Gateway) maybeStartAsyncHITLOperation(ctx context.Context, in hitlAsyncOperationInput) (hitlAsyncOperationStart, bool, error) {
-	if g == nil || g.db == nil || g.cfg == nil || g.cfg.PublicURL() == "" || in.HTTPRequest == nil || in.Endpoint == nil || in.Rule == nil || in.Approver == nil {
+	cfg := g.cfg.Load()
+	if g == nil || g.db == nil || cfg == nil || cfg.PublicURL() == "" || in.HTTPRequest == nil || in.Endpoint == nil || in.Rule == nil || in.Approver == nil {
 		return hitlAsyncOperationStart{}, false, nil
 	}
 	if in.ProfileID == "" || in.PrincipalID == "" || in.ApproverID == "" || in.MatchReq == nil {

--- a/cmd/clawpatrol/hitl_body_sample_test.go
+++ b/cmd/clawpatrol/hitl_body_sample_test.go
@@ -69,7 +69,8 @@ profile "default" { credentials = [bearer_token.pat] }
 	}
 	defer close(sink.ch)
 	certs, _ := inMemoryCertCache(t)
-	g := &Gateway{cfg: gw, certs: certs, sink: sink}
+	g := &Gateway{certs: certs, sink: sink}
+	g.cfg.Store(gw)
 	g.policy.Store(policy)
 
 	serverConn, clientConn := net.Pipe()

--- a/cmd/clawpatrol/hitl_operation_api_test.go
+++ b/cmd/clawpatrol/hitl_operation_api_test.go
@@ -432,7 +432,8 @@ func newHITLOperationAPITestHarness(t *testing.T) hitlOperationAPITestHarness {
 	}
 
 	gwCfg := loadHITLOperationAPITestConfig(t)
-	g := &Gateway{cfg: gwCfg, db: db, onboard: newOnboardRegistry()}
+	g := &Gateway{db: db, onboard: newOnboardRegistry()}
+	g.cfg.Store(gwCfg)
 	w := newWebMux(g, gwCfg.Join(), gwCfg.PublicURL())
 	return hitlOperationAPITestHarness{
 		handler:    w,

--- a/cmd/clawpatrol/hitl_registry_test.go
+++ b/cmd/clawpatrol/hitl_registry_test.go
@@ -25,7 +25,8 @@ func (a captureApproveRequestApprover) Approve(_ context.Context, req runtime.Ap
 
 func TestGatewayRunApproveChainWiresPendingMessageUpdateSink(t *testing.T) {
 	approver := captureApproveRequestApprover{got: make(chan runtime.ApproveRequest, 1)}
-	g := &Gateway{cfg: &config.Gateway{}, hitl: newHITLRegistry(nil)}
+	g := &Gateway{hitl: newHITLRegistry(nil)}
+	g.cfg.Store(&config.Gateway{})
 	g.policy.Store(&config.CompiledPolicy{Approvers: map[string]*config.Entity{"ops": {Body: approver}}})
 
 	verdict := g.runApproveChain(context.Background(), []config.ApproveStage{{Name: "ops"}}, runApproveCtx{Host: "api.example.test", Method: "POST", Path: "/v1/write"})

--- a/cmd/clawpatrol/hitl_retry_relay_test.go
+++ b/cmd/clawpatrol/hitl_retry_relay_test.go
@@ -296,13 +296,13 @@ profile "default" {
 
 	certs, _ := inMemoryCertCache(t)
 	g := &Gateway{
-		cfg:     gw,
 		db:      db,
 		certs:   certs,
 		sink:    sink,
 		hitl:    newHITLRegistry(sink),
 		secrets: newGatewaySecretStore(db, nil),
 	}
+	g.cfg.Store(gw)
 	g.policy.Store(policy)
 	g.transports.Store(ep, transport)
 

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -337,6 +337,7 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 type Gateway struct {
 	cfg      *config.Gateway
 	cfgPath  string // path the HCL config was loaded from
+	configMu sync.Mutex
 	stateDir string // resolved gateway state dir (sqlite + plugin blobs)
 	db       *sql.DB
 	policy   atomic.Pointer[config.CompiledPolicy]
@@ -584,31 +585,41 @@ func (g *Gateway) watchConfig(path string) {
 			continue
 		}
 		last = st.ModTime()
-		next, policy, err := loadConfig(path)
+		g.configMu.Lock()
+		err = g.reloadConfigFromFileLocked(path)
+		g.configMu.Unlock()
 		if err != nil {
 			log.Printf("config reload: %v", err)
-			continue
 		}
-		g.policy.Store(policy)
-		registerOAuthCredentials(g.oauth, policy)
-		newConnIdx := runtime.BuildConnIndex(policy)
-		g.connIdx.Store(newConnIdx)
-		if g.tunnels != nil {
-			g.tunnels.SetPolicy(context.Background(), policy)
-		}
-		if g.dnsvip != nil {
-			if err := g.dnsvip.RebuildFromPolicy(policy); err != nil {
-				log.Printf("dnsvip rebuild on reload: %v", err)
-			}
-		}
-		// Hot-swap the operational *config.Gateway too — AdminEmail /
-		// PublicURL / DashboardOperators reads pick up immediately.
-		// Listen / CADir / Tailscale changes are not applied (restart).
-		g.cfg = next
-		log.Printf("config reloaded: %d endpoints across %d profile(s)",
-			len(policy.Endpoints), len(policy.Profiles))
-		logDashboardAuthState(g.db, next)
 	}
+}
+
+// reloadConfigFromFileLocked reloads the HCL config and hot-swaps the
+// runtime policy. g.configMu must be held by the caller so file-watch
+// reloads and dashboard writes cannot race each other.
+func (g *Gateway) reloadConfigFromFileLocked(path string) error {
+	next, policy, err := loadConfig(path)
+	if err != nil {
+		return err
+	}
+	g.policy.Store(policy)
+	registerOAuthCredentials(g.oauth, policy)
+	g.connIdx.Store(runtime.BuildConnIndex(policy))
+	if g.tunnels != nil {
+		g.tunnels.SetPolicy(context.Background(), policy)
+	}
+	if g.dnsvip != nil {
+		if err := g.dnsvip.RebuildFromPolicy(policy); err != nil {
+			return fmt.Errorf("dnsvip rebuild on reload: %w", err)
+		}
+	}
+	// Hot-swap the operational *config.Gateway too. Listen / CA dir /
+	// Tailscale process changes are still restart-only.
+	g.cfg = next
+	log.Printf("config reloaded: %d endpoints across %d profile(s)",
+		len(policy.Endpoints), len(policy.Profiles))
+	logDashboardAuthState(g.db, next)
+	return nil
 }
 
 // logDashboardAuthState emits a one-line summary of dashboard-auth
@@ -2953,7 +2964,11 @@ func runGateway(args []string) {
 		hitl:     newHITLRegistry(sink),
 		onboard:  newOnboardRegistry(),
 	}
-	log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
+	if cfg.DashboardConfigWrites() {
+		log.Printf("config: dashboard writes enabled (generated rules can be appended to gateway.hcl)")
+	} else {
+		log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
+	}
 	g.secrets = newGatewaySecretStore(db, oauthReg)
 	g.hitl.asyncGrantResolver = g.resolveAsyncHITLGrant
 	g.hitl.pendingMessageUpdater = g.updatePendingHITLMessage

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -335,7 +335,11 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 }
 
 type Gateway struct {
-	cfg      *config.Gateway
+	// cfg is the live operational *config.Gateway. Stored as an
+	// atomic pointer because dashboard handlers and the reload loop
+	// read it without holding configMu; configMu only serialises
+	// writes (reload + dashboard-driven apply).
+	cfg      atomic.Pointer[config.Gateway]
 	cfgPath  string // path the HCL config was loaded from
 	configMu sync.Mutex
 	stateDir string // resolved gateway state dir (sqlite + plugin blobs)
@@ -454,7 +458,7 @@ func (g *Gateway) profileFor(peerIP string) string {
 			}
 		}
 	}
-	return defaultProfileName(g.cfg.Policy)
+	return defaultProfileName(g.cfg.Load().Policy)
 }
 
 // resolveTsnetAlias does a one-shot tsnet WhoIs for peerIP and, on a
@@ -615,7 +619,7 @@ func (g *Gateway) reloadConfigFromFileLocked(path string) error {
 	}
 	// Hot-swap the operational *config.Gateway too. Listen / CA dir /
 	// Tailscale process changes are still restart-only.
-	g.cfg = next
+	g.cfg.Store(next)
 	log.Printf("config reloaded: %d endpoints across %d profile(s)",
 		len(policy.Endpoints), len(policy.Profiles))
 	logDashboardAuthState(g.db, next)
@@ -2070,7 +2074,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		var truncated bool
 		retryOperationID := strings.TrimSpace(req.Header.Get(hitlRetryOperationHeader))
 		if req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH" || retryOperationID != "" {
-			matchBody, truncated = bufferHTTPBodyForMatchTruncated(req, g.cfg.BodyBufferLimit())
+			matchBody, truncated = bufferHTTPBodyForMatchTruncated(req, g.cfg.Load().BodyBufferLimit())
 		}
 
 		mreq := &match.Request{
@@ -2214,7 +2218,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 						asyncOp = updated
 					}
 					_ = tc.SetWriteDeadline(time.Now().Add(10 * time.Second))
-					if err := writeHITLOperationAcceptedToConn(tc, asyncOp, g.cfg.PublicURL()); err != nil {
+					if err := writeHITLOperationAcceptedToConn(tc, asyncOp, g.cfg.Load().PublicURL()); err != nil {
 						log.Printf("hitl async pending response write %s: %v", asyncOp.ID, err)
 					}
 					_ = tc.SetWriteDeadline(time.Time{})
@@ -2458,7 +2462,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		trackKind := trackKindFor(host)
 		var trackedReqBody []byte
 		if trackKind != "" {
-			trackedReqBody = bufferHTTPBodyForMatch(req, g.cfg.BodyBufferLimit())
+			trackedReqBody = bufferHTTPBodyForMatch(req, g.cfg.Load().BodyBufferLimit())
 		}
 		// Pre-create session from the request body so streaming SSE
 		// responses (codex /backend-api/codex/responses, anthropic
@@ -2473,7 +2477,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		if trackKind != "" && len(trackedReqBody) > 0 && g.agents != nil {
 			g.preCreateLLMSession(c, trackKind, req.URL.Path, trackedReqBody, sessionHint)
 		}
-		reqS := newSampler(g.cfg.BodyStorageLimit())
+		reqS := newSampler(g.cfg.Load().BodyStorageLimit())
 		if req.Body != nil {
 			req.Body = wrapBodySampler(req.Body, reqS)
 		}
@@ -2512,7 +2516,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				resp.Body = io.NopCloser(io.TeeReader(resp.Body, trackBuf))
 			}
 		}
-		respS := newSampler(g.cfg.BodyStorageLimit())
+		respS := newSampler(g.cfg.Load().BodyStorageLimit())
 		resp.Body = wrapBodySampler(resp.Body, respS)
 		// Close-delimited responses (no Content-Length, no Transfer-
 		// Encoding) come from h2 upstreams that we forced to http/1.1
@@ -2685,7 +2689,7 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 			AsyncPendingOnSyncTimeout: c.AsyncPendingOnSyncTimeout,
 			Pool:                      g.hitl,
 			Secrets:                   g.secrets,
-			DashboardURL:              g.cfg.PublicURL(),
+			DashboardURL:              g.cfg.Load().PublicURL(),
 			Policy:                    policy,
 			MessageUpdateSink:         g.recordHITLOperationMessageRef,
 			PendingMessageUpdateSink:  g.hitl.RecordMessageRef,
@@ -2951,7 +2955,6 @@ func runGateway(args []string) {
 		log.Fatalf("oauth: %v", err)
 	}
 	g := &Gateway{
-		cfg:      cfg,
 		cfgPath:  cfgPath,
 		stateDir: stateDir,
 		db:       db,
@@ -2964,6 +2967,7 @@ func runGateway(args []string) {
 		hitl:     newHITLRegistry(sink),
 		onboard:  newOnboardRegistry(),
 	}
+	g.cfg.Store(cfg)
 	if cfg.DashboardConfigWrites() {
 		log.Printf("config: dashboard writes enabled (generated rules can be appended to gateway.hcl)")
 	} else {

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -673,11 +673,12 @@ func (w *webMux) apiOnboardStart(rw http.ResponseWriter, r *http.Request) {
 	// don't have to go through the Funnel HTTPS relay. Use IP directly
 	// to avoid MagicDNS resolution issues with OS-hostname vs registered name.
 	verifyURL := w.publicURL
-	if w.g != nil && w.g.cfg != nil && w.g.cfg.PublicURL() != "" {
-		verifyURL = w.g.cfg.PublicURL()
+	cfg := w.g.cfg.Load()
+	if w.g != nil && cfg != nil && cfg.PublicURL() != "" {
+		verifyURL = cfg.PublicURL()
 	}
-	if w.g != nil && w.g.tailscaleIP != "" && w.g.cfg.DashboardListen() != "" {
-		port := w.g.cfg.DashboardListen()
+	if w.g != nil && w.g.tailscaleIP != "" && cfg != nil && cfg.DashboardListen() != "" {
+		port := cfg.DashboardListen()
 		if i := strings.LastIndexByte(port, ':'); i >= 0 {
 			port = port[i+1:]
 		}
@@ -755,7 +756,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 		profile = s.profile
 	}
 	if profile == "" {
-		profile = defaultProfileName(w.g.cfg.Policy)
+		profile = defaultProfileName(w.g.cfg.Load().Policy)
 	}
 	w.onboard.mu.Lock()
 	if s.approved {

--- a/cmd/clawpatrol/raw_ip_mitm_test.go
+++ b/cmd/clawpatrol/raw_ip_mitm_test.go
@@ -48,7 +48,8 @@ func TestHandleInterceptsRawIPHTTPSOnDeclaredNonDefaultPort(t *testing.T) {
 	}
 	defer tr.CloseIdleConnections()
 
-	g := &Gateway{cfg: gw, certs: certs, sink: sink, secrets: fakeSecretStore{}}
+	g := &Gateway{certs: certs, sink: sink, secrets: fakeSecretStore{}}
+	g.cfg.Store(gw)
 	g.policy.Store(policy)
 	g.transports.Store(ep, tr)
 
@@ -123,7 +124,8 @@ func TestHandleInterceptsRawIPHTTPSOnDeclaredNonDefaultPort(t *testing.T) {
 func TestRawIPHTTPSMITMPortDispatchIsLimitedToDeclaredEndpoints(t *testing.T) {
 	const rawIP = "192.168.1.50"
 	gw, policy, _ := compileRawIPPolicy(t, rawIP, 8006)
-	g := &Gateway{cfg: gw}
+	g := &Gateway{}
+	g.cfg.Store(gw)
 	g.policy.Store(policy)
 
 	if ep, authority, certHost := g.httpsMITMEndpoint("default", rawIP, 8006); ep == nil || ep.Name != "proxmox" ||

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -337,7 +337,15 @@ func safeRuleNamePart(s string) string {
 	return s
 }
 
+// celString quotes s as a CEL string literal. CEL accepts both ' and "
+// quoting; we prefer single quotes so the surrounding HCL string
+// (double-quoted) doesn't need backslash-escaped inner quotes. Values
+// containing a single quote or backslash fall back to strconv.Quote,
+// which produces a valid (if escape-heavy) CEL double-quoted string.
 func celString(s string) string {
+	if !strings.ContainsAny(s, "'\\") {
+		return "'" + s + "'"
+	}
 	return strconv.Quote(s)
 }
 

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -20,6 +20,7 @@ type RuleGenOptions struct {
 
 type GeneratedRule struct {
 	RuleName              string   `json:"rule_name"`
+	EndpointName          string   `json:"endpoint_name,omitempty"`
 	HCL                   string   `json:"hcl"`
 	Patch                 string   `json:"patch,omitempty"`
 	ConfigRevision        string   `json:"config_revision,omitempty"`
@@ -39,7 +40,7 @@ func GenerateRuleFromEvent(
 		return nil, fmt.Errorf("event is required")
 	}
 	if ev.Endpoint == "" {
-		return nil, fmt.Errorf("action has no endpoint")
+		return generateBlockHostRule(policy, ev, opts)
 	}
 	ep := policy.Endpoints[ev.Endpoint]
 	if ep == nil {
@@ -68,10 +69,45 @@ func GenerateRuleFromEvent(
 		return nil, err
 	}
 	return &GeneratedRule{
-		RuleName: name,
-		HCL:      hcl,
-		Patch:    generatedAppendPatch("gateway.hcl", hcl),
-		Warnings: warnings,
+		RuleName:     name,
+		EndpointName: ep.Name,
+		HCL:          hcl,
+		Patch:        generatedAppendPatch("gateway.hcl", hcl),
+		Warnings:     warnings,
+	}, nil
+}
+
+func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGenOptions) (*GeneratedRule, error) {
+	if opts.Verdict == "" {
+		opts.Verdict = "deny"
+	}
+	if opts.Scope == "" {
+		opts.Scope = "exact"
+	}
+	if opts.Verdict != "deny" {
+		return nil, fmt.Errorf("unsupported verdict %q", opts.Verdict)
+	}
+	if opts.Scope != "exact" {
+		return nil, fmt.Errorf("unsupported scope %q", opts.Scope)
+	}
+	host := canonicalObservedHost(ev.Host)
+	if host == "" {
+		return nil, fmt.Errorf("action has no endpoint or host")
+	}
+	endpointName := generatedEndpointName(policy, host)
+	ruleName := generatedHostBlockRuleName(ev, endpointName, host)
+	hcl, err := generatedEndpointBlockRuleHCL(endpointName, host, ruleName)
+	if err != nil {
+		return nil, err
+	}
+	return &GeneratedRule{
+		RuleName:     ruleName,
+		EndpointName: endpointName,
+		HCL:          hcl,
+		Patch:        generatedAppendPatch("gateway.hcl", hcl),
+		Warnings: []string{
+			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host and a catch-all deny rule for it.",
+		},
 	}, nil
 }
 
@@ -167,9 +203,24 @@ func generatedRuleHCL(name, endpoint, condition string) (string, error) {
 	b := f.Body().AppendNewBlock("rule", []string{name}).Body()
 	b.SetAttributeRaw("endpoint", config.TraversalTokens(endpoint))
 	b.SetAttributeValue("priority", cty.NumberIntVal(100))
-	b.SetAttributeValue("condition", cty.StringVal(condition))
+	if condition != "" {
+		b.SetAttributeValue("condition", cty.StringVal(condition))
+	}
 	b.SetAttributeValue("verdict", cty.StringVal("deny"))
 	b.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed action"))
+	return string(f.Bytes()), nil
+}
+
+func generatedEndpointBlockRuleHCL(endpointName, host, ruleName string) (string, error) {
+	f := hclwrite.NewEmptyFile()
+	eb := f.Body().AppendNewBlock("endpoint", []string{"https", endpointName}).Body()
+	eb.SetAttributeValue("hosts", cty.ListVal([]cty.Value{cty.StringVal(host)}))
+	f.Body().AppendNewline()
+	rb := f.Body().AppendNewBlock("rule", []string{ruleName}).Body()
+	rb.SetAttributeRaw("endpoint", config.TraversalTokens("https."+endpointName))
+	rb.SetAttributeValue("priority", cty.NumberIntVal(100))
+	rb.SetAttributeValue("verdict", cty.StringVal("deny"))
+	rb.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed passthrough host"))
 	return string(f.Bytes()), nil
 }
 
@@ -183,6 +234,57 @@ func generatedRuleName(ev *Event, ep *config.CompiledEndpoint) string {
 	}
 	sum := sha256.Sum256([]byte(sumInput))
 	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func generatedHostBlockRuleName(ev *Event, endpointName, host string) string {
+	base := "block_" + safeRuleNamePart(endpointName)
+	sumInput := ev.ID
+	if sumInput == "" {
+		sumInput = host
+	}
+	sum := sha256.Sum256([]byte(sumInput))
+	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func generatedEndpointName(policy *config.CompiledPolicy, host string) string {
+	base := safeRuleNamePart(strings.ToLower(host))
+	if base == "action" {
+		base = "host"
+	}
+	name := base
+	if policy == nil || policy.Endpoints[name] == nil {
+		return name
+	}
+	sum := sha256.Sum256([]byte(host))
+	name = fmt.Sprintf("%s_%x", base, sum[:3])
+	if policy.Endpoints[name] == nil {
+		return name
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%x_%d", base, sum[:3], i)
+		if policy.Endpoints[candidate] == nil {
+			return candidate
+		}
+	}
+}
+
+func canonicalObservedHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimSuffix(host, ".")
+	if host == "" {
+		return ""
+	}
+	if strings.HasPrefix(host, "[") {
+		if end := strings.IndexByte(host, ']'); end >= 0 {
+			return strings.Trim(host[:end+1], "[]")
+		}
+	}
+	if strings.Count(host, ":") == 1 {
+		if i := strings.LastIndexByte(host, ':'); i > 0 {
+			return host[:i]
+		}
+	}
+	return host
 }
 
 func safeRuleNamePart(s string) string {

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -95,8 +95,10 @@ func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGe
 		return nil, fmt.Errorf("action has no endpoint or host")
 	}
 	endpointName := generatedEndpointName(policy, host)
+	credName := generatedPassthroughCredName(policy, endpointName)
 	ruleName := generatedHostBlockRuleName(ev, endpointName, host)
-	hcl, err := generatedEndpointBlockRuleHCL(endpointName, host, ruleName)
+	profiles := generatedProfileNames(policy)
+	hcl, err := generatedEndpointBlockRuleHCL(endpointName, credName, host, profiles, ruleName)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +108,7 @@ func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGe
 		HCL:          hcl,
 		Patch:        generatedAppendPatch("gateway.hcl", hcl),
 		Warnings: []string{
-			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host and a catch-all deny rule for it.",
+			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host, claims it from existing profiles via a passthrough credential, and adds a catch-all deny rule.",
 		},
 	}, nil
 }
@@ -211,16 +213,30 @@ func generatedRuleHCL(name, endpoint, condition string) (string, error) {
 	return string(f.Bytes()), nil
 }
 
-func generatedEndpointBlockRuleHCL(endpointName, host, ruleName string) (string, error) {
+func generatedEndpointBlockRuleHCL(endpointName, credName, host string, profiles []string, ruleName string) (string, error) {
 	f := hclwrite.NewEmptyFile()
+	endpointRef := "https." + endpointName
+	credRef := "passthrough." + credName
+
 	eb := f.Body().AppendNewBlock("endpoint", []string{"https", endpointName}).Body()
 	eb.SetAttributeValue("hosts", cty.ListVal([]cty.Value{cty.StringVal(host)}))
+
+	f.Body().AppendNewline()
+	cb := f.Body().AppendNewBlock("credential", []string{"passthrough", credName}).Body()
+	cb.SetAttributeRaw("endpoint", config.TraversalTokens(endpointRef))
+
 	f.Body().AppendNewline()
 	rb := f.Body().AppendNewBlock("rule", []string{ruleName}).Body()
-	rb.SetAttributeRaw("endpoint", config.TraversalTokens("https."+endpointName))
+	rb.SetAttributeRaw("endpoint", config.TraversalTokens(endpointRef))
 	rb.SetAttributeValue("priority", cty.NumberIntVal(100))
 	rb.SetAttributeValue("verdict", cty.StringVal("deny"))
 	rb.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed passthrough host"))
+
+	for _, profile := range profiles {
+		f.Body().AppendNewline()
+		pb := f.Body().AppendNewBlock("profile", []string{profile}).Body()
+		config.SetIdentList(pb, "credentials", []string{credRef})
+	}
 	return string(f.Bytes()), nil
 }
 
@@ -244,6 +260,31 @@ func generatedHostBlockRuleName(ev *Event, endpointName, host string) string {
 	}
 	sum := sha256.Sum256([]byte(sumInput))
 	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func generatedProfileNames(policy *config.CompiledPolicy) []string {
+	if policy == nil || len(policy.Profiles) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(policy.Profiles))
+	for name := range policy.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func generatedPassthroughCredName(policy *config.CompiledPolicy, endpointName string) string {
+	base := endpointName + "_passthrough"
+	if policy == nil || policy.Credentials[base] == nil {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d", base, i)
+		if policy.Credentials[candidate] == nil {
+			return candidate
+		}
+	}
 }
 
 func generatedEndpointName(policy *config.CompiledPolicy, host string) string {

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -374,4 +374,3 @@ func celString(s string) string {
 	}
 	return strconv.Quote(s)
 }
-

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -206,11 +207,39 @@ func generatedRuleHCL(name, endpoint, condition string) (string, error) {
 	b.SetAttributeRaw("endpoint", config.TraversalTokens(endpoint))
 	b.SetAttributeValue("priority", cty.NumberIntVal(100))
 	if condition != "" {
-		b.SetAttributeValue("condition", cty.StringVal(condition))
+		setCELCondition(b, condition)
 	}
 	b.SetAttributeValue("verdict", cty.StringVal("deny"))
 	b.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed action"))
 	return string(f.Bytes()), nil
+}
+
+// setCELCondition writes `condition = ...` either as a plain quoted
+// string for single-clause expressions or as a `<<-CEL ... CEL`
+// heredoc when the expression has multiple `&&`-joined clauses,
+// matching the convention in examples/*.hcl. Splitting on ` && `
+// keeps the marker line-anchored so future readers diff each clause
+// independently.
+func setCELCondition(b *hclwrite.Body, condition string) {
+	parts := strings.Split(condition, " && ")
+	if len(parts) < 2 {
+		b.SetAttributeValue("condition", cty.StringVal(condition))
+		return
+	}
+	var body strings.Builder
+	for i, p := range parts {
+		body.WriteString("    ")
+		if i > 0 {
+			body.WriteString("&& ")
+		}
+		body.WriteString(p)
+		body.WriteString("\n")
+	}
+	b.SetAttributeRaw("condition", hclwrite.Tokens{
+		{Type: hclsyntax.TokenOHeredoc, Bytes: []byte("<<-CEL\n")},
+		{Type: hclsyntax.TokenStringLit, Bytes: []byte(body.String())},
+		{Type: hclsyntax.TokenCHeredoc, Bytes: []byte("  CEL")},
+	})
 }
 
 func generatedEndpointBlockRuleHCL(endpointName, credName, host string, profiles []string, ruleName string) (string, error) {

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type RuleGenOptions struct {
+	Verdict string
+	Scope   string
+}
+
+type GeneratedRule struct {
+	RuleName              string   `json:"rule_name"`
+	HCL                   string   `json:"hcl"`
+	Patch                 string   `json:"patch,omitempty"`
+	ConfigRevision        string   `json:"config_revision,omitempty"`
+	DashboardConfigWrites bool     `json:"dashboard_config_writes"`
+	Warnings              []string `json:"warnings,omitempty"`
+}
+
+func GenerateRuleFromEvent(
+	policy *config.CompiledPolicy,
+	ev *Event,
+	opts RuleGenOptions,
+) (*GeneratedRule, error) {
+	if policy == nil {
+		return nil, fmt.Errorf("policy not loaded")
+	}
+	if ev == nil {
+		return nil, fmt.Errorf("event is required")
+	}
+	if ev.Endpoint == "" {
+		return nil, fmt.Errorf("action has no endpoint")
+	}
+	ep := policy.Endpoints[ev.Endpoint]
+	if ep == nil {
+		return nil, fmt.Errorf("endpoint %q no longer in policy", ev.Endpoint)
+	}
+	if opts.Verdict == "" {
+		opts.Verdict = "deny"
+	}
+	if opts.Scope == "" {
+		opts.Scope = "exact"
+	}
+	if opts.Verdict != "deny" {
+		return nil, fmt.Errorf("unsupported verdict %q", opts.Verdict)
+	}
+	if opts.Scope != "exact" {
+		return nil, fmt.Errorf("unsupported scope %q", opts.Scope)
+	}
+
+	condition, warnings, err := ruleConditionFromEvent(ep.Family, ev)
+	if err != nil {
+		return nil, err
+	}
+	name := generatedRuleName(ev, ep)
+	hcl, err := generatedRuleHCL(name, endpointRef(ep), condition)
+	if err != nil {
+		return nil, err
+	}
+	return &GeneratedRule{
+		RuleName: name,
+		HCL:      hcl,
+		Patch:    generatedAppendPatch("gateway.hcl", hcl),
+		Warnings: warnings,
+	}, nil
+}
+
+func ruleConditionFromEvent(family string, ev *Event) (string, []string, error) {
+	switch family {
+	case "http":
+		return httpRuleCondition(ev)
+	case "sql":
+		return sqlRuleCondition(ev)
+	case "k8s":
+		return k8sRuleCondition(ev)
+	default:
+		return "", nil, fmt.Errorf("endpoint family %q is not supported for rule generation", family)
+	}
+}
+
+func httpRuleCondition(ev *Event) (string, []string, error) {
+	method := strings.ToUpper(strings.TrimSpace(ev.Method))
+	path, _ := splitPathQuery(ev.Path)
+	path = strings.TrimSpace(path)
+	parts := []string{}
+	if method != "" {
+		parts = append(parts, "http.method == "+celString(method))
+	}
+	warnings := []string{}
+	if path != "" {
+		parts = append(parts, "http.path == "+celString(path))
+	} else {
+		warnings = append(warnings, "Generated rule matches only the HTTP method because no request path was recorded.")
+	}
+	if len(parts) == 0 {
+		return "", warnings, fmt.Errorf("http action has no method or path")
+	}
+	return strings.Join(parts, " && "), warnings, nil
+}
+
+func sqlRuleCondition(ev *Event) (string, []string, error) {
+	verb, _ := ev.Facets["verb"].(string)
+	verb = strings.ToLower(strings.TrimSpace(verb))
+	tables := stringSliceFromFacet(ev.Facets["tables"])
+	sort.Strings(tables)
+	if verb != "" {
+		parts := []string{"sql.verb == " + celString(verb)}
+		if len(tables) == 1 {
+			parts = append(parts, celString(tables[0])+" in sql.tables")
+		} else if len(tables) > 1 {
+			tableParts := make([]string, 0, len(tables))
+			for _, table := range tables {
+				tableParts = append(tableParts, celString(table)+" in sql.tables")
+			}
+			parts = append(parts, "("+strings.Join(tableParts, " || ")+")")
+		}
+		return strings.Join(parts, " && "), nil, nil
+	}
+	stmt, _ := ev.Facets["statement"].(string)
+	if stmt == "" {
+		stmt = ev.ReqBody
+	}
+	if strings.TrimSpace(stmt) == "" {
+		return "", nil, fmt.Errorf("sql action has no structured facets or statement")
+	}
+	return "sql.statement == " + celString(stmt), []string{
+		"Generated rule matches the full SQL statement because no structured SQL facets were available. Consider broadening it manually.",
+	}, nil
+}
+
+func k8sRuleCondition(ev *Event) (string, []string, error) {
+	fields := []struct {
+		Name string
+		CEL  string
+	}{
+		{"verb", "k8s.verb"},
+		{"resource", "k8s.resource"},
+		{"namespace", "k8s.namespace"},
+		{"name", "k8s.name"},
+	}
+	parts := []string{}
+	for _, field := range fields {
+		v, _ := ev.Facets[field.Name].(string)
+		if v == "" {
+			continue
+		}
+		parts = append(parts, field.CEL+" == "+celString(v))
+	}
+	if len(parts) == 0 {
+		return "", nil, fmt.Errorf("kubernetes action has no structured facets")
+	}
+	return strings.Join(parts, " && "), nil, nil
+}
+
+func generatedRuleHCL(name, endpoint, condition string) (string, error) {
+	f := hclwrite.NewEmptyFile()
+	b := f.Body().AppendNewBlock("rule", []string{name}).Body()
+	b.SetAttributeRaw("endpoint", config.TraversalTokens(endpoint))
+	b.SetAttributeValue("priority", cty.NumberIntVal(100))
+	b.SetAttributeValue("condition", cty.StringVal(condition))
+	b.SetAttributeValue("verdict", cty.StringVal("deny"))
+	b.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed action"))
+	return string(f.Bytes()), nil
+}
+
+var generatedRuleNameChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+
+func generatedRuleName(ev *Event, ep *config.CompiledEndpoint) string {
+	base := "block_" + safeRuleNamePart(ep.Name) + "_" + safeRuleNamePart(ep.Family)
+	sumInput := ev.ID
+	if sumInput == "" {
+		sumInput = ev.Endpoint + "\x00" + ev.Family + "\x00" + ev.Method + "\x00" + ev.Path
+	}
+	sum := sha256.Sum256([]byte(sumInput))
+	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func safeRuleNamePart(s string) string {
+	s = generatedRuleNameChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if s == "" {
+		return "action"
+	}
+	return s
+}
+
+func celString(s string) string {
+	return strconv.Quote(s)
+}
+
+func generatedAppendPatch(path, hcl string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", path, path)
+	fmt.Fprintf(&b, "--- a/%s\n", path)
+	fmt.Fprintf(&b, "+++ b/%s\n", path)
+	b.WriteString("@@ -0,0 +1 @@\n")
+	for _, line := range strings.Split(strings.TrimRight(hcl, "\n"), "\n") {
+		b.WriteString("+")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func generatedAppendPatchFromBytes(path string, current []byte, hcl string) string {
+	added := strings.Split(strings.TrimRight(string(appendConfigSnippet(current, hcl)), "\n"), "\n")
+	if len(current) > 0 {
+		prefix := strings.Split(strings.TrimRight(string(current), "\n"), "\n")
+		if len(prefix) <= len(added) {
+			added = added[len(prefix):]
+		}
+	}
+	oldLine := 0
+	if len(current) > 0 {
+		oldLine = strings.Count(string(current), "\n")
+		if current[len(current)-1] != '\n' {
+			oldLine++
+		}
+	}
+	newStart := oldLine + 1
+	if oldLine == 0 {
+		newStart = 1
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", path, path)
+	fmt.Fprintf(&b, "--- a/%s\n", path)
+	fmt.Fprintf(&b, "+++ b/%s\n", path)
+	fmt.Fprintf(&b, "@@ -%d,0 +%d,%d @@\n", oldLine, newStart, len(added))
+	for _, line := range added {
+		b.WriteString("+")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -23,7 +23,6 @@ type GeneratedRule struct {
 	RuleName              string   `json:"rule_name"`
 	EndpointName          string   `json:"endpoint_name,omitempty"`
 	HCL                   string   `json:"hcl"`
-	Patch                 string   `json:"patch,omitempty"`
 	ConfigRevision        string   `json:"config_revision,omitempty"`
 	DashboardConfigWrites bool     `json:"dashboard_config_writes"`
 	Warnings              []string `json:"warnings,omitempty"`
@@ -73,7 +72,6 @@ func GenerateRuleFromEvent(
 		RuleName:     name,
 		EndpointName: ep.Name,
 		HCL:          hcl,
-		Patch:        generatedAppendPatch("gateway.hcl", hcl),
 		Warnings:     warnings,
 	}, nil
 }
@@ -107,7 +105,6 @@ func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGe
 		RuleName:     ruleName,
 		EndpointName: endpointName,
 		HCL:          hcl,
-		Patch:        generatedAppendPatch("gateway.hcl", hcl),
 		Warnings: []string{
 			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host, claims it from existing profiles via a passthrough credential, and adds a catch-all deny rule.",
 		},
@@ -378,48 +375,3 @@ func celString(s string) string {
 	return strconv.Quote(s)
 }
 
-func generatedAppendPatch(path, hcl string) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", path, path)
-	fmt.Fprintf(&b, "--- a/%s\n", path)
-	fmt.Fprintf(&b, "+++ b/%s\n", path)
-	b.WriteString("@@ -0,0 +1 @@\n")
-	for _, line := range strings.Split(strings.TrimRight(hcl, "\n"), "\n") {
-		b.WriteString("+")
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
-	return b.String()
-}
-
-func generatedAppendPatchFromBytes(path string, current []byte, hcl string) string {
-	added := strings.Split(strings.TrimRight(string(appendConfigSnippet(current, hcl)), "\n"), "\n")
-	if len(current) > 0 {
-		prefix := strings.Split(strings.TrimRight(string(current), "\n"), "\n")
-		if len(prefix) <= len(added) {
-			added = added[len(prefix):]
-		}
-	}
-	oldLine := 0
-	if len(current) > 0 {
-		oldLine = strings.Count(string(current), "\n")
-		if current[len(current)-1] != '\n' {
-			oldLine++
-		}
-	}
-	newStart := oldLine + 1
-	if oldLine == 0 {
-		newStart = 1
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", path, path)
-	fmt.Fprintf(&b, "--- a/%s\n", path)
-	fmt.Fprintf(&b, "+++ b/%s\n", path)
-	fmt.Fprintf(&b, "@@ -%d,0 +%d,%d @@\n", oldLine, newStart, len(added))
-	for _, line := range added {
-		b.WriteString("+")
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
-	return b.String()
-}

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -22,7 +22,8 @@ func TestGenerateRuleHTTPExact(t *testing.T) {
 	if !strings.Contains(rule.HCL, `endpoint  = https.github`) {
 		t.Fatalf("hcl missing typed endpoint:\n%s", rule.HCL)
 	}
-	if !strings.Contains(rule.HCL, `condition = "http.method == 'DELETE' && http.path == '/repos/me/sandbox/issues/1'"`) {
+	wantHTTP := "condition = <<-CEL\n    http.method == 'DELETE'\n    && http.path == '/repos/me/sandbox/issues/1'\n  CEL"
+	if !strings.Contains(rule.HCL, wantHTTP) {
 		t.Fatalf("hcl missing exact HTTP condition:\n%s", rule.HCL)
 	}
 	if !strings.Contains(rule.HCL, `verdict   = "deny"`) {
@@ -47,7 +48,8 @@ profile "default" { credentials = [postgres_credential.pg-user] }
 	if err != nil {
 		t.Fatalf("GenerateRuleFromEvent: %v", err)
 	}
-	if !strings.Contains(rule.HCL, `condition = "sql.verb == 'drop' && 'users' in sql.tables"`) {
+	wantSQL := "condition = <<-CEL\n    sql.verb == 'drop'\n    && 'users' in sql.tables\n  CEL"
+	if !strings.Contains(rule.HCL, wantSQL) {
 		t.Fatalf("hcl missing SQL condition:\n%s", rule.HCL)
 	}
 }
@@ -71,7 +73,7 @@ profile "default" { credentials = [bearer_token.k8s-token] }
 	if err != nil {
 		t.Fatalf("GenerateRuleFromEvent: %v", err)
 	}
-	want := `condition = "k8s.verb == 'delete' && k8s.resource == 'secrets' && k8s.namespace == 'prod' && k8s.name == 'api-token'"`
+	want := "condition = <<-CEL\n    k8s.verb == 'delete'\n    && k8s.resource == 'secrets'\n    && k8s.namespace == 'prod'\n    && k8s.name == 'api-token'\n  CEL"
 	if !strings.Contains(rule.HCL, want) {
 		t.Fatalf("hcl missing K8s condition:\n%s", rule.HCL)
 	}

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -22,7 +22,7 @@ func TestGenerateRuleHTTPExact(t *testing.T) {
 	if !strings.Contains(rule.HCL, `endpoint  = https.github`) {
 		t.Fatalf("hcl missing typed endpoint:\n%s", rule.HCL)
 	}
-	if !strings.Contains(rule.HCL, `condition = "http.method == \"DELETE\" && http.path == \"/repos/me/sandbox/issues/1\""`) {
+	if !strings.Contains(rule.HCL, `condition = "http.method == 'DELETE' && http.path == '/repos/me/sandbox/issues/1'"`) {
 		t.Fatalf("hcl missing exact HTTP condition:\n%s", rule.HCL)
 	}
 	if !strings.Contains(rule.HCL, `verdict   = "deny"`) {
@@ -47,7 +47,7 @@ profile "default" { credentials = [postgres_credential.pg-user] }
 	if err != nil {
 		t.Fatalf("GenerateRuleFromEvent: %v", err)
 	}
-	if !strings.Contains(rule.HCL, `condition = "sql.verb == \"drop\" && \"users\" in sql.tables"`) {
+	if !strings.Contains(rule.HCL, `condition = "sql.verb == 'drop' && 'users' in sql.tables"`) {
 		t.Fatalf("hcl missing SQL condition:\n%s", rule.HCL)
 	}
 }
@@ -71,7 +71,7 @@ profile "default" { credentials = [bearer_token.k8s-token] }
 	if err != nil {
 		t.Fatalf("GenerateRuleFromEvent: %v", err)
 	}
-	want := `condition = "k8s.verb == \"delete\" && k8s.resource == \"secrets\" && k8s.namespace == \"prod\" && k8s.name == \"api-token\""`
+	want := `condition = "k8s.verb == 'delete' && k8s.resource == 'secrets' && k8s.namespace == 'prod' && k8s.name == 'api-token'"`
 	if !strings.Contains(rule.HCL, want) {
 		t.Fatalf("hcl missing K8s condition:\n%s", rule.HCL)
 	}

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+func TestGenerateRuleHTTPExact(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:       "018f0000-0000-7000-8000-000000000001",
+		Endpoint: "github",
+		Method:   "DELETE",
+		Path:     "/repos/me/sandbox/issues/1?force=true",
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	if !strings.Contains(rule.HCL, `endpoint  = https.github`) {
+		t.Fatalf("hcl missing typed endpoint:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `condition = "http.method == \"DELETE\" && http.path == \"/repos/me/sandbox/issues/1\""`) {
+		t.Fatalf("hcl missing exact HTTP condition:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `verdict   = "deny"`) {
+		t.Fatalf("hcl missing deny verdict:\n%s", rule.HCL)
+	}
+}
+
+func TestGenerateRuleSQLStructuredFacets(t *testing.T) {
+	g := gatewayWithPolicy(t, `
+endpoint "postgres" "pg" { host = "pg.example.com:5432" }
+credential "postgres_credential" "pg-user" { endpoint = postgres.pg }
+profile "default" { credentials = [postgres_credential.pg-user] }
+`)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:       "018f0000-0000-7000-8000-000000000002",
+		Endpoint: "pg",
+		Facets: map[string]any{
+			"verb":   "drop",
+			"tables": []any{"users"},
+		},
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	if !strings.Contains(rule.HCL, `condition = "sql.verb == \"drop\" && \"users\" in sql.tables"`) {
+		t.Fatalf("hcl missing SQL condition:\n%s", rule.HCL)
+	}
+}
+
+func TestGenerateRuleK8sStructuredFacets(t *testing.T) {
+	g := gatewayWithPolicy(t, `
+endpoint "kubernetes" "prod" { hosts = ["k8s.example.com"] }
+credential "bearer_token" "k8s-token" { endpoint = kubernetes.prod }
+profile "default" { credentials = [bearer_token.k8s-token] }
+`)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:       "018f0000-0000-7000-8000-000000000003",
+		Endpoint: "prod",
+		Facets: map[string]any{
+			"verb":      "delete",
+			"resource":  "secrets",
+			"namespace": "prod",
+			"name":      "api-token",
+		},
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	want := `condition = "k8s.verb == \"delete\" && k8s.resource == \"secrets\" && k8s.namespace == \"prod\" && k8s.name == \"api-token\""`
+	if !strings.Contains(rule.HCL, want) {
+		t.Fatalf("hcl missing K8s condition:\n%s", rule.HCL)
+	}
+}
+
+func TestGenerateRuleRejectsMissingEndpoint(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL)
+	_, err := GenerateRuleFromEvent(g.Policy(), &Event{}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err == nil || !strings.Contains(err.Error(), "no endpoint") {
+		t.Fatalf("err=%v, want no endpoint", err)
+	}
+}

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -105,6 +105,12 @@ func TestGenerateRuleSpliceHostCreatesEndpointAndDenyRule(t *testing.T) {
 	if !strings.Contains(rule.HCL, `endpoint = https.tinyclouds_org`) {
 		t.Fatalf("hcl missing generated endpoint reference:\n%s", rule.HCL)
 	}
+	if !strings.Contains(rule.HCL, `credential "passthrough" "tinyclouds_org_passthrough"`) {
+		t.Fatalf("hcl missing generated passthrough credential:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `credentials = [passthrough.tinyclouds_org_passthrough]`) {
+		t.Fatalf("hcl missing profile credential claim:\n%s", rule.HCL)
+	}
 	if strings.Contains(rule.HCL, `condition`) {
 		t.Fatalf("host block rule should be catch-all:\n%s", rule.HCL)
 	}
@@ -114,14 +120,27 @@ func TestGenerateRuleSpliceHostCreatesEndpointAndDenyRule(t *testing.T) {
 }
 
 func TestGeneratedSpliceHostBlockRoutesInDefaultProfile(t *testing.T) {
-	g := gatewayWithPolicy(t, fixtureHCL+`
+	g := gatewayWithPolicy(t, `
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+credential "bearer_token" "tok" { endpoint = https.github }
+
 endpoint "https" "tinyclouds_org" {
   hosts = ["tinyclouds.org"]
+}
+
+credential "passthrough" "tinyclouds_org_passthrough" {
+  endpoint = https.tinyclouds_org
 }
 
 rule "block_tinyclouds_org" {
   endpoint = https.tinyclouds_org
   verdict  = "deny"
+}
+
+profile "default" {
+  credentials = [bearer_token.tok, passthrough.tinyclouds_org_passthrough]
 }
 `)
 	ep := runtime.HostEndpoint(g.Policy(), "default", "tinyclouds.org")

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
 func TestGenerateRuleHTTPExact(t *testing.T) {
@@ -79,7 +80,52 @@ profile "default" { credentials = [bearer_token.k8s-token] }
 func TestGenerateRuleRejectsMissingEndpoint(t *testing.T) {
 	g := gatewayWithPolicy(t, fixtureHCL)
 	_, err := GenerateRuleFromEvent(g.Policy(), &Event{}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
-	if err == nil || !strings.Contains(err.Error(), "no endpoint") {
-		t.Fatalf("err=%v, want no endpoint", err)
+	if err == nil || !strings.Contains(err.Error(), "no endpoint or host") {
+		t.Fatalf("err=%v, want no endpoint or host", err)
+	}
+}
+
+func TestGenerateRuleSpliceHostCreatesEndpointAndDenyRule(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:     "018f0000-0000-7000-8000-000000000004",
+		Mode:   "splice",
+		Host:   "TinyClouds.org",
+		Action: "allow",
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	if !strings.Contains(rule.HCL, `endpoint "https" "tinyclouds_org"`) {
+		t.Fatalf("hcl missing generated endpoint:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `hosts = ["tinyclouds.org"]`) {
+		t.Fatalf("hcl missing observed host:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `endpoint = https.tinyclouds_org`) {
+		t.Fatalf("hcl missing generated endpoint reference:\n%s", rule.HCL)
+	}
+	if strings.Contains(rule.HCL, `condition`) {
+		t.Fatalf("host block rule should be catch-all:\n%s", rule.HCL)
+	}
+	if len(rule.Warnings) == 0 {
+		t.Fatalf("expected warning for generated endpoint")
+	}
+}
+
+func TestGeneratedSpliceHostBlockRoutesInDefaultProfile(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL+`
+endpoint "https" "tinyclouds_org" {
+  hosts = ["tinyclouds.org"]
+}
+
+rule "block_tinyclouds_org" {
+  endpoint = https.tinyclouds_org
+  verdict  = "deny"
+}
+`)
+	ep := runtime.HostEndpoint(g.Policy(), "default", "tinyclouds.org")
+	if ep == nil || ep.Name != "tinyclouds_org" {
+		t.Fatalf("HostEndpoint = %#v, want generated endpoint", ep)
 	}
 }

--- a/cmd/clawpatrol/telegram_request_body_redaction_test.go
+++ b/cmd/clawpatrol/telegram_request_body_redaction_test.go
@@ -85,11 +85,11 @@ rule "allow-telegram" {
 
 	certs, _ := inMemoryCertCache(t)
 	g := &Gateway{
-		cfg:     gw,
 		certs:   certs,
 		sink:    sink,
 		secrets: telegramRequestBodySecretStore{},
 	}
+	g.cfg.Store(gw)
 	g.policy.Store(policy)
 	g.transports.Store(ep, tr)
 

--- a/cmd/clawpatrol/telemetry.go
+++ b/cmd/clawpatrol/telemetry.go
@@ -85,7 +85,7 @@ func telemetryEnabled(cfg *config.Gateway) bool {
 }
 
 func startTelemetry(g *Gateway) {
-	if !telemetryEnabled(g.cfg) {
+	if !telemetryEnabled(g.cfg.Load()) {
 		log.Printf("telemetry: disabled")
 		return
 	}
@@ -221,10 +221,10 @@ func buildTelemetryPayload(
 	// order (wireguard|tailscale). Single-transport gateways report
 	// just the one. Empty string only when the config is misconfigured.
 	var transports []string
-	if g.cfg.IsWireGuardEnabled() {
+	if g.cfg.Load().IsWireGuardEnabled() {
 		transports = append(transports, "wireguard")
 	}
-	if g.cfg.IsTailscaleEnabled() {
+	if g.cfg.Load().IsTailscaleEnabled() {
 		transports = append(transports, "tailscale")
 	}
 	transport := strings.Join(transports, "+")

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1414,14 +1414,125 @@ func revisionForBytes(b []byte) string {
 }
 
 func appendConfigSnippet(current []byte, snippet string) []byte {
+	if mergedCurrent, remainingSnippet, ok := mergeGeneratedProfileCredentials(current, []byte(snippet)); ok {
+		current = mergedCurrent
+		snippet = string(remainingSnippet)
+	}
 	out := make([]byte, 0, len(current)+len(snippet)+4)
 	out = append(out, current...)
 	if len(out) > 0 && out[len(out)-1] != '\n' {
 		out = append(out, '\n')
 	}
+	if strings.TrimSpace(snippet) == "" {
+		return out
+	}
 	out = append(out, '\n')
 	out = append(out, strings.TrimRight(snippet, "\n")...)
 	out = append(out, '\n')
+	return out
+}
+
+// mergeGeneratedProfileCredentials folds any `profile "<name>" {
+// credentials = [...] }` blocks in the snippet into the existing
+// profile blocks in current, returning the updated current and the
+// snippet stripped of those merged blocks. Returns ok=false when
+// nothing was merged so the caller falls back to plain append.
+func mergeGeneratedProfileCredentials(current, snippet []byte) ([]byte, []byte, bool) {
+	currentText := string(current)
+	snippetText := string(snippet)
+	changed := false
+
+	snippetText = generatedProfileCredentialsBlockRE.ReplaceAllStringFunc(snippetText, func(block string) string {
+		m := generatedProfileCredentialsBlockRE.FindStringSubmatch(block)
+		if len(m) != 3 {
+			return block
+		}
+		profile := m[1]
+		addRefs := credentialRefsFromListText(m[2])
+		if len(addRefs) == 0 {
+			return block
+		}
+		updated, ok := mergeProfileCredentialRefs(currentText, profile, addRefs)
+		if !ok {
+			return block
+		}
+		currentText = updated
+		changed = true
+		return ""
+	})
+
+	if !changed {
+		return current, snippet, false
+	}
+	return []byte(currentText), []byte(strings.TrimSpace(snippetText)), true
+}
+
+var generatedProfileCredentialsBlockRE = regexp.MustCompile(`(?ms)\n*profile\s+"([^"]+)"\s*\{\s*credentials\s*=\s*\[([^\]]*)\]\s*\}\s*`)
+
+func mergeProfileCredentialRefs(current, profile string, addRefs []string) (string, bool) {
+	profileName := regexp.QuoteMeta(profile)
+	oneLineRE := regexp.MustCompile(`(?m)^(\s*profile\s+"` + profileName + `"\s*\{\s*)([^{}\n]*?)(\s*\}\s*)$`)
+	if loc := oneLineRE.FindStringSubmatchIndex(current); loc != nil {
+		body := strings.TrimSpace(current[loc[4]:loc[5]])
+		existing := credentialRefsFromProfileBody(body)
+		refs := mergeRefLists(existing, addRefs)
+		var replacement strings.Builder
+		replacement.WriteString(`profile "` + profile + `" {` + "\n")
+		if body != "" && !profileCredentialsLineRE.MatchString(body) {
+			replacement.WriteString("  " + body + "\n")
+		}
+		replacement.WriteString("  credentials = [" + strings.Join(refs, ", ") + "]\n")
+		replacement.WriteString("}")
+		return current[:loc[0]] + replacement.String() + current[loc[1]:], true
+	}
+
+	blockRE := regexp.MustCompile(`(?ms)(profile\s+"` + profileName + `"\s*\{\n)(.*?)(\n\})`)
+	loc := blockRE.FindStringSubmatchIndex(current)
+	if loc == nil {
+		return current, false
+	}
+	body := current[loc[4]:loc[5]]
+	existing := credentialRefsFromProfileBody(body)
+	refs := mergeRefLists(existing, addRefs)
+	if profileCredentialsLineRE.MatchString(body) {
+		body = profileCredentialsLineRE.ReplaceAllString(body, "  credentials = ["+strings.Join(refs, ", ")+"]")
+	} else {
+		body = strings.TrimRight(body, "\n") + "\n  credentials = [" + strings.Join(refs, ", ") + "]"
+	}
+	return current[:loc[4]] + body + current[loc[5]:], true
+}
+
+var profileCredentialsLineRE = regexp.MustCompile(`(?m)^\s*credentials\s*=\s*\[([^\]]*)\]`)
+
+func credentialRefsFromProfileBody(body string) []string {
+	m := profileCredentialsLineRE.FindStringSubmatch(body)
+	if len(m) != 2 {
+		return nil
+	}
+	return credentialRefsFromListText(m[1])
+}
+
+func credentialRefsFromListText(raw string) []string {
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		ref := strings.TrimSpace(part)
+		if ref != "" {
+			out = append(out, ref)
+		}
+	}
+	return out
+}
+
+func mergeRefLists(existing, added []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(existing)+len(added))
+	for _, ref := range append(existing, added...) {
+		if ref == "" || seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		out = append(out, ref)
+	}
 	return out
 }
 

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -179,7 +179,7 @@ func (w *webMux) skipsDashboardPassword(path string) bool {
 
 func (w *webMux) mayUseTailnetInsteadOfDashboard(path string) bool {
 	return w.authRequirementForPath(path) == authDashboardOrTailnetOperator &&
-		w.g.cfg.IsTailscaleEnabled()
+		w.g.cfg.Load().IsTailscaleEnabled()
 }
 
 func (w *webMux) skipsTailnetGate(path string) bool {
@@ -312,7 +312,7 @@ const cpSessionCookieName = "cp_session"
 // the duplicate parse here is so a hot-reloaded config can change
 // the TTL without restarting.
 func (w *webMux) dashboardSessionTTL() time.Duration {
-	d, err := config.DashboardSessionTTLFromString(w.g.cfg.DashboardSessionTTL())
+	d, err := config.DashboardSessionTTLFromString(w.g.cfg.Load().DashboardSessionTTL())
 	if err != nil {
 		// Validator at config load would have caught this; defensive
 		// fallback to the default keeps a hot-reload typo from
@@ -367,7 +367,7 @@ func (w *webMux) dashboardAuthGate(next http.Handler) http.Handler {
 		// configured operators allowlist. Only relevant when the
 		// `tailscale {}` block is enabled — without it there's no
 		// whois identity to resolve.
-		if w.g.cfg.IsTailscaleEnabled() && len(w.g.cfg.Operators()) > 0 {
+		if w.g.cfg.Load().IsTailscaleEnabled() && len(w.g.cfg.Load().Operators()) > 0 {
 			next.ServeHTTP(rw, r)
 			return
 		}
@@ -571,7 +571,7 @@ func renderLogin(rw http.ResponseWriter, next, errMsg string, firstRun bool, sta
 // gate is skipped and dashboardAuthGate's password requirement is
 // the only auth.
 func (w *webMux) tailnetGate(next http.Handler) http.Handler {
-	skipGate := !w.g.cfg.IsTailscaleEnabled()
+	skipGate := !w.g.cfg.Load().IsTailscaleEnabled()
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if w.skipsTailnetGate(r.URL.Path) || skipGate {
@@ -629,7 +629,7 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 		// dashboardAuthGate upstream and short-circuit this gate at
 		// the principalFromContext check above.
 		if needsOperatorGate(w.authRequirementForPath(r.URL.Path)) {
-			if !config.MatchDashboardOperator(login, w.g.cfg.Operators()) {
+			if !config.MatchDashboardOperator(login, w.g.cfg.Load().Operators()) {
 				http.Error(rw, "operator routes require a dashboard password session or a tailnet login matching the operators allowlist", http.StatusForbidden)
 				return
 			}
@@ -825,8 +825,10 @@ func (w *webMux) apiHITLOperationStatus(rw http.ResponseWriter, r *http.Request)
 func (w *webMux) hitlPublicURL() string {
 	// Prefer the live config — public_url may be auto-derived from the
 	// tsnet Funnel cert AFTER webMux is constructed.
-	if w.g != nil && w.g.cfg != nil && w.g.cfg.PublicURL() != "" {
-		return w.g.cfg.PublicURL()
+	if w.g != nil {
+		if cfg := w.g.cfg.Load(); cfg != nil && cfg.PublicURL() != "" {
+			return cfg.PublicURL()
+		}
 	}
 	return w.publicURL
 }
@@ -1061,7 +1063,7 @@ func (w *webMux) selectedProfileForRequest(r *http.Request) (key, label string) 
 	if p := r.Header.Get("X-Clawpatrol-Profile"); p != "" {
 		return p, p
 	}
-	if def := defaultProfileName(w.g.cfg.Policy); def != "" {
+	if def := defaultProfileName(w.g.cfg.Load().Policy); def != "" {
 		return def, def
 	}
 	user, _, host := w.callerIdentity(r)
@@ -1083,7 +1085,7 @@ func (w *webMux) selectedProfileForRequest(r *http.Request) (key, label string) 
 // the context (e.g. on a route the gate let through without one,
 // which shouldn't happen for authDashboard but stays defensive).
 func (w *webMux) whoamiData(r *http.Request) map[string]string {
-	pu := w.g.cfg.PublicURL()
+	pu := w.g.cfg.Load().PublicURL()
 	if pu == "" {
 		pu = w.publicURL
 	}
@@ -1155,7 +1157,7 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 		"agents":                  w.agentsList(),
 		"update":                  currentUpdateBanner.Load(),
 		"config_file":             filepath.Base(w.g.cfgPath),
-		"dashboard_config_writes": w.g.cfg.DashboardConfigWrites(),
+		"dashboard_config_writes": w.g.cfg.Load().DashboardConfigWrites(),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {
@@ -1346,16 +1348,19 @@ func (w *webMux) apiConfigApply(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if !w.g.cfg.DashboardConfigWrites() {
+	w.g.configMu.Lock()
+	defer w.g.configMu.Unlock()
+
+	// Re-check writes inside the lock: a concurrent reload could
+	// have flipped the setting between the request arriving and us
+	// acquiring the lock.
+	if !w.g.cfg.Load().DashboardConfigWrites() {
 		writeJSONError(rw, http.StatusForbidden, map[string]any{
 			"error":                   "dashboard config writes are disabled",
 			"dashboard_config_writes": false,
 		})
 		return
 	}
-
-	w.g.configMu.Lock()
-	defer w.g.configMu.Unlock()
 
 	current, err := os.ReadFile(w.g.cfgPath)
 	if err != nil {
@@ -1393,6 +1398,12 @@ func (w *webMux) apiConfigApply(rw http.ResponseWriter, r *http.Request) {
 			"error": err.Error(),
 		})
 		return
+	}
+	// Preserve the original file's permissions across the atomic
+	// rename — os.CreateTemp gives us 0600 by default, which would
+	// silently downgrade a group-readable deploy file.
+	if st, err := os.Stat(w.g.cfgPath); err == nil {
+		_ = os.Chmod(tmpPath, st.Mode().Perm())
 	}
 	if err := os.Rename(tmpPath, w.g.cfgPath); err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -1492,6 +1503,16 @@ func mergeProfileCredentialRefs(current, profile string, addRefs []string) (stri
 		return current, false
 	}
 	body := current[loc[4]:loc[5]]
+	// Bail out if the body contains anything we can't reason about
+	// with the simple credentials-list regex: nested braces (inline
+	// disambiguator entries), multi-line credentials lists with `,`
+	// on continuation lines, or any non-credentials attribute that
+	// could swallow our edit. The caller falls back to a plain
+	// append, which surfaces a clean "duplicate profile" diagnostic
+	// from the loader.
+	if strings.ContainsAny(body, "{}") || !profileBodyMergeSafe(body) {
+		return current, false
+	}
 	existing := credentialRefsFromProfileBody(body)
 	refs := mergeRefLists(existing, addRefs)
 	if profileCredentialsLineRE.MatchString(body) {
@@ -1500,6 +1521,29 @@ func mergeProfileCredentialRefs(current, profile string, addRefs []string) (stri
 		body = strings.TrimRight(body, "\n") + "\n  credentials = [" + strings.Join(refs, ", ") + "]"
 	}
 	return current[:loc[4]] + body + current[loc[5]:], true
+}
+
+// profileBodyMergeSafe returns true only when every non-blank line in
+// the profile body is either the single `credentials = [...]` line we
+// know how to edit or a comment / whitespace. Anything else (extra
+// attributes, multi-line credentials lists, disambiguator literals
+// the simple regex would mis-tokenise) makes the merge unsafe.
+func profileBodyMergeSafe(body string) bool {
+	credSeen := false
+	for _, line := range strings.Split(body, "\n") {
+		s := strings.TrimSpace(line)
+		if s == "" || strings.HasPrefix(s, "#") || strings.HasPrefix(s, "//") {
+			continue
+		}
+		if !profileCredentialsLineRE.MatchString(line) {
+			return false
+		}
+		if credSeen {
+			return false
+		}
+		credSeen = true
+	}
+	return true
 }
 
 var profileCredentialsLineRE = regexp.MustCompile(`(?m)^\s*credentials\s*=\s*\[([^\]]*)\]`)
@@ -1697,7 +1741,7 @@ func (w *webMux) apiActionRulePreview(rw http.ResponseWriter, r *http.Request) {
 	if b, err := os.ReadFile(w.g.cfgPath); err == nil {
 		rule.ConfigRevision = revisionForBytes(b)
 	}
-	rule.DashboardConfigWrites = w.g.cfg.DashboardConfigWrites()
+	rule.DashboardConfigWrites = w.g.cfg.Load().DashboardConfigWrites()
 	writeJSON(rw, rule)
 }
 

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1694,10 +1694,8 @@ func (w *webMux) apiActionRulePreview(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
-	b, err := os.ReadFile(w.g.cfgPath)
-	if err == nil {
+	if b, err := os.ReadFile(w.g.cfgPath); err == nil {
 		rule.ConfigRevision = revisionForBytes(b)
-		rule.Patch = generatedAppendPatchFromBytes(filepath.Base(w.g.cfgPath), b, rule.HCL)
 	}
 	rule.DashboardConfigWrites = w.g.cfg.DashboardConfigWrites()
 	writeJSON(rw, rule)

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1567,7 +1567,7 @@ func (w *webMux) apiActionRulePreview(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ev, err := w.loadAction(body.ActionID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(rw, "not found", http.StatusNotFound)
 		return
 	}
@@ -1683,7 +1683,7 @@ func (w *webMux) apiActionByID(
 		return
 	}
 	e, err := w.loadAction(actionID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(rw, "not found", 404)
 		return
 	}

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -227,6 +227,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodGet, Path: "/api/profiles", Auth: authDashboard, Handler: w.apiProfiles},
 		{Method: http.MethodGet, Path: "/api/rules", Auth: authDashboard, Handler: w.apiRules},
 		{Method: http.MethodGet, Path: "/api/config", Auth: authDashboard, Handler: w.apiConfig},
+		{Method: http.MethodPost, Path: "/api/config/apply", Auth: authDashboard, Handler: w.apiConfigApply},
 		{Method: http.MethodGet, Path: "/api/hitl/pending", Auth: authDashboard, Handler: w.apiHITLPending},
 		{Method: http.MethodPost, Path: "/api/hitl/decide", Auth: authDashboard, Handler: w.apiHITLDecide},
 		{Method: http.MethodGet, Path: hitlOperationStatusPrefix, Auth: authSelfAuthenticating, Handler: w.apiHITLOperationStatus},
@@ -241,6 +242,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/credentials/set", Auth: authDashboard, Handler: w.apiCredentialsSet},
 		{Method: http.MethodPost, Path: "/api/credentials/clear", Auth: authDashboard, Handler: w.apiCredentialsClear},
 		{Method: http.MethodGet, Path: "/api/events", Auth: authDashboard, Handler: w.apiEventsSSE},
+		{Method: http.MethodPost, Path: "/api/actions/rule-preview", Auth: authDashboard, Handler: w.apiActionRulePreview},
 		{Method: http.MethodPost, Path: "/api/actions/", Auth: authDashboard, Handler: w.apiActionByID},
 		{Method: http.MethodGet, Path: "/api/analytics", Auth: authDashboard, Handler: w.apiAnalytics},
 		{Method: http.MethodGet, Path: "/api/facets", Auth: authDashboard, Handler: w.apiFacets},
@@ -1148,11 +1150,12 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 	w.stateCacheMu.RUnlock()
 
 	state := map[string]any{
-		"whoami":       w.whoamiData(r),
-		"integrations": w.statusList(r),
-		"agents":       w.agentsList(),
-		"update":       currentUpdateBanner.Load(),
-		"config_file":  filepath.Base(w.g.cfgPath),
+		"whoami":                  w.whoamiData(r),
+		"integrations":            w.statusList(r),
+		"agents":                  w.agentsList(),
+		"update":                  currentUpdateBanner.Load(),
+		"config_file":             filepath.Base(w.g.cfgPath),
+		"dashboard_config_writes": w.g.cfg.DashboardConfigWrites(),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {
@@ -1324,9 +1327,108 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 	_, _ = rw.Write(b)
 }
 
+func (w *webMux) apiConfigApply(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		BaseRevision string `json:"base_revision"`
+		AppendHCL    string `json:"append_hcl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(body.AppendHCL) == "" {
+		writeJSONError(rw, http.StatusBadRequest, map[string]any{
+			"error": "append_hcl is required",
+		})
+		return
+	}
+	if !w.g.cfg.DashboardConfigWrites() {
+		writeJSONError(rw, http.StatusForbidden, map[string]any{
+			"error":                   "dashboard config writes are disabled",
+			"dashboard_config_writes": false,
+		})
+		return
+	}
+
+	w.g.configMu.Lock()
+	defer w.g.configMu.Unlock()
+
+	current, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	currentRevision := revisionForBytes(current)
+	if body.BaseRevision != "" && body.BaseRevision != currentRevision {
+		writeJSONError(rw, http.StatusConflict, map[string]any{
+			"error":            "config changed",
+			"current_revision": currentRevision,
+		})
+		return
+	}
+	candidate := appendConfigSnippet(current, body.AppendHCL)
+	dir := filepath.Dir(w.g.cfgPath)
+	tmp, err := os.CreateTemp(dir, ".clawpatrol-config-*.hcl")
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(candidate); err != nil {
+		_ = tmp.Close()
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if _, _, err := loadConfig(tmpPath); err != nil {
+		writeJSONError(rw, http.StatusBadRequest, map[string]any{
+			"error": err.Error(),
+		})
+		return
+	}
+	if err := os.Rename(tmpPath, w.g.cfgPath); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := w.g.reloadConfigFromFileLocked(w.g.cfgPath); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(rw, map[string]any{
+		"ok":       true,
+		"revision": revisionForBytes(candidate),
+	})
+}
+
 func revisionForBytes(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
+}
+
+func appendConfigSnippet(current []byte, snippet string) []byte {
+	out := make([]byte, 0, len(current)+len(snippet)+4)
+	out = append(out, current...)
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	out = append(out, '\n')
+	out = append(out, strings.TrimRight(snippet, "\n")...)
+	out = append(out, '\n')
+	return out
+}
+
+func writeJSONError(rw http.ResponseWriter, status int, v any) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	_ = json.NewEncoder(rw).Encode(v)
 }
 
 func (w *webMux) apiHITLPending(rw http.ResponseWriter, _ *http.Request) {
@@ -1441,14 +1543,58 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (w *webMux) apiActionByID(
-	rw http.ResponseWriter, r *http.Request,
-) {
-	// Path: /api/actions/<uuid>
-	actionID := strings.TrimPrefix(r.URL.Path, "/api/actions/")
-	if actionID == "" {
-		http.Error(rw, "missing id", 400)
+func (w *webMux) apiActionRulePreview(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
+	}
+	var body struct {
+		ActionID string `json:"action_id"`
+		Verdict  string `json:"verdict"`
+		Scope    string `json:"scope"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.ActionID == "" {
+		http.Error(rw, "missing action_id", http.StatusBadRequest)
+		return
+	}
+	policy := w.g.Policy()
+	if policy == nil {
+		http.Error(rw, "policy not loaded", http.StatusServiceUnavailable)
+		return
+	}
+	ev, err := w.loadAction(body.ActionID)
+	if err == sql.ErrNoRows {
+		http.Error(rw, "not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rule, err := GenerateRuleFromEvent(policy, ev, RuleGenOptions{
+		Verdict: body.Verdict,
+		Scope:   body.Scope,
+	})
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	b, err := os.ReadFile(w.g.cfgPath)
+	if err == nil {
+		rule.ConfigRevision = revisionForBytes(b)
+		rule.Patch = generatedAppendPatchFromBytes(filepath.Base(w.g.cfgPath), b, rule.HCL)
+	}
+	rule.DashboardConfigWrites = w.g.cfg.DashboardConfigWrites()
+	writeJSON(rw, rule)
+}
+
+func (w *webMux) loadAction(actionID string) (*Event, error) {
+	if actionID == "" {
+		return nil, fmt.Errorf("missing id")
 	}
 	var (
 		e            Event
@@ -1494,13 +1640,8 @@ func (w *webMux) apiActionByID(
 		&endpoint, &rule,
 		&approver, &approverType, &approverBy,
 	)
-	if err == sql.ErrNoRows {
-		http.Error(rw, "not found", 404)
-		return
-	}
 	if err != nil {
-		http.Error(rw, err.Error(), 500)
-		return
+		return nil, err
 	}
 	e.ID = actionID
 	e.Ts = time.Unix(0, tsNs).UTC()
@@ -1529,8 +1670,29 @@ func (w *webMux) apiActionByID(
 	e.Approver = approver.String
 	e.ApproverType = approverType.String
 	e.ApproverBy = approverBy.String
+	return &e, nil
+}
+
+func (w *webMux) apiActionByID(
+	rw http.ResponseWriter, r *http.Request,
+) {
+	// Path: /api/actions/<uuid>
+	actionID := strings.TrimPrefix(r.URL.Path, "/api/actions/")
+	if actionID == "" {
+		http.Error(rw, "missing id", 400)
+		return
+	}
+	e, err := w.loadAction(actionID)
+	if err == sql.ErrNoRows {
+		http.Error(rw, "not found", 404)
+		return
+	}
+	if err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
 	if r.URL.Query().Get("fmt") == "fixture" {
-		w.writeActionFixture(rw, &e)
+		w.writeActionFixture(rw, e)
 		return
 	}
 	writeJSON(rw, e)

--- a/cmd/clawpatrol/web_auth_test.go
+++ b/cmd/clawpatrol/web_auth_test.go
@@ -56,10 +56,10 @@ func newOnboardAuthTestWebMuxForControl(t *testing.T, control string) *webMux {
 		Policy:   &config.Policy{},
 	}
 	g := &Gateway{
-		cfg:     cfg,
 		db:      db,
 		onboard: newOnboardRegistry(),
 	}
+	g.cfg.Store(cfg)
 	w := &webMux{g: g, ts: cfg.Join(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard}
 	w.routeAuth = routeAuthIndex(w.routes())
 	return w
@@ -297,7 +297,7 @@ func TestOnboardApproveWithDashboardPasswordInTailscaleModeDoesNotRequireTailnet
 // on operator-class routes; the test config now reflects that.
 func TestOnboardApproveWithTailnetPrincipalInTailscaleModeReachesHandler(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
-	w.g.cfg.Settings.Tailscale.Operators = []string{"*@example.com"}
+	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"*@example.com"}
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -316,7 +316,7 @@ func TestOnboardApproveWithTailnetPrincipalInTailscaleModeReachesHandler(t *test
 
 func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeReachesHandler(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "")
-	w.g.cfg.Settings.Tailscale.Operators = []string{"*@example.com"}
+	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"*@example.com"}
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -341,7 +341,7 @@ func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeReachesHandler(
 // own onboards.
 func TestOnboardApproveRejectsTailnetPrincipalNotInOperators(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
-	w.g.cfg.Settings.Tailscale.Operators = []string{"*@example.com"}
+	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"*@example.com"}
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -377,7 +377,8 @@ func TestDashboardAuthGateFirstRunRedirect(t *testing.T) {
 		},
 		Policy: &config.Policy{},
 	}
-	g := &Gateway{cfg: cfg, db: db, onboard: newOnboardRegistry()}
+	g := &Gateway{db: db, onboard: newOnboardRegistry()}
+	g.cfg.Store(cfg)
 	w := &webMux{g: g, ts: cfg.Join(), publicURL: "https://gateway.example.test", sessions: map[string]*oauthSession{}, onboard: g.onboard}
 	h := w.handler()
 
@@ -414,7 +415,7 @@ func TestDashboardAuthGateFirstRunRedirect(t *testing.T) {
 // effect for the gate's purposes.
 func TestDashboardAuthGateAllowsTailnetOperatorWhenAllowlisted(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
-	w.g.cfg.Settings.Tailscale.Operators = []string{"alice@example.com", "*@example.org"}
+	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"alice@example.com", "*@example.org"}
 	h := w.handler()
 
 	cases := []struct {

--- a/cmd/clawpatrol/web_ca_fingerprint_test.go
+++ b/cmd/clawpatrol/web_ca_fingerprint_test.go
@@ -26,10 +26,10 @@ func newFingerprintWebMux(t *testing.T) (*webMux, string) {
 		Policy: &config.Policy{},
 	}
 	g := &Gateway{
-		cfg:     cfg,
 		certs:   cc,
 		onboard: newOnboardRegistry(),
 	}
+	g.cfg.Store(cfg)
 	w := &webMux{
 		g:         g,
 		ts:        cfg.Join(),

--- a/cmd/clawpatrol/web_config_apply_test.go
+++ b/cmd/clawpatrol/web_config_apply_test.go
@@ -119,6 +119,85 @@ profile "default" {
 	}
 }
 
+// TestConfigApplyBailsOnComplexProfileBody confirms the regex merge
+// refuses to touch profile blocks it can't safely rewrite (inline
+// disambiguator entries, here) — the fallback is a plain append that
+// validates as a duplicate-profile error rather than silently
+// corrupting the existing block.
+func TestConfigApplyBailsOnComplexProfileBody(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	// Replace the simple "default" profile in the seed config with a
+	// disambiguator-heavy one so the merge has to bail.
+	complexSrc := `gateway {
+  state_dir = "` + filepath.ToSlash(filepath.Dir(w.g.cfgPath)) + `"
+  dashboard_config_writes = true
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "127.0.0.1:51820"
+  }
+}
+
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+credential "bearer_token" "tok-a" { endpoint = https.github }
+credential "bearer_token" "tok-b" { endpoint = https.github }
+
+profile "default" {
+  credentials = [
+    { placeholder = "PH_a", credential = bearer_token.tok-a },
+    { placeholder = "PH_b", credential = bearer_token.tok-b },
+  ]
+}
+`
+	if err := os.WriteFile(w.g.cfgPath, []byte(complexSrc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, policy, err := loadConfig(w.g.cfgPath)
+	if err != nil {
+		t.Fatalf("reload seeded config: %v", err)
+	}
+	w.g.cfg.Store(cfg)
+	w.g.policy.Store(policy)
+
+	before, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snippet := `endpoint "https" "tinyclouds_org" {
+  hosts = ["tinyclouds.org"]
+}
+credential "passthrough" "tinyclouds_org_passthrough" {
+  endpoint = https.tinyclouds_org
+}
+profile "default" {
+  credentials = [passthrough.tinyclouds_org_passthrough]
+}`
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": revisionForBytes(before),
+		"append_hcl":    snippet,
+	}))
+	// Plain append produces a duplicate "default" profile, which
+	// loadConfig rejects. We want the file unchanged and a 400 with
+	// the loader's error.
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	after, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("config changed after rejected apply")
+	}
+	// The disambiguator entries must still be intact in the
+	// untouched config.
+	if !strings.Contains(string(after), `placeholder = "PH_a"`) {
+		t.Fatalf("disambiguator body corrupted:\n%s", after)
+	}
+}
+
 func TestConfigApplyAppendsAndReloads(t *testing.T) {
 	w := configApplyTestMux(t, true)
 	before, err := os.ReadFile(w.g.cfgPath)
@@ -191,7 +270,8 @@ profile "default" { credentials = [bearer_token.tok] }
 		t.Fatalf("OpenDB: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	g := &Gateway{cfg: cfg, cfgPath: cfgPath, stateDir: dir, db: db}
+	g := &Gateway{cfgPath: cfgPath, stateDir: dir, db: db}
+	g.cfg.Store(cfg)
 	g.policy.Store(policy)
 	return &webMux{g: g}
 }

--- a/cmd/clawpatrol/web_config_apply_test.go
+++ b/cmd/clawpatrol/web_config_apply_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+func TestConfigApplyRejectsWhenDashboardWritesDisabled(t *testing.T) {
+	w := configApplyTestMux(t, false)
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"append_hcl": `rule "x" { endpoint = https.github verdict = "deny" }`,
+	}))
+	if rw.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "dashboard config writes are disabled") {
+		t.Fatalf("body=%s", rw.Body.String())
+	}
+}
+
+func TestConfigApplyRejectsRevisionMismatch(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": "not-current",
+		"append_hcl":    `rule "x" { endpoint = https.github verdict = "deny" }`,
+	}))
+	if rw.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "config changed") {
+		t.Fatalf("body=%s", rw.Body.String())
+	}
+}
+
+func TestConfigApplyRejectsInvalidSnippet(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	before, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": revisionForBytes(before),
+		"append_hcl":    `rule "bad" { endpoint = https.missing verdict = "deny" }`,
+	}))
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	after, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("config changed after rejected apply")
+	}
+}
+
+func TestConfigApplyAppendsAndReloads(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	before, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snippet := `rule "block-delete" {
+  endpoint = https.github
+  condition = "http.method == \"DELETE\""
+  verdict = "deny"
+}`
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": revisionForBytes(before),
+		"append_hcl":    snippet,
+	}))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	after, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), `rule "block-delete"`) {
+		t.Fatalf("config missing appended rule:\n%s", after)
+	}
+	ep := w.g.Policy().Endpoints["github"]
+	if ep == nil {
+		t.Fatal("github endpoint missing after reload")
+	}
+	found := false
+	for _, rule := range ep.Rules {
+		if rule.Name == "block-delete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("policy did not reload appended rule: %+v", ep.Rules)
+	}
+}
+
+func configApplyTestMux(t *testing.T, writes bool) *webMux {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	src := `gateway {
+  state_dir = "` + filepath.ToSlash(dir) + `"
+  dashboard_config_writes = ` + map[bool]string{true: "true", false: "false"}[writes] + `
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "127.0.0.1:51820"
+  }
+}
+
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+credential "bearer_token" "tok" { endpoint = https.github }
+profile "default" { credentials = [bearer_token.tok] }
+`
+	if err := os.WriteFile(cfgPath, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, policy, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	db, err := OpenDB(filepath.Join(dir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	g := &Gateway{cfg: cfg, cfgPath: cfgPath, stateDir: dir, db: db}
+	g.policy.Store(policy)
+	return &webMux{g: g}
+}
+
+func jsonReq(v any) *http.Request {
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(v)
+	req := httptest.NewRequest(http.MethodPost, "/api/config/apply", &b)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}

--- a/cmd/clawpatrol/web_config_apply_test.go
+++ b/cmd/clawpatrol/web_config_apply_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
 func TestConfigApplyRejectsWhenDashboardWritesDisabled(t *testing.T) {
@@ -62,6 +63,59 @@ func TestConfigApplyRejectsInvalidSnippet(t *testing.T) {
 	}
 	if !bytes.Equal(before, after) {
 		t.Fatalf("config changed after rejected apply")
+	}
+}
+
+func TestConfigApplyMergesGeneratedProfileCredentials(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	before, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snippet := `endpoint "https" "tinyclouds_org" {
+  hosts = ["tinyclouds.org"]
+}
+
+credential "passthrough" "tinyclouds_org_passthrough" {
+  endpoint = https.tinyclouds_org
+}
+
+rule "block_tinyclouds_org" {
+  endpoint = https.tinyclouds_org
+  verdict = "deny"
+}
+
+profile "default" {
+  credentials = [passthrough.tinyclouds_org_passthrough]
+}`
+	candidate := appendConfigSnippet(before, snippet)
+	if strings.Count(string(candidate), `profile "default"`) != 1 {
+		t.Fatalf("candidate should keep one default profile block:\n%s", candidate)
+	}
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": revisionForBytes(before),
+		"append_hcl":    snippet,
+	}))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	after, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(after), `profile "default"`) != 1 {
+		t.Fatalf("config should keep one default profile block:\n%s", after)
+	}
+	if !strings.Contains(string(after), `passthrough.tinyclouds_org_passthrough`) {
+		t.Fatalf("config missing merged profile credential:\n%s", after)
+	}
+	if !strings.Contains(string(after), `bearer_token.tok`) {
+		t.Fatalf("config should retain existing credential:\n%s", after)
+	}
+	ep := runtime.HostEndpoint(w.g.Policy(), "default", "tinyclouds.org")
+	if ep == nil || ep.Name != "tinyclouds_org" {
+		t.Fatalf("HostEndpoint = %#v, want generated endpoint", ep)
 	}
 }
 

--- a/cmd/clawpatrol/web_dashboard_auth_test.go
+++ b/cmd/clawpatrol/web_dashboard_auth_test.go
@@ -29,7 +29,9 @@ func newDashboardTestMux(t *testing.T, cfg *config.Gateway, rootPassword string)
 			t.Fatalf("seed root password: %v", err)
 		}
 	}
-	return &webMux{g: &Gateway{cfg: cfg, db: db}}
+	g := &Gateway{db: db}
+	g.cfg.Store(cfg)
+	return &webMux{g: g}
 }
 
 // mintTestSessionCookie creates a real session row + returns the

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -338,13 +338,15 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
 
   const writesEnabled = !!preview?.dashboard_config_writes;
   const createsEndpoint = !!preview?.endpoint_name && preview.endpoint_name !== ev.endpoint;
+  const passthrough = createsEndpoint || ev.mode === "splice";
 
   return (
     <Modal title="Block requests like this" size="lg" onClose={onClose}>
       <div className="p-4 space-y-3 overflow-auto">
         <p className="text-sm text-text-muted">
-          Claw Patrol generated HCL from this observed action. For matched endpoints this adds a
-          narrow deny rule; for passthrough hosts it creates an endpoint and blocks that host.
+          {passthrough
+            ? "This request was passed through without MITM inspection because no endpoint matched it. Claw Patrol generated HCL that creates an endpoint for the observed host and denies future matching requests before they pass through."
+            : "Claw Patrol generated a narrow deny rule from this inspected action. Edit the condition if you want to broaden it."}
         </p>
         {busy ? (
           <div className="text-xs text-text-subtle">Generating rule...</div>
@@ -365,8 +367,9 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             ))}
             {createsEndpoint && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
-                This will create endpoint <code>{preview.endpoint_name}</code>. Credential creation
-                is not part of this flow yet.
+                This will create endpoint <code>{preview.endpoint_name}</code> for future traffic.
+                It does not retroactively inspect this request. Credential creation is not part of
+                this flow yet.
               </div>
             )}
             <textarea

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -361,7 +361,17 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
           <>
             {!writesEnabled && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs text-text">
-                Dashboard config writes are disabled for this gateway. Copy this rule into your HCL
+                Dashboard config writes are disabled for this gateway. Set{" "}
+                <code>dashboard_config_writes = true</code> in the{" "}
+                <a
+                  href="https://clawpatrol.dev/docs/config-reference/#gateway--"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  gateway block
+                </a>{" "}
+                to let the dashboard apply rules directly; until then, copy this HCL into your
                 config and deploy it through your normal workflow.
               </div>
             )}

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -273,6 +273,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   const [hcl, setHCL] = useState("");
   const [busy, setBusy] = useState(true);
   const [applying, setApplying] = useState(false);
+  const [applied, setApplied] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [msg, setMsg] = useState<string | null>(null);
 
@@ -310,7 +311,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
     setMsg(null);
     try {
       await applyGeneratedRule(preview.config_revision, hcl);
-      setMsg("Rule applied. New matching requests will be denied.");
+      setApplied(true);
     } catch (e) {
       const text = (e as Error).message || "apply failed";
       if (text.includes("config changed")) {
@@ -343,16 +344,31 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   return (
     <Modal title="Block requests like this" size="lg" onClose={onClose}>
       <div className="p-4 space-y-3 overflow-auto">
-        <p className="text-sm text-text-muted">
-          {passthrough
-            ? "This request was passed through without MITM inspection because no endpoint matched it. Claw Patrol generated HCL that creates an endpoint for the observed host and denies future matching requests before they pass through."
-            : "Claw Patrol generated a narrow deny rule from this inspected action. Edit the condition if you want to broaden it."}
-        </p>
-        {busy ? (
-          <div className="text-xs text-text-subtle">Generating rule...</div>
-        ) : err && !preview ? (
-          <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>
+        {applied ? (
+          <div className="min-h-[300px] flex flex-col items-center justify-center text-center gap-4">
+            <div className="flex items-center justify-center w-14 h-14 rounded-full border-2 border-success-600 text-success-600">
+              <CheckLargeIcon />
+            </div>
+            <div className="space-y-2 max-w-[34rem]">
+              <h3 className="text-lg font-semibold text-text">Rule applied</h3>
+              <p className="text-sm text-text-muted">
+                The generated HCL was validated, written to disk, and reloaded by the gateway. New
+                matching requests will be denied.
+              </p>
+            </div>
+          </div>
         ) : (
+          <p className="text-sm text-text-muted">
+            {passthrough
+              ? "This request was passed through without MITM inspection because no endpoint matched it. Claw Patrol generated HCL that creates an endpoint for the observed host, claims it from existing profiles via a passthrough credential, and denies future matching requests before they pass through."
+              : "Claw Patrol generated a narrow deny rule from this inspected action. Edit the condition if you want to broaden it."}
+          </p>
+        )}
+        {!applied && busy ? (
+          <div className="text-xs text-text-subtle">Generating rule...</div>
+        ) : !applied && err && !preview ? (
+          <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>
+        ) : !applied ? (
           <>
             {!writesEnabled && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs text-text">
@@ -368,8 +384,8 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             {createsEndpoint && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
                 This will create endpoint <code>{preview.endpoint_name}</code> for future traffic.
-                It does not retroactively inspect this request. Credential creation is not part of
-                this flow yet.
+                It does not retroactively inspect this request. A passthrough credential is added so
+                existing profiles claim the endpoint; no auth is injected.
               </div>
             )}
             <textarea
@@ -381,10 +397,19 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             {err && <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>}
             {msg && <div className="text-sm text-success-600">{msg}</div>}
           </>
-        )}
+        ) : null}
       </div>
       <div className="flex items-center gap-2 justify-end px-4 py-3 border-t border-navy bg-navy-100">
-        {writesEnabled ? (
+        {applied ? (
+          <>
+            <Button variant="outline" disabled={!preview} onClick={copyHCL}>
+              Copy HCL
+            </Button>
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+          </>
+        ) : writesEnabled ? (
           <Button disabled={!preview || applying} onClick={applyRule}>
             {applying ? "Applying..." : "Apply rule"}
           </Button>
@@ -393,21 +418,41 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             Copy HCL
           </Button>
         )}
-        {writesEnabled && (
+        {!applied && writesEnabled && (
           <Button variant="outline" disabled={!preview} onClick={copyHCL}>
             Copy HCL
           </Button>
         )}
-        {!writesEnabled && (
+        {!applied && !writesEnabled && (
           <Button variant="outline" disabled={!preview?.patch} onClick={downloadPatch}>
             Download patch
           </Button>
         )}
-        <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
-          Download fixture
-        </Button>
+        {!applied && (
+          <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
+            Download fixture
+          </Button>
+        )}
       </div>
     </Modal>
+  );
+}
+
+function CheckLargeIcon() {
+  return (
+    <svg
+      width="28"
+      height="28"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m5 12 5 5L20 7" />
+    </svg>
   );
 }
 

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
 import {
+  applyGeneratedRule,
   downloadActionFixture,
   getAction,
+  previewRuleFromAction,
   type Agent,
   type EventRecord,
   type FacetSchema,
+  type RulePreview,
 } from "../lib/api";
 import { headersToJSON } from "../lib/clipboard";
 import { formatFacetValue, useFacets } from "../lib/facets";
@@ -13,6 +16,7 @@ import { Button } from "./Button";
 import { CopyButton } from "./CopyButton";
 import { ApprovalStatusIcon, LockGlyph } from "./LiveRequests";
 import { Main } from "./Main";
+import { Modal } from "./Modal";
 import { PageTitle, type Crumb } from "./PageTitle";
 import { Tag } from "./Tag";
 
@@ -130,7 +134,7 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
             {fullUrl}
           </span>
           <span className="ml-auto">
-            <DownloadActionButton ev={ev} />
+            <ActionButtons ev={ev} />
           </span>
         </div>
         <div className="flex items-center gap-4 text-xs text-text-muted flex-wrap">
@@ -214,6 +218,21 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
   );
 }
 
+function ActionButtons({ ev }: { ev: EventRecord }) {
+  const [ruleOpen, setRuleOpen] = useState(false);
+  return (
+    <div className="flex items-center gap-2 flex-wrap justify-end">
+      {ev.id && ev.endpoint && ev.action !== "in_flight" && (
+        <Button variant="outline" onClick={() => setRuleOpen(true)}>
+          Block requests like this
+        </Button>
+      )}
+      <DownloadActionButton ev={ev} />
+      {ruleOpen && <RulePreviewModal ev={ev} onClose={() => setRuleOpen(false)} />}
+    </div>
+  );
+}
+
 // DownloadActionButton triggers a server-side reshape of this event
 // into a `clawpatrol test` fixture and saves it as a .json file. The
 // runner reads files in this exact format — drop the download into a
@@ -234,14 +253,7 @@ function DownloadActionButton({ ev }: { ev: EventRecord }) {
         setErr(null);
         try {
           const blob = await downloadActionFixture(ev.id!);
-          const href = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = href;
-          a.download = `${ev.id}.json`;
-          document.body.appendChild(a);
-          a.click();
-          a.remove();
-          URL.revokeObjectURL(href);
+          downloadBlob(blob, `${ev.id}.json`);
         } catch (e) {
           setErr((e as Error).message || "download failed");
         } finally {
@@ -253,6 +265,150 @@ function DownloadActionButton({ ev }: { ev: EventRecord }) {
       {busy ? "Downloading…" : "Download action"}
     </Button>
   );
+}
+
+function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => void }) {
+  const [preview, setPreview] = useState<RulePreview | null>(null);
+  const [hcl, setHCL] = useState("");
+  const [busy, setBusy] = useState(true);
+  const [applying, setApplying] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!ev.id) return;
+    setBusy(true);
+    setErr(null);
+    previewRuleFromAction(ev.id)
+      .then((p) => {
+        if (cancelled) return;
+        setPreview(p);
+        setHCL(p.hcl);
+      })
+      .catch((e) => {
+        if (!cancelled) setErr((e as Error).message || "rule preview failed");
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ev.id]);
+
+  async function copyHCL() {
+    await navigator.clipboard.writeText(hcl);
+    setMsg("HCL copied.");
+  }
+
+  async function applyRule() {
+    if (!preview?.config_revision) return;
+    setApplying(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      await applyGeneratedRule(preview.config_revision, hcl);
+      setMsg("Rule applied. New matching requests will be denied.");
+    } catch (e) {
+      const text = (e as Error).message || "apply failed";
+      if (text.includes("config changed")) {
+        setErr(
+          "The config changed since this rule was generated. Regenerate the rule and try again.",
+        );
+      } else {
+        setErr(text);
+      }
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  async function downloadFixture() {
+    if (!ev.id) return;
+    const blob = await downloadActionFixture(ev.id);
+    downloadBlob(blob, `${ev.id}.json`);
+  }
+
+  function downloadPatch() {
+    if (!preview?.patch) return;
+    downloadBlob(new Blob([preview.patch], { type: "text/plain;charset=utf-8" }), "rule.patch");
+  }
+
+  const writesEnabled = !!preview?.dashboard_config_writes;
+
+  return (
+    <Modal title="Block requests like this" size="lg" onClose={onClose}>
+      <div className="p-4 space-y-3 overflow-auto">
+        <p className="text-sm text-text-muted">
+          Claw Patrol generated a deny rule from this observed action. The rule starts narrow. Edit
+          the condition if you want to broaden it.
+        </p>
+        {busy ? (
+          <div className="text-xs text-text-subtle">Generating rule...</div>
+        ) : err && !preview ? (
+          <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>
+        ) : (
+          <>
+            {!writesEnabled && (
+              <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs text-text">
+                Dashboard config writes are disabled for this gateway. Copy this rule into your HCL
+                config and deploy it through your normal workflow.
+              </div>
+            )}
+            {preview?.warnings?.map((w) => (
+              <div key={w} className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
+                {w}
+              </div>
+            ))}
+            <textarea
+              value={hcl}
+              onChange={(e) => setHCL(e.target.value)}
+              spellCheck={false}
+              className="w-full min-h-[300px] resize-y border-1.5 border-navy bg-canvas p-3 font-mono text-xs text-text outline-none focus:bg-white"
+            />
+            {err && <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>}
+            {msg && <div className="text-sm text-success-600">{msg}</div>}
+          </>
+        )}
+      </div>
+      <div className="flex items-center gap-2 justify-end px-4 py-3 border-t border-navy bg-navy-100">
+        {writesEnabled ? (
+          <Button disabled={!preview || applying} onClick={applyRule}>
+            {applying ? "Applying..." : "Apply rule"}
+          </Button>
+        ) : (
+          <Button disabled={!preview} onClick={copyHCL}>
+            Copy HCL
+          </Button>
+        )}
+        {writesEnabled && (
+          <Button variant="outline" disabled={!preview} onClick={copyHCL}>
+            Copy HCL
+          </Button>
+        )}
+        {!writesEnabled && (
+          <Button variant="outline" disabled={!preview?.patch} onClick={downloadPatch}>
+            Download patch
+          </Button>
+        )}
+        <Button variant="outline" disabled={!ev.id} onClick={downloadFixture}>
+          Download fixture
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const href = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(href);
 }
 
 // --- SQL detail ---

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -326,17 +326,6 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
     }
   }
 
-  async function downloadFixture() {
-    if (!ev.id || !ev.endpoint) return;
-    const blob = await downloadActionFixture(ev.id);
-    downloadBlob(blob, `${ev.id}.json`);
-  }
-
-  function downloadPatch() {
-    if (!preview?.patch) return;
-    downloadBlob(new Blob([preview.patch], { type: "text/plain;charset=utf-8" }), "rule.patch");
-  }
-
   const writesEnabled = !!preview?.dashboard_config_writes;
   const createsEndpoint = !!preview?.endpoint_name && preview.endpoint_name !== ev.endpoint;
   const passthrough = createsEndpoint || ev.mode === "splice";
@@ -421,16 +410,6 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
         {!applied && writesEnabled && (
           <Button variant="outline" disabled={!preview} onClick={copyHCL}>
             Copy HCL
-          </Button>
-        )}
-        {!applied && !writesEnabled && (
-          <Button variant="outline" disabled={!preview?.patch} onClick={downloadPatch}>
-            Download patch
-          </Button>
-        )}
-        {!applied && (
-          <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
-            Download fixture
           </Button>
         )}
       </div>

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -220,9 +220,10 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
 
 function ActionButtons({ ev }: { ev: EventRecord }) {
   const [ruleOpen, setRuleOpen] = useState(false);
+  const canBlock = !!ev.id && ev.action !== "in_flight" && (!!ev.endpoint || ev.mode === "splice");
   return (
     <div className="flex items-center gap-2 flex-wrap justify-end">
-      {ev.id && ev.endpoint && ev.action !== "in_flight" && (
+      {canBlock && (
         <Button variant="outline" onClick={() => setRuleOpen(true)}>
           Block requests like this
         </Button>
@@ -325,7 +326,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   }
 
   async function downloadFixture() {
-    if (!ev.id) return;
+    if (!ev.id || !ev.endpoint) return;
     const blob = await downloadActionFixture(ev.id);
     downloadBlob(blob, `${ev.id}.json`);
   }
@@ -336,13 +337,14 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   }
 
   const writesEnabled = !!preview?.dashboard_config_writes;
+  const createsEndpoint = !!preview?.endpoint_name && preview.endpoint_name !== ev.endpoint;
 
   return (
     <Modal title="Block requests like this" size="lg" onClose={onClose}>
       <div className="p-4 space-y-3 overflow-auto">
         <p className="text-sm text-text-muted">
-          Claw Patrol generated a deny rule from this observed action. The rule starts narrow. Edit
-          the condition if you want to broaden it.
+          Claw Patrol generated HCL from this observed action. For matched endpoints this adds a
+          narrow deny rule; for passthrough hosts it creates an endpoint and blocks that host.
         </p>
         {busy ? (
           <div className="text-xs text-text-subtle">Generating rule...</div>
@@ -361,6 +363,12 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
                 {w}
               </div>
             ))}
+            {createsEndpoint && (
+              <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
+                This will create endpoint <code>{preview.endpoint_name}</code>. Credential creation
+                is not part of this flow yet.
+              </div>
+            )}
             <textarea
               value={hcl}
               onChange={(e) => setHCL(e.target.value)}
@@ -392,7 +400,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             Download patch
           </Button>
         )}
-        <Button variant="outline" disabled={!ev.id} onClick={downloadFixture}>
+        <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
           Download fixture
         </Button>
       </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -382,6 +382,7 @@ type StateResp = {
   // "dev.hcl"). Surfaced in UI hints so operators see the actual
   // running config name rather than a hardcoded string.
   config_file?: string;
+  dashboard_config_writes?: boolean;
 };
 let lastStateTag = "";
 let lastState: StateResp | null = null;
@@ -495,6 +496,45 @@ export async function downloadActionFixture(id: string): Promise<Blob> {
   const r = await api(`/api/actions/${id}?fmt=fixture`);
   if (!r.ok) throw new Error(await r.text());
   return r.blob();
+}
+
+export type RulePreview = {
+  rule_name: string;
+  hcl: string;
+  patch?: string;
+  config_revision?: string;
+  dashboard_config_writes: boolean;
+  warnings?: string[];
+};
+
+export async function previewRuleFromAction(id: string): Promise<RulePreview> {
+  const r = await api("/api/actions/rule-preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      action_id: id,
+      verdict: "deny",
+      scope: "exact",
+    }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+export async function applyGeneratedRule(
+  baseRevision: string,
+  appendHCL: string,
+): Promise<{ ok: boolean; revision: string }> {
+  const r = await api("/api/config/apply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      base_revision: baseRevision,
+      append_hcl: appendHCL,
+    }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
 }
 
 // FacetSchema mirrors the JSON returned by GET /api/facets — the

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -500,6 +500,7 @@ export async function downloadActionFixture(id: string): Promise<Blob> {
 
 export type RulePreview = {
   rule_name: string;
+  endpoint_name?: string;
   hcl: string;
   patch?: string;
   config_revision?: string;

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -502,7 +502,6 @@ export type RulePreview = {
   rule_name: string;
   endpoint_name?: string;
   hcl: string;
-  patch?: string;
   config_revision?: string;
   dashboard_config_writes: boolean;
   warnings?: string[];

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -46,6 +46,13 @@ gateway {
   public_url       = "https://gw.example.com"
   state_dir        = "/opt/clawpatrol"
 
+  # Demo mode: allow the dashboard's "Block requests like this"
+  # flow to append generated deny rules to this file after previewing
+  # and validating the full candidate config. For Git-managed
+  # production policy, omit this or set it false; the dashboard will
+  # still generate HCL to copy into a PR.
+  dashboard_config_writes = true
+
   # Dashboard auth: there is no HCL field for the root password. The
   # first time you open the dashboard you set a "root" password; it
   # lives bcrypt-hashed in clawpatrol.db. To skip the web first-run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,6 +158,11 @@ type GatewaySettings struct {
 	// format ("24h", "30m"). Default 24h.
 	DashboardSessionTTL string `hcl:"dashboard_session_ttl,optional"`
 
+	// DashboardConfigWrites allows authenticated dashboard users to
+	// append generated config snippets to the gateway HCL. Default
+	// false: config remains read-only and changes happen out-of-band.
+	DashboardConfigWrites bool `hcl:"dashboard_config_writes,optional"`
+
 	// Resolver is the DNS resolver address the gateway uses for
 	// upstream lookups when the runtime needs an explicit resolver.
 	Resolver string `hcl:"resolver,optional"`
@@ -340,6 +345,12 @@ func (g *Gateway) SetPublicURL(s string) {
 // DashboardListen returns the configured dashboard HTTP bind
 // address, or empty string when unset.
 func (g *Gateway) DashboardListen() string { return g.settings().DashboardListen }
+
+// DashboardConfigWrites reports whether dashboard-originated config
+// mutations are enabled for this gateway.
+func (g *Gateway) DashboardConfigWrites() bool {
+	return g != nil && g.Settings != nil && g.Settings.DashboardConfigWrites
+}
 
 // StateDir returns the configured state directory, or empty string.
 func (g *Gateway) StateDir() string { return g.settings().StateDir }

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -193,6 +193,9 @@ func emitGatewayBlock(body *hclwrite.Body, s *GatewaySettings) {
 	setStr("public_url", s.PublicURL)
 	setStr("state_dir", s.StateDir)
 	setStr("dashboard_session_ttl", s.DashboardSessionTTL)
+	if s.DashboardConfigWrites {
+		gw.SetAttributeValue("dashboard_config_writes", cty.BoolVal(true))
+	}
 	setStr("resolver", s.Resolver)
 	setStr("log_path", s.LogPath)
 	if s.Telemetry != nil {

--- a/internal/config/emit_test.go
+++ b/internal/config/emit_test.go
@@ -79,3 +79,24 @@ func TestEmitFullSpec(t *testing.T) {
 		t.Errorf("full-spec round-trip mismatch:\n%s", diff)
 	}
 }
+
+func TestEmitDashboardConfigWrites(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(`gateway {
+  dashboard_config_writes = true
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "127.0.0.1:51820"
+  }
+}
+`), "writes.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	emitted, err := config.Emit(gw)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(string(emitted), "dashboard_config_writes = true") {
+		t.Fatalf("emitted config missing dashboard_config_writes:\n%s", emitted)
+	}
+}

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -27,9 +27,12 @@ fields you need to edit.
 clawpatrol gateway <config.hcl>
 ```
 
-The gateway is read-only-config — the dashboard surfaces the running
-HCL for reading but never writes it. Push edits via your own deploy
-script (typically SSH from a config repo). See
+By default the gateway is read-only-config: the dashboard can
+generate HCL from observed actions, but it will not edit the running
+file. Set `dashboard_config_writes = true` in `gateway {}` to let the
+dashboard append generated rules after validating the full candidate
+config and hot-reloading it. Git-managed deployments should leave it
+false and push edits through their normal review/deploy flow. See
 [config-reference](config-reference) for the HCL grammar.
 
 ### `clawpatrol join`

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -43,6 +43,7 @@ The gateway block carries operational settings — listen addresses, the WireGua
 | `public_url` | `string` | no | The canonical externally-reachable gateway URL. Used in generated control-plane links such as join targets, OAuth redirect URIs, and (when public_url has a host but wireguard.endpoint doesn't) the host clients dial for WireGuard. |
 | `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol. |
 | `dashboard_session_ttl` | `string` | no | How long a dashboard login session stays valid after the operator types the password. time.ParseDuration format ("24h", "30m"). Default 24h. |
+| `dashboard_config_writes` | `bool` | no | Allows authenticated dashboard users to append generated config snippets to the gateway HCL. Default false: config remains read-only and changes happen out-of-band. |
 | `resolver` | `string` | no | The DNS resolver address the gateway uses for upstream lookups when the runtime needs an explicit resolver. |
 | `log_path` | `string` | no | An optional file path for gateway log output. |
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -48,6 +48,13 @@ the operator login. The CA certificate and private key are
 lazy-minted into sqlite under `state_dir` on first boot; there's
 nothing else to pre-create.
 
+The example config enables `dashboard_config_writes = true` so the
+dashboard can turn an observed action into a generated deny rule,
+append it to `gateway.hcl`, validate the full candidate config, and
+hot-reload it. For Git-managed production policy, omit that field or
+set it to `false`; the dashboard will still generate HCL you can copy
+into your normal review flow.
+
 The credentials in the example config (Anthropic, OpenAI,
 GitHub, Slack, Notion, Grafana) are declared in HCL, but each
 one still has to be connected before it can be used. Open the


### PR DESCRIPTION

<img width="2320" height="1034" alt="Screenshot 2026-06-01 at 12 52 46 PM" src="https://github.com/user-attachments/assets/be95fef7-d5e3-4595-a40c-6d79074a0192" />

<img width="792" height="578" alt="Screenshot 2026-06-01 at 12 52 52 PM" src="https://github.com/user-attachments/assets/79f01e4c-da87-4e1e-8603-12f7010e0987" />


Implements the proposed "Block requests like this" flow for action details.

- Adds `dashboard_config_writes` as an opt-in gateway setting, defaulting to read-only config behavior.
- Adds deterministic rule generation for HTTP, SQL, and Kubernetes actions without using an LLM.
- Adds `/api/actions/rule-preview` and `/api/config/apply`, including revision checks, full candidate config validation, atomic file replacement, and immediate policy reload.
- Adds the dashboard modal for previewing/editing generated HCL, copying it, downloading a patch/fixture, and applying it when writes are enabled.
- Updates the example config and docs so demo mode enables dashboard writes while Git-managed production remains safe by default.
