### PR TITLE
feat: profiles can declare endpoints directly, credential-less (cl-2d49)

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -1102,7 +1102,15 @@ func (w *webMux) apiRules(rw http.ResponseWriter, r *http.Request) {
 // Sort: by profile, then endpoint, then descending priority (so the
 // dashboard mirrors first-match-wins order within each endpoint).
 func (w *webMux) collectRuleSummaries(profileFilter string) []RuleSummary {
-	policy := w.g.Policy()
+	return collectRuleSummaries(w.g.Policy(), profileFilter)
+}
+
+// collectRuleSummaries is the policy-only core of the dashboard rules
+// listing, split out so it's testable without a live gateway. It walks
+// each profile's claimed endpoints — both credential-bound and
+// directly-declared — so rules on credential-less endpoints surface
+// under the claiming profile (and only that profile).
+func collectRuleSummaries(policy *config.CompiledPolicy, profileFilter string) []RuleSummary {
 	if policy == nil {
 		return []RuleSummary{}
 	}

--- a/cmd/clawpatrol/credential_bindings_test.go
+++ b/cmd/clawpatrol/credential_bindings_test.go
@@ -187,3 +187,53 @@ func sliceEq(a, b []string) bool {
 	}
 	return true
 }
+
+// TestRuleSummariesSurfaceDirectEndpoints verifies the dashboard rules
+// listing surfaces rules on a directly-declared, credential-less
+// endpoint under the claiming profile — and does NOT leak them onto a
+// sibling profile that never claims the endpoint. This is the
+// API-layer view of the cl-2d49 direct-endpoint feature: the device
+// page's RulesPanel filters this list by profile.
+func TestRuleSummariesSurfaceDirectEndpoints(t *testing.T) {
+	src := `
+endpoint "https" "public" {
+  hosts = ["status.example.com"]
+}
+
+rule "public-reads" {
+  endpoint  = https.public
+  condition = "http.method == 'GET'"
+  verdict   = "allow"
+}
+
+profile "data" {
+  credentials = []
+  endpoints   = [https.public]
+}
+profile "other" {
+  credentials = []
+}
+`
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "direct-rules-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	// "data" claims the endpoint directly → its rule shows up.
+	dataRules := collectRuleSummaries(policy, "data")
+	if len(dataRules) != 1 {
+		t.Fatalf("data profile: got %d rule summaries, want 1: %+v", len(dataRules), dataRules)
+	}
+	if r := dataRules[0]; r.Name != "public-reads" || r.Endpoint != "public" || r.Profile != "data" {
+		t.Errorf("data rule summary = %+v, want public-reads/public/data", r)
+	}
+
+	// "other" never claims it → no leak.
+	if otherRules := collectRuleSummaries(policy, "other"); len(otherRules) != 0 {
+		t.Errorf("other profile leaked direct-endpoint rules: %+v", otherRules)
+	}
+}

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -354,30 +354,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 				if !ok {
 					continue
 				}
-				profile.Endpoints[epName] = ce
-				// DNS hostnames are case-insensitive; index lowercase
-				// so a SNI-peek lookup (TLS clients usually lowercase
-				// SNI on the wire) matches a config-declared host
-				// regardless of its casing.
-				for _, h := range ce.Hosts {
-					host, _, hpErr := hostmatch.SplitHostPort(h)
-					if hpErr != nil || host == "" {
-						continue
-					}
-					if hostmatch.IsWildcardHost(host) {
-						// Wildcard patterns route on the SNI/authority
-						// host alone (no port), so collapse port-qualified
-						// `*.foo.com:443` and bare `*.foo.com` to a single
-						// pattern keyed on the host portion. Duplicates
-						// from listing both forms are removed below.
-						profile.HostPatterns = append(profile.HostPatterns, HostPattern{
-							Pattern:  strings.ToLower(host),
-							Endpoint: ce,
-						})
-						continue
-					}
-					profile.HostIndex[strings.ToLower(h)] = ce
-				}
+				profile.claimEndpoint(ce)
 				profile.EndpointCredentials[epName] = append(
 					profile.EndpointCredentials[epName],
 					&CompiledCredential{
@@ -386,6 +363,20 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 					},
 				)
 			}
