### PR TITLE
feat: clawpatrol apply — config version store, semantic diff, history

### DIFF
--- a/cmd/clawpatrol/apply.go
+++ b/cmd/clawpatrol/apply.go
@@ -22,7 +22,9 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"database/sql"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -60,6 +62,27 @@ func loadDesired(path string) (*config.Gateway, *config.CompiledPolicy, []byte, 
 		return nil, nil, nil, err
 	}
 	return gw, cp, raw, nil
+}
+
+// compileBytes validates raw config bytes (load + compile + plugin
+// verify), the bytes-input twin of loadDesired. Used by apply, whose
+// desired config may come from a file or from a saved plan.
+func compileBytes(raw []byte) (*config.Gateway, *config.CompiledPolicy, error) {
+	mgr := extplugin.New(nil)
+	defer mgr.Stop()
+	config.SetPluginLoader(mgr)
+	gw, diags := config.LoadBytes(raw, "apply.hcl")
+	if diags.HasErrors() {
+		return nil, nil, fmt.Errorf("%s", diags.Error())
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("compile: %w", err)
+	}
+	if d := mgr.Verify(); d.HasErrors() {
+		return nil, nil, fmt.Errorf("%s", d.Error())
+	}
+	return gw, cp, nil
 }
 
 // openStateDB resolves the state dir from the config and opens the
@@ -117,15 +140,51 @@ func (p configPlan) print(w bufWriter, cp *config.CompiledPolicy) {
 	p.diff.render(w)
 }
 
-// runPlan is `clawpatrol plan <config.hcl>` — read-only.
+// savedPlanVersion is the on-disk format version of a saved plan.
+const savedPlanVersion = 1
+
+// savedPlan is a plan written by `plan --out` and consumed by `apply
+// <planfile>`. It binds the desired config to the serial it was planned
+// against (ExpectedSerial); apply refuses it if the deployed serial has
+// moved since — Terraform's "saved plan is stale" guard, which is what
+// makes a real conflict (not just a lock wait) observable.
+type savedPlan struct {
+	Version        int      `json:"version"`
+	Config         []byte   `json:"config"` // raw desired HCL (base64 in JSON)
+	Revision       string   `json:"revision"`
+	SchemaVersion  int      `json:"schema_version"`
+	ExpectedSerial int64    `json:"expected_serial"`
+	Added          []string `json:"added,omitempty"`
+	Removed        []string `json:"removed,omitempty"`
+	Changed        []string `json:"changed,omitempty"`
+	CreatedNs      int64    `json:"created_ns"`
+}
+
+// looksLikeSavedPlan reports whether bytes parse as a saved plan (vs raw
+// HCL). A plan file is JSON with a positive version; HCL never is.
+func looksLikeSavedPlan(b []byte) (savedPlan, bool) {
+	t := bytes.TrimSpace(b)
+	if len(t) == 0 || t[0] != '{' {
+		return savedPlan{}, false
+	}
+	var sp savedPlan
+	if err := json.Unmarshal(t, &sp); err != nil || sp.Version == 0 || len(sp.Config) == 0 {
+		return savedPlan{}, false
+	}
+	return sp, true
+}
+
+// runPlan is `clawpatrol plan [-out file] <config.hcl>` — read-only,
+// optionally saving a plan for a later `apply <planfile>`.
 func runPlan(args []string) {
 	fs := flag.NewFlagSet("plan", flag.ExitOnError)
+	out := fs.String("out", "", "write the plan to this file for `clawpatrol apply <planfile>`")
 	if err := fs.Parse(args); err != nil {
 		os.Exit(2)
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol plan <config.hcl>")
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol plan [-out file] <config.hcl>")
 		os.Exit(2)
 	}
 	gw, cp, raw, err := loadDesired(rest[0])
@@ -149,29 +208,84 @@ func runPlan(args []string) {
 	if p.noChanges() {
 		fmt.Println("\nNo changes. Deployed config is up to date.")
 	}
+	if *out != "" {
+		sp := savedPlan{
+			Version:        savedPlanVersion,
+			Config:         raw,
+			Revision:       p.desiredRev,
+			SchemaVersion:  gw.SchemaVersion,
+			ExpectedSerial: p.deployedSerial,
+			Added:          p.diff.added,
+			Removed:        p.diff.removed,
+			Changed:        p.diff.changed,
+		}
+		blob, _ := json.MarshalIndent(sp, "", "  ")
+		if err := os.WriteFile(*out, blob, 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "plan: write %s: %v\n", *out, err)
+			os.Exit(1)
+		}
+		fmt.Printf("\nplan saved to %s (bound to serial %d) — apply with `clawpatrol apply %s`\n", *out, p.deployedSerial, *out)
+	}
 }
 
-// runApply is `clawpatrol apply [-y] <config.hcl>`.
+// runApply is `clawpatrol apply [-y] [--expect N] <config.hcl | planfile>`.
+// Given a saved plan it applies that plan, refusing if the deployed
+// serial has moved since the plan was made (stale-plan conflict). Given
+// an .hcl it plans fresh under the lock; --expect N asserts the base
+// serial for CI without a saved plan.
 func runApply(args []string) {
 	fs := flag.NewFlagSet("apply", flag.ExitOnError)
 	autoApprove := fs.Bool("y", false, "apply without the interactive confirmation prompt")
 	by := fs.String("by", "", "who is applying (default: $SUDO_USER, then $USER)")
 	note := fs.String("note", "", "optional note recorded with this version")
+	expect := fs.Int64("expect", -1, "require the deployed serial to equal this (conflict if not); -1 = no assertion")
 	if err := fs.Parse(args); err != nil {
 		os.Exit(2)
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol apply [-y] [--by who] [--note text] <config.hcl>")
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol apply [-y] [--expect N] [--by who] [--note text] <config.hcl | planfile>")
 		os.Exit(2)
 	}
 	path := rest[0]
 
-	gw, cp, raw, err := loadDesired(path)
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: read %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	// A saved plan carries its own desired config + the serial it was
+	// planned against; a raw .hcl is planned fresh.
+	var (
+		raw            []byte
+		expectSerial   int64 = *expect
+		fromSavedPlan  bool
+		savedSchemaVer int
+	)
+	if sp, ok := looksLikeSavedPlan(fileBytes); ok {
+		fromSavedPlan = true
+		raw = sp.Config
+		expectSerial = sp.ExpectedSerial
+		savedSchemaVer = sp.SchemaVersion
+	} else {
+		raw = fileBytes
+	}
+
+	// Validate the desired config (compile + plugin verify) regardless of
+	// source — a stored plan still gets re-checked against this binary.
+	gw, cp, err := compileBytes(raw)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apply: %s: %v\n", path, err)
 		os.Exit(1)
 	}
+	if fromSavedPlan && savedSchemaVer != gw.SchemaVersion {
+		// Defensive: the stored schema_version should match what we just
+		// parsed; a mismatch means a tampered/corrupt plan file.
+		fmt.Fprintf(os.Stderr, "apply: saved plan schema_version (%d) disagrees with its config (%d)\n", savedSchemaVer, gw.SchemaVersion)
+		os.Exit(1)
+	}
+
 	db, err := openStateDB(gw)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apply: %v\n", err)
@@ -190,41 +304,74 @@ func runApply(args []string) {
 			cur.Holder, time.Unix(0, cur.LockedNs).Format(applyTimeFormat), reasonSuffix(cur.Reason), path)
 		os.Exit(1)
 	}
-	defer releaseConfigLock(db, who)
 
-	p, err := computePlan(db, gw, raw)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "apply: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Printf("config: %s\n", path)
-	p.print(os.Stdout, cp)
-	fmt.Println()
+	// Everything below runs while holding the lock. It's wrapped in a
+	// closure so the deferred release runs on EVERY exit path — a bare
+	// os.Exit here would skip the defer and leak the lock, wedging the
+	// next apply until the staleness steal kicks in.
+	err = func() error {
+		defer releaseConfigLock(db, who)
 
-	if p.noChanges() {
-		fmt.Println("No changes. Deployed config is up to date.")
-		return
-	}
-	if !*autoApprove {
-		if !confirm("Apply this config?") {
-			fmt.Println("aborted.")
-			return
+		deployedSerial, err := currentSerial(db)
+		if err != nil {
+			return fmt.Errorf("read serial: %w", err)
 		}
-	}
 
-	rev, serial, ok, err := recordConfigVersionCAS(db, raw, gw.SchemaVersion, resolveApplier(*by), *note, p.deployedSerial)
+		// Stale-plan / expectation conflict: the deployed serial moved
+		// since the plan was made (or since the asserted base). This is
+		// the real conflict the lock alone can't surface — another writer
+		// landed a change between plan and apply.
+		if expectSerial >= 0 && deployedSerial != expectSerial {
+			src := "the saved plan was"
+			if !fromSavedPlan {
+				src = "--expect was"
+			}
+			return fmt.Errorf(
+				"conflict — deployed serial is %d but %s built against serial %d.\nSomeone applied a change in between. Re-run `clawpatrol plan` and review before applying",
+				deployedSerial, src, expectSerial)
+		}
+
+		p, err := computePlan(db, gw, raw)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("config: %s\n", path)
+		p.print(os.Stdout, cp)
+		if fromSavedPlan {
+			fmt.Println("\n(applying saved plan)")
+		}
+		fmt.Println()
+
+		if p.noChanges() {
+			fmt.Println("No changes. Deployed config is up to date.")
+			return nil
+		}
+		// A reviewed saved plan applies without re-prompting (Terraform
+		// behavior); a fresh .hcl prompts unless -y.
+		if !fromSavedPlan && !*autoApprove {
+			if !confirm("Apply this config?") {
+				fmt.Println("aborted.")
+				return nil
+			}
+		}
+
+		rev, serial, ok, err := recordConfigVersionCAS(db, raw, gw.SchemaVersion, resolveApplier(*by), *note, deployedSerial)
+		if err != nil {
+			return fmt.Errorf("record version: %w", err)
+		}
+		if !ok {
+			// Serial moved between the check above and the insert — only
+			// possible if the lock was forced mid-apply.
+			return fmt.Errorf("state changed during apply (expected serial %d, no longer current). Re-run apply", deployedSerial)
+		}
+		fmt.Printf("Apply complete. serial %d, revision %s, by %s.\n", serial, shortRev(rev), resolveApplier(*by))
+		fmt.Println("The running gateway will reload from the backend within a few seconds.")
+		return nil
+	}()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "apply: record version: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	if !ok {
-		// The serial moved between plan and write despite the lock —
-		// only possible if the lock was stolen/forced mid-apply.
-		fmt.Fprintf(os.Stderr, "Error: state changed during apply (expected serial %d, no longer current). Re-run apply.\n", p.deployedSerial)
-		os.Exit(1)
-	}
-	fmt.Printf("Apply complete. serial %d, revision %s, by %s.\n", serial, shortRev(rev), resolveApplier(*by))
-	fmt.Println("The running gateway will reload from the backend within a few seconds.")
 }
 
 // digestDiff is the categorized result of comparing two PolicyDigests.

--- a/cmd/clawpatrol/apply.go
+++ b/cmd/clawpatrol/apply.go
@@ -373,10 +373,14 @@ func runApply(args []string) {
 }
 
 // digestDiff is the categorized result of comparing two PolicyDigests.
+// changed is block-level (by name); details carries the within-block
+// line delta for each changed block so an edit to one field — e.g. a
+// rule's CEL condition — is shown, not just "this rule changed".
 type digestDiff struct {
 	added   []string
 	removed []string
 	changed []string
+	details map[string][2]string // changed key -> {old canonical, new canonical}
 }
 
 func (d digestDiff) empty() bool {
@@ -397,14 +401,58 @@ func (d digestDiff) render() {
 	}
 	for _, k := range d.changed {
 		fmt.Printf("  ~ %s\n", k)
+		// Show the within-block line delta (which field actually
+		// changed) when we have the before/after canonical HCL.
+		if pair, ok := d.details[k]; ok {
+			rem, add := lineDelta(pair[0], pair[1])
+			for _, l := range rem {
+				fmt.Printf("      - %s\n", strings.TrimSpace(l))
+			}
+			for _, l := range add {
+				fmt.Printf("      + %s\n", strings.TrimSpace(l))
+			}
+		}
 	}
+}
+
+// lineDelta returns the lines present in old but not new (rem) and in
+// new but not old (add). A multiset difference — enough to surface the
+// one attribute line that changed inside an otherwise-identical block
+// (e.g. a CEL `condition` edit), without pulling in a full diff lib.
+func lineDelta(oldText, newText string) (rem, add []string) {
+	count := func(lines []string) map[string]int {
+		m := map[string]int{}
+		for _, l := range lines {
+			if strings.TrimSpace(l) != "" {
+				m[l]++
+			}
+		}
+		return m
+	}
+	oldLines := strings.Split(oldText, "\n")
+	newLines := strings.Split(newText, "\n")
+	inNew := count(newLines)
+	inOld := count(oldLines)
+	for _, l := range oldLines {
+		if strings.TrimSpace(l) != "" && inNew[l] == 0 {
+			rem = append(rem, l)
+		}
+	}
+	for _, l := range newLines {
+		if strings.TrimSpace(l) != "" && inOld[l] == 0 {
+			add = append(add, l)
+		}
+	}
+	return rem, add
 }
 
 // diffDigests compares two block digests by key. Keys present only in
 // new are added, only in old are removed, in both with differing
