### PR TITLE
[codex] allow profiles to include direct endpoints

### DIFF
--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -342,6 +342,14 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			EndpointCredentials: map[string][]*CompiledCredential{},
 			HITLAsyncGrants:     pr.HITLAsyncGrants,
 		}
+		for _, epName := range pr.Endpoints {
+			ce, ok := cp.Endpoints[epName]
+			if !ok {
+				continue
+			}
+			profile.Endpoints[epName] = ce
+			indexProfileEndpointHosts(profile, ce)
+		}
 		for _, credName := range pr.Credentials {
 			credEnt, ok := p.Credentials[credName]
 			if !ok {
@@ -355,29 +363,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 					continue
 				}
 				profile.Endpoints[epName] = ce
-				// DNS hostnames are case-insensitive; index lowercase
-				// so a SNI-peek lookup (TLS clients usually lowercase
-				// SNI on the wire) matches a config-declared host
-				// regardless of its casing.
-				for _, h := range ce.Hosts {
-					host, _, hpErr := hostmatch.SplitHostPort(h)
-					if hpErr != nil || host == "" {
-						continue
-					}
-					if hostmatch.IsWildcardHost(host) {
-						// Wildcard patterns route on the SNI/authority
-						// host alone (no port), so collapse port-qualified
-						// `*.foo.com:443` and bare `*.foo.com` to a single
-						// pattern keyed on the host portion. Duplicates
-						// from listing both forms are removed below.
-						profile.HostPatterns = append(profile.HostPatterns, HostPattern{
-							Pattern:  strings.ToLower(host),
-							Endpoint: ce,
-						})
-						continue
-					}
-					profile.HostIndex[strings.ToLower(h)] = ce
-				}
+				indexProfileEndpointHosts(profile, ce)
 				profile.EndpointCredentials[epName] = append(
 					profile.EndpointCredentials[epName],
 					&CompiledCredential{
@@ -411,6 +397,29 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	}
 
 	return cp, nil
+}
+
+func indexProfileEndpointHosts(profile *CompiledProfile, ce *CompiledEndpoint) {
+	// DNS hostnames are case-insensitive; index lowercase so a SNI-peek
+	// lookup matches a config-declared host regardless of its casing.
+	for _, h := range ce.Hosts {
+		host, _, hpErr := hostmatch.SplitHostPort(h)
+		if hpErr != nil || host == "" {
+			continue
+		}
+		if hostmatch.IsWildcardHost(host) {
+			// Wildcard patterns route on the SNI/authority host alone
+			// (no port), so collapse port-qualified `*.foo.com:443`
+			// and bare `*.foo.com` to a single pattern keyed on the
+			// host portion. Duplicates are removed below.
+			profile.HostPatterns = append(profile.HostPatterns, HostPattern{
+				Pattern:  strings.ToLower(host),
+				Endpoint: ce,
+			})
+			continue
+		}
+		profile.HostIndex[strings.ToLower(h)] = ce
+	}
 }
 
 // CredentialEndpointTargets returns the endpoint names a credential

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -157,6 +157,118 @@ profile "p" { credentials = [bearer_token.tok] }
 	}
 }
 
