### PR TITLE
feat: RBAC roles (tiered, profile-scoped)

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -1050,6 +1050,10 @@ func (w *webMux) apiAgentProfile(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "unknown profile", 400)
 		return
 	}
+	if bindings, _ := rolesFromContext(r.Context()); !canEditProfile(bindings, profile) {
+		http.Error(rw, "editing profile "+profile+" requires editor on that profile", http.StatusForbidden)
+		return
+	}
 	w.g.onboard.AssignProfile(ip, profile)
 	writeJSON(rw, map[string]any{"ok": true, "ip": ip, "profile": profile})
 }

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2902,6 +2902,9 @@ func runGateway(args []string) {
 	warnIfStateLooselyPermissioned(stateDir)
 	setDB(db)
 	applyDashboardPasswordFlags(db, *setDashboardPassword, *resetDashboardPassword)
+	if err := seedRBAC(db, cfg.Operators()); err != nil {
+		log.Printf("rbac seed: %v", err)
+	}
 	logDashboardAuthState(db, cfg)
 	blobs := newGatewayBlobStore(db)
 	endpoints.SetBlobStore(blobs)

--- a/cmd/clawpatrol/migrations/sqlite/0020_rbac.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0020_rbac.sql
@@ -1,0 +1,52 @@
+-- RBAC: transport-agnostic roles.
+--
+-- Until now authorization was binary: a caller who cleared the
+-- dashboard gate (root password, or a tailnet login in the operators
+-- allowlist) could do everything — edit any profile, set any
+-- credential, approve any device. These tables add a roles layer on
+-- top of that gate: identity is established by the existing gate
+-- (password session or tailscale whois), then a (role, scope) lookup
+-- decides what the identity may actually do.
+--
+-- Three tables, deliberately decoupled so identity is independent of
+-- transport:
+--
+--   rbac_users         one row per principal (human or machine)
+--   rbac_identities    external logins bound to a user — provider is
+--                      'password' (dashboard username) or 'tailscale'
+--                      (whois login); future: 'oidc', 'device_token'
+--   rbac_role_bindings (role, scope) grants per user; scope is '*'
+--                      (global) or 'profile:<name>'
+--
+-- A tailnet login becomes just one identity provider rather than the
+-- authorization mechanism, so the same role model works for
+-- WireGuard-only nodes (which have no whois) the moment they get a
+-- password or OIDC identity.
+
+CREATE TABLE rbac_users (
+  id           TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL DEFAULT '',
+  disabled     INTEGER NOT NULL DEFAULT 0,
+  created_ns   INTEGER NOT NULL,
+  updated_ns   INTEGER NOT NULL
+);
+
+CREATE TABLE rbac_identities (
+  provider    TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  user_id     TEXT NOT NULL REFERENCES rbac_users(id) ON DELETE CASCADE,
+  created_ns  INTEGER NOT NULL,
+  PRIMARY KEY (provider, external_id)
+);
+
+CREATE INDEX rbac_identities_user_idx ON rbac_identities(user_id);
+
+CREATE TABLE rbac_role_bindings (
+  user_id    TEXT NOT NULL REFERENCES rbac_users(id) ON DELETE CASCADE,
+  role       TEXT NOT NULL,
+  scope      TEXT NOT NULL,
+  created_ns INTEGER NOT NULL,
+  PRIMARY KEY (user_id, role, scope)
+);
+
+CREATE INDEX rbac_role_bindings_user_idx ON rbac_role_bindings(user_id);

--- a/cmd/clawpatrol/roles.go
+++ b/cmd/clawpatrol/roles.go
@@ -1,0 +1,370 @@
+package main
+
+// Role-based access control. See migrations/sqlite/0020_rbac.sql for
+// the data model and the rationale for decoupling identity from
+// transport.
+//
+// The model is three tiers crossed with a scope:
+//
+//	viewer  read-only dashboard access
+//	editor  viewer + profile assignment + credential / OAuth edits
+//	admin   editor + user/role management
+//
+// A binding's scope is either scopeGlobal ("*") or a single profile
+// ("profile:<name>"). A global editor may edit every profile; a
+// profile-scoped editor may only touch the one named profile and may
+// not edit global credentials.
+//
+// Backward compatibility: any identity the dashboard gate already lets
+// through (root password, or a tailnet login matching the operators
+// allowlist) is lazily granted admin/* the first time it is seen, so
+// upgrading an existing deployment changes no behavior. Narrowing a
+// principal is opt-in — an admin revokes the admin/* binding and
+// grants something tighter.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RBAC roles, weakest to strongest.
+const (
+	roleViewer = "viewer"
+	roleEditor = "editor"
+	roleAdmin  = "admin"
+)
+
+// Binding scopes. scopeGlobal grants the role across every profile;
+// otherwise a binding is pinned to one profile via scopeProfilePrefix.
+const (
+	scopeGlobal        = "*"
+	scopeProfilePrefix = "profile:"
+)
+
+// Identity providers. A tailnet login and a dashboard username are two
+// providers binding to (possibly different) users — the role model
+// does not care which transport the request arrived on.
+const (
+	rbacProviderPassword  = "password"
+	rbacProviderTailscale = "tailscale"
+)
+
+// profileScope builds the scope string for a single profile.
+func profileScope(name string) string { return scopeProfilePrefix + name }
+
+// roleRank orders the tiers so a stronger role satisfies a weaker
+// requirement. Unknown strings rank 0 and satisfy nothing.
+func roleRank(role string) int {
+	switch role {
+	case roleViewer:
+		return 1
+	case roleEditor:
+		return 2
+	case roleAdmin:
+		return 3
+	}
+	return 0
+}
+
+// validRole reports whether role is one of the three known tiers.
+func validRole(role string) bool { return roleRank(role) > 0 }
+
+// roleBinding is a single (role, scope) grant.
+type roleBinding struct {
+	Role  string `json:"role"`
+	Scope string `json:"scope"`
+}
+
+// providerForPrincipal maps a request principal to its RBAC identity
+// coordinates. ok is false for principals that carry no stable
+// identity (which never reach an authorized route).
+func providerForPrincipal(p principal) (provider, externalID string, ok bool) {
+	switch p.Kind {
+	case principalDashboardPassword:
+		return rbacProviderPassword, p.Owner, p.Owner != ""
+	case principalTailnet:
+		return rbacProviderTailscale, p.Owner, p.Owner != ""
+	}
+	return "", "", false
+}
+
+// rbacUserID is the stable internal id for an identity. One user per
+// identity in V1 (id encodes the binding); the schema still supports
+// many identities per user for a future merge.
+func rbacUserID(provider, externalID string) string {
+	return provider + ":" + externalID
+}
+
+// ensureUser inserts the user + identity rows for (provider,
+// externalID) if absent and returns the user id. Idempotent.
+func ensureUser(db *sql.DB, provider, externalID, displayName string) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("no db")
+	}
+	if provider == "" || externalID == "" {
+		return "", fmt.Errorf("rbac: empty provider or external id")
+	}
+	id := rbacUserID(provider, externalID)
+	now := time.Now().UnixNano()
+	if displayName == "" {
+		displayName = externalID
+	}
+	if _, err := db.Exec(
+		`INSERT INTO rbac_users (id, display_name, disabled, created_ns, updated_ns)
+		 VALUES (?, ?, 0, ?, ?)
+		 ON CONFLICT(id) DO NOTHING`,
+		id, displayName, now, now,
+	); err != nil {
+		return "", fmt.Errorf("rbac: ensure user: %w", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO rbac_identities (provider, external_id, user_id, created_ns)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(provider, external_id) DO NOTHING`,
+		provider, externalID, id, now,
+	); err != nil {
+		return "", fmt.Errorf("rbac: ensure identity: %w", err)
+	}
+	return id, nil
+}
+
+// bindingsForUser returns every (role, scope) grant for a user id.
+func bindingsForUser(db *sql.DB, userID string) ([]roleBinding, error) {
+	if db == nil {
+		return nil, fmt.Errorf("no db")
+	}
+	rows, err := db.Query(
+		`SELECT role, scope FROM rbac_role_bindings WHERE user_id = ? ORDER BY role, scope`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []roleBinding
+	for rows.Next() {
+		var b roleBinding
+		if err := rows.Scan(&b.Role, &b.Scope); err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// grantRole ensures the user exists and upserts a (role, scope)
+// binding. Validates the role tier; scope shape is the caller's
+// responsibility (the API layer validates against declared profiles).
+func grantRole(db *sql.DB, provider, externalID, role, scope string) error {
+	if !validRole(role) {
+		return fmt.Errorf("rbac: unknown role %q", role)
+	}
+	if scope == "" {
+		return fmt.Errorf("rbac: empty scope")
+	}
+	userID, err := ensureUser(db, provider, externalID, "")
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(
+		`INSERT INTO rbac_role_bindings (user_id, role, scope, created_ns)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(user_id, role, scope) DO NOTHING`,
+		userID, role, scope, time.Now().UnixNano(),
+	)
+	return err
+}
+
+// revokeRole removes one (role, scope) binding for the identity.
+// Idempotent — revoking an absent binding is a no-op.
+func revokeRole(db *sql.DB, provider, externalID, role, scope string) error {
+	if db == nil {
+		return fmt.Errorf("no db")
+	}
+	_, err := db.Exec(
+		`DELETE FROM rbac_role_bindings WHERE user_id = ? AND role = ? AND scope = ?`,
+		rbacUserID(provider, externalID), role, scope,
+	)
+	return err
+}
+
+// --- authorization predicates -------------------------------------
+
+// hasGlobal reports whether any binding grants at least minRole at the
+// global scope.
+func hasGlobal(bindings []roleBinding, minRole string) bool {
+	want := roleRank(minRole)
+	for _, b := range bindings {
+		if b.Scope == scopeGlobal && roleRank(b.Role) >= want {
+			return true
+		}
+	}
+	return false
+}
+
+// canView reports whether the principal may read the dashboard. Any
+// binding at any scope is enough — a profile-scoped editor still needs
+// to see the dashboard to do its job.
+func canView(bindings []roleBinding) bool { return len(bindings) > 0 }
+
+// canManageUsers reports whether the principal may grant/revoke roles.
+// Admin at the global scope only.
+func canManageUsers(bindings []roleBinding) bool { return hasGlobal(bindings, roleAdmin) }
+
+// canEditGlobal reports whether the principal may perform an
+// unscoped write (e.g. editing a credential, which is global). Global
+// editor or admin.
+func canEditGlobal(bindings []roleBinding) bool { return hasGlobal(bindings, roleEditor) }
+
+// canEditProfile reports whether the principal may edit the named
+// profile — a global editor/admin, or an editor/admin scoped to that
+// profile.
+func canEditProfile(bindings []roleBinding, profile string) bool {
+	if hasGlobal(bindings, roleEditor) {
+		return true
+	}
+	want := profileScope(profile)
+	for _, b := range bindings {
+		if b.Scope == want && roleRank(b.Role) >= roleRank(roleEditor) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- request-scoped role context ----------------------------------
+
+type rolesContextKey struct{}
+
+func contextWithRoles(ctx context.Context, bindings []roleBinding) context.Context {
+	return context.WithValue(ctx, rolesContextKey{}, bindings)
+}
+
+func rolesFromContext(ctx context.Context) ([]roleBinding, bool) {
+	b, ok := ctx.Value(rolesContextKey{}).([]roleBinding)
+	return b, ok
+}
+
+// --- seeding -------------------------------------------------------
+
+// effectiveBindings resolves a principal to its bindings, lazily
+// granting admin/* the first time an already-gated identity is seen.
+// This is the backward-compatibility hinge: every caller the dashboard
+// gate admits keeps full access until an admin narrows them.
+func effectiveBindings(db *sql.DB, p principal) ([]roleBinding, error) {
+	provider, externalID, ok := providerForPrincipal(p)
+	if !ok {
+		return nil, fmt.Errorf("rbac: principal has no identity")
+	}
+	userID, err := ensureUser(db, provider, externalID, p.Host)
+	if err != nil {
+		return nil, err
+	}
+	bindings, err := bindingsForUser(db, userID)
+	if err != nil {
+		return nil, err
+	}
+	if len(bindings) == 0 {
+		if err := grantRole(db, provider, externalID, roleAdmin, scopeGlobal); err != nil {
+			return nil, err
+		}
+		bindings = []roleBinding{{Role: roleAdmin, Scope: scopeGlobal}}
+	}
+	return bindings, nil
+}
+
+// seedRBAC bootstraps role rows at startup so the dashboard reflects
+// them before anyone logs in. The root password user becomes admin/*,
+// and every concrete operator login (non-wildcard entries) is seeded
+// admin/* too. Wildcard operator entries ("*@domain") and any login
+// not listed here are seeded lazily by effectiveBindings on first
+// request. Existing bindings are never overwritten, so admin edits
+// survive restarts.
+func seedRBAC(db *sql.DB, operators []string) error {
+	if db == nil {
+		return fmt.Errorf("no db")
+	}
+	if err := seedAdminIfUnbound(db, rbacProviderPassword, dashboardRootUsername); err != nil {
+		return fmt.Errorf("rbac: seed root: %w", err)
+	}
+	for _, entry := range operators {
+		if strings.HasPrefix(entry, "*@") || !strings.Contains(entry, "@") {
+			continue // wildcard / non-login — handled lazily
+		}
+		if err := seedAdminIfUnbound(db, rbacProviderTailscale, entry); err != nil {
+			return fmt.Errorf("rbac: seed operator %q: %w", entry, err)
+		}
+	}
+	return nil
+}
+
+// seedAdminIfUnbound grants admin/* to an identity only when it has no
+// bindings yet, preserving any narrower grant an admin set later.
+func seedAdminIfUnbound(db *sql.DB, provider, externalID string) error {
+	userID, err := ensureUser(db, provider, externalID, "")
+	if err != nil {
+		return err
+	}
+	bindings, err := bindingsForUser(db, userID)
+	if err != nil {
+		return err
+	}
+	if len(bindings) > 0 {
+		return nil
+	}
+	return grantRole(db, provider, externalID, roleAdmin, scopeGlobal)
+}
+
+// --- listing (for the management API) ------------------------------
+
+// rbacUserView is the dashboard-facing shape of a user: its identities
+// folded in and its bindings sorted for stable rendering.
+type rbacUserView struct {
+	ID          string        `json:"id"`
+	DisplayName string        `json:"display_name"`
+	Provider    string        `json:"provider"`
+	ExternalID  string        `json:"external_id"`
+	Bindings    []roleBinding `json:"bindings"`
+}
+
+// listRBACUsers returns every user with its identity + bindings, sorted
+// by id for deterministic output.
+func listRBACUsers(db *sql.DB) ([]rbacUserView, error) {
+	if db == nil {
+		return nil, fmt.Errorf("no db")
+	}
+	rows, err := db.Query(
+		`SELECT u.id, u.display_name, i.provider, i.external_id
+		   FROM rbac_users u
+		   JOIN rbac_identities i ON i.user_id = u.id
+		  ORDER BY u.id`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []rbacUserView
+	for rows.Next() {
+		var v rbacUserView
+		if err := rows.Scan(&v.ID, &v.DisplayName, &v.Provider, &v.ExternalID); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range out {
+		b, err := bindingsForUser(db, out[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		out[i].Bindings = b
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}

--- a/cmd/clawpatrol/roles.go
+++ b/cmd/clawpatrol/roles.go
@@ -144,7 +144,7 @@ func bindingsForUser(db *sql.DB, userID string) ([]roleBinding, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var out []roleBinding
 	for rows.Next() {
 		var b roleBinding
@@ -346,7 +346,7 @@ func listRBACUsers(db *sql.DB) ([]rbacUserView, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var out []rbacUserView
 	for rows.Next() {
 		var v rbacUserView

--- a/cmd/clawpatrol/roles_api.go
+++ b/cmd/clawpatrol/roles_api.go
@@ -1,0 +1,199 @@
+package main
+
+// Dashboard endpoints + middleware for RBAC. The middleware
+// (authzGate) runs after the identity gates (dashboardAuthGate,
+// tailnetGate) have injected a principal: it resolves the principal to
+// its role bindings, enforces admin-only management routes, and stashes
+// the bindings on the request context for per-handler scope checks.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// RBAC management route paths. /me is readable by any authorized
+// caller (the SPA uses it to hide controls it can't use); the rest
+// mutate or list grants and require admin/*.
+const (
+	rbacRouteMe     = "/api/rbac/me"
+	rbacRouteUsers  = "/api/rbac/users"
+	rbacRouteGrant  = "/api/rbac/grant"
+	rbacRouteRevoke = "/api/rbac/revoke"
+)
+
+// isRBACAdminRoute reports whether path is an RBAC management route
+// that requires admin/*. /api/rbac/me is excluded — it only reflects
+// the caller's own grants.
+func isRBACAdminRoute(path string) bool {
+	return strings.HasPrefix(path, "/api/rbac/") && path != rbacRouteMe
+}
+
+// authzGate resolves the request principal to its role bindings,
+// enforces admin-only management routes, and attaches the bindings to
+// the context for downstream scope checks. Public and
+// self-authenticating routes carry no dashboard principal and are
+// passed straight through.
+func (w *webMux) authzGate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		req := w.authRequirementForPath(r.URL.Path)
+		if req == authPublic || req == authSelfAuthenticating {
+			next.ServeHTTP(rw, r)
+			return
+		}
+		p, ok := principalFromContext(r.Context())
+		if !ok {
+			// No principal on a gated route should be impossible — the
+			// upstream gates 401/403 first. Pass through defensively
+			// rather than masking that bug with a confusing 403 here.
+			next.ServeHTTP(rw, r)
+			return
+		}
+		bindings, err := effectiveBindings(w.g.db, p)
+		if err != nil {
+			http.Error(rw, "authz lookup failed", http.StatusServiceUnavailable)
+			return
+		}
+		if !canView(bindings) {
+			http.Error(rw, "no role grants for this identity", http.StatusForbidden)
+			return
+		}
+		if isRBACAdminRoute(r.URL.Path) && !canManageUsers(bindings) {
+			http.Error(rw, "role management requires admin", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(rw, r.WithContext(contextWithRoles(r.Context(), bindings)))
+	})
+}
+
+// apiRBACMe returns the caller's own bindings + derived capabilities so
+// the dashboard can show/hide controls.
+func (w *webMux) apiRBACMe(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(rw, "GET", http.StatusMethodNotAllowed)
+		return
+	}
+	bindings, _ := rolesFromContext(r.Context())
+	writeJSON(rw, map[string]any{
+		"bindings":     bindings,
+		"can_manage":   canManageUsers(bindings),
+		"can_edit_all": canEditGlobal(bindings),
+	})
+}
+
+// apiRBACUsers lists every user with identities + bindings. Admin-only
+// (enforced by authzGate).
+func (w *webMux) apiRBACUsers(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(rw, "GET", http.StatusMethodNotAllowed)
+		return
+	}
+	users, err := listRBACUsers(w.g.db)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(rw, users)
+}
+
+// rbacGrantBody is the shared shape for grant/revoke. provider is
+// "password" or "tailscale"; external_id is the username or whois
+// login; scope is "*" or "profile:<name>".
+type rbacGrantBody struct {
+	Provider   string `json:"provider"`
+	ExternalID string `json:"external_id"`
+	Role       string `json:"role"`
+	Scope      string `json:"scope"`
+}
+
+// validateScope accepts "*" or "profile:<name>" where the profile is
+// declared in the loaded policy. A scope naming an unknown profile is
+// rejected so a typo can't mint a binding that grants nothing (or, on
+// a later profile rename, silently grants something).
+func (w *webMux) validateScope(scope string) bool {
+	if scope == scopeGlobal {
+		return true
+	}
+	name, ok := strings.CutPrefix(scope, scopeProfilePrefix)
+	if !ok || name == "" {
+		return false
+	}
+	for _, n := range orderedProfileNames(w.g.cfg.Policy) {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func validProvider(p string) bool {
+	return p == rbacProviderPassword || p == rbacProviderTailscale
+}
+
+// apiRBACGrant upserts a (role, scope) binding for an identity.
+func (w *webMux) apiRBACGrant(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	var body rbacGrantBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !validProvider(body.Provider) || body.ExternalID == "" {
+		http.Error(rw, "missing or invalid provider/external_id", http.StatusBadRequest)
+		return
+	}
+	if !validRole(body.Role) {
+		http.Error(rw, "role must be viewer, editor, or admin", http.StatusBadRequest)
+		return
+	}
+	if !w.validateScope(body.Scope) {
+		http.Error(rw, `scope must be "*" or "profile:<declared-profile>"`, http.StatusBadRequest)
+		return
+	}
+	if err := grantRole(w.g.db, body.Provider, body.ExternalID, body.Role, body.Scope); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(rw, map[string]any{"ok": true})
+}
+
+// apiRBACRevoke deletes one (role, scope) binding. Revoking the last
+// admin/* binding is allowed — the lazy seed in effectiveBindings will
+// not re-grant admin to an identity that still has any other binding,
+// so an admin can fully demote an operator. Guard against locking
+// everyone out by refusing to revoke the caller's own last admin
+// binding.
+func (w *webMux) apiRBACRevoke(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	var body rbacGrantBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !validProvider(body.Provider) || body.ExternalID == "" {
+		http.Error(rw, "missing or invalid provider/external_id", http.StatusBadRequest)
+		return
+	}
+	// Self-lockout guard: don't let an admin revoke their own admin/*
+	// if it's their only admin grant.
+	if body.Role == roleAdmin && body.Scope == scopeGlobal {
+		if p, ok := principalFromContext(r.Context()); ok {
+			prov, ext, ok := providerForPrincipal(p)
+			if ok && prov == body.Provider && ext == body.ExternalID {
+				http.Error(rw, "refusing to revoke your own admin/* binding", http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	if err := revokeRole(w.g.db, body.Provider, body.ExternalID, body.Role, body.Scope); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(rw, map[string]any{"ok": true})
+}

--- a/cmd/clawpatrol/roles_test.go
+++ b/cmd/clawpatrol/roles_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func newRBACTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRoleRankOrdering(t *testing.T) {
+	if !(roleRank(roleAdmin) > roleRank(roleEditor) && roleRank(roleEditor) > roleRank(roleViewer)) {
+		t.Fatal("role ranks must be admin > editor > viewer")
+	}
+	if roleRank("nonsense") != 0 {
+		t.Fatal("unknown role must rank 0")
+	}
+}
+
+func TestGrantAndBindings(t *testing.T) {
+	db := newRBACTestDB(t)
+	if err := grantRole(db, rbacProviderTailscale, "alice@example.com", roleEditor, profileScope("avocet2")); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	// Idempotent re-grant.
+	if err := grantRole(db, rbacProviderTailscale, "alice@example.com", roleEditor, profileScope("avocet2")); err != nil {
+		t.Fatalf("regrant: %v", err)
+	}
+	bs, err := bindingsForUser(db, rbacUserID(rbacProviderTailscale, "alice@example.com"))
+	if err != nil {
+		t.Fatalf("bindings: %v", err)
+	}
+	if len(bs) != 1 || bs[0].Role != roleEditor || bs[0].Scope != profileScope("avocet2") {
+		t.Fatalf("unexpected bindings: %+v", bs)
+	}
+}
+
+func TestGrantRejectsUnknownRole(t *testing.T) {
+	db := newRBACTestDB(t)
+	if err := grantRole(db, rbacProviderPassword, "root", "superuser", scopeGlobal); err == nil {
+		t.Fatal("expected error for unknown role")
+	}
+}
+
+func TestAuthorizePredicates(t *testing.T) {
+	globalAdmin := []roleBinding{{roleAdmin, scopeGlobal}}
+	globalEditor := []roleBinding{{roleEditor, scopeGlobal}}
+	scopedEditor := []roleBinding{{roleEditor, profileScope("avocet2")}}
+	viewerOnly := []roleBinding{{roleViewer, scopeGlobal}}
+
+	cases := []struct {
+		name     string
+		bindings []roleBinding
+		view     bool
+		manage   bool
+		editAll  bool
+		editAvo  bool
+		editOrd  bool
+	}{
+		{"admin", globalAdmin, true, true, true, true, true},
+		{"global editor", globalEditor, true, false, true, true, true},
+		{"scoped editor", scopedEditor, true, false, false, true, false},
+		{"viewer", viewerOnly, true, false, false, false, false},
+		{"none", nil, false, false, false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if canView(c.bindings) != c.view {
+				t.Errorf("canView = %v, want %v", canView(c.bindings), c.view)
+			}
+			if canManageUsers(c.bindings) != c.manage {
+				t.Errorf("canManageUsers = %v, want %v", canManageUsers(c.bindings), c.manage)
+			}
+			if canEditGlobal(c.bindings) != c.editAll {
+				t.Errorf("canEditGlobal = %v, want %v", canEditGlobal(c.bindings), c.editAll)
+			}
+			if canEditProfile(c.bindings, "avocet2") != c.editAvo {
+				t.Errorf("canEditProfile(avocet2) = %v, want %v", canEditProfile(c.bindings, "avocet2"), c.editAvo)
+			}
+			if canEditProfile(c.bindings, "ord") != c.editOrd {
+				t.Errorf("canEditProfile(ord) = %v, want %v", canEditProfile(c.bindings, "ord"), c.editOrd)
+			}
+		})
+	}
+}
+
+func TestSeedRBACRootAndOperators(t *testing.T) {
+	db := newRBACTestDB(t)
+	ops := []string{"alice@example.com", "*@example.com", "tagged-devices"}
+	if err := seedRBAC(db, ops); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// root → admin/*
+	rootBindings, _ := bindingsForUser(db, rbacUserID(rbacProviderPassword, dashboardRootUsername))
+	if !canManageUsers(rootBindings) {
+		t.Fatalf("root must be admin/*, got %+v", rootBindings)
+	}
+	// concrete operator → admin/*
+	aliceBindings, _ := bindingsForUser(db, rbacUserID(rbacProviderTailscale, "alice@example.com"))
+	if !canManageUsers(aliceBindings) {
+		t.Fatalf("alice must be admin/*, got %+v", aliceBindings)
+	}
+	// wildcard + non-login entries are NOT pre-seeded
+	wildBindings, _ := bindingsForUser(db, rbacUserID(rbacProviderTailscale, "*@example.com"))
+	if len(wildBindings) != 0 {
+		t.Fatalf("wildcard entry must not be seeded, got %+v", wildBindings)
+	}
+}
+
+func TestSeedDoesNotOverrideNarrowedGrant(t *testing.T) {
+	db := newRBACTestDB(t)
+	// Admin narrows alice to a scoped editor.
+	if err := grantRole(db, rbacProviderTailscale, "alice@example.com", roleEditor, profileScope("avocet2")); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	// A later restart re-seeds operators.
+	if err := seedRBAC(db, []string{"alice@example.com"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	bs, _ := bindingsForUser(db, rbacUserID(rbacProviderTailscale, "alice@example.com"))
+	if canManageUsers(bs) {
+		t.Fatalf("seed must not re-promote a narrowed operator, got %+v", bs)
+	}
+	if !canEditProfile(bs, "avocet2") || canEditProfile(bs, "ord") {
+		t.Fatalf("narrowed grant must survive restart, got %+v", bs)
+	}
+}
+
+func TestEffectiveBindingsLazyAdminSeed(t *testing.T) {
+	db := newRBACTestDB(t)
+	// A wildcard-matched operator with no pre-seed gets admin/* lazily,
+	// preserving pre-RBAC behavior.
+	p := principal{Kind: principalTailnet, Owner: "bob@example.com", User: "bob@example.com"}
+	bs, err := effectiveBindings(db, p)
+	if err != nil {
+		t.Fatalf("effectiveBindings: %v", err)
+	}
+	if !canManageUsers(bs) {
+		t.Fatalf("first sight of gated identity must be admin/*, got %+v", bs)
+	}
+	// Persisted, so a second call returns the same without re-seeding.
+	again, _ := bindingsForUser(db, rbacUserID(rbacProviderTailscale, "bob@example.com"))
+	if !canManageUsers(again) {
+		t.Fatalf("lazy seed must persist, got %+v", again)
+	}
+}
+
+func TestRevokeRole(t *testing.T) {
+	db := newRBACTestDB(t)
+	_ = grantRole(db, rbacProviderTailscale, "alice@example.com", roleAdmin, scopeGlobal)
+	_ = grantRole(db, rbacProviderTailscale, "alice@example.com", roleEditor, profileScope("avocet2"))
+	if err := revokeRole(db, rbacProviderTailscale, "alice@example.com", roleAdmin, scopeGlobal); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	bs, _ := bindingsForUser(db, rbacUserID(rbacProviderTailscale, "alice@example.com"))
+	if canManageUsers(bs) {
+		t.Fatalf("admin should be revoked, got %+v", bs)
+	}
+	if !canEditProfile(bs, "avocet2") {
+		t.Fatalf("scoped editor should remain, got %+v", bs)
+	}
+}
+
+func TestListRBACUsers(t *testing.T) {
+	db := newRBACTestDB(t)
+	_ = grantRole(db, rbacProviderPassword, "root", roleAdmin, scopeGlobal)
+	_ = grantRole(db, rbacProviderTailscale, "alice@example.com", roleEditor, profileScope("avocet2"))
+	users, err := listRBACUsers(db)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("want 2 users, got %d: %+v", len(users), users)
+	}
+	// Sorted by id: "password:root" < "tailscale:alice@..."
+	if users[0].Provider != rbacProviderPassword || users[1].Provider != rbacProviderTailscale {
+		t.Fatalf("unexpected ordering: %+v", users)
+	}
+}

--- a/cmd/clawpatrol/roles_test.go
+++ b/cmd/clawpatrol/roles_test.go
@@ -17,7 +17,7 @@ func newRBACTestDB(t *testing.T) *sql.DB {
 }
 
 func TestRoleRankOrdering(t *testing.T) {
-	if !(roleRank(roleAdmin) > roleRank(roleEditor) && roleRank(roleEditor) > roleRank(roleViewer)) {
+	if roleRank(roleAdmin) <= roleRank(roleEditor) || roleRank(roleEditor) <= roleRank(roleViewer) {
 		t.Fatal("role ranks must be admin > editor > viewer")
 	}
 	if roleRank("nonsense") != 0 {

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -207,7 +207,7 @@ func (w *webMux) handler() http.Handler {
 	}
 	w.mountCredentialWebhooks(mux)
 	mux.Handle("/", w.staticHandler())
-	return w.dashboardAuthGate(w.tailnetGate(mux))
+	return w.dashboardAuthGate(w.tailnetGate(w.authzGate(mux)))
 }
 
 func (w *webMux) routes() []webRoute {
@@ -264,6 +264,13 @@ func (w *webMux) routes() []webRoute {
 		// session to clear; the dashboard SPA disables the button for
 		// them rather than calling this endpoint).
 		{Method: http.MethodPost, Path: "/__logout", Auth: authDashboard, Handler: w.apiDashboardLogout},
+		// RBAC management. All authDashboard for reachability; authzGate
+		// enforces the actual role requirement (admin/* for users/grant/
+		// revoke, any grant for /me).
+		{Method: http.MethodGet, Path: rbacRouteMe, Auth: authDashboard, Handler: w.apiRBACMe},
+		{Method: http.MethodGet, Path: rbacRouteUsers, Auth: authDashboard, Handler: w.apiRBACUsers},
+		{Method: http.MethodPost, Path: rbacRouteGrant, Auth: authDashboard, Handler: w.apiRBACGrant},
+		{Method: http.MethodPost, Path: rbacRouteRevoke, Auth: authDashboard, Handler: w.apiRBACRevoke},
 	}
 }
 
@@ -1221,6 +1228,10 @@ func (w *webMux) apiCredentialsSet(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "missing id", 400)
 		return
 	}
+	if bindings, _ := rolesFromContext(r.Context()); !canEditGlobal(bindings) {
+		http.Error(rw, "editing credentials requires a global editor or admin role", http.StatusForbidden)
+		return
+	}
 	policy := w.g.policy.Load()
 	ent, ok := policy.Credentials[body.ID]
 	if !ok {
@@ -1276,6 +1287,10 @@ func (w *webMux) apiCredentialsClear(rw http.ResponseWriter, r *http.Request) {
 	}
 	if body.ID == "" {
 		http.Error(rw, "missing id", 400)
+		return
+	}
+	if bindings, _ := rolesFromContext(r.Context()); !canEditGlobal(bindings) {
+		http.Error(rw, "editing credentials requires a global editor or admin role", http.StatusForbidden)
 		return
 	}
 	if err := clearCredentialSecrets(w.g.db, body.ID); err != nil {

--- a/cmd/clawpatrol/web_credentials_test.go
+++ b/cmd/clawpatrol/web_credentials_test.go
@@ -52,6 +52,7 @@ func TestAPICredentialsSetPreservesUntouchedSlotsAndClearsExplicitEmpty(t *testi
 		"/api/credentials/set",
 		strings.NewReader(`{"id":"client-tls","owner":"default","slots":{"cert":"new-cert","ca":""}}`),
 	)
+	req = req.WithContext(contextWithRoles(req.Context(), []roleBinding{{roleAdmin, scopeGlobal}}))
 	rr := httptest.NewRecorder()
 	w.apiCredentialsSet(rr, req)
 

--- a/doc/roles.md
+++ b/doc/roles.md
@@ -1,0 +1,145 @@
+# Roles (RBAC)
+
+Status: **V1 backend, additive.** No behavior change on upgrade. The
+dashboard UI and the deeper follow-ups (removing the operators
+allowlist, multi-user password login, onboarding-approve scoping, audit
+log) are intentionally **not** in this change — see [Not in
+V1](#not-in-v1).
+
+## Why
+
+Before this, authorization was binary. Any caller who cleared the
+dashboard gate — the root password, or a tailnet login in the
+`tailscale { operators = [...] }` allowlist — could do everything: edit
+any profile, set any credential, approve any device. There was no way
+to say "this operator may only manage the `avocet2` profile."
+
+Roles add a layer on top of the existing identity gate: the gate still
+decides *who you are*; roles decide *what you may do*.
+
+## Model
+
+Identity is decoupled from transport. A Tailscale whois login and a
+dashboard password are two **identity providers** that bind to a user;
+roles live in the database, not in the tailnet. The same role model
+therefore works for a WireGuard-only node — which has no whois — the
+moment that node gets a password (or, later, an OIDC) identity. This is
+the property the standup flagged that pure Tailscale-groups ACLs can
+never have.
+
+Three tiers, weakest to strongest:
+
+| Role     | Capability                                                  |
+| -------- | ----------------------------------------------------------- |
+| `viewer` | read the dashboard                                          |
+| `editor` | viewer + assign devices to a profile + edit credentials     |
+| `admin`  | editor + grant/revoke roles                                 |
+
+Each grant is a **binding** of `(role, scope)`:
+
+- `scope = "*"` — global; the role applies to every profile.
+- `scope = "profile:<name>"` — the role applies to that one profile.
+
+A global `editor` may edit every profile. A `profile:avocet2` editor
+may assign devices to `avocet2` and nothing else, and may **not** edit
+credentials (credentials are global — see
+`migrations/sqlite/0011_credentials_global.sql`).
+
+## Schema
+
+`migrations/sqlite/0020_rbac.sql`:
+
+```
+rbac_users         (id, display_name, disabled, created_ns, updated_ns)
+rbac_identities    (provider, external_id) -> user_id     provider ∈ {password, tailscale}
+rbac_role_bindings (user_id, role, scope)
+```
+
+One user per identity in V1 (the user id encodes the identity); the
+split into three tables keeps the door open for a future
+many-identities-per-user merge and for new providers (`oidc`,
+`device_token`) without a reshape.
+
+## Enforcement
+
+The middleware chain in `web.go` `handler()` is:
+
+```
+dashboardAuthGate( tailnetGate( authzGate( mux ) ) )
+```
+
+`dashboardAuthGate` and `tailnetGate` are unchanged — they still
+establish the `principal` (password session or tailnet whois).
+`authzGate` (new, `roles_api.go`) runs last:
+
+1. resolves the principal to its `(role, scope)` bindings;
+2. blocks `/api/rbac/{users,grant,revoke}` unless the caller is
+   `admin/*`;
+3. attaches the bindings to the request context for per-handler scope
+   checks.
+
+Per-handler scope checks:
+
+| Handler                       | Check                          |
+| ----------------------------- | ------------------------------ |
+| `apiAgentProfile`             | `canEditProfile(targetProfile)`|
+| `apiCredentialsSet` / `Clear` | `canEditGlobal` (creds global) |
+
+## Backward compatibility
+
+This change ships **additive**. The hinge is `effectiveBindings`: the
+first time an already-gated identity is seen with no bindings, it is
+lazily granted `admin/*`. Because the only identities that reach
+`authzGate` are ones the existing gates already admit (root password,
+or a login matching the `operators` allowlist), every caller keeps the
+exact access they had before. Narrowing a principal is **opt-in**: an
+admin revokes the `admin/*` binding and grants something tighter.
+
+`seedRBAC` (called at boot from `main.go`) seeds the root password user
+and every concrete operator login as `admin/*`, but never overwrites an
+existing binding — so a narrower grant set by an admin survives
+restarts. Wildcard operator entries (`*@domain`) are seeded lazily on
+first request.
+
+## API
+
+All under `/api/rbac/`, reachable on the dashboard auth path; `authzGate`
+enforces the role requirement.
+
+- `GET  /api/rbac/me` — caller's own bindings + derived capabilities
+  (the SPA uses this to show/hide controls). Any authorized caller.
+- `GET  /api/rbac/users` — list users with identities + bindings.
+  Admin only.
+- `POST /api/rbac/grant` — `{provider, external_id, role, scope}`.
+  Upsert a binding. Admin only. Scope is validated against declared
+  profiles.
+- `POST /api/rbac/revoke` — `{provider, external_id, role, scope}`.
+  Delete a binding. Admin only. Refuses to revoke the caller's own
+  `admin/*` (self-lockout guard).
+
+Example — restrict an operator to one profile:
+
+```sh
+# grant scoped editor
+curl -X POST .../api/rbac/grant -d \
+  '{"provider":"tailscale","external_id":"alice@example.com","role":"editor","scope":"profile:avocet2"}'
+# remove their inherited admin
+curl -X POST .../api/rbac/revoke -d \
+  '{"provider":"tailscale","external_id":"alice@example.com","role":"admin","scope":"*"}'
+```
+
+## Not in V1
+
+Deferred deliberately; each is a follow-up:
+
+- **Dashboard UI** for grant/revoke (the API is ready).
+- **Removing the `operators` allowlist.** Today it stays the hard
+  tailnet gate; roles only refine what an admitted operator may do.
+  Making roles the *sole* authority is a breaking change to
+  `gateway.hcl` and to how the first admin bootstraps — out of scope
+  here.
+- **Multi-user password login.** The schema supports it; the login
+  form is still root-only.
+- **Onboarding `/approve` scoping.** Still on the existing operator
+  gate, not yet `canEditProfile`-scoped.
+- **Audit log** of grants/revokes/edits.


### PR DESCRIPTION
## What

Adds a role layer on top of the existing dashboard identity gate. Authorization was binary: any caller who cleared the gate (root password or a tailnet \`operators\` allowlist login) could edit any profile, set any credential, approve any device. Roles let an admin scope an operator to a single profile.

## Model

Identity decoupled from transport — tailscale whois and dashboard password are **identity providers**; roles live in the DB, so the same model works for WireGuard-only nodes that have no whois.

- Roles: \`viewer\` < \`editor\` < \`admin\`
- Scope: \`*\` (global) or \`profile:<name>\`

## Changes

- migration \`0020_rbac.sql\`: \`rbac_users\` / \`rbac_identities\` / \`rbac_role_bindings\`
- \`roles.go\`: authorize predicates, seeding
- \`roles_api.go\`: \`authzGate\` middleware + \`/api/rbac/{me,users,grant,revoke}\`
- enforce: device→profile assign (\`canEditProfile\`), credential edits (\`canEditGlobal\`); \`/api/rbac/*\` admin-only with self-lockout guard
- \`doc/roles.md\`

## Backward compatibility

Additive / non-breaking. An already-gated identity with no bindings is lazily granted \`admin/*\`, so upgrade changes no behavior; narrowing is opt-in.

## Not in V1 (see doc/roles.md)

Operators-allowlist removal, multi-user password login, dashboard UI, onboarding-approve scoping, audit log.

## Test

\`go test ./cmd/clawpatrol/ -run 'TestRole|TestGrant|TestAuthorize|TestSeed|TestEffective|TestRevoke|TestList'\` — green. gofmt clean.