### PR TITLE
docs: document the gateway { } block in config-reference

### DIFF
--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -148,6 +148,9 @@ func (r *renderer) writeOperational() {
 	r.out.WriteString("## Top-level blocks\n\n")
 	r.out.WriteString("Operational settings live under the required top-level `gateway { ... }` block. The optional `defaults { ... }` block carries policy fallbacks. Labeled policy blocks (`profile`, `approver`, `credential`, `endpoint`, `rule`, `tunnel`) are documented in their own sections.\n\n")
 	r.writeStructTable("config", "Gateway", reflect.TypeOf(config.Gateway{}))
+	r.out.WriteString("## `gateway { ... }`\n\n")
+	r.out.WriteString("The gateway block carries operational settings — listen addresses, the WireGuard / Tailscale transport sub-blocks, session and retention windows, telemetry, and the resolver.\n\n")
+	r.writeStructTable("config", "GatewaySettings", reflect.TypeOf(config.GatewaySettings{}))
 }
 
 // writeProfile documents the `profile "<name>" {}` block. The body

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -33,6 +33,75 @@ Operational settings live under the required top-level `gateway { ... }` block. 
 | `defaults` | `block` | no | Holds the optional `defaults { ... }` block with the policy defaults (unknown_host, llm_*, human_*). nil when the block is absent — every field has a built-in default. |
 | `plugin` | `block` | no | Lists every `plugin "<name>" { source = "..." }` block at the top of the file. The loader spawns each subprocess (and registers its declared types) before running pass-1 symbol building, so plugin-supplied (kind, type) pairs are available by the time policy blocks are dispatched. |
 