+func TestCompileProfileDirectEndpoints(t *testing.T) {
+	src := `
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.github
+}
+
+endpoint "https" "blocked" {
+  hosts = ["blocked.example.com"]
+}
+rule "block-host" {
+  endpoint = https.blocked
+  verdict  = "deny"
+}
+
+profile "p" {
+  credentials = [bearer_token.tok]
+  endpoints   = [https.blocked]
+}
+`
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	prof := cp.Profiles["p"]
+	if prof == nil {
+		t.Fatal("missing profile p")
+	}
+	if prof.Endpoints["github"] == nil {
+		t.Fatal("credential-bound endpoint missing")
+	}
+	if prof.Endpoints["blocked"] == nil {
+		t.Fatal("direct endpoint missing")
+	}
+	if prof.HostIndex["blocked.example.com"] == nil {
+		t.Fatal("direct endpoint host not indexed")
+	}
+	if got := len(prof.EndpointCredentials["blocked"]); got != 0 {
+		t.Fatalf("direct endpoint has %d credentials, want 0", got)
+	}
+	if got := len(prof.EndpointCredentials["github"]); got != 1 {
+		t.Fatalf("credential-bound endpoint has %d credentials, want 1", got)
+	}
+}
+
+func TestCompileProfileEndpointOnly(t *testing.T) {
+	src := `
+endpoint "https" "blocked" {
+  hosts = ["blocked.example.com"]
+}
+rule "block-host" {
+  endpoint = https.blocked
+  verdict  = "deny"
+}
+profile "p" {
+  endpoints = [https.blocked]
+}
+`
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	prof := cp.Profiles["p"]
+	if prof == nil || prof.Endpoints["blocked"] == nil {
+		t.Fatalf("endpoint-only profile did not compile: %#v", prof)
+	}
+}
+
+func TestLoadRejectsUnknownProfileEndpoint(t *testing.T) {
+	src := `
+endpoint "https" "known" {
+  hosts = ["known.example.com"]
+}
+profile "p" {
+  endpoints = [https.missing]
+}
+`
+	_, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("LoadBytes succeeded, want unknown endpoint diagnostic")
+	}
+	if !strings.Contains(diags.Error(), "Unknown variable") &&
+		!strings.Contains(diags.Error(), "missing") {
+		t.Fatalf("diagnostics do not mention missing endpoint: %v", diags)
+	}
+}
+
+func TestLoadRejectsEmptyProfile(t *testing.T) {
+	src := `
+profile "p" {
+  hitl_async_grants = true
+}
+`
+	_, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("LoadBytes succeeded, want empty profile diagnostic")
+	}
+	if !strings.Contains(diags.Error(), "Set at least one of") {
+		t.Fatalf("diagnostics do not mention required credentials or endpoints: %v", diags)
+	}
+}
+
 func TestCompileRejectsBadHosts(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -555,9 +555,10 @@ func (noopPluginLoader) LoadPlugins([]PluginSource) hcl.Diagnostics { return nil
 
 // Profile is the lowered shape of a profile "<name>" {} block. Name
 // is the block's single label (set by the loader). Credentials is
-// the membership list; endpoint membership rides along as the
-// transitive closure profile → credential → endpoint, and rules
-// attach to endpoints (so they ride along too).
+// the credential membership list; endpoint membership rides along as
+// the transitive closure profile → credential → endpoint. Endpoints
+// is the direct endpoint membership list; it carries endpoint rules
+// into the profile without granting any credentials.
 //
 // Disambiguators is the per-credential profile-side dispatch
 // discriminator. Outer key is credential name; inner map is
@@ -576,6 +577,7 @@ func (noopPluginLoader) LoadPlugins([]PluginSource) hcl.Diagnostics { return nil
 type Profile struct {
 	Name            string                       `json:"name"`
 	Credentials     []string                     `json:"credentials"`
+	Endpoints       []string                     `json:"endpoints,omitempty"`
 	Disambiguators  map[string]map[string]string `json:"disambiguators,omitempty"`
 	HITLAsyncGrants bool                         `json:"hitl_async_grants,omitempty"`
 }
@@ -1509,7 +1511,8 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 	pr := &Profile{Name: sym.Name}
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "credentials", Required: true},
+			{Name: "credentials"},
+			{Name: "endpoints"},
 			{Name: "hitl_async_grants"},
 		},
 	}
@@ -1521,14 +1524,31 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 			pr.HITLAsyncGrants = hv.True()
 		}
 	}
-	attr, ok := content.Attributes["credentials"]
-	if !ok {
-		return pr, diags
+	if attr, ok := content.Attributes["credentials"]; ok {
+		diags = append(diags, decodeProfileCredentials(pr, sym, attr, evalCtx)...)
 	}
+	if attr, ok := content.Attributes["endpoints"]; ok {
+		endpoints, ed := decodeProfileEndpoints(sym, attr, evalCtx)
+		diags = append(diags, ed...)
+		pr.Endpoints = endpoints
+	}
+	if len(pr.Credentials) == 0 && len(pr.Endpoints) == 0 {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Invalid profile %q", sym.Name),
+			Detail:   "Set at least one of `credentials = [...]` or `endpoints = [...]`.",
+			Subject:  &sym.Block.DefRange,
+		})
+	}
+	return pr, diags
+}
+
+func decodeProfileCredentials(pr *Profile, sym *Symbol, attr *hcl.Attribute, evalCtx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
 	val, evalDiags := attr.Expr.Value(evalCtx)
 	diags = append(diags, evalDiags...)
 	if evalDiags.HasErrors() {
-		return pr, diags
+		return diags
 	}
 	t := val.Type()
 	if !t.IsTupleType() && !t.IsListType() {
@@ -1539,7 +1559,7 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 			Detail:   fmt.Sprintf("Expected a list; got %s.", t.FriendlyName()),
 			Subject:  &rng,
 		})
-		return pr, diags
+		return diags
 	}
 	rng := attr.Expr.Range()
 	it := val.ElementIterator()
