### PR TITLE
fix: resolve credential before rule matching on HTTPS path

### DIFF
--- a/cmd/clawpatrol/credential_match_test.go
+++ b/cmd/clawpatrol/credential_match_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+// TestMITMCredentialPinnedRuleMatchesOnHTTPSPath is a regression test for
+// the bug reported in the "Claw Patrol HITL not triggering for Deno Deploy
+// sandbox deploy mutations" handoff.
+//
+// Root cause: the HTTPS MITM handler ran runtime.MatchRequest *before*
+// resolving the dispatching credential, and never populated
+// match.Request.Credential. So any rule carrying a `credential =
+// bearer_token.X` pin (dispatch.go:100-104 compares req.Credential against
+// the rule's pin by bare name) was silently skipped on the HTTPS path —
+// req.Credential was always "". The request then fell through to a
+// low-priority default-deny rule, producing a 403 instead of the intended
+// verdict.
+//
+// This test pins an *allow* rule to the endpoint's credential and adds a
+// lower-priority default deny. Before the fix the pinned rule never
+// matches and the request is denied (403); after the fix the credential is
+// resolved before matching, the pin matches, and the request is forwarded
+// upstream (200). The gist's approve→202 symptom shares this exact root
+// cause — verdict type is irrelevant to whether the pinned rule is even
+// reached.
+func TestMITMCredentialPinnedRuleMatchesOnHTTPSPath(t *testing.T) {
+	const policyHCL = `
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gateway.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+endpoint "https" "api" {
+  hosts = ["api.example.test"]
+}
+credential "bearer_token" "pat" {
+  endpoint = https.api
+}
+rule "pat-mutations" {
+  endpoint   = https.api
+  credential = bearer_token.pat
+  priority   = 100
+  condition  = "http.method != 'GET'"
+  verdict    = "allow"
+  reason     = "pinned credential allows mutations"
+}
+rule "api-default" {
+  endpoint = https.api
+  priority = -100
+  verdict  = "deny"
+  reason   = "console mutations require an explicit rule"
+}
+profile "default" {
+  credentials = [bearer_token.pat]
+}
+`
+
+	h := newCredentialMatchHarness(t, policyHCL)
+
+	t.Run("pinned credential allows mutation", func(t *testing.T) {
+		resp := h.send(t, http.MethodPost, `{"app":"avocet-test"}`)
+		if resp.status != http.StatusOK {
+			t.Fatalf("POST status = %d (body %q); want 200 — the credential-pinned rule should match on the HTTPS path", resp.status, resp.body)
+		}
+		if !strings.Contains(resp.body, "upstream-ok") {
+			t.Fatalf("POST body = %q; want upstream response forwarded", resp.body)
+		}
+	})
+
+	// Sanity check: the pin must not blanket-allow. A GET fails the rule's
+	// `http.method != 'GET'` condition, so it still falls through to the
+	// default deny. This guards against a "fix" that ignores the condition.
+	t.Run("condition still gates the pinned rule", func(t *testing.T) {
+		resp := h.send(t, http.MethodGet, "")
+		if resp.status != http.StatusForbidden {
+			t.Fatalf("GET status = %d (body %q); want 403 from the default deny", resp.status, resp.body)
+		}
+	})
+}
+
+type credentialMatchHarness struct {
+	gateway  *Gateway
+	endpoint *config.CompiledEndpoint
+}
+
+type credentialMatchResponse struct {
+	status int
+	body   string
+}
+
+func newCredentialMatchHarness(t *testing.T, policyHCL string) *credentialMatchHarness {
+	t.Helper()
+
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	gw, diags := config.LoadBytes([]byte(policyHCL), "credential-match-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load config: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile config: %v", err)
+	}
+	ep := policy.Endpoints["api"]
+	if ep == nil {
+		t.Fatal("missing compiled api endpoint")
+	}
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream-ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamAddr := upstream.Listener.Addr().String()
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upstreamAddr)
+		},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: false,
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	t.Cleanup(func() { close(sink.ch) })
+
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{
+		cfg:     gw,
+		db:      db,
+		certs:   certs,
+		sink:    sink,
+		hitl:    newHITLRegistry(sink),
+		secrets: newGatewaySecretStore(db, nil),
+		onboard: newOnboardRegistry(),
+	}
+	g.policy.Store(policy)
+	g.transports.Store(ep, transport)
+
+	return &credentialMatchHarness{gateway: g, endpoint: ep}
+}
+
+func (h *credentialMatchHarness) send(t *testing.T, method, body string) credentialMatchResponse {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.gateway.mitmHTTPS(serverConn, "api.example.test", h.endpoint)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: "api.example.test"})
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, "https://api.example.test/api/v2/sandboxes/sbx_nonexistent/deploy", reqBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// The agent dispatches with a placeholder bearer token, mirroring the
+	// gist's `Authorization: Bearer PH_deno_sandbox`.
+	req.Header.Set("Authorization", "Bearer PH_pat")
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if err := req.Write(clientTLS); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientTLS), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	_ = resp.Body.Close()
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
+	}
+	return credentialMatchResponse{status: resp.StatusCode, body: string(respBody)}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2080,6 +2080,21 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 			fac.PrepareRequest(mreq)
 		}
 
