### PR TITLE
tailscale tunnel: OAuth-client auth via oauth_client_secret

### DIFF
--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -105,7 +105,7 @@ gateway {
   state_dir        = "/opt/clawpatrol/ts-state"
 
   tailscale {
-    authkey             = "{{secret:TS_AUTHKEY}}"  # gateway-node auth key
+    authkey             = "tskey-auth-xxxxx"       # gateway-node key; or set $TS_AUTHKEY and omit
     hostname            = "clawpatrol-gateway"     # gateway's name on the tailnet
     tags                = ["tag:client"]           # applied to minted client keys
     oauth_client_id     = "{{secret:TS_OAUTH_CLIENT_ID}}"
@@ -264,7 +264,7 @@ configs don't have to migrate in a hurry:
 
 ```hcl
 tunnel "tailscale" "corp" {
-  authkey   = "{{secret:TS_TUNNEL_CORP_AUTHKEY}}"  # or $CLAWPATROL_TUNNEL_CORP_AUTHKEY
+  authkey   = "tskey-auth-xxxxx"  # or env CLAWPATROL_TUNNEL_CORP_AUTHKEY
   hostname  = "clawpatrol-tunnel-corp"
   state_dir = "/opt/clawpatrol/ts-tunnel-corp"
 }
@@ -274,6 +274,16 @@ endpoint "https" "grafana-internal" {
   tunnel = tailscale.corp
 }
 ```
+
+`{{secret:...}}` expansion runs only on a few gateway fields — the
+`tailscale` block's `oauth_client_id`/`oauth_client_secret` and
+integration OAuth credentials — never on any Tailscale `authkey`
+(gateway or tunnel) or a tunnel's `oauth_client_secret`. A
+`{{secret:...}}` placeholder in one of those would reach tsnet
+verbatim. To keep the value out of the HCL, use the env fallback
+instead: `CLAWPATROL_TUNNEL_<UPPER_NAME>_AUTHKEY` /
+`CLAWPATROL_TUNNEL_<UPPER_NAME>_OAUTH_CLIENT_SECRET` for tunnels, or
+`$TS_AUTHKEY` for the gateway node.
 
 In this mode the tunnel node joins synchronously at gateway startup
 (`tsnet.Up` blocks), reads `authkey` (literal or env fallback), and

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -213,6 +213,48 @@ they then share a single tsnet node identity (one node per credential,
 not per tunnel). Per-tailnet selection (`control_url`) lives on the
 tunnel block, not the credential.
 
+### OAuth client — self-renewing keys, no Connect click
+
+Set `oauth_client_secret` (a `tskey-client-...` secret from an OAuth
+client with the `write:auth_keys` scope) and `tags` on the tunnel.
+tsnet then mints a fresh, short-lived device key from the OAuth client
+on **every** join — first boot, restart, and re-auth after node-key
+expiry — so there is no long-lived auth key that can expire out from
+under the tunnel. This is the recommended mode for unattended gateways:
+unlike the interactive credential flow there is no Connect click, and
+unlike a static `authkey` there is no key to rotate.
+
+```hcl
+credential "tailscale_auth" "corp-tailnet" {}
+
+tunnel "tailscale" "corp" {
+  credential          = tailscale_auth.corp-tailnet
+  oauth_client_secret = "tskey-client-xxxxx"  # or env CLAWPATROL_TUNNEL_CORP_OAUTH_CLIENT_SECRET
+  tags                = ["tag:bot"]            # required — untagged OAuth keys are rejected
+  keepalive           = "always"              # keep the node joined; avoid lazy cold-starts
+}
+```
+
+Notes:
+
+- The secret comes from the HCL field or the per-tunnel env fallback
+  `CLAWPATROL_TUNNEL_<UPPER_NAME>_OAUTH_CLIENT_SECRET` (hyphens folded
+  to underscores), mirroring `authkey`.
+- `tags` are mandatory. Tailscale refuses to mint untagged keys, and an
+  untagged node would be owner-associated (its `whois` returns the OAuth
+  client owner), which could bypass an operator allowlist.
+- clawpatrol appends `?ephemeral=false&preauthorized=true` to the secret
+  so the node persists across restarts and joins without manual
+  approval. Supply your own `?...` query string on the secret to
+  override either default.
+- Pairs with a `credential` block: the credential's SQLite `StateStore`
+  still persists node identity (so steady-state restarts rejoin from
+  cached state), while the OAuth client supplies the key whenever a join
+  actually needs one. The OAuth secret also takes precedence over any
+  ambient `TS_AUTHKEY` in the gateway environment, so a stray static key
+  in the process env can't shadow it.
+- A literal `authkey` (if also set) wins over `oauth_client_secret`.
+
 ### Legacy — literal authkey / env-var fallback
 
 Pre-credential deployments keep working unchanged. The literal

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -240,13 +240,18 @@ Notes:
 - The secret comes from the HCL field or the per-tunnel env fallback
   `CLAWPATROL_TUNNEL_<UPPER_NAME>_OAUTH_CLIENT_SECRET` (hyphens folded
   to underscores), mirroring `authkey`.
-- `tags` are mandatory. Tailscale refuses to mint untagged keys, and an
-  untagged node would be owner-associated (its `whois` returns the OAuth
-  client owner), which could bypass an operator allowlist.
+- `tags` are mandatory here. Tailscale refuses to mint untagged keys,
+  and an untagged node would be owner-associated (its `whois` returns
+  the OAuth client owner), which could bypass an operator allowlist.
+  Note the `tags` field is advertised to tsnet **only** in this OAuth
+  mode — with a static `authkey` or the interactive credential login the
+  node's tags come from the key itself or your tailnet's autoApprovers
+  ACL, and the tunnel's `tags` field is ignored.
 - clawpatrol appends `?ephemeral=false&preauthorized=true` to the secret
   so the node persists across restarts and joins without manual
-  approval. Supply your own `?...` query string on the secret to
-  override either default.
+  approval. Supplying your own `?...` query string replaces **both**
+  defaults — tsnet falls back to `ephemeral=true`, `preauthorized=false`
+  for anything you omit — so re-specify any attribute you want to keep.
 - Pairs with a `credential` block: the credential's SQLite `StateStore`
   still persists node identity (so steady-state restarts rejoin from
   cached state), while the OAuth client supplies the key whenever a join

--- a/internal/config/plugins/tunnels/tailscale.go
+++ b/internal/config/plugins/tunnels/tailscale.go
@@ -41,6 +41,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
+	// Registers the OAuth-client auth-key resolver hook tsnet uses when
+	// a tunnel is configured with `oauth_client_secret` — tsnet exchanges
+	// the `tskey-client-...` secret for a fresh device key on every join.
+	_ "tailscale.com/feature/oauthkey"
 	"tailscale.com/ipn"
 	"tailscale.com/tsnet"
 
@@ -53,6 +57,14 @@ import (
 type TailscaleTunnel struct {
 	// AuthKey is the Tailscale auth key; env fallback is CLAWPATROL_TUNNEL_<NAME>_AUTHKEY.
 	AuthKey string `hcl:"authkey,optional"`
+	// OAuthClientSecret is a Tailscale OAuth client secret
+	// (tskey-client-...). When set, tsnet mints a fresh, short-lived
+	// device key from the OAuth client on every join instead of relying
+	// on a static authkey — so there is no long-lived key that can
+	// expire out from under the tunnel. Requires `tags` (untagged OAuth
+	// keys are rejected by Tailscale). Env fallback is
+	// CLAWPATROL_TUNNEL_<NAME>_OAUTH_CLIENT_SECRET.
+	OAuthClientSecret string `hcl:"oauth_client_secret,optional"`
 	// ControlURL overrides the Tailscale control-plane URL.
 	ControlURL string `hcl:"control_url,optional"`
 	// Hostname is the tsnet node name; defaults to clawpatrol-tunnel-<name>.
@@ -142,8 +154,9 @@ func (t *TailscaleTunnel) Open(ctx context.Context, host runtime.TunnelHost, _ r
 	if authKey == "" {
 		authKey = os.Getenv(envAuthKey(host.Name))
 	}
-	if authKey == "" {
-		return nil, fmt.Errorf("tailscale tunnel %q: no authkey (set HCL `authkey = ...`, env %s, or wire a `credential = ...` reference)", host.Name, envAuthKey(host.Name))
+	oauthSecret := t.oauthClientSecret(host.Name)
+	if authKey == "" && oauthSecret == "" {
+		return nil, fmt.Errorf("tailscale tunnel %q: no auth material (set HCL `authkey`/`oauth_client_secret`, env %s/%s, or wire a `credential = ...` reference)", host.Name, envAuthKey(host.Name), envOAuthClientSecret(host.Name))
 	}
 	stateDir, err := tunnelStateDir(t, host)
 	if err != nil {
@@ -156,6 +169,12 @@ func (t *TailscaleTunnel) Open(ctx context.Context, host runtime.TunnelHost, _ r
 		ControlURL: t.ControlURL,
 		Dir:        stateDir,
 		Logf:       func(f string, args ...any) { logger.Printf(f, args...) },
+	}
+	// A static authkey wins if both are set; otherwise mint via OAuth.
+	if authKey == "" {
+		if err := t.applyOAuth(srv, host.Name, oauthSecret); err != nil {
+			return nil, err
+		}
 	}
 	// Up brings the node online and waits for it to register with
 	// the control plane. Without this, the first Dial after Open
@@ -210,6 +229,19 @@ func (t *TailscaleTunnel) openWithCredential(_ context.Context, host runtime.Tun
 		Store:      store,
 		Dir:        dir,
 		Logf:       func(f string, args ...any) { logger.Printf(f, args...) },
+	}
+	// When the tunnel carries an OAuth client, mint join keys through it
+	// rather than leaning on the persisted StateStore alone. This both
+	// drives the very first join without an interactive Connect click
+	// and, crucially, overrides any ambient TS_AUTHKEY in the gateway
+	// environment that tsnet would otherwise pick up — a static key that
+	// expires (and whose expiry silently breaks re-auth) is exactly the
+	// failure OAuth minting avoids. The StateStore still persists node
+	// identity, so the key only matters on first join and on re-auth.
+	if oauthSecret := t.oauthClientSecret(host.Name); oauthSecret != "" {
+		if err := t.applyOAuth(srv, host.Name, oauthSecret); err != nil {
+			return nil, err
+		}
 	}
 
 	tc := newTailscaleTunnelConn(host.Name, srv, logger)
@@ -409,6 +441,55 @@ func envAuthKey(name string) string {
 	return "CLAWPATROL_TUNNEL_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_AUTHKEY"
 }
 
+// envOAuthClientSecret returns the env-var name for this tunnel's OAuth
+// client-secret fallback, mirroring envAuthKey:
+// CLAWPATROL_TUNNEL_<UPPER_NAME>_OAUTH_CLIENT_SECRET.
+func envOAuthClientSecret(name string) string {
+	return "CLAWPATROL_TUNNEL_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_OAUTH_CLIENT_SECRET"
+}
+
+// oauthClientSecret resolves the tunnel's OAuth client secret from the
+// HCL field, falling back to the per-tunnel env var. Returns "" when
+// neither is set.
+func (t *TailscaleTunnel) oauthClientSecret(name string) string {
+	if t.OAuthClientSecret != "" {
+		return t.OAuthClientSecret
+	}
+	return os.Getenv(envOAuthClientSecret(name))
+}
+
+// oauthSecretWithDefaults appends the device-key attributes a gateway
+// tunnel needs onto a bare OAuth client secret. tsnet's oauthkey
+// resolver defaults to ephemeral=true, preauthorized=false — both wrong
+// here: the credential's StateStore persists node identity across
+// restarts (so the node must not be ephemeral), and there is no
+// operator approval step in the gateway path (so it must be
+// preauthorized). A secret that already carries a `?` query string is
+// left untouched, letting an operator override either default.
+func oauthSecretWithDefaults(secret string) string {
+	if secret == "" || strings.Contains(secret, "?") {
+		return secret
+	}
+	return secret + "?ephemeral=false&preauthorized=true"
+}
+
+// applyOAuth points srv's auth material at the OAuth client secret so
+// tsnet's resolveAuthKey hands it to the oauthkey hook and mints a
+// fresh device key per join. The secret goes in AuthKey (not
+// ClientSecret) deliberately: AuthKey takes precedence over an ambient
+// TS_AUTHKEY in the gateway environment, so a stray static key in the
+// process env can't shadow the OAuth flow. The oauthkey resolver
+// requires non-empty tags, so reject an untagged config up front with a
+// clear error rather than failing deep inside tsnet.Up.
+func (t *TailscaleTunnel) applyOAuth(srv *tsnet.Server, name, secret string) error {
+	if len(t.Tags) == 0 {
+		return fmt.Errorf("tailscale tunnel %q: oauth_client_secret requires `tags` (untagged OAuth keys are rejected by Tailscale)", name)
+	}
+	srv.AuthKey = oauthSecretWithDefaults(secret)
+	srv.AdvertiseTags = t.Tags
+	return nil
+}
+
 func init() {
 	config.Register(&config.Plugin{
 		Kind:    config.KindTunnel,
@@ -421,6 +502,9 @@ func init() {
 			t := body.(*TailscaleTunnel)
 			if t.AuthKey != "" {
 				b.SetAttributeValue("authkey", cty.StringVal(t.AuthKey))
+			}
+			if t.OAuthClientSecret != "" {
+				b.SetAttributeValue("oauth_client_secret", cty.StringVal(t.OAuthClientSecret))
 			}
 			if t.ControlURL != "" {
 				b.SetAttributeValue("control_url", cty.StringVal(t.ControlURL))

--- a/internal/config/plugins/tunnels/tailscale_test.go
+++ b/internal/config/plugins/tunnels/tailscale_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"tailscale.com/tsnet"
+
 	cruntime "github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
@@ -49,5 +51,61 @@ func TestTunnelStateDir_TunnelOverride(t *testing.T) {
 func TestTunnelStateDir_Empty(t *testing.T) {
 	if _, err := tunnelStateDir(&TailscaleTunnel{}, cruntime.TunnelHost{Name: "ts1"}); err == nil {
 		t.Fatal("expected error for empty state_dir")
+	}
+}
+
+func TestOAuthSecretWithDefaults(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"tskey-client-abc", "tskey-client-abc?ephemeral=false&preauthorized=true"},
+		// An operator-supplied query string is preserved verbatim.
+		{"tskey-client-abc?ephemeral=true", "tskey-client-abc?ephemeral=true"},
+	}
+	for _, c := range cases {
+		if got := oauthSecretWithDefaults(c.in); got != c.want {
+			t.Errorf("oauthSecretWithDefaults(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEnvOAuthClientSecret(t *testing.T) {
+	if got, want := envOAuthClientSecret("deno-tailnet-tunnel"), "CLAWPATROL_TUNNEL_DENO_TAILNET_TUNNEL_OAUTH_CLIENT_SECRET"; got != want {
+		t.Errorf("envOAuthClientSecret = %q, want %q", got, want)
+	}
+}
+
+func TestOAuthClientSecretResolution(t *testing.T) {
+	// HCL field wins over the env fallback.
+	t.Setenv("CLAWPATROL_TUNNEL_CORP_OAUTH_CLIENT_SECRET", "from-env")
+	tn := &TailscaleTunnel{OAuthClientSecret: "from-hcl"}
+	if got := tn.oauthClientSecret("corp"); got != "from-hcl" {
+		t.Fatalf("oauthClientSecret = %q, want from-hcl", got)
+	}
+	// Falls back to the per-tunnel env var when the field is empty.
+	if got := (&TailscaleTunnel{}).oauthClientSecret("corp"); got != "from-env" {
+		t.Fatalf("oauthClientSecret (env) = %q, want from-env", got)
+	}
+}
+
+func TestApplyOAuth(t *testing.T) {
+	// Untagged OAuth config is rejected up front — Tailscale refuses to
+	// mint untagged keys, and an untagged node would be owner-associated.
+	if err := (&TailscaleTunnel{}).applyOAuth(&tsnet.Server{}, "corp", "tskey-client-abc"); err == nil {
+		t.Fatal("applyOAuth without tags: expected error, got nil")
+	}
+	// With tags it lands the secret in AuthKey (so an ambient TS_AUTHKEY
+	// can't shadow it) plus the advertised tags.
+	var srv tsnet.Server
+	tn := &TailscaleTunnel{Tags: []string{"tag:bot"}}
+	if err := tn.applyOAuth(&srv, "corp", "tskey-client-abc"); err != nil {
+		t.Fatalf("applyOAuth: %v", err)
+	}
+	if srv.AuthKey != "tskey-client-abc?ephemeral=false&preauthorized=true" {
+		t.Errorf("AuthKey = %q", srv.AuthKey)
+	}
+	if len(srv.AdvertiseTags) != 1 || srv.AdvertiseTags[0] != "tag:bot" {
+		t.Errorf("AdvertiseTags = %v", srv.AdvertiseTags)
 	}
 }

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -671,6 +671,7 @@ Configures the tunnel runtime.
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `authkey` | `string` | no | The Tailscale auth key; env fallback is CLAWPATROL_TUNNEL_<NAME>_AUTHKEY. |
+| `oauth_client_secret` | `string` | no | A Tailscale OAuth client secret (tskey-client-...). When set, tsnet mints a fresh, short-lived device key from the OAuth client on every join instead of relying on a static authkey — so there is no long-lived key that can expire out from under the tunnel. Requires `tags` (untagged OAuth keys are rejected by Tailscale). Env fallback is CLAWPATROL_TUNNEL_<NAME>_OAUTH_CLIENT_SECRET. |
 | `control_url` | `string` | no | Overrides the Tailscale control-plane URL. |
 | `hostname` | `string` | no | The tsnet node name; defaults to clawpatrol-tunnel-<name>. |
 | `state_dir` | `string` | no | Stores tsnet node state; defaults under the gateway CA directory. |


### PR DESCRIPTION
* Add an `oauth_client_secret` field to the `tailscale` tunnel, with
  env fallback `CLAWPATROL_TUNNEL_<NAME>_OAUTH_CLIENT_SECRET`
  (mirroring `authkey`). When set, the `tskey-client-...` secret is
  handed to tsnet so its `oauthkey` resolver mints a fresh,
  short-lived device key on every join and re-auth — there is no
  long-lived key to expire.
* Until now a tunnel could authenticate only via a static `authkey`
  or the interactive credential login, both of which leave a
  long-lived key. When that key expires or is revoked, every join
  fails with `invalid key: API key does not exist` and tsnet emits no
  login URL, so the dashboard Connect card cannot recover it — an
  unattended-gateway footgun.
* The secret is set on `tsnet.Server.AuthKey` (not `ClientSecret`) so
  it takes precedence over an ambient `TS_AUTHKEY` in the gateway
  environment that would otherwise shadow the OAuth flow.
* Requires `tags` — Tailscale rejects untagged keys, and an untagged
  node is owner-associated. clawpatrol appends
  `?ephemeral=false&preauthorized=true` so the node persists and joins
  without manual approval; an explicit query string overrides.
* Works alongside a `credential` block (its SQLite `StateStore` still
  persists node identity) and a literal `authkey` (which wins if both
  are set). Registers `tailscale.com/feature/oauthkey` for the
  resolver hook; no new module dependencies.
* Adds unit tests for the helpers and a doc section in
  `doc/tailscale.md`.