@@ -1571,7 +1591,45 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 			})
 		}
 	}
-	return pr, diags
+	return diags
+}
+
+func decodeProfileEndpoints(sym *Symbol, attr *hcl.Attribute, evalCtx *hcl.EvalContext) ([]string, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	val, evalDiags := attr.Expr.Value(evalCtx)
+	diags = append(diags, evalDiags...)
+	if evalDiags.HasErrors() {
+		return nil, diags
+	}
+	t := val.Type()
+	rng := attr.Expr.Range()
+	if !t.IsTupleType() && !t.IsListType() {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Invalid profile %q endpoints", sym.Name),
+			Detail:   fmt.Sprintf("Expected a list; got %s.", t.FriendlyName()),
+			Subject:  &rng,
+		})
+		return nil, diags
+	}
+	var out []string
+	it := val.ElementIterator()
+	for it.Next() {
+		_, el := it.Element()
+		if el.Type() != cty.String {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid profile %q endpoints entry", sym.Name),
+				Detail:   fmt.Sprintf("Each entry must be a bare endpoint reference; got %s.", el.Type().FriendlyName()),
+				Subject:  &rng,
+			})
+			continue
+		}
+		if endpoint := el.AsString(); endpoint != "" {
+			out = append(out, endpoint)
+		}
+	}
+	return out, diags
 }
 
 // profileCredEntry is the result of decoding one object-literal entry

--- a/internal/config/dump.go
+++ b/internal/config/dump.go
@@ -212,7 +212,13 @@ func dumpProfiles(m map[string]*Profile) map[string]any {
 	}
 	out := map[string]any{}
 	for name, p := range m {
-		row := map[string]any{"credentials": p.Credentials}
+		row := map[string]any{}
+		if len(p.Credentials) > 0 {
+			row["credentials"] = p.Credentials
+		}
+		if len(p.Endpoints) > 0 {
+			row["endpoints"] = p.Endpoints
+		}
 		if len(p.Disambiguators) > 0 {
 			row["disambiguators"] = p.Disambiguators
 		}

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -396,6 +396,10 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 		if len(pr.Credentials) > 0 {
 			setProfileCredentials(b, pr.Credentials, pr.Disambiguators)
 		}
+		if len(pr.Endpoints) > 0 {
+			ri := EmitRefIndex()
+			SetIdentList(b, "endpoints", ri.Refs(KindEndpoint, pr.Endpoints))
+		}
 		if pr.HITLAsyncGrants {
 			b.SetAttributeValue("hitl_async_grants", cty.True)
 		}

--- a/internal/config/emit_test.go
+++ b/internal/config/emit_test.go
@@ -79,3 +79,26 @@ func TestEmitFullSpec(t *testing.T) {
 		t.Errorf("full-spec round-trip mismatch:\n%s", diff)
 	}
 }
