### PR TITLE
telemetry: drop dev-version pings on both ends

### DIFF
--- a/cmd/clawpatrol/telemetry.go
+++ b/cmd/clawpatrol/telemetry.go
@@ -65,6 +65,11 @@ type updateBanner struct {
 var currentUpdateBanner atomic.Pointer[updateBanner]
 
 func telemetryEnabled(cfg *config.Gateway) bool {
+	// Dev builds (no -ldflags version stamp) never ping. Keeps local
+	// `go run` and `make run` out of the active-gateway count.
+	if buildVersion == "dev" {
+		return false
+	}
 	if os.Getenv("DO_NOT_TRACK") == "1" {
 		return false
 	}

--- a/site/worker/index.test.ts
+++ b/site/worker/index.test.ts
@@ -57,6 +57,30 @@ test("rejects oversized telemetry payloads from Content-Length before reading th
   assert.equal(calls.prepare, 0);
 });
 
+test("check ping with version=dev is dropped without touching the DB", async () => {
+  const { env: testEnv, calls } = env();
+  globalThis.fetch = async () => {
+    calls.releaseFetch++;
+    return Response.json({ tag_name: "v1.0.0", html_url: "https://x" });
+  };
+  const res = await worker.fetch(
+    new Request("https://clawpatrol.dev/api/telemetry/v1/check", {
+      method: "POST",
+      body: JSON.stringify({
+        instance_id: "01HZDEV",
+        version: "dev",
+        os: "linux",
+        arch: "amd64",
+      }),
+    }),
+    testEnv,
+  );
+
+  assert.equal(res.status, 204);
+  assert.equal(calls.prepare, 0);
+  assert.equal(calls.releaseFetch, 0);
+});
+
 test("install ping inserts a row and 204s", async () => {
   const { env: testEnv, calls } = env();
   const body = JSON.stringify({

--- a/site/worker/index.ts
+++ b/site/worker/index.ts
@@ -72,6 +72,13 @@ async function handleCheck(
     return new Response(null, { status: 400 });
   }
 
+  // Dev builds (unreleased local binaries) are not real installs.
+  // Drop the ping silently so they don't show up in active counts.
+  // The Go client already skips sending; this guards legacy binaries.
+  if (version === "dev") {
+    return new Response(null, { status: 204 });
+  }
+
   const now = Math.floor(Date.now() / 1000);
   await env.TELEMETRY_DB.prepare(
     `INSERT INTO gateways (


### PR DESCRIPTION
## Summary
- Gateway client: `telemetryEnabled` short-circuits when `buildVersion == "dev"` so local `go run` / `make run` never ping.
- Worker: `/api/telemetry/v1/check` drops `version == "dev"` requests with 204 before touching D1 (covers legacy dev binaries already deployed).
- Today's active-7d shows ~18 `dev` pings inflating the count; after this lands, new dev runs stop pinging and old dev rows age out of the 7-day window naturally (no DB rows are deleted).

## Test plan
- [x] `npm test` (worker): new `check ping with version=dev is dropped without touching the DB` passes alongside existing 4.
- [x] `go test ./cmd/clawpatrol/...` clean.
- [x] `gofmt -l .` + `deno task format:check` clean.

## Follow-up (not in this PR)
- Existing `gateways` rows with `version='dev'` will age out of the 7-day rolling window on their own. If you want them purged immediately, run `DELETE FROM gateways WHERE version = 'dev'` against the prod D1 — destructive, so worth a separate eyeball.