### PR TITLE
Add schema_version to gateway config

### DIFF
--- a/cmd/clawpatrol/testdata/example.hcl
+++ b/cmd/clawpatrol/testdata/example.hcl
@@ -6,6 +6,8 @@
 //
 // Edit any rule below and re-run to see a mismatch.
 
+schema_version = 1
+
 gateway {
   state_dir  = "/opt/clawpatrol"
   public_url = "https://gw.example.test"

--- a/doc/multi-file-config.md
+++ b/doc/multi-file-config.md
@@ -35,6 +35,12 @@ gohcl decodes and what pass-1 walks for symbol building.
   must appear in **exactly one** file. Duplicates surface as
   gohcl's standard `Duplicate gateway block` / `Duplicate defaults
   block` diagnostic with both source ranges.
+- **`schema_version`** is a top-level singleton attribute and, like
+  the singleton blocks, must appear in at most one file. It is read
+  in a lenient pre-pass over the merged body before the strict
+  decode, so a version newer than the binary supports fails with one
+  upgrade error rather than a wall of unknown-field noise. Absent ⇒
+  legacy grammar (version 0) with a warning.
 - **Repeatable blocks** (`plugin "..." { ... }`, every named
   policy entity) can appear in any file. Each named entity is
   still unique within its kind across the whole module — declaring

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -36,6 +36,11 @@
 # References are bare names — no kind prefix. The flat namespace is
 # globally unique; collisions are a load error.
 
+# Config grammar this file targets. The gateway accepts a window of
+# versions and rejects anything newer than it understands; omitting it
+# loads as legacy grammar with a warning.
+schema_version = 1
+
 gateway {
   dashboard_listen = "127.0.0.1:8080"
   public_url       = "https://gw.example.com"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,84 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
 )
+
+const (
+	// MinSchemaVersion is the oldest config grammar this binary still
+	// decodes. 0 covers unversioned legacy configs (no top-level
+	// `schema_version` attribute); they load with a deprecation
+	// warning. Bump this only at a major when ancient syntax is
+	// finally dropped.
+	MinSchemaVersion = 0
+
+	// MaxSchemaVersion is the newest grammar this binary understands.
+	// Bump it whenever a breaking grammar change ships. Configs
+	// declaring a higher version are rejected with an "upgrade
+	// clawpatrol" error rather than a wall of decode noise.
+	MaxSchemaVersion = 1
+)
+
+// schemaVersionSchema matches just the top-level `schema_version`
+// attribute, so the version pre-pass can read it via PartialContent
+// without consuming (or tripping over) anything else in the body.
+var schemaVersionSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{{Name: "schema_version"}},
+}
+
+// readSchemaVersion pulls the top-level `schema_version` off the merged
+// body in a lenient pass. PartialContent ignores every other attribute
+// and block, so a config written for a newer grammar (unknown
+// blocks/attrs) still yields a clean version number here instead of the
+// pile of "Unsupported argument" diagnostics a strict gohcl decode would
+// produce. Absent ⇒ 0 (unversioned legacy).
+func readSchemaVersion(body hcl.Body) (int, hcl.Diagnostics) {
+	content, _, diags := body.PartialContent(schemaVersionSchema)
+	if diags.HasErrors() {
+		return 0, diags
+	}
+	attr, ok := content.Attributes["schema_version"]
+	if !ok {
+		return 0, diags
+	}
+	val, valDiags := attr.Expr.Value(nil)
+	diags = append(diags, valDiags...)
+	if valDiags.HasErrors() {
+		return 0, diags
+	}
+	var v int
+	if err := gocty.FromCtyValue(val, &v); err != nil {
+		return 0, append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid schema_version",
+			Detail:   fmt.Sprintf("`schema_version` must be a whole integer: %v", err),
+			Subject:  attr.Expr.Range().Ptr(),
+		})
+	}
+	return v, diags
+}
+
+// checkSchemaVersion gates a resolved schema version against the window
+// this binary supports, returning the single clean error the caller
+// should surface (and nothing else — the caller skips the strict decode
+// when this errors, so the upgrade/migrate message isn't buried).
+func checkSchemaVersion(v int) hcl.Diagnostics {
+	if v > MaxSchemaVersion {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Config schema_version too new",
+			Detail:   fmt.Sprintf("schema_version = %d, but this clawpatrol understands up to %d. Upgrade clawpatrol to load this config.", v, MaxSchemaVersion),
+		}}
+	}
+	if v < MinSchemaVersion {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Config schema_version too old",
+			Detail:   fmt.Sprintf("schema_version = %d is below the minimum supported version (%d). Update the config to the current grammar.", v, MinSchemaVersion),
+		}}
+	}
+	return nil
+}
 
 // Gateway is the fully-loaded clawpatrol gateway config: a single
 // `gateway { ... }` block of operational settings (with nested
@@ -21,6 +98,14 @@ import (
 // optional top-level `defaults { ... }` block of policy defaults, and
 // the labeled policy blocks the plugins dispatch on.
 type Gateway struct {
+	// SchemaVersion is the top-level `schema_version` attribute: the
+	// config grammar this file targets. Absent ⇒ 0 ("unversioned
+	// legacy"), which loads with a deprecation warning. The binary
+	// accepts the window [MinSchemaVersion, MaxSchemaVersion]; configs
+	// outside it are rejected early with a clean upgrade/migrate error.
+	// See readSchemaVersion / checkSchemaVersion.
+	SchemaVersion int `hcl:"schema_version,optional"`
+
 	// Settings carries every operational scalar and the two transport
 	// sub-blocks. Required: configs missing the block fail to load.
 	Settings *GatewaySettings `hcl:"gateway,block"`
@@ -678,6 +763,22 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 	// through, so the multi-file code path is exercised uniformly.
 	body := hcl.MergeFiles(files)
 
+	// Read and gate the schema version before the strict decode. This
+	// pre-pass is lenient (PartialContent), so a config authored for a
+	// newer grammar fails with one "upgrade clawpatrol" line here
+	// rather than a wall of unknown-field noise from gohcl below. A
+	// version outside the supported window short-circuits the decode
+	// entirely. The absent-version warning is deferred to the end of
+	// the load so it only fires on otherwise-clean configs.
+	ver, verDiags := readSchemaVersion(body)
+	diags = append(diags, verDiags...)
+	if verDiags.HasErrors() {
+		return nil, diags
+	}
+	if d := checkSchemaVersion(ver); d.HasErrors() {
+		return nil, append(diags, d...)
+	}
+
 	// Decode operational fields. Policy blocks land in gw.Remain.
 	gw := &Gateway{}
 	if d := gohcl.DecodeBody(body, nil, gw); d.HasErrors() {
@@ -738,6 +839,20 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 	// goldens compare structural shape, not file contents.
 	includeDiags := expandFileIncludes(gw.Policy, configDir)
 	diags = append(diags, includeDiags...)
+
+	// Record the resolved version (gohcl already set it from the
+	// attribute; this keeps the field authoritative even via paths that
+	// bypass the decode) and nag on legacy configs — but only when the
+	// load is otherwise clean, so the reminder never crowds out the real
+	// errors on a config that fails anyway.
+	gw.SchemaVersion = ver
+	if ver == 0 && !diags.HasErrors() {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "No schema_version declared",
+			Detail:   fmt.Sprintf("This config has no top-level `schema_version`; it loads as legacy grammar. Add `schema_version = %d` to pin the grammar and silence this warning.", MaxSchemaVersion),
+		})
+	}
 
 	return gw, diags
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,12 +98,10 @@ func checkSchemaVersion(v int) hcl.Diagnostics {
 // optional top-level `defaults { ... }` block of policy defaults, and
 // the labeled policy blocks the plugins dispatch on.
 type Gateway struct {
-	// SchemaVersion is the top-level `schema_version` attribute: the
-	// config grammar this file targets. Absent ⇒ 0 ("unversioned
-	// legacy"), which loads with a deprecation warning. The binary
-	// accepts the window [MinSchemaVersion, MaxSchemaVersion]; configs
-	// outside it are rejected early with a clean upgrade/migrate error.
-	// See readSchemaVersion / checkSchemaVersion.
+	// SchemaVersion is the config grammar this file targets. The
+	// gateway accepts a range of versions and rejects anything newer
+	// than it understands with an upgrade error. Omitting it loads as
+	// legacy grammar (version 0) with a deprecation warning.
 	SchemaVersion int `hcl:"schema_version,optional"`
 
 	// Settings carries every operational scalar and the two transport

--- a/internal/config/testdata/error_schema_version_too_new.errors.txt
+++ b/internal/config/testdata/error_schema_version_too_new.errors.txt
@@ -1,0 +1,1 @@
+error: Config schema_version too new — schema_version = 999, but this clawpatrol understands up to 1. Upgrade clawpatrol to load this config.

--- a/internal/config/testdata/error_schema_version_too_new.hcl
+++ b/internal/config/testdata/error_schema_version_too_new.hcl
@@ -1,0 +1,19 @@
+# schema_version higher than this binary supports. Loading must fail
+# with a single "upgrade clawpatrol" error — NOT the wall of
+# "Unsupported argument" diagnostics the strict decode would emit for
+# the (hypothetical) newer-grammar syntax below. The lenient version
+# pre-pass reads the version and short-circuits before the decode.
+schema_version = 999
+
+gateway {
+  state_dir = "/opt/clawpatrol"
+
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+
+  # Pretend this is a future-grammar attribute the current binary
+  # doesn't know. It must not surface as a decode error, because the
+  # version gate fires first.
+  some_future_attr = "from a newer grammar"
+}

--- a/internal/config/testdata/full.hcl
+++ b/internal/config/testdata/full.hcl
@@ -365,6 +365,10 @@
 #   stamps the `k8s-aws-v1.<…>` bearer; cluster name and region live
 #   on the endpoint.
 
+# The config grammar this file targets. The gateway accepts a window of
+# versions; omitting it loads as legacy grammar with a warning.
+schema_version = 1
+
 gateway {
   state_dir  = "/opt/clawpatrol"
   public_url = "https://gw.example.test"

--- a/internal/config/version_test.go
+++ b/internal/config/version_test.go
@@ -1,0 +1,119 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// minimalConfig is the smallest body that loads without errors: one
+// transport with a dial target. Prefixed per-test with a schema_version
+// line (or not) to exercise the version gate.
+const minimalConfig = `
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
+`
+
+func loadStr(t *testing.T, src string) (*config.Gateway, hcl.Diagnostics) {
+	t.Helper()
+	return config.LoadBytes([]byte(src), "version_test.hcl")
+}
+
+func hasWarning(diags hcl.Diagnostics, summary string) bool {
+	for _, d := range diags {
+		if d.Severity == hcl.DiagWarning && d.Summary == summary {
+			return true
+		}
+	}
+	return false
+}
+
+func errorText(diags hcl.Diagnostics) string {
+	var b strings.Builder
+	for _, d := range diags {
+		if d.Severity == hcl.DiagError {
+			b.WriteString(d.Summary)
+			b.WriteString(": ")
+			b.WriteString(d.Detail)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// Absent schema_version loads as legacy (version 0) and warns, without
+// erroring.
+func TestSchemaVersionAbsentWarns(t *testing.T) {
+	gw, diags := loadStr(t, minimalConfig)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", errorText(diags))
+	}
+	if !hasWarning(diags, "No schema_version declared") {
+		t.Fatalf("expected absent-version warning, got: %v", diags)
+	}
+	if gw.SchemaVersion != 0 {
+		t.Fatalf("SchemaVersion = %d, want 0", gw.SchemaVersion)
+	}
+}
+
+// An explicit current version loads clean — no warning.
+func TestSchemaVersionExplicitNoWarn(t *testing.T) {
+	gw, diags := loadStr(t, "schema_version = 1\n"+minimalConfig)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", errorText(diags))
+	}
+	if hasWarning(diags, "No schema_version declared") {
+		t.Fatalf("did not expect absent-version warning with explicit version")
+	}
+	if gw.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", gw.SchemaVersion)
+	}
+}
+
+// A version newer than the binary supports fails with the single
+// upgrade error and nothing else — the lenient pre-pass suppresses the
+// strict-decode noise from the (unknown) newer-grammar attribute.
+func TestSchemaVersionTooNew(t *testing.T) {
+	src := "schema_version = 2\n" + minimalConfig + "\nfuture_block \"x\" {}\n"
+	_, diags := loadStr(t, src)
+	if !diags.HasErrors() {
+		t.Fatalf("expected an error for version > max")
+	}
+	got := errorText(diags)
+	if !strings.Contains(got, "too new") || !strings.Contains(got, "Upgrade clawpatrol") {
+		t.Fatalf("expected upgrade error, got: %s", got)
+	}
+	if strings.Contains(got, "Unsupported") || strings.Contains(got, "future_block") {
+		t.Fatalf("strict-decode noise leaked past the version gate: %s", got)
+	}
+}
+
+// A version below the supported minimum fails with the migrate error.
+// Min is currently 0, so only a negative version trips this arm; the
+// check still guards the window for when Min advances.
+func TestSchemaVersionTooOld(t *testing.T) {
+	_, diags := loadStr(t, "schema_version = -1\n"+minimalConfig)
+	got := errorText(diags)
+	if !strings.Contains(got, "too old") {
+		t.Fatalf("expected too-old error, got: %s", got)
+	}
+}
+
+// A non-integer version is rejected as malformed rather than silently
+// coerced.
+func TestSchemaVersionInvalid(t *testing.T) {
+	_, diags := loadStr(t, "schema_version = \"nope\"\n"+minimalConfig)
+	got := errorText(diags)
+	if !strings.Contains(got, "Invalid schema_version") {
+		t.Fatalf("expected invalid-version error, got: %s", got)
+	}
+}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -28,6 +28,7 @@ Operational settings live under the required top-level `gateway { ... }` block. 
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `schema_version` | `int` | no | The config grammar this file targets. The gateway accepts a range of versions and rejects anything newer than it understands with an upgrade error. Omitting it loads as legacy grammar (version 0) with a deprecation warning. |
 | `gateway` | `block` | yes | Carries every operational scalar and the two transport sub-blocks. Required: configs missing the block fail to load. |
 | `defaults` | `block` | no | Holds the optional `defaults { ... }` block with the policy defaults (unknown_host, llm_*, human_*). nil when the block is absent — every field has a built-in default. |
 | `plugin` | `block` | no | Lists every `plugin "<name>" { source = "..." }` block at the top of the file. The loader spawns each subprocess (and registers its declared types) before running pass-1 symbol building, so plugin-supplied (kind, type) pairs are available by the time policy blocks are dispatched. |


### PR DESCRIPTION
* Introduce a top-level `schema_version` integer attribute on the
  gateway config so the HCL grammar can evolve with an explicit
  binary/config compatibility contract. The binary accepts a window
  `[MinSchemaVersion, MaxSchemaVersion]`, today `[0, 1]`.
* Read the version in a lenient `PartialContent` pre-pass before the
  strict `gohcl` decode. A config authored for a newer grammar fails
  with a single "upgrade" error instead of a wall of
  "Unsupported argument" noise from the decode.
* Absent attribute is treated as version 0 (legacy) and loads with a
  deprecation warning — but only when the config is otherwise clean, so
  the reminder never crowds out real errors on a config that fails
  anyway.
* Versions above the max are rejected with an upgrade error; versions
  below the min with a migrate error. Non-integer values are rejected
  as malformed.
* Declare `schema_version = 1` in the shipped example config, the
  `clawpatrol test` example, and the full spec fixture; document the
  singleton in `doc/multi-file-config.md`.

Gate only — no migration tooling. The `schema_version` attribute is a
top-level singleton (at most one across a multi-file module), parsed
on the merged body.