+		// Resolve the dispatching credential *before* matching so rules
+		// carrying a `credential = bearer_token.X` pin can fire:
+		// runtime.MatchRequest compares mreq.Credential (the bare
+		// credential name) against each rule's pin. The wire-protocol
+		// frontends (postgres/clickhouse) already resolve-then-match; the
+		// HTTPS path historically matched first and resolved only at
+		// injection time, leaving mreq.Credential empty — so every
+		// credential-pinned rule silently fell through to the endpoint's
+		// default rule. Resolve once here and reuse the entry for
+		// credential injection further down.
+		resolvedCred := runtime.ResolveCredential(g.Policy(), profile, ep, mreq)
+		if resolvedCred != nil {
+			mreq.Credential = resolvedCred.Credential.Symbol.Name
+		}
+
 		ev := Event{
 			ID:     newReqID(),
 			Mode:   "mitm",
@@ -2340,7 +2355,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		// verbatim and rely on policy alone.
 		var rewriteWSPayload wsPayloadRewriter
 		var reqBodySecretRedactions []string
-		if cc := runtime.ResolveCredential(g.Policy(), profile, ep, mreq); cc != nil {
+		if cc := resolvedCred; cc != nil {
 			// Plugin.Runtime is a typed-nil sentinel used only for
 			// interface-compliance assertions; the actual decoded HCL
 			// values (BearerToken.IdempotencyKey, PostgresCredential.User,


### PR DESCRIPTION
## Summary

Credential-pinned rules (`credential = bearer_token.X`) were silently unreachable on the HTTPS MITM path, so requests that should have matched a pinned rule fell through to the endpoint's default rule. In production this surfaced as a `403 ... mutations require an explicit approval rule` instead of the intended HITL approval (`202 pending_approval` + Slack notification).

### Root cause

`mitmHTTPSWithCertHost` ran `runtime.MatchRequest` **before** resolving the dispatching credential, and never populated `match.Request.Credential`. The matcher skips any rule with a credential pin unless `req.Credential` equals the pin (`internal/config/runtime/dispatch.go:100-104`) — but on the HTTPS path that field was always `""`, so pinned rules never matched. The credential was resolved only later, at injection time (`main.go`), too late to affect matching.

The SQL frontends (postgres/clickhouse) were unaffected because they already resolve-then-match. The offline `clawpatrol test` fixture loader sets `Credential` directly, which masked the bug under self-test.

### Fix

Resolve the credential **once, before** matching; stamp `mreq.Credential` with the resolved bare name; reuse the same resolution for credential injection (replacing a second `ResolveCredential` call). Net `ResolveCredential` call count is unchanged.

The credential **pin is preserved** — approval stays scoped to the pinned credential rather than widening to every credential on the endpoint.

## Test plan

- New regression test `cmd/clawpatrol/credential_match_test.go` drives a credential-pinned `allow` rule + default deny through the real `mitmHTTPS` handler (net.Pipe + TLS):
  - **Before fix:** POST → `403` (default deny) — reproduces the reported symptom.
  - **After fix:** POST → `200` (forwarded upstream). A second subtest (GET → `403`) guards that the pin does not bypass the rule's CEL `condition`.
- `go test ./cmd/clawpatrol/` — full package passes (exit 0).
- `gofmt -l` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)