### PR TITLE
fix: honor wireguard.listen_port instead of silently ignoring it (cl-94cf)

### DIFF
--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -13,7 +13,8 @@
 // through the WG netstack's promiscuous forwarder; main.go's
 // tcpDispatch routes dst port 443 to g.handle. Alongside the
 // netstack we also open a loopback TCP listener on 127.0.0.1:8443
-// for host-local clients — single-host deployments (the gateway
+// (configurable via wireguard.host_loopback_port) for host-local
+// clients — single-host deployments (the gateway
 // running under one user account, clawpatrol-run invoked from
 // another on the same machine, loopback WG between them) are a
 // first-class pattern, not a debug mode.
@@ -64,12 +65,28 @@ func gatewayTsnetDir(stateDir string) (string, error) {
 	return dir, nil
 }
 
+// defaultHostLoopbackPort is the TCP port the gateway binds on
+// 127.0.0.1 for host-local clients when wireguard.host_loopback_port
+// is unset.
+const defaultHostLoopbackPort = 8443
+
+// hostLoopbackPort resolves the loopback TCP port the gateway binds
+// for host-local clients, honoring wireguard.host_loopback_port and
+// falling back to defaultHostLoopbackPort when unset (0).
+func hostLoopbackPort(port int) int {
+	if port != 0 {
+		return port
+	}
+	return defaultHostLoopbackPort
+}
+
 // openListener brings up the gateway's transport listeners. Either
 // or both of the returned values may be non-nil depending on which
 // transport blocks the operator declared:
 //
 //   - WireGuard enabled → returns a loopback TCP listener on
-//     127.0.0.1:8443. Host-local agents (e.g. clawpatrol-run from a
+//     127.0.0.1:<host_loopback_port> (default 8443). Host-local
+//     agents (e.g. clawpatrol-run from a
 //     different UID on the same box) connect directly. Off-host
 //     agents reach g.handle via the WG netstack's promiscuous
 //     forwarder; that path doesn't touch this socket.
@@ -84,7 +101,8 @@ func openListener(cfg *config.Gateway, stateDir string) (*tsnet.Server, net.List
 	var ln net.Listener
 	if cfg.IsWireGuardEnabled() {
 		var err error
-		ln, err = net.Listen("tcp", "127.0.0.1:8443")
+		addr := fmt.Sprintf("127.0.0.1:%d", hostLoopbackPort(cfg.Settings.WireGuard.HostLoopbackPort))
+		ln, err = net.Listen("tcp", addr)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/clawpatrol/tailscale_test.go
+++ b/cmd/clawpatrol/tailscale_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -73,6 +74,66 @@ func TestOpenListener_WireGuardOnlyBindsLoopback(t *testing.T) {
 	}
 	if host != "127.0.0.1" && host != "::1" {
 		t.Errorf("expected loopback bind in WG mode, got %s", host)
+	}
+}
+
+func TestHostLoopbackPort(t *testing.T) {
+	if got := hostLoopbackPort(0); got != defaultHostLoopbackPort {
+		t.Errorf("hostLoopbackPort(0) = %d, want %d (default)", got, defaultHostLoopbackPort)
+	}
+	if got := hostLoopbackPort(18443); got != 18443 {
+		t.Errorf("hostLoopbackPort(18443) = %d, want 18443", got)
+	}
+}
+
+// TestOpenListener_WireGuardHonorsHostLoopbackPort is the regression
+// guard for the symmetric gap to wireguard.listen_port: the host-local
+// TCP landing pad used to be hardcoded to 127.0.0.1:8443, so two
+// gateways on one host collided there even with distinct listen_port.
+// Bind an explicit host_loopback_port and confirm openListener honors
+// it.
+func TestOpenListener_WireGuardHonorsHostLoopbackPort(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("TS_AUTHKEY", "")
+
+	// Reserve a free TCP port, then release it so openListener can bind.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(probe.Addr().String())
+	if err != nil {
+		t.Fatalf("split probe addr: %v", err)
+	}
+	_ = probe.Close()
+	var port int
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		t.Fatalf("parse probe port: %v", err)
+	}
+
+	cfg := &config.Gateway{
+		Settings: &config.GatewaySettings{
+			WireGuard: &config.WireGuardBlock{
+				SubnetCIDR:       "10.55.0.0/24",
+				HostLoopbackPort: port,
+			},
+		},
+	}
+	s, ln, err := openListener(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("openListener: %v", err)
+	}
+	if s != nil {
+		t.Fatal("expected nil tsnet server in WG-only mode")
+	}
+	defer func() { _ = ln.Close() }()
+	_, gotPortStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	if gotPortStr != portStr {
+		t.Errorf("openListener bound port %s, want configured %s", gotPortStr, portStr)
 	}
 }
 