+
+func TestEmitProfileEndpoints(t *testing.T) {
+	src := testGatewayPrefix + `
+endpoint "https" "blocked" {
+  hosts = ["blocked.example.com"]
+}
+
+profile "p" {
+  endpoints = [https.blocked]
+}
+`
+	gw, diags := config.LoadBytes([]byte(src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	emitted, err := config.Emit(gw)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(string(emitted), "endpoints = [https.blocked]") {
+		t.Fatalf("emitted HCL missing profile endpoints:\n%s", emitted)
+	}
+}

--- a/internal/config/testdata/error_old_grammar.errors.txt
+++ b/internal/config/testdata/error_old_grammar.errors.txt
@@ -1,3 +1,1 @@
-error: error_old_grammar.hcl:23:19: Missing required argument — The argument "credentials" is required, but no definition was found.
-error: error_old_grammar.hcl:24:3: Unsupported argument — An argument named "endpoints" is not expected here.
 error: error_old_grammar.hcl:20:3: Unsupported argument — An argument named "credential" is not expected here.

--- a/internal/config/testdata/error_old_grammar.hcl
+++ b/internal/config/testdata/error_old_grammar.hcl
@@ -7,11 +7,11 @@ gateway {
   }
 }
 
-# Old (pre-inversion) grammar: endpoint carries `credential = X` and
-# profile carries `endpoints = [...]`. Under the inverted grammar
-# the credential→endpoint binding lives on the credential, profiles
-# list credentials, and endpoints are bare network targets. Loading
-# the old shape must fail rather than silently succeed.
+# Old (pre-inversion) grammar: endpoint carries `credential = X`.
+# The credential→endpoint binding lives on the credential, so loading
+# the old endpoint-side credential shape must fail rather than
+# silently succeed. `profile.endpoints` is valid for direct rule-only
+# endpoint membership, but it does not grant credentials.
 
 credential "bearer_token" "pat" {}
 

--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -151,15 +151,17 @@ func (r *renderer) writeOperational() {
 }
 
 // writeProfile documents the `profile "<name>" {}` block. The body
-// is decoded manually (mixed-shape `credentials` list), so we inline
-// its attributes rather than going through reflection.
+// is decoded manually (mixed-shape `credentials` list and typed
+// endpoint refs), so we inline its attributes rather than going
+// through reflection.
 func (r *renderer) writeProfile() {
 	r.out.WriteString("## `profile \"<name>\" { ... }`\n\n")
-	r.out.WriteString("Names a set of credentials. Profiles bind to dashboard owners; an owner's profile determines which credentials — and, transitively via each credential's `endpoint` / `endpoints` binding, which endpoints — their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.\n\n")
+	r.out.WriteString("Names a set of credentials and endpoints. Profiles bind to dashboard owners; an owner's profile determines which credentials they can use and which endpoint rules apply. Endpoint membership comes from the transitive closure of `credentials` → credential `endpoint` / `endpoints`, plus any direct `endpoints` listed on the profile. Direct endpoints carry rules without granting credentials.\n\n")
 	r.out.WriteString("| Attribute | Type | Required | Description |\n")
 	r.out.WriteString("|-----------|------|----------|-------------|\n")
-	r.out.WriteString("| `credentials` | `[]credential` | yes | Bare-name credential references, or `{ credential = name, <disambiguator> = \"...\" }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). |\n\n")
-	r.out.WriteString("```hcl\nprofile \"default\" {\n  credentials = [bearer_token.github, postgres_credential.postgres-prod]\n}\n```\n\n")
+	r.out.WriteString("| `credentials` | `[]credential` | no | Bare-name credential references, or `{ credential = name, <disambiguator> = \"...\" }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). Required when `endpoints` is empty. |\n")
+	r.out.WriteString("| `endpoints` | `[]endpoint` | no | Direct endpoint references. Use for rule-only membership, such as deny rules for hosts that should be blocked without granting a credential. Required when `credentials` is empty. |\n\n")
+	r.out.WriteString("```hcl\nprofile \"default\" {\n  credentials = [bearer_token.github, postgres_credential.postgres-prod]\n  endpoints   = [https.blocked_host]\n}\n```\n\n")
 }
 
 // ── plugin-dispatched kinds ─────────────────────────────────────────

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -35,15 +35,17 @@ Operational settings live under the required top-level `gateway { ... }` block. 
 
 ## `profile "<name>" { ... }`
 
-Names a set of credentials. Profiles bind to dashboard owners; an owner's profile determines which credentials — and, transitively via each credential's `endpoint` / `endpoints` binding, which endpoints — their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.
+Names a set of credentials and endpoints. Profiles bind to dashboard owners; an owner's profile determines which credentials they can use and which endpoint rules apply. Endpoint membership comes from the transitive closure of `credentials` → credential `endpoint` / `endpoints`, plus any direct `endpoints` listed on the profile. Direct endpoints carry rules without granting credentials.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `credentials` | `[]credential` | yes | Bare-name credential references, or `{ credential = name, <disambiguator> = "..." }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). |
+| `credentials` | `[]credential` | no | Bare-name credential references, or `{ credential = name, <disambiguator> = "..." }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). Required when `endpoints` is empty. |
+| `endpoints` | `[]endpoint` | no | Direct endpoint references. Use for rule-only membership, such as deny rules for hosts that should be blocked without granting a credential. Required when `credentials` is empty. |
 
 ```hcl
 profile "default" {
   credentials = [bearer_token.github, postgres_credential.postgres-prod]
+  endpoints   = [https.blocked_host]
 }
 ```
 


### PR DESCRIPTION
Adds direct endpoint membership to profiles via `endpoints = [...]`. This lets a profile carry rules for an endpoint without granting any credentials for it.

```hcl
endpoint "https" "deno_com" {
  hosts = ["deno.com"]
}

rule "block_deno_com" {
  endpoint = https.deno_com
  priority = 100
  verdict  = "deny"
  reason   = "Blocked from dashboard"
}

profile "default" {
  credentials = [
    anthropic_oauth_subscription.anthropic-oauth,
  ]
  endpoints = [
    https.deno_com,
  ]
}
```

In this example, `default` will apply the deny rule for `deno.com`, but `https.deno_com` does not add any credential grants to the profile.
