### PR TITLE
[codex] make generated host blocks explicit

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -337,6 +337,7 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 type Gateway struct {
 	cfg      *config.Gateway
 	cfgPath  string // path the HCL config was loaded from
+	configMu sync.Mutex
 	stateDir string // resolved gateway state dir (sqlite + plugin blobs)
 	db       *sql.DB
 	policy   atomic.Pointer[config.CompiledPolicy]
@@ -584,31 +585,41 @@ func (g *Gateway) watchConfig(path string) {
 			continue
 		}
 		last = st.ModTime()
-		next, policy, err := loadConfig(path)
+		g.configMu.Lock()
+		err = g.reloadConfigFromFileLocked(path)
+		g.configMu.Unlock()
 		if err != nil {
 			log.Printf("config reload: %v", err)
-			continue
 		}
-		g.policy.Store(policy)
-		registerOAuthCredentials(g.oauth, policy)
-		newConnIdx := runtime.BuildConnIndex(policy)
-		g.connIdx.Store(newConnIdx)
-		if g.tunnels != nil {
-			g.tunnels.SetPolicy(context.Background(), policy)
-		}
-		if g.dnsvip != nil {
-			if err := g.dnsvip.RebuildFromPolicy(policy); err != nil {
-				log.Printf("dnsvip rebuild on reload: %v", err)
-			}
-		}
-		// Hot-swap the operational *config.Gateway too — AdminEmail /
-		// PublicURL / DashboardOperators reads pick up immediately.
-		// Listen / CADir / Tailscale changes are not applied (restart).
-		g.cfg = next
-		log.Printf("config reloaded: %d endpoints across %d profile(s)",
-			len(policy.Endpoints), len(policy.Profiles))
-		logDashboardAuthState(g.db, next)
 	}
+}
+
+// reloadConfigFromFileLocked reloads the HCL config and hot-swaps the
+// runtime policy. g.configMu must be held by the caller so file-watch
+// reloads and dashboard writes cannot race each other.
+func (g *Gateway) reloadConfigFromFileLocked(path string) error {
+	next, policy, err := loadConfig(path)
+	if err != nil {
+		return err
+	}
+	g.policy.Store(policy)
+	registerOAuthCredentials(g.oauth, policy)
+	g.connIdx.Store(runtime.BuildConnIndex(policy))
+	if g.tunnels != nil {
+		g.tunnels.SetPolicy(context.Background(), policy)
+	}
+	if g.dnsvip != nil {
+		if err := g.dnsvip.RebuildFromPolicy(policy); err != nil {
+			return fmt.Errorf("dnsvip rebuild on reload: %w", err)
+		}
+	}
+	// Hot-swap the operational *config.Gateway too. Listen / CA dir /
+	// Tailscale process changes are still restart-only.
+	g.cfg = next
+	log.Printf("config reloaded: %d endpoints across %d profile(s)",
+		len(policy.Endpoints), len(policy.Profiles))
+	logDashboardAuthState(g.db, next)
+	return nil
 }
 
 // logDashboardAuthState emits a one-line summary of dashboard-auth
@@ -2935,7 +2946,11 @@ func runGateway(args []string) {
 		hitl:     newHITLRegistry(sink),
 		onboard:  newOnboardRegistry(),
 	}
-	log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
+	if cfg.DashboardConfigWrites() {
+		log.Printf("config: dashboard writes enabled (generated rules can be appended to gateway.hcl)")
+	} else {
+		log.Printf("config: read-only (the dashboard cannot edit gateway.hcl)")
+	}
 	g.secrets = newGatewaySecretStore(db, oauthReg)
 	g.hitl.asyncGrantResolver = g.resolveAsyncHITLGrant
 	g.hitl.pendingMessageUpdater = g.updatePendingHITLMessage

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -20,6 +20,7 @@ type RuleGenOptions struct {
 
 type GeneratedRule struct {
 	RuleName              string   `json:"rule_name"`
+	EndpointName          string   `json:"endpoint_name,omitempty"`
 	HCL                   string   `json:"hcl"`
 	Patch                 string   `json:"patch,omitempty"`
 	ConfigRevision        string   `json:"config_revision,omitempty"`
@@ -39,7 +40,7 @@ func GenerateRuleFromEvent(
 		return nil, fmt.Errorf("event is required")
 	}
 	if ev.Endpoint == "" {
-		return nil, fmt.Errorf("action has no endpoint")
+		return generateBlockHostRule(policy, ev, opts)
 	}
 	ep := policy.Endpoints[ev.Endpoint]
 	if ep == nil {
@@ -68,10 +69,45 @@ func GenerateRuleFromEvent(
 		return nil, err
 	}
 	return &GeneratedRule{
-		RuleName: name,
-		HCL:      hcl,
-		Patch:    generatedAppendPatch("gateway.hcl", hcl),
-		Warnings: warnings,
+		RuleName:     name,
+		EndpointName: ep.Name,
+		HCL:          hcl,
+		Patch:        generatedAppendPatch("gateway.hcl", hcl),
+		Warnings:     warnings,
+	}, nil
+}
+
+func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGenOptions) (*GeneratedRule, error) {
+	if opts.Verdict == "" {
+		opts.Verdict = "deny"
+	}
+	if opts.Scope == "" {
+		opts.Scope = "exact"
+	}
+	if opts.Verdict != "deny" {
+		return nil, fmt.Errorf("unsupported verdict %q", opts.Verdict)
+	}
+	if opts.Scope != "exact" {
+		return nil, fmt.Errorf("unsupported scope %q", opts.Scope)
+	}
+	host := canonicalObservedHost(ev.Host)
+	if host == "" {
+		return nil, fmt.Errorf("action has no endpoint or host")
+	}
+	endpointName := generatedEndpointName(policy, host)
+	ruleName := generatedHostBlockRuleName(ev, endpointName, host)
+	hcl, err := generatedEndpointBlockRuleHCL(endpointName, host, ruleName)
+	if err != nil {
+		return nil, err
+	}
+	return &GeneratedRule{
+		RuleName:     ruleName,
+		EndpointName: endpointName,
+		HCL:          hcl,
+		Patch:        generatedAppendPatch("gateway.hcl", hcl),
+		Warnings: []string{
+			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host and a catch-all deny rule for it.",
+		},
 	}, nil
 }
 
@@ -167,9 +203,24 @@ func generatedRuleHCL(name, endpoint, condition string) (string, error) {
 	b := f.Body().AppendNewBlock("rule", []string{name}).Body()
 	b.SetAttributeRaw("endpoint", config.TraversalTokens(endpoint))
 	b.SetAttributeValue("priority", cty.NumberIntVal(100))
-	b.SetAttributeValue("condition", cty.StringVal(condition))
+	if condition != "" {
+		b.SetAttributeValue("condition", cty.StringVal(condition))
+	}
 	b.SetAttributeValue("verdict", cty.StringVal("deny"))
 	b.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed action"))
+	return string(f.Bytes()), nil
+}
+
+func generatedEndpointBlockRuleHCL(endpointName, host, ruleName string) (string, error) {
+	f := hclwrite.NewEmptyFile()
+	eb := f.Body().AppendNewBlock("endpoint", []string{"https", endpointName}).Body()
+	eb.SetAttributeValue("hosts", cty.ListVal([]cty.Value{cty.StringVal(host)}))
+	f.Body().AppendNewline()
+	rb := f.Body().AppendNewBlock("rule", []string{ruleName}).Body()
+	rb.SetAttributeRaw("endpoint", config.TraversalTokens("https."+endpointName))
+	rb.SetAttributeValue("priority", cty.NumberIntVal(100))
+	rb.SetAttributeValue("verdict", cty.StringVal("deny"))
+	rb.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed passthrough host"))
 	return string(f.Bytes()), nil
 }
 
@@ -183,6 +234,57 @@ func generatedRuleName(ev *Event, ep *config.CompiledEndpoint) string {
 	}
 	sum := sha256.Sum256([]byte(sumInput))
 	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func generatedHostBlockRuleName(ev *Event, endpointName, host string) string {
+	base := "block_" + safeRuleNamePart(endpointName)
+	sumInput := ev.ID
+	if sumInput == "" {
+		sumInput = host
+	}
+	sum := sha256.Sum256([]byte(sumInput))
+	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func generatedEndpointName(policy *config.CompiledPolicy, host string) string {
+	base := safeRuleNamePart(strings.ToLower(host))
+	if base == "action" {
+		base = "host"
+	}
+	name := base
+	if policy == nil || policy.Endpoints[name] == nil {
+		return name
+	}
+	sum := sha256.Sum256([]byte(host))
+	name = fmt.Sprintf("%s_%x", base, sum[:3])
+	if policy.Endpoints[name] == nil {
+		return name
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%x_%d", base, sum[:3], i)
+		if policy.Endpoints[candidate] == nil {
+			return candidate
+		}
+	}
+}
+
+func canonicalObservedHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimSuffix(host, ".")
+	if host == "" {
+		return ""
+	}
+	if strings.HasPrefix(host, "[") {
+		if end := strings.IndexByte(host, ']'); end >= 0 {
+			return strings.Trim(host[:end+1], "[]")
+		}
+	}
+	if strings.Count(host, ":") == 1 {
+		if i := strings.LastIndexByte(host, ':'); i > 0 {
+			return host[:i]
+		}
+	}
+	return host
 }
 
 func safeRuleNamePart(s string) string {

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -96,7 +96,8 @@ func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGe
 	}
 	endpointName := generatedEndpointName(policy, host)
 	ruleName := generatedHostBlockRuleName(ev, endpointName, host)
-	hcl, err := generatedEndpointBlockRuleHCL(endpointName, host, ruleName)
+	profiles := generatedDenyProfiles(policy)
+	hcl, err := generatedEndpointBlockRuleHCL(endpointName, host, profiles, ruleName)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func generateBlockHostRule(policy *config.CompiledPolicy, ev *Event, opts RuleGe
 		HCL:          hcl,
 		Patch:        generatedAppendPatch("gateway.hcl", hcl),
 		Warnings: []string{
-			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host and a catch-all deny rule for it.",
+			"This action did not match a configured endpoint. Generated HCL creates a new HTTPS endpoint for the observed host, attaches it to profile deny lists, and adds a catch-all deny rule.",
 		},
 	}, nil
 }
