### PR TITLE
rules: fail closed via viral CEL unknowns instead of dispatch gates

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1963,8 +1963,8 @@ func bufferHTTPBodyForMatch(req *http.Request, capBytes int) []byte {
 // front of the original stream so upstream still receives the body
 // byte-for-byte. truncated is true iff the body extended beyond
 // maxHTTPMatchBody; callers stash this on match.Request.Truncated so
-// the dispatcher can fail-close rules that read http.body /
-// http.body_json.
+// http.body / http.body_json become CEL unknowns and rules whose
+// outcome depends on them fail-close.
 func bufferHTTPBodyForMatchTruncated(req *http.Request, capBytes int) (body []byte, truncated bool) {
 	if req.Body == nil {
 		return nil, false

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -92,17 +92,17 @@ func TestCompile(t *testing.T) {
 	}
 	getReq := &match.Request{Family: "http", Method: "GET"}
 	postReq := &match.Request{Family: "http", Method: "POST"}
-	if !reads.Matcher.Match(getReq) {
+	if reads.Matcher.Match(getReq).Result != match.Matched {
 		t.Errorf("github-reads should match GET")
 	}
-	if reads.Matcher.Match(postReq) {
-		t.Errorf("github-reads should NOT match POST")
+	if got := reads.Matcher.Match(postReq).Result; got != match.NoMatch {
+		t.Errorf("github-reads should NOT match POST, got %v", got)
 	}
-	if !writes.Matcher.Match(postReq) {
+	if writes.Matcher.Match(postReq).Result != match.Matched {
 		t.Errorf("github-writes should match POST")
 	}
-	if writes.Matcher.Match(getReq) {
-		t.Errorf("github-writes should NOT match GET")
+	if got := writes.Matcher.Match(getReq).Result; got != match.NoMatch {
+		t.Errorf("github-writes should NOT match GET, got %v", got)
 	}
 
 	// Outcomes wired correctly.

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -394,8 +394,8 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 	// Build a match.Request rich enough for the matcher AND for the
 	// HITL prompt fields a human approver might render. Truncated
 	// is set when at least one stream field hit its cap before
-	// EOF — runtime.MatchRequest's fail-closed gate then auto-denies
-	// any rule whose matcher reads a stream-typed field.
+	// EOF — the matcher then marks stream-typed fields CEL-unknown
+	// and any rule whose outcome depends on one is denied.
 	var req *match.Request
 	if pf != nil {
 		req = &match.Request{

--- a/internal/config/extplugin/celenv.go
+++ b/internal/config/extplugin/celenv.go
@@ -19,11 +19,12 @@ import (
 //
 // streamFields names the FACET_STREAM fields on the facet. They're
 // passed to match.CompileCondition as truncatablePaths so the
-// dispatcher's existing fail-closed-on-truncation gate applies to
-// plugin facets too: when the gateway's pullStream had to cap a
-// stream short of EOF, the EvaluateAction handler sets
-// Request.Truncated and runtime.MatchRequest auto-denies any rule
-// whose CEL condition reads the stream-typed bytes.
+// fail-closed-on-truncation contract applies to plugin facets too:
+// when the gateway's pullStream had to cap a stream short of EOF,
+// the EvaluateAction handler sets Request.Truncated, the matcher
+// marks the stream-typed paths as CEL unknowns, and any rule whose
+// condition outcome depends on the capped bytes evaluates
+// Unevaluable — which runtime.MatchRequest turns into a deny.
 //
 // The returned matcher additionally implements SubFieldReferencer
 // so the gateway adapter can decide, per evaluation, which
@@ -81,20 +82,16 @@ type pluginMatcher struct {
 	subFieldRefs map[string]bool
 }
 
-func (m *pluginMatcher) Match(req *match.Request) bool { return m.inner.Match(req) }
+func (m *pluginMatcher) Match(req *match.Request) match.Decision { return m.inner.Match(req) }
 
-// InspectsTruncatableFacet forwards the inner CEL matcher's
-// answer. The dispatcher uses it together with Request.Truncated
-// to fail-close any rule that reads a stream-typed field on a
-// request the gateway had to cap mid-pull.
+// InspectsTruncatableFacet forwards the inner CEL matcher's answer —
+// the compile-time laziness signal that tells the adapter whether
+// any rule needs a stream-typed field pulled in full. Verdicts on
+// truncated streams come from the inner matcher's Unevaluable result
+// (the stream fields are marked CEL-unknown on a Truncated request).
 func (m *pluginMatcher) InspectsTruncatableFacet() bool {
 	return m.inner.InspectsTruncatableFacet()
 }
-
-// InspectsUnparseableFacet always returns false: plugin facets have
-// no parser failure mode (see newPluginFacetMatcher's nil unparseable
-// path), so the Unparseable gate is structurally a no-op here.
-func (m *pluginMatcher) InspectsUnparseableFacet() bool { return false }
 
 // References preserves whatever the inner matcher reports so the
 // gateway's existing body-buffering check (top-level identifier

--- a/internal/config/extplugin/facet.go
+++ b/internal/config/extplugin/facet.go
@@ -41,8 +41,8 @@ type pluginFacet struct {
 	optionalFields map[string]bool
 	// streamFields lists the FACET_STREAM field names. Passed to
 	// the CEL compiler as truncatablePaths so the dispatcher's
-	// fail-closed-on-truncation gate (req.Truncated +
-	// matcher.InspectsTruncatableFacet) applies to plugin facets.
+	// fail-closed-on-truncation contract (req.Truncated marks the
+	// stream paths CEL-unknown) applies to plugin facets.
 	streamFields []string
 }
 

--- a/internal/config/facet/composition.go
+++ b/internal/config/facet/composition.go
@@ -13,7 +13,8 @@ import (
 // matcher: env options that declare its variable(s) and the Go types
 // behind them, an activation builder that populates its bindings on
 // the request's activation map, and the path lists CompileCondition
-// needs for case-normalization and truncation-fail-close.
+// needs for case-normalization and the unevaluable-fail-close
+// contract (truncated / unparseable values become CEL unknowns).
 //
 // Built-in facets return their own contribution via CELContributor.
 // Composition (a k8s_rule referencing http.method) is performed in
@@ -27,8 +28,8 @@ import (
 //
 // AddActivation writes the facet's bindings into act. It returns
 // false to refuse the match (e.g. wrong Meta type for the family);
-// when any contributor refuses, the composed matcher's Match returns
-// false without evaluating the CEL program.
+// when any contributor refuses, the composed matcher's Match reports
+// Unevaluable (fail closed) without evaluating the CEL program.
 type CELContrib struct {
 	EnvOptions       []cel.EnvOption
 	AddActivation    func(req *match.Request, act map[string]any) bool
@@ -36,9 +37,10 @@ type CELContrib struct {
 	TruncatablePaths []string
 	// UnparseablePaths lists the fields a wire frontend's parser
 	// derives from the request bytes — when the parser refuses the
-	// input, the frontend sets req.Unparseable=true and the
-	// dispatcher auto-denies any rule whose CEL reads one of these
-	// paths. Empty for facets with no parser-failure mode (http, k8s).
+	// input, the frontend sets req.Unparseable=true and the matcher
+	// marks these paths as CEL unknowns: any rule whose condition
+	// outcome depends on one evaluates Unevaluable and is denied.
+	// Empty for facets with no parser-failure mode (http, k8s).
 	UnparseablePaths []string
 }
 

--- a/internal/config/match/cel.go
+++ b/internal/config/match/cel.go
@@ -38,8 +38,10 @@ type ActivationBuilder func(req *Request) map[string]any
 // values come from bytes a wire frontend may truncate at its
 // inspection cap (HTTPS body, SQL statement, SSH stdin). On a request
 // with Truncated set, these paths are marked as CEL unknowns via a
-// partial activation: a condition whose outcome depends on one
-// evaluates Unevaluable (the unknown propagates virally, NaN-style),
+// partial activation (only for conditions that reference one — an
+// unreferenced path cannot affect the outcome): a condition whose
+// outcome depends on one evaluates Unevaluable (the unknown
+// propagates virally, NaN-style),
 // while a condition that resolves through &&/|| absorption on its
 // other predicates still matches or no-matches honestly. The same
 // paths also feed a pre-computed bool exposed via
@@ -79,8 +81,9 @@ func CompileCondition(env *cel.Env, condition string, buildAct ActivationBuilder
 		if err != nil {
 			return nil, err
 		}
-		inspectsTruncatable = referencesPath(ast.NativeRep().Expr(), paths)
-		truncatedUnknowns = unknownPatterns(paths)
+		if inspectsTruncatable = referencesPath(ast.NativeRep().Expr(), paths); inspectsTruncatable {
+			truncatedUnknowns = unknownPatterns(paths)
+		}
 	}
 	var unparseableUnknowns []*cel.AttributePatternType
 	if len(unparseablePaths) > 0 {
@@ -88,13 +91,23 @@ func CompileCondition(env *cel.Env, condition string, buildAct ActivationBuilder
 		if err != nil {
 			return nil, err
 		}
-		unparseableUnknowns = unknownPatterns(paths)
+		if referencesPath(ast.NativeRep().Expr(), paths) {
+			unparseableUnknowns = unknownPatterns(paths)
+		}
 	}
 	// OptPartialEval swaps in the partial-attribute factory so the
 	// unknown patterns of a PartialVars activation are honored at
-	// attribute-resolution time. With a plain map activation (the
-	// common untruncated case) it changes nothing.
-	prog, err := env.Program(ast, cel.EvalOptions(cel.OptPartialEval))
+	// attribute-resolution time. The factory adds a per-attribute
+	// AsPartialActivation check on every eval, so it is only enabled
+	// for conditions that actually reference a truncatable or
+	// parser-derived path — anything else never receives a partial
+	// activation (Match only wraps when a pattern list is non-empty)
+	// and keeps the default factory on the hot path.
+	var progOpts []cel.ProgramOption
+	if len(truncatedUnknowns)+len(unparseableUnknowns) > 0 {
+		progOpts = append(progOpts, cel.EvalOptions(cel.OptPartialEval))
+	}
+	prog, err := env.Program(ast, progOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("cel program: %w", err)
 	}
@@ -230,6 +243,11 @@ func unknownDetail(unk *types.Unknown, req *Request) string {
 	for _, id := range unk.IDs() {
 		trails, _ := unk.GetAttributeTrails(id)
 		for _, tr := range trails {
+			// NOTE: this leans on cel-go's AttributeTrail.String()
+			// ("var.field" / "var[key]" shapes) — an undocumented
+			// format that a cel-go upgrade could change. The output
+			// feeds the operator log only (never agent-visible
+			// reasons, never test assertions), so drift is cosmetic.
 			s := fmt.Sprintf("%v", tr)
 			if !seen[s] {
 				seen[s] = true

--- a/internal/config/match/cel.go
+++ b/internal/config/match/cel.go
@@ -13,7 +13,8 @@ import (
 // ActivationBuilder builds a CEL activation (variable bindings) from
 // a request. Each facet owns its own builder so it can pull the
 // right fields off Request / Request.Meta. Returning nil means the
-// matcher should refuse to match (e.g. wrong-shaped Meta).
+// condition can't be evaluated against this request (e.g.
+// wrong-shaped Meta) — the matcher reports Unevaluable.
 type ActivationBuilder func(req *Request) map[string]any
 
 // CompileCondition compiles a CEL condition source against env and
@@ -35,21 +36,24 @@ type ActivationBuilder func(req *Request) map[string]any
 //
 // truncatablePaths names the dotted identifier paths whose activation
 // values come from bytes a wire frontend may truncate at its
-// inspection cap (HTTPS body, SQL statement). CompileCondition walks
-// the AST and pre-computes a single bool: does this condition read
-// any of those paths? The result is exposed via
-// InspectsTruncatableFacet() so the dispatcher can fail-close on a
-// truncated request without re-walking the AST per match.
+// inspection cap (HTTPS body, SQL statement, SSH stdin). On a request
+// with Truncated set, these paths are marked as CEL unknowns via a
+// partial activation: a condition whose outcome depends on one
+// evaluates Unevaluable (the unknown propagates virally, NaN-style),
+// while a condition that resolves through &&/|| absorption on its
+// other predicates still matches or no-matches honestly. The same
+// paths also feed a pre-computed bool exposed via
+// InspectsTruncatableFacet() — that one is purely the compile-time
+// laziness signal (does any rule need the capped bytes buffered at
+// all), not a verdict input.
 //
 // unparseablePaths names the dotted identifier paths whose activation
 // values are derived by a frontend's parser and therefore left zero
 // when the parser refuses the input (SQL verb / tables / functions).
-// Pre-computed the same way as truncatablePaths and exposed via
-// InspectsUnparseableFacet() so the dispatcher can fail-close on an
-// unparseable request without re-walking the AST per match. The
-// raw statement text is intentionally NOT in this set — it's still
-// populated when the parser fails, so rules that key only on
-// `<facet>.statement` keep evaluating honestly.
+// On a request with Unparseable set, these are marked unknown the
+// same way. The raw statement text is intentionally NOT in this set —
+// it's still populated when the parser fails, so rules that key only
+// on `<facet>.statement` keep evaluating honestly.
 //
 // Paths must be of the form "<var>.<field>" — single-level selection
 // off a top-level identifier. That's all the facets need today.
@@ -69,22 +73,28 @@ func CompileCondition(env *cel.Env, condition string, buildAct ActivationBuilder
 		normalizeWantLiterals(ast.NativeRep().Expr(), paths)
 	}
 	var inspectsTruncatable bool
+	var truncatedUnknowns []*cel.AttributePatternType
 	if len(truncatablePaths) > 0 {
 		paths, err := parsePaths(truncatablePaths)
 		if err != nil {
 			return nil, err
 		}
 		inspectsTruncatable = referencesPath(ast.NativeRep().Expr(), paths)
+		truncatedUnknowns = unknownPatterns(paths)
 	}
-	var inspectsUnparseable bool
+	var unparseableUnknowns []*cel.AttributePatternType
 	if len(unparseablePaths) > 0 {
 		paths, err := parsePaths(unparseablePaths)
 		if err != nil {
 			return nil, err
 		}
-		inspectsUnparseable = referencesPath(ast.NativeRep().Expr(), paths)
+		unparseableUnknowns = unknownPatterns(paths)
 	}
-	prog, err := env.Program(ast)
+	// OptPartialEval swaps in the partial-attribute factory so the
+	// unknown patterns of a PartialVars activation are honored at
+	// attribute-resolution time. With a plain map activation (the
+	// common untruncated case) it changes nothing.
+	prog, err := env.Program(ast, cel.EvalOptions(cel.OptPartialEval))
 	if err != nil {
 		return nil, fmt.Errorf("cel program: %w", err)
 	}
@@ -94,8 +104,21 @@ func CompileCondition(env *cel.Env, condition string, buildAct ActivationBuilder
 		buildAct:            buildAct,
 		refs:                refs,
 		inspectsTruncatable: inspectsTruncatable,
-		inspectsUnparseable: inspectsUnparseable,
+		truncatedUnknowns:   truncatedUnknowns,
+		unparseableUnknowns: unparseableUnknowns,
 	}, nil
+}
+
+// unknownPatterns converts parsed "<var>.<field>" paths into the
+// attribute patterns a partial activation uses to mark those values
+// unknown. Built once at compile time; the patterns are immutable
+// afterwards, so sharing them across concurrent Match calls is safe.
+func unknownPatterns(paths []celPath) []*cel.AttributePatternType {
+	out := make([]*cel.AttributePatternType, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, cel.AttributePattern(p.ident).QualString(p.field))
+	}
+	return out
 }
 
 // MatcherReferences returns the variable names a Matcher's compiled
@@ -106,22 +129,19 @@ func (m *celMatcher) References() map[string]bool { return m.refs }
 
 // InspectsTruncatableFacet reports whether the matcher's CEL
 // condition reads any of the truncatablePaths declared when the
-// matcher was compiled. Pre-computed at compile time so the
-// dispatcher's fail-closed check is O(1) per match.
+// matcher was compiled. This is the laziness signal Compile rolls
+// up into CompiledEndpoint.InspectsTruncatable — wire frontends use
+// it to skip buffering capped bytes no rule reads. Verdicts on
+// truncated requests come from Match's Unevaluable result, not from
+// this flag.
 func (m *celMatcher) InspectsTruncatableFacet() bool { return m.inspectsTruncatable }
 
-// InspectsUnparseableFacet reports whether the matcher's CEL
-// condition reads any of the unparseablePaths declared when the
-// matcher was compiled. Mirror of InspectsTruncatableFacet for the
-// parser-failure gate; see CompileCondition.
-func (m *celMatcher) InspectsUnparseableFacet() bool { return m.inspectsUnparseable }
-
-// PassThrough is a Matcher that always returns true. Facets use it
-// for empty conditions (catch-all rules).
+// PassThrough is a Matcher that always matches. Facets use it for
+// empty conditions (catch-all rules).
 type PassThrough struct{}
 
-// Match always returns true.
-func (PassThrough) Match(*Request) bool { return true }
+// Match always reports Matched.
+func (PassThrough) Match(*Request) Decision { return Decision{Result: Matched} }
 
 // References reports no variable use.
 func (PassThrough) References() map[string]bool { return nil }
@@ -132,36 +152,103 @@ func (PassThrough) References() map[string]bool { return nil }
 // request — operators can still attach a default-deny verdict to it.
 func (PassThrough) InspectsTruncatableFacet() bool { return false }
 
-// InspectsUnparseableFacet reports false: a catch-all rule reads no
-// parser-derived facet, so an unparseable request can still match it
-// normally. Same reasoning as InspectsTruncatableFacet.
-func (PassThrough) InspectsUnparseableFacet() bool { return false }
-
 type celMatcher struct {
 	prog                cel.Program
 	buildAct            ActivationBuilder
 	refs                map[string]bool
 	inspectsTruncatable bool
-	inspectsUnparseable bool
+	truncatedUnknowns   []*cel.AttributePatternType
+	unparseableUnknowns []*cel.AttributePatternType
 }
 
-func (m *celMatcher) Match(req *Request) bool {
+// Match evaluates the compiled condition against req. Anything that
+// prevents an honest true/false — a CEL runtime error, a result that
+// depends on a facet marked unknown (truncated / unparseable), a
+// wrong-shaped activation — comes back Unevaluable so the dispatcher
+// fails closed instead of treating the rule as silently non-matching
+// (which would let a deny rule fail open).
+func (m *celMatcher) Match(req *Request) Decision {
 	if m == nil || m.prog == nil {
-		return false
+		return unevaluable("matcher has no compiled program")
 	}
 	act := m.buildAct(req)
 	if act == nil {
-		return false
+		return unevaluable("facet activation could not be built for this request")
 	}
-	out, _, err := m.prog.Eval(act)
+	// On a truncated / unparseable request, mark the affected facet
+	// paths unknown via a partial activation. The unknowns propagate
+	// virally through evaluation; &&/|| absorption still lets the
+	// condition resolve when its outcome provably doesn't depend on
+	// the unavailable value (false && unknown == false).
+	var vars any = act
+	if req != nil {
+		var patterns []*cel.AttributePatternType
+		if req.Truncated {
+			patterns = append(patterns, m.truncatedUnknowns...)
+		}
+		if req.Unparseable {
+			patterns = append(patterns, m.unparseableUnknowns...)
+		}
+		if len(patterns) > 0 {
+			pv, err := cel.PartialVars(act, patterns...)
+			if err != nil {
+				return unevaluable("partial activation: " + err.Error())
+			}
+			vars = pv
+		}
+	}
+	out, _, err := m.prog.Eval(vars)
+	if types.IsUnknown(out) {
+		return unevaluable("condition depends on " + unknownDetail(out.(*types.Unknown), req))
+	}
 	if err != nil {
-		return false
+		return unevaluable("evaluation error: " + err.Error())
 	}
 	b, ok := out.(types.Bool)
 	if !ok {
-		return false
+		return unevaluable(fmt.Sprintf("condition yielded non-bool %v", out))
 	}
-	return bool(b)
+	if bool(b) {
+		return Decision{Result: Matched}
+	}
+	return Decision{Result: NoMatch}
+}
+
+// unevaluable builds the fail-closed Decision with its detail line.
+func unevaluable(detail string) Decision {
+	return Decision{Result: Unevaluable, Detail: detail}
+}
+
+// unknownDetail renders a CEL unknown as an operator-readable line:
+// the facet paths the condition's outcome depends on, deduplicated
+// and without cel-go's expression-id noise, plus why they were
+// unavailable (truncated / unparseable, taken from the request
+// flags that caused the partial activation).
+func unknownDetail(unk *types.Unknown, req *Request) string {
+	var paths []string
+	seen := map[string]bool{}
+	for _, id := range unk.IDs() {
+		trails, _ := unk.GetAttributeTrails(id)
+		for _, tr := range trails {
+			s := fmt.Sprintf("%v", tr)
+			if !seen[s] {
+				seen[s] = true
+				paths = append(paths, s)
+			}
+		}
+	}
+	var causes []string
+	if req != nil && req.Truncated {
+		causes = append(causes, "bytes truncated at the inspection buffer")
+	}
+	if req != nil && req.Unparseable {
+		causes = append(causes, "statement unparseable")
+	}
+	cause := strings.Join(causes, "; ")
+	if cause == "" {
+		cause = "unavailable"
+	}
+	return "facet value(s) the gateway does not have (" + cause + "): " + strings.Join(paths, ", ")
 }
 
 // collectReferencedVars walks the CEL AST and returns every top-level

--- a/internal/config/match/match.go
+++ b/internal/config/match/match.go
@@ -68,22 +68,22 @@ type Request struct {
 	// Truncated is set by a wire frontend when the bytes it could
 	// expose to the matcher were capped by a per-plugin inspection
 	// buffer (HTTPS body cap, postgres frame cap, clickhouse query
-	// body cap). The dispatcher reads it together with each rule's
-	// InspectsTruncatableFacet() to synthesize a fail-closed deny on
-	// any rule whose CEL condition reads bytes that aren't there —
-	// rules that don't read the truncated facet still fire on their
-	// other predicates.
+	// body cap). The matcher marks every truncatable facet path as a
+	// CEL unknown on such a request, so a condition whose outcome
+	// depends on the capped bytes evaluates Unevaluable (→ the
+	// dispatcher fails closed), while a condition that resolves on
+	// its other predicates still matches or no-matches honestly.
 	Truncated bool
 
 	// Unparseable is set by a wire frontend when its SQL parser
 	// refuses the Query bytes outright (the statement is still on
 	// Meta.Statement, but Verb / Tables / Functions are left zero
-	// because the parser couldn't derive them). The dispatcher reads
-	// it together with each rule's InspectsUnparseableFacet() to
-	// synthesize a fail-closed deny on any rule whose CEL condition
-	// references a parser-derived SQL facet that wasn't populated —
-	// rules keyed only on connection-level facets (credential,
-	// peer_ip) or on the raw statement still fire normally.
+	// because the parser couldn't derive them). The matcher marks
+	// every parser-derived facet path as a CEL unknown on such a
+	// request — a condition whose outcome depends on one evaluates
+	// Unevaluable, while rules keyed only on connection-level facets
+	// (credential, peer_ip) or on the raw statement still fire
+	// normally.
 	//
 	// Differs from Truncated in two ways: (a) the statement text
 	// IS populated when Unparseable=true, so `sql.statement` rules
@@ -93,31 +93,51 @@ type Request struct {
 	Unparseable bool
 }
 
-// Matcher walks a Request and returns true when the rule's match
-// predicate is satisfied. Implementations are family-specific and
-// live in their facet plugin's package.
+// Result is the three-valued outcome of evaluating a rule's
+// condition against a request.
+type Result int
+
+const (
+	// NoMatch reports that the condition evaluated cleanly to false.
+	NoMatch Result = iota
+	// Matched reports that the condition evaluated cleanly to true.
+	Matched
+	// Unevaluable reports that the condition's outcome could not be
+	// determined honestly — it depends on a facet value the gateway
+	// doesn't have (truncated bytes, parser-refused fields), or
+	// evaluation errored at runtime (missing JSON key, type
+	// mismatch). The dispatcher fails closed on this result: an
+	// unevaluable rule synthesizes a deny rather than being silently
+	// skipped, because "skipped" would let a deny rule fail open.
+	Unevaluable
+)
+
+// Decision is a Result plus, for Unevaluable, a human-readable
+// detail naming what made the condition unevaluable (the unknown
+// facet paths, or the CEL evaluation error). Detail is "" for
+// NoMatch / Matched.
+type Decision struct {
+	Result Result
+	Detail string
+}
+
+// Matcher evaluates a rule's match predicate against a Request and
+// returns a three-valued Decision. Implementations are
+// family-specific and live in their facet plugin's package.
 //
 // InspectsTruncatableFacet reports whether the matcher's compiled
 // condition reads any field of the request whose value could be
 // truncated by a wire frontend's inspection buffer (HTTPS body /
-// body_json, SQL verb / tables / functions / statement). The
-// dispatcher gates on this together with Request.Truncated to fail
-// closed on policy-bypass-by-truncation: a rule that asks about the
-// body of a request whose body was capped is auto-denied; a rule
-// that only reads the request method or credential is allowed to
-// run its own Match against whatever bytes did fit.
+// body_json, SQL verb / tables / functions / statement, SSH stdin).
+// It does NOT drive verdicts — those come from Match's Unevaluable
+// result — it is the compile-time laziness signal: Compile rolls it
+// up into CompiledEndpoint.InspectsTruncatable so wire frontends
+// know whether any rule needs the capped bytes buffered at all
+// (e.g. the ssh endpoint only takes the stdin-buffering path when
+// some rule reads ssh.stdin).
 type Matcher interface {
-	Match(req *Request) bool
+	Match(req *Request) Decision
 	InspectsTruncatableFacet() bool
-	// InspectsUnparseableFacet reports whether the matcher's compiled
-	// condition reads any field of the request whose value the
-	// frontend's parser would leave zero on parse failure (SQL verb,
-	// tables, functions). The dispatcher gates on this together with
-	// Request.Unparseable to fail closed on policy-bypass-by-unparser:
-	// a rule that asks about the verb of a query the parser rejected
-	// is auto-denied; a rule that only reads the raw statement or
-	// the credential is allowed to run its own Match.
-	InspectsUnparseableFacet() bool
 }
 
 // PathOf returns the URL's path, or "" when u is nil. Common enough

--- a/internal/config/match/match.go
+++ b/internal/config/match/match.go
@@ -112,6 +112,17 @@ const (
 	Unevaluable
 )
 
+// ResultOf converts a boolean match expectation to a Result: true
+// is Matched, false is NoMatch. A convenience for callers (mostly
+// tests) asserting two-valued outcomes; Unevaluable never maps from
+// a bool.
+func ResultOf(matched bool) Result {
+	if matched {
+		return Matched
+	}
+	return NoMatch
+}
+
 // Decision is a Result plus, for Unevaluable, a human-readable
 // detail naming what made the condition unevaluable (the unknown
 // facet paths, or the CEL evaluation error). Detail is "" for

--- a/internal/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/internal/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -900,9 +900,9 @@ func chRewindReader(head []byte, tail *chgoproto.Reader) *chgoproto.Reader {
 // entering. The new value only enters circulation on the next
 // statement.
 //
-// unparseable propagates onto match.Request so the dispatcher's
-// fail-closed-on-Unparseable gate auto-denies any rule reading
-// verb / tables / functions for a query the parser refused.
+// unparseable propagates onto match.Request so verb / tables /
+// functions become CEL unknowns for a query the parser refused —
+// any rule whose outcome depends on them is denied.
 func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, database string, truncated bool) (verdict, reason, nextDB string) {
 	info, unparseable := parseChSQL(sql)
 	defer func() {

--- a/internal/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/internal/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -933,7 +933,7 @@ func chEvaluateSQL(ctx context.Context, ch *runtime.ConnHandle, sql, credName, d
 	if f := facet.Lookup("sql"); f != nil {
 		facets = f.Report(mreq)
 	}
-	cr := runtime.MatchRequest(ch.Endpoint, mreq)
+	cr := runtime.MatchRequestFailClosed(ch.Endpoint, mreq)
 	if cr == nil {
 		chEmit(ch, runtime.ConnEvent{
 			Action: "allow", Verb: info.Verb, Summary: chSummary(info), Facets: facets,

--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -507,24 +507,27 @@ func pgClientToServer(ctx context.Context, ch *runtime.ConnHandle, upstream net.
 //
 //   - Build a SQL match.Request with Truncated=true and empty
 //     Verb / Statement / Tables / Functions. The frontend can't
-//     parse SQL out of bytes it refused to buffer, and the
-//     dispatcher's job is to decide off the rule's truncatable-facet
-//     references, not off whatever prefix did fit.
-//   - runtime.MatchRequest walks the rule list. A rule whose CEL
-//     reads sql.* will be auto-synthesized to deny (config/runtime/
-//     dispatch.go); a rule that only reads credential or has no
-//     condition still matches normally.
+//     parse SQL out of bytes it refused to buffer; every sql.* facet
+//     path is a CEL unknown, so a rule whose outcome depends on the
+//     discarded bytes evaluates Unevaluable and synth-denies, while
+//     a rule that resolves on credential / sql.database / a catch-all
+//     still matches normally.
+//   - runtime.MatchRequestFailClosed walks the rule list. When the
+//     endpoint declares rules and none matched (every condition
+//     resolved independent of the missing bytes), it synthesizes a
+//     deny rather than letting the uninspectable frame ride the
+//     implicit-allow default. Rule-less endpoints keep pass-through.
 //
 // Then:
 //
 //   - Deny → drain remaining frame bytes from the wire, send
 //     ErrorResponse + ReadyForQuery to the agent (pgWriteDeny), do
 //     NOT touch upstream.
-//   - Allow / no match → forward every byte verbatim to upstream
-//     (the buffered prefix + the wire tail streamed through
-//     io.CopyN). The upstream sees a single oversize Q / P frame
-//     exactly as the agent emitted it; the gateway just declined to
-//     materialize the body in memory.
+//   - Allow (a rule explicitly matched) / no rules on the endpoint →
+//     forward every byte verbatim to upstream (the buffered prefix +
+//     the wire tail streamed through io.CopyN). The upstream sees a
+//     single oversize Q / P frame exactly as the agent emitted it;
+//     the gateway just declined to materialize the body in memory.
 //   - Approve chain → treated as deny. HITL can't make a decision
 //     on bytes that aren't there.
 func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName, database string, buf []byte, length uint32) ([]byte, bool) {
@@ -550,7 +553,7 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName, 
 	if f := facet.Lookup("sql"); f != nil {
 		facets = f.Report(mreq)
 	}
-	cr := runtime.MatchRequest(ch.Endpoint, mreq)
+	cr := runtime.MatchRequestFailClosed(ch.Endpoint, mreq)
 
 	deny, reason := false, ""
 	if cr != nil {
@@ -662,7 +665,7 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 	if f := facet.Lookup("sql"); f != nil {
 		facets = f.Report(mreq)
 	}
-	cr := runtime.MatchRequest(ch.Endpoint, mreq)
+	cr := runtime.MatchRequestFailClosed(ch.Endpoint, mreq)
 	if cr == nil {
 		// No rule matched — implicit allow. Emit so the query
 		// shows up in the dashboard's actions tab anyway; the

--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -124,8 +124,8 @@ func (PostgresEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidate
 // Returns *sqlfacet.Meta as `any` to keep the runtime interface free
 // of the facets-package import. The bool mirrors the Unparseable
 // contract — true when pgplex refused the bytes; the fixture loader
-// then sets match.Request.Unparseable so the dispatcher's fail-closed
-// gate evaluates the test request the same way live dispatch would.
+// then sets match.Request.Unparseable so the unevaluable fail-close
+// evaluates the test request the same way live dispatch would.
 func (PostgresEndpointRuntime) ParseStatement(sql string) (any, bool) {
 	info, unparseable := parseSQL(sql)
 	return &sqlfacet.Meta{
@@ -390,8 +390,8 @@ func pgStartupParam(body []byte, key string) string {
 // force the gateway to either accumulate it (OOM) or forward it
 // uninspected. The wire pump refuses to buffer past this cap: Q / P
 // frames whose declared length exceeds it take the truncated-frame
-// path (pgHandleOversizeFrame), which lets the dispatcher fail-close
-// any rule that would have read the now-discarded statement bytes,
+// path (pgHandleOversizeFrame), which fail-closes any rule whose
+// outcome would have depended on the now-discarded statement bytes,
 // and otherwise streams the frame through unbuffered.
 const maxPgMessage = 1 << 20
 
@@ -635,9 +635,9 @@ func pgEvaluate(ch *runtime.ConnHandle, sql, credName, database string) (string,
 // suppresses emission on allow / hitl_allow so synthesised
 // sub-statements don't pollute the dashboard; deny emissions still
 // fire either way (operators need to see *why* a batch was denied).
-// unparseable propagates onto match.Request so the dispatcher's
-// fail-closed-on-Unparseable gate auto-denies any rule reading
-// verb / tables / functions for a piece pgplex refused.
+// unparseable propagates onto match.Request so the matcher marks
+// verb / tables / functions as CEL unknowns for a piece pgplex
+// refused — any rule whose outcome depends on them is denied.
 func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database string, shadow, unparseable bool) (string, string) {
 	summary := pgSummary(info)
 	mreq := &match.Request{
@@ -872,10 +872,10 @@ type pgInfo struct {
 // Unparseable mirrors match.Request.Unparseable for this piece — set
 // when pgplex's grammar refuses the bytes outright. The wire-protocol
 // gateway propagates the flag onto each per-statement match.Request,
-// so the dispatcher's fail-closed-on-Unparseable gate auto-denies any
-// rule whose CEL reads verb / tables / functions on a piece the
-// parser couldn't analyse. Statement text is preserved either way,
-// so `sql.statement.contains(...)` rules still evaluate honestly.
+// so verb / tables / functions become CEL unknowns on a piece the
+// parser couldn't analyse and any rule whose outcome depends on them
+// is denied. Statement text is preserved either way, so
+// `sql.statement.contains(...)` rules still evaluate honestly.
 type analysedStmt struct {
 	Outer       pgInfo
 	Inner       []pgInfo

--- a/internal/config/plugins/endpoints/postgres_runtime_test.go
+++ b/internal/config/plugins/endpoints/postgres_runtime_test.go
@@ -919,3 +919,45 @@ func TestPgEvaluateThreadsDatabaseIntoMeta(t *testing.T) {
 		t.Errorf("SELECT on Prod verdict = %q, want allow (verb mismatch)", v)
 	}
 }
+
+// TestPgEvaluateUnparseableBackstopDeny pins the wiring of
+// runtime.MatchRequestFailClosed through pgEvaluateInfo: an
+// unparseable statement whose only rule resolves via absorption
+// (`unknown && false == false` → NoMatch) must NOT ride the
+// implicit-allow default — the backstop denies because the endpoint
+// declares rules and the bytes were uninspectable.
+func TestPgEvaluateUnparseableBackstopDeny(t *testing.T) {
+	ep := pgEndpointFromHCL(t, `
+endpoint "postgres" "db" {
+  host = "db.example.com:5432"
+}
+credential "postgres_credential" "db-cred" { endpoint = postgres.db }
+profile "default" { credentials = [postgres_credential.db-cred] }
+
+rule "deny-prod-drops" {
+  endpoint  = postgres.db
+  condition = "sql.verb == 'drop' && sql.database == 'prod'"
+  verdict   = "deny"
+}
+`)
+	ch := &runtime.ConnHandle{
+		Endpoint: ep,
+		Emit:     func(runtime.ConnEvent) {},
+	}
+	// Unparseable piece, database 'dev': the rule absorbs to false,
+	// no rule matches, the backstop denies.
+	v, reason := pgEvaluate(ch, "DROP;", "", "dev")
+	if v != "deny" {
+		t.Fatalf("pgEvaluate(\"DROP;\", db=dev) verdict = %q reason = %q, want backstop deny", v, reason)
+	}
+	if !strings.Contains(reason, "unparseable") {
+		t.Errorf("reason = %q, want it to name the cause", reason)
+	}
+	// A parseable SELECT against the same endpoint still falls
+	// through to implicit allow — the backstop only guards
+	// uninspectable requests.
+	v, reason = pgEvaluate(ch, "SELECT 1", "", "dev")
+	if v != "" {
+		t.Fatalf("pgEvaluate(\"SELECT 1\") verdict = %q reason = %q, want implicit allow", v, reason)
+	}
+}

--- a/internal/config/plugins/endpoints/postgres_runtime_test.go
+++ b/internal/config/plugins/endpoints/postgres_runtime_test.go
@@ -704,9 +704,10 @@ func TestPgEvaluate_Audit143(t *testing.T) {
 // statement to the matcher at all, the matcher will fire."
 type passThrough struct{}
 
-func (passThrough) Match(*match.Request) bool      { return true }
+func (passThrough) Match(*match.Request) match.Decision {
+	return match.Decision{Result: match.Matched}
+}
 func (passThrough) InspectsTruncatableFacet() bool { return false }
-func (passThrough) InspectsUnparseableFacet() bool { return false }
 
 // TestPgEvaluateUnparseableSynthDeny exercises the postgres side of
 // the Unparseable contract end-to-end: a request whose parser
@@ -748,7 +749,7 @@ rule "ban-drops" {
 		t.Fatalf("pgEvaluate(\"DROP;\") verdict = %q reason = %q, want deny", v, reason)
 	}
 	// The synth reason names the rule whose contract the unparseable
-	// request broke — dispatch.go:134's generic phrasing.
+	// request broke and the cause the matcher reported.
 	if !strings.Contains(reason, "ban-drops") || !strings.Contains(reason, "unparseable") {
 		t.Errorf("reason = %q, want it to name the rule and mention 'unparseable'", reason)
 	}

--- a/internal/config/plugins/endpoints/postgres_sql.go
+++ b/internal/config/plugins/endpoints/postgres_sql.go
@@ -45,9 +45,9 @@ import (
 //   - Parse succeeds → unparseable=false, every facet populated.
 //   - Parse fails    → unparseable=true,  only Statement populated
 //     (Verb / Tables / Functions left zero). The runtime stashes
-//     the flag on match.Request.Unparseable, and the dispatcher's
-//     fail-closed-on-Unparseable gate (config/runtime/dispatch.go)
-//     synth-denies any rule whose CEL reads the unset facets.
+//     the flag on match.Request.Unparseable; the matcher marks the
+//     unset facets as CEL unknowns and any rule whose condition
+//     outcome depends on one synth-denies (fail closed).
 //
 // No verb-sniffing fallback: any input pgplex refuses (exotic
 // syntax, garbled bytes, future shapes the grammar doesn't yet

--- a/internal/config/plugins/endpoints/ssh.go
+++ b/internal/config/plugins/endpoints/ssh.go
@@ -607,9 +607,10 @@ func proxyChannel(a ssh.Channel, aReqs <-chan *ssh.Request, b ssh.Channel, bReqs
 // client→server stdin up to stdinMatchCap, withholding it from upstream
 // until a rule verdict, so a denied script never runs. Buffering stops
 // at the first of: agent EOF (the bounded `ssh host < file` case), the
-// cap (truncated → the dispatcher fail-closes any rule reading
-// ssh.stdin), or stdinIdle with no new bytes (so typed/streamed stdin
-// doesn't hang — its prefix is judged, the rest streams on unjudged).
+// cap (truncated → ssh.stdin becomes a CEL unknown and any rule
+// whose outcome depends on it fail-closes), or stdinIdle with no new
+// bytes (so typed/streamed stdin doesn't hang — its prefix is judged,
+// the rest streams on unjudged).
 const (
 	stdinMatchCap = 1 << 20 // mirror cmd/clawpatrol maxHTTPMatchBody
 	stdinIdle     = 250 * time.Millisecond
@@ -925,9 +926,10 @@ func (rt *SSHEndpointRuntime) makeGate(ch *runtime.ConnHandle, emit func(runtime
 			User:       agentUser,
 			Meta:       m,
 			// Truncated is only ever set on the stdin pre-gate path,
-			// when buffered stdin overflowed the cap; the dispatcher
-			// then fail-closes any rule reading ssh.stdin. Every other
-			// caller leaves it false, so the fast path is unchanged.
+			// when buffered stdin overflowed the cap; ssh.stdin then
+			// becomes a CEL unknown and any rule whose outcome depends
+			// on it fail-closes. Every other caller leaves it false,
+			// so the fast path is unchanged.
 			Truncated: m.Truncated,
 		}
 		var facets map[string]any

--- a/internal/config/plugins/facets/https/https.go
+++ b/internal/config/plugins/facets/https/https.go
@@ -105,10 +105,11 @@ func init() {
 // case-sensitive (paths, headers, body bytes are operator-controlled).
 //
 // truncatablePaths: http.body and http.body_json come from the buffer
-// the gateway capped at maxHTTPMatchBody (main.go); a rule that
-// reads either on a request whose body overflowed can't be evaluated
-// honestly, so the dispatcher synthesizes a deny. Fields whose value
-// is body-independent (method, path, query, headers) are
+// the gateway capped at maxHTTPMatchBody (main.go). On a request
+// whose body overflowed, both paths are marked CEL-unknown; a
+// condition whose outcome depends on the capped bytes evaluates
+// Unevaluable and the dispatcher synthesizes a deny. Fields whose
+// value is body-independent (method, path, query, headers) are
 // intentionally absent — `http.method == "GET"` still fires on its
 // own predicate even when the body was capped. Because the k8s
 // family composes the http facet alongside its own, a k8s_rule that
@@ -130,8 +131,8 @@ func (Facet) CELContrib() facet.CELContrib {
 		// HTTPS has no parser-failure mode: every field (method,
 		// headers, body, body_json) is decoded directly from the wire,
 		// not derived by a parser that could refuse the input.
-		// UnparseablePaths stays nil so the dispatcher's Unparseable
-		// gate is a no-op for HTTPS rules.
+		// UnparseablePaths stays nil so Request.Unparseable marks
+		// nothing unknown for HTTPS rules.
 	}
 }
 
@@ -164,9 +165,11 @@ func addActivation(req *match.Request, act map[string]any) bool {
 	}
 	// body_json is parsed eagerly when the body looks like JSON. The
 	// cost is bounded by request body size, which the gateway already
-	// limits. Empty body / parse error → an empty struct value, so
-	// `http.body_json.<field>` evaluates to null rather than blowing
-	// up at request time.
+	// limits. Empty body / parse error → an empty struct value.
+	// NOTE: selecting a field the payload doesn't carry is a CEL
+	// eval error, and eval errors fail closed (Unevaluable → deny).
+	// Rules over optional fields must guard with has():
+	// `has(http.body_json.archived) && http.body_json.archived == true`.
 	f.BodyJSON = parseBodyJSON(req.Body)
 	act["http"] = f
 	return true
@@ -176,7 +179,9 @@ func addActivation(req *match.Request, act map[string]any) bool {
 // for the body_json field. JSON-shaped input lands as the matching
 // structpb tree (objects → Struct, arrays → List, scalars → their
 // natural type); non-JSON / empty input falls back to an empty
-// struct so field accesses yield null.
+// struct. Selecting a missing field off the struct is a CEL eval
+// error — fail-closed per the strict Unevaluable contract — so
+// conditions over optional fields need a has() guard.
 func parseBodyJSON(body []byte) *structpb.Value {
 	empty := structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{}})
 	if len(body) == 0 {

--- a/internal/config/plugins/facets/https/https_test.go
+++ b/internal/config/plugins/facets/https/https_test.go
@@ -11,6 +11,16 @@ import (
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/https"
 )
 
+// wantResult adapts a boolean match expectation to the three-valued
+// Result, so an unexpected Unevaluable fails the assertion
+// instead of being conflated with "no match".
+func wantResult(b bool) match.Result {
+	if b {
+		return match.Matched
+	}
+	return match.NoMatch
+}
+
 // httpReq builds a minimal Request for the HTTP matcher tests.
 // Header / body / credential default to empty unless the test sets
 // them via the Request returned (callers mutate before calling Match).
@@ -86,8 +96,8 @@ func TestHTTPMatcherMethodAndPath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
-			if got := m.Match(tc.req); got != tc.want {
-				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			if got := m.Match(tc.req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
 			}
 		})
 	}
@@ -132,8 +142,8 @@ func TestHTTPMatcherMethodCaseInsensitive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
-			if got := m.Match(httpReq(tc.method, "/x")); got != tc.want {
-				t.Errorf("Match=%v want %v (condition=%q method=%q)", got, tc.want, tc.condition, tc.method)
+			if got := m.Match(httpReq(tc.method, "/x")).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q method=%q)", got, wantResult(tc.want), tc.condition, tc.method)
 			}
 		})
 	}
@@ -146,11 +156,91 @@ func TestHTTPMatcherBodyJSON(t *testing.T) {
 	}
 	req := httpReq("PATCH", "/v1/pages/abc")
 	req.Body = []byte(`{"archived":true,"title":"x"}`)
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("expected body_json subset match")
 	}
 	req.Body = []byte(`{"archived":false,"title":"x"}`)
-	if m.Match(req) {
-		t.Errorf("expected body_json mismatch")
+	if got := m.Match(req).Result; got != match.NoMatch {
+		t.Errorf("expected body_json mismatch, got %v", got)
+	}
+}
+
+// TestHTTPMatcherBodyJSONMissingFieldUnevaluable pins strict-mode
+// fail-closed evaluation: selecting a body_json field the payload
+// doesn't carry is a CEL eval error, which surfaces as Unevaluable
+// (the dispatcher synthesizes a deny) instead of silently
+// no-matching — silent no-match would let a deny rule fail open.
+// Rules with optional fields must guard with has().
+func TestHTTPMatcherBodyJSONMissingFieldUnevaluable(t *testing.T) {
+	m, err := facet.NewMatcher("http", "http.body_json.archived == true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httpReq("PATCH", "/v1/pages/abc")
+	req.Body = []byte(`{"title":"x"}`)
+	if got := m.Match(req).Result; got != match.Unevaluable {
+		t.Errorf("missing field: Match=%v, want Unevaluable", got)
+	}
+	// Empty / non-JSON bodies parse to an empty object — same deal.
+	req.Body = nil
+	if got := m.Match(req).Result; got != match.Unevaluable {
+		t.Errorf("empty body: Match=%v, want Unevaluable", got)
+	}
+}
+
+// TestHTTPMatcherBodyJSONHasGuard pins the has() escape hatch on a
+// fully captured body: presence-testing a missing key is false, not
+// an error, so the guarded condition cleanly no-matches and the
+// rule keeps working for payloads where the field is optional.
+func TestHTTPMatcherBodyJSONHasGuard(t *testing.T) {
+	m, err := facet.NewMatcher("http", "has(http.body_json.archived) && http.body_json.archived == true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httpReq("PATCH", "/v1/pages/abc")
+	req.Body = []byte(`{"title":"x"}`)
+	if got := m.Match(req).Result; got != match.NoMatch {
+		t.Errorf("guarded missing field: Match=%v, want NoMatch", got)
+	}
+	req.Body = []byte(`{"archived":true}`)
+	if got := m.Match(req).Result; got != match.Matched {
+		t.Errorf("guarded present field: Match=%v, want Matched", got)
+	}
+}
+
+// TestHTTPMatcherTruncatedBodyUnknown pins the viral-unknown
+// contract on a Truncated request: http.body / http.body_json are
+// marked CEL-unknown, so a condition whose outcome depends on the
+// capped bytes is Unevaluable — and has() cannot rescue it, because
+// the presence test itself is unknown (whatever was cut off might
+// have carried the key). Conditions that resolve through &&/||
+// absorption still evaluate honestly.
+func TestHTTPMatcherTruncatedBodyUnknown(t *testing.T) {
+	cases := []struct {
+		name      string
+		condition string
+		method    string
+		want      match.Result
+	}{
+		{"body contains", "http.body.contains('drop')", "POST", match.Unevaluable},
+		{"body_json field", "http.body_json.archived == true", "POST", match.Unevaluable},
+		{"has() is unknown too", "has(http.body_json.archived) && http.body_json.archived == true", "POST", match.Unevaluable},
+		{"absorbed by false &&", "http.method == 'post' && http.body.contains('drop')", "GET", match.NoMatch},
+		{"absorbed by true ||", "http.method == 'get' || http.body.contains('drop')", "GET", match.Matched},
+		{"method only — unaffected", "http.method == 'get'", "GET", match.Matched},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := facet.NewMatcher("http", tc.condition)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := httpReq(tc.method, "/x")
+			req.Body = []byte(`{"archived":true}`) // whatever fit before the cap
+			req.Truncated = true
+			if got := m.Match(req).Result; got != tc.want {
+				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			}
+		})
 	}
 }

--- a/internal/config/plugins/facets/https/https_test.go
+++ b/internal/config/plugins/facets/https/https_test.go
@@ -11,16 +11,6 @@ import (
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/https"
 )
 
-// wantResult adapts a boolean match expectation to the three-valued
-// Result, so an unexpected Unevaluable fails the assertion
-// instead of being conflated with "no match".
-func wantResult(b bool) match.Result {
-	if b {
-		return match.Matched
-	}
-	return match.NoMatch
-}
-
 // httpReq builds a minimal Request for the HTTP matcher tests.
 // Header / body / credential default to empty unless the test sets
 // them via the Request returned (callers mutate before calling Match).
@@ -96,8 +86,8 @@ func TestHTTPMatcherMethodAndPath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
-			if got := m.Match(tc.req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
+			if got := m.Match(tc.req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, match.ResultOf(tc.want), tc.condition)
 			}
 		})
 	}
@@ -142,8 +132,8 @@ func TestHTTPMatcherMethodCaseInsensitive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMatcher: %v", err)
 			}
-			if got := m.Match(httpReq(tc.method, "/x")).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v (condition=%q method=%q)", got, wantResult(tc.want), tc.condition, tc.method)
+			if got := m.Match(httpReq(tc.method, "/x")).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q method=%q)", got, match.ResultOf(tc.want), tc.condition, tc.method)
 			}
 		})
 	}

--- a/internal/config/plugins/facets/k8s/k8s.go
+++ b/internal/config/plugins/facets/k8s/k8s.go
@@ -147,9 +147,9 @@ func (Facet) CELContrib() facet.CELContrib {
 		},
 		AddActivation:   addActivation,
 		LowercasedPaths: []string{"k8s.verb"},
-		// k8s has no parser; the Unparseable gate is a no-op for k8s
-		// rules. UnparseablePaths stays nil so the AST pre-walk skips
-		// any unparseable-fail-close check for k8s.* fields. Composed
+		// k8s has no parser; Request.Unparseable marks nothing
+		// unknown for k8s rules. UnparseablePaths stays nil so no
+		// k8s.* field is poisoned on an unparseable request. Composed
 		// http.* fields keep their own truncation contract through the
 		// http facet's TruncatablePaths.
 	}

--- a/internal/config/plugins/facets/k8s/k8s_composition_test.go
+++ b/internal/config/plugins/facets/k8s/k8s_composition_test.go
@@ -62,8 +62,8 @@ func TestK8sMatcherComposesHTTPFacets(t *testing.T) {
 				Headers: http.Header{"Content-Type": []string{"application/json"}},
 				Meta:    &k8sfacet.Meta{Verb: "create", Resource: "pods", Namespace: "default"},
 			}
-			if got := m.Match(req); got != tc.want {
-				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			if got := m.Match(req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
 			}
 		})
 	}

--- a/internal/config/plugins/facets/k8s/k8s_composition_test.go
+++ b/internal/config/plugins/facets/k8s/k8s_composition_test.go
@@ -62,8 +62,8 @@ func TestK8sMatcherComposesHTTPFacets(t *testing.T) {
 				Headers: http.Header{"Content-Type": []string{"application/json"}},
 				Meta:    &k8sfacet.Meta{Verb: "create", Resource: "pods", Namespace: "default"},
 			}
-			if got := m.Match(req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
+			if got := m.Match(req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, match.ResultOf(tc.want), tc.condition)
 			}
 		})
 	}

--- a/internal/config/plugins/facets/k8s/k8s_match_test.go
+++ b/internal/config/plugins/facets/k8s/k8s_match_test.go
@@ -8,6 +8,16 @@ import (
 	k8sfacet "github.com/denoland/clawpatrol/internal/config/plugins/facets/k8s"
 )
 
+// wantResult adapts a boolean match expectation to the three-valued
+// Result, so an unexpected Unevaluable fails the assertion
+// instead of being conflated with "no match".
+func wantResult(b bool) match.Result {
+	if b {
+		return match.Matched
+	}
+	return match.NoMatch
+}
+
 // TestK8sMatcherVerbCaseInsensitive locks in that a rule written as
 // `k8s.verb == "GET"` matches a list/get request even though the
 // activation normalizes the got value to lowercase. CompileCondition
@@ -33,8 +43,8 @@ func TestK8sMatcherVerbCaseInsensitive(t *testing.T) {
 				t.Fatalf("NewMatcher: %v", err)
 			}
 			req := &match.Request{Family: "k8s", Meta: &k8sfacet.Meta{Verb: tc.verb}}
-			if got := m.Match(req); got != tc.want {
-				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			if got := m.Match(req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
 			}
 		})
 	}
@@ -60,8 +70,8 @@ func TestK8sMatcherNegationAndGlobs(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := &match.Request{Family: "k8s", Meta: tc.meta}
-			if got := m.Match(req); got != tc.want {
-				t.Errorf("Match=%v want %v", got, tc.want)
+			if got := m.Match(req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v", got, wantResult(tc.want))
 			}
 		})
 	}
@@ -77,12 +87,12 @@ func TestK8sMatcherParams(t *testing.T) {
 		Params: map[string]string{"stdin": "true"},
 	}
 	req := &match.Request{Family: "k8s", Meta: meta}
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("expected interactive exec to match")
 	}
 	meta.Params = map[string]string{"stdin": "false"}
-	if m.Match(req) {
-		t.Errorf("expected non-interactive exec to NOT match")
+	if got := m.Match(req).Result; got != match.NoMatch {
+		t.Errorf("expected non-interactive exec to NOT match, got %v", got)
 	}
 }
 
@@ -96,11 +106,11 @@ func TestK8sMatcherWatchVerbAndParams(t *testing.T) {
 		Verb: "watch", Resource: "pods", Params: map[string]string{"watch": "true"},
 	}
 	req := &match.Request{Family: "k8s", Meta: meta}
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("expected watch pod list to match")
 	}
 	meta.Verb = "list"
-	if m.Match(req) {
-		t.Errorf("expected plain list to miss watch rule")
+	if got := m.Match(req).Result; got != match.NoMatch {
+		t.Errorf("expected plain list to miss watch rule, got %v", got)
 	}
 }

--- a/internal/config/plugins/facets/k8s/k8s_match_test.go
+++ b/internal/config/plugins/facets/k8s/k8s_match_test.go
@@ -8,16 +8,6 @@ import (
 	k8sfacet "github.com/denoland/clawpatrol/internal/config/plugins/facets/k8s"
 )
 
-// wantResult adapts a boolean match expectation to the three-valued
-// Result, so an unexpected Unevaluable fails the assertion
-// instead of being conflated with "no match".
-func wantResult(b bool) match.Result {
-	if b {
-		return match.Matched
-	}
-	return match.NoMatch
-}
-
 // TestK8sMatcherVerbCaseInsensitive locks in that a rule written as
 // `k8s.verb == "GET"` matches a list/get request even though the
 // activation normalizes the got value to lowercase. CompileCondition
@@ -43,8 +33,8 @@ func TestK8sMatcherVerbCaseInsensitive(t *testing.T) {
 				t.Fatalf("NewMatcher: %v", err)
 			}
 			req := &match.Request{Family: "k8s", Meta: &k8sfacet.Meta{Verb: tc.verb}}
-			if got := m.Match(req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
+			if got := m.Match(req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, match.ResultOf(tc.want), tc.condition)
 			}
 		})
 	}
@@ -70,8 +60,8 @@ func TestK8sMatcherNegationAndGlobs(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := &match.Request{Family: "k8s", Meta: tc.meta}
-			if got := m.Match(req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v", got, wantResult(tc.want))
+			if got := m.Match(req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v", got, match.ResultOf(tc.want))
 			}
 		})
 	}

--- a/internal/config/plugins/facets/sql/sql.go
+++ b/internal/config/plugins/facets/sql/sql.go
@@ -144,8 +144,9 @@ func init() {
 // the matcher one piece of text — the raw statement — and every
 // CEL field (verb, tables, functions, statement) is derived from
 // the same parsed bytes. When the frontend caps the frame, all four
-// are simultaneously untrustworthy, so any condition reading any of
-// them must fail closed on a truncated request.
+// are simultaneously untrustworthy — they become CEL unknowns, so
+// any condition whose outcome depends on one fails closed on a
+// truncated request.
 //
 // Note credential and database are intentionally absent: they
 // resolve off-wire (StartupMessage user / database, Hello username
@@ -158,8 +159,8 @@ func init() {
 // unparseablePaths declares the SQL fields a wire frontend's parser
 // derives from the Query bytes — verb, tables, functions. When the
 // parser refuses the input, the frontend leaves these zero and sets
-// req.Unparseable=true; the dispatcher then auto-denies any rule
-// whose CEL reads one of these paths (see runtime/dispatch.go).
+// req.Unparseable=true; the matcher then marks these paths as CEL
+// unknowns and any rule whose outcome depends on one is denied.
 //
 // sql.statement is intentionally absent: the frontend populates it
 // with the raw bytes regardless of parse success, so a rule keyed on

--- a/internal/config/plugins/facets/sql/sql_match_test.go
+++ b/internal/config/plugins/facets/sql/sql_match_test.go
@@ -8,16 +8,6 @@ import (
 	sqlfacet "github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
 )
 
-// wantResult adapts a boolean match expectation to the three-valued
-// Result, so an unexpected Unevaluable fails the assertion
-// instead of being conflated with "no match".
-func wantResult(b bool) match.Result {
-	if b {
-		return match.Matched
-	}
-	return match.NoMatch
-}
-
 func TestSQLMatcherVerbAndTables(t *testing.T) {
 	m, err := facet.NewMatcher("sql", "sql.verb == 'select' && sets.intersects(sql.tables, ['github_identities', 'tokens'])")
 	if err != nil {
@@ -60,8 +50,8 @@ func TestSQLMatcherVerbCaseInsensitive(t *testing.T) {
 				t.Fatalf("NewMatcher: %v", err)
 			}
 			req := &match.Request{Family: "sql", Meta: &sqlfacet.Meta{Verb: "select"}}
-			if got := m.Match(req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
+			if got := m.Match(req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, match.ResultOf(tc.want), tc.condition)
 			}
 		})
 	}
@@ -94,8 +84,8 @@ func TestSQLMatcherDatabaseCaseSensitive(t *testing.T) {
 			}
 			meta := tc.meta
 			req := &match.Request{Family: "sql", Meta: &meta}
-			if got := m.Match(req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v (condition=%q meta=%+v)", got, wantResult(tc.want), tc.condition, tc.meta)
+			if got := m.Match(req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q meta=%+v)", got, match.ResultOf(tc.want), tc.condition, tc.meta)
 			}
 		})
 	}
@@ -123,8 +113,8 @@ func TestSQLMatcherDatabaseSources(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := m.Match(tc.req).Result; got != wantResult(tc.want) {
-				t.Errorf("Match=%v want %v", got, wantResult(tc.want))
+			if got := m.Match(tc.req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v", got, match.ResultOf(tc.want))
 			}
 		})
 	}

--- a/internal/config/plugins/facets/sql/sql_match_test.go
+++ b/internal/config/plugins/facets/sql/sql_match_test.go
@@ -8,6 +8,16 @@ import (
 	sqlfacet "github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
 )
 
+// wantResult adapts a boolean match expectation to the three-valued
+// Result, so an unexpected Unevaluable fails the assertion
+// instead of being conflated with "no match".
+func wantResult(b bool) match.Result {
+	if b {
+		return match.Matched
+	}
+	return match.NoMatch
+}
+
 func TestSQLMatcherVerbAndTables(t *testing.T) {
 	m, err := facet.NewMatcher("sql", "sql.verb == 'select' && sets.intersects(sql.tables, ['github_identities', 'tokens'])")
 	if err != nil {
@@ -18,12 +28,12 @@ func TestSQLMatcherVerbAndTables(t *testing.T) {
 		Tables: []string{"users", "github_identities"},
 	}
 	req := &match.Request{Family: "sql", Meta: meta}
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("expected select on github_identities to match")
 	}
 	meta.Verb = "insert"
-	if m.Match(req) {
-		t.Errorf("expected verb mismatch to fail")
+	if got := m.Match(req).Result; got != match.NoMatch {
+		t.Errorf("expected verb mismatch to fail, got %v", got)
 	}
 }
 
@@ -50,8 +60,8 @@ func TestSQLMatcherVerbCaseInsensitive(t *testing.T) {
 				t.Fatalf("NewMatcher: %v", err)
 			}
 			req := &match.Request{Family: "sql", Meta: &sqlfacet.Meta{Verb: "select"}}
-			if got := m.Match(req); got != tc.want {
-				t.Errorf("Match=%v want %v (condition=%q)", got, tc.want, tc.condition)
+			if got := m.Match(req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q)", got, wantResult(tc.want), tc.condition)
 			}
 		})
 	}
@@ -84,8 +94,8 @@ func TestSQLMatcherDatabaseCaseSensitive(t *testing.T) {
 			}
 			meta := tc.meta
 			req := &match.Request{Family: "sql", Meta: &meta}
-			if got := m.Match(req); got != tc.want {
-				t.Errorf("Match=%v want %v (condition=%q meta=%+v)", got, tc.want, tc.condition, tc.meta)
+			if got := m.Match(req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v (condition=%q meta=%+v)", got, wantResult(tc.want), tc.condition, tc.meta)
 			}
 		})
 	}
@@ -113,8 +123,8 @@ func TestSQLMatcherDatabaseSources(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := m.Match(tc.req); got != tc.want {
-				t.Errorf("Match=%v want %v", got, tc.want)
+			if got := m.Match(tc.req).Result; got != wantResult(tc.want) {
+				t.Errorf("Match=%v want %v", got, wantResult(tc.want))
 			}
 		})
 	}
@@ -133,7 +143,7 @@ func TestSQLMatcherDatabaseSurvivesTruncation(t *testing.T) {
 		t.Errorf("a rule reading only sql.database must not be flagged truncatable")
 	}
 	req := &match.Request{Family: "sql", Database: "prod", Truncated: true, Meta: &sqlfacet.Meta{}}
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("truncated request with database=prod should still match")
 	}
 }