+		}
+		// Directly-declared endpoints: the profile claims these by name
+		// without a credential binding, so its rules apply to requests
+		// routed there even though nothing is injected (public APIs,
+		// mTLS / network-position auth, open internal tools). Claiming is
+		// idempotent — an endpoint reached both via a credential above
+		// and listed here is a no-op the second time, and carries no
+		// EndpointCredentials entry from this loop.
+		for _, epName := range pr.Endpoints {
+			ce, ok := cp.Endpoints[epName]
+			if !ok {
+				continue
+			}
+			profile.claimEndpoint(ce)
 		}
 		// Add default-port TLS aliases only after every exact host is
 		// indexed. That lets an explicit bare host beat any alias, while
@@ -411,6 +402,42 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	}
 
 	return cp, nil
+}
+
+// claimEndpoint registers ce under the profile: adds it to the
+// endpoint set and indexes its hosts for SNI/authority lookup (exact
+// hosts → HostIndex, wildcard `*.suffix` declarations → HostPatterns).
+// DNS hostnames are case-insensitive, so keys are lowercased to match
+// the lowercase SNI/authority values the dispatcher looks up.
+//
+// Idempotent: re-claiming an endpoint the profile already holds (an
+// endpoint reached both transitively via a credential and declared
+// directly) re-assigns the same map entries and re-appends the same
+// wildcard patterns, which dedupePatterns collapses. Credential
+// dispatch entries are NOT touched here — the caller appends to
+// EndpointCredentials only for credential-backed claims, so a
+// directly-declared endpoint stays credential-less.
+func (cp *CompiledProfile) claimEndpoint(ce *CompiledEndpoint) {
+	cp.Endpoints[ce.Name] = ce
+	for _, h := range ce.Hosts {
+		host, _, hpErr := hostmatch.SplitHostPort(h)
+		if hpErr != nil || host == "" {
+			continue
+		}
+		if hostmatch.IsWildcardHost(host) {
+			// Wildcard patterns route on the SNI/authority host alone
+			// (no port), so collapse port-qualified `*.foo.com:443` and
+			// bare `*.foo.com` to a single pattern keyed on the host
+			// portion. Duplicates from listing both forms (or from a
+			// dual credential+direct claim) are removed by dedupePatterns.
+			cp.HostPatterns = append(cp.HostPatterns, HostPattern{
+				Pattern:  strings.ToLower(host),
+				Endpoint: ce,
+			})
+			continue
+		}
+		cp.HostIndex[strings.ToLower(h)] = ce
+	}
 }
 
 // CredentialEndpointTargets returns the endpoint names a credential

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -505,3 +505,162 @@ func TestCompileFullSpec(t *testing.T) {
 		t.Errorf("expected ~50+ rule attachments, got %d", totalRules)
 	}
 }