-// canonical HCL are changed. Each category is sorted for stable output.
+// canonical HCL are changed. For changed blocks the before/after text is
+// kept in details for a within-block line delta. Each category is sorted
+// for stable output.
 func diffDigests(oldD, newD map[string]string) digestDiff {
-	var d digestDiff
+	d := digestDiff{details: map[string][2]string{}}
 	for k, nv := range newD {
 		ov, ok := oldD[k]
 		if !ok {
@@ -413,6 +461,7 @@ func diffDigests(oldD, newD map[string]string) digestDiff {
 		}
 		if ov != nv {
 			d.changed = append(d.changed, k)
+			d.details[k] = [2]string{ov, nv}
 		}
 	}
 	for k := range oldD {

--- a/cmd/clawpatrol/apply.go
+++ b/cmd/clawpatrol/apply.go
@@ -236,15 +236,13 @@ func runPlan(args []string) {
 func runApply(args []string) {
 	fs := flag.NewFlagSet("apply", flag.ExitOnError)
 	autoApprove := fs.Bool("y", false, "apply without the interactive confirmation prompt")
-	by := fs.String("by", "", "who is applying (default: $SUDO_USER, then $USER)")
-	note := fs.String("note", "", "optional note recorded with this version")
 	expect := fs.Int64("expect", -1, "require the deployed serial to equal this (conflict if not); -1 = no assertion")
 	if err := fs.Parse(args); err != nil {
 		os.Exit(2)
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol apply [-y] [--expect N] [--by who] [--note text] <config.hcl | planfile>")
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol apply [-y] [--expect N] <config.hcl | planfile>")
 		os.Exit(2)
 	}
 	path := rest[0]
@@ -293,7 +291,7 @@ func runApply(args []string) {
 	}
 	defer db.Close()
 
-	who := lockHolder(*by)
+	who := lockHolder()
 	locked, cur, err := acquireConfigLock(db, who, "apply "+path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apply: lock: %v\n", err)
@@ -355,7 +353,7 @@ func runApply(args []string) {
 			}
 		}
 
-		rev, serial, ok, err := recordConfigVersionCAS(db, raw, gw.SchemaVersion, resolveApplier(*by), *note, deployedSerial)
+		rev, serial, ok, err := recordConfigVersionCAS(db, raw, gw.SchemaVersion, deployedSerial)
 		if err != nil {
 			return fmt.Errorf("record version: %w", err)
 		}
@@ -364,7 +362,7 @@ func runApply(args []string) {
 			// possible if the lock was forced mid-apply.
 			return fmt.Errorf("state changed during apply (expected serial %d, no longer current). Re-run apply", deployedSerial)
 		}
-		fmt.Printf("Apply complete. serial %d, revision %s, by %s.\n", serial, shortRev(rev), resolveApplier(*by))
+		fmt.Printf("Apply complete. serial %d, revision %s.\n", serial, shortRev(rev))
 		fmt.Println("The running gateway will reload from the backend within a few seconds.")
 		return nil
 	}()
@@ -481,11 +479,7 @@ func runConfigHistory(args []string) {
 	}
 	for _, v := range versions {
 		ts := time.Unix(0, v.AppliedNs).Format(applyTimeFormat)
-		line := fmt.Sprintf("serial %-4d  %s  %s  schema=%d  by %s", v.ID, ts, shortRev(v.Revision), v.SchemaVersion, orUnknown(v.AppliedBy))
-		if v.Note != "" {
-			line += "  — " + v.Note
-		}
-		fmt.Println(line)
+		fmt.Printf("serial %-4d  %s  %s  schema=%d\n", v.ID, ts, shortRev(v.Revision), v.SchemaVersion)
 	}
 }
 
@@ -539,13 +533,6 @@ func shortRev(rev string) string {
 	return rev
 }
 
-func orUnknown(s string) string {
-	if s == "" {
-		return "unknown"
-	}
-	return s
-}
-
 func reasonSuffix(reason string) string {
 	if reason == "" {
 		return ""
@@ -553,25 +540,17 @@ func reasonSuffix(reason string) string {
 	return " (" + reason + ")"
 }
 
-// resolveApplier picks the recorded identity: explicit --by, then
-// $SUDO_USER (apply is usually run as root on the gateway), then $USER.
-func resolveApplier(by string) string {
-	if by != "" {
-		return by
-	}
+// lockHolder is the OS user plus hostname, recorded on the lock so a
+// contended lock names a recognizable owner across machines. This is
+// Terraform's lock "Who" (user@host) — derived from the environment,
+// never a flag.
+func lockHolder() string {
+	who := "unknown"
 	if u := os.Getenv("SUDO_USER"); u != "" {
-		return u
+		who = u
+	} else if u := os.Getenv("USER"); u != "" {
+		who = u
 	}
-	if u := os.Getenv("USER"); u != "" {
-		return u
-	}
-	return "unknown"
-}
-
-// lockHolder is the applier identity plus hostname, so a contended lock
-// names a recognizable owner across machines.
-func lockHolder(by string) string {
-	who := resolveApplier(by)
 	if h, err := os.Hostname(); err == nil && h != "" {
 		return who + "@" + h
 	}

--- a/cmd/clawpatrol/apply.go
+++ b/cmd/clawpatrol/apply.go
@@ -1,21 +1,28 @@
 package main
 
-// `clawpatrol apply` and `clawpatrol config history`.
+// `clawpatrol plan`, `clawpatrol apply`, `clawpatrol config history`,
+// and `clawpatrol config unlock`.
 //
-// apply is the audited, validated path for changing a gateway's config.
-// It loads + compiles the target file (the same pipeline the daemon runs
-// at startup, so an invalid config is rejected before it can reach a
-// running gateway), shows a semantic diff against the last applied
-// version, and on confirmation rewrites the file atomically and records
-// a version row. The running gateway's file watcher then reloads.
+// The state backend is config_versions in the gateway DB: its latest
+// row is the deployed config and its id is the serial. This mirrors
+// Terraform — the file passed to plan/apply is the *desired* config
+// (like a .tf), the DB is the deployed state, and apply reconciles them
+// under a lock.
+//
+//   plan   load + validate the file, diff it against the deployed
+//          config, print. Lock-free, read-only.
+//   apply  re-plan under an exclusive lock, confirm, compare-and-swap a
+//          new version (rejecting a stale apply), release. The running
+//          gateway polls the serial and reloads.
 //
 // "Semantic" diff: each config block is rendered through config's
-// deterministic Emit hooks (see config.PolicyDigest) and compared by
-// name, so reordering blocks or editing a comment shows as no change —
-// only a real change to a block's content does.
+// deterministic Emit hooks (config.PolicyDigest) and compared by name,
+// so reordering blocks or editing a comment shows as no change — only a
+// real change to a block's content does.
 
 import (
 	"bufio"
+	"database/sql"
 	"flag"
 	"fmt"
 	"os"
@@ -32,7 +39,119 @@ import (
 // (yyyy-MM-dd HH:mm:ss.SSS, 24-hour, locale-independent).
 const applyTimeFormat = "2006-01-02 15:04:05.000"
 
-// runApply is the `clawpatrol apply <config.hcl>` entry point.
+// loadDesired loads + compiles the file the operator wants to apply,
+// running the same pipeline (including external-plugin verification)
+// the daemon runs at startup. An invalid config is rejected here,
+// before it can become deployed state. Returns the gateway, compiled
+// policy, and raw bytes.
+func loadDesired(path string) (*config.Gateway, *config.CompiledPolicy, []byte, error) {
+	mgr := extplugin.New(nil)
+	defer mgr.Stop()
+	config.SetPluginLoader(mgr)
+	gw, cp, err := loadConfig(path)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if d := mgr.Verify(); d.HasErrors() {
+		return nil, nil, nil, fmt.Errorf("%s", d.Error())
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return gw, cp, raw, nil
+}
+
+// openStateDB resolves the state dir from the config and opens the
+// gateway DB (the state backend).
+func openStateDB(gw *config.Gateway) (*sql.DB, error) {
+	stateDir := resolveStateDir(gw)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, fmt.Errorf("state dir: %w", err)
+	}
+	return OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
+}
+
+// configPlan is the result of diffing a desired config against the
+// deployed state.
+type configPlan struct {
+	desiredRev     string
+	deployedRev    string
+	deployedSerial int64
+	hasDeployed    bool
+	diff           digestDiff
+}
+
+func (p configPlan) noChanges() bool { return p.hasDeployed && p.diff.empty() }
+
+// computePlan diffs the desired gateway/raw against the deployed config
+// in the backend.
+func computePlan(db *sql.DB, gw *config.Gateway, raw []byte) (configPlan, error) {
+	p := configPlan{desiredRev: revisionForBytes(raw)}
+	content, serial, ok, err := activeConfig(db)
+	if err != nil {
+		return p, err
+	}
+	newDigest := config.PolicyDigest(gw)
+	var oldDigest map[string]string
+	if ok {
+		p.hasDeployed = true
+		p.deployedSerial = serial
+		p.deployedRev = revisionForBytes(content)
+		if oldGw, diags := config.LoadBytes(content, "deployed.hcl"); !diags.HasErrors() {
+			oldDigest = config.PolicyDigest(oldGw)
+		}
+	}
+	p.diff = diffDigests(oldDigest, newDigest)
+	return p, nil
+}
+
+func (p configPlan) print(w bufWriter, cp *config.CompiledPolicy) {
+	fmt.Fprintf(w, "revision: %s  (%d endpoints, %d profiles)\n", shortRev(p.desiredRev), len(cp.Endpoints), len(cp.Profiles))
+	if p.hasDeployed {
+		fmt.Fprintf(w, "deployed: %s  (serial %d)\n\n", shortRev(p.deployedRev), p.deployedSerial)
+	} else {
+		fmt.Fprintln(w, "deployed: (none — backend is empty, this seeds serial 1)")
+		fmt.Fprintln(w)
+	}
+	p.diff.render(w)
+}
+
+// runPlan is `clawpatrol plan <config.hcl>` — read-only.
+func runPlan(args []string) {
+	fs := flag.NewFlagSet("plan", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol plan <config.hcl>")
+		os.Exit(2)
+	}
+	gw, cp, raw, err := loadDesired(rest[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "plan: %s: %v\n", rest[0], err)
+		os.Exit(1)
+	}
+	db, err := openStateDB(gw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "plan: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	p, err := computePlan(db, gw, raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "plan: %v\n", err)
+		os.Exit(1)
+	}
+	p.print(os.Stdout, cp)
+	if p.noChanges() {
+		fmt.Println("\nNo changes. Deployed config is up to date.")
+	}
+}
+
+// runApply is `clawpatrol apply [-y] <config.hcl>`.
 func runApply(args []string) {
 	fs := flag.NewFlagSet("apply", flag.ExitOnError)
 	autoApprove := fs.Bool("y", false, "apply without the interactive confirmation prompt")
@@ -48,99 +167,64 @@ func runApply(args []string) {
 	}
 	path := rest[0]
 
-	// Same validation the daemon does at startup, plus external-plugin
-	// schema verification — an invalid config never gets recorded or
-	// activated.
-	mgr := extplugin.New(nil)
-	defer mgr.Stop()
-	config.SetPluginLoader(mgr)
-	gw, cp, err := loadConfig(path)
+	gw, cp, raw, err := loadDesired(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apply: %s: %v\n", path, err)
 		os.Exit(1)
 	}
-	if d := mgr.Verify(); d.HasErrors() {
-		fmt.Fprintf(os.Stderr, "apply: %s: %s\n", path, d.Error())
-		os.Exit(1)
-	}
-
-	raw, err := os.ReadFile(path)
+	db, err := openStateDB(gw)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "apply: read %s: %v\n", path, err)
-		os.Exit(1)
-	}
-	revision := revisionForBytes(raw)
-
-	stateDir := resolveStateDir(gw)
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		fmt.Fprintf(os.Stderr, "apply: state dir: %v\n", err)
-		os.Exit(1)
-	}
-	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "apply: open db: %v\n", err)
+		fmt.Fprintf(os.Stderr, "apply: %v\n", err)
 		os.Exit(1)
 	}
 	defer db.Close()
 
-	latest, hasLatest, err := latestConfigVersion(db)
+	who := lockHolder(*by)
+	locked, cur, err := acquireConfigLock(db, who, "apply "+path)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "apply: read history: %v\n", err)
+		fmt.Fprintf(os.Stderr, "apply: lock: %v\n", err)
 		os.Exit(1)
 	}
-
-	// Build the semantic diff against the last applied version.
-	newDigest := config.PolicyDigest(gw)
-	var oldDigest map[string]string
-	if hasLatest {
-		if oldGw, diags := config.LoadBytes(latest.Content, "applied.hcl"); !diags.HasErrors() {
-			oldDigest = config.PolicyDigest(oldGw)
-		}
+	if !locked {
+		fmt.Fprintf(os.Stderr, "Error: config is locked by %s since %s%s\nAnother apply may be in progress. If it crashed, run `clawpatrol config unlock %s`.\n",
+			cur.Holder, time.Unix(0, cur.LockedNs).Format(applyTimeFormat), reasonSuffix(cur.Reason), path)
+		os.Exit(1)
 	}
-	d := diffDigests(oldDigest, newDigest)
+	defer releaseConfigLock(db, who)
 
-	if hasLatest && latest.Revision == revision {
-		fmt.Printf("no changes — config already at revision %s\n", shortRev(revision))
+	p, err := computePlan(db, gw, raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("config: %s\n", path)
+	p.print(os.Stdout, cp)
+	fmt.Println()
+
+	if p.noChanges() {
+		fmt.Println("No changes. Deployed config is up to date.")
 		return
 	}
-
-	fmt.Printf("config: %s\n", path)
-	fmt.Printf("revision: %s  (%d endpoints, %d profiles)\n", shortRev(revision), len(cp.Endpoints), len(cp.Profiles))
-	if hasLatest {
-		fmt.Printf("last applied: %s by %s at %s\n",
-			shortRev(latest.Revision), orUnknown(latest.AppliedBy), time.Unix(0, latest.AppliedNs).Format(applyTimeFormat))
-	} else {
-		fmt.Println("last applied: (none — this is the first recorded version)")
-	}
-	fmt.Println()
-	d.render(os.Stdout)
-	fmt.Println()
-
 	if !*autoApprove {
-		if !confirm(fmt.Sprintf("Apply this config to %s?", path)) {
+		if !confirm("Apply this config?") {
 			fmt.Println("aborted.")
 			return
 		}
 	}
 
-	// Rewrite atomically so the running gateway never reads a half-written
-	// file, and so the mtime bump triggers its watcher to reload.
-	if err := writeFileAtomic(path, raw); err != nil {
-		fmt.Fprintf(os.Stderr, "apply: write %s: %v\n", path, err)
-		os.Exit(1)
-	}
-
-	who := resolveApplier(*by)
-	rev, inserted, err := recordConfigVersion(db, raw, gw.SchemaVersion, who, *note)
+	rev, serial, ok, err := recordConfigVersionCAS(db, raw, gw.SchemaVersion, resolveApplier(*by), *note, p.deployedSerial)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apply: record version: %v\n", err)
 		os.Exit(1)
 	}
-	if inserted {
-		fmt.Printf("applied: revision %s recorded by %s\n", shortRev(rev), who)
-	} else {
-		fmt.Printf("applied: revision %s (already recorded)\n", shortRev(rev))
+	if !ok {
+		// The serial moved between plan and write despite the lock —
+		// only possible if the lock was stolen/forced mid-apply.
+		fmt.Fprintf(os.Stderr, "Error: state changed during apply (expected serial %d, no longer current). Re-run apply.\n", p.deployedSerial)
+		os.Exit(1)
 	}
+	fmt.Printf("Apply complete. serial %d, revision %s, by %s.\n", serial, shortRev(rev), resolveApplier(*by))
+	fmt.Println("The running gateway will reload from the backend within a few seconds.")
 }
 
 // digestDiff is the categorized result of comparing two PolicyDigests.
@@ -200,22 +284,22 @@ func diffDigests(oldD, newD map[string]string) digestDiff {
 // runConfig dispatches `clawpatrol config <subcommand>`.
 func runConfig(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol config history <config.hcl>")
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol config <history|unlock> <config.hcl>")
 		os.Exit(2)
 	}
 	switch args[0] {
 	case "history":
 		runConfigHistory(args[1:])
+	case "unlock":
+		runConfigUnlock(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown config subcommand: %s\n", args[0])
-		fmt.Fprintln(os.Stderr, "usage: clawpatrol config history <config.hcl>")
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol config <history|unlock> <config.hcl>")
 		os.Exit(2)
 	}
 }
 
-// runConfigHistory lists recorded config versions. The config path is
-// used only to resolve the state dir (and thus the DB) — it is not
-// re-parsed for policy.
+// runConfigHistory lists recorded config versions.
 func runConfigHistory(args []string) {
 	fs := flag.NewFlagSet("config history", flag.ExitOnError)
 	limit := fs.Int("limit", 20, "max versions to show (0 = all)")
@@ -232,14 +316,9 @@ func runConfigHistory(args []string) {
 		fmt.Fprintf(os.Stderr, "config history: %s: %v\n", rest[0], err)
 		os.Exit(1)
 	}
-	stateDir := resolveStateDir(gw)
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		fmt.Fprintf(os.Stderr, "config history: state dir: %v\n", err)
-		os.Exit(1)
-	}
-	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
+	db, err := openStateDB(gw)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "config history: open db: %v\n", err)
+		fmt.Fprintf(os.Stderr, "config history: %v\n", err)
 		os.Exit(1)
 	}
 	defer db.Close()
@@ -255,7 +334,7 @@ func runConfigHistory(args []string) {
 	}
 	for _, v := range versions {
 		ts := time.Unix(0, v.AppliedNs).Format(applyTimeFormat)
-		line := fmt.Sprintf("%s  %s  schema=%d  by %s", ts, shortRev(v.Revision), v.SchemaVersion, orUnknown(v.AppliedBy))
+		line := fmt.Sprintf("serial %-4d  %s  %s  schema=%d  by %s", v.ID, ts, shortRev(v.Revision), v.SchemaVersion, orUnknown(v.AppliedBy))
 		if v.Note != "" {
 			line += "  — " + v.Note
 		}
@@ -263,10 +342,47 @@ func runConfigHistory(args []string) {
 	}
 }
 
+// runConfigUnlock force-releases the state lock (Terraform's
+// force-unlock). For recovering from a crashed apply.
+func runConfigUnlock(args []string) {
+	fs := flag.NewFlagSet("config unlock", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol config unlock <config.hcl>")
+		os.Exit(2)
+	}
+	gw, _, err := loadConfig(rest[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config unlock: %s: %v\n", rest[0], err)
+		os.Exit(1)
+	}
+	db, err := openStateDB(gw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config unlock: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	cur, held, _ := readConfigLock(db)
+	released, err := forceUnlockConfigLock(db)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config unlock: %v\n", err)
+		os.Exit(1)
+	}
+	if !released || !held {
+		fmt.Println("no lock held.")
+		return
+	}
+	fmt.Printf("released lock held by %s since %s.\n", cur.Holder, time.Unix(0, cur.LockedNs).Format(applyTimeFormat))
+}
+
 // --- helpers -------------------------------------------------------
 
-// bufWriter is the minimal io.Writer surface render needs; aliased so
-// the signature reads clearly and tests can pass a *strings.Builder.
+// bufWriter is the minimal io.Writer surface render/print need; aliased
+// so signatures read clearly and tests can pass a *strings.Builder.
 type bufWriter = interface{ Write([]byte) (int, error) }
 
 func shortRev(rev string) string {
@@ -281,6 +397,13 @@ func orUnknown(s string) string {
 		return "unknown"
 	}
 	return s
+}
+
+func reasonSuffix(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return " (" + reason + ")"
 }
 
 // resolveApplier picks the recorded identity: explicit --by, then
@@ -298,6 +421,16 @@ func resolveApplier(by string) string {
 	return "unknown"
 }
 
+// lockHolder is the applier identity plus hostname, so a contended lock
+// names a recognizable owner across machines.
+func lockHolder(by string) string {
+	who := resolveApplier(by)
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return who + "@" + h
+	}
+	return who
+}
+
 // confirm prompts on stderr and reads a yes/no from stdin.
 func confirm(prompt string) bool {
 	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
@@ -305,33 +438,4 @@ func confirm(prompt string) bool {
 	line, _ := r.ReadString('\n')
 	line = strings.ToLower(strings.TrimSpace(line))
 	return line == "y" || line == "yes"
-}
-
-// writeFileAtomic writes content to a temp file in the same directory
-// and renames it over path, preserving the existing file mode (or 0600
-// for a new file — the config may hold authkeys / secrets). The
-// same-dir temp keeps the rename atomic (no cross-device move).
-func writeFileAtomic(path string, content []byte) error {
-	dir := filepath.Dir(path)
-	mode := os.FileMode(0o600)
-	if fi, err := os.Stat(path); err == nil {
-		mode = fi.Mode().Perm()
-	}
-	tmp, err := os.CreateTemp(dir, ".clawpatrol-apply-*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName) // no-op after a successful rename
-	if _, err := tmp.Write(content); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Chmod(tmpName, mode); err != nil {
-		return err
-	}
-	return os.Rename(tmpName, path)
 }

--- a/cmd/clawpatrol/apply.go
+++ b/cmd/clawpatrol/apply.go
@@ -1,0 +1,337 @@
+package main
+
+// `clawpatrol apply` and `clawpatrol config history`.
+//
+// apply is the audited, validated path for changing a gateway's config.
+// It loads + compiles the target file (the same pipeline the daemon runs
+// at startup, so an invalid config is rejected before it can reach a
+// running gateway), shows a semantic diff against the last applied
+// version, and on confirmation rewrites the file atomically and records
+// a version row. The running gateway's file watcher then reloads.
+//
+// "Semantic" diff: each config block is rendered through config's
+// deterministic Emit hooks (see config.PolicyDigest) and compared by
+// name, so reordering blocks or editing a comment shows as no change —
+// only a real change to a block's content does.
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+)
+
+// applyTimeFormat matches the repo-wide timestamp convention
+// (yyyy-MM-dd HH:mm:ss.SSS, 24-hour, locale-independent).
+const applyTimeFormat = "2006-01-02 15:04:05.000"
+
+// runApply is the `clawpatrol apply <config.hcl>` entry point.
+func runApply(args []string) {
+	fs := flag.NewFlagSet("apply", flag.ExitOnError)
+	autoApprove := fs.Bool("y", false, "apply without the interactive confirmation prompt")
+	by := fs.String("by", "", "who is applying (default: $SUDO_USER, then $USER)")
+	note := fs.String("note", "", "optional note recorded with this version")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol apply [-y] [--by who] [--note text] <config.hcl>")
+		os.Exit(2)
+	}
+	path := rest[0]
+
+	// Same validation the daemon does at startup, plus external-plugin
+	// schema verification — an invalid config never gets recorded or
+	// activated.
+	mgr := extplugin.New(nil)
+	defer mgr.Stop()
+	config.SetPluginLoader(mgr)
+	gw, cp, err := loadConfig(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	if d := mgr.Verify(); d.HasErrors() {
+		fmt.Fprintf(os.Stderr, "apply: %s: %s\n", path, d.Error())
+		os.Exit(1)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: read %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	revision := revisionForBytes(raw)
+
+	stateDir := resolveStateDir(gw)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "apply: state dir: %v\n", err)
+		os.Exit(1)
+	}
+	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: open db: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	latest, hasLatest, err := latestConfigVersion(db)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: read history: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Build the semantic diff against the last applied version.
+	newDigest := config.PolicyDigest(gw)
+	var oldDigest map[string]string
+	if hasLatest {
+		if oldGw, diags := config.LoadBytes(latest.Content, "applied.hcl"); !diags.HasErrors() {
+			oldDigest = config.PolicyDigest(oldGw)
+		}
+	}
+	d := diffDigests(oldDigest, newDigest)
+
+	if hasLatest && latest.Revision == revision {
+		fmt.Printf("no changes — config already at revision %s\n", shortRev(revision))
+		return
+	}
+
+	fmt.Printf("config: %s\n", path)
+	fmt.Printf("revision: %s  (%d endpoints, %d profiles)\n", shortRev(revision), len(cp.Endpoints), len(cp.Profiles))
+	if hasLatest {
+		fmt.Printf("last applied: %s by %s at %s\n",
+			shortRev(latest.Revision), orUnknown(latest.AppliedBy), time.Unix(0, latest.AppliedNs).Format(applyTimeFormat))
+	} else {
+		fmt.Println("last applied: (none — this is the first recorded version)")
+	}
+	fmt.Println()
+	d.render(os.Stdout)
+	fmt.Println()
+
+	if !*autoApprove {
+		if !confirm(fmt.Sprintf("Apply this config to %s?", path)) {
+			fmt.Println("aborted.")
+			return
+		}
+	}
+
+	// Rewrite atomically so the running gateway never reads a half-written
+	// file, and so the mtime bump triggers its watcher to reload.
+	if err := writeFileAtomic(path, raw); err != nil {
+		fmt.Fprintf(os.Stderr, "apply: write %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	who := resolveApplier(*by)
+	rev, inserted, err := recordConfigVersion(db, raw, gw.SchemaVersion, who, *note)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apply: record version: %v\n", err)
+		os.Exit(1)
+	}
+	if inserted {
+		fmt.Printf("applied: revision %s recorded by %s\n", shortRev(rev), who)
+	} else {
+		fmt.Printf("applied: revision %s (already recorded)\n", shortRev(rev))
+	}
+}
+
+// digestDiff is the categorized result of comparing two PolicyDigests.
+type digestDiff struct {
+	added   []string
+	removed []string
+	changed []string
+}
+
+func (d digestDiff) empty() bool {
+	return len(d.added) == 0 && len(d.removed) == 0 && len(d.changed) == 0
+}
+
+func (d digestDiff) render(w bufWriter) {
+	if d.empty() {
+		fmt.Fprintln(w, "no semantic changes")
+		return
+	}
+	fmt.Fprintf(w, "changes: +%d  -%d  ~%d\n", len(d.added), len(d.removed), len(d.changed))
+	for _, k := range d.added {
+		fmt.Fprintf(w, "  + %s\n", k)
+	}
+	for _, k := range d.removed {
+		fmt.Fprintf(w, "  - %s\n", k)
+	}
+	for _, k := range d.changed {
+		fmt.Fprintf(w, "  ~ %s\n", k)
+	}
+}
+
+// diffDigests compares two block digests by key. Keys present only in
+// new are added, only in old are removed, in both with differing
+// canonical HCL are changed. Each category is sorted for stable output.
+func diffDigests(oldD, newD map[string]string) digestDiff {
+	var d digestDiff
+	for k, nv := range newD {
+		ov, ok := oldD[k]
+		if !ok {
+			d.added = append(d.added, k)
+			continue
+		}
+		if ov != nv {
+			d.changed = append(d.changed, k)
+		}
+	}
+	for k := range oldD {
+		if _, ok := newD[k]; !ok {
+			d.removed = append(d.removed, k)
+		}
+	}
+	sort.Strings(d.added)
+	sort.Strings(d.removed)
+	sort.Strings(d.changed)
+	return d
+}
+
+// runConfig dispatches `clawpatrol config <subcommand>`.
+func runConfig(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol config history <config.hcl>")
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "history":
+		runConfigHistory(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown config subcommand: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol config history <config.hcl>")
+		os.Exit(2)
+	}
+}
+
+// runConfigHistory lists recorded config versions. The config path is
+// used only to resolve the state dir (and thus the DB) — it is not
+// re-parsed for policy.
+func runConfigHistory(args []string) {
+	fs := flag.NewFlagSet("config history", flag.ExitOnError)
+	limit := fs.Int("limit", 20, "max versions to show (0 = all)")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: clawpatrol config history [--limit N] <config.hcl>")
+		os.Exit(2)
+	}
+	gw, _, err := loadConfig(rest[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config history: %s: %v\n", rest[0], err)
+		os.Exit(1)
+	}
+	stateDir := resolveStateDir(gw)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "config history: state dir: %v\n", err)
+		os.Exit(1)
+	}
+	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config history: open db: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	versions, err := listConfigVersions(db, *limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config history: %v\n", err)
+		os.Exit(1)
+	}
+	if len(versions) == 0 {
+		fmt.Println("no config versions recorded yet")
+		return
+	}
+	for _, v := range versions {
+		ts := time.Unix(0, v.AppliedNs).Format(applyTimeFormat)
+		line := fmt.Sprintf("%s  %s  schema=%d  by %s", ts, shortRev(v.Revision), v.SchemaVersion, orUnknown(v.AppliedBy))
+		if v.Note != "" {
+			line += "  — " + v.Note
+		}
+		fmt.Println(line)
+	}
+}
+
+// --- helpers -------------------------------------------------------
+
+// bufWriter is the minimal io.Writer surface render needs; aliased so
+// the signature reads clearly and tests can pass a *strings.Builder.
+type bufWriter = interface{ Write([]byte) (int, error) }
+
+func shortRev(rev string) string {
+	if len(rev) > 12 {
+		return rev[:12]
+	}
+	return rev
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// resolveApplier picks the recorded identity: explicit --by, then
+// $SUDO_USER (apply is usually run as root on the gateway), then $USER.
+func resolveApplier(by string) string {
+	if by != "" {
+		return by
+	}
+	if u := os.Getenv("SUDO_USER"); u != "" {
+		return u
+	}
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	return "unknown"
+}
+
+// confirm prompts on stderr and reads a yes/no from stdin.
+func confirm(prompt string) bool {
+	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
+	r := bufio.NewReader(os.Stdin)
+	line, _ := r.ReadString('\n')
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}
+
+// writeFileAtomic writes content to a temp file in the same directory
+// and renames it over path, preserving the existing file mode (or 0600
+// for a new file — the config may hold authkeys / secrets). The
+// same-dir temp keeps the rename atomic (no cross-device move).
+func writeFileAtomic(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	mode := os.FileMode(0o600)
+	if fi, err := os.Stat(path); err == nil {
+		mode = fi.Mode().Perm()
+	}
+	tmp, err := os.CreateTemp(dir, ".clawpatrol-apply-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/cmd/clawpatrol/apply.go
+++ b/cmd/clawpatrol/apply.go
@@ -129,15 +129,15 @@ func computePlan(db *sql.DB, gw *config.Gateway, raw []byte) (configPlan, error)
 	return p, nil
 }
 
-func (p configPlan) print(w bufWriter, cp *config.CompiledPolicy) {
-	fmt.Fprintf(w, "revision: %s  (%d endpoints, %d profiles)\n", shortRev(p.desiredRev), len(cp.Endpoints), len(cp.Profiles))
+func (p configPlan) print(cp *config.CompiledPolicy) {
+	fmt.Printf("revision: %s  (%d endpoints, %d profiles)\n", shortRev(p.desiredRev), len(cp.Endpoints), len(cp.Profiles))
 	if p.hasDeployed {
-		fmt.Fprintf(w, "deployed: %s  (serial %d)\n\n", shortRev(p.deployedRev), p.deployedSerial)
+		fmt.Printf("deployed: %s  (serial %d)\n\n", shortRev(p.deployedRev), p.deployedSerial)
 	} else {
-		fmt.Fprintln(w, "deployed: (none — backend is empty, this seeds serial 1)")
-		fmt.Fprintln(w)
+		fmt.Println("deployed: (none — backend is empty, this seeds serial 1)")
+		fmt.Println()
 	}
-	p.diff.render(w)
+	p.diff.render()
 }
 
 // savedPlanVersion is the on-disk format version of a saved plan.
@@ -197,14 +197,14 @@ func runPlan(args []string) {
 		fmt.Fprintf(os.Stderr, "plan: %v\n", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	p, err := computePlan(db, gw, raw)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "plan: %v\n", err)
 		os.Exit(1)
 	}
-	p.print(os.Stdout, cp)
+	p.print(cp)
 	if p.noChanges() {
 		fmt.Println("\nNo changes. Deployed config is up to date.")
 	}
@@ -257,7 +257,7 @@ func runApply(args []string) {
 	// planned against; a raw .hcl is planned fresh.
 	var (
 		raw            []byte
-		expectSerial   int64 = *expect
+		expectSerial   = *expect
 		fromSavedPlan  bool
 		savedSchemaVer int
 	)
@@ -289,7 +289,7 @@ func runApply(args []string) {
 		fmt.Fprintf(os.Stderr, "apply: %v\n", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	who := lockHolder()
 	locked, cur, err := acquireConfigLock(db, who, "apply "+path)
@@ -308,7 +308,7 @@ func runApply(args []string) {
 	// os.Exit here would skip the defer and leak the lock, wedging the
 	// next apply until the staleness steal kicks in.
 	err = func() error {
-		defer releaseConfigLock(db, who)
+		defer func() { _ = releaseConfigLock(db, who) }()
 
 		deployedSerial, err := currentSerial(db)
 		if err != nil {
@@ -334,7 +334,7 @@ func runApply(args []string) {
 			return err
 		}
 		fmt.Printf("config: %s\n", path)
-		p.print(os.Stdout, cp)
+		p.print(cp)
 		if fromSavedPlan {
 			fmt.Println("\n(applying saved plan)")
 		}
@@ -383,20 +383,20 @@ func (d digestDiff) empty() bool {
 	return len(d.added) == 0 && len(d.removed) == 0 && len(d.changed) == 0
 }
 
-func (d digestDiff) render(w bufWriter) {
+func (d digestDiff) render() {
 	if d.empty() {
-		fmt.Fprintln(w, "no semantic changes")
+		fmt.Println("no semantic changes")
 		return
 	}
-	fmt.Fprintf(w, "changes: +%d  -%d  ~%d\n", len(d.added), len(d.removed), len(d.changed))
+	fmt.Printf("changes: +%d  -%d  ~%d\n", len(d.added), len(d.removed), len(d.changed))
 	for _, k := range d.added {
-		fmt.Fprintf(w, "  + %s\n", k)
+		fmt.Printf("  + %s\n", k)
 	}
 	for _, k := range d.removed {
-		fmt.Fprintf(w, "  - %s\n", k)
+		fmt.Printf("  - %s\n", k)
 	}
 	for _, k := range d.changed {
-		fmt.Fprintf(w, "  ~ %s\n", k)
+		fmt.Printf("  ~ %s\n", k)
 	}
 }
 
@@ -466,7 +466,7 @@ func runConfigHistory(args []string) {
 		fmt.Fprintf(os.Stderr, "config history: %v\n", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	versions, err := listConfigVersions(db, *limit)
 	if err != nil {
@@ -505,7 +505,7 @@ func runConfigUnlock(args []string) {
 		fmt.Fprintf(os.Stderr, "config unlock: %v\n", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	cur, held, _ := readConfigLock(db)
 	released, err := forceUnlockConfigLock(db)
@@ -521,10 +521,6 @@ func runConfigUnlock(args []string) {
 }
 
 // --- helpers -------------------------------------------------------
-
-// bufWriter is the minimal io.Writer surface render/print need; aliased
-// so signatures read clearly and tests can pass a *strings.Builder.
-type bufWriter = interface{ Write([]byte) (int, error) }
 
 func shortRev(rev string) string {
 	if len(rev) > 12 {

--- a/cmd/clawpatrol/apply_test.go
+++ b/cmd/clawpatrol/apply_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLooksLikeSavedPlan(t *testing.T) {
+	sp := savedPlan{
+		Version:        savedPlanVersion,
+		Config:         []byte("gateway {}\n"),
+		Revision:       "abc",
+		ExpectedSerial: 3,
+		Added:          []string{"endpoint x"},
+	}
+	blob, err := json.Marshal(sp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, ok := looksLikeSavedPlan(blob)
+	if !ok {
+		t.Fatal("marshaled plan should be detected as a saved plan")
+	}
+	if got.ExpectedSerial != 3 || string(got.Config) != "gateway {}\n" {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+
+	// Raw HCL is not a saved plan.
+	if _, ok := looksLikeSavedPlan([]byte("gateway {\n  state_dir = \"/x\"\n}\n")); ok {
+		t.Fatal("HCL must not be mistaken for a saved plan")
+	}
+	// JSON without a version is not a saved plan.
+	if _, ok := looksLikeSavedPlan([]byte(`{"foo":1}`)); ok {
+		t.Fatal("versionless JSON must not be a saved plan")
+	}
+	// Empty input.
+	if _, ok := looksLikeSavedPlan(nil); ok {
+		t.Fatal("empty input must not be a saved plan")
+	}
+}

--- a/cmd/clawpatrol/config_state.go
+++ b/cmd/clawpatrol/config_state.go
@@ -1,0 +1,170 @@
+package main
+
+// State-backend operations for `clawpatrol apply`: the config lock and
+// the compare-and-swap insert that together give Terraform-style
+// concurrency safety. config_versions is the authoritative state (its
+// latest id is the deployed serial); this file is the locking + CAS
+// layer over it. See migrations/sqlite/0021_config_lock.sql.
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+// configLockStaleAfter bounds how long a lock survives its holder. A
+// crashed apply leaves the row behind; once it is older than this, the
+// next acquirer steals it (logged). Terraform leaves stale locks for a
+// manual force-unlock; we add a TTL so a crashed CLI can't wedge the
+// gateway's config forever.
+const configLockStaleAfter = 10 * time.Minute
+
+// configLock is the single-row lock state.
+type configLock struct {
+	Holder   string `json:"holder"`
+	Reason   string `json:"reason"`
+	LockedNs int64  `json:"locked_ns"`
+}
+
+// readConfigLock returns the current lock holder, if any.
+func readConfigLock(db *sql.DB) (configLock, bool, error) {
+	if db == nil {
+		return configLock{}, false, fmt.Errorf("no db")
+	}
+	var l configLock
+	err := db.QueryRow(`SELECT holder, reason, locked_ns FROM config_lock WHERE id = 0`).
+		Scan(&l.Holder, &l.Reason, &l.LockedNs)
+	if errors.Is(err, sql.ErrNoRows) {
+		return configLock{}, false, nil
+	}
+	if err != nil {
+		return configLock{}, false, err
+	}
+	return l, true, nil
+}
+
+// acquireConfigLock takes the lock for holder. Returns (true, _) on
+// success. On contention returns (false, current) with the existing
+// holder so the caller can report it. A lock older than
+// configLockStaleAfter is stolen.
+func acquireConfigLock(db *sql.DB, holder, reason string) (bool, configLock, error) {
+	if db == nil {
+		return false, configLock{}, fmt.Errorf("no db")
+	}
+	now := time.Now().UnixNano()
+	mine := configLock{Holder: holder, Reason: reason, LockedNs: now}
+
+	if _, err := db.Exec(
+		`INSERT INTO config_lock (id, holder, reason, locked_ns) VALUES (0, ?, ?, ?)`,
+		holder, reason, now,
+	); err == nil {
+		return true, mine, nil
+	}
+
+	// Insert failed — almost certainly the row already exists (lock
+	// held). Read it to decide whether to report contention or steal a
+	// stale lock.
+	cur, held, rerr := readConfigLock(db)
+	if rerr != nil {
+		return false, configLock{}, rerr
+	}
+	if !held {
+		// Raced with a release between our failed insert and this read;
+		// try once more.
+		if _, err := db.Exec(
+			`INSERT INTO config_lock (id, holder, reason, locked_ns) VALUES (0, ?, ?, ?)`,
+			holder, reason, now,
+		); err == nil {
+			return true, mine, nil
+		}
+		cur, held, _ = readConfigLock(db)
+		if !held {
+			return false, configLock{}, fmt.Errorf("config lock: could not acquire")
+		}
+	}
+	if now-cur.LockedNs > int64(configLockStaleAfter) {
+		if _, err := db.Exec(
+			`UPDATE config_lock SET holder = ?, reason = ?, locked_ns = ? WHERE id = 0`,
+			holder, reason, now,
+		); err != nil {
+			return false, cur, err
+		}
+		log.Printf("config lock: stole stale lock from %q (held %s)", cur.Holder,
+			time.Duration(now-cur.LockedNs).Round(time.Second))
+		return true, mine, nil
+	}
+	return false, cur, nil
+}
+
+// releaseConfigLock drops the lock if held by holder. Idempotent.
+func releaseConfigLock(db *sql.DB, holder string) error {
+	if db == nil {
+		return fmt.Errorf("no db")
+	}
+	_, err := db.Exec(`DELETE FROM config_lock WHERE id = 0 AND holder = ?`, holder)
+	return err
+}
+
+// forceUnlockConfigLock drops the lock regardless of holder. Backs
+// `clawpatrol config unlock`.
+func forceUnlockConfigLock(db *sql.DB) (bool, error) {
+	if db == nil {
+		return false, fmt.Errorf("no db")
+	}
+	res, err := db.Exec(`DELETE FROM config_lock WHERE id = 0`)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// recordConfigVersionCAS inserts a new version only if the current
+// latest serial equals expectedSerial — the compare-and-swap that
+// rejects a stale apply (one whose plan was computed against a serial
+// another writer has since superseded). ok is false on a CAS miss;
+// serial is the new row's id on success.
+func recordConfigVersionCAS(db *sql.DB, content []byte, schemaVersion int, appliedBy, note string, expectedSerial int64) (revision string, serial int64, ok bool, err error) {
+	if db == nil {
+		return "", 0, false, fmt.Errorf("no db")
+	}
+	revision = revisionForBytes(content)
+	res, err := db.Exec(
+		`INSERT INTO config_versions (revision, schema_version, content, applied_by, note, applied_ns)
+		 SELECT ?, ?, ?, ?, ?, ?
+		  WHERE (SELECT COALESCE(MAX(id), 0) FROM config_versions) = ?`,
+		revision, schemaVersion, content, appliedBy, note, time.Now().UnixNano(), expectedSerial,
+	)
+	if err != nil {
+		return "", 0, false, err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return revision, 0, false, nil
+	}
+	id, _ := res.LastInsertId()
+	return revision, id, true, nil
+}
+
+// activeConfig returns the deployed config: the content + serial of the
+// latest version. ok is false when the backend is empty (no config has
+// been seeded/applied yet).
+func activeConfig(db *sql.DB) (content []byte, serial int64, ok bool, err error) {
+	v, found, err := latestConfigVersion(db)
+	if err != nil || !found {
+		return nil, 0, false, err
+	}
+	return v.Content, v.ID, true, nil
+}
+
+// currentSerial returns the latest serial (0 when the backend is empty).
+func currentSerial(db *sql.DB) (int64, error) {
+	if db == nil {
+		return 0, fmt.Errorf("no db")
+	}
+	var s int64
+	err := db.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM config_versions`).Scan(&s)
+	return s, err
+}

--- a/cmd/clawpatrol/config_state.go
+++ b/cmd/clawpatrol/config_state.go
@@ -126,16 +126,16 @@ func forceUnlockConfigLock(db *sql.DB) (bool, error) {
 // rejects a stale apply (one whose plan was computed against a serial
 // another writer has since superseded). ok is false on a CAS miss;
 // serial is the new row's id on success.
-func recordConfigVersionCAS(db *sql.DB, content []byte, schemaVersion int, appliedBy, note string, expectedSerial int64) (revision string, serial int64, ok bool, err error) {
+func recordConfigVersionCAS(db *sql.DB, content []byte, schemaVersion int, expectedSerial int64) (revision string, serial int64, ok bool, err error) {
 	if db == nil {
 		return "", 0, false, fmt.Errorf("no db")
 	}
 	revision = revisionForBytes(content)
 	res, err := db.Exec(
-		`INSERT INTO config_versions (revision, schema_version, content, applied_by, note, applied_ns)
-		 SELECT ?, ?, ?, ?, ?, ?
+		`INSERT INTO config_versions (revision, schema_version, content, applied_ns)
+		 SELECT ?, ?, ?, ?
 		  WHERE (SELECT COALESCE(MAX(id), 0) FROM config_versions) = ?`,
-		revision, schemaVersion, content, appliedBy, note, time.Now().UnixNano(), expectedSerial,
+		revision, schemaVersion, content, time.Now().UnixNano(), expectedSerial,
 	)
 	if err != nil {
 		return "", 0, false, err

--- a/cmd/clawpatrol/config_state_test.go
+++ b/cmd/clawpatrol/config_state_test.go
@@ -73,7 +73,7 @@ func TestRecordConfigVersionCAS(t *testing.T) {
 	db := newCVTestDB(t)
 
 	// Seed serial 1 from an empty backend (expected serial 0).
-	rev1, s1, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n"), 1, "alice", "v1", 0)
+	rev1, s1, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n"), 1, 0)
 	if err != nil || !ok {
 		t.Fatalf("seed: ok=%v err=%v", ok, err)
 	}
@@ -82,12 +82,12 @@ func TestRecordConfigVersionCAS(t *testing.T) {
 	}
 
 	// A stale writer that still thinks the latest is 0 is rejected.
-	if _, _, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n# x\n"), 1, "bob", "stale", 0); err != nil || ok {
+	if _, _, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n# x\n"), 1, 0); err != nil || ok {
 		t.Fatalf("stale CAS should fail: ok=%v err=%v", ok, err)
 	}
 
 	// A writer with the current serial succeeds and advances it.
-	rev2, s2, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n# x\n"), 1, "alice", "v2", s1)
+	rev2, s2, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n# x\n"), 1, s1)
 	if err != nil || !ok {
 		t.Fatalf("fresh CAS: ok=%v err=%v", ok, err)
 	}

--- a/cmd/clawpatrol/config_state_test.go
+++ b/cmd/clawpatrol/config_state_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigLockMutualExclusion(t *testing.T) {
+	db := newCVTestDB(t)
+
+	ok, _, err := acquireConfigLock(db, "alice@host", "apply x")
+	if err != nil || !ok {
+		t.Fatalf("first acquire: ok=%v err=%v", ok, err)
+	}
+	// Second acquirer is blocked and learns the holder.
+	ok, cur, err := acquireConfigLock(db, "bob@host", "apply y")
+	if err != nil {
+		t.Fatalf("second acquire err: %v", err)
+	}
+	if ok {
+		t.Fatal("second acquire should be blocked while held")
+	}
+	if cur.Holder != "alice@host" {
+		t.Fatalf("contention should report holder alice@host, got %q", cur.Holder)
+	}
+	// Holder releases; now bob can take it.
+	if err := releaseConfigLock(db, "alice@host"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if ok, _, err := acquireConfigLock(db, "bob@host", "apply y"); err != nil || !ok {
+		t.Fatalf("acquire after release: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestConfigLockStealsStale(t *testing.T) {
+	db := newCVTestDB(t)
+	// Plant a lock older than the staleness window (simulating a crashed
+	// apply that never released).
+	old := time.Now().Add(-2 * configLockStaleAfter).UnixNano()
+	if _, err := db.Exec(
+		`INSERT INTO config_lock (id, holder, reason, locked_ns) VALUES (0, ?, ?, ?)`,
+		"ghost@host", "crashed", old,
+	); err != nil {
+		t.Fatalf("plant: %v", err)
+	}
+	ok, _, err := acquireConfigLock(db, "alice@host", "apply x")
+	if err != nil || !ok {
+		t.Fatalf("should steal stale lock: ok=%v err=%v", ok, err)
+	}
+	cur, held, _ := readConfigLock(db)
+	if !held || cur.Holder != "alice@host" {
+		t.Fatalf("after steal holder should be alice@host, got %q held=%v", cur.Holder, held)
+	}
+}
+
+func TestForceUnlock(t *testing.T) {
+	db := newCVTestDB(t)
+	_, _, _ = acquireConfigLock(db, "alice@host", "apply x")
+	released, err := forceUnlockConfigLock(db)
+	if err != nil || !released {
+		t.Fatalf("force unlock: released=%v err=%v", released, err)
+	}
+	if _, held, _ := readConfigLock(db); held {
+		t.Fatal("lock should be gone after force unlock")
+	}
+	// Idempotent on an unlocked backend.
+	if released, _ := forceUnlockConfigLock(db); released {
+		t.Fatal("second force unlock should report nothing released")
+	}
+}
+
+func TestRecordConfigVersionCAS(t *testing.T) {
+	db := newCVTestDB(t)
+
+	// Seed serial 1 from an empty backend (expected serial 0).
+	rev1, s1, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n"), 1, "alice", "v1", 0)
+	if err != nil || !ok {
+		t.Fatalf("seed: ok=%v err=%v", ok, err)
+	}
+	if s1 != 1 {
+		t.Fatalf("first serial = %d, want 1", s1)
+	}
+
+	// A stale writer that still thinks the latest is 0 is rejected.
+	if _, _, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n# x\n"), 1, "bob", "stale", 0); err != nil || ok {
+		t.Fatalf("stale CAS should fail: ok=%v err=%v", ok, err)
+	}
+
+	// A writer with the current serial succeeds and advances it.
+	rev2, s2, ok, err := recordConfigVersionCAS(db, []byte("gateway {}\n# x\n"), 1, "alice", "v2", s1)
+	if err != nil || !ok {
+		t.Fatalf("fresh CAS: ok=%v err=%v", ok, err)
+	}
+	if s2 != 2 {
+		t.Fatalf("second serial = %d, want 2", s2)
+	}
+	if rev1 == rev2 {
+		t.Fatal("different content should yield different revisions")
+	}
+
+	cur, err := currentSerial(db)
+	if err != nil || cur != 2 {
+		t.Fatalf("currentSerial = %d err=%v, want 2", cur, err)
+	}
+	content, serial, present, err := activeConfig(db)
+	if err != nil || !present || serial != 2 || string(content) != "gateway {}\n# x\n" {
+		t.Fatalf("activeConfig = serial %d present=%v err=%v", serial, present, err)
+	}
+}

--- a/cmd/clawpatrol/config_versions.go
+++ b/cmd/clawpatrol/config_versions.go
@@ -62,7 +62,7 @@ func listConfigVersions(db *sql.DB, limit int) ([]configVersion, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var out []configVersion
 	for rows.Next() {
 		var v configVersion

--- a/cmd/clawpatrol/config_versions.go
+++ b/cmd/clawpatrol/config_versions.go
@@ -1,8 +1,10 @@
 package main
 
-// Persistence for the gateway config version history — the audit trail
-// behind `clawpatrol apply` and `clawpatrol config history`. See
+// Persistence for the config state backend — the rows behind
+// `clawpatrol apply` and `clawpatrol config history`. See
 // migrations/sqlite/0020_config_versions.sql for the schema rationale.
+// OSS-Terraform-shaped: a row carries only what conflict detection
+// needs (serial=id, content, revision) plus a convenience timestamp.
 
 import (
 	"database/sql"
@@ -17,8 +19,6 @@ type configVersion struct {
 	Revision      string `json:"revision"`
 	SchemaVersion int    `json:"schema_version"`
 	Content       []byte `json:"-"`
-	AppliedBy     string `json:"applied_by"`
-	Note          string `json:"note"`
 	AppliedNs     int64  `json:"applied_ns"`
 }
 
@@ -30,11 +30,11 @@ func latestConfigVersion(db *sql.DB) (configVersion, bool, error) {
 	}
 	var v configVersion
 	err := db.QueryRow(
-		`SELECT id, revision, schema_version, content, applied_by, note, applied_ns
+		`SELECT id, revision, schema_version, content, applied_ns
 		   FROM config_versions
 		  ORDER BY id DESC
 		  LIMIT 1`,
-	).Scan(&v.ID, &v.Revision, &v.SchemaVersion, &v.Content, &v.AppliedBy, &v.Note, &v.AppliedNs)
+	).Scan(&v.ID, &v.Revision, &v.SchemaVersion, &v.Content, &v.AppliedNs)
 	if errors.Is(err, sql.ErrNoRows) {
 		return configVersion{}, false, nil
 	}
@@ -50,7 +50,7 @@ func listConfigVersions(db *sql.DB, limit int) ([]configVersion, error) {
 	if db == nil {
 		return nil, fmt.Errorf("no db")
 	}
-	q := `SELECT id, revision, schema_version, applied_by, note, applied_ns
+	q := `SELECT id, revision, schema_version, applied_ns
 	        FROM config_versions
 	       ORDER BY id DESC`
 	args := []any{}
@@ -66,7 +66,7 @@ func listConfigVersions(db *sql.DB, limit int) ([]configVersion, error) {
 	var out []configVersion
 	for rows.Next() {
 		var v configVersion
-		if err := rows.Scan(&v.ID, &v.Revision, &v.SchemaVersion, &v.AppliedBy, &v.Note, &v.AppliedNs); err != nil {
+		if err := rows.Scan(&v.ID, &v.Revision, &v.SchemaVersion, &v.AppliedNs); err != nil {
 			return nil, err
 		}
 		out = append(out, v)
@@ -77,8 +77,8 @@ func listConfigVersions(db *sql.DB, limit int) ([]configVersion, error) {
 // recordConfigVersion inserts a new version row unless its revision
 // matches the latest (so boot + apply + reload of the same config don't
 // pile up duplicates). Returns the revision and whether a row was
-// inserted.
-func recordConfigVersion(db *sql.DB, content []byte, schemaVersion int, appliedBy, note string) (revision string, inserted bool, err error) {
+// inserted. Used for the boot seed; apply uses recordConfigVersionCAS.
+func recordConfigVersion(db *sql.DB, content []byte, schemaVersion int) (revision string, inserted bool, err error) {
 	if db == nil {
 		return "", false, fmt.Errorf("no db")
 	}
@@ -91,9 +91,9 @@ func recordConfigVersion(db *sql.DB, content []byte, schemaVersion int, appliedB
 		return revision, false, nil
 	}
 	_, err = db.Exec(
-		`INSERT INTO config_versions (revision, schema_version, content, applied_by, note, applied_ns)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-		revision, schemaVersion, content, appliedBy, note, time.Now().UnixNano(),
+		`INSERT INTO config_versions (revision, schema_version, content, applied_ns)
+		 VALUES (?, ?, ?, ?)`,
+		revision, schemaVersion, content, time.Now().UnixNano(),
 	)
 	if err != nil {
 		return "", false, err

--- a/cmd/clawpatrol/config_versions.go
+++ b/cmd/clawpatrol/config_versions.go
@@ -8,8 +8,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"time"
 )
 
@@ -101,30 +99,4 @@ func recordConfigVersion(db *sql.DB, content []byte, schemaVersion int, appliedB
 		return "", false, err
 	}
 	return revision, true, nil
-}
-
-// recordBootConfigVersion records the config the gateway loaded at
-// startup, so the history begins from the running config rather than
-// from the first `apply`. Best-effort: a recording failure must never
-// block the gateway from starting. Skipped for directory configs
-// (multi-file merges have no single-file byte stream to hash); apply is
-// the path for those.
-func recordBootConfigVersion(db *sql.DB, cfgPath string, schemaVersion int) {
-	fi, err := os.Stat(cfgPath)
-	if err != nil || fi.IsDir() {
-		return
-	}
-	raw, err := os.ReadFile(cfgPath)
-	if err != nil {
-		log.Printf("config history: read boot config: %v", err)
-		return
-	}
-	rev, inserted, err := recordConfigVersion(db, raw, schemaVersion, "boot", "")
-	if err != nil {
-		log.Printf("config history: record boot config: %v", err)
-		return
-	}
-	if inserted {
-		log.Printf("config history: recorded boot config revision %s", rev[:min(12, len(rev))])
-	}
 }

--- a/cmd/clawpatrol/config_versions.go
+++ b/cmd/clawpatrol/config_versions.go
@@ -1,0 +1,130 @@
+package main
+
+// Persistence for the gateway config version history — the audit trail
+// behind `clawpatrol apply` and `clawpatrol config history`. See
+// migrations/sqlite/0020_config_versions.sql for the schema rationale.
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+// configVersion is one recorded config snapshot.
+type configVersion struct {
+	ID            int64  `json:"id"`
+	Revision      string `json:"revision"`
+	SchemaVersion int    `json:"schema_version"`
+	Content       []byte `json:"-"`
+	AppliedBy     string `json:"applied_by"`
+	Note          string `json:"note"`
+	AppliedNs     int64  `json:"applied_ns"`
+}
+
+// latestConfigVersion returns the most recently applied version. ok is
+// false when the table is empty (no apply / boot recorded yet).
+func latestConfigVersion(db *sql.DB) (configVersion, bool, error) {
+	if db == nil {
+		return configVersion{}, false, fmt.Errorf("no db")
+	}
+	var v configVersion
+	err := db.QueryRow(
+		`SELECT id, revision, schema_version, content, applied_by, note, applied_ns
+		   FROM config_versions
+		  ORDER BY id DESC
+		  LIMIT 1`,
+	).Scan(&v.ID, &v.Revision, &v.SchemaVersion, &v.Content, &v.AppliedBy, &v.Note, &v.AppliedNs)
+	if errors.Is(err, sql.ErrNoRows) {
+		return configVersion{}, false, nil
+	}
+	if err != nil {
+		return configVersion{}, false, err
+	}
+	return v, true, nil
+}
+
+// listConfigVersions returns up to limit versions, newest first. limit
+// <= 0 returns all.
+func listConfigVersions(db *sql.DB, limit int) ([]configVersion, error) {
+	if db == nil {
+		return nil, fmt.Errorf("no db")
+	}
+	q := `SELECT id, revision, schema_version, applied_by, note, applied_ns
+	        FROM config_versions
+	       ORDER BY id DESC`
+	args := []any{}
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []configVersion
+	for rows.Next() {
+		var v configVersion
+		if err := rows.Scan(&v.ID, &v.Revision, &v.SchemaVersion, &v.AppliedBy, &v.Note, &v.AppliedNs); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// recordConfigVersion inserts a new version row unless its revision
+// matches the latest (so boot + apply + reload of the same config don't
+// pile up duplicates). Returns the revision and whether a row was
+// inserted.
+func recordConfigVersion(db *sql.DB, content []byte, schemaVersion int, appliedBy, note string) (revision string, inserted bool, err error) {
+	if db == nil {
+		return "", false, fmt.Errorf("no db")
+	}
+	revision = revisionForBytes(content)
+	latest, ok, err := latestConfigVersion(db)
+	if err != nil {
+		return "", false, err
+	}
+	if ok && latest.Revision == revision {
+		return revision, false, nil
+	}
+	_, err = db.Exec(
+		`INSERT INTO config_versions (revision, schema_version, content, applied_by, note, applied_ns)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		revision, schemaVersion, content, appliedBy, note, time.Now().UnixNano(),
+	)
+	if err != nil {
+		return "", false, err
+	}
+	return revision, true, nil
+}
+
+// recordBootConfigVersion records the config the gateway loaded at
+// startup, so the history begins from the running config rather than
+// from the first `apply`. Best-effort: a recording failure must never
+// block the gateway from starting. Skipped for directory configs
+// (multi-file merges have no single-file byte stream to hash); apply is
+// the path for those.
+func recordBootConfigVersion(db *sql.DB, cfgPath string, schemaVersion int) {
+	fi, err := os.Stat(cfgPath)
+	if err != nil || fi.IsDir() {
+		return
+	}
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		log.Printf("config history: read boot config: %v", err)
+		return
+	}
+	rev, inserted, err := recordConfigVersion(db, raw, schemaVersion, "boot", "")
+	if err != nil {
+		log.Printf("config history: record boot config: %v", err)
+		return
+	}
+	if inserted {
+		log.Printf("config history: recorded boot config revision %s", rev[:min(12, len(rev))])
+	}
+}

--- a/cmd/clawpatrol/config_versions_test.go
+++ b/cmd/clawpatrol/config_versions_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"database/sql"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -92,32 +91,5 @@ func TestDiffDigestsEmpty(t *testing.T) {
 	m := map[string]string{"gateway": "a"}
 	if !diffDigests(m, m).empty() {
 		t.Error("identical digests should diff empty")
-	}
-}
-
-func TestWriteFileAtomicPreservesMode(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "gateway.hcl")
-	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-	if err := writeFileAtomic(path, []byte("new content")); err != nil {
-		t.Fatalf("writeFileAtomic: %v", err)
-	}
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if string(got) != "new content" {
-		t.Fatalf("content = %q", got)
-	}
-	fi, _ := os.Stat(path)
-	if fi.Mode().Perm() != 0o640 {
-		t.Fatalf("mode = %o, want 640", fi.Mode().Perm())
-	}
-	// No temp file left behind.
-	entries, _ := os.ReadDir(dir)
-	if len(entries) != 1 {
-		t.Fatalf("expected only the config file, got %d entries", len(entries))
 	}
 }

--- a/cmd/clawpatrol/config_versions_test.go
+++ b/cmd/clawpatrol/config_versions_test.go
@@ -18,7 +18,7 @@ func newCVTestDB(t *testing.T) *sql.DB {
 
 func TestRecordConfigVersionDedup(t *testing.T) {
 	db := newCVTestDB(t)
-	rev1, inserted, err := recordConfigVersion(db, []byte("gateway {}\n"), 1, "alice", "first")
+	rev1, inserted, err := recordConfigVersion(db, []byte("gateway {}\n"), 1)
 	if err != nil {
 		t.Fatalf("record: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestRecordConfigVersionDedup(t *testing.T) {
 		t.Fatal("first record should insert")
 	}
 	// Same bytes → no new row.
-	rev2, inserted, err := recordConfigVersion(db, []byte("gateway {}\n"), 1, "bob", "dup")
+	rev2, inserted, err := recordConfigVersion(db, []byte("gateway {}\n"), 1)
 	if err != nil {
 		t.Fatalf("record dup: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestRecordConfigVersionDedup(t *testing.T) {
 		t.Fatalf("same bytes → same revision, got %s vs %s", rev1, rev2)
 	}
 	// Different bytes → new row.
-	if _, inserted, _ := recordConfigVersion(db, []byte("gateway {}\n# changed\n"), 1, "alice", "second"); !inserted {
+	if _, inserted, _ := recordConfigVersion(db, []byte("gateway {}\n# changed\n"), 1); !inserted {
 		t.Fatal("changed bytes must insert")
 	}
 	versions, err := listConfigVersions(db, 0)
@@ -47,9 +47,9 @@ func TestRecordConfigVersionDedup(t *testing.T) {
 	if len(versions) != 2 {
 		t.Fatalf("want 2 versions, got %d", len(versions))
 	}
-	// Newest first.
-	if versions[0].Note != "second" {
-		t.Fatalf("want newest-first ordering, got note %q", versions[0].Note)
+	// Newest first (highest serial).
+	if versions[0].ID <= versions[1].ID {
+		t.Fatalf("want newest-first ordering, got ids %d, %d", versions[0].ID, versions[1].ID)
 	}
 }
 

--- a/cmd/clawpatrol/config_versions_test.go
+++ b/cmd/clawpatrol/config_versions_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newCVTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRecordConfigVersionDedup(t *testing.T) {
+	db := newCVTestDB(t)
+	rev1, inserted, err := recordConfigVersion(db, []byte("gateway {}\n"), 1, "alice", "first")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if !inserted {
+		t.Fatal("first record should insert")
+	}
+	// Same bytes → no new row.
+	rev2, inserted, err := recordConfigVersion(db, []byte("gateway {}\n"), 1, "bob", "dup")
+	if err != nil {
+		t.Fatalf("record dup: %v", err)
+	}
+	if inserted {
+		t.Fatal("identical revision must not insert a second row")
+	}
+	if rev1 != rev2 {
+		t.Fatalf("same bytes → same revision, got %s vs %s", rev1, rev2)
+	}
+	// Different bytes → new row.
+	if _, inserted, _ := recordConfigVersion(db, []byte("gateway {}\n# changed\n"), 1, "alice", "second"); !inserted {
+		t.Fatal("changed bytes must insert")
+	}
+	versions, err := listConfigVersions(db, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("want 2 versions, got %d", len(versions))
+	}
+	// Newest first.
+	if versions[0].Note != "second" {
+		t.Fatalf("want newest-first ordering, got note %q", versions[0].Note)
+	}
+}
+
+func TestLatestConfigVersionEmpty(t *testing.T) {
+	db := newCVTestDB(t)
+	if _, ok, err := latestConfigVersion(db); err != nil || ok {
+		t.Fatalf("empty table: want (_, false, nil), got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestDiffDigests(t *testing.T) {
+	old := map[string]string{
+		"gateway":            "a",
+		"endpoint anthropic": "x",
+		"endpoint slack":     "y",
+	}
+	newD := map[string]string{
+		"gateway":            "a",  // unchanged
+		"endpoint anthropic": "x2", // changed
+		"endpoint github":    "z",  // added
+		// "endpoint slack" removed
+	}
+	d := diffDigests(old, newD)
+	if len(d.added) != 1 || d.added[0] != "endpoint github" {
+		t.Errorf("added = %v", d.added)
+	}
+	if len(d.removed) != 1 || d.removed[0] != "endpoint slack" {
+		t.Errorf("removed = %v", d.removed)
+	}
+	if len(d.changed) != 1 || d.changed[0] != "endpoint anthropic" {
+		t.Errorf("changed = %v", d.changed)
+	}
+	if d.empty() {
+		t.Error("diff should not be empty")
+	}
+}
+
+func TestDiffDigestsEmpty(t *testing.T) {
+	m := map[string]string{"gateway": "a"}
+	if !diffDigests(m, m).empty() {
+		t.Error("identical digests should diff empty")
+	}
+}
+
+func TestWriteFileAtomicPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gateway.hcl")
+	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := writeFileAtomic(path, []byte("new content")); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "new content" {
+		t.Fatalf("content = %q", got)
+	}
+	fi, _ := os.Stat(path)
+	if fi.Mode().Perm() != 0o640 {
+		t.Fatalf("mode = %o, want 640", fi.Mode().Perm())
+	}
+	// No temp file left behind.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Fatalf("expected only the config file, got %d entries", len(entries))
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -340,9 +340,13 @@ type Gateway struct {
 	stateDir string // resolved gateway state dir (sqlite + plugin blobs)
 	db       *sql.DB
 	policy   atomic.Pointer[config.CompiledPolicy]
-	certs    *CertCache
-	dialer   *net.Dialer
-	sink     *Sink
+	// configSerial is the config_versions id the gateway is currently
+	// running (0 = pre-backend / file-only). watchConfig polls the
+	// backend's latest serial against this to pick up applies.
+	configSerial atomic.Int64
+	certs        *CertCache
+	dialer       *net.Dialer
+	sink         *Sink
 	// blobs is the gateway-side plugin blob store (sqlite-backed).
 	// Used by endpoint plugins that need per-endpoint persistent
 	// bytes — SSH host keys today, future JWT signing keys.
@@ -571,28 +575,34 @@ func defaultProfileName(p *config.Policy) string {
 // re-decodes the HCL and atomically swaps in the new rules + admin_email
 // + integrations list. Listen ports / CA dir / OAuth dir / Tailscale
 // block changes still require a restart (logged but not applied).
-func (g *Gateway) watchConfig(path string) {
-	st, err := os.Stat(path)
-	if err != nil {
-		return
-	}
-	last := st.ModTime()
+// watchConfig polls the state backend for a newer applied serial and
+// hot-swaps the running policy when `clawpatrol apply` records one.
+// This replaces the old file-mtime watch: the backend (config_versions)
+// is authoritative, so editing the file on disk no longer changes the
+// running config — only an apply does.
+func (g *Gateway) watchConfig() {
 	for {
 		time.Sleep(3 * time.Second)
-		st, err := os.Stat(path)
-		if err != nil || !st.ModTime().After(last) {
+		latest, err := currentSerial(g.db)
+		if err != nil || latest <= g.configSerial.Load() {
 			continue
 		}
-		last = st.ModTime()
-		next, policy, err := loadConfig(path)
+		content, serial, ok, err := activeConfig(g.db)
+		if err != nil || !ok {
+			continue
+		}
+		next, policy, err := loadConfigBytes(content)
 		if err != nil {
-			log.Printf("config reload: %v", err)
+			// A recorded version that won't load (e.g. a schema bump this
+			// binary predates). Advance past it so we don't retry every
+			// tick; keep running the previous policy.
+			log.Printf("config reload: serial %d failed to load: %v", serial, err)
+			g.configSerial.Store(serial)
 			continue
 		}
 		g.policy.Store(policy)
 		registerOAuthCredentials(g.oauth, policy)
-		newConnIdx := runtime.BuildConnIndex(policy)
-		g.connIdx.Store(newConnIdx)
+		g.connIdx.Store(runtime.BuildConnIndex(policy))
 		if g.tunnels != nil {
 			g.tunnels.SetPolicy(context.Background(), policy)
 		}
@@ -602,13 +612,62 @@ func (g *Gateway) watchConfig(path string) {
 			}
 		}
 		// Hot-swap the operational *config.Gateway too — AdminEmail /
-		// PublicURL / DashboardOperators reads pick up immediately.
-		// Listen / CADir / Tailscale changes are not applied (restart).
+		// PublicURL reads pick up immediately. Listen / CADir / Tailscale
+		// changes are not applied (restart).
 		g.cfg = next
-		log.Printf("config reloaded: %d endpoints across %d profile(s)",
-			len(policy.Endpoints), len(policy.Profiles))
+		g.configSerial.Store(serial)
+		log.Printf("config reloaded from backend: serial %d, %d endpoints across %d profile(s)",
+			serial, len(policy.Endpoints), len(policy.Profiles))
 		logDashboardAuthState(g.db, next)
 	}
+}
+
+// resolveBackendConfig seeds the state backend from the bootstrap file
+// when empty, then returns the config the gateway should actually run
+// (the backend's deployed version) along with its serial. The file is
+// only authoritative for the very first boot; thereafter `clawpatrol
+// apply` owns the deployed config.
+func resolveBackendConfig(db *sql.DB, cfgPath string, fileCfg *config.Gateway, filePolicy *config.CompiledPolicy) (*config.Gateway, *config.CompiledPolicy, int64) {
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		// Directory config or unreadable path: no single byte stream to
+		// seed/serve from the backend. Run the file as loaded.
+		log.Printf("config backend: not seeding (%v); running file config", err)
+		return fileCfg, filePolicy, 0
+	}
+	if _, _, serr := recordConfigVersion(db, raw, fileCfg.SchemaVersion, "boot", ""); serr != nil {
+		log.Printf("config backend: seed: %v", serr)
+	}
+	content, serial, ok, err := activeConfig(db)
+	if err != nil || !ok {
+		return fileCfg, filePolicy, serial
+	}
+	// Deployed config equals the file we just loaded → reuse the
+	// already-compiled result.
+	if revisionForBytes(content) == revisionForBytes(raw) {
+		return fileCfg, filePolicy, serial
+	}
+	bcfg, bpolicy, cerr := loadConfigBytes(content)
+	if cerr != nil {
+		log.Printf("config backend: deployed serial %d failed to load (%v); running file config", serial, cerr)
+		return fileCfg, filePolicy, serial
+	}
+	log.Printf("config backend: running deployed serial %d (started from file %s)", serial, cfgPath)
+	return bcfg, bpolicy, serial
+}
+
+// loadConfigBytes parses + compiles a config from raw bytes (the
+// backend-stored content). Mirrors loadConfig, which reads from a path.
+func loadConfigBytes(content []byte) (*config.Gateway, *config.CompiledPolicy, error) {
+	gw, diags := config.LoadBytes(content, "deployed.hcl")
+	if diags.HasErrors() {
+		return nil, nil, fmt.Errorf("%s", diags.Error())
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("compile: %w", err)
+	}
+	return gw, cp, nil
 }
 
 // logDashboardAuthState emits a one-line summary of dashboard-auth
@@ -2725,6 +2784,8 @@ func main() {
 		runEnv(os.Args[2:])
 	case "validate":
 		runValidate(os.Args[2:])
+	case "plan":
+		runPlan(os.Args[2:])
 	case "apply":
 		runApply(os.Args[2:])
 	case "config":
@@ -2820,8 +2881,10 @@ usage:
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing
   clawpatrol validate <config.hcl>       parse + compile a config and exit
-  clawpatrol apply [-y] <config.hcl>     validate, diff vs last applied, record + activate
+  clawpatrol plan <config.hcl>           diff a config against the deployed state
+  clawpatrol apply [-y] <config.hcl>     validate, diff, lock + record (terraform-style)
   clawpatrol config history <config.hcl> list recorded config versions
+  clawpatrol config unlock <config.hcl>  force-release a stuck apply lock
   clawpatrol test <config> <path>        replay action fixtures against a candidate policy
   clawpatrol version | -v | --version    print version and exit
 
@@ -2909,7 +2972,12 @@ func runGateway(args []string) {
 	setDB(db)
 	applyDashboardPasswordFlags(db, *setDashboardPassword, *resetDashboardPassword)
 	logDashboardAuthState(db, cfg)
-	recordBootConfigVersion(db, cfgPath, cfg.SchemaVersion)
+	// State backend: seed the backend from the file when empty, then run
+	// whatever the backend says is deployed. After bootstrap the file is
+	// just desired-config input — `clawpatrol apply` is the path that
+	// changes the running config (validated, locked, audited).
+	var bootSerial int64
+	cfg, policy, bootSerial = resolveBackendConfig(db, cfgPath, cfg, policy)
 	blobs := newGatewayBlobStore(db)
 	endpoints.SetBlobStore(blobs)
 	certs, err := loadOrMintCA(db)
@@ -2949,6 +3017,7 @@ func runGateway(args []string) {
 	g.tunnels = NewTunnelManager(g.secrets, stateDir)
 	registerOAuthCredentials(oauthReg, policy)
 	g.policy.Store(policy)
+	g.configSerial.Store(bootSerial)
 	g.connIdx.Store(runtime.BuildConnIndex(policy))
 	g.tunnels.SetPolicy(context.Background(), policy)
 	// dnsvip is opt-in by policy: if no endpoint requires VIPs, the
@@ -2967,7 +3036,7 @@ func runGateway(args []string) {
 	}
 	log.Printf("policy: %d endpoints across %d profiles", len(policy.Endpoints), len(policy.Profiles))
 	go g.sweepDashboardSessions()
-	go g.watchConfig(cfgPath)
+	go g.watchConfig()
 	if err := g.onboard.Load(db); err != nil {
 		log.Fatalf("onboard load: %v", err)
 	}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -635,7 +635,7 @@ func resolveBackendConfig(db *sql.DB, cfgPath string, fileCfg *config.Gateway, f
 		log.Printf("config backend: not seeding (%v); running file config", err)
 		return fileCfg, filePolicy, 0
 	}
-	if _, _, serr := recordConfigVersion(db, raw, fileCfg.SchemaVersion, "boot", ""); serr != nil {
+	if _, _, serr := recordConfigVersion(db, raw, fileCfg.SchemaVersion); serr != nil {
 		log.Printf("config backend: seed: %v", serr)
 	}
 	content, serial, ok, err := activeConfig(db)

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2725,6 +2725,10 @@ func main() {
 		runEnv(os.Args[2:])
 	case "validate":
 		runValidate(os.Args[2:])
+	case "apply":
+		runApply(os.Args[2:])
+	case "config":
+		runConfig(os.Args[2:])
 	case "test":
 		runTest(os.Args[2:])
 	case "uninstall":
@@ -2816,6 +2820,8 @@ usage:
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing
   clawpatrol validate <config.hcl>       parse + compile a config and exit
+  clawpatrol apply [-y] <config.hcl>     validate, diff vs last applied, record + activate
+  clawpatrol config history <config.hcl> list recorded config versions
   clawpatrol test <config> <path>        replay action fixtures against a candidate policy
   clawpatrol version | -v | --version    print version and exit
 
@@ -2903,6 +2909,7 @@ func runGateway(args []string) {
 	setDB(db)
 	applyDashboardPasswordFlags(db, *setDashboardPassword, *resetDashboardPassword)
 	logDashboardAuthState(db, cfg)
+	recordBootConfigVersion(db, cfgPath, cfg.SchemaVersion)
 	blobs := newGatewayBlobStore(db)
 	endpoints.SetBlobStore(blobs)
 	certs, err := loadOrMintCA(db)

--- a/cmd/clawpatrol/migrations/sqlite/0020_config_versions.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0020_config_versions.sql
@@ -5,11 +5,16 @@
 -- file watcher. There was no record of WHAT changed, WHO changed it, or
 -- WHEN — and no way to see the sequence of configs a gateway has run.
 --
--- This table is the audit trail. `clawpatrol apply` validates a config,
--- shows a semantic diff against the last applied version, and on
--- confirmation records a row here. The gateway also records the config
--- it loads at boot, so the trail starts from the currently-running
--- config rather than from the first apply.
+-- This is the authoritative state backend (Terraform's model): the
+-- latest row is the deployed config and its id is the serial. A change
+-- is a new row; `clawpatrol apply` records one under a lock with a
+-- compare-and-swap on the serial. The gateway records the config it
+-- loads at boot so the backend starts from the running config.
+--
+-- Deliberately OSS-Terraform-shaped: no who/why audit columns. State
+-- carries only what conflict detection needs — serial (id), the config
+-- bytes, and the revision. (applied_ns is a convenience timestamp for
+-- `config history`; the lock row, not this table, records the actor.)
 --
 -- content holds the exact HCL bytes (comments preserved — we store the
 -- operator's file, not an Emit() round-trip). revision is the SHA-256
@@ -22,8 +27,6 @@ CREATE TABLE config_versions (
   revision       TEXT NOT NULL,
   schema_version INTEGER NOT NULL,
   content        BLOB NOT NULL,
-  applied_by     TEXT NOT NULL DEFAULT '',
-  note           TEXT NOT NULL DEFAULT '',
   applied_ns     INTEGER NOT NULL
 );
 

--- a/cmd/clawpatrol/migrations/sqlite/0020_config_versions.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0020_config_versions.sql
@@ -1,0 +1,30 @@
+-- Config version history for `clawpatrol apply`.
+--
+-- The gateway config has always been read-only-from-file: edits land
+-- via SSH push / git, and the running gateway picks them up through the
+-- file watcher. There was no record of WHAT changed, WHO changed it, or
+-- WHEN — and no way to see the sequence of configs a gateway has run.
+--
+-- This table is the audit trail. `clawpatrol apply` validates a config,
+-- shows a semantic diff against the last applied version, and on
+-- confirmation records a row here. The gateway also records the config
+-- it loads at boot, so the trail starts from the currently-running
+-- config rather than from the first apply.
+--
+-- content holds the exact HCL bytes (comments preserved — we store the
+-- operator's file, not an Emit() round-trip). revision is the SHA-256
+-- of those bytes, matching the dashboard's X-Config-Revision so the two
+-- views agree. A new row is only inserted when the revision differs
+-- from the latest, so boot + apply + reload don't pile up duplicates.
+
+CREATE TABLE config_versions (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  revision       TEXT NOT NULL,
+  schema_version INTEGER NOT NULL,
+  content        BLOB NOT NULL,
+  applied_by     TEXT NOT NULL DEFAULT '',
+  note           TEXT NOT NULL DEFAULT '',
+  applied_ns     INTEGER NOT NULL
+);
+
+CREATE INDEX config_versions_applied_ns_idx ON config_versions(applied_ns);

--- a/cmd/clawpatrol/migrations/sqlite/0021_config_lock.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0021_config_lock.sql
@@ -1,0 +1,20 @@
+-- State lock for `clawpatrol apply`, modeled on Terraform's state
+-- locking (DynamoDB LockID item).
+--
+-- config_versions is the authoritative state backend: the latest row's
+-- id is the serial of the deployed config. A change is a new row. To
+-- make concurrent changes safe, apply takes this lock for the duration
+-- of the plan→write→release window. The single-row PRIMARY KEY (id = 0)
+-- is the mutual-exclusion primitive: a second acquirer's INSERT fails
+-- the uniqueness check and reports who holds it.
+--
+-- A lock left behind by a crashed apply is recoverable two ways:
+-- `clawpatrol config unlock`, or automatic steal once locked_ns is
+-- older than the staleness window (see configLockStaleAfter).
+
+CREATE TABLE config_lock (
+  id        INTEGER PRIMARY KEY CHECK (id = 0),
+  holder    TEXT NOT NULL,
+  reason    TEXT NOT NULL DEFAULT '',
+  locked_ns INTEGER NOT NULL
+);

--- a/doc/rfc-clawpatrol-apply.md
+++ b/doc/rfc-clawpatrol-apply.md
@@ -1,0 +1,180 @@
+# RFC: `clawpatrol apply`
+
+Status: **V1 (local) implemented; remote apply proposed.**
+Author: config-workflow track
+Related: R&D standup 2026-06-01 (config editing + `cloudpatrol apply`),
+[doc/roles.md](roles.md) (RBAC, the auth basis for remote apply).
+
+## Problem
+
+The gateway config is read-only-from-file. To change a deployed
+gateway today you:
+
+1. edit `gateway.hcl` locally (or in a config repo),
+2. `scp` it to the box (`scp gateway.hcl root@deno.clawpatrol.dev:/opt/clawall/`),
+3. restart or let the 3-second file watcher pick it up,
+4. hope it parses — an invalid config that reaches the watcher can break
+   a running gateway with no gate in front of it.
+
+There is **no record** of what changed, who changed it, or when; no diff
+before the change goes live; no way to see the sequence of configs a
+gateway has run; and no rollback. The "push from CI" story is just
+`scp` in a CI runner with an SSH key.
+
+The standup framed the fix as a Terraform-`apply`-like workflow: textual
+HCL stays the source of truth, but changes go through a validated,
+diffed, audited, reversible command.
+
+## Goals
+
+- **Validate before activate.** An invalid config never reaches a
+  running gateway.
+- **Diff before activate.** Show what actually changes, semantically.
+- **Audit.** Every applied config is recorded: bytes, who, when, why.
+- **Reversible.** History is queryable; rollback is "apply an old
+  version".
+- **Eventually: kill `scp`.** A `clawpatrol apply --remote` that pushes
+  to a running gateway over its existing authenticated API, so neither
+  an SSH key nor filesystem access to the box is needed.
+
+## Non-goals (for now)
+
+- A config *editor* in the dashboard (separate track; this is the
+  plumbing it would sit on).
+- Multi-gateway fan-out / fleet orchestration.
+- Secret material in the version store (secrets live in the DB secret
+  store, never in HCL — unchanged).
+
+## Design
+
+### Config version store — implemented
+
+`migrations/sqlite/0020_config_versions.sql`:
+
+```
+config_versions(id, revision, schema_version, content, applied_by, note, applied_ns)
+```
+
+- `content` is the **exact operator bytes** — comments preserved. We
+  store the file, not an `Emit()` round-trip, so the audit trail is
+  byte-faithful.
+- `revision` is `SHA-256(content)`, matching the dashboard's existing
+  `X-Config-Revision` header so the CLI and dashboard agree on identity.
+- A row is inserted only when the revision differs from the latest, so
+  boot + apply + reload of the same config don't pile up duplicates
+  (`recordConfigVersion`).
+
+The gateway records the config it loads **at boot**
+(`recordBootConfigVersion`), so history starts from the
+currently-running config rather than from the first `apply`.
+
+### Semantic diff — implemented
+
+`config.PolicyDigest(gw)` renders every operational and policy block to
+its own canonical HCL string via the existing deterministic `Emit`
+hooks, keyed by a human label (`gateway`, `endpoint anthropic`,
+`profile avocet2`, …). `diffDigests` compares two digests by key →
+added / removed / changed. Because each block is canonicalized,
+reordering blocks or editing a comment shows as **no change** — only a
+real content change to a block registers. This is the "semantic, not
+textual" diff the standup asked for, without a full field-level
+differ.
+
+### `clawpatrol apply <config.hcl>` — implemented (local)
+
+Runs **on the gateway host**:
+
+1. load + compile + external-plugin verify (same pipeline as daemon
+   startup) — reject invalid configs here, before they can go live;
+2. open the gateway's DB (resolved from the config's `state_dir`);
+3. semantic-diff against the last applied version, print it;
+4. confirm (`-y` to skip; `--by`, `--note` for the audit row);
+5. rewrite the file **atomically** (temp + rename, mode preserved) so
+   the watcher never sees a half-written file and the mtime bump
+   triggers reload;
+6. record a `config_versions` row.
+
+`clawpatrol config history <config.hcl>` lists recorded versions
+(newest first, with revision, schema version, who, when, note).
+
+### Drift & conflict — partially proposed
+
+- **Drift** (file changed out-of-band vs last applied): boot-recording
+  already captures out-of-band edits into history. `apply` could warn
+  "the on-disk config differs from the last applied revision" before
+  proceeding. *Not yet wired.*
+- **Conflict / optimistic lock** for CI: `apply --expect <revision>`
+  fails if the latest recorded revision isn't `<revision>`, so two CI
+  jobs can't silently clobber each other. *Proposed.*
+
+### Remote apply — proposed (this is the `scp` killer)
+
+> **Direct answer to "does this solve the remote / scp problem?": not
+> the V1 above — this section does.**
+
+V1 still runs on the box. To remove `scp` and read-only-file pushes
+entirely, add `clawpatrol apply --remote <gateway-url> config.hcl`:
+
+1. CLI validates + compiles locally (fail fast, no round-trip);
+2. CLI POSTs the config bytes to a new authenticated gateway endpoint
+   `POST /api/config` with `If-Match: <expected-revision>`;
+3. the gateway re-validates, computes the diff, applies in-process
+   (atomic write to its own config path **or** direct in-memory swap),
+   records the `config_versions` row with `applied_by` = the caller's
+   RBAC identity, and returns the new revision;
+4. `412 Precondition Failed` on revision mismatch (the optimistic lock).
+
+This reuses machinery that already exists:
+
+- **Auth**: the dashboard API gate + [RBAC roles](roles.md). Applying
+  config is an `admin`/global-`editor` action — `POST /api/config` slots
+  into the same `authzGate` as every other write. CI gets a scoped
+  identity instead of a root SSH key.
+- **Transport**: the gateway is already reachable over Tailscale /
+  WireGuard / its public URL. No new listener.
+- **Storage + diff + audit**: identical to V1; only the *trigger* moves
+  from local CLI to an authenticated request.
+
+Result: editing config from a laptop or CI becomes
+`clawpatrol apply --remote` — authenticated by role, validated before it
+lands, diffed, audited, and reversible. No SSH key on the box, no
+filesystem write, no read-only-file dance.
+
+### Rollback — proposed
+
+`clawpatrol config rollback <config.hcl> --to <revision>` writes the
+stored `content` of an earlier version back through the same apply path
+(local or remote). The bytes are already in `config_versions`.
+
+## Implementation status
+
+| Piece                                  | Status        |
+| -------------------------------------- | ------------- |
+| `config_versions` table + DB layer     | ✅ implemented |
+| Boot-time version recording            | ✅ implemented |
+| `config.PolicyDigest` semantic diff     | ✅ implemented |
+| `clawpatrol apply` (local)             | ✅ implemented |
+| `clawpatrol config history`            | ✅ implemented |
+| Atomic file write + watcher reload     | ✅ implemented |
+| Drift warning on apply                 | ⬜ proposed    |
+| `--expect` optimistic lock             | ⬜ proposed    |
+| `apply --remote` + `POST /api/config`  | ⬜ proposed    |
+| `config rollback --to <rev>`           | ⬜ proposed    |
+| Reload-time version recording          | ⬜ proposed    |
+
+## Open questions
+
+1. **In-place rewrite vs in-memory swap for remote apply.** Rewriting
+   the gateway's config file keeps a single source of truth on disk
+   (good for an operator who SSHes in); an in-memory swap avoids
+   trusting the filesystem but makes the running config and the on-disk
+   file diverge. Probably: write the file *and* swap, atomically.
+2. **Directory configs.** `LoadDir` merges multiple `*.hcl` files;
+   there's no single byte stream to hash. V1 boot-recording skips
+   directory configs. Remote apply of a directory config needs a
+   defined canonical serialization (likely `Emit()` of the merged
+   result, accepting comment loss).
+3. **schema_version bumps.** Should `apply` refuse a config whose
+   `schema_version` is newer than the running binary understands?
+   (`checkSchemaVersion` already gates load; apply inherits it, but a
+   remote apply should return a clear 4xx, not a generic parse error.)

--- a/doc/rfc-clawpatrol-apply.md
+++ b/doc/rfc-clawpatrol-apply.md
@@ -1,180 +1,150 @@
 # RFC: `clawpatrol apply`
 
-Status: **V1 (local) implemented; remote apply proposed.**
-Author: config-workflow track
+Status: **implemented (local, DB-authoritative with locking); remote
+apply proposed.**
 Related: R&D standup 2026-06-01 (config editing + `cloudpatrol apply`),
 [doc/roles.md](roles.md) (RBAC, the auth basis for remote apply).
 
 ## Problem
 
-The gateway config is read-only-from-file. To change a deployed
-gateway today you:
+The gateway config was read-only-from-file: edit `gateway.hcl`, `scp`
+it to the box, let the file watcher pick it up. No record of what
+changed, who, or when; no diff before it went live; an invalid file
+that reached the watcher could break a running gateway; no rollback.
+"Push from CI" was just `scp` with an SSH key.
 
-1. edit `gateway.hcl` locally (or in a config repo),
-2. `scp` it to the box (`scp gateway.hcl root@deno.clawpatrol.dev:/opt/clawall/`),
-3. restart or let the 3-second file watcher pick it up,
-4. hope it parses — an invalid config that reaches the watcher can break
-   a running gateway with no gate in front of it.
+The first cut of this work added a `config_versions` audit table but
+left the **HCL file as the source of truth** — which doesn't actually
+solve anything, because there's no single authoritative store to lock
+against. Two `apply`s, or an `apply` racing an `scp`, still clobber each
+other. That's the hole this RFC closes.
 
-There is **no record** of what changed, who changed it, or when; no diff
-before the change goes live; no way to see the sequence of configs a
-gateway has run; and no rollback. The "push from CI" story is just
-`scp` in a CI runner with an SSH key.
+## Model — exactly Terraform's
 
-The standup framed the fix as a Terraform-`apply`-like workflow: textual
-HCL stays the source of truth, but changes go through a validated,
-diffed, audited, reversible command.
+Terraform is safe because the **state backend is authoritative**, every
+change takes a **lock**, and writes check a **serial**. We do the same:
 
-## Goals
+- **State backend** = `config_versions` in the gateway DB. The latest
+  row is the deployed config; its `id` is the **serial**.
+- **The gateway runs from the backend**, not from a watched file. The
+  `gateway <file>` argument only *seeds* the backend on first boot
+  (when it's empty). After that the file is the **desired** input to
+  `apply` — like a `.tf` — and editing it on disk no longer changes the
+  running config. Only an `apply` does.
+- **Lock** (`config_lock`, single row): `apply` holds it for the
+  plan→write→release window. A concurrent `apply` fails with "config is
+  locked by X". A lock left by a crashed apply is stolen after
+  `configLockStaleAfter` (10m) or cleared with `clawpatrol config
+  unlock`.
+- **Serial CAS**: the new version inserts only if the latest serial is
+  still the one the plan was computed against, so a stale apply is
+  rejected even if the lock was forced mid-flight.
 
-- **Validate before activate.** An invalid config never reaches a
-  running gateway.
-- **Diff before activate.** Show what actually changes, semantically.
-- **Audit.** Every applied config is recorded: bytes, who, when, why.
-- **Reversible.** History is queryable; rollback is "apply an old
-  version".
-- **Eventually: kill `scp`.** A `clawpatrol apply --remote` that pushes
-  to a running gateway over its existing authenticated API, so neither
-  an SSH key nor filesystem access to the box is needed.
+This eliminates every clobber path from the first cut:
 
-## Non-goals (for now)
+| Scenario | Behavior now |
+| --- | --- |
+| Two `apply` at once | Second fails: "config is locked by X". |
+| `scp`/`vim` on the box | No effect on the running gateway — it reads the backend, not the file. |
+| Stale plan applied | Serial CAS rejects it: "state changed during apply". |
+| Crashed apply holding the lock | Auto-stolen after 10m, or `config unlock`. |
 
-- A config *editor* in the dashboard (separate track; this is the
-  plumbing it would sit on).
-- Multi-gateway fan-out / fleet orchestration.
-- Secret material in the version store (secrets live in the DB secret
-  store, never in HCL — unchanged).
-
-## Design
-
-### Config version store — implemented
-
-`migrations/sqlite/0020_config_versions.sql`:
+## Commands (implemented)
 
 ```
-config_versions(id, revision, schema_version, content, applied_by, note, applied_ns)
+clawpatrol plan   <config.hcl>   diff desired file vs deployed state (read-only, lock-free)
+clawpatrol apply  [-y] [--by w] [--note t] <config.hcl>
+                                 re-plan under lock, confirm, CAS-record a new serial
+clawpatrol config history <config.hcl>   list versions (serial, time, revision, who, note)
+clawpatrol config unlock  <config.hcl>   force-release a stuck lock
 ```
 
-- `content` is the **exact operator bytes** — comments preserved. We
-  store the file, not an `Emit()` round-trip, so the audit trail is
-  byte-faithful.
-- `revision` is `SHA-256(content)`, matching the dashboard's existing
-  `X-Config-Revision` header so the CLI and dashboard agree on identity.
-- A row is inserted only when the revision differs from the latest, so
-  boot + apply + reload of the same config don't pile up duplicates
-  (`recordConfigVersion`).
+The running gateway polls the backend serial (`watchConfig`) and
+hot-swaps policy when a new version lands — typically within ~3s of an
+apply.
 
-The gateway records the config it loads **at boot**
-(`recordBootConfigVersion`), so history starts from the
-currently-running config rather than from the first `apply`.
+## Real output
 
-### Semantic diff — implemented
+```
+$ clawpatrol plan gateway.hcl
+revision: b5e35ff59d74  (1 endpoints, 1 profiles)
+deployed: (none — backend is empty, this seeds serial 1)
+changes: +6  -0  ~0
+  + credential github
+  + endpoint github
+  + gateway
+  + profile default
+  + rule github-reads
+  + rule github-writes
 
-`config.PolicyDigest(gw)` renders every operational and policy block to
-its own canonical HCL string via the existing deterministic `Emit`
-hooks, keyed by a human label (`gateway`, `endpoint anthropic`,
-`profile avocet2`, …). `diffDigests` compares two digests by key →
-added / removed / changed. Because each block is canonicalized,
-reordering blocks or editing a comment shows as **no change** — only a
-real content change to a block registers. This is the "semantic, not
-textual" diff the standup asked for, without a full field-level
-differ.
+$ clawpatrol apply -y --by divy --note init gateway.hcl
+...
+Apply complete. serial 1, revision b5e35ff59d74, by divy.
 
-### `clawpatrol apply <config.hcl>` — implemented (local)
+# someone else (or a crashed run) holds the lock:
+$ clawpatrol apply -y gateway.hcl
+Error: config is locked by bob@laptop since 2026-06-02 19:33:39.000 (apply gateway.hcl)
+Another apply may be in progress. If it crashed, run `clawpatrol config unlock gateway.hcl`.
 
-Runs **on the gateway host**:
+$ clawpatrol config history gateway.hcl
+serial 2     2026-06-02 19:33:39.679  9dbd1e870a72  schema=1  by divy  — add newsvc
+serial 1     2026-06-02 19:33:39.640  b5e35ff59d74  schema=1  by divy  — init
+```
 
-1. load + compile + external-plugin verify (same pipeline as daemon
-   startup) — reject invalid configs here, before they can go live;
-2. open the gateway's DB (resolved from the config's `state_dir`);
-3. semantic-diff against the last applied version, print it;
-4. confirm (`-y` to skip; `--by`, `--note` for the audit row);
-5. rewrite the file **atomically** (temp + rename, mode preserved) so
-   the watcher never sees a half-written file and the mtime bump
-   triggers reload;
-6. record a `config_versions` row.
+## Semantic diff
 
-`clawpatrol config history <config.hcl>` lists recorded versions
-(newest first, with revision, schema version, who, when, note).
+`config.PolicyDigest(gw)` renders each operational and policy block to
+canonical HCL via the existing deterministic `Emit` hooks, keyed by a
+human label. `diffDigests` compares two digests → added / removed /
+changed. Reordering blocks or editing a comment is **no change**; only
+a real content change to a block registers.
 
-### Drift & conflict — partially proposed
+## Remote apply — proposed (the `scp` killer)
 
-- **Drift** (file changed out-of-band vs last applied): boot-recording
-  already captures out-of-band edits into history. `apply` could warn
-  "the on-disk config differs from the last applied revision" before
-  proceeding. *Not yet wired.*
-- **Conflict / optimistic lock** for CI: `apply --expect <revision>`
-  fails if the latest recorded revision isn't `<revision>`, so two CI
-  jobs can't silently clobber each other. *Proposed.*
+Local `apply` already coordinates with the running gateway through the
+shared DB + lock, so on the gateway host `scp` is gone. To apply from a
+laptop or CI **without** filesystem/DB access to the box, add
+`clawpatrol apply --remote <gateway-url> config.hcl`:
 
-### Remote apply — proposed (this is the `scp` killer)
+1. CLI validates + compiles locally (fail fast, no round-trip).
+2. CLI POSTs the bytes to `POST /api/config` with `If-Match: <serial>`.
+3. The gateway runs the same lock → plan → CAS-record → release
+   in-process, attributing `applied_by` to the caller's RBAC identity,
+   and returns the new serial.
+4. `412 Precondition Failed` on a serial mismatch (the lock + CAS,
+   surfaced over HTTP).
 
-> **Direct answer to "does this solve the remote / scp problem?": not
-> the V1 above — this section does.**
-
-V1 still runs on the box. To remove `scp` and read-only-file pushes
-entirely, add `clawpatrol apply --remote <gateway-url> config.hcl`:
-
-1. CLI validates + compiles locally (fail fast, no round-trip);
-2. CLI POSTs the config bytes to a new authenticated gateway endpoint
-   `POST /api/config` with `If-Match: <expected-revision>`;
-3. the gateway re-validates, computes the diff, applies in-process
-   (atomic write to its own config path **or** direct in-memory swap),
-   records the `config_versions` row with `applied_by` = the caller's
-   RBAC identity, and returns the new revision;
-4. `412 Precondition Failed` on revision mismatch (the optimistic lock).
-
-This reuses machinery that already exists:
-
-- **Auth**: the dashboard API gate + [RBAC roles](roles.md). Applying
-  config is an `admin`/global-`editor` action — `POST /api/config` slots
-  into the same `authzGate` as every other write. CI gets a scoped
-  identity instead of a root SSH key.
-- **Transport**: the gateway is already reachable over Tailscale /
-  WireGuard / its public URL. No new listener.
-- **Storage + diff + audit**: identical to V1; only the *trigger* moves
-  from local CLI to an authenticated request.
-
-Result: editing config from a laptop or CI becomes
-`clawpatrol apply --remote` — authenticated by role, validated before it
-lands, diffed, audited, and reversible. No SSH key on the box, no
-filesystem write, no read-only-file dance.
-
-### Rollback — proposed
-
-`clawpatrol config rollback <config.hcl> --to <revision>` writes the
-stored `content` of an earlier version back through the same apply path
-(local or remote). The bytes are already in `config_versions`.
+Reuses what exists: auth = the dashboard gate + [RBAC roles](roles.md)
+(apply is an `admin`/global-`editor` action); transport = the gateway's
+existing TS/WG/public listener; storage/diff/lock = identical to local.
+CI gets a scoped role instead of a root SSH key.
 
 ## Implementation status
 
-| Piece                                  | Status        |
-| -------------------------------------- | ------------- |
-| `config_versions` table + DB layer     | ✅ implemented |
-| Boot-time version recording            | ✅ implemented |
-| `config.PolicyDigest` semantic diff     | ✅ implemented |
-| `clawpatrol apply` (local)             | ✅ implemented |
-| `clawpatrol config history`            | ✅ implemented |
-| Atomic file write + watcher reload     | ✅ implemented |
-| Drift warning on apply                 | ⬜ proposed    |
-| `--expect` optimistic lock             | ⬜ proposed    |
-| `apply --remote` + `POST /api/config`  | ⬜ proposed    |
-| `config rollback --to <rev>`           | ⬜ proposed    |
-| Reload-time version recording          | ⬜ proposed    |
+| Piece                                       | Status        |
+| ------------------------------------------- | ------------- |
+| `config_versions` backend + serial           | ✅ implemented |
+| `config_lock` + acquire/release/steal        | ✅ implemented |
+| Serial compare-and-swap insert               | ✅ implemented |
+| Gateway runs from backend; serial-poll reload | ✅ implemented |
+| `plan` / `apply` / `config history` / `config unlock` | ✅ implemented |
+| Semantic block diff (`PolicyDigest`)          | ✅ implemented |
+| `apply --remote` + `POST /api/config`         | ⬜ proposed    |
+| `config rollback --to <serial>`               | ⬜ proposed    |
 
 ## Open questions
 
-1. **In-place rewrite vs in-memory swap for remote apply.** Rewriting
-   the gateway's config file keeps a single source of truth on disk
-   (good for an operator who SSHes in); an in-memory swap avoids
-   trusting the filesystem but makes the running config and the on-disk
-   file diverge. Probably: write the file *and* swap, atomically.
-2. **Directory configs.** `LoadDir` merges multiple `*.hcl` files;
-   there's no single byte stream to hash. V1 boot-recording skips
-   directory configs. Remote apply of a directory config needs a
-   defined canonical serialization (likely `Emit()` of the merged
+1. **Directory configs.** `LoadDir` merges multiple `*.hcl`; there's no
+   single byte stream to seed/serve. Boot skips seeding for a directory
+   config and runs it file-only (serial 0). A backend representation
+   would need a canonical serialization (likely `Emit()` of the merged
    result, accepting comment loss).
-3. **schema_version bumps.** Should `apply` refuse a config whose
-   `schema_version` is newer than the running binary understands?
-   (`checkSchemaVersion` already gates load; apply inherits it, but a
-   remote apply should return a clear 4xx, not a generic parse error.)
+2. **Operator who edits the file and restarts.** Under DB-authority the
+   restart re-runs the backend, not the edited file — intentional (it's
+   `terraform apply` against a checked-in `.tf`), but it's a behavior
+   change worth a clear boot log line (present: "running deployed serial
+   N (started from file …)").
+3. **schema_version downgrade.** A backend version newer than the
+   running binary fails `loadConfigBytes`; `watchConfig` logs and skips
+   it. A remote apply should return a clear 4xx rather than a generic
+   parse error.

--- a/internal/config/digest_test.go
+++ b/internal/config/digest_test.go
@@ -1,0 +1,62 @@
+package config_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+func loadFull(t *testing.T) *config.Gateway {
+	t.Helper()
+	gw, diags := config.Load(filepath.Join("testdata", "full.hcl"))
+	if diags.HasErrors() {
+		t.Fatalf("load full.hcl: %s", diags.Error())
+	}
+	return gw
+}
+
+func TestPolicyDigestStable(t *testing.T) {
+	gw := loadFull(t)
+	d1 := config.PolicyDigest(gw)
+	d2 := config.PolicyDigest(gw)
+	if len(d1) == 0 {
+		t.Fatal("digest is empty")
+	}
+	if len(d1) != len(d2) {
+		t.Fatalf("digest not stable: %d vs %d keys", len(d1), len(d2))
+	}
+	for k, v := range d1 {
+		if d2[k] != v {
+			t.Fatalf("digest key %q unstable", k)
+		}
+	}
+	if _, ok := d1["gateway"]; !ok {
+		t.Errorf("expected a 'gateway' operational key, got keys: %v", keys(d1))
+	}
+}
+
+func TestPolicyDigestKeysCoverEntities(t *testing.T) {
+	gw := loadFull(t)
+	d := config.PolicyDigest(gw)
+	// full.hcl declares profiles; every profile should appear as
+	// "profile <name>".
+	var profileKeys int
+	for k := range d {
+		if strings.HasPrefix(k, "profile ") {
+			profileKeys++
+		}
+	}
+	if profileKeys == 0 {
+		t.Fatalf("expected at least one profile key, got: %v", keys(d))
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -173,6 +173,56 @@ func Emit(gw *Gateway) ([]byte, error) {
 	return f.Bytes(), nil
 }
 
+// PolicyDigest emits each operational and policy block to its own
+// canonical HCL string, keyed by a human label ("gateway", "endpoint
+// anthropic", "profile avocet2", …). It is the basis for the semantic
+// diff `clawpatrol apply` shows: because each block is rendered through
+// the same deterministic Emit hooks, comparing two digests by key
+// surfaces added / removed / changed blocks while ignoring comment,
+// whitespace, and source-ordering noise that a raw text diff would
+// flag.
+func PolicyDigest(gw *Gateway) map[string]string {
+	out := map[string]string{}
+	if gw == nil {
+		return out
+	}
+
+	if gw.Settings != nil {
+		f := hclwrite.NewEmptyFile()
+		emitGatewayBlock(f.Body(), gw.Settings)
+		out["gateway"] = strings.TrimSpace(string(f.Bytes()))
+	}
+	if gw.Defaults != nil {
+		f := hclwrite.NewEmptyFile()
+		emitDefaultsBlock(f.Body(), gw.Defaults)
+		out["defaults"] = strings.TrimSpace(string(f.Bytes()))
+	}
+
+	if gw.Policy == nil {
+		return out
+	}
+	p := gw.Policy
+
+	// Per-Emit RefIndex so emitOne's plugin hooks resolve typed
+	// traversals. Same lock discipline as Emit — never concurrent with
+	// itself.
+	emitRIMu.Lock()
+	defer emitRIMu.Unlock()
+	emitRI = newRefIndex(p)
+	defer func() { emitRI = nil }()
+
+	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule, KindProfile} {
+		for _, name := range leftoverNames(p, kind, map[string]bool{}) {
+			f := hclwrite.NewEmptyFile()
+			if !emitOne(f.Body(), p, kind, name) {
+				continue
+			}
+			out[string(kind)+" "+name] = strings.TrimSpace(string(f.Bytes()))
+		}
+	}
+	return out
+}
+
 func emitOperational(body *hclwrite.Body, gw *Gateway) {
 	if gw.Settings != nil {
 		emitGatewayBlock(body, gw.Settings)


### PR DESCRIPTION
## What

`clawpatrol apply` — a Terraform-style config workflow. The **DB is the authoritative state backend**, every change takes a **lock**, and writes check a **serial**, so concurrent applies and stale plans can't clobber each other.

- **State backend** = `config_versions`; the latest row is the deployed config, its `id` is the **serial**.
- **The gateway runs from the backend**, not a watched file. `gateway <file>` only *seeds* the backend when empty; after that the file is the *desired* input to `apply` (like a `.tf`). `watchConfig` polls the serial and hot-swaps. Editing the file on disk no longer changes the running config — only `apply` does.
- **Lock** (`config_lock`, migration `0021`): `apply` holds it plan→write→release; a concurrent apply fails "locked by X". Stale locks stolen after 10m or via `config unlock`. The lock records `who@host` (Terraform's lock "Who", env-derived).
- **Serial CAS** (`recordConfigVersionCAS`): insert only if the latest serial is still the one planned against.
- **Saved-plan staleness**: `plan -out` binds a plan to a serial; `apply <planfile>` refuses if the deployed serial moved since.

State is **OSS-Terraform-shaped**: no who/why audit columns — just serial, content, revision (+ a timestamp for `history`). No `--by`/`--note`.

## Commands

```
clawpatrol plan   [-out file] <config.hcl>       diff desired vs deployed (read-only)
clawpatrol apply  [-y] [--expect N] <config.hcl | planfile>   locked re-plan + CAS
clawpatrol config history <config.hcl>           serial, time, revision, schema
clawpatrol config unlock  <config.hcl>           force-release a stuck lock
```

## Conflicts — actually handled

| Scenario | Behavior |
|---|---|
| Two `apply` at once | Second fails: "config is locked by X". |
| Stale saved plan / `--expect` mismatch | Rejected: "deployed serial is M but the plan was built against N". |
| `scp`/`vim` on the box | No effect — gateway reads the backend, not the file. |
| Crashed apply holding lock | Auto-stolen after 10m, or `config unlock`. |

## Real output

Plan + apply, seeding an empty backend:

```
$ clawpatrol plan gateway.hcl
revision: 9fb793ddb751  (1 endpoints, 1 profiles)
deployed: (none — backend is empty, this seeds serial 1)
changes: +6  -0  ~0
  + credential github
  + endpoint github
  + gateway
  + profile default
  + rule github-reads
  + rule github-writes

$ clawpatrol apply -y gateway.hcl
...
Apply complete. serial 1, revision 9fb793ddb751.
```

Stale-plan and lock conflicts:

```
# operator B landed serial 2 while A held a plan bound to serial 1:
$ clawpatrol apply -y a.plan
Error: conflict — deployed serial is 2 but the saved plan was built against serial 1.
Someone applied a change in between. Re-run `clawpatrol plan` and review before applying

# concurrent apply while another holds the lock:
$ clawpatrol apply -y gateway.hcl
Error: config is locked by bob@laptop since 2026-06-02 19:33:39.000 (apply gateway.hcl)
Another apply may be in progress. If it crashed, run `clawpatrol config unlock gateway.hcl`.
```

Within-block edits (e.g. a CEL `condition`) show the line delta, not just "rule changed":

```
$ clawpatrol plan gateway.hcl
changes: +0  -0  ~1
  ~ rule github-writes
      - condition = "http.method in ['POST', 'PATCH', 'PUT', 'DELETE']"
      + condition = "http.method in ['POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS']"

$ clawpatrol config history gateway.hcl
serial 2     2026-06-02 20:18:43.867  3690337a99d5  schema=1
serial 1     2026-06-02 20:18:43.828  9fb793ddb751  schema=1
```

## Semantic diff

`config.PolicyDigest` renders each block to canonical HCL via the existing `Emit` hooks; `diffDigests` → +/-/~. Reordering blocks or editing a comment is no change. For a changed block, a within-block line delta surfaces which attribute changed (CEL condition, verdict, hosts, …). It's a line delta over the canonical render — not a CEL-semantic-equivalence check (won't tell you two conditions are logically equal, only that the text differs).

## CI ↔ dashboard drift (when dashboard editing lands later)

A dashboard edit is just another writer on the same serial-CAS backend (the dashboard's "save" must itself go through apply). If the dashboard moved the serial since CI planned, `apply --expect <serial>` fails closed and `plan` shows the unexpected +/-/~ — exactly Terraform's clickops-vs-code drift. Reconcile = pull the change into git, or code-wins revert (reviewed).

## Not built (proposed — doc/rfc-clawpatrol-apply.md)

- `apply --remote <url>` + `POST /api/config` — the laptop/CI **scp-killer**, authed by RBAC roles (#624), `If-Match: <serial>` → `412` on conflict.
- `config rollback --to <serial>`.

## Behavior change

Editing `gateway.hcl` and restarting re-runs the **backend**, not the edited file (intentional — `terraform apply` against a checked-in `.tf`). Boot logs "running deployed serial N (started from file …)".

## Notes

- Migrations `0020`/`0021`; `0020` collides with #624 (RBAC) — second to merge renumbers.
- Tests: lock mutual-exclusion, stale-steal, force-unlock, CAS, plan-file detection, semantic digest. `go test` + `go vet` + golangci-lint + gofmt all clean.
