### PR TITLE
aws_credential: re-sign non-EKS proxied requests + inject placeholder AWS env vars

### DIFF
--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -127,6 +127,7 @@ func caPathPushdownVars(caPath string) []pushdownEnvVar {
 		"GIT_SSL_CAINFO",
 		"DENO_CERT",
 		"PIP_CERT",
+		"AWS_CA_BUNDLE",
 	}
 	out := make([]pushdownEnvVar, 0, len(keys))
 	for _, k := range keys {

--- a/internal/config/plugins/credentials/aws.go
+++ b/internal/config/plugins/credentials/aws.go
@@ -17,10 +17,14 @@ package credentials
 // Either way the agent never sees real credentials.
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -39,9 +43,14 @@ import (
 )
 
 // emptyPayloadHash is the SHA-256 of the empty string — the SigV4
-// payload hash the signer requires when an incoming request carried no
-// X-Amz-Content-Sha256 header to reuse.
+// payload hash for a request with no body.
 const emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+// unsignedPayload is the SigV4 sentinel that omits the body from the
+// canonical request's payload hash. S3 emits it as a literal
+// X-Amz-Content-Sha256 header for streaming / chunked uploads; we also
+// fall back to it for non-S3 bodies too large to buffer for hashing.
+const unsignedPayload = "UNSIGNED-PAYLOAD"
 
 // AWSCredential is part of the clawpatrol plugin API.
 //
@@ -111,11 +120,24 @@ func (c *AWSCredential) reSignProxiedRequest(ctx context.Context, req *http.Requ
 		return fmt.Errorf("aws_credential: cannot derive service/region for %q (no SigV4 credential scope and unrecognized host)", req.URL.Host)
 	}
 
-	// Reuse the hash the agent already computed and signed over rather
-	// than recomputing from the (possibly already-consumed) body.
+	// Determine the SigV4 payload hash the agent signed over.
+	//
+	// botocore only puts X-Amz-Content-Sha256 on the wire for S3
+	// (S3SigV4Auth); every other service still signs over SHA256(body)
+	// in its canonical request but sends no such header. So:
+	//   header present → reuse it verbatim. It's the value the client
+	//     signed over and may be one we cannot recompute from the body
+	//     (S3 UNSIGNED-PAYLOAD, a streaming-chunked literal, …).
+	//   header absent  → the client signed over SHA256(body); recompute
+	//     it from the actual body so the canonical requests agree. The
+	//     old empty-string fallback broke every non-S3 service with a
+	//     body (STS, IAM, DynamoDB, …) with SignatureDoesNotMatch.
 	payloadHash := req.Header.Get("X-Amz-Content-Sha256")
 	if payloadHash == "" {
-		payloadHash = emptyPayloadHash
+		payloadHash, err = hashRequestBody(req)
+		if err != nil {
+			return fmt.Errorf("aws_credential: hash %s request body: %w", service, err)
+		}
 	}
 
 	// Drop the agent's placeholder signature + any session token it
@@ -129,6 +151,42 @@ func (c *AWSCredential) reSignProxiedRequest(ctx context.Context, req *http.Requ
 		return fmt.Errorf("aws_credential: re-sign %s request: %w", service, err)
 	}
 	return nil
+}
+
+// hashRequestBody computes the SigV4 payload hash over req.Body — what
+// botocore's base SigV4Auth signs over for non-S3 services — and
+// restores the body so the upstream send is unchanged. A nil/empty body
+// hashes to SHA256(""). Bodies over the buffer cap return
+// UNSIGNED-PAYLOAD rather than buffering unbounded memory; the gateway
+// terminates TLS, so transport integrity still covers the streamed body.
+func hashRequestBody(req *http.Request) (string, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return emptyPayloadHash, nil
+	}
+	// The gateway already buffers POST/PUT/PATCH bodies up to this cap
+	// for the rules engine before we sign, so for the path that needs a
+	// recomputed hash (non-S3 bodies) the bytes are typically in memory
+	// already — reading here is cheap.
+	const limit = config.DefaultBodyBufferLimit
+	orig := req.Body
+	buf, err := io.ReadAll(io.LimitReader(orig, limit+1))
+	if err != nil {
+		return "", err
+	}
+	if int64(len(buf)) > limit {
+		// Over the cap: don't buffer the rest. Stitch the bytes we
+		// peeked back ahead of the untouched remainder and sign
+		// UNSIGNED-PAYLOAD.
+		req.Body = struct {
+			io.Reader
+			io.Closer
+		}{io.MultiReader(bytes.NewReader(buf), orig), orig}
+		return unsignedPayload, nil
+	}
+	sum := sha256.Sum256(buf)
+	req.Body = io.NopCloser(bytes.NewReader(buf))
+	req.ContentLength = int64(len(buf))
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // awsServiceRegion derives the SigV4 service + region for re-signing. It