@@ -145,14 +155,57 @@ func TestSQLMatcherStatementRegex(t *testing.T) {
 	}
 	meta := &sqlfacet.Meta{Verb: "select", Statement: "SELECT secret FROM vault"}
 	req := &match.Request{Family: "sql", Meta: meta}
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("expected regex hit on bare 'secret'")
 	}
 	// `_` is a word character, so \btoken\b should NOT match inside
 	// "api_token" — confirms the regex isn't accidentally
 	// substring-matching.
 	meta.Statement = "SELECT api_token FROM keys"
-	if m.Match(req) {
-		t.Errorf("expected no regex hit on api_token (word boundary)")
+	if got := m.Match(req).Result; got != match.NoMatch {
+		t.Errorf("expected no regex hit on api_token (word boundary), got %v", got)
+	}
+}
+
+// TestSQLMatcherUnparseableViralUnknown pins that the parser-facet
+// unknown propagates to Unevaluable through every operator shape on
+// an Unparseable request — equality, negation, `in` over the unknown
+// list, and a comprehension macro — while the raw statement text
+// (populated regardless of parse success) keeps evaluating honestly.
+func TestSQLMatcherUnparseableViralUnknown(t *testing.T) {
+	unevaluable := []string{
+		"sql.verb == 'select'",
+		"!(sql.verb == 'select')",
+		"'users' in sql.tables",
+		"sql.tables.exists(t, t == 'users')",
+	}
+	for _, cond := range unevaluable {
+		t.Run(cond, func(t *testing.T) {
+			m, err := facet.NewMatcher("sql", cond)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			req := &match.Request{
+				Family:      "sql",
+				Unparseable: true,
+				Meta:        &sqlfacet.Meta{Statement: "DROP;"},
+			}
+			if got := m.Match(req).Result; got != match.Unevaluable {
+				t.Errorf("Match=%v, want Unevaluable (condition=%q)", got, cond)
+			}
+		})
+	}
+
+	m, err := facet.NewMatcher("sql", "sql.statement.contains('DROP')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &match.Request{
+		Family:      "sql",
+		Unparseable: true,
+		Meta:        &sqlfacet.Meta{Statement: "DROP;"},
+	}
+	if got := m.Match(req).Result; got != match.Matched {
+		t.Errorf("statement rule on unparseable request: Match=%v, want Matched", got)
 	}
 }