+
+// TestCompileDirectEndpoints covers a profile that claims an endpoint
+// directly via the `endpoints` list, with no credential binding. The
+// endpoint must land in the profile's endpoint set and host index, its
+// rules must be attached, and it must carry NO credential dispatch
+// entry (nothing to inject).
+func TestCompileDirectEndpoints(t *testing.T) {
+	src := `
+endpoint "https" "public" {
+  hosts = ["status.example.com", "*.metrics.example.com"]
+}
+
+rule "public-reads" {
+  endpoint  = https.public
+  condition = "http.method in ['GET', 'HEAD']"
+  verdict   = "allow"
+}
+rule "public-default" {
+  endpoint = https.public
+  priority = -100
+  verdict  = "deny"
+  reason   = "no policy matched"
+}
+
+profile "data" {
+  credentials = []
+  endpoints   = [https.public]
+}
+`
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	prof := cp.Profiles["data"]
+	if prof == nil {
+		t.Fatalf("missing profile data")
+	}
+	ep := prof.Endpoints["public"]
+	if ep == nil {
+		t.Fatalf("directly-declared endpoint not claimed by profile")
+	}
+	// Profile claims no credential, so its credential list is empty and
+	// the endpoint carries no profile-scoped dispatch entry.
+	if len(prof.Credentials) != 0 {
+		t.Errorf("expected 0 profile credentials, got %d", len(prof.Credentials))
+	}
+	if got := prof.EndpointCredentials["public"]; len(got) != 0 {
+		t.Errorf("directly-declared endpoint must have no EndpointCredentials, got %+v", got)
+	}
+	if len(ep.Credentials) != 0 {
+		t.Errorf("expected 0 globally-bound credentials, got %d", len(ep.Credentials))
+	}
+	// Exact host indexed, wildcard in HostPatterns.
+	if prof.HostIndex["status.example.com"] != ep {
+		t.Errorf("HostIndex[status.example.com] missing or wrong")
+	}
+	if len(prof.HostPatterns) != 1 || prof.HostPatterns[0].Pattern != "*.metrics.example.com" {
+		t.Errorf("HostPatterns=%+v, want one *.metrics.example.com", prof.HostPatterns)
+	}
+	// Rules attached to the endpoint are reachable through the profile.
+	if len(ep.Rules) != 2 {
+		t.Fatalf("expected 2 rules on directly-declared endpoint, got %d", len(ep.Rules))
+	}
+}
+
+// TestCompileDirectEndpointDedup verifies that an endpoint reached both
+// transitively (via a credential) AND declared directly collapses to a
+// single endpoint entry, a single host-pattern entry, and keeps its
+// credential dispatch entry intact (the direct claim doesn't erase it).
+func TestCompileDirectEndpointDedup(t *testing.T) {
+	src := `
+endpoint "https" "api" {
+  hosts = ["api.example.com", "*.api.example.com"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.api
+}
+profile "p" {
+  credentials = [bearer_token.tok]
+  endpoints   = [https.api]
+}
+`
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	prof := cp.Profiles["p"]
+	if len(prof.Endpoints) != 1 {
+		t.Errorf("expected 1 endpoint after dedup, got %d", len(prof.Endpoints))
+	}
+	if got := len(prof.HostPatterns); got != 1 {
+		t.Errorf("HostPatterns count = %d, want 1 (dedup); entries: %+v", got, prof.HostPatterns)
+	}
+	// Credential binding survives the direct claim.
+	if got := prof.EndpointCredentials["api"]; len(got) != 1 {
+		t.Errorf("expected credential dispatch entry preserved, got %+v", got)
+	}
+}
+
+// TestCompileDirectEndpointIsolation guards against the sibling-leak
+// failure mode (cf. cl-lgwg): a directly-declared endpoint in profile A
+// must not appear under profile B.
+func TestCompileDirectEndpointIsolation(t *testing.T) {
+	src := `
+endpoint "https" "shared" {
+  hosts = ["shared.example.com"]
+}
+profile "a" {
+  credentials = []
+  endpoints   = [https.shared]
+}
+profile "b" {
+  credentials = []
+}
+`
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if cp.Profiles["a"].Endpoints["shared"] == nil {
+		t.Errorf("profile a should claim shared endpoint")
+	}
+	if cp.Profiles["b"].Endpoints["shared"] != nil {
+		t.Errorf("profile b leaked sibling's directly-declared endpoint")
+	}
+	if cp.Profiles["b"].HostIndex["shared.example.com"] != nil {
+		t.Errorf("profile b host index leaked sibling's endpoint")
+	}
+}
+
+// TestCompileRejectsUnknownDirectEndpoint verifies the load-time cross
+// check: a profile referencing an undeclared endpoint is a diagnostic.
+func TestCompileRejectsUnknownDirectEndpoint(t *testing.T) {
+	src := `
+endpoint "https" "real" {
+  hosts = ["real.example.com"]
+}
+profile "p" {
+  credentials = []
+  endpoints   = [https.real, endpoint.ghost]
+}
+`
+	_, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	if !diags.HasErrors() {
+		t.Fatalf("load accepted unknown endpoint reference; want diagnostic")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -568,8 +568,16 @@ func (noopPluginLoader) LoadPlugins([]PluginSource) hcl.Diagnostics { return nil
 // block-side values; on conflict, profile-inline wins (the operator's
 // most-specific declaration).
 type Profile struct {
-	Name            string                       `json:"name"`
-	Credentials     []string                     `json:"credentials"`
+	Name        string   `json:"name"`
+	Credentials []string `json:"credentials"`
+	// Endpoints are endpoints the profile claims directly, by name,
+	// independent of any credential binding. Used for credential-less
+	// endpoints (public APIs, mTLS / network-position auth, open
+	// internal tools) so the profile's rules still apply to requests
+	// routed to them. Endpoints reached transitively via a credential
+	// need not be listed here; the two sets are merged (deduplicated)
+	// at compile time.
+	Endpoints       []string                     `json:"endpoints,omitempty"`
 	Disambiguators  map[string]map[string]string `json:"disambiguators,omitempty"`
 	HITLAsyncGrants bool                         `json:"hitl_async_grants,omitempty"`
 }
@@ -1107,6 +1115,19 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 				Subject:  &sym.Block.DefRange,
 			})
 		}
