### PR TITLE
tailscale tunnel: wait for lazy re-join instead of failing the dial

### DIFF
--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -231,9 +231,14 @@ tunnel "tailscale" "corp" {
   credential          = tailscale_auth.corp-tailnet
   oauth_client_secret = "tskey-client-xxxxx"  # or env CLAWPATROL_TUNNEL_CORP_OAUTH_CLIENT_SECRET
   tags                = ["tag:bot"]            # required — untagged OAuth keys are rejected
-  keepalive           = "always"              # keep the node joined; avoid lazy cold-starts
+  keepalive           = "5m"                  # optional: keep warm to skip the ~1s rejoin on sparse traffic
 }
 ```
+
+A dial that lands while the tunnel is mid-(re)join waits for the join
+to finish rather than failing, so `keepalive` is a latency optimisation
+(skip the ~1s rejoin), not a correctness requirement. Pick a duration;
+`"always"` pins the node forever, which is rarely what you want.
 
 Notes:
 

--- a/internal/config/plugins/tunnels/tailscale.go
+++ b/internal/config/plugins/tunnels/tailscale.go
@@ -38,6 +38,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -292,28 +293,50 @@ func newTailscaleTunnelConn(name string, srv *tsnet.Server, logger *log.Logger) 
 	}
 }
 
-// Dial routes through the embedded tsnet node. For credential-driven
-// tunnels in the pending-auth window, returns a clear "node not
-// connected" error so the dashboard's pending integrations list reads
-// correctly; the literal-authkey path is always already joined.
+// tunnelJoinWait bounds how long Dial blocks waiting for a still-joining
+// tunnel before giving up. A credential/OAuth tunnel that idled out and
+// re-opened lazily rejoins from cached state in ~1s; this window covers a
+// slow control-plane/DERP handshake while staying short enough that a
+// credential blocked on interactive operator sign-in (which may never
+// complete) fails fast with the actionable error. A var, not a const, so
+// tests can shorten it.
+var tunnelJoinWait = 15 * time.Second
+
+// Dial routes through the embedded tsnet node. Tunnels open lazily and
+// close on idle, so the first dial after a teardown lands while the
+// background Up is still joining; rather than racing it and returning a
+// spurious "node not connected", wait up to tunnelJoinWait for the join
+// to finish. The literal-authkey path pre-closes joined, so it falls
+// straight through. A credential still in the interactive pending-auth
+// window never closes joined, so it times out into the clear "visit
+// dashboard" error the integrations list keys off.
 func (t *tailscaleTunnelConn) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
 	if t.srv == nil {
 		return nil, errors.New("tailscale tunnel closed")
 	}
 	select {
 	case <-t.joined:
-		if e := t.upErr.Load(); e != nil {
-			if err, ok := e.(error); ok && err != nil {
-				return nil, err
-			}
-		}
-		return t.srv.Dial(ctx, network, addr)
+		// Already joined — fall through to the dial below.
 	default:
-		if t.credential != "" {
-			return nil, fmt.Errorf("tailscale tunnel %q: node not connected — visit dashboard to complete %q sign-in", t.name, t.credential)
+		timer := time.NewTimer(tunnelJoinWait)
+		defer timer.Stop()
+		select {
+		case <-t.joined:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+			if t.credential != "" {
+				return nil, fmt.Errorf("tailscale tunnel %q: node not connected — visit dashboard to complete %q sign-in", t.name, t.credential)
+			}
+			return nil, fmt.Errorf("tailscale tunnel %q: still joining", t.name)
 		}
-		return nil, fmt.Errorf("tailscale tunnel %q: still joining", t.name)
 	}
+	if e := t.upErr.Load(); e != nil {
+		if err, ok := e.(error); ok && err != nil {
+			return nil, err
+		}
+	}
+	return t.srv.Dial(ctx, network, addr)
 }
 
 // CredentialName implements runtime.TunnelCredentialNamer so the

--- a/internal/config/plugins/tunnels/tailscale_test.go
+++ b/internal/config/plugins/tunnels/tailscale_test.go
@@ -1,9 +1,13 @@
 package tunnels
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"tailscale.com/tsnet"
 
@@ -107,5 +111,82 @@ func TestApplyOAuth(t *testing.T) {
 	}
 	if len(srv.AdvertiseTags) != 1 || srv.AdvertiseTags[0] != "tag:bot" {
 		t.Errorf("AdvertiseTags = %v", srv.AdvertiseTags)
+	}
+}
+
+func TestDialClosedServer(t *testing.T) {
+	tc := &tailscaleTunnelConn{joined: make(chan struct{})}
+	if _, err := tc.Dial(context.Background(), "tcp", "x:1"); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("want tunnel-closed error, got %v", err)
+	}
+}
+
+func TestDialReturnsUpErrAfterJoin(t *testing.T) {
+	// joined already closed with a permanent up error: Dial surfaces it
+	// without touching srv.Dial.
+	tc := &tailscaleTunnelConn{name: "corp", srv: &tsnet.Server{}, joined: make(chan struct{})}
+	tc.upErr.Store(errors.New("up boom"))
+	close(tc.joined)
+	if _, err := tc.Dial(context.Background(), "tcp", "x:1"); err == nil || !strings.Contains(err.Error(), "up boom") {
+		t.Fatalf("want up boom, got %v", err)
+	}
+}
+
+func TestDialCtxCancelWhileJoining(t *testing.T) {
+	tc := &tailscaleTunnelConn{name: "corp", srv: &tsnet.Server{}, joined: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if _, err := tc.Dial(ctx, "tcp", "x:1"); err != context.Canceled {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if d := time.Since(start); d > time.Second {
+		t.Fatalf("ctx-cancel dial did not return promptly: %v", d)
+	}
+}
+
+func TestDialTimesOutToActionableError(t *testing.T) {
+	old := tunnelJoinWait
+	tunnelJoinWait = 20 * time.Millisecond
+	defer func() { tunnelJoinWait = old }()
+
+	// credential variant -> "node not connected" dashboard hint
+	cred := &tailscaleTunnelConn{name: "corp", credential: "corp-tailnet", srv: &tsnet.Server{}, joined: make(chan struct{})}
+	if _, err := cred.Dial(context.Background(), "tcp", "x:1"); err == nil || !strings.Contains(err.Error(), "node not connected") {
+		t.Fatalf("want node-not-connected, got %v", err)
+	}
+	// literal-authkey variant (no credential) -> "still joining"
+	auth := &tailscaleTunnelConn{name: "corp", srv: &tsnet.Server{}, joined: make(chan struct{})}
+	if _, err := auth.Dial(context.Background(), "tcp", "x:1"); err == nil || !strings.Contains(err.Error(), "still joining") {
+		t.Fatalf("want still-joining, got %v", err)
+	}
+}
+
+func TestDialWaitsForLateJoin(t *testing.T) {
+	// The fix: a dial that lands while the tunnel is still joining waits
+	// for the join instead of failing fast. joined closes ~30ms in; Dial
+	// must block until then (not return immediately) and then proceed past
+	// the join gate (observed here via the up error it surfaces).
+	old := tunnelJoinWait
+	tunnelJoinWait = 2 * time.Second
+	defer func() { tunnelJoinWait = old }()
+
+	tc := &tailscaleTunnelConn{name: "corp", srv: &tsnet.Server{}, joined: make(chan struct{})}
+	tc.upErr.Store(errors.New("joined late"))
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		close(tc.joined)
+	}()
+	start := time.Now()
+	_, err := tc.Dial(context.Background(), "tcp", "x:1")
+	d := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "joined late") {
+		t.Fatalf("want late up error after waiting, got %v", err)
+	}
+	if d < 25*time.Millisecond {
+		t.Fatalf("Dial returned before the join completed (%v) — it did not wait", d)
+	}
+	if d >= tunnelJoinWait {
+		t.Fatalf("Dial hit the timeout (%v) instead of returning when joined closed", d)
 	}
 }

--- a/internal/config/plugins/tunnels/tailscale_test.go
+++ b/internal/config/plugins/tunnels/tailscale_test.go
@@ -137,7 +137,7 @@ func TestDialCtxCancelWhileJoining(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	start := time.Now()
-	if _, err := tc.Dial(ctx, "tcp", "x:1"); err != context.Canceled {
+	if _, err := tc.Dial(ctx, "tcp", "x:1"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled, got %v", err)
 	}
 	if d := time.Since(start); d > time.Second {


### PR DESCRIPTION
* The first dial after an idle tunnel teardown re-opens the tunnel and
  lands while the background tsnet `Up` is still joining (~1s). `Dial`
  did a non-blocking check and returned `node not connected`
  immediately, so sparse-traffic endpoints (e.g. the ClickHouse o11y
  tunnel) saw spurious failures. `keepalive = "always"` was the
  workaround — it just prevents the teardown so the race never fires.
* `Dial` now waits up to `tunnelJoinWait` (15s) for an in-progress join
  to complete before giving up. The literal-authkey path pre-closes
  `joined` and falls straight through (no behavior change); a credential
  still in the interactive pending-auth window never closes `joined` and
  times out into the same actionable "visit dashboard" error as before.
* With the race fixed, `keepalive` becomes a latency optimisation (skip
  the ~1s rejoin on sparse traffic), not a correctness requirement —
  doc updated accordingly.
* Tests cover the closed-server, up-error, ctx-cancel, timeout (both
  credential and authkey variants), and the wait-for-late-join paths.

Stacks on #641 (needs the OAuth tunnel changes that touch the same
file); retarget to main once that lands.