--- a/internal/config/plugins/facets/ssh/ssh.go
+++ b/internal/config/plugins/facets/ssh/ssh.go
@@ -93,8 +93,9 @@ type Meta struct {
 	// Stdin is the buffered client→server stdin for a shell/exec action,
 	// populated only when the endpoint has a rule reading ssh.stdin (the
 	// runtime keeps the splice untouched otherwise). Truncated is set
-	// when the stdin exceeded the inspection cap; the dispatcher then
-	// fail-closes any rule reading ssh.stdin.
+	// when the stdin exceeded the inspection cap; ssh.stdin then
+	// becomes a CEL unknown and any rule whose outcome depends on it
+	// fail-closes.
 	Stdin     string
 	Truncated bool
 }
@@ -187,8 +188,9 @@ func init() {
 // truncatablePaths: ssh.stdin. Stdin is the one field drawn from a
 // streamed, capped inspection buffer (the endpoint buffers a session's
 // client→server bytes up to a cap before forwarding); when it overflows
-// the endpoint sets req.Truncated and the dispatcher fail-closes any
-// rule reading ssh.stdin. Declaring it here is also what makes
+// the endpoint sets req.Truncated, ssh.stdin becomes a CEL unknown,
+// and any rule whose outcome depends on it is denied. Declaring it
+// here is also what makes
 // matcher.InspectsTruncatableFacet() report true for stdin rules, which
 // the endpoint reads (via CompiledEndpoint.InspectsTruncatable) to keep
 // the splice untouched when no rule needs stdin. The remaining ssh

--- a/internal/config/plugins/facets/ssh/ssh_match_test.go
+++ b/internal/config/plugins/facets/ssh/ssh_match_test.go
@@ -50,12 +50,8 @@ func TestSSHMatcherVerbCaseInsensitive(t *testing.T) {
 		t.Run(tc.cond, func(t *testing.T) {
 			m := mustMatcher(t, tc.cond)
 			req := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell}}
-			want := match.NoMatch
-			if tc.want {
-				want = match.Matched
-			}
-			if got := m.Match(req).Result; got != want {
-				t.Errorf("Match=%v want %v", got, want)
+			if got := m.Match(req).Result; got != match.ResultOf(tc.want) {
+				t.Errorf("Match=%v want %v", got, match.ResultOf(tc.want))
 			}
 		})
 	}