+		// Cross-check: each directly-declared endpoint name resolves to
+		// a declared endpoint.
+		for _, e := range pr.Endpoints {
+			if table.Get(KindEndpoint, e) != nil {
+				continue
+			}
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Unknown endpoint %q", e),
+				Detail:   fmt.Sprintf("Profile %q references endpoint %q which is not declared.", sym.Name, e),
+				Subject:  &sym.Block.DefRange,
+			})
+		}
 		p.Profiles[sym.Name] = pr
 		p.Order = append(p.Order, sym.Name)
 	}
@@ -1502,6 +1523,7 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
 			{Name: "credentials", Required: true},
+			{Name: "endpoints"},
 			{Name: "hitl_async_grants"},
 		},
 	}
@@ -1512,6 +1534,11 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 		if !hd.HasErrors() && hv.Type() == cty.Bool {
 			pr.HITLAsyncGrants = hv.True()
 		}
+	}
+	if epAttr, ok := content.Attributes["endpoints"]; ok {
+		eps, epDiags := decodeProfileEndpoints(sym.Name, epAttr, evalCtx)
+		diags = append(diags, epDiags...)
+		pr.Endpoints = eps
 	}
 	attr, ok := content.Attributes["credentials"]
 	if !ok {
@@ -1564,6 +1591,48 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 		}
 	}
 	return pr, diags
+}
+
+// decodeProfileEndpoints decodes a profile's `endpoints` attribute — a
+// list of bare endpoint-name references (`[endpoint.foo, endpoint.bar]`)
+// resolved through the eval context to their string names. Unlike the
+// credentials list, no object-literal/disambiguator form is allowed:
+// a directly-declared endpoint carries no credential dispatch, so there
+// is nothing to disambiguate. Each entry must be a string; anything
+// else is reported. Cross-checking that the names resolve to declared
+// endpoints happens in decodePolicyBlocks against the symbol table.
+func decodeProfileEndpoints(profile string, attr *hcl.Attribute, evalCtx *hcl.EvalContext) ([]string, hcl.Diagnostics) {
+	val, diags := attr.Expr.Value(evalCtx)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	t := val.Type()
+	rng := attr.Expr.Range()
+	if !t.IsTupleType() && !t.IsListType() {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Invalid profile %q endpoints", profile),
+			Detail:   fmt.Sprintf("Expected a list; got %s.", t.FriendlyName()),
+			Subject:  &rng,
+		})
+		return nil, diags
+	}
+	var out []string
+	it := val.ElementIterator()
+	for it.Next() {
+		_, el := it.Element()
+		if el.Type() != cty.String {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid profile %q endpoints entry", profile),
+				Detail:   fmt.Sprintf("Each entry must be a bare endpoint reference (e.g. `endpoint.name`); got %s.", el.Type().FriendlyName()),
+				Subject:  &rng,
+			})
+			continue
+		}
+		out = append(out, el.AsString())
+	}
+	return out, diags
 }
 
 // profileCredEntry is the result of decoding one object-literal entry

