### PR TITLE
site: replace hero video with asciinema demo

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.17",
+    "asciinema-player": "^3.15.1",
     "highlight.js": "^11.11.1",
     "marked": "^18.0.3",
     "marked-highlight": "^2.2.4",

--- a/site/public/clawpatrol-demo.cast
+++ b/site/public/clawpatrol-demo.cast
@@ -1,0 +1,12 @@
+{"version":2,"width":90,"height":24,"timestamp":1780680000,"env":{"SHELL":"/bin/zsh","TERM":"xterm-256color"}}
+[0.0,"o","\u001b[1;38;5;222m$ clawpatrol run codex\u001b[0m\r\n"]
+[0.35,"o","\u001b[38;5;244mjoining gateway: https://gw.example.com\u001b[0m\r\n"]
+[0.8,"o","\u001b[38;5;244mprofile: prod-support  endpoint: postgres.main\u001b[0m\r\n\r\n"]
+[1.25,"o","\u001b[1;38;5;81mcodex>\u001b[0m Check whether the sessions table can be deleted.\r\n\r\n"]
+[2.0,"o","\u001b[38;5;244m→ postgres query\u001b[0m\r\n"]
+[2.25,"o","  DROP TABLE sessions;\r\n\r\n"]
+[2.9,"o","\u001b[38;5;203m✗ denied by Claw Patrol\u001b[0m\r\n"]
+[3.25,"o","\u001b[38;5;244m  rule:\u001b[0m pg-destructive-statements\r\n"]
+[3.55,"o","\u001b[38;5;244m  reason:\u001b[0m destructive SQL requires human approval\r\n\r\n"]
+[4.2,"o","\u001b[1;38;5;118m✓ audit log written\u001b[0m  request_id=req_01HV...\r\n"]
+[4.75,"o","\u001b[1;38;5;222m$\u001b[0m "]

--- a/site/src/components/AsciinemaDemo.tsx
+++ b/site/src/components/AsciinemaDemo.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "preact/hooks";
+
+type AsciinemaPlayer = {
+  dispose: () => void;
+};
+
+const playerOptions = {
+  autoPlay: true,
+  loop: true,
+  controls: false,
+  fit: "width",
+  terminalFontFamily:
+    '"IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace',
+  terminalFontSize: 14,
+  terminalLineHeight: 1.25,
+  theme: "monokai",
+  idleTimeLimit: 1.2,
+  poster: "npt:0",
+};
+
+export function AsciinemaDemo() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let player: AsciinemaPlayer | undefined;
+    let cancelled = false;
+
+    async function mountPlayer() {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const { create } = await import("asciinema-player");
+      if (cancelled) return;
+
+      player = create("/clawpatrol-demo.cast", container, playerOptions);
+    }
+
+    mountPlayer();
+
+    return () => {
+      cancelled = true;
+      player?.dispose();
+    };
+  }, []);
+
+  return (
+    <div
+      class="asciinema-hero w-full md:max-w-[92%] border border-navy squircle-lg shadow-[4px_6px_0_0_var(--color-canvas-300)] overflow-hidden bg-[#121314]"
+      aria-label="Claw Patrol terminal demo"
+    >
+      <div ref={containerRef} class="asciinema-hero__player" />
+      <noscript>
+        <pre class="m-0 p-5 text-sm text-canvas overflow-x-auto">
+          {`$ clawpatrol run codex
+→ postgres query
+  DROP TABLE sessions;
+✗ denied by Claw Patrol
+✓ audit log written`}
+        </pre>
+      </noscript>
+    </div>
+  );
+}

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -1,4 +1,5 @@
 @import "./docs.css";
+@import "asciinema-player/dist/bundle/asciinema-player.css";
 @import "highlight.js/styles/atom-one-dark.css";
 @import "tailwindcss";
 @import "../../shared/fonts.css";
@@ -112,6 +113,24 @@
   .squircle-full {
     border-radius: 0.375rem;
   }
+}
+
+.asciinema-hero .asciinema-player {
+  width: 100%;
+  max-width: none;
+  background: #121314;
+}
+
+.asciinema-hero .asciinema-player-wrapper {
+  outline: 0;
+}
+
+.asciinema-hero .ap-player {
+  border-radius: 0;
+}
+
+.asciinema-hero__player:empty {
+  aspect-ratio: 90 / 24;
 }
 
 /* Inline `<code>` (excluding fenced `<pre><code>`) wraps as a single

--- a/site/src/sections/HeroSection.tsx
+++ b/site/src/sections/HeroSection.tsx
@@ -1,3 +1,4 @@
+import { AsciinemaDemo } from "../components/AsciinemaDemo";
 import { InstallTerminal } from "../components/InstallTerminal";
 
 // Single source of truth for the hero H1 and the page <title>.
@@ -39,15 +40,7 @@ export function HeroSection() {
         </div>
 
         <div class="w-full mt-16 md:mt-0 min-w-0 flex md:justify-end">
-          <video
-            src="/clawpatrol-demo4.mp4"
-            autoPlay
-            loop
-            muted
-            playsInline
-            class="w-full md:max-w-[85%] h-auto border border-navy squircle-lg shadow-[4px_6px_0_0_var(--color-canvas-300)]"
-            aria-label="Claw Patrol demo screencast"
-          />
+          <AsciinemaDemo />
         </div>
       </div>
     </section>

--- a/site/src/types/asciinema-player.d.ts
+++ b/site/src/types/asciinema-player.d.ts
@@ -1,0 +1,20 @@
+declare module "asciinema-player" {
+  export type Player = {
+    el: HTMLElement;
+    dispose: () => void;
+    getCurrentTime: () => Promise<number>;
+    getDuration: () => Promise<number>;
+    play: () => Promise<void>;
+    pause: () => Promise<void>;
+    seek: (pos: number) => Promise<void>;
+    addEventListener: (name: string, callback: () => void) => unknown;
+  };
+
+  export type Options = Record<string, unknown>;
+
+  export function create(
+    src: string,
+    elem: HTMLElement,
+    opts?: Options,
+  ): Player;
+}


### PR DESCRIPTION
## Summary
- Replace the landing-page hero MP4 with an embedded asciinema terminal demo
- Add the `.cast` fixture and a small Preact wrapper that dynamically imports `asciinema-player`
- Scope player styling to the hero demo area

## Verification
- `npm test`
- `npm run build`
- `git diff --check`

## Preview
The repo PR preview workflow should publish this to `https://demo.clawpatrol.dev/pr-preview/pr-<PR number>/` and comment the concrete link on this PR.