### PR TITLE
Add Linux tsnet UDP relay for clawpatrol run

### DIFF
--- a/cmd/clawpatrol/daemon_session_linux.go
+++ b/cmd/clawpatrol/daemon_session_linux.go
@@ -35,6 +35,8 @@ import (
 // child-side TUN doesn't need to cap.
 const runStackTunMTU = 65535
 
+var runUDPFlowIdleTimeout = 30 * time.Second
+
 // newRunStack creates a gVisor TCP/IP stack bound to localIP, which
 // is the transport's underlay address (tsnet 100.x.x.x or wg /32).
 // Promiscuous + spoofing enabled so the stack accepts inbound
@@ -212,7 +214,7 @@ func (f *runUDPForwarder) handle(pkt []byte) {
 func (f *runUDPForwarder) readResponses(conn net.Conn, srcIP, dstIP [4]byte, srcPort, dstPort uint16) {
 	buf := make([]byte, 65535)
 	for {
-		_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+		_ = conn.SetReadDeadline(time.Now().Add(runUDPFlowIdleTimeout))
 		n, err := conn.Read(buf)
 		if err != nil {
 			return

--- a/cmd/clawpatrol/daemon_session_linux_test.go
+++ b/cmd/clawpatrol/daemon_session_linux_test.go
@@ -1,0 +1,156 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunUDPForwarderCleansIdleFlowAfterReadTimeout(t *testing.T) {
+	oldTimeout := runUDPFlowIdleTimeout
+	runUDPFlowIdleTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { runUDPFlowIdleTimeout = oldTimeout })
+
+	transport := &cleanupTestTransport{conn: newCleanupTestConn()}
+	f := &runUDPForwarder{
+		transport: transport,
+		flows:     map[udpFlowKey]net.Conn{},
+	}
+	pkt := buildUDPPacket([4]byte{100, 98, 20, 53}, [4]byte{192, 0, 2, 10}, 53000, 9999, []byte("ping"))
+	f.handle(pkt)
+
+	if got := transport.conn.writes(); got != 1 {
+		t.Fatalf("transport writes = %d, want 1", got)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		flows := len(f.flows)
+		f.mu.Unlock()
+		if flows == 0 {
+			if !transport.conn.closed() {
+				t.Fatal("flow was removed before conn closed")
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	f.mu.Lock()
+	flows := len(f.flows)
+	f.mu.Unlock()
+	t.Fatalf("flow count = %d after timeout, want 0", flows)
+}
+
+type cleanupTestTransport struct{ conn *cleanupTestConn }
+
+func (t *cleanupTestTransport) Dial(context.Context, string, string) (net.Conn, error) {
+	return t.conn, nil
+}
+func (t *cleanupTestTransport) LocalAddr() netip.Addr {
+	return netip.MustParseAddr("100.98.20.53")
+}
+
+func (t *cleanupTestTransport) BootWarning() string {
+	return ""
+}
+
+func (t *cleanupTestTransport) Close() error {
+	return nil
+}
+
+type cleanupTestConn struct {
+	mu       sync.Mutex
+	deadline time.Time
+	writeN   int
+	closedV  bool
+}
+
+func newCleanupTestConn() *cleanupTestConn {
+	return &cleanupTestConn{}
+}
+
+func (c *cleanupTestConn) Read([]byte) (int, error) {
+	for {
+		c.mu.Lock()
+		deadline := c.deadline
+		closed := c.closedV
+		c.mu.Unlock()
+		if closed {
+			return 0, net.ErrClosed
+		}
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return 0, timeoutErr{}
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func (c *cleanupTestConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closedV {
+		return 0, net.ErrClosed
+	}
+	c.writeN++
+	return len(b), nil
+}
+
+func (c *cleanupTestConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closedV = true
+	return nil
+}
+func (c *cleanupTestConn) LocalAddr() net.Addr {
+	return net.UDPAddrFromAddrPort(netip.MustParseAddrPort("100.98.20.53:53000"))
+}
+
+func (c *cleanupTestConn) RemoteAddr() net.Addr {
+	return net.UDPAddrFromAddrPort(netip.MustParseAddrPort("192.0.2.10:9999"))
+}
+
+func (c *cleanupTestConn) SetDeadline(t time.Time) error {
+	_ = c.SetReadDeadline(t)
+	return nil
+}
+
+func (c *cleanupTestConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+func (c *cleanupTestConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deadline = t
+	return nil
+}
+func (c *cleanupTestConn) writes() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writeN
+}
+func (c *cleanupTestConn) closed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closedV
+}
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string {
+	return "i/o timeout"
+}
+
+func (timeoutErr) Timeout() bool {
+	return true
+}
+
+func (timeoutErr) Temporary() bool {
+	return true
+}
+
+var _ net.Error = timeoutErr{}

--- a/cmd/clawpatrol/daemon_transport_tsnet_linux.go
+++ b/cmd/clawpatrol/daemon_transport_tsnet_linux.go
@@ -3,11 +3,11 @@
 package main
 
 // tsnetTransport: daemonTransport implementation backed by an embedded
-// tsnet.Server with the gateway pinned as its exit node. Every Dial
-// returns a tsnet.Server.Dial conn, which the tailnet routes through
-// the gateway — the gateway then picks it up in its tsnet
-// RegisterFallbackTCPHandler with the original dst intact (no
-// PROXY-v1 framing).
+// tsnet.Server with the gateway pinned as its exit node. TCP dials use
+// tsnet.Server.Dial and land in the gateway's tsnet
+// RegisterFallbackTCPHandler with the original dst intact. UDP dials use
+// Claw Patrol's framed tailnet relay because tsnet exposes no arbitrary-UDP
+// fallback equivalent to RegisterFallbackTCPHandler.
 
 import (
 	"context"
@@ -25,11 +25,16 @@ import (
 
 type tsnetTransport struct {
 	s           *tsnet.Server
+	gatewayAddr netip.Addr
+	apiToken    string
 	localAddr   netip.Addr
 	bootWarning string
 }
 
 func (t *tsnetTransport) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	if strings.HasPrefix(network, "udp") {
+		return dialTsnetUDPRelay(ctx, t.s.Dial, t.gatewayAddr, t.localAddr, t.apiToken, addr)
+	}
 	return t.s.Dial(ctx, network, addr)
 }
 
@@ -120,13 +125,15 @@ func startTsnetTransport() (daemonTransport, error) {
 	// gatewayClient → /api/env-pushdown) reach 100.x via tsnet.
 	gatewayDialOverride = s.Dial
 
+	apiToken := strings.TrimSpace(readFileSilent(filepath.Join(defaultClawpatrolDir(), "api-token")))
+
 	// Register this tsnet IP with the gateway so it maps to the host's
 	// device row (and therefore its profile). Best-effort: a failure
 	// only means traffic lands in the default profile until the next
 	// daemon restart.
 	daemonRegisterTsnetPeer(s, tsIP)
 
-	return &tsnetTransport{s: s, localAddr: tsIP, bootWarning: bootWarning}, nil
+	return &tsnetTransport{s: s, gatewayAddr: gwIP, apiToken: apiToken, localAddr: tsIP, bootWarning: bootWarning}, nil
 }
 
 // daemonRegisterTsnetPeer POSTs this daemon's tsnet IP to the

--- a/cmd/clawpatrol/integrations_test.go
+++ b/cmd/clawpatrol/integrations_test.go
@@ -113,9 +113,14 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 // vars (client-side) plus the server-supplied ones in a single
 // flat list.
 func TestEnvPushdownVarsServerDriven(t *testing.T) {
-	prev := envPushdownGatewayFetcher
+	prevGateway := envPushdownGatewayFetcher
+	prevDaemon := envPushdownDaemonFetcher
 	envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
-	t.Cleanup(func() { envPushdownGatewayFetcher = prev })
+	envPushdownDaemonFetcher = nil
+	t.Cleanup(func() {
+		envPushdownGatewayFetcher = prevGateway
+		envPushdownDaemonFetcher = prevDaemon
+	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -160,10 +165,17 @@ func TestEnvPushdownVarsErrorReturnsCAOnly(t *testing.T) {
 	// init() in run_tsnet_darwin.go rewires this to the NE session
 	// socket, which would dial /tmp/clawpatrol.sock and return whatever
 	// the host's running NE happens to have to say, instead of the
-	// gateway-URL-missing error this test exercises.
-	prev := envPushdownGatewayFetcher
+	// gateway-URL-missing error this test exercises. Disable the Linux daemon
+	// fetcher too, or a joined developer machine with a live daemon can satisfy
+	// the request from its cached gateway state instead of this temp dir.
+	prevGateway := envPushdownGatewayFetcher
+	prevDaemon := envPushdownDaemonFetcher
 	envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
-	t.Cleanup(func() { envPushdownGatewayFetcher = prev })
+	envPushdownDaemonFetcher = nil
+	t.Cleanup(func() {
+		envPushdownGatewayFetcher = prevGateway
+		envPushdownDaemonFetcher = prevDaemon
+	})
 
 	dir := t.TempDir()
 	caPath := filepath.Join(dir, "ca.crt")

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3205,6 +3205,7 @@ func runGateway(args []string) {
 		} else {
 			log.Printf("tsnet: LocalClient for whois: %v", err)
 		}
+		g.startTsnetUDPRelay(tsnetServer)
 		// Serve the dashboard mux on tsnet's virtual network so
 		// clawpatrol-run clients connecting to this tsnet IP on the
 		// dashboard port can mint ephemeral auth keys and reach the

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -947,6 +947,12 @@ func (w *webMux) apiPeerTsnetRegister(rw http.ResponseWriter, r *http.Request) {
 		if w.g.agents != nil {
 			w.g.agents.Seed(tsnetIP)
 		}
+	} else if hostname != "" && w.g.onboard.AgentIPFor(tsnetIP) == parentIP {
+		// The UDP relay can promote the placeholder first if it is the daemon's
+		// first successful gateway contact. Preserve the normal register call's
+		// device-identity behavior when it follows that promotion, but do not let a
+		// valid bearer create hostname-only device rows for unrelated tailnet IPs.
+		w.g.onboard.SetHostname(tsnetIP, hostname)
 	}
 	// Map the daemon's IPv6 ULA too — tsnet traffic from this peer
 	// frequently arrives on fd7a:115c:a1e0::/48 rather than the 100.x.

--- a/cmd/clawpatrol/udp_relay.go
+++ b/cmd/clawpatrol/udp_relay.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"tailscale.com/tsnet"
+)
+
+const (
+	tsnetUDPRelayPort      = 45353
+	udpRelayMaxDatagram    = 65507
+	udpRelayMaxTokenLength = 4096
+)
+
+var (
+	udpRelayHandshakeLimit = 2 * time.Second
+	udpRelayIdleTimeout    = 30 * time.Second
+)
+
+var udpRelayMagic = [8]byte{'C', 'P', 'U', 'D', 'P', 'R', '1', '\n'}
+
+// Linux tsnet clients cannot use tsnet's exit-node path for arbitrary UDP:
+// tsnet has RegisterFallbackTCPHandler for TCP, but no UDP equivalent. The
+// relay below keeps the child-facing UDP contract intact while carrying each
+// child UDP flow over a tailnet TCP stream to the gateway. The gateway accepts
+// streams only from peers already known to the onboard registry or peers that
+// present the per-peer API token minted during onboarding, then applies the
+// same UDP dispatch as WG mode: dnsvip owns UDP/53 and all other UDP is
+// transparently relayed to the original destination.
+type udpRelayDialer func(context.Context, string, string) (net.Conn, error)
+
+func dialTsnetUDPRelay(ctx context.Context, dial udpRelayDialer, gateway, local netip.Addr, token, dstAddr string) (net.Conn, error) {
+	if !gateway.IsValid() {
+		return nil, errors.New("tsnet udp relay: gateway address is not set")
+	}
+	dst, err := netip.ParseAddrPort(dstAddr)
+	if err != nil {
+		return nil, fmt.Errorf("tsnet udp relay: parse destination %q: %w", dstAddr, err)
+	}
+	relayAddr := net.JoinHostPort(gateway.String(), strconv.Itoa(tsnetUDPRelayPort))
+	dialCtx, dialCancel := context.WithTimeout(ctx, udpRelayHandshakeLimit)
+	defer dialCancel()
+	c, err := dial(dialCtx, "tcp", relayAddr)
+	if err != nil {
+		return nil, fmt.Errorf("tsnet udp relay: dial gateway %s: %w", relayAddr, err)
+	}
+	deadline := time.Now().Add(udpRelayHandshakeLimit)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = c.SetDeadline(deadline)
+	if err := writeUDPRelayHello(c, dst, local, token); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	_ = c.SetDeadline(time.Time{})
+	return newUDPRelayStreamConn(c), nil
+}
+
+func (g *Gateway) startTsnetUDPRelay(s *tsnet.Server) {
+	if g == nil || s == nil {
+		return
+	}
+	ln, err := s.Listen("tcp", net.JoinHostPort("", strconv.Itoa(tsnetUDPRelayPort)))
+	if err != nil {
+		log.Printf("tsnet: udp relay listen :%d: %v", tsnetUDPRelayPort, err)
+		return
+	}
+	log.Printf("tsnet: udp relay listening on :%d", tsnetUDPRelayPort)
+	go func() {
+		defer func() { _ = ln.Close() }()
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go g.handleTsnetUDPRelayConn(c)
+		}
+	}()
+}
+
+func (g *Gateway) handleTsnetUDPRelayConn(raw net.Conn) {
+	peer := peerIP(raw)
+	_ = raw.SetDeadline(time.Now().Add(udpRelayHandshakeLimit))
+	dst, claimedPeer, token, err := readUDPRelayHello(raw)
+	if err != nil {
+		log.Printf("tsnet udp-relay: malformed hello from %s: %v", peer, err)
+		_ = raw.Close()
+		return
+	}
+	_ = raw.SetDeadline(time.Time{})
+
+	agentIP, profile, ok := g.authorizeTsnetUDPRelayPeer(peer, claimedPeer, token)
+	if !ok {
+		log.Printf("tsnet udp-relay: reject unauthorized peer %q", peer)
+		_ = raw.Close()
+		return
+	}
+
+	conn := newUDPRelayStreamConnWithIdle(raw, udpRelayIdleTimeout)
+	dstIP := dst.Addr().String()
+	dstPort := dst.Port()
+	log.Printf("tsnet udp-relay: %s profile=%s -> %s", agentIP, profile, dst)
+	if dstPort == 53 && g.dnsvip != nil {
+		g.dnsvip.ServeUDP(conn, g.udpRelayDNSOrigDst(dstIP, raw.LocalAddr()))
+		return
+	}
+	relayUDP(conn, dstIP, dstPort)
+}
+
+func (g *Gateway) authorizeTsnetUDPRelayPeer(peer string, claimedPeer netip.Addr, token string) (agentIP, profile string, ok bool) {
+	if g == nil || g.onboard == nil || peer == "" {
+		return "", "", false
+	}
+	if agentIP, profile, ok := g.authorizeTsnetUDPRelayKnownPeer(peer); ok {
+		return agentIP, profile, true
+	}
+	if token == "" || g.db == nil {
+		return "", "", false
+	}
+	parentIP := peerIPForAPIToken(g.db, token)
+	if parentIP == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(parentIP, tsnetPlaceholderPrefix) {
+		// daemonRegisterTsnetPeer is intentionally best-effort. If the daemon's
+		// first successful contact with the gateway is this UDP relay, the same
+		// per-peer bearer can safely promote the tsnet placeholder here. The
+		// placeholder's profile is memory-only and can be lost on gateway restart,
+		// so fall back to the configured default just like profileFor does.
+		profile := g.onboard.ProfileForIP(parentIP)
+		if profile == "" {
+			profile = g.udpRelayDefaultProfile()
+		}
+		promotedPeer := peer
+		if claimedPeer.IsValid() {
+			promotedPeer = g.verifiedUDPRelayClaimedPeer(peer, claimedPeer)
+		}
+		_, _ = g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", promotedPeer, parentIP)
+		g.onboard.ForgetIP(parentIP)
+		if g.agents != nil {
+			g.agents.Delete(parentIP)
+		}
+		g.onboard.AssignProfile(promotedPeer, profile)
+		if promotedPeer != peer {
+			g.onboard.RegisterIPAlias(peer, promotedPeer)
+		}
+		if hostname := strings.TrimPrefix(parentIP, tsnetPlaceholderPrefix); hostname != "" && hostname != parentIP {
+			g.onboard.SetHostname(promotedPeer, hostname)
+		}
+		if g.agents != nil {
+			g.agents.Seed(promotedPeer)
+		}
+		return promotedPeer, profile, true
+	}
+	if p, ok := g.udpRelayProfileForRegisteredIP(parentIP); ok {
+		return parentIP, p, true
+	}
+	return "", "", false
+}
+
+func (g *Gateway) verifiedUDPRelayClaimedPeer(peer string, claimed netip.Addr) string {
+	if g.tsnetLC == nil || !claimed.IsValid() || claimed.String() == peer {
+		return peer
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	w, err := g.tsnetLC.WhoIs(ctx, net.JoinHostPort(peer, "0"))
+	if err != nil || w == nil || w.Node == nil {
+		return peer
+	}
+	for _, addr := range w.Node.Addresses {
+		if addr.Addr() == claimed {
+			return claimed.String()
+		}
+	}
+	return peer
+}
+
+func (g *Gateway) authorizeTsnetUDPRelayKnownPeer(peer string) (agentIP, profile string, ok bool) {
+	if p, ok := g.udpRelayProfileForRegisteredIP(peer); ok {
+		return g.onboard.AgentIPFor(peer), p, true
+	}
+	if g.tsnetLC != nil && g.onboard.ClaimAliasResolve(peer, 5*time.Minute) {
+		if canonical := g.resolveTsnetAlias(peer); canonical != "" {
+			if p, ok := g.udpRelayProfileForRegisteredIP(canonical); ok {
+				return g.onboard.AgentIPFor(canonical), p, true
+			}
+		}
+	}
+	if canonical := g.onboard.AgentIPFor(peer); canonical != peer {
+		if p, ok := g.udpRelayProfileForRegisteredIP(canonical); ok {
+			return canonical, p, true
+		}
+	}
+	return "", "", false
+}
+
+func (g *Gateway) udpRelayProfileForRegisteredIP(ip string) (string, bool) {
+	if p := g.onboard.ProfileForIP(ip); p != "" {
+		return p, true
+	}
+	if !g.onboard.HasDevice(ip) {
+		return "", false
+	}
+	return g.udpRelayDefaultProfile(), true
+}
+
+func (g *Gateway) udpRelayDefaultProfile() string {
+	if cfg := g.cfg.Load(); cfg != nil {
+		return defaultProfileName(cfg.Policy)
+	}
+	return ""
+}
+
+func (g *Gateway) udpRelayDNSOrigDst(dstIP string, local net.Addr) string {
+	if dstIP == g.tailscaleIP {
+		return ""
+	}
+	if local != nil {
+		host, _, err := net.SplitHostPort(local.String())
+		if err != nil {
+			host = local.String()
+		}
+		if host == dstIP {
+			return ""
+		}
+	}
+	return dstIP
+}
+
+func writeUDPRelayHello(w io.Writer, dst netip.AddrPort, peer netip.Addr, token string) error {
+	dstAddr := dst.Addr()
+	if !dstAddr.IsValid() || dst.Port() == 0 {
+		return fmt.Errorf("udp relay hello: invalid destination %s", dst)
+	}
+	dstBytes := dstAddr.AsSlice()
+	if len(dstBytes) != 4 && len(dstBytes) != 16 {
+		return fmt.Errorf("udp relay hello: unsupported address %s", dstAddr)
+	}
+	var peerBytes []byte
+	if peer.IsValid() {
+		peerBytes = peer.AsSlice()
+		if len(peerBytes) != 4 && len(peerBytes) != 16 {
+			return fmt.Errorf("udp relay hello: unsupported peer address %s", peer)
+		}
+	}
+	if len(token) > udpRelayMaxTokenLength {
+		return fmt.Errorf("udp relay hello: token length %d exceeds %d", len(token), udpRelayMaxTokenLength)
+	}
+	header := make([]byte, 14+len(dstBytes)+len(peerBytes)+len(token))
+	copy(header[:8], udpRelayMagic[:])
+	header[8] = byte(len(dstBytes))
+	header[9] = byte(len(peerBytes))
+	binary.BigEndian.PutUint16(header[10:12], dst.Port())
+	binary.BigEndian.PutUint16(header[12:14], uint16(len(token)))
+	pos := 14
+	copy(header[pos:], dstBytes)
+	pos += len(dstBytes)
+	copy(header[pos:], peerBytes)
+	pos += len(peerBytes)
+	copy(header[pos:], token)
+	return writeUDPRelayFull(w, header)
+}
+
+func readUDPRelayHello(r io.Reader) (netip.AddrPort, netip.Addr, string, error) {
+	var fixed [14]byte
+	if _, err := io.ReadFull(r, fixed[:]); err != nil {
+		return netip.AddrPort{}, netip.Addr{}, "", err
+	}
+	if string(fixed[:8]) != string(udpRelayMagic[:]) {
+		return netip.AddrPort{}, netip.Addr{}, "", errors.New("bad magic")
+	}
+	dstLen := int(fixed[8])
+	peerLen := int(fixed[9])
+	if dstLen != 4 && dstLen != 16 {
+		return netip.AddrPort{}, netip.Addr{}, "", fmt.Errorf("bad destination address length %d", dstLen)
+	}
+	if peerLen != 0 && peerLen != 4 && peerLen != 16 {
+		return netip.AddrPort{}, netip.Addr{}, "", fmt.Errorf("bad peer address length %d", peerLen)
+	}
+	port := binary.BigEndian.Uint16(fixed[10:12])
+	if port == 0 {
+		return netip.AddrPort{}, netip.Addr{}, "", errors.New("zero destination port")
+	}
+	tokenLen := int(binary.BigEndian.Uint16(fixed[12:14]))
+	if tokenLen > udpRelayMaxTokenLength {
+		return netip.AddrPort{}, netip.Addr{}, "", fmt.Errorf("token length %d exceeds %d", tokenLen, udpRelayMaxTokenLength)
+	}
+	dstBytes := make([]byte, dstLen)
+	if _, err := io.ReadFull(r, dstBytes); err != nil {
+		return netip.AddrPort{}, netip.Addr{}, "", err
+	}
+	dstAddr, ok := netip.AddrFromSlice(dstBytes)
+	if !ok || !dstAddr.IsValid() {
+		return netip.AddrPort{}, netip.Addr{}, "", errors.New("invalid destination address")
+	}
+	peerBytes := make([]byte, peerLen)
+	if _, err := io.ReadFull(r, peerBytes); err != nil {
+		return netip.AddrPort{}, netip.Addr{}, "", err
+	}
+	var peer netip.Addr
+	if peerLen > 0 {
+		var ok bool
+		peer, ok = netip.AddrFromSlice(peerBytes)
+		if !ok || !peer.IsValid() {
+			return netip.AddrPort{}, netip.Addr{}, "", errors.New("invalid peer address")
+		}
+	}
+	tokenBytes := make([]byte, tokenLen)
+	if _, err := io.ReadFull(r, tokenBytes); err != nil {
+		return netip.AddrPort{}, netip.Addr{}, "", err
+	}
+	return netip.AddrPortFrom(dstAddr, port), peer, string(tokenBytes), nil
+}
+
+func newUDPRelayStreamConn(c net.Conn) net.Conn {
+	return newUDPRelayStreamConnWithIdle(c, 0)
+}
+
+func newUDPRelayStreamConnWithIdle(c net.Conn, idle time.Duration) net.Conn {
+	return &udpRelayStreamConn{Conn: c, idleTimeout: idle}
+}
+
+type udpRelayStreamConn struct {
+	net.Conn
+	writeMu     sync.Mutex
+	idleTimeout time.Duration
+}
+
+func (c *udpRelayStreamConn) Read(b []byte) (int, error) {
+	c.refreshIdleDeadline()
+	var hdr [2]byte
+	if _, err := io.ReadFull(c.Conn, hdr[:]); err != nil {
+		return 0, err
+	}
+	n := int(binary.BigEndian.Uint16(hdr[:]))
+	if n > udpRelayMaxDatagram {
+		return 0, fmt.Errorf("udp relay frame: invalid length %d", n)
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	if n > len(b) {
+		if _, err := io.CopyN(io.Discard, c.Conn, int64(n)); err != nil {
+			return 0, err
+		}
+		return 0, io.ErrShortBuffer
+	}
+	_, err := io.ReadFull(c.Conn, b[:n])
+	return n, err
+}
+
+func (c *udpRelayStreamConn) Write(b []byte) (int, error) {
+	c.refreshIdleDeadline()
+	if len(b) > udpRelayMaxDatagram {
+		return 0, fmt.Errorf("udp relay frame: invalid length %d", len(b))
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(b)))
+	if err := writeUDPRelayFull(c.Conn, hdr[:]); err != nil {
+		return 0, err
+	}
+	if err := writeUDPRelayFull(c.Conn, b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (c *udpRelayStreamConn) refreshIdleDeadline() {
+	if c.idleTimeout > 0 {
+		_ = c.SetDeadline(time.Now().Add(c.idleTimeout))
+	}
+}
+
+func writeUDPRelayFull(w io.Writer, b []byte) error {
+	for len(b) > 0 {
+		n, err := w.Write(b)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		b = b[n:]
+	}
+	return nil
+}

--- a/cmd/clawpatrol/udp_relay_test.go
+++ b/cmd/clawpatrol/udp_relay_test.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/cmd/clawpatrol/dnsvip"
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/miekg/dns"
+	_ "modernc.org/sqlite"
+)
+
+func TestUDPRelayRejectsUnauthorizedPeer(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	g := &Gateway{onboard: newOnboardRegistry()}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.handleTsnetUDPRelayConn(&addrOverrideConn{
+			Conn:  server,
+			raddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.98.20.53:12345")),
+			laddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.64.91.47:45353")),
+		})
+	}()
+	if err := writeUDPRelayHello(client, netip.MustParseAddrPort("192.0.2.10:9999"), netip.Addr{}, ""); err != nil {
+		t.Fatalf("write relay hello: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("unauthorized relay connection did not close")
+	}
+}
+
+func TestUDPRelayRejectsMalformedHello(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	reg := newOnboardRegistry()
+	reg.AssignProfile("100.98.20.53", "default")
+	g := &Gateway{onboard: reg}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.handleTsnetUDPRelayConn(&addrOverrideConn{
+			Conn:  server,
+			raddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.98.20.53:12345")),
+			laddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.64.91.47:45353")),
+		})
+	}()
+	_, _ = client.Write([]byte("not-a-valid-udp-relay-hello"))
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("malformed relay connection did not close")
+	}
+}
+
+func TestUDPRelayNonDNSRoundTrip(t *testing.T) {
+	upstream := startUDPEcho(t)
+	client := startAuthorizedUDPRelay(t, &Gateway{onboard: authorizedRegistry()}, upstream)
+	defer func() { _ = client.Close() }()
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("relay write: %v", err)
+	}
+	buf := make([]byte, 64)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("relay read: %v", err)
+	}
+	if got, want := string(buf[:n]), "echo:ping"; got != want {
+		t.Fatalf("relay response = %q, want %q", got, want)
+	}
+}
+
+func TestUDPRelayRejectsUnregisteredPeerWithoutTokenEvenWithDefaultProfile(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	g := &Gateway{onboard: newOnboardRegistry()}
+	storeDefaultProfileConfig(g)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.handleTsnetUDPRelayConn(&addrOverrideConn{
+			Conn:  server,
+			raddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.98.20.53:12345")),
+			laddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.64.91.47:45353")),
+		})
+	}()
+	if err := writeUDPRelayHello(client, netip.MustParseAddrPort("192.0.2.10:9999"), netip.Addr{}, ""); err != nil {
+		t.Fatalf("write relay hello: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("unregistered relay connection without token did not close")
+	}
+}
+
+func TestUDPRelayNonDNSIdleTimeoutClosesStream(t *testing.T) {
+	oldTimeout := udpRelayIdleTimeout
+	udpRelayIdleTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { udpRelayIdleTimeout = oldTimeout })
+
+	upstream := startUDPEcho(t)
+	client := startAuthorizedUDPRelay(t, &Gateway{onboard: authorizedRegistry()}, upstream)
+	defer func() { _ = client.Close() }()
+	buf := make([]byte, 1)
+	_ = client.SetReadDeadline(time.Now().Add(time.Second))
+	start := time.Now()
+	n, err := client.Read(buf)
+	if err == nil {
+		t.Fatalf("idle relay read returned n=%d, want close/error", n)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("idle relay closed after %s, want server-side idle timeout", elapsed)
+	}
+}
+
+func TestUDPRelayRegisteredPeerUsesDefaultProfile(t *testing.T) {
+	upstream := startUDPEcho(t)
+	reg, db := newTestOnboardRegistryWithDB(t)
+	reg.SetHostname("100.98.20.53", "ip-10-0-128-236")
+	g := &Gateway{onboard: reg, db: db}
+	storeDefaultProfileConfig(g)
+	client := startAuthorizedUDPRelay(t, g, upstream)
+	defer func() { _ = client.Close() }()
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("relay write: %v", err)
+	}
+	buf := make([]byte, 64)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("relay read: %v", err)
+	}
+	if got, want := string(buf[:n]), "echo:ping"; got != want {
+		t.Fatalf("relay response = %q, want %q", got, want)
+	}
+}
+
+func TestUDPRelayAuthorizesUnregisteredPeerWithAPIToken(t *testing.T) {
+	upstream := startUDPEcho(t)
+	reg := newOnboardRegistry()
+	placeholder := tsnetPlaceholderPrefix + "ip-10-0-128-236"
+	reg.assignProfileMemOnly(placeholder, "default")
+	db, err := OpenDB(filepath.Join(t.TempDir(), "gateway.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	token, err := mintAndPersistPeerAPIToken(db, placeholder)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	client := startUDPRelay(t, &Gateway{onboard: reg, db: db}, upstream, token)
+	defer func() { _ = client.Close() }()
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("relay write: %v", err)
+	}
+	buf := make([]byte, 64)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("relay read: %v", err)
+	}
+	if got, want := string(buf[:n]), "echo:ping"; got != want {
+		t.Fatalf("relay response = %q, want %q", got, want)
+	}
+	if got := peerIPForAPIToken(db, token); got != "100.98.20.53" {
+		t.Fatalf("token peer = %q, want promoted tsnet peer", got)
+	}
+	if got := reg.ProfileForIP("100.98.20.53"); got != "default" {
+		t.Fatalf("promoted peer profile = %q, want default", got)
+	}
+	if got := reg.HostnameForIP("100.98.20.53"); got != "ip-10-0-128-236" {
+		t.Fatalf("promoted peer hostname = %q, want ip-10-0-128-236", got)
+	}
+}
+
+func TestUDPRelayDoesNotTrustUnverifiedClaimedPeer(t *testing.T) {
+	upstream := startUDPEcho(t)
+	reg := newOnboardRegistry()
+	placeholder := tsnetPlaceholderPrefix + "ip-10-0-128-236"
+	reg.assignProfileMemOnly(placeholder, "default")
+	db, err := OpenDB(filepath.Join(t.TempDir(), "gateway.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	token, err := mintAndPersistPeerAPIToken(db, placeholder)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	client := startUDPRelayWithPeer(t, &Gateway{onboard: reg, db: db}, upstream, token, "100.98.20.53", netip.MustParseAddr("100.88.88.88"))
+	defer func() { _ = client.Close() }()
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("relay write: %v", err)
+	}
+	buf := make([]byte, 64)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := client.Read(buf); err != nil {
+		t.Fatalf("relay read: %v", err)
+	}
+	if got := peerIPForAPIToken(db, token); got != "100.98.20.53" {
+		t.Fatalf("token peer = %q, want authenticated remote peer", got)
+	}
+	if reg.HasDevice("100.88.88.88") {
+		t.Fatal("unverified claimed peer created a device row")
+	}
+}
+
+func TestUDPRelayPlaceholderTokenFallsBackToDefaultProfileAfterRestart(t *testing.T) {
+	upstream := startUDPEcho(t)
+	reg := newOnboardRegistry()
+	placeholder := tsnetPlaceholderPrefix + "ip-10-0-128-236"
+	db, err := OpenDB(filepath.Join(t.TempDir(), "gateway.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	token, err := mintAndPersistPeerAPIToken(db, placeholder)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	g := &Gateway{onboard: reg, db: db}
+	storeDefaultProfileConfig(g)
+	client := startUDPRelay(t, g, upstream, token)
+	defer func() { _ = client.Close() }()
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("relay write: %v", err)
+	}
+	buf := make([]byte, 64)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("relay read: %v", err)
+	}
+	if got, want := string(buf[:n]), "echo:ping"; got != want {
+		t.Fatalf("relay response = %q, want %q", got, want)
+	}
+	if got := reg.ProfileForIP("100.98.20.53"); got != "default" {
+		t.Fatalf("promoted peer profile = %q, want default", got)
+	}
+}
+
+func TestUDPRelayDNSOverUDP(t *testing.T) {
+	g := &Gateway{
+		onboard:     authorizedRegistry(),
+		dnsvip:      newTestDNSVIP(t),
+		tailscaleIP: "100.64.91.47",
+	}
+	client := startAuthorizedUDPRelay(t, g, netip.MustParseAddrPort("100.64.91.47:53"))
+	defer func() { _ = client.Close() }()
+	q := new(dns.Msg)
+	q.SetQuestion("localhost.", dns.TypeA)
+	wire, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack DNS query: %v", err)
+	}
+	if _, err := client.Write(wire); err != nil {
+		t.Fatalf("relay DNS write: %v", err)
+	}
+	buf := make([]byte, 512)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("relay DNS read: %v", err)
+	}
+	var resp dns.Msg
+	if err := resp.Unpack(buf[:n]); err != nil {
+		t.Fatalf("unpack DNS response: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+		t.Fatalf("DNS response rcode=%d answers=%d, want success with answers", resp.Rcode, len(resp.Answer))
+	}
+}
+
+func TestPeerTsnetRegisterRejectsUnrelatedHostnameOnlyRow(t *testing.T) {
+	reg, db := newTestOnboardRegistryWithDB(t)
+	reg.AssignProfile("100.98.20.53", "default")
+	token, err := mintAndPersistPeerAPIToken(db, "100.98.20.53")
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	w := &webMux{g: &Gateway{db: db, onboard: reg}}
+	req := httptest.NewRequest(http.MethodPost, "/api/peer/tsnet/register?ip=100.88.88.88&hostname=unrelated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	w.apiPeerTsnetRegister(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("register status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+	if reg.HasDevice("100.88.88.88") {
+		t.Fatal("register created a hostname-only row for unrelated tsnet IP")
+	}
+}
+
+func TestUDPRelayStreamConnPreservesZeroLengthDatagrams(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	conn := newUDPRelayStreamConn(client)
+	defer func() { _ = conn.Close() }()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		n, err := conn.Write(nil)
+		if err == nil && n != 0 {
+			err = fmt.Errorf("zero-length write returned n=%d, want 0", n)
+		}
+		writeDone <- err
+	}()
+	var hdr [2]byte
+	if _, err := server.Read(hdr[:]); err != nil {
+		t.Fatalf("read zero-length frame header: %v", err)
+	}
+	if got := binary.BigEndian.Uint16(hdr[:]); got != 0 {
+		t.Fatalf("zero-length frame length = %d, want 0", got)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write zero-length frame: %v", err)
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		buf := []byte("unchanged")
+		n, err := conn.Read(buf)
+		if err == nil && n != 0 {
+			err = fmt.Errorf("zero-length read returned n=%d, want 0", n)
+		}
+		readDone <- err
+	}()
+	if _, err := server.Write([]byte{0, 0}); err != nil {
+		t.Fatalf("write zero-length frame header: %v", err)
+	}
+	if err := <-readDone; err != nil {
+		t.Fatalf("read zero-length frame: %v", err)
+	}
+}
+
+func TestDialTsnetUDPRelayBoundsDialContext(t *testing.T) {
+	oldLimit := udpRelayHandshakeLimit
+	udpRelayHandshakeLimit = 10 * time.Millisecond
+	t.Cleanup(func() { udpRelayHandshakeLimit = oldLimit })
+
+	start := time.Now()
+	dial := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	_, err := dialTsnetUDPRelay(context.Background(), dial, netip.MustParseAddr("100.64.91.47"), netip.MustParseAddr("100.98.20.53"), "relay-token", "192.0.2.10:9999")
+	if err == nil {
+		t.Fatal("dialTsnetUDPRelay unexpectedly succeeded")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("relay dial returned after %s, want bounded dial timeout", elapsed)
+	}
+}
+
+func TestUDPRelayStreamConnWriteRefreshesIdleReadDeadline(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	conn := newUDPRelayStreamConnWithIdle(client, 30*time.Millisecond)
+	defer func() { _ = conn.Close() }()
+
+	readDone := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 8)
+		n, err := conn.Read(buf)
+		if err != nil {
+			readDone <- err
+			return
+		}
+		if got := string(buf[:n]); got != "ok" {
+			readDone <- fmt.Errorf("read payload = %q, want ok", got)
+			return
+		}
+		readDone <- nil
+	}()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		n, err := conn.Write([]byte("x"))
+		if err == nil && n != 1 {
+			err = fmt.Errorf("write returned n=%d, want 1", n)
+		}
+		writeDone <- err
+	}()
+	var outbound [3]byte
+	if _, err := io.ReadFull(server, outbound[:]); err != nil {
+		t.Fatalf("read outbound frame: %v", err)
+	}
+	if binary.BigEndian.Uint16(outbound[:2]) != 1 || outbound[2] != 'x' {
+		t.Fatalf("outbound frame = %v, want len=1 body=x", outbound)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write outbound frame: %v", err)
+	}
+
+	// Wait past the original read deadline. Write must refresh the shared idle
+	// deadline, otherwise the blocked Read above would time out before this frame.
+	time.Sleep(20 * time.Millisecond)
+	if _, err := server.Write([]byte{0, 2, 'o', 'k'}); err != nil {
+		t.Fatalf("write inbound frame: %v", err)
+	}
+	if err := <-readDone; err != nil {
+		t.Fatalf("read after write-refresh: %v", err)
+	}
+}
+
+func TestDialTsnetUDPRelayFramesDestinationAndDatagrams(t *testing.T) {
+	server, client := net.Pipe()
+	dial := func(context.Context, string, string) (net.Conn, error) { return client, nil }
+	type helloResult struct {
+		dst   netip.AddrPort
+		peer  netip.Addr
+		token string
+		err   error
+	}
+	helloCh := make(chan helloResult, 1)
+	go func() {
+		dst, peer, token, err := readUDPRelayHello(server)
+		helloCh <- helloResult{dst: dst, peer: peer, token: token, err: err}
+	}()
+	conn, err := dialTsnetUDPRelay(context.Background(), dial, netip.MustParseAddr("100.64.91.47"), netip.MustParseAddr("100.98.20.53"), "relay-token", "192.0.2.10:9999")
+	if err != nil {
+		t.Fatalf("dialTsnetUDPRelay: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	res := <-helloCh
+	if res.err != nil {
+		t.Fatalf("read hello: %v", res.err)
+	}
+	if want := netip.MustParseAddrPort("192.0.2.10:9999"); res.dst != want {
+		t.Fatalf("hello dst = %v, want %v", res.dst, want)
+	}
+	if want := netip.MustParseAddr("100.98.20.53"); res.peer != want {
+		t.Fatalf("hello peer = %v, want %v", res.peer, want)
+	}
+	if res.token != "relay-token" {
+		t.Fatalf("hello token = %q, want relay-token", res.token)
+	}
+	frameCh := make(chan error, 1)
+	go func() {
+		var hdr [2]byte
+		if _, err := server.Read(hdr[:]); err != nil {
+			frameCh <- fmt.Errorf("read frame header: %w", err)
+			return
+		}
+		if got := binary.BigEndian.Uint16(hdr[:]); got != 3 {
+			frameCh <- fmt.Errorf("frame length = %d, want 3", got)
+			return
+		}
+		body := make([]byte, 3)
+		if _, err := server.Read(body); err != nil {
+			frameCh <- fmt.Errorf("read frame body: %w", err)
+			return
+		}
+		if string(body) != "abc" {
+			frameCh <- fmt.Errorf("frame body = %q, want abc", body)
+			return
+		}
+		frameCh <- nil
+	}()
+	if _, err := conn.Write([]byte("abc")); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+	if err := <-frameCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestOnboardRegistryWithDB(t *testing.T) (*onboardRegistry, *sql.DB) {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "gateway.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	reg := newOnboardRegistry()
+	if err := reg.Load(db); err != nil {
+		t.Fatalf("onboard Load: %v", err)
+	}
+	return reg, db
+}
+
+func storeDefaultProfileConfig(g *Gateway) {
+	g.cfg.Store(&config.Gateway{Policy: &config.Policy{
+		Profiles: map[string]*config.Profile{"default": {Name: "default"}},
+		Order:    []string{"default"},
+	}})
+}
+
+func authorizedRegistry() *onboardRegistry {
+	reg := newOnboardRegistry()
+	reg.AssignProfile("100.98.20.53", "default")
+	return reg
+}
+
+func startAuthorizedUDPRelay(t *testing.T, g *Gateway, dst netip.AddrPort) net.Conn {
+	t.Helper()
+	return startUDPRelay(t, g, dst, "")
+}
+
+func startUDPRelay(t *testing.T, g *Gateway, dst netip.AddrPort, token string) net.Conn {
+	t.Helper()
+	return startUDPRelayWithPeer(t, g, dst, token, "100.98.20.53", netip.MustParseAddr("100.98.20.53"))
+}
+
+func startUDPRelayWithPeer(t *testing.T, g *Gateway, dst netip.AddrPort, token, remotePeer string, claimedPeer netip.Addr) net.Conn {
+	t.Helper()
+	server, client := net.Pipe()
+	go g.handleTsnetUDPRelayConn(&addrOverrideConn{
+		Conn:  server,
+		raddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort(remotePeer + ":12345")),
+		laddr: net.TCPAddrFromAddrPort(netip.MustParseAddrPort("100.64.91.47:45353")),
+	})
+	if err := writeUDPRelayHello(client, dst, claimedPeer, token); err != nil {
+		t.Fatalf("write relay hello: %v", err)
+	}
+	return newUDPRelayStreamConn(client)
+}
+
+func startUDPEcho(t *testing.T) netip.AddrPort {
+	t.Helper()
+	pc, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("udp echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, addr, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			_, _ = pc.WriteTo(append([]byte("echo:"), buf[:n]...), addr)
+		}
+	}()
+	addr, err := netip.ParseAddrPort(pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("parse echo addr: %v", err)
+	}
+	return addr
+}
+
+func newTestDNSVIP(t *testing.T) *dnsvip.Allocator {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dnsvip.db")
+	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)", path))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE dnsvip_allocations (
+		id INTEGER PRIMARY KEY,
+		hostname TEXT NOT NULL UNIQUE,
+		v4 TEXT NOT NULL UNIQUE,
+		v6 TEXT NOT NULL UNIQUE
+	)`); err != nil {
+		t.Fatalf("create dnsvip table: %v", err)
+	}
+	a, err := dnsvip.New(db, dnsvip.DefaultCIDR4, dnsvip.DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("dnsvip.New: %v", err)
+	}
+	return a
+}
+
+type addrOverrideConn struct {
+	net.Conn
+	raddr net.Addr
+	laddr net.Addr
+}
+
+func (c *addrOverrideConn) RemoteAddr() net.Addr { return c.raddr }
+func (c *addrOverrideConn) LocalAddr() net.Addr  { return c.laddr }

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -28,7 +28,15 @@ no subnet allocation — Tailscale's control plane handles all of that.
 4. All outbound traffic now exits through the gateway. The gateway
    intercepts at L4 — TCP/443 → SNI peek → MITM or splice, everything
    else forwarded via `wgRelay` / `relayUDP`. Tailscale handles NAT
-   traversal and relay (DERP).
+   traversal and relay (DERP). Linux per-process tsnet clients use a
+   Claw Patrol UDP relay over tailnet TCP for child UDP flows because
+   tsnet exposes a TCP fallback hook but no equivalent arbitrary-UDP
+   fallback. The gateway accepts relay streams only from registered
+   onboarded peers or from peers that present the per-peer API token minted
+   during onboarding, attributes them to the peer's profile, applies the
+   same UDP semantics as WireGuard mode (`dnsvip` for UDP/53, transparent
+   relay for other UDP), and then returns datagrams to the child's UDP
+   socket.
 5. Device identity (hostname, OS, Tailscale user) is populated via
    `tailscale whois` at first connection — richer than WireGuard mode
    which only captures hostname at join time.


### PR DESCRIPTION
## Summary

Adds a first-class UDP relay for Linux `clawpatrol run` in tsnet mode. Embedded tsnet exposes a TCP fallback handler but not an equivalent arbitrary-UDP fallback, so child UDP flows now use a Claw Patrol-owned framed stream over tailnet TCP to the gateway instead of relying on unsupported tsnet exit-node UDP routing.

## Architecture

- The Linux run daemon still captures child UDP packets from the per-process gVisor TUN and preserves the child-facing UDP contract.
- For tsnet transports, each child UDP flow opens a bounded tailnet TCP stream to the gateway UDP relay listener.
- The relay hello carries:
  - original UDP destination IP/port,
  - daemon tsnet peer address,
  - the per-peer API token minted during onboarding when needed for first-contact placeholder promotion.
- The gateway accepts relay streams only from already-known onboard peers or peers presenting a valid per-peer onboarding token.
- Placeholder-token promotion mirrors `/api/peer/tsnet/register`, including hostname/profile preservation, while verifying any client-claimed peer address against Tailscale WhoIs before trusting it.
- Gateway UDP dispatch matches existing WG semantics:
  - UDP/53 goes to `dnsvip`.
  - Other UDP goes through existing `relayUDP`.
- TCP forwarding, WG-mode UDP behavior, dashboard/onboarding flows, and existing tsnet state/config are preserved.

## Security notes

- The relay is not an unauthenticated open UDP proxy: unregistered peers without a valid per-peer token are rejected, even when a default profile exists.
- Relay dials and handshakes are bounded to avoid blocking the per-session TUN reader on old gateways, missing listeners, or ACL issues.
- Non-DNS relay streams have server-side idle deadlines that are refreshed by traffic in either direction.
- Zero-length UDP datagrams are preserved.

## Tests / verification run locally

- `autoreview --mode local` → clean, no accepted/actionable findings.
- `git diff --check`
- `go test ./... -count=1`
- `make build`

Focused coverage added for:

- unauthorized relay peer rejection
- malformed relay hello rejection
- unregistered peer rejection even with default profile
- per-peer-token placeholder promotion
- unverified claimed-peer rejection/canonicalization
- registered peer default-profile fallback
- server-side relay idle timeout
- idle deadline refresh from downstream traffic
- zero-length UDP datagrams
- DNS over UDP through relay
- non-DNS UDP echo round-trip
- daemon UDP flow cleanup
- `/api/peer/tsnet/register` hostname-only row guard

## Manual gateway validation pending

This PR needs a matched gateway/client deployment for live validation because the relay is a client+gateway protocol change. The branch has been pushed so the gateway can be upgraded manually, preserving existing config/state. After the gateway is running this branch, validate:

- DNS canaries without `/etc/hosts` wrapper and without `RES_OPTIONS=use-vc`.
- Arbitrary UDP through `clawpatrol run` against a controlled UDP echo server.
- Codex/GitHub DNS canary.

## Rollback

The change is binary-only and preserves existing state/config. To roll back, restore the pre-upgrade gateway/client binaries and restart their existing supervisors. Do not rerun `clawpatrol join` and do not replace gateway state.