@@ -211,10 +212,17 @@ func generatedRuleHCL(name, endpoint, condition string) (string, error) {
 	return string(f.Bytes()), nil
 }
 
-func generatedEndpointBlockRuleHCL(endpointName, host, ruleName string) (string, error) {
+func generatedEndpointBlockRuleHCL(endpointName, host string, profiles []string, ruleName string) (string, error) {
 	f := hclwrite.NewEmptyFile()
 	eb := f.Body().AppendNewBlock("endpoint", []string{"https", endpointName}).Body()
 	eb.SetAttributeValue("hosts", cty.ListVal([]cty.Value{cty.StringVal(host)}))
+	if len(profiles) > 0 {
+		profileRefs := make([]string, 0, len(profiles))
+		for _, profile := range profiles {
+			profileRefs = append(profileRefs, "profile."+profile)
+		}
+		config.SetIdentList(eb, "deny_profiles", profileRefs)
+	}
 	f.Body().AppendNewline()
 	rb := f.Body().AppendNewBlock("rule", []string{ruleName}).Body()
 	rb.SetAttributeRaw("endpoint", config.TraversalTokens("https."+endpointName))
@@ -244,6 +252,18 @@ func generatedHostBlockRuleName(ev *Event, endpointName, host string) string {
 	}
 	sum := sha256.Sum256([]byte(sumInput))
 	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func generatedDenyProfiles(policy *config.CompiledPolicy) []string {
+	if policy == nil || len(policy.Profiles) == 0 {
+		return nil
+	}
+	profiles := make([]string, 0, len(policy.Profiles))
+	for name := range policy.Profiles {
+		profiles = append(profiles, name)
+	}
+	sort.Strings(profiles)
+	return profiles
 }
 
 func generatedEndpointName(policy *config.CompiledPolicy, host string) string {

--- a/cmd/clawpatrol/rulegen.go
+++ b/cmd/clawpatrol/rulegen.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type RuleGenOptions struct {
+	Verdict string
+	Scope   string
+}
+
+type GeneratedRule struct {
+	RuleName              string   `json:"rule_name"`
+	HCL                   string   `json:"hcl"`
+	Patch                 string   `json:"patch,omitempty"`
+	ConfigRevision        string   `json:"config_revision,omitempty"`
+	DashboardConfigWrites bool     `json:"dashboard_config_writes"`
+	Warnings              []string `json:"warnings,omitempty"`
+}
+
+func GenerateRuleFromEvent(
+	policy *config.CompiledPolicy,
+	ev *Event,
+	opts RuleGenOptions,
+) (*GeneratedRule, error) {
+	if policy == nil {
+		return nil, fmt.Errorf("policy not loaded")
+	}
+	if ev == nil {
+		return nil, fmt.Errorf("event is required")
+	}
+	if ev.Endpoint == "" {
+		return nil, fmt.Errorf("action has no endpoint")
+	}
+	ep := policy.Endpoints[ev.Endpoint]
+	if ep == nil {
+		return nil, fmt.Errorf("endpoint %q no longer in policy", ev.Endpoint)
+	}
+	if opts.Verdict == "" {
+		opts.Verdict = "deny"
+	}
+	if opts.Scope == "" {
+		opts.Scope = "exact"
+	}
+	if opts.Verdict != "deny" {
+		return nil, fmt.Errorf("unsupported verdict %q", opts.Verdict)
+	}
+	if opts.Scope != "exact" {
+		return nil, fmt.Errorf("unsupported scope %q", opts.Scope)
+	}
+
+	condition, warnings, err := ruleConditionFromEvent(ep.Family, ev)
+	if err != nil {
+		return nil, err
+	}
+	name := generatedRuleName(ev, ep)
+	hcl, err := generatedRuleHCL(name, endpointRef(ep), condition)
+	if err != nil {
+		return nil, err
+	}
+	return &GeneratedRule{
+		RuleName: name,
+		HCL:      hcl,
+		Patch:    generatedAppendPatch("gateway.hcl", hcl),
+		Warnings: warnings,
+	}, nil
+}
+
+func ruleConditionFromEvent(family string, ev *Event) (string, []string, error) {
+	switch family {
+	case "http":
+		return httpRuleCondition(ev)
+	case "sql":
+		return sqlRuleCondition(ev)
+	case "k8s":
+		return k8sRuleCondition(ev)
+	default:
+		return "", nil, fmt.Errorf("endpoint family %q is not supported for rule generation", family)
+	}
+}
+
+func httpRuleCondition(ev *Event) (string, []string, error) {
+	method := strings.ToUpper(strings.TrimSpace(ev.Method))
+	path, _ := splitPathQuery(ev.Path)
+	path = strings.TrimSpace(path)
+	parts := []string{}
+	if method != "" {
+		parts = append(parts, "http.method == "+celString(method))
+	}
+	warnings := []string{}
+	if path != "" {
+		parts = append(parts, "http.path == "+celString(path))
+	} else {
+		warnings = append(warnings, "Generated rule matches only the HTTP method because no request path was recorded.")
+	}
+	if len(parts) == 0 {
+		return "", warnings, fmt.Errorf("http action has no method or path")
+	}
+	return strings.Join(parts, " && "), warnings, nil
+}
+
+func sqlRuleCondition(ev *Event) (string, []string, error) {
+	verb, _ := ev.Facets["verb"].(string)
+	verb = strings.ToLower(strings.TrimSpace(verb))
+	tables := stringSliceFromFacet(ev.Facets["tables"])
+	sort.Strings(tables)
+	if verb != "" {
+		parts := []string{"sql.verb == " + celString(verb)}
+		if len(tables) == 1 {
+			parts = append(parts, celString(tables[0])+" in sql.tables")
+		} else if len(tables) > 1 {
+			tableParts := make([]string, 0, len(tables))
+			for _, table := range tables {
+				tableParts = append(tableParts, celString(table)+" in sql.tables")
+			}
+			parts = append(parts, "("+strings.Join(tableParts, " || ")+")")
+		}
+		return strings.Join(parts, " && "), nil, nil
+	}
+	stmt, _ := ev.Facets["statement"].(string)
+	if stmt == "" {
+		stmt = ev.ReqBody
+	}
+	if strings.TrimSpace(stmt) == "" {
+		return "", nil, fmt.Errorf("sql action has no structured facets or statement")
+	}
+	return "sql.statement == " + celString(stmt), []string{
+		"Generated rule matches the full SQL statement because no structured SQL facets were available. Consider broadening it manually.",
+	}, nil
+}
+
+func k8sRuleCondition(ev *Event) (string, []string, error) {
+	fields := []struct {
+		Name string
+		CEL  string
+	}{
+		{"verb", "k8s.verb"},
+		{"resource", "k8s.resource"},
+		{"namespace", "k8s.namespace"},
+		{"name", "k8s.name"},
+	}
+	parts := []string{}
+	for _, field := range fields {
+		v, _ := ev.Facets[field.Name].(string)
+		if v == "" {
+			continue
+		}
+		parts = append(parts, field.CEL+" == "+celString(v))
+	}
+	if len(parts) == 0 {
+		return "", nil, fmt.Errorf("kubernetes action has no structured facets")
+	}
+	return strings.Join(parts, " && "), nil, nil
+}
+
+func generatedRuleHCL(name, endpoint, condition string) (string, error) {
+	f := hclwrite.NewEmptyFile()
+	b := f.Body().AppendNewBlock("rule", []string{name}).Body()
+	b.SetAttributeRaw("endpoint", config.TraversalTokens(endpoint))
+	b.SetAttributeValue("priority", cty.NumberIntVal(100))
+	b.SetAttributeValue("condition", cty.StringVal(condition))
+	b.SetAttributeValue("verdict", cty.StringVal("deny"))
+	b.SetAttributeValue("reason", cty.StringVal("Blocked from dashboard: generated from observed action"))
+	return string(f.Bytes()), nil
+}
+
+var generatedRuleNameChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+
+func generatedRuleName(ev *Event, ep *config.CompiledEndpoint) string {
+	base := "block_" + safeRuleNamePart(ep.Name) + "_" + safeRuleNamePart(ep.Family)
+	sumInput := ev.ID
+	if sumInput == "" {
+		sumInput = ev.Endpoint + "\x00" + ev.Family + "\x00" + ev.Method + "\x00" + ev.Path
+	}
+	sum := sha256.Sum256([]byte(sumInput))
+	return fmt.Sprintf("%s_%x", base, sum[:3])
+}
+
+func safeRuleNamePart(s string) string {
+	s = generatedRuleNameChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if s == "" {
+		return "action"
+	}
+	return s
+}
+
+func celString(s string) string {
+	return strconv.Quote(s)
+}
+
+func generatedAppendPatch(path, hcl string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", path, path)
+	fmt.Fprintf(&b, "--- a/%s\n", path)
+	fmt.Fprintf(&b, "+++ b/%s\n", path)
+	b.WriteString("@@ -0,0 +1 @@\n")
+	for _, line := range strings.Split(strings.TrimRight(hcl, "\n"), "\n") {
+		b.WriteString("+")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func generatedAppendPatchFromBytes(path string, current []byte, hcl string) string {
+	added := strings.Split(strings.TrimRight(string(appendConfigSnippet(current, hcl)), "\n"), "\n")
+	if len(current) > 0 {
+		prefix := strings.Split(strings.TrimRight(string(current), "\n"), "\n")
+		if len(prefix) <= len(added) {
+			added = added[len(prefix):]
+		}
+	}
+	oldLine := 0
+	if len(current) > 0 {
+		oldLine = strings.Count(string(current), "\n")
+		if current[len(current)-1] != '\n' {
+			oldLine++
+		}
+	}
+	newStart := oldLine + 1
+	if oldLine == 0 {
+		newStart = 1
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", path, path)
+	fmt.Fprintf(&b, "--- a/%s\n", path)
+	fmt.Fprintf(&b, "+++ b/%s\n", path)
+	fmt.Fprintf(&b, "@@ -%d,0 +%d,%d @@\n", oldLine, newStart, len(added))
+	for _, line := range added {
+		b.WriteString("+")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+func TestGenerateRuleHTTPExact(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:       "018f0000-0000-7000-8000-000000000001",
+		Endpoint: "github",
+		Method:   "DELETE",
+		Path:     "/repos/me/sandbox/issues/1?force=true",
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	if !strings.Contains(rule.HCL, `endpoint  = https.github`) {
+		t.Fatalf("hcl missing typed endpoint:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `condition = "http.method == \"DELETE\" && http.path == \"/repos/me/sandbox/issues/1\""`) {
+		t.Fatalf("hcl missing exact HTTP condition:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `verdict   = "deny"`) {
+		t.Fatalf("hcl missing deny verdict:\n%s", rule.HCL)
+	}
+}
+
+func TestGenerateRuleSQLStructuredFacets(t *testing.T) {
+	g := gatewayWithPolicy(t, `
+endpoint "postgres" "pg" { host = "pg.example.com:5432" }
+credential "postgres_credential" "pg-user" { endpoint = postgres.pg }
+profile "default" { credentials = [postgres_credential.pg-user] }
+`)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:       "018f0000-0000-7000-8000-000000000002",
+		Endpoint: "pg",
+		Facets: map[string]any{
+			"verb":   "drop",
+			"tables": []any{"users"},
+		},
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	if !strings.Contains(rule.HCL, `condition = "sql.verb == \"drop\" && \"users\" in sql.tables"`) {
+		t.Fatalf("hcl missing SQL condition:\n%s", rule.HCL)
+	}
+}
+
+func TestGenerateRuleK8sStructuredFacets(t *testing.T) {
+	g := gatewayWithPolicy(t, `
+endpoint "kubernetes" "prod" { hosts = ["k8s.example.com"] }
+credential "bearer_token" "k8s-token" { endpoint = kubernetes.prod }
+profile "default" { credentials = [bearer_token.k8s-token] }
+`)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:       "018f0000-0000-7000-8000-000000000003",
+		Endpoint: "prod",
+		Facets: map[string]any{
+			"verb":      "delete",
+			"resource":  "secrets",
+			"namespace": "prod",
+			"name":      "api-token",
+		},
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	want := `condition = "k8s.verb == \"delete\" && k8s.resource == \"secrets\" && k8s.namespace == \"prod\" && k8s.name == \"api-token\""`
+	if !strings.Contains(rule.HCL, want) {
+		t.Fatalf("hcl missing K8s condition:\n%s", rule.HCL)
+	}
+}
+
+func TestGenerateRuleRejectsMissingEndpoint(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL)
+	_, err := GenerateRuleFromEvent(g.Policy(), &Event{}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err == nil || !strings.Contains(err.Error(), "no endpoint") {
+		t.Fatalf("err=%v, want no endpoint", err)
+	}
+}

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -99,8 +99,11 @@ func TestGenerateRuleSpliceHostCreatesEndpointAndDenyRule(t *testing.T) {
 	if !strings.Contains(rule.HCL, `endpoint "https" "tinyclouds_org"`) {
 		t.Fatalf("hcl missing generated endpoint:\n%s", rule.HCL)
 	}
-	if !strings.Contains(rule.HCL, `hosts = ["tinyclouds.org"]`) {
+	if !strings.Contains(rule.HCL, `hosts`) || !strings.Contains(rule.HCL, `["tinyclouds.org"]`) {
 		t.Fatalf("hcl missing observed host:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `deny_profiles = [profile.default]`) {
+		t.Fatalf("hcl missing explicit deny profile:\n%s", rule.HCL)
 	}
 	if !strings.Contains(rule.HCL, `endpoint = https.tinyclouds_org`) {
 		t.Fatalf("hcl missing generated endpoint reference:\n%s", rule.HCL)
@@ -116,7 +119,8 @@ func TestGenerateRuleSpliceHostCreatesEndpointAndDenyRule(t *testing.T) {
 func TestGeneratedSpliceHostBlockRoutesInDefaultProfile(t *testing.T) {
 	g := gatewayWithPolicy(t, fixtureHCL+`
 endpoint "https" "tinyclouds_org" {
-  hosts = ["tinyclouds.org"]
+  hosts         = ["tinyclouds.org"]
+  deny_profiles = [profile.default]
 }
 
 rule "block_tinyclouds_org" {
@@ -127,5 +131,22 @@ rule "block_tinyclouds_org" {
 	ep := runtime.HostEndpoint(g.Policy(), "default", "tinyclouds.org")
 	if ep == nil || ep.Name != "tinyclouds_org" {
 		t.Fatalf("HostEndpoint = %#v, want generated endpoint", ep)
+	}
+}
+
+func TestGeneratedSpliceHostBlockWithoutDenyProfileDoesNotRoute(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL+`
+endpoint "https" "tinyclouds_org" {
+  hosts = ["tinyclouds.org"]
+}
+
+rule "block_tinyclouds_org" {
+  endpoint = https.tinyclouds_org
+  verdict  = "deny"
+}
+`)
+	ep := runtime.HostEndpoint(g.Policy(), "default", "tinyclouds.org")
+	if ep != nil {
+		t.Fatalf("HostEndpoint = %#v, want no route without deny_profiles", ep)
 	}
 }

--- a/cmd/clawpatrol/rulegen_test.go
+++ b/cmd/clawpatrol/rulegen_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
 func TestGenerateRuleHTTPExact(t *testing.T) {
@@ -79,7 +80,52 @@ profile "default" { credentials = [bearer_token.k8s-token] }
 func TestGenerateRuleRejectsMissingEndpoint(t *testing.T) {
 	g := gatewayWithPolicy(t, fixtureHCL)
 	_, err := GenerateRuleFromEvent(g.Policy(), &Event{}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
-	if err == nil || !strings.Contains(err.Error(), "no endpoint") {
-		t.Fatalf("err=%v, want no endpoint", err)
+	if err == nil || !strings.Contains(err.Error(), "no endpoint or host") {
+		t.Fatalf("err=%v, want no endpoint or host", err)
+	}
+}
+
+func TestGenerateRuleSpliceHostCreatesEndpointAndDenyRule(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL)
+	rule, err := GenerateRuleFromEvent(g.Policy(), &Event{
+		ID:     "018f0000-0000-7000-8000-000000000004",
+		Mode:   "splice",
+		Host:   "TinyClouds.org",
+		Action: "allow",
+	}, RuleGenOptions{Verdict: "deny", Scope: "exact"})
+	if err != nil {
+		t.Fatalf("GenerateRuleFromEvent: %v", err)
+	}
+	if !strings.Contains(rule.HCL, `endpoint "https" "tinyclouds_org"`) {
+		t.Fatalf("hcl missing generated endpoint:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `hosts = ["tinyclouds.org"]`) {
+		t.Fatalf("hcl missing observed host:\n%s", rule.HCL)
+	}
+	if !strings.Contains(rule.HCL, `endpoint = https.tinyclouds_org`) {
+		t.Fatalf("hcl missing generated endpoint reference:\n%s", rule.HCL)
+	}
+	if strings.Contains(rule.HCL, `condition`) {
+		t.Fatalf("host block rule should be catch-all:\n%s", rule.HCL)
+	}
+	if len(rule.Warnings) == 0 {
+		t.Fatalf("expected warning for generated endpoint")
+	}
+}
+
+func TestGeneratedSpliceHostBlockRoutesInDefaultProfile(t *testing.T) {
+	g := gatewayWithPolicy(t, fixtureHCL+`
+endpoint "https" "tinyclouds_org" {
+  hosts = ["tinyclouds.org"]
+}
+
+rule "block_tinyclouds_org" {
+  endpoint = https.tinyclouds_org
+  verdict  = "deny"
+}
+`)
+	ep := runtime.HostEndpoint(g.Policy(), "default", "tinyclouds.org")
+	if ep == nil || ep.Name != "tinyclouds_org" {
+		t.Fatalf("HostEndpoint = %#v, want generated endpoint", ep)
 	}
 }

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -227,6 +227,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodGet, Path: "/api/profiles", Auth: authDashboard, Handler: w.apiProfiles},
 		{Method: http.MethodGet, Path: "/api/rules", Auth: authDashboard, Handler: w.apiRules},
 		{Method: http.MethodGet, Path: "/api/config", Auth: authDashboard, Handler: w.apiConfig},
+		{Method: http.MethodPost, Path: "/api/config/apply", Auth: authDashboard, Handler: w.apiConfigApply},
 		{Method: http.MethodGet, Path: "/api/hitl/pending", Auth: authDashboard, Handler: w.apiHITLPending},
 		{Method: http.MethodPost, Path: "/api/hitl/decide", Auth: authDashboard, Handler: w.apiHITLDecide},
 		{Method: http.MethodGet, Path: hitlOperationStatusPrefix, Auth: authSelfAuthenticating, Handler: w.apiHITLOperationStatus},
@@ -241,6 +242,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/credentials/set", Auth: authDashboard, Handler: w.apiCredentialsSet},
 		{Method: http.MethodPost, Path: "/api/credentials/clear", Auth: authDashboard, Handler: w.apiCredentialsClear},
 		{Method: http.MethodGet, Path: "/api/events", Auth: authDashboard, Handler: w.apiEventsSSE},
+		{Method: http.MethodPost, Path: "/api/actions/rule-preview", Auth: authDashboard, Handler: w.apiActionRulePreview},
 		{Method: http.MethodPost, Path: "/api/actions/", Auth: authDashboard, Handler: w.apiActionByID},
 		{Method: http.MethodGet, Path: "/api/analytics", Auth: authDashboard, Handler: w.apiAnalytics},
 		{Method: http.MethodGet, Path: "/api/facets", Auth: authDashboard, Handler: w.apiFacets},
@@ -1148,11 +1150,12 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 	w.stateCacheMu.RUnlock()
 
 	state := map[string]any{
-		"whoami":       w.whoamiData(r),
-		"integrations": w.statusList(r),
-		"agents":       w.agentsList(),
-		"update":       currentUpdateBanner.Load(),
-		"config_file":  filepath.Base(w.g.cfgPath),
+		"whoami":                  w.whoamiData(r),
+		"integrations":            w.statusList(r),
+		"agents":                  w.agentsList(),
+		"update":                  currentUpdateBanner.Load(),
+		"config_file":             filepath.Base(w.g.cfgPath),
+		"dashboard_config_writes": w.g.cfg.DashboardConfigWrites(),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {
@@ -1324,9 +1327,108 @@ func (w *webMux) apiConfig(rw http.ResponseWriter, r *http.Request) {
 	_, _ = rw.Write(b)
 }
 
+func (w *webMux) apiConfigApply(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		BaseRevision string `json:"base_revision"`
+		AppendHCL    string `json:"append_hcl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(body.AppendHCL) == "" {
+		writeJSONError(rw, http.StatusBadRequest, map[string]any{
+			"error": "append_hcl is required",
+		})
+		return
+	}
+	if !w.g.cfg.DashboardConfigWrites() {
+		writeJSONError(rw, http.StatusForbidden, map[string]any{
+			"error":                   "dashboard config writes are disabled",
+			"dashboard_config_writes": false,
+		})
+		return
+	}
+
+	w.g.configMu.Lock()
+	defer w.g.configMu.Unlock()
+
+	current, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	currentRevision := revisionForBytes(current)
+	if body.BaseRevision != "" && body.BaseRevision != currentRevision {
+		writeJSONError(rw, http.StatusConflict, map[string]any{
+			"error":            "config changed",
+			"current_revision": currentRevision,
+		})
+		return
+	}
+	candidate := appendConfigSnippet(current, body.AppendHCL)
+	dir := filepath.Dir(w.g.cfgPath)
+	tmp, err := os.CreateTemp(dir, ".clawpatrol-config-*.hcl")
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(candidate); err != nil {
+		_ = tmp.Close()
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if _, _, err := loadConfig(tmpPath); err != nil {
+		writeJSONError(rw, http.StatusBadRequest, map[string]any{
+			"error": err.Error(),
+		})
+		return
+	}
+	if err := os.Rename(tmpPath, w.g.cfgPath); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := w.g.reloadConfigFromFileLocked(w.g.cfgPath); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(rw, map[string]any{
+		"ok":       true,
+		"revision": revisionForBytes(candidate),
+	})
+}
+
 func revisionForBytes(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
+}
+
+func appendConfigSnippet(current []byte, snippet string) []byte {
+	out := make([]byte, 0, len(current)+len(snippet)+4)
+	out = append(out, current...)
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	out = append(out, '\n')
+	out = append(out, strings.TrimRight(snippet, "\n")...)
+	out = append(out, '\n')
+	return out
+}
+
+func writeJSONError(rw http.ResponseWriter, status int, v any) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	_ = json.NewEncoder(rw).Encode(v)
 }
 
 func (w *webMux) apiHITLPending(rw http.ResponseWriter, _ *http.Request) {
@@ -1441,14 +1543,58 @@ func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (w *webMux) apiActionByID(
-	rw http.ResponseWriter, r *http.Request,
-) {
-	// Path: /api/actions/<uuid>
-	actionID := strings.TrimPrefix(r.URL.Path, "/api/actions/")
-	if actionID == "" {
-		http.Error(rw, "missing id", 400)
+func (w *webMux) apiActionRulePreview(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
 		return
+	}
+	var body struct {
+		ActionID string `json:"action_id"`
+		Verdict  string `json:"verdict"`
+		Scope    string `json:"scope"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.ActionID == "" {
+		http.Error(rw, "missing action_id", http.StatusBadRequest)
+		return
+	}
+	policy := w.g.Policy()
+	if policy == nil {
+		http.Error(rw, "policy not loaded", http.StatusServiceUnavailable)
+		return
+	}
+	ev, err := w.loadAction(body.ActionID)
+	if err == sql.ErrNoRows {
+		http.Error(rw, "not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rule, err := GenerateRuleFromEvent(policy, ev, RuleGenOptions{
+		Verdict: body.Verdict,
+		Scope:   body.Scope,
+	})
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	b, err := os.ReadFile(w.g.cfgPath)
+	if err == nil {
+		rule.ConfigRevision = revisionForBytes(b)
+		rule.Patch = generatedAppendPatchFromBytes(filepath.Base(w.g.cfgPath), b, rule.HCL)
+	}
+	rule.DashboardConfigWrites = w.g.cfg.DashboardConfigWrites()
+	writeJSON(rw, rule)
+}
+
+func (w *webMux) loadAction(actionID string) (*Event, error) {
+	if actionID == "" {
+		return nil, fmt.Errorf("missing id")
 	}
 	var (
 		e            Event
@@ -1494,13 +1640,8 @@ func (w *webMux) apiActionByID(
 		&endpoint, &rule,
 		&approver, &approverType, &approverBy,
 	)
-	if err == sql.ErrNoRows {
-		http.Error(rw, "not found", 404)
-		return
-	}
 	if err != nil {
-		http.Error(rw, err.Error(), 500)
-		return
+		return nil, err
 	}
 	e.ID = actionID
 	e.Ts = time.Unix(0, tsNs).UTC()
@@ -1529,8 +1670,29 @@ func (w *webMux) apiActionByID(
 	e.Approver = approver.String
 	e.ApproverType = approverType.String
 	e.ApproverBy = approverBy.String
+	return &e, nil
+}
+
+func (w *webMux) apiActionByID(
+	rw http.ResponseWriter, r *http.Request,
+) {
+	// Path: /api/actions/<uuid>
+	actionID := strings.TrimPrefix(r.URL.Path, "/api/actions/")
+	if actionID == "" {
+		http.Error(rw, "missing id", 400)
+		return
+	}
+	e, err := w.loadAction(actionID)
+	if err == sql.ErrNoRows {
+		http.Error(rw, "not found", 404)
+		return
+	}
+	if err != nil {
+		http.Error(rw, err.Error(), 500)
+		return
+	}
 	if r.URL.Query().Get("fmt") == "fixture" {
-		w.writeActionFixture(rw, &e)
+		w.writeActionFixture(rw, e)
 		return
 	}
 	writeJSON(rw, e)

--- a/cmd/clawpatrol/web_config_apply_test.go
+++ b/cmd/clawpatrol/web_config_apply_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+func TestConfigApplyRejectsWhenDashboardWritesDisabled(t *testing.T) {
+	w := configApplyTestMux(t, false)
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"append_hcl": `rule "x" { endpoint = https.github verdict = "deny" }`,
+	}))
+	if rw.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "dashboard config writes are disabled") {
+		t.Fatalf("body=%s", rw.Body.String())
+	}
+}
+
+func TestConfigApplyRejectsRevisionMismatch(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": "not-current",
+		"append_hcl":    `rule "x" { endpoint = https.github verdict = "deny" }`,
+	}))
+	if rw.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "config changed") {
+		t.Fatalf("body=%s", rw.Body.String())
+	}
+}
+
+func TestConfigApplyRejectsInvalidSnippet(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	before, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": revisionForBytes(before),
+		"append_hcl":    `rule "bad" { endpoint = https.missing verdict = "deny" }`,
+	}))
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	after, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("config changed after rejected apply")
+	}
+}
+
+func TestConfigApplyAppendsAndReloads(t *testing.T) {
+	w := configApplyTestMux(t, true)
+	before, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snippet := `rule "block-delete" {
+  endpoint = https.github
+  condition = "http.method == \"DELETE\""
+  verdict = "deny"
+}`
+	rw := httptest.NewRecorder()
+	w.apiConfigApply(rw, jsonReq(map[string]string{
+		"base_revision": revisionForBytes(before),
+		"append_hcl":    snippet,
+	}))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	after, err := os.ReadFile(w.g.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), `rule "block-delete"`) {
+		t.Fatalf("config missing appended rule:\n%s", after)
+	}
+	ep := w.g.Policy().Endpoints["github"]
+	if ep == nil {
+		t.Fatal("github endpoint missing after reload")
+	}
+	found := false
+	for _, rule := range ep.Rules {
+		if rule.Name == "block-delete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("policy did not reload appended rule: %+v", ep.Rules)
+	}
+}
+
+func configApplyTestMux(t *testing.T, writes bool) *webMux {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gateway.hcl")
+	src := `gateway {
+  state_dir = "` + filepath.ToSlash(dir) + `"
+  dashboard_config_writes = ` + map[bool]string{true: "true", false: "false"}[writes] + `
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "127.0.0.1:51820"
+  }
+}
+
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+credential "bearer_token" "tok" { endpoint = https.github }
+profile "default" { credentials = [bearer_token.tok] }
+`
+	if err := os.WriteFile(cfgPath, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, policy, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	db, err := OpenDB(filepath.Join(dir, "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	g := &Gateway{cfg: cfg, cfgPath: cfgPath, stateDir: dir, db: db}
+	g.policy.Store(policy)
+	return &webMux{g: g}
+}
+
+func jsonReq(v any) *http.Request {
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(v)
+	req := httptest.NewRequest(http.MethodPost, "/api/config/apply", &b)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -338,13 +338,15 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
 
   const writesEnabled = !!preview?.dashboard_config_writes;
   const createsEndpoint = !!preview?.endpoint_name && preview.endpoint_name !== ev.endpoint;
+  const passthrough = createsEndpoint || ev.mode === "splice";
 
   return (
     <Modal title="Block requests like this" size="lg" onClose={onClose}>
       <div className="p-4 space-y-3 overflow-auto">
         <p className="text-sm text-text-muted">
-          Claw Patrol generated HCL from this observed action. For matched endpoints this adds a
-          narrow deny rule; for passthrough hosts it creates an endpoint and blocks that host.
+          {passthrough
+            ? "This request was passed through without MITM inspection because no endpoint matched it. Claw Patrol generated HCL that creates an endpoint for the observed host and denies future matching requests before they pass through."
+            : "Claw Patrol generated a narrow deny rule from this inspected action. Edit the condition if you want to broaden it."}
         </p>
         {busy ? (
           <div className="text-xs text-text-subtle">Generating rule...</div>
@@ -365,8 +367,9 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             ))}
             {createsEndpoint && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
-                This will create endpoint <code>{preview.endpoint_name}</code>. Credential creation
-                is not part of this flow yet.
+                This will create endpoint <code>{preview.endpoint_name}</code> for future traffic.
+                It does not retroactively inspect this request. Credential creation is not part of
+                this flow yet.
               </div>
             )}
             <textarea

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
 import {
+  applyGeneratedRule,
   downloadActionFixture,
   getAction,
+  previewRuleFromAction,
   type Agent,
   type EventRecord,
   type FacetSchema,
+  type RulePreview,
 } from "../lib/api";
 import { headersToJSON } from "../lib/clipboard";
 import { formatFacetValue, useFacets } from "../lib/facets";
@@ -13,6 +16,7 @@ import { Button } from "./Button";
 import { CopyButton } from "./CopyButton";
 import { ApprovalStatusIcon, LockGlyph } from "./LiveRequests";
 import { Main } from "./Main";
+import { Modal } from "./Modal";
 import { PageTitle, type Crumb } from "./PageTitle";
 import { Tag } from "./Tag";
 
@@ -130,7 +134,7 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
             {fullUrl}
           </span>
           <span className="ml-auto">
-            <DownloadActionButton ev={ev} />
+            <ActionButtons ev={ev} />
           </span>
         </div>
         <div className="flex items-center gap-4 text-xs text-text-muted flex-wrap">
@@ -214,6 +218,21 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
   );
 }
 
+function ActionButtons({ ev }: { ev: EventRecord }) {
+  const [ruleOpen, setRuleOpen] = useState(false);
+  return (
+    <div className="flex items-center gap-2 flex-wrap justify-end">
+      {ev.id && ev.endpoint && ev.action !== "in_flight" && (
+        <Button variant="outline" onClick={() => setRuleOpen(true)}>
+          Block requests like this
+        </Button>
+      )}
+      <DownloadActionButton ev={ev} />
+      {ruleOpen && <RulePreviewModal ev={ev} onClose={() => setRuleOpen(false)} />}
+    </div>
+  );
+}
+
 // DownloadActionButton triggers a server-side reshape of this event
 // into a `clawpatrol test` fixture and saves it as a .json file. The
 // runner reads files in this exact format — drop the download into a
@@ -234,14 +253,7 @@ function DownloadActionButton({ ev }: { ev: EventRecord }) {
         setErr(null);
         try {
           const blob = await downloadActionFixture(ev.id!);
-          const href = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = href;
-          a.download = `${ev.id}.json`;
-          document.body.appendChild(a);
-          a.click();
-          a.remove();
-          URL.revokeObjectURL(href);
+          downloadBlob(blob, `${ev.id}.json`);
         } catch (e) {
           setErr((e as Error).message || "download failed");
         } finally {
@@ -253,6 +265,150 @@ function DownloadActionButton({ ev }: { ev: EventRecord }) {
       {busy ? "Downloading…" : "Download action"}
     </Button>
   );
+}
+
+function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => void }) {
+  const [preview, setPreview] = useState<RulePreview | null>(null);
+  const [hcl, setHCL] = useState("");
+  const [busy, setBusy] = useState(true);
+  const [applying, setApplying] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!ev.id) return;
+    setBusy(true);
+    setErr(null);
+    previewRuleFromAction(ev.id)
+      .then((p) => {
+        if (cancelled) return;
+        setPreview(p);
+        setHCL(p.hcl);
+      })
+      .catch((e) => {
+        if (!cancelled) setErr((e as Error).message || "rule preview failed");
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ev.id]);
+
+  async function copyHCL() {
+    await navigator.clipboard.writeText(hcl);
+    setMsg("HCL copied.");
+  }
+
+  async function applyRule() {
+    if (!preview?.config_revision) return;
+    setApplying(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      await applyGeneratedRule(preview.config_revision, hcl);
+      setMsg("Rule applied. New matching requests will be denied.");
+    } catch (e) {
+      const text = (e as Error).message || "apply failed";
+      if (text.includes("config changed")) {
+        setErr(
+          "The config changed since this rule was generated. Regenerate the rule and try again.",
+        );
+      } else {
+        setErr(text);
+      }
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  async function downloadFixture() {
+    if (!ev.id) return;
+    const blob = await downloadActionFixture(ev.id);
+    downloadBlob(blob, `${ev.id}.json`);
+  }
+
+  function downloadPatch() {
+    if (!preview?.patch) return;
+    downloadBlob(new Blob([preview.patch], { type: "text/plain;charset=utf-8" }), "rule.patch");
+  }
+
+  const writesEnabled = !!preview?.dashboard_config_writes;
+
+  return (
+    <Modal title="Block requests like this" size="lg" onClose={onClose}>
+      <div className="p-4 space-y-3 overflow-auto">
+        <p className="text-sm text-text-muted">
+          Claw Patrol generated a deny rule from this observed action. The rule starts narrow. Edit
+          the condition if you want to broaden it.
+        </p>
+        {busy ? (
+          <div className="text-xs text-text-subtle">Generating rule...</div>
+        ) : err && !preview ? (
+          <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>
+        ) : (
+          <>
+            {!writesEnabled && (
+              <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs text-text">
+                Dashboard config writes are disabled for this gateway. Copy this rule into your HCL
+                config and deploy it through your normal workflow.
+              </div>
+            )}
+            {preview?.warnings?.map((w) => (
+              <div key={w} className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
+                {w}
+              </div>
+            ))}
+            <textarea
+              value={hcl}
+              onChange={(e) => setHCL(e.target.value)}
+              spellCheck={false}
+              className="w-full min-h-[300px] resize-y border-1.5 border-navy bg-canvas p-3 font-mono text-xs text-text outline-none focus:bg-white"
+            />
+            {err && <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>}
+            {msg && <div className="text-sm text-success-600">{msg}</div>}
+          </>
+        )}
+      </div>
+      <div className="flex items-center gap-2 justify-end px-4 py-3 border-t border-navy bg-navy-100">
+        {writesEnabled ? (
+          <Button disabled={!preview || applying} onClick={applyRule}>
+            {applying ? "Applying..." : "Apply rule"}
+          </Button>
+        ) : (
+          <Button disabled={!preview} onClick={copyHCL}>
+            Copy HCL
+          </Button>
+        )}
+        {writesEnabled && (
+          <Button variant="outline" disabled={!preview} onClick={copyHCL}>
+            Copy HCL
+          </Button>
+        )}
+        {!writesEnabled && (
+          <Button variant="outline" disabled={!preview?.patch} onClick={downloadPatch}>
+            Download patch
+          </Button>
+        )}
+        <Button variant="outline" disabled={!ev.id} onClick={downloadFixture}>
+          Download fixture
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const href = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(href);
 }
 
 // --- SQL detail ---

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -220,9 +220,10 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
 
 function ActionButtons({ ev }: { ev: EventRecord }) {
   const [ruleOpen, setRuleOpen] = useState(false);
+  const canBlock = !!ev.id && ev.action !== "in_flight" && (!!ev.endpoint || ev.mode === "splice");
   return (
     <div className="flex items-center gap-2 flex-wrap justify-end">
-      {ev.id && ev.endpoint && ev.action !== "in_flight" && (
+      {canBlock && (
         <Button variant="outline" onClick={() => setRuleOpen(true)}>
           Block requests like this
         </Button>
@@ -325,7 +326,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   }
 
   async function downloadFixture() {
-    if (!ev.id) return;
+    if (!ev.id || !ev.endpoint) return;
     const blob = await downloadActionFixture(ev.id);
     downloadBlob(blob, `${ev.id}.json`);
   }
@@ -336,13 +337,14 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   }
 
   const writesEnabled = !!preview?.dashboard_config_writes;
+  const createsEndpoint = !!preview?.endpoint_name && preview.endpoint_name !== ev.endpoint;
 
   return (
     <Modal title="Block requests like this" size="lg" onClose={onClose}>
       <div className="p-4 space-y-3 overflow-auto">
         <p className="text-sm text-text-muted">
-          Claw Patrol generated a deny rule from this observed action. The rule starts narrow. Edit
-          the condition if you want to broaden it.
+          Claw Patrol generated HCL from this observed action. For matched endpoints this adds a
+          narrow deny rule; for passthrough hosts it creates an endpoint and blocks that host.
         </p>
         {busy ? (
           <div className="text-xs text-text-subtle">Generating rule...</div>
@@ -361,6 +363,12 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
                 {w}
               </div>
             ))}
+            {createsEndpoint && (
+              <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
+                This will create endpoint <code>{preview.endpoint_name}</code>. Credential creation
+                is not part of this flow yet.
+              </div>
+            )}
             <textarea
               value={hcl}
               onChange={(e) => setHCL(e.target.value)}
@@ -392,7 +400,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             Download patch
           </Button>
         )}
-        <Button variant="outline" disabled={!ev.id} onClick={downloadFixture}>
+        <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
           Download fixture
         </Button>
       </div>

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -273,6 +273,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   const [hcl, setHCL] = useState("");
   const [busy, setBusy] = useState(true);
   const [applying, setApplying] = useState(false);
+  const [appliedRevision, setAppliedRevision] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [msg, setMsg] = useState<string | null>(null);
 
@@ -309,8 +310,8 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
     setErr(null);
     setMsg(null);
     try {
-      await applyGeneratedRule(preview.config_revision, hcl);
-      setMsg("Rule applied. New matching requests will be denied.");
+      const applied = await applyGeneratedRule(preview.config_revision, hcl);
+      setAppliedRevision(applied.revision);
     } catch (e) {
       const text = (e as Error).message || "apply failed";
       if (text.includes("config changed")) {
@@ -343,16 +344,36 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   return (
     <Modal title="Block requests like this" size="lg" onClose={onClose}>
       <div className="p-4 space-y-3 overflow-auto">
-        <p className="text-sm text-text-muted">
-          {passthrough
-            ? "This request was passed through without MITM inspection because no endpoint matched it. Claw Patrol generated HCL that creates an endpoint for the observed host and denies future matching requests before they pass through."
-            : "Claw Patrol generated a narrow deny rule from this inspected action. Edit the condition if you want to broaden it."}
-        </p>
-        {busy ? (
-          <div className="text-xs text-text-subtle">Generating rule...</div>
-        ) : err && !preview ? (
-          <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>
+        {appliedRevision ? (
+          <div className="min-h-[300px] flex flex-col items-center justify-center text-center gap-4">
+            <div className="flex items-center justify-center w-14 h-14 rounded-full border-2 border-success-600 text-success-600">
+              <CheckLargeIcon />
+            </div>
+            <div className="space-y-2 max-w-[34rem]">
+              <h3 className="text-lg font-semibold text-text">Rule applied</h3>
+              <p className="text-sm text-text-muted">
+                The generated HCL was validated, written to disk, and reloaded by the gateway. New
+                matching requests will be denied.
+              </p>
+              <p className="text-xs text-text-subtle">
+                Dashboard writes are enabled by <code>gateway.dashboard_config_writes</code>. When
+                this setting is disabled, this flow offers copy and patch downloads instead of
+                writing the config.
+              </p>
+            </div>
+          </div>
         ) : (
+          <p className="text-sm text-text-muted">
+            {passthrough
+              ? "This request was passed through without MITM inspection because no endpoint matched it. Claw Patrol generated HCL that creates an endpoint for the observed host, attaches it with deny_profiles, and denies future matching requests before they pass through."
+              : "Claw Patrol generated a narrow deny rule from this inspected action. Edit the condition if you want to broaden it."}
+          </p>
+        )}
+        {!appliedRevision && busy ? (
+          <div className="text-xs text-text-subtle">Generating rule...</div>
+        ) : !appliedRevision && err && !preview ? (
+          <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>
+        ) : !appliedRevision ? (
           <>
             {!writesEnabled && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs text-text">
@@ -368,8 +389,8 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             {createsEndpoint && (
               <div className="border border-butter-600 bg-butter-100 px-3 py-2 text-xs">
                 This will create endpoint <code>{preview.endpoint_name}</code> for future traffic.
-                It does not retroactively inspect this request. Credential creation is not part of
-                this flow yet.
+                It does not retroactively inspect this request. The <code>deny_profiles</code> list
+                makes the block explicit; credential creation is not part of this flow yet.
               </div>
             )}
             <textarea
@@ -381,10 +402,22 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             {err && <div className="text-sm text-danger-500 whitespace-pre-wrap">{err}</div>}
             {msg && <div className="text-sm text-success-600">{msg}</div>}
           </>
-        )}
+        ) : null}
       </div>
       <div className="flex items-center gap-2 justify-end px-4 py-3 border-t border-navy bg-navy-100">
-        {writesEnabled ? (
+        {appliedRevision ? (
+          <>
+            <Button href="#/settings" onClick={onClose}>
+              View configuration
+            </Button>
+            <Button variant="outline" disabled={!preview} onClick={copyHCL}>
+              Copy HCL
+            </Button>
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+          </>
+        ) : writesEnabled ? (
           <Button disabled={!preview || applying} onClick={applyRule}>
             {applying ? "Applying..." : "Apply rule"}
           </Button>
@@ -393,21 +426,41 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
             Copy HCL
           </Button>
         )}
-        {writesEnabled && (
+        {!appliedRevision && writesEnabled && (
           <Button variant="outline" disabled={!preview} onClick={copyHCL}>
             Copy HCL
           </Button>
         )}
-        {!writesEnabled && (
+        {!appliedRevision && !writesEnabled && (
           <Button variant="outline" disabled={!preview?.patch} onClick={downloadPatch}>
             Download patch
           </Button>
         )}
-        <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
-          Download fixture
-        </Button>
+        {!appliedRevision && (
+          <Button variant="outline" disabled={!ev.id || !ev.endpoint} onClick={downloadFixture}>
+            Download fixture
+          </Button>
+        )}
       </div>
     </Modal>
+  );
+}
+
+function CheckLargeIcon() {
+  return (
+    <svg
+      width="28"
+      height="28"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m5 12 5 5L20 7" />
+    </svg>
   );
 }
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -378,6 +378,7 @@ type StateResp = {
   // "dev.hcl"). Surfaced in UI hints so operators see the actual
   // running config name rather than a hardcoded string.
   config_file?: string;
+  dashboard_config_writes?: boolean;
 };
 let lastStateTag = "";
 let lastState: StateResp | null = null;
@@ -491,6 +492,45 @@ export async function downloadActionFixture(id: string): Promise<Blob> {
   const r = await api(`/api/actions/${id}?fmt=fixture`);
   if (!r.ok) throw new Error(await r.text());
   return r.blob();
+}
+
+export type RulePreview = {
+  rule_name: string;
+  hcl: string;
+  patch?: string;
+  config_revision?: string;
+  dashboard_config_writes: boolean;
+  warnings?: string[];
+};
+
+export async function previewRuleFromAction(id: string): Promise<RulePreview> {
+  const r = await api("/api/actions/rule-preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      action_id: id,
+      verdict: "deny",
+      scope: "exact",
+    }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+export async function applyGeneratedRule(
+  baseRevision: string,
+  appendHCL: string,
+): Promise<{ ok: boolean; revision: string }> {
+  const r = await api("/api/config/apply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      base_revision: baseRevision,
+      append_hcl: appendHCL,
+    }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
 }
 
 // FacetSchema mirrors the JSON returned by GET /api/facets — the

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -496,6 +496,7 @@ export async function downloadActionFixture(id: string): Promise<Blob> {
 
 export type RulePreview = {
   rule_name: string;
+  endpoint_name?: string;
   hcl: string;
   patch?: string;
   config_revision?: string;

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -41,6 +41,13 @@ gateway {
   public_url       = "https://gw.example.com"
   state_dir        = "/opt/clawpatrol"
 
+  # Demo mode: allow the dashboard's "Block requests like this"
+  # flow to append generated deny rules to this file after previewing
+  # and validating the full candidate config. For Git-managed
+  # production policy, omit this or set it false; the dashboard will
+  # still generate HCL to copy into a PR.
+  dashboard_config_writes = true
+
   # Dashboard auth: there is no HCL field for the root password. The
   # first time you open the dashboard you set a "root" password; it
   # lives bcrypt-hashed in clawpatrol.db. To skip the web first-run

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -387,6 +387,13 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				)
 			}
 		}
+		for _, ce := range cp.Endpoints {
+			if profile.Endpoints[ce.Name] != nil || !credentiallessCatchallDenyEndpoint(ce) {
+				continue
+			}
+			profile.Endpoints[ce.Name] = ce
+			indexProfileEndpointHosts(profile, ce)
+		}
 		// Add default-port TLS aliases only after every exact host is
 		// indexed. That lets an explicit bare host beat any alias, while
 		// keeping the alias attached to the HTTPS-family endpoint that
@@ -411,6 +418,38 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	}
 
 	return cp, nil
+}
+
+func indexProfileEndpointHosts(profile *CompiledProfile, ce *CompiledEndpoint) {
+	for _, h := range ce.Hosts {
+		host, _, hpErr := hostmatch.SplitHostPort(h)
+		if hpErr != nil || host == "" {
+			continue
+		}
+		if hostmatch.IsWildcardHost(host) {
+			profile.HostPatterns = append(profile.HostPatterns, HostPattern{
+				Pattern:  strings.ToLower(host),
+				Endpoint: ce,
+			})
+			continue
+		}
+		profile.HostIndex[strings.ToLower(h)] = ce
+	}
+}
+
+func credentiallessCatchallDenyEndpoint(ce *CompiledEndpoint) bool {
+	if ce == nil || len(ce.Credentials) > 0 {
+		return false
+	}
+	for _, r := range ce.Rules {
+		if r == nil || r.Disabled || r.Credential != "" || r.Condition != "" {
+			continue
+		}
+		if r.Outcome.Verdict == "deny" {
+			return true
+		}
+	}
+	return false
 }
 
 // CredentialEndpointTargets returns the endpoint names a credential

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -103,13 +103,14 @@ type HostPattern struct {
 // dispatch reads CompiledProfile.EndpointCredentials instead, because
 // the placeholder discriminator lives on the profile in v15.
 type CompiledEndpoint struct {
-	Name        string
-	Family      string // "http" | "sql" | "k8s"
-	Plugin      *Plugin
-	Body        any
-	Hosts       []string
-	Credentials []*Entity       // credentials globally bound to this endpoint
-	Rules       []*CompiledRule // sorted by priority desc
+	Name         string
+	Family       string // "http" | "sql" | "k8s"
+	Plugin       *Plugin
+	Body         any
+	Hosts        []string
+	DenyProfiles []string
+	Credentials  []*Entity       // credentials globally bound to this endpoint
+	Rules        []*CompiledRule // sorted by priority desc
 
 	// Tunnel is the resolved tunnel this endpoint dials through, or
 	// nil for endpoints reached over the gateway's plain dialer.
@@ -388,8 +389,11 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			}
 		}
 		for _, ce := range cp.Endpoints {
-			if profile.Endpoints[ce.Name] != nil || !credentiallessCatchallDenyEndpoint(ce) {
+			if profile.Endpoints[ce.Name] != nil || !stringSliceContains(ce.DenyProfiles, name) {
 				continue
+			}
+			if !credentiallessCatchallDenyEndpoint(ce) {
+				return nil, fmt.Errorf("endpoint %q sets deny_profiles but is not a credentialless endpoint with a catch-all deny rule", ce.Name)
 			}
 			profile.Endpoints[ce.Name] = ce
 			indexProfileEndpointHosts(profile, ce)
@@ -446,6 +450,15 @@ func credentiallessCatchallDenyEndpoint(ce *CompiledEndpoint) bool {
 			continue
 		}
 		if r.Outcome.Verdict == "deny" {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
 			return true
 		}
 	}
@@ -528,10 +541,11 @@ func attachCredentials(cp *CompiledPolicy, p *Policy) error {
 
 func compileEndpoint(name string, ent *Entity, cp *CompiledPolicy) (*CompiledEndpoint, error) {
 	ce := &CompiledEndpoint{
-		Name:   name,
-		Family: ent.Plugin.Family,
-		Plugin: ent.Plugin,
-		Body:   ent.Body,
+		Name:         name,
+		Family:       ent.Plugin.Family,
+		Plugin:       ent.Plugin,
+		Body:         ent.Body,
+		DenyProfiles: ent.Framework.RefList("deny_profiles"),
 	}
 	// Hosts live on the plugin's typed body. We cross-cut via a small
 	// interface so the compile pass doesn't have to know every

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,11 @@ type GatewaySettings struct {
 	// format ("24h", "30m"). Default 24h.
 	DashboardSessionTTL string `hcl:"dashboard_session_ttl,optional"`
 
+	// DashboardConfigWrites allows authenticated dashboard users to
+	// append generated config snippets to the gateway HCL. Default
+	// false: config remains read-only and changes happen out-of-band.
+	DashboardConfigWrites bool `hcl:"dashboard_config_writes,optional"`
+
 	// Resolver is the DNS resolver address the gateway uses for
 	// upstream lookups when the runtime needs an explicit resolver.
 	Resolver string `hcl:"resolver,optional"`
@@ -251,6 +256,12 @@ func (g *Gateway) SetPublicURL(s string) {
 // DashboardListen returns the configured dashboard HTTP bind
 // address, or empty string when unset.
 func (g *Gateway) DashboardListen() string { return g.settings().DashboardListen }
+
+// DashboardConfigWrites reports whether dashboard-originated config
+// mutations are enabled for this gateway.
+func (g *Gateway) DashboardConfigWrites() bool {
+	return g != nil && g.Settings != nil && g.Settings.DashboardConfigWrites
+}
 
 // StateDir returns the configured state directory, or empty string.
 func (g *Gateway) StateDir() string { return g.settings().StateDir }

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -193,6 +193,9 @@ func emitGatewayBlock(body *hclwrite.Body, s *GatewaySettings) {
 	setStr("public_url", s.PublicURL)
 	setStr("state_dir", s.StateDir)
 	setStr("dashboard_session_ttl", s.DashboardSessionTTL)
+	if s.DashboardConfigWrites {
+		gw.SetAttributeValue("dashboard_config_writes", cty.BoolVal(true))
+	}
 	setStr("resolver", s.Resolver)
 	setStr("log_path", s.LogPath)
 	if s.Telemetry != nil {

--- a/internal/config/emit_test.go
+++ b/internal/config/emit_test.go
@@ -79,3 +79,24 @@ func TestEmitFullSpec(t *testing.T) {
 		t.Errorf("full-spec round-trip mismatch:\n%s", diff)
 	}
 }
+
+func TestEmitDashboardConfigWrites(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(`gateway {
+  dashboard_config_writes = true
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "127.0.0.1:51820"
+  }
+}
+`), "writes.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	emitted, err := config.Emit(gw)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(string(emitted), "dashboard_config_writes = true") {
+		t.Fatalf("emitted config missing dashboard_config_writes:\n%s", emitted)
+	}
+}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -181,6 +181,7 @@ type FrameworkAttrSpec struct {
 var frameworkAttrsByKind = map[Kind][]FrameworkAttrSpec{
 	KindEndpoint: {
 		{Name: "tunnel", Kind: KindTunnel, Optional: true},
+		{Name: "deny_profiles", Kind: KindProfile, Optional: true, List: true},
 	},
 	// credential→endpoint binding lives on the credential block. A
 	// credential names either a single endpoint or a list of them

--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -148,6 +148,9 @@ func (r *renderer) writeOperational() {
 	r.out.WriteString("## Top-level blocks\n\n")
 	r.out.WriteString("Operational settings live under the required top-level `gateway { ... }` block. The optional `defaults { ... }` block carries policy fallbacks. Labeled policy blocks (`profile`, `approver`, `credential`, `endpoint`, `rule`, `tunnel`) are documented in their own sections.\n\n")
 	r.writeStructTable("config", "Gateway", reflect.TypeOf(config.Gateway{}))
+	r.out.WriteString("## `gateway { ... }`\n\n")
+	r.out.WriteString("The gateway block carries operational settings. Most deployments keep policy in this same HCL file and push edits out-of-band. Set `dashboard_config_writes = true` only when authenticated dashboard users should be allowed to append generated rules from observed actions.\n\n")
+	r.writeStructTable("config", "GatewaySettings", reflect.TypeOf(config.GatewaySettings{}))
 }
 
 // writeProfile documents the `profile "<name>" {}` block. The body

--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -186,10 +186,21 @@ func (r *renderer) writeKind(kind config.Kind) {
 		}
 		r.out.WriteString(".\n\n")
 	}
+	if kind == config.KindEndpoint {
+		r.writeEndpointFrameworkAttrs()
+	}
 
 	for _, p := range plugins {
 		r.writePlugin(kind, p)
 	}
+}
+
+func (r *renderer) writeEndpointFrameworkAttrs() {
+	r.out.WriteString("Endpoint blocks also accept these framework attributes:\n\n")
+	r.out.WriteString("| Attribute | Type | Required | Description |\n")
+	r.out.WriteString("|-----------|------|----------|-------------|\n")
+	r.out.WriteString("| `tunnel` | `ref(tunnel)` | no | Routes this endpoint through the named tunnel runtime. |\n")
+	r.out.WriteString("| `deny_profiles` | `[]profile` | no | Makes a credentialless endpoint routeable for the listed profiles when the endpoint has a catch-all deny rule. Used for explicit host blocks generated from passthrough requests. |\n\n")
 }
 
 func (r *renderer) writePlugin(kind config.Kind, p *config.Plugin) {

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -27,9 +27,12 @@ fields you need to edit.
 clawpatrol gateway <config.hcl>
 ```
 
-The gateway is read-only-config — the dashboard surfaces the running
-HCL for reading but never writes it. Push edits via your own deploy
-script (typically SSH from a config repo). See
+By default the gateway is read-only-config: the dashboard can
+generate HCL from observed actions, but it will not edit the running
+file. Set `dashboard_config_writes = true` in `gateway {}` to let the
+dashboard append generated rules after validating the full candidate
+config and hot-reloading it. Git-managed deployments should leave it
+false and push edits through their normal review/deploy flow. See
 [config-reference](config-reference) for the HCL grammar.
 
 ### `clawpatrol join`

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -32,6 +32,54 @@ Operational settings live under the required top-level `gateway { ... }` block. 
 | `defaults` | `block` | no | Holds the optional `defaults { ... }` block with the policy defaults (unknown_host, llm_*, human_*). nil when the block is absent — every field has a built-in default. |
 | `plugin` | `block` | no | Lists every `plugin "<name>" { source = "..." }` block at the top of the file. The loader spawns each subprocess (and registers its declared types) before running pass-1 symbol building, so plugin-supplied (kind, type) pairs are available by the time policy blocks are dispatched. |
 
+## `gateway { ... }`
+
+The gateway block carries operational settings. Most deployments keep policy in this same HCL file and push edits out-of-band. Set `dashboard_config_writes = true` only when authenticated dashboard users should be allowed to append generated rules from observed actions.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_listen` | `string` | no | The bind address for the dashboard + JSON API HTTP server. Default 127.0.0.1:8080. Set to a routable address to expose the dashboard off-host (the same mux is also served on the WG netstack / tsnet stack at this port). |
+| `public_url` | `string` | no | The canonical externally-reachable gateway URL. Used in generated control-plane links such as join targets, OAuth redirect URIs, and (when public_url has a host but wireguard.endpoint doesn't) the host clients dial for WireGuard. |
+| `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol. |
+| `dashboard_session_ttl` | `string` | no | How long a dashboard login session stays valid after the operator types the password. time.ParseDuration format ("24h", "30m"). Default 24h. |
+| `dashboard_config_writes` | `bool` | no | Allows authenticated dashboard users to append generated config snippets to the gateway HCL. Default false: config remains read-only and changes happen out-of-band. |
+| `resolver` | `string` | no | The DNS resolver address the gateway uses for upstream lookups when the runtime needs an explicit resolver. |
+| `log_path` | `string` | no | An optional file path for gateway log output. |
+| `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
+| `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Default 720h (30d), "0" / "off" disables. time.ParseDuration format. |
+| `wireguard` | `block` | no | WireGuard, if present, enables the embedded userspace WireGuard server. Required block when running WG-mode deployments. |
+| `tailscale` | `block` | no | Tailscale, if present, enables the embedded tsnet node and the Tailscale control plane (OAuth key minting, exit-node routing). Both transports may be enabled simultaneously. |
+
+**Nested block `wireguard {}`:**
+
+The body of the `wireguard { ... }` sub-block
+inside `gateway { ... }`. Presence of the block enables the WG
+transport.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subnet_cidr` | `string` | no | The private subnet assigned to onboarded clients. Required (e.g. "10.55.0.0/24"). |
+| `listen_port` | `int` | no | The UDP port the gateway binds for WG peers. Default 51820. |
+| `endpoint` | `string` | no | The host:port advertised in client wg.conf as `Endpoint = ...`. Host defaults to public_url's host; port defaults to listen_port. Set only for split-host deployments (gateway sits behind a different hostname/IP for WG than for the dashboard). |
+| `interface` | `string` | no | The WireGuard interface name the gateway manages. Mostly irrelevant in userspace mode; leave unset. |
+| `server_pub` | `string` | no | The WireGuard server public key advertised to clients. Normally derived from gateway state; only set when bootstrapping from an external key. |
+
+**Nested block `tailscale {}`:**
+
+The body of the `tailscale { ... }` sub-block
+inside `gateway { ... }`. Presence of the block enables tsnet.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | `string` | no | The Tailscale auth key for the embedded tsnet node. Required when the `tailscale` block is present. Falls back to $TS_AUTHKEY if empty. |
+| `hostname` | `string` | no | The device name requested for the tsnet node. Default "clawpatrol-gateway". |
+| `control_url` | `string` | no | The Tailscale control-plane URL. Empty → Tailscale's hosted control plane. |
+| `tags` | `[]string` | no | The Tailscale device-tag list applied to keys the gateway mints for onboarded clients (`tag:client` etc.). The autoApprovers exit-node ACL must reference these tags. |
+| `operators` | `[]string` | no | Allowlists tailnet logins permitted to use the dashboard without typing the root password. Each entry is either an exact login ("alice@example.com") or a domain wildcard ("*@example.com"). Tagged devices (whose whois login is the tag name, not a user email) never match a wildcard entry — agents on the tailnet can never bypass the gate through this path. Empty / unset → tailnet-allowlist auth is disabled. The stored root password is then the only way in. Lives under `tailscale {}` because matching requires the tsnet whois identity; there is no whois without an active tsnet node. |
+| `funnel` | `bool` | no | Enables Tailscale Funnel on :443 so the join bootstrap and credential webhook paths are internet-reachable via the tsnet cert domain. Requires HTTPS enabled for the tailnet; if public_url is unset the gateway derives it from the tsnet cert domain at startup. |
+| `oauth_client_id` | `string` | no | The OAuth client id used to mint per-device tailnet auth keys at approval time. |
+| `oauth_client_secret` | `string` | no | The OAuth client secret paired with OAuthClientID. |
+
 ## `profile "<name>" { ... }`
 
 Names a set of credentials. Profiles bind to dashboard owners; an owner's profile determines which credentials — and, transitively via each credential's `endpoint` / `endpoints` binding, which endpoints — their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -359,6 +359,13 @@ Block syntax: `endpoint "<type>" "<name>" { ... }`
 
 Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
 
+Endpoint blocks also accept these framework attributes:
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tunnel` | `ref(tunnel)` | no | Routes this endpoint through the named tunnel runtime. |
+| `deny_profiles` | `[]profile` | no | Makes a credentialless endpoint routeable for the listed profiles when the endpoint has a catch-all deny rule. Used for explicit host blocks generated from passthrough requests. |
+
 ### `endpoint "clickhouse_https" "<name>"`
 
 Family: `sql`.

--- a/site/doc/getting-started.md
+++ b/site/doc/getting-started.md
@@ -48,6 +48,13 @@ the operator login. The CA certificate and private key are
 lazy-minted into sqlite under `state_dir` on first boot; there's
 nothing else to pre-create.
 
+The example config enables `dashboard_config_writes = true` so the
+dashboard can turn an observed action into a generated deny rule,
+append it to `gateway.hcl`, validate the full candidate config, and
+hot-reload it. For Git-managed production policy, omit that field or
+set it to `false`; the dashboard will still generate HCL you can copy
+into your normal review flow.
+
 The credentials in the example config (Anthropic, OpenAI,
 GitHub, Slack, Notion, Grafana) are declared in HCL, but each
 one still has to be connected before it can be used. Open the


### PR DESCRIPTION
Stacked on #614.\n\nThis follow-up keeps passthrough host blocking understandable from the HCL itself:\n\n- Adds endpoint-level `deny_profiles` for credentialless catch-all deny endpoints.\n- Generated passthrough host blocks now include `deny_profiles = [profile.default]` instead of relying on implicit compiler routing.\n- Adds a clearer post-apply success state in the modal with a link to the current config.\n- Documents `deny_profiles` in the generated config reference.\n\nValidation run on the stacked branch:\n- `go test ./cmd/clawpatrol -run 'TestGenerateRule|TestGeneratedSpliceHostBlock'`\n- `go test ./internal/config ./internal/tools/docgen`\n- `cd dashboard && deno task format:check && npm run build`