--- a/internal/config/dump.go
+++ b/internal/config/dump.go
@@ -201,6 +201,9 @@ func dumpProfiles(m map[string]*Profile) map[string]any {
 	out := map[string]any{}
 	for name, p := range m {
 		row := map[string]any{"credentials": p.Credentials}
+		if len(p.Endpoints) > 0 {
+			row["endpoints"] = p.Endpoints
+		}
 		if len(p.Disambiguators) > 0 {
 			row["disambiguators"] = p.Disambiguators
 		}

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -386,6 +386,13 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 		if len(pr.Credentials) > 0 {
 			setProfileCredentials(b, pr.Credentials, pr.Disambiguators)
 		}
+		if len(pr.Endpoints) > 0 {
+			// Directly-declared, credential-less endpoint claims. Emitted
+			// as `endpoints = [endpoint.foo, ...]` so HCL → load → emit
+			// round-trips the profile's full endpoint set.
+			ri := EmitRefIndex()
+			SetIdentList(b, "endpoints", ri.Refs(KindEndpoint, pr.Endpoints))
+		}
 		if pr.HITLAsyncGrants {
 			b.SetAttributeValue("hitl_async_grants", cty.True)
 		}

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -1254,3 +1254,60 @@ func containsCI(haystack, needle string) bool {
 	}
 	return false
 }
+
+// TestDirectEndpointRulesFireWithoutCredential exercises the
+// credential-less runtime path: a profile declares an endpoint directly
+// (no credential bound), and a request routed there must (a) resolve to
+// the endpoint via the profile's host index, (b) fire the profile's
+// rules, and (c) resolve no credential without error.
+func TestDirectEndpointRulesFireWithoutCredential(t *testing.T) {
+	src := `
+endpoint "https" "public" {
+  hosts = ["status.example.com"]
+}
+
+rule "public-reads" {
+  endpoint  = https.public
+  condition = "http.method in ['GET', 'HEAD']"
+  verdict   = "allow"
+}
+rule "public-writes" {
+  endpoint  = https.public
+  condition = "http.method in ['POST', 'PUT', 'DELETE']"
+  verdict   = "deny"
+  reason    = "read-only public endpoint"
+}
+
+profile "data" {
+  credentials = []
+  endpoints   = [https.public]
+}
+`
+	cp := compileFixture(t, src)
+
+	// Routing: the directly-declared endpoint is reachable via the
+	// profile's host index.
+	ep := runtime.HostEndpoint(cp, "data", "status.example.com")
+	if ep == nil || ep.Name != "public" {
+		t.Fatalf("HostEndpoint(data, status.example.com) = %+v, want public", ep)
+	}
+
+	// Rules fire even though no credential is bound.
+	getReq := &match.Request{Family: "http", Method: "GET"}
+	postReq := &match.Request{Family: "http", Method: "POST"}
+	if cr := runtime.MatchRequest(ep, getReq); cr == nil || cr.Outcome.Verdict != "allow" {
+		t.Errorf("GET → %+v, want allow rule public-reads", cr)
+	}
+	if cr := runtime.MatchRequest(ep, postReq); cr == nil || cr.Outcome.Verdict != "deny" {
+		t.Errorf("POST → %+v, want deny rule public-writes", cr)
+	}
+
+	// No credential resolves, and the dispatcher must not raise a
+	// missing-credential diagnostic for a directly-declared endpoint.
+	if cc := runtime.ResolveCredential(cp, "data", ep, getReq); cc != nil {
+		t.Errorf("ResolveCredential for credential-less endpoint = %+v, want nil", cc)
+	}
+	if reason := runtime.CredentialMismatchReason(cp, "data", ep, getReq); reason != "" {
+		t.Errorf("CredentialMismatchReason for credential-less endpoint = %q, want empty", reason)
+	}
+}

--- a/internal/config/testdata/error_old_grammar.errors.txt
+++ b/internal/config/testdata/error_old_grammar.errors.txt
@@ -1,3 +1,2 @@
-error: error_old_grammar.hcl:23:19: Missing required argument — The argument "credentials" is required, but no definition was found.
-error: error_old_grammar.hcl:24:3: Unsupported argument — An argument named "endpoints" is not expected here.
-error: error_old_grammar.hcl:20:3: Unsupported argument — An argument named "credential" is not expected here.
+error: error_old_grammar.hcl:27:19: Missing required argument — The argument "credentials" is required, but no definition was found.
+error: error_old_grammar.hcl:24:3: Unsupported argument — An argument named "credential" is not expected here.

--- a/internal/config/testdata/error_old_grammar.hcl
+++ b/internal/config/testdata/error_old_grammar.hcl
@@ -7,11 +7,15 @@ gateway {
   }
 }
 