+## `gateway { ... }`
+
+The gateway block carries operational settings — listen addresses, the WireGuard / Tailscale transport sub-blocks, session and retention windows, telemetry, and the resolver.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_listen` | `string` | no | The bind address for the dashboard + JSON API HTTP server. Default 127.0.0.1:8080. Set to a routable address to expose the dashboard off-host (the same mux is also served on the WG netstack / tsnet stack at this port). |
+| `public_url` | `string` | no | The canonical externally-reachable gateway URL. Used in generated control-plane links such as join targets, OAuth redirect URIs, and (when public_url has a host but wireguard.endpoint doesn't) the host clients dial for WireGuard. |
+| `state_dir` | `string` | no | The directory holding clawpatrol.db (and anything a plugin persists to disk under it). Defaults to ${HOME}/.clawpatrol. |
+| `dashboard_session_ttl` | `string` | no | How long a dashboard login session stays valid after the operator types the password. time.ParseDuration format ("24h", "30m"). Default 24h. |
+| `resolver` | `string` | no | The DNS resolver address the gateway uses for upstream lookups when the runtime needs an explicit resolver. |
+| `log_path` | `string` | no | An optional file path for gateway log output. |
+| `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
+| `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Default 720h (30d), "0" / "off" disables. time.ParseDuration format. |
+| `limits` | `block` | no | Limits, if present, overrides the two gateway-wide body-size limits (rules-engine body buffer and persisted action body storage). nil uses the DefaultBody*Limit constants, which match today's hardcoded behavior. |
+| `wireguard` | `block` | no | WireGuard, if present, enables the embedded userspace WireGuard server. Required block when running WG-mode deployments. |
+| `tailscale` | `block` | no | Tailscale, if present, enables the embedded tsnet node and the Tailscale control plane (OAuth key minting, exit-node routing). Both transports may be enabled simultaneously. |
+
+**Nested block `limits {}`:**
+
+The optional `limits { ... }` sub-block inside
+`gateway { ... }`. It exposes the two independent body-size limits as
+human-readable size strings (e.g. "256KiB", "1MiB"):
+
+  - BodyBuffer bounds the hot-path buffer the rules engine matches
+    against. Trade-off: latency / memory vs. how much body rules see.
+  - BodyStorage bounds the cold-storage sample persisted per action.
+    Trade-off: disk / db size vs. how useful the action details page
+    is for debugging.
+
+Both are independent: a deployment may log more (or less) than it
+rule-matches. Empty fields fall back to the DefaultBody*Limit
+constants, which equal today's hardcoded behavior.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `body_buffer` | `string` | no |  |
+| `body_storage` | `string` | no |  |
+
+**Nested block `wireguard {}`:**
+
+The body of the `wireguard { ... }` sub-block
+inside `gateway { ... }`. Presence of the block enables the WG
+transport.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subnet_cidr` | `string` | no | The private subnet assigned to onboarded clients. Required (e.g. "10.55.0.0/24"). |
+| `listen_port` | `int` | no | The UDP port the gateway binds for WG peers. Default 51820. |
+| `endpoint` | `string` | no | The host:port advertised in client wg.conf as `Endpoint = ...`. Host defaults to public_url's host; port defaults to listen_port. Set only for split-host deployments (gateway sits behind a different hostname/IP for WG than for the dashboard). |
+| `interface` | `string` | no | The WireGuard interface name the gateway manages. Mostly irrelevant in userspace mode; leave unset. |
+| `server_pub` | `string` | no | The WireGuard server public key advertised to clients. Normally derived from gateway state; only set when bootstrapping from an external key. |
+
+**Nested block `tailscale {}`:**
+
+The body of the `tailscale { ... }` sub-block
+inside `gateway { ... }`. Presence of the block enables tsnet.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | `string` | no | The Tailscale auth key for the embedded tsnet node. Required when the `tailscale` block is present. Falls back to $TS_AUTHKEY if empty. |
+| `hostname` | `string` | no | The device name requested for the tsnet node. Default "clawpatrol-gateway". |
+| `control_url` | `string` | no | The Tailscale control-plane URL. Empty → Tailscale's hosted control plane. |
+| `tags` | `[]string` | no | The Tailscale device-tag list applied to keys the gateway mints for onboarded clients (`tag:client` etc.). The autoApprovers exit-node ACL must reference these tags. |
+| `operators` | `[]string` | no | Allowlists tailnet logins permitted to use the dashboard without typing the root password. Each entry is either an exact login ("alice@example.com") or a domain wildcard ("*@example.com"). Tagged devices (whose whois login is the tag name, not a user email) never match a wildcard entry — agents on the tailnet can never bypass the gate through this path. Empty / unset → tailnet-allowlist auth is disabled. The stored root password is then the only way in. Lives under `tailscale {}` because matching requires the tsnet whois identity; there is no whois without an active tsnet node. |
+| `funnel` | `bool` | no | Enables Tailscale Funnel on :443 so the join bootstrap and credential webhook paths are internet-reachable via the tsnet cert domain. Requires HTTPS enabled for the tailnet; if public_url is unset the gateway derives it from the tsnet cert domain at startup. |
+| `oauth_client_id` | `string` | no | The OAuth client id used to mint per-device tailnet auth keys at approval time. |
+| `oauth_client_secret` | `string` | no | The OAuth client secret paired with OAuthClientID. |
+
 ## `profile "<name>" { ... }`
 
 Names a set of credentials. Profiles bind to dashboard owners; an owner's profile determines which credentials — and, transitively via each credential's `endpoint` / `endpoints` binding, which endpoints — their gateway requests can reach. Rules ride along automatically because they're attached to endpoints.


### PR DESCRIPTION
## Summary

The operational `gateway { ... }` block had no section in `site/doc/config-reference.md`. The Top-level blocks table only said `Settings: block` without expanding it, so `dashboard_listen`, `public_url`, `state_dir`, `dashboard_session_ttl`, `resolver`, `log_path`, `telemetry`, `session_keep`, the `wireguard {}` / `tailscale {}` sub-blocks, and the recently-added `limits {}` sub-block were invisible to anyone reading the reference.

Adds a `## \`gateway { ... }\`` section driven by reflection over `GatewaySettings`, matching the style used for every other top-level kind. Field docs come from the existing Go comments — no new prose was hand-written.

Split out of #614 so that PR can stay focused on the rule-generation feature.

## Test plan

- [x] `go test ./internal/tools/docgen/...` — docgen drift test passes
- [x] `gofmt -l .` — clean