--- a/internal/config/plugins/facets/ssh/ssh_match_test.go
+++ b/internal/config/plugins/facets/ssh/ssh_match_test.go
@@ -24,11 +24,11 @@ func TestSSHMatcherVerb(t *testing.T) {
 	m := mustMatcher(t, "ssh.verb == 'shell'")
 	shell := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell}}
 	exec := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbExec, Command: "ls"}}
-	if !m.Match(shell) {
+	if m.Match(shell).Result != match.Matched {
 		t.Errorf("expected shell to match ssh.verb == 'shell'")
 	}
-	if m.Match(exec) {
-		t.Errorf("expected exec to NOT match ssh.verb == 'shell'")
+	if got := m.Match(exec).Result; got != match.NoMatch {
+		t.Errorf("expected exec to NOT match ssh.verb == 'shell', got %v", got)
 	}
 }
 
@@ -50,8 +50,12 @@ func TestSSHMatcherVerbCaseInsensitive(t *testing.T) {
 		t.Run(tc.cond, func(t *testing.T) {
 			m := mustMatcher(t, tc.cond)
 			req := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell}}
-			if got := m.Match(req); got != tc.want {
-				t.Errorf("Match=%v want %v", got, tc.want)
+			want := match.NoMatch
+			if tc.want {
+				want = match.Matched
+			}
+			if got := m.Match(req).Result; got != want {
+				t.Errorf("Match=%v want %v", got, want)
 			}
 		})
 	}