-# Old (pre-inversion) grammar: endpoint carries `credential = X` and
-# profile carries `endpoints = [...]`. Under the inverted grammar
-# the credential→endpoint binding lives on the credential, profiles
-# list credentials, and endpoints are bare network targets. Loading
-# the old shape must fail rather than silently succeed.
+# Old (pre-inversion) grammar: endpoint carries `credential = X`.
+# Under the inverted grammar the credential→endpoint binding lives on
+# the credential, and profiles list credentials. Loading the old shape
+# must fail rather than silently succeed. `credentials` is still a
+# required profile argument, so omitting it is an error too.
+#
+# (A profile MAY now also carry an `endpoints = [...]` list to claim
+# credential-less endpoints directly — that grammar is valid and is
+# covered by compile_test.go, so it is intentionally absent here.)
 
 credential "bearer_token" "pat" {}
 
@@ -21,5 +25,4 @@ endpoint "https" "github" {
 }
 
 profile "default" {
-  endpoints = [https.github]
 }

--- a/internal/config/testdata/feature_direct_endpoints.hcl
+++ b/internal/config/testdata/feature_direct_endpoints.hcl
@@ -1,0 +1,50 @@
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
+
+defaults {
+  unknown_host  = "passthrough"
+  llm_fail_mode = "closed"
+}
+
+# Credential-bound endpoint (transitive claim via the credential).
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+
+credential "bearer_token" "github" {
+  endpoint = https.github
+}
+
+# Credential-less endpoints claimed directly by the profile. No
+# credential binds them; the profile's rules still apply.
+endpoint "https" "public_status" {
+  hosts = ["status.example.com"]
+}
+
+endpoint "https" "internal_metrics" {
+  hosts = ["metrics.internal"]
+}
+
+rule "status-reads" {
+  endpoint  = https.public_status
+  condition = "http.method in ['GET', 'HEAD']"
+  verdict   = "allow"
+}
+
+rule "metrics-default-deny" {
+  endpoint = https.internal_metrics
+  priority = -100
+  verdict  = "deny"
+  reason   = "metrics endpoint is read-path only"
+}
+
+profile "data" {
+  credentials = [bearer_token.github]
+  endpoints   = [https.public_status, https.internal_metrics]
+}

