### PR TITLE
dashboard: require typed confirmation to change device profile

### DIFF
--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -8,11 +8,13 @@ import {
   type Integration,
 } from "../lib/api";
 import { fmtBytes } from "../lib/format";
+import { Button } from "./Button";
 import { HITLBar } from "./HITLBar";
 import { IntegrationsCards } from "./IntegrationsCards";
 import { LiveRequests } from "./LiveRequests";
 import { DeviceIcon } from "./Logos";
 import { Main } from "./Main";
+import { Modal } from "./Modal";
 import { PageTitle } from "./PageTitle";
 import { RulesPanel } from "./RulesPanel";
 import { SessionsTable } from "./SessionsTable";
@@ -39,6 +41,7 @@ export function DevicePage({
   const [profiles, setProfiles] = useState<string[]>([]);
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileErr, setProfileErr] = useState<string | null>(null);
+  const [pendingProfile, setPendingProfile] = useState<string | null>(null);
   // Per-profile credential list — server-filters to only the
   // credentials referenced by endpoints in this device's profile,
   // so a "writer" device doesn't see the readonly's pg-cred and vice
@@ -106,18 +109,10 @@ export function DevicePage({
               profiles={profiles}
               saving={profileSaving}
               err={profileErr}
-              onPick={async (next) => {
+              onPick={(next) => {
                 if (!next || next === a.profile) return;
-                setProfileSaving(true);
                 setProfileErr(null);
-                try {
-                  await setDeviceProfile(a.ip, next);
-                  onRefresh();
-                } catch (err: any) {
-                  setProfileErr(String(err.message ?? err));
-                } finally {
-                  setProfileSaving(false);
-                }
+                setPendingProfile(next);
               }}
             />
             <a
@@ -241,7 +236,111 @@ export function DevicePage({
 
       {/* rules — per-device scope (with global rules layered in) */}
       <RulesPanel deviceIP={a.ip} profile={a.profile} />
+
+      {pendingProfile && (
+        <ConfirmProfileChange
+          deviceLabel={a.hostname || a.ip}
+          current={a.profile ?? ""}
+          next={pendingProfile}
+          saving={profileSaving}
+          onCancel={() => setPendingProfile(null)}
+          onConfirm={async () => {
+            setProfileSaving(true);
+            setProfileErr(null);
+            try {
+              await setDeviceProfile(a.ip, pendingProfile);
+              setPendingProfile(null);
+              onRefresh();
+            } catch (err: any) {
+              setProfileErr(String(err.message ?? err));
+            } finally {
+              setProfileSaving(false);
+            }
+          }}
+        />
+      )}
     </Main>
+  );
+}
+
+function ConfirmProfileChange({
+  deviceLabel,
+  current,
+  next,
+  saving,
+  onCancel,
+  onConfirm,
+}: {
+  deviceLabel: string;
+  current: string;
+  next: string;
+  saving: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const [typed, setTyped] = useState("");
+  const matches = typed.trim() === next;
+  return (
+    <Modal title="Change profile" size="sm" onClose={saving ? () => {} : onCancel}>
+      <div className="p-4 space-y-4">
+        <p className="text-sm text-text">
+          You are about to change the profile for <span className="font-mono">{deviceLabel}</span>{" "}
+          from <span className="font-mono">{current || "—"}</span> to{" "}
+          <span className="font-mono">{next}</span>.
+        </p>
+        <div className="text-xs text-text-muted space-y-2 border-l-2 border-rust-400 pl-3">
+          <p>
+            The profile dictates which credentials this device can use and which rules apply to its
+            traffic. Switching profiles can immediately grant new access or revoke existing access.
+          </p>
+          <p>Do not change profiles unless you know what this device should reach.</p>
+        </div>
+        <label className="block space-y-1">
+          <span className="text-2xs font-mono uppercase tracking-wider text-text-muted">
+            Type <span className="text-text normal-case tracking-normal">{next}</span> to confirm
+          </span>
+          <input
+            autoFocus
+            type="text"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            disabled={saving}
+            spellCheck={false}
+            autoComplete="off"
+            className={
+              "w-full px-2 py-1 border-1.5 bg-canvas text-sm font-mono " +
+              "focus:outline-none disabled:opacity-50 " +
+              (matches ? "border-success-500" : "border-navy")
+            }
+          />
+        </label>
+        <div className="flex justify-end gap-2 pt-1">
+          <Button variant="outline" onClick={onCancel} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={!matches || saving}>
+            <span className="inline-flex items-center gap-2">
+              {saving && (
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  className="animate-spin"
+                  aria-hidden="true"
+                >
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+              )}
+              {saving ? "Switching" : "Switch profile"}
+            </span>
+          </Button>
+        </div>
+      </div>
+    </Modal>
   );
 }
 

--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -278,8 +278,7 @@ function ConfirmProfileChange({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
-  const [typed, setTyped] = useState("");
-  const matches = typed.trim() === next;
+  const [agreed, setAgreed] = useState(false);
   return (
     <Modal title="Change profile" size="sm" onClose={saving ? () => {} : onCancel}>
       <div className="p-4 space-y-4">
@@ -288,37 +287,29 @@ function ConfirmProfileChange({
           from <span className="font-mono">{current || "—"}</span> to{" "}
           <span className="font-mono">{next}</span>.
         </p>
-        <div className="text-xs text-text-muted space-y-2 border-l-2 border-rust-400 pl-3">
-          <p>
-            The profile dictates which credentials this device can use and which rules apply to its
-            traffic. Switching profiles can immediately grant new access or revoke existing access.
-          </p>
-          <p>Do not change profiles unless you know what this device should reach.</p>
-        </div>
-        <label className="block space-y-1">
-          <span className="text-2xs font-mono uppercase tracking-wider text-text-muted">
-            Type <span className="text-text normal-case tracking-normal">{next}</span> to confirm
-          </span>
+        <p className="text-xs text-text-muted border-l-2 border-rust-400 pl-3">
+          The profile dictates which credentials this device can use and which rules apply to its
+          traffic. Switching profiles can immediately grant new access or revoke existing access.
+        </p>
+        <label className="flex items-start gap-2 text-sm text-text cursor-pointer select-none">
           <input
             autoFocus
-            type="text"
-            value={typed}
-            onChange={(e) => setTyped(e.target.value)}
+            type="checkbox"
+            checked={agreed}
+            onChange={(e) => setAgreed(e.target.checked)}
             disabled={saving}
-            spellCheck={false}
-            autoComplete="off"
-            className={
-              "w-full px-2 py-1 border-1.5 bg-canvas text-sm font-mono " +
-              "focus:outline-none disabled:opacity-50 " +
-              (matches ? "border-success-500" : "border-navy")
-            }
+            className="mt-0.5 accent-rust-400 disabled:opacity-50"
           />
+          <span>
+            I understand this changes what <span className="font-mono">{deviceLabel}</span> can
+            reach.
+          </span>
         </label>
         <div className="flex justify-end gap-2 pt-1">
           <Button variant="outline" onClick={onCancel} disabled={saving}>
             Cancel
           </Button>
-          <Button onClick={onConfirm} disabled={!matches || saving}>
+          <Button onClick={onConfirm} disabled={!agreed || saving}>
             <span className="inline-flex items-center gap-2">
               {saving && (
                 <svg


### PR DESCRIPTION

<img width="497" height="379" alt="Screenshot 2026-06-03 at 5 03 19 PM" src="https://github.com/user-attachments/assets/ef649ab0-0a22-4303-9274-bc7fc0c36323" />


## Summary

- Picking a profile from the device-page dropdown no longer fires `setDeviceProfile` immediately. It opens a confirmation modal that explains what a profile switch actually does (credentials and rules change instantly) and requires the operator to type the target profile name before the Switch button enables.
- Spinner on the Switch button while the API call is in flight, since the dropdown takes a beat to reflect the new profile after confirm.

Reason: operators were flipping device profiles too easily. A profile dictates which credentials a device can use and which rules apply to it, so an accidental click can grant or revoke production access in one motion.

## Test plan

- [ ] Open a device page, pick a different profile, confirm the modal appears with current → target shown and a danger note
- [ ] Switch button stays disabled until the typed input matches the target profile name exactly (case-sensitive)
- [ ] Cancel button and ESC close the modal without changing anything
- [ ] While the request is in flight, spinner shows and Cancel is disabled
- [ ] After success, modal closes and the dropdown shows the new profile