@@ -65,11 +69,11 @@ func TestSSHMatcherPTY(t *testing.T) {
 	m := mustMatcher(t, "ssh.verb == 'pty'")
 	pty := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbPTY}}
 	exec := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbExec, Command: "uname -a"}}
-	if !m.Match(pty) {
+	if m.Match(pty).Result != match.Matched {
 		t.Errorf("expected pty-req to match ssh.verb == 'pty'")
 	}
-	if m.Match(exec) {
-		t.Errorf("expected a command to NOT match ssh.verb == 'pty'")
+	if got := m.Match(exec).Result; got != match.NoMatch {
+		t.Errorf("expected a command to NOT match ssh.verb == 'pty', got %v", got)
 	}
 }
 
@@ -84,11 +88,11 @@ func TestSSHMatcherCommand(t *testing.T) {
 	restore := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{
 		Verb: sshfacet.VerbExec, Command: "restore --all /data",
 	}}
-	if !m.Match(backup) {
+	if m.Match(backup).Result != match.Matched {
 		t.Errorf("expected `backup ...` to match")
 	}
-	if m.Match(restore) {
-		t.Errorf("expected `restore ...` to NOT match")
+	if got := m.Match(restore).Result; got != match.NoMatch {
+		t.Errorf("expected `restore ...` to NOT match, got %v", got)
 	}
 }
 
@@ -98,11 +102,11 @@ func TestSSHMatcherSubsystem(t *testing.T) {
 	m := mustMatcher(t, "ssh.subsystem == 'sftp'")
 	sftp := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbSubsystem, Subsystem: "sftp"}}
 	shell := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell}}
-	if !m.Match(sftp) {
+	if m.Match(sftp).Result != match.Matched {
 		t.Errorf("expected sftp subsystem to match")
 	}
-	if m.Match(shell) {
-		t.Errorf("expected shell to NOT match a subsystem condition")
+	if got := m.Match(shell).Result; got != match.NoMatch {
+		t.Errorf("expected shell to NOT match a subsystem condition, got %v", got)
 	}
 }
 
@@ -117,11 +121,11 @@ func TestSSHMatcherForwardPort(t *testing.T) {
 	web := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{
 		Verb: sshfacet.VerbForward, ForwardHost: "db.internal", ForwardPort: 8080,
 	}}
-	if !m.Match(pg) {
+	if m.Match(pg).Result != match.Matched {
 		t.Errorf("expected forward to :5432 to match")
 	}
-	if m.Match(web) {
-		t.Errorf("expected forward to :8080 to NOT match")
+	if got := m.Match(web).Result; got != match.NoMatch {
+		t.Errorf("expected forward to :8080 to NOT match, got %v", got)
 	}
 }
 
@@ -133,28 +137,29 @@ func TestSSHMatcherUserFromRequest(t *testing.T) {
 	fromReq := &match.Request{Family: "ssh", User: "deploy", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell}}
 	fromMeta := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell, User: "deploy"}}
 	other := &match.Request{Family: "ssh", User: "intern", Meta: &sshfacet.Meta{Verb: sshfacet.VerbShell, User: "deploy"}}