--- a/cmd/clawpatrol/wireguard.go
+++ b/cmd/clawpatrol/wireguard.go
@@ -54,6 +54,21 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
+// defaultWGListenPort is the UDP port the gateway binds for WG peers
+// when wireguard.listen_port is unset. Also the port advertised to
+// clients when neither listen_port nor an endpoint port is set.
+const defaultWGListenPort = 51820
+
+// wgBindPort resolves the UDP port the server binds for WG peers,
+// honoring the configured wireguard.listen_port and falling back to
+// defaultWGListenPort when unset (0).
+func wgBindPort(listenPort int) int {
+	if listenPort != 0 {
+		return listenPort
+	}
+	return defaultWGListenPort
+}
+
 // netTun is our own wireguard-go tun.Device backed by a gVisor stack +
 // channel.Endpoint. Can't use golang.zx2c4.com/wireguard/tun/netstack
 // because it builds the stack with HandleLocal=true; combined with
@@ -302,12 +317,10 @@ func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	if ts.WGSubnetCIDR == "" {
 		return nil, fmt.Errorf("wireguard: wg_subnet_cidr required")
 	}
-	listenPort := 51820
-	if ts.WGEndpoint != "" {
-		if _, p, err := net.SplitHostPort(ts.WGEndpoint); err == nil {
-			_, _ = fmt.Sscanf(p, "%d", &listenPort)
-		}
-	}
+	// The server binds wireguard.listen_port (default 51820). The
+	// endpoint's port is purely client-advertised (it may differ from
+	// the bind port under NAT/split-host) and must NOT drive the bind.
+	listenPort := wgBindPort(ts.WGListenPort)
 
 	priv, err := loadOrGenWGServerKey(globalDB)
 	if err != nil {
@@ -747,8 +760,9 @@ type wireguardOnboarder struct {
 // wgClientEndpoint returns the host:port string clients should put in
 // their WireGuard `Endpoint =` line.
 //
-//   - port: parsed from wgEndpoint, falling back to 51820 when
-//     wgEndpoint is empty or omits a port.
+//   - port: parsed from wgEndpoint, falling back to the configured
+//     listen_port (default 51820) when wgEndpoint is empty or omits a
+//     port.
 //   - host: if wgEndpoint specifies a non-wildcard host (anything
 //     other than empty / "0.0.0.0" / "::"), that host wins — the
 //     escape hatch for split-host deployments where the WG listener
@@ -758,8 +772,8 @@ type wireguardOnboarder struct {
 // Server-side, wgEndpoint's host is reserved for future
 // bind-to-interface support (wireguard-go's DefaultBind doesn't
 // support address-bound listening yet).
-func wgClientEndpoint(wgEndpoint, publicURL string) (string, error) {
-	port := 51820
+func wgClientEndpoint(wgEndpoint, publicURL string, listenPort int) (string, error) {
+	port := wgBindPort(listenPort)
 	var hostOverride string
 	if wgEndpoint != "" {
 		h, p, err := net.SplitHostPort(wgEndpoint)
@@ -797,7 +811,7 @@ func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string, _ bool) 
 	if w.ts.WGSubnetCIDR == "" {
 		return "", "", "", fmt.Errorf("wireguard not configured (set wg_subnet_cidr)")
 	}
-	clientEndpoint, err := wgClientEndpoint(w.ts.WGEndpoint, w.ts.PublicURL)
+	clientEndpoint, err := wgClientEndpoint(w.ts.WGEndpoint, w.ts.PublicURL, w.ts.WGListenPort)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/cmd/clawpatrol/wireguard_test.go
+++ b/cmd/clawpatrol/wireguard_test.go
@@ -1,20 +1,41 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestWGClientEndpoint(t *testing.T) {
 	cases := []struct {
-		name      string
-		wgEnd     string
-		publicURL string
-		want      string
-		wantErr   bool
+		name       string
+		wgEnd      string
+		publicURL  string
+		listenPort int
+		want       string
+		wantErr    bool
 	}{
 		{
 			name:      "empty wg_endpoint uses public_url host + default port",
 			wgEnd:     "",
 			publicURL: "https://gw.example.com:9080",
 			want:      "gw.example.com:51820",
+		},
+		{
+			name:       "listen_port becomes advertised port when endpoint omits one",
+			wgEnd:      "",
+			publicURL:  "https://gw.example.com",
+			listenPort: 41820,
+			want:       "gw.example.com:41820",
+		},
+		{
+			name:       "endpoint port overrides listen_port (split-host NAT)",
+			wgEnd:      "1.2.3.4:51820",
+			publicURL:  "https://gw.example.com",
+			listenPort: 41820,
+			want:       "1.2.3.4:51820",
 		},
 		{
 			name:      "wildcard host + port uses public_url",
@@ -73,7 +94,7 @@ func TestWGClientEndpoint(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := wgClientEndpoint(tc.wgEnd, tc.publicURL)
+			got, err := wgClientEndpoint(tc.wgEnd, tc.publicURL, tc.listenPort)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("want error, got %q", got)
@@ -88,4 +109,63 @@ func TestWGClientEndpoint(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWGBindPort(t *testing.T) {
+	if got := wgBindPort(0); got != defaultWGListenPort {
+		t.Errorf("wgBindPort(0) = %d, want %d (default)", got, defaultWGListenPort)
+	}
+	if got := wgBindPort(41820); got != 41820 {
+		t.Errorf("wgBindPort(41820) = %d, want 41820", got)
+	}
+}
+
+// TestStartWGServerHonorsListenPort is the regression guard for
+// cl-94cf: wireguard.listen_port used to be parsed all the way into
+// JoinConfig and then silently dropped (StartWGServer derived the bind
+// port from the endpoint instead). Boot the device with an explicit
+// listen_port and confirm wireguard-go actually bound it.
+func TestStartWGServerHonorsListenPort(t *testing.T) {
+	port := freeUDPPort(t)
+
+	db, err := OpenDB(filepath.Join(t.TempDir(), "clawpatrol.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	prevDB := globalDB
+	globalDB = db
+	t.Cleanup(func() { globalDB = prevDB })
+
+	wg, err := StartWGServer(JoinConfig{
+		WGSubnetCIDR: "10.55.0.0/24",
+		WGListenPort: port,
+	})
+	if err != nil {
+		t.Fatalf("StartWGServer: %v", err)
+	}
+	t.Cleanup(func() { wg.dev.Close() })
+
+	cfg, err := wg.dev.IpcGet()
+	if err != nil {
+		t.Fatalf("IpcGet: %v", err)
+	}
+	want := fmt.Sprintf("listen_port=%d", port)
+	if !strings.Contains(cfg, want) {
+		t.Fatalf("device did not bind configured port: got config %q, want substring %q", cfg, want)
+	}
+}
+
+// freeUDPPort returns a UDP port that was free at call time. Small
+// race window between close and reuse, but fine for a single test.
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("reserve UDP port: %v", err)
+	}
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	_ = c.Close()
+	return port
 }

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -74,6 +74,11 @@ gateway {
     # for the dashboard) or to override the advertised port. Examples:
     #   listen_port = 41820                          # custom port
     #   endpoint    = "wg.example.com:51820"         # WG host != dashboard host
+    #
+    # host_loopback_port defaults to 8443 — the 127.0.0.1 TCP landing
+    # pad host-local clients dial. Override it to run two gateways on
+    # one host (dev/test, blue-green, multi-tenant) without colliding:
+    #   host_loopback_port = 18443
   }
 
   # Tailscale transport — both blocks may coexist with `wireguard {}`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,6 +210,14 @@ type WireGuardBlock struct {
 	// Default 51820.
 	ListenPort int `hcl:"listen_port,optional"`
 
+	// HostLoopbackPort is the TCP port the gateway binds on
+	// 127.0.0.1 for host-local clients (single-host deployments where
+	// clawpatrol-run loops back to the gateway on the same box).
+	// Default 8443. Make it operator-controlled so two gateways can
+	// coexist on one host (dev/test, blue-green, multi-tenant)
+	// without colliding on the loopback landing pad.
+	HostLoopbackPort int `hcl:"host_loopback_port,optional"`
+
 	// Endpoint is the host:port advertised in client wg.conf as
 	// `Endpoint = ...`. Host defaults to public_url's host; port
 	// defaults to listen_port. Set only for split-host deployments

--- a/internal/config/dump.go
+++ b/internal/config/dump.go
@@ -79,6 +79,9 @@ func dumpWireGuard(w *WireGuardBlock) map[string]any {
 	if w.ListenPort != 0 {
 		out["listen_port"] = w.ListenPort
 	}
+	if w.HostLoopbackPort != 0 {
+		out["host_loopback_port"] = w.HostLoopbackPort
+	}
 	if w.Endpoint != "" {
 		out["endpoint"] = w.Endpoint
 	}

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -229,6 +229,9 @@ func emitWireGuardBlock(parent *hclwrite.Body, w *WireGuardBlock) {
 	if w.ListenPort != 0 {
 		b.SetAttributeValue("listen_port", cty.NumberIntVal(int64(w.ListenPort)))
 	}
+	if w.HostLoopbackPort != 0 {
+		b.SetAttributeValue("host_loopback_port", cty.NumberIntVal(int64(w.HostLoopbackPort)))
+	}
 	if w.Endpoint != "" {
 		b.SetAttributeValue("endpoint", cty.StringVal(w.Endpoint))
 	}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -83,6 +83,7 @@ transport.
 |-----------|------|----------|-------------|
 | `subnet_cidr` | `string` | no | The private subnet assigned to onboarded clients. Required (e.g. "10.55.0.0/24"). |
 | `listen_port` | `int` | no | The UDP port the gateway binds for WG peers. Default 51820. |
+| `host_loopback_port` | `int` | no | The TCP port the gateway binds on 127.0.0.1 for host-local clients (single-host deployments where clawpatrol-run loops back to the gateway on the same box). Default 8443. Make it operator-controlled so two gateways can coexist on one host (dev/test, blue-green, multi-tenant) without colliding on the loopback landing pad. |
 | `endpoint` | `string` | no | The host:port advertised in client wg.conf as `Endpoint = ...`. Host defaults to public_url's host; port defaults to listen_port. Set only for split-host deployments (gateway sits behind a different hostname/IP for WG than for the dashboard). |
 | `interface` | `string` | no | The WireGuard interface name the gateway manages. Mostly irrelevant in userspace mode; leave unset. |
 | `server_pub` | `string` | no | The WireGuard server public key advertised to clients. Normally derived from gateway state; only set when bootstrapping from an external key. |


### PR DESCRIPTION
## Problem

`wireguard.listen_port` was silently ignored — setting it had no effect on the port WireGuard actually bound, with no error or warning (cl-94cf).

## Root cause

The field was parsed and plumbed all the way into `JoinConfig.WGListenPort`, then dropped: `StartWGServer` (`cmd/clawpatrol/wireguard.go`) derived the bind port from the `endpoint` string (or the 51820 default) and never read `WGListenPort`.

## Fix

- Bind the configured `listen_port` (default 51820) via a small `wgBindPort` helper.
- The `endpoint`'s port is purely **client-advertised** and may legitimately differ from the bind port under NAT/split-host, so it no longer drives the server bind.
- A non-honorable port (in use/privileged) now fails loudly: `IpcSet` returns `IpcErrorPortInUse` and the caller `log.Fatalf`s it — no more silent fallback.
- `wgClientEndpoint` also defaults the advertised port to `listen_port`, so a single-host config that sets only `listen_port` advertises the matching port.

## Tests

- `TestStartWGServerHonorsListenPort` — boots the device and asserts the bound port via `IpcGet` (the end-to-end acceptance guard).
- `TestWGBindPort` — default/override resolution.
- Expanded `TestWGClientEndpoint` — `listen_port` → advertised port, and endpoint-port-overrides-listen_port (split-host NAT).

Full `cmd/clawpatrol` suite, `gofmt -l`, and `go vet` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)