### PR TITLE
ci: set DO_NOT_TRACK=1 to keep CI out of telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# Belt-and-suspenders: the gateway's 30s telemetry grace already shields
+# short-lived CI invocations, but set DO_NOT_TRACK so any future job that
+# runs the binary longer can't pollute the active-gateway count.
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Set `DO_NOT_TRACK=1` at the workflow level in `ci.yml` so any gateway invocation in CI opts out of telemetry.
- Today this is a no-op (CI only runs `make test`, `make lint`, and `clawpatrol validate`, all of which exit well before the 30s telemetry grace fires). Belt-and-suspenders against a future job that runs the binary longer and silently pollutes the active-gateway count.

## Test plan
- [ ] CI passes.