-	if !m.Match(fromReq) {
+	if m.Match(fromReq).Result != match.Matched {
 		t.Errorf("expected req.User=deploy to match")
 	}
-	if !m.Match(fromMeta) {
+	if m.Match(fromMeta).Result != match.Matched {
 		t.Errorf("expected meta.User=deploy fallback to match")
 	}
-	if m.Match(other) {
-		t.Errorf("expected req.User to win over meta.User")
+	if got := m.Match(other).Result; got != match.NoMatch {
+		t.Errorf("expected req.User to win over meta.User, got %v", got)
 	}
 }
 
-// TestSSHMatcherWrongMeta confirms a non-ssh Meta fails the match
-// cleanly (the activation builder refuses), rather than panicking —
-// e.g. if an ssh rule somehow saw a request without a *Meta.
+// TestSSHMatcherWrongMeta confirms a non-ssh Meta is Unevaluable
+// (the activation builder refuses, and the dispatcher fails closed)
+// rather than panicking or silently no-matching — e.g. if an ssh
+// rule somehow saw a request without a *Meta.
 func TestSSHMatcherWrongMeta(t *testing.T) {
 	m := mustMatcher(t, "ssh.verb == 'shell'")
 	req := &match.Request{Family: "ssh", Meta: struct{}{}}
-	if m.Match(req) {
-		t.Errorf("expected non-ssh Meta to fail the match")
+	if got := m.Match(req).Result; got != match.Unevaluable {
+		t.Errorf("expected non-ssh Meta to be Unevaluable, got %v", got)
 	}
-	if m.Match(&match.Request{Family: "ssh"}) {
-		t.Errorf("expected nil Meta to fail the match")
+	if got := m.Match(&match.Request{Family: "ssh"}).Result; got != match.Unevaluable {
+		t.Errorf("expected nil Meta to be Unevaluable, got %v", got)
 	}
 }
 
@@ -164,7 +169,7 @@ func TestSSHMatcherWrongMeta(t *testing.T) {
 func TestSSHEmptyConditionMatchesEverything(t *testing.T) {
 	m := mustMatcher(t, "")
 	req := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{Verb: sshfacet.VerbExec, Command: "anything"}}
-	if !m.Match(req) {
+	if m.Match(req).Result != match.Matched {
 		t.Errorf("expected empty condition to match everything")
 	}
 }
@@ -179,18 +184,19 @@ func TestSSHStdinMatch(t *testing.T) {
 	ok := &match.Request{Family: "ssh", Meta: &sshfacet.Meta{
 		Verb: sshfacet.VerbShell, Stdin: "#!/bin/sh\necho hello\n",
 	}}
-	if !m.Match(bad) {
+	if m.Match(bad).Result != match.Matched {
 		t.Errorf("expected a destructive script to match ssh.stdin.contains(...)")
 	}
-	if m.Match(ok) {
-		t.Errorf("expected a benign script to NOT match")
+	if got := m.Match(ok).Result; got != match.NoMatch {
+		t.Errorf("expected a benign script to NOT match, got %v", got)
 	}
 }
 
 // TestSSHStdinIsTruncatable pins the wiring that makes lazy buffering
 // work: a rule reading ssh.stdin reports InspectsTruncatableFacet()
-// (so CompiledEndpoint.InspectsTruncatable flips and the dispatcher
-// fail-closes on overflow), while a rule that doesn't read stdin does
+// (so CompiledEndpoint.InspectsTruncatable flips and the endpoint
+// takes the buffering path; overflow then fail-closes through the
+// matcher's stdin-unknown), while a rule that doesn't read stdin does
 // not — keeping the splice on the zero-overhead fast path.
 func TestSSHStdinIsTruncatable(t *testing.T) {
 	if !mustMatcher(t, "ssh.stdin.contains('x')").InspectsTruncatableFacet() {

--- a/internal/config/runtime/dispatch.go
+++ b/internal/config/runtime/dispatch.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
@@ -106,10 +107,50 @@ func MatchRequest(ep *config.CompiledEndpoint, req *match.Request) *config.Compi
 		case match.Matched:
 			return r
 		case match.Unevaluable:
-			return synthesizeUnevaluableDeny(r, d.Detail)
+			return synthesizeUnevaluableDeny(r, req, d.Detail)
 		}
 	}
 	return nil
+}
+
+// MatchRequestFailClosed wraps MatchRequest for wire frontends whose
+// request bytes the gateway could not fully inspect (Truncated /
+// Unparseable). On such a request, "no rule matched" may simply mean
+// every rule's outcome was independent of the missing bytes
+// (absorption) — not that the operator intended the bytes to flow.
+// When the endpoint declares at least one enabled rule and none
+// matched, this returns a synthesized catch-all deny instead of nil,
+// so an uninspectable payload never rides the implicit-allow default
+// past a rule set that exists. Endpoints with no rules at all keep
+// their legacy pass-through default, and fully-inspected requests
+// behave exactly like MatchRequest.
+//
+// SQL frontends (postgres, clickhouse_native) route their statement
+// evaluation through this; the HTTPS path deliberately does NOT —
+// rule-less LLM endpoints routinely forward >cap request bodies, and
+// inspectable header/method facets remain matchable there.
+func MatchRequestFailClosed(ep *config.CompiledEndpoint, req *match.Request) *config.CompiledRule {
+	cr := MatchRequest(ep, req)
+	if cr != nil || ep == nil || req == nil || (!req.Truncated && !req.Unparseable) {
+		return cr
+	}
+	hasRules := false
+	for _, r := range ep.Rules {
+		if !r.Disabled {
+			hasRules = true
+			break
+		}
+	}
+	if !hasRules {
+		return nil
+	}
+	return &config.CompiledRule{
+		Outcome: config.Outcome{
+			Verdict: "deny",
+			Reason: "request bytes were " + unevaluableCause(req) +
+				" and no rule explicitly allowed the request; failing closed",
+		},
+	}
 }
 
 // synthesizeUnevaluableDeny returns a CompiledRule that mirrors r's
@@ -118,16 +159,42 @@ func MatchRequest(ep *config.CompiledEndpoint, req *match.Request) *config.Compi
 // honestly — its condition depends on a facet value the gateway
 // doesn't have (truncated bytes, parser-refused fields) or errored
 // at runtime — so we surface a fail-closed deny attributed to the
-// rule that owns the contract. The detail comes from the matcher and
-// names what broke (the unknown facet paths or the eval error).
-func synthesizeUnevaluableDeny(r *config.CompiledRule, detail string) *config.CompiledRule {
-	reason := "rule \"" + r.Name + "\" could not be evaluated against this request (" + detail + "); failing closed"
+// rule that owns the contract.
+//
+// The agent-visible reason names only the rule and the coarse cause.
+// The matcher's full detail (the unknown facet paths, or the CEL
+// evaluation error text) is deliberately kept out of it: cel-go
+// errors like `no such key: <field>` would let an agent probe which
+// fields a rule inspects by varying request payloads and reading
+// deny reasons. The detail goes to the gateway log for the operator
+// instead.
+func synthesizeUnevaluableDeny(r *config.CompiledRule, req *match.Request, detail string) *config.CompiledRule {
+	reason := "rule \"" + r.Name + "\" could not be evaluated against this request (" + unevaluableCause(req) + "); failing closed"
+	log.Printf("rule %q unevaluable: %s", r.Name, detail)
 	synth := *r
 	synth.Outcome = config.Outcome{
 		Verdict: "deny",
 		Reason:  reason,
 	}
 	return &synth
+}
+
+// unevaluableCause renders the agent-safe cause of an unevaluable
+// condition from the request's inspection flags. The agent already
+// knows it sent an oversized or garbled payload, so naming the
+// category leaks nothing; anything finer-grained stays in the
+// operator log.
+func unevaluableCause(req *match.Request) string {
+	switch {
+	case req != nil && req.Truncated && req.Unparseable:
+		return "truncated at the inspection buffer and unparseable"
+	case req != nil && req.Truncated:
+		return "truncated at the inspection buffer"
+	case req != nil && req.Unparseable:
+		return "unparseable"
+	default:
+		return "evaluation error"
+	}
 }
 
 // ResolveCredential picks the credential entry that applies to req

--- a/internal/config/runtime/dispatch.go
+++ b/internal/config/runtime/dispatch.go
@@ -60,31 +60,23 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 // applies the defaults.unknown_host policy (or the endpoint plugin's
 // own default).
 //
-// Truncated-request fail-close: when req.Truncated is set, a rule
-// whose matcher reports InspectsTruncatableFacet() == true is
-// auto-fired with a synthesized deny verdict — the matcher is NOT
-// called, because its CEL condition reads bytes the wire frontend
-// already discarded. Higher-priority rules that don't read truncated
-// facets still get to match normally; this only fails the rules
-// that would have been evaluating ghost bytes. The returned
+// Unevaluable fail-close: a matcher returns three-valued Decisions.
+// When a rule's condition cannot be evaluated honestly — its outcome
+// depends on a facet value the gateway doesn't have (bytes capped at
+// the inspection buffer, parser-refused SQL fields, both surfaced as
+// viral CEL unknowns), or evaluation errored at runtime — the rule is
+// fired with a synthesized deny verdict instead of being silently
+// skipped (skipping would let a deny rule fail open). The returned
 // CompiledRule keeps the original rule's identity (name / priority)
-// so logs still attribute the deny to the rule whose contract the
-// truncation broke.
+// so logs still attribute the deny to the rule whose contract broke.
 //
-// Unparseable-request fail-close: same shape as the truncated path,
-// but keyed on req.Unparseable + InspectsUnparseableFacet(). When a
-// frontend's parser refused the inbound bytes, the parser-derived
-// facets (e.g. for SQL: verb / tables / functions) are zero on the
-// request; a rule that reads any of them on an Unparseable request
-// would be evaluating zero values that don't reflect the actual
-// payload, so it synthesizes a deny instead. Rules that read only
-// the raw payload (e.g. sql.statement), the credential, or the
-// peer IP still get a normal Match call — those facets are populated
-// regardless of parse success. Rule priority is walked first, so a
-// higher-priority payload-only rule that matches keeps its verdict;
-// an unparseable request only triggers the synthesized deny when no
-// higher-priority rule covers it AND a lower-priority rule references
-// an unset parser facet.
+// Because the unknowns are value-level, a rule that merely mentions a
+// truncated / unparseable facet still resolves honestly when its
+// outcome doesn't depend on it: `sql.verb == 'select' && sql.database
+// == 'x'` on an unparseable request with database 'y' evaluates
+// `unknown && false == false` and cleanly falls through to the next
+// rule. Rules keyed only on always-available facets (credential,
+// peer IP, sql.statement on an unparseable query) are unaffected.
 func MatchRequest(ep *config.CompiledEndpoint, req *match.Request) *config.CompiledRule {
 	if ep == nil {
 		return nil
@@ -110,44 +102,26 @@ func MatchRequest(ep *config.CompiledEndpoint, req *match.Request) *config.Compi
 			// req.Truncated.
 			return r
 		}
-		if req != nil && req.Truncated && r.Matcher.InspectsTruncatableFacet() {
-			return synthesizeTruncatedDeny(r)
-		}
-		if req != nil && req.Unparseable && r.Matcher.InspectsUnparseableFacet() {
-			return synthesizeUnparseableDeny(r)
-		}
-		if r.Matcher.Match(req) {
+		switch d := r.Matcher.Match(req); d.Result {
+		case match.Matched:
 			return r
+		case match.Unevaluable:
+			return synthesizeUnevaluableDeny(r, d.Detail)
 		}
 	}
 	return nil
 }
 
-// synthesizeTruncatedDeny returns a CompiledRule that mirrors r's
+// synthesizeUnevaluableDeny returns a CompiledRule that mirrors r's
 // identity but forces a deny verdict with a fabricated reason. Used
-// by MatchRequest when a rule that reads a truncatable facet meets
-// a request whose facet bytes were capped at the wire — the rule's
-// match predicate can't be evaluated honestly, so we surface a
-// fail-closed deny attributed to the rule that owns the contract.
-func synthesizeTruncatedDeny(r *config.CompiledRule) *config.CompiledRule {
-	reason := "rule \"" + r.Name + "\" reads a request facet whose bytes were truncated by the gateway's inspection buffer; failing closed"
-	synth := *r
-	synth.Outcome = config.Outcome{
-		Verdict: "deny",
-		Reason:  reason,
-	}
-	return &synth
-}
-
-// synthesizeUnparseableDeny mirrors synthesizeTruncatedDeny for the
-// parser-failure gate. The reason names the rule whose contract the
-// unparseable-request case broke, so logs / dashboard cards attribute
-// the synthesized deny to the matching rule rather than to an opaque
-// "unparseable" line item. The string is intentionally generic across
-// facet families: any plugin whose parser refused its inbound bytes
-// (SQL today; an external rule plugin tomorrow) routes through here.
-func synthesizeUnparseableDeny(r *config.CompiledRule) *config.CompiledRule {
-	reason := "rule \"" + r.Name + "\" references a facet that the gateway's parser could not derive from the unparseable request; failing closed"
+// by MatchRequest when a rule's match predicate can't be evaluated
+// honestly — its condition depends on a facet value the gateway
+// doesn't have (truncated bytes, parser-refused fields) or errored
+// at runtime — so we surface a fail-closed deny attributed to the
+// rule that owns the contract. The detail comes from the matcher and
+// names what broke (the unknown facet paths or the eval error).
+func synthesizeUnevaluableDeny(r *config.CompiledRule, detail string) *config.CompiledRule {
+	reason := "rule \"" + r.Name + "\" could not be evaluated against this request (" + detail + "); failing closed"
 	synth := *r
 	synth.Outcome = config.Outcome{
 		Verdict: "deny",

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -1472,11 +1472,107 @@ rule "allow-rest" {
 	if !strings.Contains(r.Outcome.Reason, "deny-rm-tool") {
 		t.Errorf("reason = %q, want it to name the rule", r.Outcome.Reason)
 	}
+	// The agent-visible reason must NOT carry the raw cel-go error
+	// text — `no such key: tool` would let an agent probe which
+	// fields the rule inspects by varying payloads and reading deny
+	// reasons. The full detail goes to the gateway log instead.
+	if strings.Contains(r.Outcome.Reason, "no such key") || strings.Contains(r.Outcome.Reason, "tool'") {
+		t.Errorf("reason = %q leaks evaluator internals", r.Outcome.Reason)
+	}
 
 	// A body that does carry the field keeps evaluating honestly.
 	req.Body = []byte(`{"tool":"ls"}`)
 	r = runtime.MatchRequest(ep, req)
 	if r == nil || r.Name != "allow-rest" || r.Outcome.Verdict != "allow" {
 		t.Fatalf("got %+v, want allow-rest (tool != 'rm' cleanly no-matches)", r)
+	}
+}
+
+// TestMatchRequestFailClosedBackstop pins the uninspectable-request
+// backstop: when every rule on the endpoint resolves independently of
+// the missing bytes (absorption → NoMatch) and there is no catch-all,
+// MatchRequestFailClosed synthesizes a deny instead of returning nil —
+// an oversize/unparseable payload must not ride the implicit-allow
+// default past a rule set that exists. Rule-less endpoints keep the
+// legacy pass-through, and fully-inspected requests are unaffected.
+func TestMatchRequestFailClosedBackstop(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "postgres" "db" {
+  host = "db.example.com:5432"
+}
+credential "postgres_credential" "db-cred" { endpoint = postgres.db }
+profile "default" { credentials = [postgres_credential.db-cred] }
+
+rule "deny-prod-writes" {
+  endpoint  = postgres.db
+  condition = "sql.verb == 'insert' && sql.database == 'prod'"
+  verdict   = "deny"
+}
+`)
+	ep := cp.Endpoints["db"]
+
+	// Truncated frame against database 'dev': the rule absorbs
+	// (`unknown && false == false`) → NoMatch → the backstop denies.
+	req := &match.Request{
+		Family:    "sql",
+		Database:  "dev",
+		Truncated: true,
+		Meta:      &sqlfacet.Meta{Database: "dev"},
+	}
+	r := runtime.MatchRequestFailClosed(ep, req)
+	if r == nil {
+		t.Fatalf("truncated no-match: got nil, want backstop deny")
+	}
+	if r.Outcome.Verdict != "deny" {
+		t.Errorf("verdict = %q, want deny", r.Outcome.Verdict)
+	}
+	if !strings.Contains(r.Outcome.Reason, "truncated") {
+		t.Errorf("reason = %q, want it to name the truncation", r.Outcome.Reason)
+	}
+
+	// Same shape, unparseable: backstop denies and the reason names
+	// the cause without leaking which facet paths rules read.
+	req = &match.Request{
+		Family:      "sql",
+		Database:    "dev",
+		Unparseable: true,
+		Meta:        &sqlfacet.Meta{Statement: "DROP;", Database: "dev"},
+	}
+	r = runtime.MatchRequestFailClosed(ep, req)
+	if r == nil || r.Outcome.Verdict != "deny" {
+		t.Fatalf("unparseable no-match: got %+v, want backstop deny", r)
+	}
+	if strings.Contains(r.Outcome.Reason, "sql.verb") {
+		t.Errorf("reason = %q leaks rule facet paths", r.Outcome.Reason)
+	}
+
+	// Fully-inspected request: identical to MatchRequest — a SELECT
+	// against 'dev' matches nothing and returns nil (implicit allow).
+	req = &match.Request{
+		Family:   "sql",
+		Database: "dev",
+		Meta:     &sqlfacet.Meta{Verb: "select", Database: "dev"},
+	}
+	if r := runtime.MatchRequestFailClosed(ep, req); r != nil {
+		t.Errorf("inspected no-match: got %+v, want nil", r)
+	}
+
+	// Rule-less endpoint: keeps the legacy pass-through default even
+	// for a truncated request.
+	cpNone := compileFixture(t, `
+endpoint "postgres" "bare" {
+  host = "bare.example.com:5432"
+}
+credential "postgres_credential" "bare-cred" { endpoint = postgres.bare }
+profile "default" { credentials = [postgres_credential.bare-cred] }
+`)
+	bare := cpNone.Endpoints["bare"]
+	req = &match.Request{
+		Family:    "sql",
+		Truncated: true,
+		Meta:      &sqlfacet.Meta{},
+	}
+	if r := runtime.MatchRequestFailClosed(bare, req); r != nil {
+		t.Errorf("rule-less endpoint: got %+v, want nil (pass-through)", r)
 	}
 }

--- a/internal/config/runtime/dispatch_test.go
+++ b/internal/config/runtime/dispatch_test.go
@@ -676,9 +676,9 @@ rule "verb-allow-select" {
 // TestMatchRequestUnparseable_CredentialOnlyRuleStillAllows is the
 // Unparseable analogue of the Truncated/credential test: a rule that
 // reads zero parser-derived facets (here, only the credential pin)
-// must still fire normally on an Unparseable request. The
-// fail-closed gate keys on `InspectsUnparseableFacet()`, and that
-// returns false for a connection-only rule.
+// must still fire normally on an Unparseable request: no parser
+// facet path appears in its condition, so no CEL unknown is in
+// play and the condition resolves honestly.
 func TestMatchRequestUnparseable_CredentialOnlyRuleStillAllows(t *testing.T) {
 	cp := compileFixture(t, `
 endpoint "clickhouse_native" "ch" {
@@ -1343,4 +1343,140 @@ func containsCI(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+// TestMatchRequestUnparseableAbsorptionAndFalse pins the precision
+// the value-level unknowns buy over the old reads-the-path gate: a
+// rule that MENTIONS a parser-derived facet still resolves honestly
+// when its outcome doesn't depend on it. `sql.verb == 'select' &&
+// sql.database == 'prod'` on an unparseable request against database
+// 'dev' evaluates `unknown && false == false` — the rule cleanly
+// no-matches and the catch-all fires, instead of a synthesized deny
+// attributed to the verb rule.
+func TestMatchRequestUnparseableAbsorptionAndFalse(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "postgres" "db" {
+  host = "db.example.com:5432"
+}
+credential "postgres_credential" "db-cred" { endpoint = postgres.db }
+profile "default" { credentials = [postgres_credential.db-cred] }
+
+rule "select-on-prod" {
+  endpoint  = postgres.db
+  condition = "sql.verb == 'select' && sql.database == 'prod'"
+  verdict   = "allow"
+}
+rule "default-deny" {
+  endpoint = postgres.db
+  priority = -100
+  verdict  = "deny"
+  reason   = "no policy matched"
+}
+`)
+	ep := cp.Endpoints["db"]
+	req := &match.Request{
+		Family:      "sql",
+		Database:    "dev",
+		Unparseable: true,
+		Meta:        &sqlfacet.Meta{Statement: "DROP;", Database: "dev"},
+	}
+	r := runtime.MatchRequest(ep, req)
+	if r == nil || r.Name != "default-deny" {
+		t.Fatalf("got %+v, want default-deny (verb rule should cleanly no-match via absorption)", r)
+	}
+	if r.Outcome.Reason != "no policy matched" {
+		t.Errorf("reason = %q, want the catch-all's own reason, not a synthesized one", r.Outcome.Reason)
+	}
+}
+
+// TestMatchRequestUnparseableAbsorptionOrTrue pins the symmetric
+// case: `unknown || true == true`. An allow rule whose outcome
+// provably doesn't depend on the parser-derived facet fires on an
+// unparseable request — whatever the verb was, the database
+// predicate alone satisfies the disjunction.
+func TestMatchRequestUnparseableAbsorptionOrTrue(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "postgres" "db" {
+  host = "db.example.com:5432"
+}
+credential "postgres_credential" "db-cred" { endpoint = postgres.db }
+profile "default" { credentials = [postgres_credential.db-cred] }
+
+rule "select-or-prod" {
+  endpoint  = postgres.db
+  condition = "sql.verb == 'select' || sql.database == 'prod'"
+  verdict   = "allow"
+}
+rule "default-deny" {
+  endpoint = postgres.db
+  priority = -100
+  verdict  = "deny"
+  reason   = "no policy matched"
+}
+`)
+	ep := cp.Endpoints["db"]
+	req := &match.Request{
+		Family:      "sql",
+		Database:    "prod",
+		Unparseable: true,
+		Meta:        &sqlfacet.Meta{Statement: "DROP;", Database: "prod"},
+	}
+	r := runtime.MatchRequest(ep, req)
+	if r == nil || r.Name != "select-or-prod" || r.Outcome.Verdict != "allow" {
+		t.Fatalf("got %+v, want select-or-prod allow (the disjunction resolves without the verb)", r)
+	}
+}
+
+// TestMatchRequestEvalErrorFailsClosed pins the closure of the old
+// fail-open hole: a deny rule whose condition errors at runtime
+// (selecting a body_json field the payload doesn't carry) used to be
+// silently skipped — the request fell through as if the rule didn't
+// exist. It now synthesizes a deny attributed to that rule.
+func TestMatchRequestEvalErrorFailsClosed(t *testing.T) {
+	cp := compileFixture(t, `
+endpoint "https" "api" {
+  hosts = ["api.example.com"]
+}
+credential "bearer_token" "tok" {
+  endpoint = https.api
+}
+profile "default" { credentials = [bearer_token.tok] }
+
+rule "deny-rm-tool" {
+  endpoint  = https.api
+  condition = "http.body_json.tool == 'rm'"
+  verdict   = "deny"
+}
+rule "allow-rest" {
+  endpoint = https.api
+  priority = -100
+  verdict  = "allow"
+}
+`)
+	ep := cp.Endpoints["api"]
+	req := &match.Request{
+		Family: "https",
+		Method: "POST",
+		Body:   []byte(`{"other":"field"}`),
+	}
+	r := runtime.MatchRequest(ep, req)
+	if r == nil {
+		t.Fatalf("got nil, want synth deny attributed to deny-rm-tool")
+	}
+	if r.Name != "deny-rm-tool" {
+		t.Errorf("rule = %q, want deny-rm-tool (eval error must not skip the rule)", r.Name)
+	}
+	if r.Outcome.Verdict != "deny" {
+		t.Errorf("verdict = %q, want deny", r.Outcome.Verdict)
+	}
+	if !strings.Contains(r.Outcome.Reason, "deny-rm-tool") {
+		t.Errorf("reason = %q, want it to name the rule", r.Outcome.Reason)
+	}
+
+	// A body that does carry the field keeps evaluating honestly.
+	req.Body = []byte(`{"tool":"ls"}`)
+	r = runtime.MatchRequest(ep, req)
+	if r == nil || r.Name != "allow-rest" || r.Outcome.Verdict != "allow" {
+		t.Fatalf("got %+v, want allow-rest (tool != 'rm' cleanly no-matches)", r)
+	}
 }

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -760,9 +760,9 @@ type PlaceholderDetector interface {
 // Implementations return the per-family `*sqlfacet.Meta` value the
 // SQL matcher expects on `match.Request.Meta`, plus a bool reporting
 // whether the parser refused the input. When the bool is true the
-// fixture loader sets `match.Request.Unparseable` so the dispatcher's
-// fail-closed-on-unparseable gate (config/runtime/dispatch.go) runs
-// against the test rule set, mirroring live wire-frame dispatch.
+// fixture loader sets `match.Request.Unparseable` so the unevaluable
+// fail-close (parser facets become CEL unknowns) runs against the
+// test rule set, mirroring live wire-frame dispatch.
 // Endpoints whose runtime doesn't implement this aren't usable as
 // SQL test fixtures.
 type SQLParser interface {

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -224,7 +224,7 @@ gateway {
 
 | Field | Default | What it bounds |
 |-------|---------|----------------|
-| `body_buffer` | `1MiB` (1048576 bytes) | The hot-path buffer the rules engine matches against (`http.body` / `http.body_json`). Every request pays this. Larger means rules can match more body at the cost of latency and memory; bodies past the cap are matched on the prefix and flagged truncated so body-reading rules fail closed. |
+| `body_buffer` | `1MiB` (1048576 bytes) | The hot-path buffer the rules engine matches against (`http.body` / `http.body_json`). Every request pays this. Larger means rules can match more body at the cost of latency and memory; bodies past the cap are matched on the prefix and flagged truncated so rules whose outcome depends on the body fail closed. |
 | `body_storage` | `4KiB` (4096 bytes) | The body sample persisted per action for the audit log shown on the action details page. Cold storage, per action. Larger means more useful debugging at the cost of disk and database size. |
 
 Both fields are optional; omitting the block (or either field) keeps

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -170,9 +170,10 @@ The gateway pulls bytes only as deeply as needed:
   to ~1 MiB so the matcher sees the full value, then cancels.
 
 When the plugin sees the cancel it can drop its source reader.
-Bodies that overflow the cap mark the request `Truncated`; any
-rule reading the truncated field is auto-denied (the dispatcher’s
-fail-closed gate, same one that protects the built-in HTTPS body
+Bodies that overflow the cap mark the request `Truncated`: the
+stream-typed fields become CEL unknowns and any rule whose
+condition outcome depends on one is auto-denied (the same
+unevaluable fail-close that protects the built-in HTTPS body
 buffer).
 
 ### Optional facet fields

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -183,6 +183,16 @@ map. The gateway substitutes the kind-zero value (empty string,
 empty list, empty map, 0) before CEL evaluation, so rule
 conditions can reference them without `has()` guards.
 
+The zero-fill covers **declared** fields only. Selecting anything
+else is a runtime evaluation error, which **fails closed**: the
+rule synthesizes a deny instead of silently no-matching (see
+"Unevaluable conditions fail closed" in the rules doc). That
+includes a typo'd field name, a field the manifest never declared,
+and a nested key off a map-shaped value — e.g.
+`example_smtp.headers.x_priority` errors whenever the action's
+`headers` map lacks that key. Guard nested lookups the same way as
+the built-in facets: `'x_priority' in example_smtp.headers && ...`.
+
 ### Reusing a built-in facet
 
 A plugin endpoint that gates HTTPS doesn’t need to redeclare a

--- a/site/doc/rules.md
+++ b/site/doc/rules.md
@@ -134,7 +134,7 @@ rule "k8s-no-secrets" {
 | `k8s.resource` | `string` | `<resource>` or `<resource>/<sub>` for subresources |
 | `k8s.namespace` | `string` | Kubernetes namespace |
 | `k8s.name` | `string` | Resource name |
-| `k8s.params` | `map<string, string>` | Query-string params (e.g. `kubectl exec --stdin`) |
+| `k8s.params` | `map<string, string>` | Query-string params (e.g. `kubectl exec --stdin`). Selecting a key the request doesn't carry is an evaluation error, which **fails closed** — guard with `'<key>' in k8s.params` (see "Unevaluable conditions fail closed" below). |
 
 ```hcl
 condition = "k8s.verb in ['create', 'delete'] && k8s.resource == 'pods'"
@@ -463,7 +463,10 @@ fail open. A condition becomes unevaluable in three ways:
    `http.body_json.archived == true` errors on `{"title": "x"}`.
    Guard optional fields with `has()`:
    `has(http.body_json.archived) && http.body_json.archived == true`
-   cleanly no-matches when the field is absent.
+   cleanly no-matches when the field is absent. The same applies to
+   any map-typed facet — `k8s.params.stdin == 'true'` errors when the
+   request URL carries no `stdin` query param; guard with
+   `'stdin' in k8s.params && ...`.
 
 ### Viral unknowns
 
@@ -684,6 +687,7 @@ rule "k8s-no-interactive" {
   priority  = 1000
   condition = <<-CEL
     k8s.resource in ['pods/exec', 'pods/attach']
+    && 'stdin' in k8s.params
     && k8s.params.stdin == 'true'
   CEL
   verdict = "deny"

--- a/site/doc/rules.md
+++ b/site/doc/rules.md
@@ -59,13 +59,13 @@ CEL variables (all optional in any given condition):
 | `http.query` | `map<string, list<string>>` | Query parameters (multi-valued) |
 | `http.headers` | `map<string, list<string>>` | Request headers (multi-valued) |
 | `http.body` | `string` | Raw request body |
-| `http.body_json` | `dyn` | Parsed JSON body (when `Content-Type` is JSON) |
+| `http.body_json` | `dyn` | Parsed JSON body (when `Content-Type` is JSON). Selecting a field the payload doesn't carry is an evaluation error, which **fails closed** (see "Unevaluable conditions fail closed" below) — guard optional fields with `has()`. |
 
 ```hcl
 condition = "http.method == 'POST' && http.path in ['/v1/refunds', '/v1/payouts']"
 condition = "http.method in ['GET', 'HEAD']"
 condition = "http.body.contains('BEGIN PRIVATE KEY')"
-condition = "http.body_json.archived == true"
+condition = "has(http.body_json.archived) && http.body_json.archived == true"
 ```
 
 ### `sql` family
@@ -221,10 +221,11 @@ Key properties:
   terminals (`pty`) are never stdin-buffered (block those with
   `ssh.verb == 'pty'`). A stream the gateway can't bound — stdin past
   the inspection cap, or a pause mid-stream with bytes already buffered
-  — is reported truncated and **fail-closes** any `ssh.stdin` rule
-  (deny), so a slow writer can't hide a payload after the inspection
-  window. A command with no stdin at all evaluates against empty stdin
-  and runs normally.
+  — is reported truncated: `ssh.stdin` becomes a CEL unknown and any
+  rule whose outcome depends on it **fail-closes** (deny), so a slow
+  writer can't hide a payload after the inspection window. A command
+  with no stdin at all evaluates against empty stdin and runs
+  normally.
 - **Pre-gate, not envelope only.** Command rules still apply on this
   path — a denied `ssh.command` never reaches upstream either.
 
@@ -438,59 +439,77 @@ code. Otherwise the inner client times out locally and the agent never
 sees the deny response Claw Patrol synthesizes on approval timeout.
 
 
-## Inspection-buffer overflow
+## Unevaluable conditions fail closed
 
-To bound memory, the wire endpoints cap how much of each request they
-buffer for the matcher. A request that exceeds its cap is **not**
-dropped on the floor — the frame still forwards to upstream
-byte-for-byte. What's bounded is the matcher's view of it: the
-endpoint truncates the buffered slice and flags the request as
-truncated. The facet fields that draw their value from this slice
-are **truncatable facet fields** (listed per-endpoint in the table
-below). When a rule's CEL reads a truncatable facet field on a
-request that was flagged truncated, the rule is automatically
-matched without comparing the matching values, and the dispatcher
-returns a deny verdict for it.
+A rule's condition can only produce an honest verdict when every facet
+value its outcome depends on is actually available to the gateway.
+When it isn't, the condition is **unevaluable**, and the dispatcher
+fails closed: the rule fires with a synthesized deny attributed to it
+instead of being silently skipped — skipping would let a deny rule
+fail open. A condition becomes unevaluable in three ways:
 
-| Endpoint | Inspected slice | Cap | Truncatable facet fields |
-|----------|-----------------|-----|--------------------|
-| `https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `http.body`, `http.body_json` |
-| `kubernetes` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | *(none — every `k8s.*` facet is derived from the URL and method)* |
-| `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
-| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
-| `clickhouse_native` | `Query` packet body | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
+1. **Truncation.** The request overflowed the endpoint's inspection
+   buffer (table below), so facet fields derived from the buffered
+   bytes describe only a prefix. The frame itself still forwards to
+   upstream byte-for-byte (except SSH stdin, which is withheld until
+   the verdict); only the matcher's view is bounded.
+2. **Parser refusal.** A SQL frontend's parser refused the statement,
+   so the parser-derived fields (`sql.verb`, `sql.tables`,
+   `sql.functions`) were never populated. `sql.statement` — the raw
+   text — is populated regardless of parse success and stays
+   matchable.
+3. **Evaluation error.** The CEL program errored at runtime. The
+   common case is selecting a JSON field the body doesn't carry:
+   `http.body_json.archived == true` errors on `{"title": "x"}`.
+   Guard optional fields with `has()`:
+   `has(http.body_json.archived) && http.body_json.archived == true`
+   cleanly no-matches when the field is absent.
 
-The caps are per-plugin constants in the gateway source — **not
-operator-tunable** today, and not surfaced in `gateway.hcl`. Header
-and URL bytes are bounded separately by `net/http`'s defaults and
-aren't covered here. The `ssh` endpoint has no inspection cap: its
-facet fields come from small, fully-read channel envelopes (the
-channel-open ExtraData and channel-request payloads), never from a
-buffered slice of streamed bytes, so no `ssh.*` field is truncatable.
+### Viral unknowns
 
-### Rule matching semantics on truncated fields
+Truncated and parser-refused facet fields are evaluated as CEL
+**unknowns**. An unknown propagates virally through every operator
+that touches it — `==`, `in`, `exists()`, string functions — the way
+NaN propagates through float arithmetic. The condition only comes
+back unevaluable when its **outcome actually depends** on the
+unavailable value; `&&` / `||` absorption resolves the rest:
 
-When a request overflows its cap, the dispatcher walks the endpoint's
-rules in priority order as usual. For each rule:
+- `sql.verb == 'select' && sql.database == 'prod'` on an unparseable
+  query against database `dev` evaluates `unknown && false == false`:
+  the rule cleanly no-matches and the walk continues to
+  lower-priority rules.
+- `sql.verb == 'select' || sql.database == 'prod'` on an unparseable
+  query against `prod` evaluates `unknown || true == true`: the rule
+  fires as written — whatever the verb was, the outcome is the same.
+- `sql.verb == 'select'` alone is unknown → unevaluable → deny.
 
-- **Catch-all rule** (no `condition`): fires as written. A truncated
-  body can't poison a rule that reads nothing.
-- **Rule whose CEL reads no truncatable facet field** (e.g.
-  `http.method == 'GET'`, `credential = X`, any `k8s.*` predicate):
-  the matcher runs normally — the truncated bytes are irrelevant to
-  its decision.
-- **Rule whose CEL reads a truncatable facet field**: the rule is
-  automatically matched without comparing the matching values. The
-  dispatcher synthesizes a deny attributed to that rule, with this
-  exact reason:
+Note `has()` does **not** rescue a truncated field: the presence test
+itself is unknown (the cut-off bytes might have carried the key). It
+only helps the evaluation-error case on a fully captured body.
+
+### Per-rule dispatch
+
+The dispatcher walks the endpoint's rules in priority order as usual.
+For each rule:
+
+- **Catch-all rule** (no `condition`): fires as written. Unavailable
+  bytes can't poison a rule that reads nothing.
+- **Rule whose condition resolves without the unavailable value**
+  (e.g. `http.method == 'GET'`, `credential = X`, any `k8s.*`
+  predicate, or a compound condition saved by absorption): the
+  matcher runs normally and the verdict is honest.
+- **Rule whose condition is unevaluable**: the dispatcher synthesizes
+  a deny attributed to that rule, with this reason shape:
 
   ```
-  rule "<name>" reads a request facet whose bytes were truncated by the gateway's inspection buffer; failing closed
+  rule "<name>" could not be evaluated against this request (<detail>); failing closed
   ```
 
-  The synthesized rule keeps the original rule's name and priority,
-  so logs and dashboards still attribute the deny to the rule whose
-  contract the truncation broke.
+  where `<detail>` names the unknown facet paths and the cause
+  (truncated / unparseable), or the CEL evaluation error. The
+  synthesized rule keeps the original rule's name and priority, so
+  logs and dashboards still attribute the deny to the rule whose
+  contract broke.
 
 The upshot: a rule matching on `http.method` and/or `credential` on
 an `https` endpoint still fires on a 2 MiB body, but a
@@ -501,6 +520,25 @@ is forced to deny without paging the approver (HITL can't reason about
 bytes that aren't there); the postgres endpoint surfaces this with the
 reason `"approval required but request was truncated by inspection
 buffer"`.
+
+### Inspection caps
+
+| Endpoint | Inspected slice | Cap | Truncatable facet fields |
+|----------|-----------------|-----|--------------------|
+| `https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `http.body`, `http.body_json` |
+| `kubernetes` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | *(none — every `k8s.*` facet is derived from the URL and method)* |
+| `clickhouse_https` | request body on `POST` / `PUT` / `PATCH` | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
+| `postgres` | `Query` (`Q`) and `Parse` (`P`) frame | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
+| `clickhouse_native` | `Query` packet body | 1 MiB | `sql.verb`, `sql.tables`, `sql.functions`, `sql.statement` |
+| `ssh` | session stdin (only on endpoints with an `ssh.stdin` rule) | 1 MiB | `ssh.stdin` |
+
+The caps are per-plugin constants in the gateway source — **not
+operator-tunable** today, and not surfaced in `gateway.hcl`. Header
+and URL bytes are bounded separately by `net/http`'s defaults and
+aren't covered here. The other `ssh.*` facet fields come from small,
+fully-read channel envelopes (the channel-open ExtraData and
+channel-request payloads), never from a buffered slice of streamed
+bytes, so they are never truncatable.
 
 ### How the deny reaches the agent
 
@@ -520,10 +558,13 @@ driver doesn't disconnect:
 ### Why fail-closed
 
 A truncated body might contain content that *would* have triggered a
-deny rule the gateway can't see, so refusing is the safe default. If
-legitimate traffic is expected to exceed the cap, write the rules
-against non-truncatable facet fields only (see the table above) — those
-rules still match on a truncated request and won't auto-deny.
+deny rule the gateway can't see, an unparseable statement might hide a
+write behind syntax the parser couldn't analyse, and a rule that
+errors at evaluation time has expressed an intent the gateway couldn't
+honor — in every case, refusing is the safe default. If legitimate
+traffic is expected to exceed the cap, write the rules against
+non-truncatable facet fields only (see the table above) — those rules
+still match on a truncated request and won't auto-deny.
 
 
 ## Examples

--- a/site/doc/rules.md
+++ b/site/doc/rules.md
@@ -505,14 +505,27 @@ For each rule:
   a deny attributed to that rule, with this reason shape:
 
   ```
-  rule "<name>" could not be evaluated against this request (<detail>); failing closed
+  rule "<name>" could not be evaluated against this request (<cause>); failing closed
   ```
 
-  where `<detail>` names the unknown facet paths and the cause
-  (truncated / unparseable), or the CEL evaluation error. The
-  synthesized rule keeps the original rule's name and priority, so
-  logs and dashboards still attribute the deny to the rule whose
-  contract broke.
+  where `<cause>` is the coarse category: truncated at the inspection
+  buffer, unparseable, or evaluation error. The full detail — which
+  facet paths the condition depended on, or the CEL error text — is
+  written to the gateway log only. Deny reasons are returned to the
+  agent verbatim, and evaluator errors like `no such key: <field>`
+  would let an agent probe which fields a rule inspects by varying
+  request payloads. The synthesized rule keeps the original rule's
+  name and priority, so logs and dashboards still attribute the deny
+  to the rule whose contract broke.
+
+- **No rule matches at all** (SQL endpoints): when a truncated or
+  unparseable request resolves every rule via absorption and the
+  endpoint declares at least one rule, the gateway denies instead of
+  applying the implicit-allow default — "no rule matched" may simply
+  mean every condition was independent of the missing bytes, not that
+  the operator intended them to flow. Endpoints with no rules keep
+  pass-through, and the backstop never fires on fully-inspected
+  requests.
 
 The upshot: a rule matching on `http.method` and/or `credential` on
 an `https` endpoint still fires on a 2 MiB body, but a


### PR DESCRIPTION
Replaces the dispatch-level truncation/unparseable pre-checks with
value-level unknowns from cel-go partial evaluation, and makes runtime
CEL evaluation errors fail closed.

* `match.Matcher.Match` is now three-valued (Matched / NoMatch /
  Unevaluable). On a Truncated or Unparseable request the matcher
  marks the affected facet paths (the declared `TruncatablePaths` /
  `UnparseablePaths`) as CEL unknowns via a partial activation
  (`cel.PartialVars` + `OptPartialEval`); the unknowns propagate
  virally, NaN-style, and surface as Unevaluable, which the
  dispatcher turns into a synthesized deny attributed to the rule
  whose contract broke
* More precise than the old reads-the-path gate: `&&`/`||`
  absorption lets a condition resolve honestly when its outcome
  doesn't depend on the unavailable value. `sql.verb == 'select' &&
  sql.database == 'x'` on an unparseable query against database 'y'
  now cleanly no-matches (`unknown && false == false`) instead of
  synth-denying; the symmetric `unknown || true` fires as written
* CEL eval errors no longer coerce to "no match" — a deny rule whose
  condition errors at runtime used to be silently skipped, failing
  open; it now synth-denies. The common case is selecting a
  `body_json` field the payload doesn't carry — or a missing map key
  like `k8s.params.stdin`. Guard optional fields with `has()` /
  `'key' in map`. `has()` cannot rescue a *truncated* field: the
  presence test itself is unknown
* Agent-visible deny reasons carry only the rule name and the coarse
  cause (truncated / unparseable / evaluation error); the full
  detail — unknown facet paths or the raw CEL error text — goes to
  the gateway log. cel-go errors like `no such key: <field>` would
  otherwise let an agent probe which fields a rule inspects by
  varying payloads and reading deny reasons
* New `runtime.MatchRequestFailClosed` backstop for SQL frontends
  (postgres, clickhouse_native): when a truncated or unparseable
  request matches no rule on an endpoint that declares rules, it
  denies instead of riding the implicit-allow default — "no rule
  matched" may just mean every condition resolved independent of the
  missing bytes. Rule-less endpoints keep pass-through; the HTTPS
  path keeps plain MatchRequest (rule-less LLM endpoints routinely
  forward >cap bodies)
* `InspectsTruncatableFacet` stays as the compile-time laziness
  signal (`CompiledEndpoint.InspectsTruncatable` / ssh stdin
  buffering); `InspectsUnparseableFacet` is removed along with the
  dispatch gate. `OptPartialEval` and the unknown-pattern slices are
  built only for conditions that reference a truncatable /
  unparseable path, keeping cel-go's default attribute factory on
  the hot path
* New tests pin the absorption semantics, the strict-error deny, the
  has() guard behavior on captured vs truncated bodies, unknown
  propagation through `==` / `in` / `exists()`, reason sanitization,
  and the SQL backstop; the `clawpatrol test` fixture corpus passes
  unchanged
* Docs: rules.md gains a unified "Unevaluable conditions fail
  closed" section covering truncation, parser refusal, eval errors,
  and the SQL backstop; adds the missing ssh stdin row to the
  inspection-cap table; the body_json and k8s-no-interactive
  examples use guards; plugins.md documents that the optional-field
  zero-fill covers declared fields only