--- a/internal/config/plugins/credentials/aws.go
+++ b/internal/config/plugins/credentials/aws.go
@@ -1,24 +1,33 @@
 package credentials
 
 // aws_credential: static AWS API credentials (access key + secret +
-// optional session token) used to mint an EKS-style bearer token for
-// the kubernetes endpoint. At inject time the gateway calls STS
-// GetCallerIdentity via aws-sdk-go-v2's presigner with the
-// `x-k8s-aws-id` header carrying the cluster name; the presigned URL
-// is base64url-encoded as `k8s-aws-v1.<url>` and stamped as the
-// upstream Authorization. The agent never sees real credentials.
+// optional session token). Two jobs:
 //
-// Only the kubernetes endpoint consumes this credential today. Generic
-// SigV4-signed API calls (DynamoDB, S3, etc.) are out of scope.
+//  1. EKS bearer: when bound to a kubernetes endpoint the gateway calls
+//     STS GetCallerIdentity via aws-sdk-go-v2's presigner with the
+//     `x-k8s-aws-id` header carrying the cluster name; the presigned URL
+//     is base64url-encoded as `k8s-aws-v1.<url>` and stamped as the
+//     upstream Authorization.
+//
+//  2. SigV4 re-signing: when bound to a plain `("https" "aws")` endpoint
+//     the agent's aws-cli signs the request with injected placeholder
+//     creds (see EnvVars); the gateway strips that signature and re-signs
+//     with the operator's real stored creds (see reSignProxiedRequest).
+//
+// Either way the agent never sees real credentials.
 
 import (
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
@@ -28,6 +37,11 @@ import (
 	"github.com/denoland/clawpatrol/internal/config"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
+
+// emptyPayloadHash is the SHA-256 of the empty string — the SigV4
+// payload hash the signer requires when an incoming request carried no
+// X-Amz-Content-Sha256 header to reuse.
+const emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 // AWSCredential is part of the clawpatrol plugin API.
 //
@@ -49,7 +63,10 @@ type awsEKSParams interface {
 func (c *AWSCredential) SignHTTPRequest(ctx context.Context, req *http.Request, sec runtime.Secret, endpoint any) error {
 	params, ok := endpoint.(awsEKSParams)
 	if !ok {
-		return errors.New("aws_credential: endpoint does not declare EKS auth params (use `endpoint \"kubernetes\"` with cluster_name + region)")
+		// Non-EKS endpoint (a plain `("https" "aws")` upstream): the
+		// agent already produced a SigV4 signature with placeholder
+		// creds — replace it with one minted from the real stored creds.
+		return c.reSignProxiedRequest(ctx, req, sec)
 	}
 	cluster, region := params.AWSEKSAuthParams()
 	if cluster == "" || region == "" {
@@ -76,6 +93,97 @@ func (*AWSCredential) MintEKSBearer(ctx context.Context, sec runtime.Secret, reg
 		return "", err
 	}
 	return mintEKSBearerToken(ctx, akid, secret, token, region, cluster)
+}
+
+// reSignProxiedRequest replaces the agent's placeholder-cred SigV4
+// signature with one minted from the operator's real stored creds. The
+// agent's aws-cli already canonicalized the request (host, x-amz-date,
+// x-amz-content-sha256, …); we strip its auth headers and re-sign in
+// place so the upstream sees a request signed by real credentials.
+func (c *AWSCredential) reSignProxiedRequest(ctx context.Context, req *http.Request, sec runtime.Secret) error {
+	akid, secret, token, err := awsCredentialMaterial(sec)
+	if err != nil {
+		return err
+	}
+
+	service, region := awsServiceRegion(req.Header.Get("Authorization"), req.URL.Host)
+	if service == "" || region == "" {
+		return fmt.Errorf("aws_credential: cannot derive service/region for %q (no SigV4 credential scope and unrecognized host)", req.URL.Host)
+	}
+
+	// Reuse the hash the agent already computed and signed over rather
+	// than recomputing from the (possibly already-consumed) body.
+	payloadHash := req.Header.Get("X-Amz-Content-Sha256")
+	if payloadHash == "" {
+		payloadHash = emptyPayloadHash
+	}
+
+	// Drop the agent's placeholder signature + any session token it
+	// carried; SignHTTP re-stamps Authorization (and X-Amz-Security-Token
+	// when our creds are STS-issued).
+	req.Header.Del("Authorization")
+	req.Header.Del("X-Amz-Security-Token")
+
+	creds := aws.Credentials{AccessKeyID: akid, SecretAccessKey: secret, SessionToken: token}
+	if err := v4.NewSigner().SignHTTP(ctx, creds, req, payloadHash, service, region, time.Now()); err != nil {
+		return fmt.Errorf("aws_credential: re-sign %s request: %w", service, err)
+	}
+	return nil
+}
+
+// awsServiceRegion derives the SigV4 service + region for re-signing. It
+// prefers the credential scope the agent baked into the incoming
+// Authorization header (Credential=AKID/<date>/<region>/<service>/aws4_request)
+// — exactly what aws-cli computed for this request — and falls back to
+// the upstream hostname when that header is absent or unparseable.
+func awsServiceRegion(authHeader, host string) (service, region string) {
+	if svc, reg := parseSigV4CredentialScope(authHeader); svc != "" && reg != "" {
+		return svc, reg
+	}
+	return serviceRegionFromHost(host)
+}
+
+// parseSigV4CredentialScope pulls service + region out of a SigV4
+// Authorization header's `Credential=` element. Returns empty strings
+// when the header is missing or doesn't match the expected shape.
+func parseSigV4CredentialScope(authHeader string) (service, region string) {
+	const marker = "Credential="
+	i := strings.Index(authHeader, marker)
+	if i < 0 {
+		return "", ""
+	}
+	scope := authHeader[i+len(marker):]
+	// The scope ends at the first comma or space (SignedHeaders follows).
+	if j := strings.IndexAny(scope, ", "); j >= 0 {
+		scope = scope[:j]
+	}
+	// AKID / date / region / service / aws4_request
+	parts := strings.Split(scope, "/")
+	if len(parts) != 5 || parts[4] != "aws4_request" {
+		return "", ""
+	}
+	return parts[3], parts[2]
+}
+
+// serviceRegionFromHost recovers service + region from a standard AWS
+// endpoint hostname: `service.region.amazonaws.com`, or
+// `service.amazonaws.com` for global endpoints (iam, sts, …) which AWS
+// treats as us-east-1.
+func serviceRegionFromHost(host string) (service, region string) {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimSuffix(host, ".amazonaws.com")
+	if host == "" {
+		return "", ""
+	}
+	labels := strings.Split(host, ".")
+	service = labels[0]
+	if len(labels) >= 2 {
+		region = labels[len(labels)-1]
+		return service, region
+	}
+	return service, "us-east-1"
 }
 
 // awsCredentialMaterial reads the three secret slots. access_key_id
@@ -159,9 +267,26 @@ func (*AWSCredential) SecretSlots() []config.SecretSlot {
 	}
 }
 
+// EnvVars is part of the clawpatrol plugin API.
+//
+// Mirrors the Anthropic OAuth credential's pushdown (see
+// anthropic_oauth.go): aws-cli and the AWS SDKs read credentials out of
+// the process environment, so `clawpatrol env` exports placeholders that
+// satisfy local SigV4 signing. The gateway re-signs the proxied request
+// with the operator's real stored creds at MITM time (reSignProxiedRequest),
+// so these placeholder bytes never authenticate anything upstream.
+func (*AWSCredential) EnvVars() []config.EnvVar {
+	return []config.EnvVar{
+		{Name: "AWS_ACCESS_KEY_ID", Value: phAWSKeyID, Description: "aws-cli / AWS SDKs (placeholder; gateway re-signs)"},
+		{Name: "AWS_SECRET_ACCESS_KEY", Value: phAWSSecret, Description: "aws-cli / AWS SDKs (placeholder; gateway re-signs)"},
+		{Name: "AWS_DEFAULT_REGION", Value: "us-east-1", Description: "aws-cli default region (overridable per call)"},
+	}
+}
+
 func init() {
 	var _ runtime.HTTPRequestSigner = (*AWSCredential)(nil)
 	var _ runtime.EKSBearerMinter = (*AWSCredential)(nil)
+	var _ config.EnvPushdownProvider = (*AWSCredential)(nil)
 	config.Register(&config.Plugin{
 		Kind:    config.KindCredential,
 		Type:    "aws_credential",

--- a/internal/config/plugins/credentials/aws_test.go
+++ b/internal/config/plugins/credentials/aws_test.go
@@ -2,12 +2,16 @@ package credentials
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/denoland/clawpatrol/internal/config"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
@@ -124,6 +128,111 @@ func TestAWSCredentialReSignsNonEKSRequest(t *testing.T) {
 	if got := req.Header.Get("X-Amz-Content-Sha256"); got != contentHash {
 		t.Errorf("X-Amz-Content-Sha256 = %q, want reused %q", got, contentHash)
 	}
+}
+
+// TestAWSCredentialReSignsNonEKSRequestNoContentHashHeader mirrors the
+// reviewer's repro: a non-S3 POST (sts get-caller-identity) whose client
+// (botocore's base SigV4Auth) signs over SHA256(body) but sends no
+// X-Amz-Content-Sha256 header. The gateway must recompute the hash from
+// the body, not fall back to SHA256(""), or AWS rejects with
+// SignatureDoesNotMatch. The body must also survive for the upstream send.
+func TestAWSCredentialReSignsNonEKSRequestNoContentHashHeader(t *testing.T) {
+	cred := &AWSCredential{}
+	const body = "Action=GetCallerIdentity&Version=2011-06-15"
+	req, err := http.NewRequest("POST", "https://sts.amazonaws.com/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// Scope present, but deliberately NO X-Amz-Content-Sha256 header.
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIACLAWPATROLPLACE0/20260609/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date, Signature=deadbeef")
+
+	sec := runtime.Secret{Extras: map[string]string{
+		"access_key_id":     "AKIDEXAMPLE",
+		"secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+	}}
+	if err := cred.SignHTTPRequest(context.Background(), req, sec, struct{}{}); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") || strings.Contains(auth, "deadbeef") {
+		t.Fatalf("Authorization = %q, want a fresh SigV4 signature", auth)
+	}
+	rest, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(rest) != body {
+		t.Errorf("restored body = %q, want %q", rest, body)
+	}
+}
+
+// TestHashRequestBody covers the no-header payload-hash path directly:
+// a non-empty body hashes to SHA256(body) (the bug used SHA256("")), an
+// empty/absent body hashes to the empty-payload constant, and an
+// over-cap body falls back to UNSIGNED-PAYLOAD with the full body
+// preserved. Every case must leave req.Body readable for the send.
+func TestHashRequestBody(t *testing.T) {
+	t.Run("non-empty body hashes the body", func(t *testing.T) {
+		const body = "Action=GetCallerIdentity&Version=2011-06-15"
+		req, err := http.NewRequest("POST", "https://sts.amazonaws.com/", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		got, err := hashRequestBody(req)
+		if err != nil {
+			t.Fatalf("hashRequestBody: %v", err)
+		}
+		sum := sha256.Sum256([]byte(body))
+		if want := hex.EncodeToString(sum[:]); got != want {
+			t.Errorf("hash = %q, want SHA256(body) %q", got, want)
+		}
+		if got == emptyPayloadHash {
+			t.Error("fell back to the empty-payload hash for a non-empty body")
+		}
+		rest, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read restored body: %v", err)
+		}
+		if string(rest) != body {
+			t.Errorf("restored body = %q, want %q", rest, body)
+		}
+	})
+
+	t.Run("nil body hashes empty", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "https://sts.amazonaws.com/", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		got, err := hashRequestBody(req)
+		if err != nil {
+			t.Fatalf("hashRequestBody: %v", err)
+		}
+		if got != emptyPayloadHash {
+			t.Errorf("hash = %q, want empty-payload hash %q", got, emptyPayloadHash)
+		}
+	})
+
+	t.Run("over-cap body is UNSIGNED-PAYLOAD with body preserved", func(t *testing.T) {
+		big := strings.Repeat("a", int(config.DefaultBodyBufferLimit)+512)
+		req, err := http.NewRequest("PUT", "https://example.amazonaws.com/", strings.NewReader(big))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		got, err := hashRequestBody(req)
+		if err != nil {
+			t.Fatalf("hashRequestBody: %v", err)
+		}
+		if got != unsignedPayload {
+			t.Errorf("hash = %q, want %q for an over-cap body", got, unsignedPayload)
+		}
+		rest, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read restored body: %v", err)
+		}
+		if len(rest) != len(big) {
+			t.Errorf("restored body length = %d, want %d (full body must survive)", len(rest), len(big))
+		}
+	})
 }
 
 // TestAWSCredentialReSignFallsBackToHost covers the path where the

--- a/internal/config/plugins/credentials/aws_test.go
+++ b/internal/config/plugins/credentials/aws_test.go
@@ -76,17 +76,140 @@ func TestAWSCredentialSignHTTPRequestEmitsEKSBearer(t *testing.T) {
 	}
 }
 
-func TestAWSCredentialSignHTTPRequestRejectsNonEKSEndpoint(t *testing.T) {
+// TestAWSCredentialReSignsNonEKSRequest verifies that a proxied
+// `*.amazonaws.com` request bound to a non-EKS endpoint is re-signed
+// with the gateway's creds: the client's placeholder Authorization /
+// X-Amz-Security-Token are replaced, service + region come from the
+// incoming credential scope, and the reused content hash is signed over.
+func TestAWSCredentialReSignsNonEKSRequest(t *testing.T) {
 	cred := &AWSCredential{}
-	req, err := http.NewRequest("GET", "https://example/", nil)
+	req, err := http.NewRequest("POST", "https://dynamodb.eu-west-1.amazonaws.com/", strings.NewReader("{}"))
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	err = cred.SignHTTPRequest(context.Background(), req, runtime.Secret{
-		Extras: map[string]string{"access_key_id": "x", "secret_access_key": "y"},
-	}, struct{}{})
-	if err == nil || !strings.Contains(err.Error(), "kubernetes") {
-		t.Fatalf("err = %v, want one mentioning kubernetes endpoint", err)
+	const contentHash = "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+	// The agent's aws-cli signed with placeholder creds: scope names the
+	// real service (dynamodb) + region (us-west-2), which must win over
+	// the hostname's eu-west-1.
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIACLAWPATROLPLACE0/20260609/us-west-2/dynamodb/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=deadbeef")
+	req.Header.Set("X-Amz-Content-Sha256", contentHash)
+	req.Header.Set("X-Amz-Security-Token", "placeholder-session-token")
+
+	sec := runtime.Secret{Extras: map[string]string{
+		"access_key_id":     "AKIDEXAMPLE",
+		"secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+	}}
+	if err := cred.SignHTTPRequest(context.Background(), req, sec, struct{}{}); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") {
+		t.Fatalf("Authorization = %q, want a fresh SigV4 signature", auth)
+	}
+	if strings.Contains(auth, "deadbeef") {
+		t.Errorf("Authorization still carries the client signature: %q", auth)
+	}
+	if got := "AKIDEXAMPLE/"; !strings.Contains(auth, "Credential="+got) {
+		t.Errorf("Authorization = %q, want gateway key %q in credential scope", auth, got)
+	}
+	if !strings.Contains(auth, "/us-west-2/dynamodb/aws4_request") {
+		t.Errorf("Authorization = %q, want scope from the incoming credential header (us-west-2/dynamodb)", auth)
+	}
+	// Real creds carry no session token → the placeholder one must be gone.
+	if tok := req.Header.Get("X-Amz-Security-Token"); tok != "" {
+		t.Errorf("X-Amz-Security-Token = %q, want it stripped", tok)
+	}
+	// The content hash the agent signed over must be reused verbatim.
+	if got := req.Header.Get("X-Amz-Content-Sha256"); got != contentHash {
+		t.Errorf("X-Amz-Content-Sha256 = %q, want reused %q", got, contentHash)
+	}
+}
+
+// TestAWSCredentialReSignFallsBackToHost covers the path where the
+// incoming request has no parseable SigV4 credential scope, so service +
+// region must be recovered from the hostname.
+func TestAWSCredentialReSignFallsBackToHost(t *testing.T) {
+	cred := &AWSCredential{}
+	req, err := http.NewRequest("GET", "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// No Authorization header → forces the hostname fallback.
+	sec := runtime.Secret{Extras: map[string]string{
+		"access_key_id":     "AKIDEXAMPLE",
+		"secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		"session_token":     "FwoGZXIvYXdzEXAMPLE",
+	}}
+	if err := cred.SignHTTPRequest(context.Background(), req, sec, struct{}{}); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	// sts.amazonaws.com is a global endpoint → service sts, region us-east-1.
+	if !strings.Contains(auth, "/us-east-1/sts/aws4_request") {
+		t.Errorf("Authorization = %q, want host-derived scope us-east-1/sts", auth)
+	}
+	// STS-issued gateway creds carry a session token → signer must stamp it.
+	if tok := req.Header.Get("X-Amz-Security-Token"); tok != "FwoGZXIvYXdzEXAMPLE" {
+		t.Errorf("X-Amz-Security-Token = %q, want the gateway session token", tok)
+	}
+}
+
+func TestParseSigV4CredentialScope(t *testing.T) {
+	cases := []struct {
+		name, header, svc, reg string
+	}{
+		{"well-formed", "AWS4-HMAC-SHA256 Credential=AKID/20260609/ap-south-1/s3/aws4_request, SignedHeaders=host, Signature=abc", "s3", "ap-south-1"},
+		{"missing", "Bearer something", "", ""},
+		{"truncated scope", "AWS4-HMAC-SHA256 Credential=AKID/20260609/s3, SignedHeaders=host", "", ""},
+		{"not aws4_request", "AWS4-HMAC-SHA256 Credential=AKID/20260609/ap-south-1/s3/v2_request, Signature=abc", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, reg := parseSigV4CredentialScope(tc.header)
+			if svc != tc.svc || reg != tc.reg {
+				t.Errorf("parseSigV4CredentialScope(%q) = (%q,%q), want (%q,%q)", tc.header, svc, reg, tc.svc, tc.reg)
+			}
+		})
+	}
+}
+
+func TestServiceRegionFromHost(t *testing.T) {
+	cases := []struct {
+		host, svc, reg string
+	}{
+		{"sts.us-west-2.amazonaws.com", "sts", "us-west-2"},
+		{"dynamodb.eu-central-1.amazonaws.com", "dynamodb", "eu-central-1"},
+		{"iam.amazonaws.com", "iam", "us-east-1"},
+		{"sts.amazonaws.com:443", "sts", "us-east-1"},
+		{"not-an-aws-host", "not-an-aws-host", "us-east-1"},
+	}
+	for _, tc := range cases {
+		svc, reg := serviceRegionFromHost(tc.host)
+		if svc != tc.svc || reg != tc.reg {
+			t.Errorf("serviceRegionFromHost(%q) = (%q,%q), want (%q,%q)", tc.host, svc, reg, tc.svc, tc.reg)
+		}
+	}
+}
+
+// TestAWSCredentialEnvVarsMirrorsAnthropic asserts the aws credential
+// auto-injects placeholder env vars the same way anthropic_oauth does.
+func TestAWSCredentialEnvVarsMirrorsAnthropic(t *testing.T) {
+	got := map[string]string{}
+	for _, ev := range (&AWSCredential{}).EnvVars() {
+		got[ev.Name] = ev.Value
+	}
+	for _, name := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"} {
+		if got[name] == "" {
+			t.Errorf("EnvVars missing %s", name)
+		}
+	}
+	if len(got["AWS_ACCESS_KEY_ID"]) != 20 {
+		t.Errorf("AWS_ACCESS_KEY_ID = %q, want a 20-char AKIA-shaped placeholder", got["AWS_ACCESS_KEY_ID"])
+	}
+	if len(got["AWS_SECRET_ACCESS_KEY"]) != 40 {
+		t.Errorf("AWS_SECRET_ACCESS_KEY = %q, want a 40-char placeholder", got["AWS_SECRET_ACCESS_KEY"])
 	}
 }
 

--- a/internal/config/plugins/credentials/util.go
+++ b/internal/config/plugins/credentials/util.go
@@ -55,4 +55,11 @@ const (
 	phOpenAI = "sk-clawpatrol-placeholder-do-not-use"
 	phGitHub = "ghp_clawpatrol_placeholder_do_not_use"
 	phGemini = "AIzaClawpatrolPlaceholderDoNotUse00000000"
+	// phAWSKeyID is a 20-char AKIA-prefixed access key id and
+	// phAWSSecret a 40-char secret — the shapes aws-cli expects so its
+	// SigV4 signing succeeds locally. The gateway re-signs the proxied
+	// request with the operator's real stored creds (see aws.go), so
+	// these bytes never authenticate anything upstream.
+	phAWSKeyID  = "AKIACLAWPATROLPLACE0"
+	phAWSSecret = "clawpatrolPlaceholderSecretAccessKeyDoNo"
 )

--- a/internal/config/runtime/secrets.go
+++ b/internal/config/runtime/secrets.go
@@ -9,8 +9,14 @@ import (
 // envParts lists the recognized "multi-part" suffixes EnvSecretStore
 // folds into Secret.Extras when the bare CLAWPATROL_SECRET_<NAME> var
 // is empty. Plugins like mtls_credential need three pieces (cert /
-// key / ca); the env-var convention is one var per piece.
-var envParts = []string{"CA", "CERT", "KEY"}
+// key / ca); aws_credential needs three more (access key id / secret
+// access key / session token). The env-var convention is one var per
+// piece, and the suffix lowercased is the Extras key the plugin reads
+// (e.g. CLAWPATROL_SECRET_AWS_ACCESS_KEY_ID -> Extras["access_key_id"]).
+var envParts = []string{
+	"CA", "CERT", "KEY",
+	"ACCESS_KEY_ID", "SECRET_ACCESS_KEY", "SESSION_TOKEN",
+}
 
 // SecretStore returns the secret material a credential plugin's
 // InjectHTTP / InjectPostgres needs at request time. Lookup key is

--- a/internal/config/runtime/secrets_test.go
+++ b/internal/config/runtime/secrets_test.go
@@ -1,0 +1,53 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// TestEnvSecretStore_AWSParts verifies the AWS credential slots are
+// reachable via the CLAWPATROL_SECRET_<NAME>_<SLOT> env-var path. The
+// suffix lowercased is the Extras key aws_credential reads, so
+// ACCESS_KEY_ID must land in Extras["access_key_id"], etc.
+func TestEnvSecretStore_AWSParts(t *testing.T) {
+	t.Setenv("CLAWPATROL_SECRET_AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	t.Setenv("CLAWPATROL_SECRET_AWS_SECRET_ACCESS_KEY", "secret-material")
+	t.Setenv("CLAWPATROL_SECRET_AWS_SESSION_TOKEN", "session-token")
+
+	sec, err := runtime.EnvSecretStore{}.Get("aws")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for key, want := range map[string]string{
+		"access_key_id":     "AKIAEXAMPLE",
+		"secret_access_key": "secret-material",
+		"session_token":     "session-token",
+	} {
+		if got := sec.Extras[key]; got != want {
+			t.Errorf("Extras[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// TestEnvSecretStore_MTLSParts guards the original cert/key/ca suffixes
+// so extending envParts for AWS didn't regress the mtls path.
+func TestEnvSecretStore_MTLSParts(t *testing.T) {
+	t.Setenv("CLAWPATROL_SECRET_MTLS_CERT", "cert-pem")
+	t.Setenv("CLAWPATROL_SECRET_MTLS_KEY", "key-pem")
+	t.Setenv("CLAWPATROL_SECRET_MTLS_CA", "ca-pem")
+
+	sec, err := runtime.EnvSecretStore{}.Get("mtls")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for key, want := range map[string]string{
+		"cert": "cert-pem",
+		"key":  "key-pem",
+		"ca":   "ca-pem",
+	} {
+		if got := sec.Extras[key]; got != want {
+			t.Errorf("Extras[%q] = %q, want %q", key, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Implements **cl-pqgf**: extend the `aws_credential` plugin so plain aws-cli calls to `*.amazonaws.com` work through an `("https" "aws")` endpoint on a host with no real AWS credentials.

## Part 1 — Re-sign non-EKS proxied requests
`SignHTTPRequest` now branches on the endpoint type:
- **EKS endpoint** (`awsEKSParams` satisfied): unchanged — mints the `k8s-aws-v1.` bearer.
- **Non-EKS endpoint**: new `reSignProxiedRequest` path. It strips the client's `Authorization` + `X-Amz-Security-Token`, derives service/region from the incoming SigV4 credential scope (`Credential=AKID/<date>/<region>/<service>/aws4_request`, falling back to the hostname), reuses the existing `X-Amz-Content-Sha256` as the payload hash, and re-signs with the gateway's stored creds via `aws-sdk-go-v2/aws/signer/v4`.

## Part 2 — Auto-inject placeholder AWS env vars
`AWSCredential` now implements `EnvPushdownProvider`, exporting placeholder `AWS_ACCESS_KEY_ID` (20-char AKIA shape), `AWS_SECRET_ACCESS_KEY` (40-char), and `AWS_DEFAULT_REGION` — mirroring how `anthropic_oauth` injects `ANTHROPIC_AUTH_TOKEN`. aws-cli signs locally with placeholders; the gateway re-signs with real creds per Part 1.

## Tests
- `TestAWSCredentialReSignsNonEKSRequest` — scope wins over host, client signature/session-token replaced, content hash reused.
- `TestAWSCredentialReSignFallsBackToHost` — hostname fallback + STS session-token stamping.
- `TestParseSigV4CredentialScope` / `TestServiceRegionFromHost` — unit coverage incl. global-endpoint defaults.
- `TestAWSCredentialEnvVarsMirrorsAnthropic` — env-var shapes.
- EKS path regression guard (`...EmitsEKSBearer`) unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)