--- a/internal/config/testdata/feature_direct_endpoints.want.json
+++ b/internal/config/testdata/feature_direct_endpoints.want.json
@@ -1,0 +1,89 @@
+{
+  "defaults": {
+    "llm_fail_mode": "closed",
+    "unknown_host": "passthrough"
+  },
+  "gateway": {
+    "public_url": "https://gw.example.test",
+    "state_dir": "/opt/clawpatrol",
+    "wireguard": {
+      "subnet_cidr": "10.55.0.0/24"
+    }
+  },
+  "policy": {
+    "credentials": {
+      "github": {
+        "body": {
+          "IdempotencyKey": false
+        },
+        "endpoint": "github",
+        "type": "bearer_token"
+      }
+    },
+    "endpoints": {
+      "github": {
+        "body": {
+          "Hosts": [
+            "api.github.com"
+          ]
+        },
+        "family": "http",
+        "type": "https"
+      },
+      "internal_metrics": {
+        "body": {
+          "Hosts": [
+            "metrics.internal"
+          ]
+        },
+        "family": "http",
+        "type": "https"
+      },
+      "public_status": {
+        "body": {
+          "Hosts": [
+            "status.example.com"
+          ]
+        },
+        "family": "http",
+        "type": "https"
+      }
+    },
+    "profiles": {
+      "data": {
+        "credentials": [
+          "github"
+        ],
+        "endpoints": [
+          "public_status",
+          "internal_metrics"
+        ]
+      }
+    },
+    "rules": {
+      "metrics-default-deny": {
+        "body": {
+          "name": "metrics-default-deny",
+          "family": "http",
+          "endpoints": [
+            "internal_metrics"
+          ],
+          "priority": -100,
+          "verdict": "deny",
+          "reason": "metrics endpoint is read-path only"
+        }
+      },
+      "status-reads": {
+        "body": {
+          "name": "status-reads",
+          "family": "http",
+          "endpoints": [
+            "public_status"
+          ],
+          "condition": "http.method in ['GET', 'HEAD']",
+          "verdict": "allow"
+        }
+      }
+    }
+  }
+}

--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -156,10 +156,12 @@ func (r *renderer) writeOperational() {
 func (r *renderer) writeProfile() {
 	r.out.WriteString("## `profile \"<name>\" { ... }`\n\n")
 	r.out.WriteString("Names a set of credentials. Profiles bind to dashboard owners; an owner's profile determines which credentials — and, transitively via each credential's `endpoint` / `endpoints` binding, which endpoints — their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.\n\n")
+	r.out.WriteString("A profile may also claim endpoints **directly** via the `endpoints` list, independent of any credential. Use this for credential-less endpoints — public APIs the gateway proxies, upstreams authenticated by mTLS / network position / the tunnel itself, or open internal tools. The profile's rules apply to requests routed to a directly-declared endpoint exactly as they do for credential-bound ones; no credential is injected. An endpoint reached both ways (named here *and* via a listed credential) is claimed once — the two sets are merged.\n\n")
 	r.out.WriteString("| Attribute | Type | Required | Description |\n")
 	r.out.WriteString("|-----------|------|----------|-------------|\n")
-	r.out.WriteString("| `credentials` | `[]credential` | yes | Bare-name credential references, or `{ credential = name, <disambiguator> = \"...\" }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). |\n\n")
-	r.out.WriteString("```hcl\nprofile \"default\" {\n  credentials = [bearer_token.github, postgres_credential.postgres-prod]\n}\n```\n\n")
+	r.out.WriteString("| `credentials` | `[]credential` | yes | Bare-name credential references, or `{ credential = name, <disambiguator> = \"...\" }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). May be empty (`[]`) for a profile that only claims endpoints directly. |\n")
+	r.out.WriteString("| `endpoints` | `[]endpoint` | no | Bare-name endpoint references the profile claims directly, with no credential injected. Rules attached to these endpoints still evaluate. |\n\n")
+	r.out.WriteString("```hcl\nprofile \"default\" {\n  credentials = [bearer_token.github, postgres_credential.postgres-prod]\n}\n\n# Credential-less: rules apply, nothing is injected.\nprofile \"public\" {\n  credentials = []\n  endpoints   = [endpoint.public_status, endpoint.internal_metrics]\n}\n```\n\n")
 }
 
 // ── plugin-dispatched kinds ─────────────────────────────────────────

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -37,13 +37,22 @@ Operational settings live under the required top-level `gateway { ... }` block. 
 
 Names a set of credentials. Profiles bind to dashboard owners; an owner's profile determines which credentials — and, transitively via each credential's `endpoint` / `endpoints` binding, which endpoints — their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.
 
+A profile may also claim endpoints **directly** via the `endpoints` list, independent of any credential. Use this for credential-less endpoints — public APIs the gateway proxies, upstreams authenticated by mTLS / network position / the tunnel itself, or open internal tools. The profile's rules apply to requests routed to a directly-declared endpoint exactly as they do for credential-bound ones; no credential is injected. An endpoint reached both ways (named here *and* via a listed credential) is claimed once — the two sets are merged.
+
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `credentials` | `[]credential` | yes | Bare-name credential references, or `{ credential = name, <disambiguator> = "..." }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). |
+| `credentials` | `[]credential` | yes | Bare-name credential references, or `{ credential = name, <disambiguator> = "..." }` object entries for multi-credential dispatch (e.g. `placeholder` for header-token credentials). May be empty (`[]`) for a profile that only claims endpoints directly. |
+| `endpoints` | `[]endpoint` | no | Bare-name endpoint references the profile claims directly, with no credential injected. Rules attached to these endpoints still evaluate. |
 
 ```hcl
 profile "default" {
   credentials = [bearer_token.github, postgres_credential.postgres-prod]
+}
+
+# Credential-less: rules apply, nothing is injected.
+profile "public" {
+  credentials = []
+  endpoints   = [endpoint.public_status, endpoint.internal_metrics]
 }
 ```
 


### PR DESCRIPTION
## Summary

Profiles previously claimed an endpoint only **transitively, via a credential** bound to it. Endpoints with no credential — public APIs the gateway proxies, upstreams authenticated by mTLS / network position / the tunnel itself, or open internal tools — could not be claimed, so the profile's rules never ran for requests routed to them.

This adds an `endpoints = [endpoint.foo, ...]` list to the `profile` block. Endpoints listed there are claimed **directly**: routed and rule-matched under the profile, with no credential injected. The transitive set (via credentials) and the direct set are merged and deduplicated.

```hcl
profile "public" {
  credentials = []
  endpoints   = [endpoint.public_status, endpoint.internal_metrics]
}
```

## Changes

- **config** — `Profile.Endpoints`; profile-block `endpoints` attribute + decoder; load-time cross-check that each reference resolves to a declared endpoint.
- **compile** — extracted `CompiledProfile.claimEndpoint` helper (host indexing, idempotent); the profile loop now claims directly-declared endpoints without an `EndpointCredentials` entry. Endpoints reached both ways collapse to one claim.
- **emit / dump** — round-trip the new field.
- **runtime** — the HTTP dispatcher already tolerates a nil credential (forwards without injection; `MatchRequest` fires rules unconditionally), so no change was needed for credential-less HTTP endpoints. SQL families that genuinely require auth are unchanged (out of scope).
- **dashboard** — rules on directly-declared endpoints surface through the existing rules listing (`collectRuleSummaries` walks `prof.Endpoints`), now split into a testable free function. The device-page RulesPanel and `/api/rules` pick them up automatically, scoped to the claiming profile.
- **doc** — `site/doc/config-reference.md` profile section.

## Tests

- Compile: profile shape, credential+direct dedup, sibling-leak isolation, unknown-reference rejection.
- Runtime: rules fire for a credential-less endpoint; dispatcher raises no missing-credential error.
- API: rule summaries surface direct-endpoint rules under the claiming profile only.
- `feature_direct_endpoints.hcl` fixture exercises load + emit round-trip goldens.

All Go tests green (`internal/config/...`, `cmd/clawpatrol`); `gofmt` clean.

Closes cl-2d49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)