### PR TITLE
Address review comment on clawpatrol PR #645: This is not useful for agents. We should tell the agent that their gateway profile is empty, and give some hints s (cl-trz6)

### DIFF
--- a/cmd/clawpatrol/discovery.go
+++ b/cmd/clawpatrol/discovery.go
@@ -101,6 +101,19 @@ type DiscoveryManifest struct {
 	// Notes carries profile-level caveats — e.g. the profile resolved
 	// to a name with no policy entry, so the manifest is empty.
 	Notes []string `json:"notes,omitempty"`
+	// Dashboard is the gateway's public URL (gateway.public_url), where a
+	// human operator configures this device's profile. Surfaced so an
+	// agent whose profile grants nothing can tell its human where to go.
+	// Empty when public_url is unset.
+	Dashboard string `json:"dashboard,omitempty"`
+}
+
+// isEmpty reports whether the profile grants nothing — no endpoints and
+// no credentials. This is the state the empty-profile guidance speaks
+// to: a manifest that lists nothing actionable is useless to an agent
+// unless it explains why and how to fix it.
+func (m *DiscoveryManifest) isEmpty() bool {
+	return len(m.Endpoints) == 0 && len(m.Credentials) == 0
 }
 
 // DiscoveryEndpoint is one reachable endpoint plus the full how-to for
@@ -165,6 +178,7 @@ func buildDiscoveryManifest(policy *config.CompiledPolicy, profileName string) *
 	prof := policy.Profiles[profileName]
 	if prof == nil {
 		m.Notes = append(m.Notes, fmt.Sprintf("profile %q grants no endpoints or credentials", profileName))
+		m.Dashboard = policy.DashboardURL
 		return m
 	}
 
@@ -215,6 +229,14 @@ func buildDiscoveryManifest(policy *config.CompiledPolicy, profileName string) *
 		m.Credentials = append(m.Credentials, dc)
 	}
 	sort.Slice(m.Credentials, func(i, j int) bool { return m.Credentials[i].Name < m.Credentials[j].Name })
+
+	// A profile that grants nothing leaves the agent with nothing to act
+	// on; surface the dashboard URL so it can point its human at where the
+	// device's profile gets configured. Non-empty manifests already carry
+	// everything actionable, so the pointer would just be noise there.
+	if m.isEmpty() {
+		m.Dashboard = policy.DashboardURL
+	}
 	return m
 }
 
@@ -437,6 +459,10 @@ func (m *DiscoveryManifest) Markdown() string {
 		fmt.Fprintf(&b, "> Note: %s\n\n", n)
 	}
 
+	if m.isEmpty() {
+		b.WriteString(m.emptyGuidance())
+	}
+
 	fmt.Fprintf(&b, "## Endpoints (%d)\n\n", len(m.Endpoints))
 	if len(m.Endpoints) == 0 {
 		b.WriteString("_None reachable for this profile._\n\n")
@@ -477,6 +503,35 @@ func (m *DiscoveryManifest) Markdown() string {
 		b.WriteString("\n")
 	}
 
+	return b.String()
+}
+
+// emptyGuidance is the block rendered when a profile grants nothing. A
+// bare "none reachable / none granted" manifest is dead-on-arrival for
+// an agent: it can't tell whether the gateway is broken, whether it's
+// the wrong device, or what to do next. This explains that the empty
+// result is a configuration state, what unlocks Claw Patrol's value, and
+// where the operator changes this device's profile.
+func (m *DiscoveryManifest) emptyGuidance() string {
+	var b strings.Builder
+	b.WriteString("## This profile is empty\n\n")
+	fmt.Fprintf(&b, "Your device is mapped to the `%s` profile, which currently grants no\n", m.Profile)
+	b.WriteString("endpoints and no credentials. That's why there's nothing actionable\n")
+	b.WriteString("below. This is a configuration state, not an error — the gateway is\n")
+	b.WriteString("reachable, your device just hasn't been granted anything yet.\n\n")
+	b.WriteString("To get value from Claw Patrol, this profile needs endpoints and the\n")
+	b.WriteString("credentials to reach them bound to it. An operator does that in the\n")
+	b.WriteString("dashboard by either assigning this device a profile that already grants\n")
+	b.WriteString("what you need, or adding endpoints and credentials to this one.\n\n")
+	if m.Dashboard != "" {
+		fmt.Fprintf(&b, "Ask the person who runs this gateway to open the dashboard at %s\n", m.Dashboard)
+		b.WriteString("and update this device's profile.\n\n")
+	} else {
+		b.WriteString("Ask the person who runs this gateway to open the Claw Patrol dashboard\n")
+		b.WriteString("and update this device's profile.\n\n")
+	}
+	b.WriteString("Once the profile is configured, re-fetch this manifest (GET\n")
+	b.WriteString("https://clawpatrol/) and the endpoints and credentials will appear below.\n\n")
 	return b.String()
 }
 

--- a/cmd/clawpatrol/discovery.go
+++ b/cmd/clawpatrol/discovery.go
@@ -1,0 +1,560 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/plugins/endpoints"
+)
+
+// discoveryHostname is the reserved name an agent inside the tunnel
+// hits to learn what its profile can reach. The gateway intercepts a
+// TLS connection whose SNI is this name and answers locally — the
+// request never leaves the box. DNS for the name resolves to the
+// reserved VIP pair the dnsvip allocator hands back (see dnsvip's
+// DiscoveryV4/DiscoveryV6), but because the WG forwarder routes every
+// :443 SYN through g.handle regardless of dst IP, any IP the agent was
+// handed lands here as long as the SNI matches.
+const discoveryHostname = "clawpatrol"
+
+// isDiscoveryHost reports whether host names the reserved discovery
+// endpoint. The match is case-insensitive (DNS is) and tolerates a
+// trailing dot and an explicit :443 suffix, both of which clients may
+// attach to the authority.
+func isDiscoveryHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	return host == discoveryHostname
+}
+
+// serveDiscovery terminates TLS for a reserved-name connection and
+// answers it with the caller's profile manifest. The profile is
+// resolved from the connection's peer IP (the same connection-derived
+// identity the request handler uses) — never from a token — so the
+// manifest reflects exactly this device's grants. certHost is the SNI
+// (or the dst VIP on the IP-literal fallback path); we mint a leaf for
+// it so the agent's CA-trusting client accepts the handshake.
+func (g *Gateway) serveDiscovery(c net.Conn, certHost string) {
+	defer func() { _ = c.Close() }()
+	defer otelTrackConn("discovery")()
+	profile := g.profileFor(peerIP(c))
+	cert, err := g.certs.mint(certHost)
+	if err != nil {
+		log.Printf("discovery: mint %s: %v", certHost, err)
+		return
+	}
+	tc := tls.Server(c, &tls.Config{
+		Certificates: []tls.Certificate{*cert},
+		NextProtos:   []string{"http/1.1"},
+	})
+	if err := tc.Handshake(); err != nil {
+		log.Printf("discovery: tls %s: %v", certHost, err)
+		return
+	}
+	defer func() { _ = tc.Close() }()
+	policy := g.Policy()
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeDiscoveryResponse(w, r, policy, profile)
+	})
+	_ = http.Serve(&oneShotListener{c: tc}, h)
+}
+
+// isDiscoveryVIP reports whether dstIP is the fixed VIP the dnsvip
+// allocator reserves for the discovery name — the signal the IP-literal
+// fallback path keys on when there's no SNI.
+func (g *Gateway) isDiscoveryVIP(dstIP string) bool {
+	if g.dnsvip == nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(dstIP)
+	if err != nil {
+		return false
+	}
+	v4, v6 := g.dnsvip.DiscoveryVIPs()
+	return addr == v4 || addr == v6
+}
+
+// DiscoveryManifest is the one internal representation both output
+// formats render from. It describes, scoped to a single device
+// profile, exactly which endpoints and credentials the caller can use
+// and how to reach each one. It is computed live from the calling
+// device's current profile — it is NOT a dump of the whole gateway
+// config.
+type DiscoveryManifest struct {
+	Profile     string                `json:"profile"`
+	Endpoints   []DiscoveryEndpoint   `json:"endpoints"`
+	Credentials []DiscoveryCredential `json:"credentials"`
+	// Notes carries profile-level caveats — e.g. the profile resolved
+	// to a name with no policy entry, so the manifest is empty.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// DiscoveryEndpoint is one reachable endpoint plus the full how-to for
+// connecting to it: protocol/type, host(s)/port(s), database/path
+// where applicable, the credential(s) the profile can present, and
+// whether a tunnel must be active.
+type DiscoveryEndpoint struct {
+	Name        string                   `json:"name"`
+	Type        string                   `json:"type"`   // plugin type: https, postgres, kubernetes, ...
+	Family      string                   `json:"family"` // http | sql | k8s | ssh
+	Hosts       []string                 `json:"hosts,omitempty"`
+	Port        int                      `json:"port,omitempty"`
+	Database    string                   `json:"database,omitempty"`
+	SSLMode     string                   `json:"sslmode,omitempty"`
+	Path        string                   `json:"path,omitempty"`
+	Tunnel      *DiscoveryTunnel         `json:"tunnel,omitempty"`
+	Credentials []DiscoveryCredentialRef `json:"credentials"`
+	// Hint is a concrete client invocation when the protocol makes one
+	// unambiguous (psql / kubectl / clickhouse-client / ssh / curl).
+	Hint string `json:"hint,omitempty"`
+}
+
+// DiscoveryTunnel reports the tunnel an endpoint dials through. When
+// present the agent must have the named tunnel active to reach the
+// endpoint; the gateway can't recover the upstream otherwise.
+type DiscoveryTunnel struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// DiscoveryCredentialRef is a credential the profile can present at a
+// specific endpoint. Placeholder is the literal string the agent sends
+// where a secret would go (the gateway swaps it for the real secret);
+// Disambiguators carries non-placeholder dispatch fields (postgres /
+// clickhouse user + database) so the agent connects with the values
+// that route to this credential.
+type DiscoveryCredentialRef struct {
+	Name           string            `json:"name"`
+	Type           string            `json:"type"`
+	Placeholder    string            `json:"placeholder,omitempty"`
+	Disambiguators map[string]string `json:"disambiguators,omitempty"`
+}
+
+// DiscoveryCredential is the profile-level view of one credential: its
+// type, placeholder, and the endpoints it authenticates against that
+// this profile can reach.
+type DiscoveryCredential struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Placeholder string   `json:"placeholder,omitempty"`
+	Endpoints   []string `json:"endpoints,omitempty"`
+}
+
+// buildDiscoveryManifest computes the manifest for one profile from the
+// compiled policy. It reuses the same per-profile resolution the
+// request handler walks — CompiledProfile.Endpoints and
+// EndpointCredentials — so the manifest reports exactly what dispatch
+// would honor, nothing more. A profile name with no policy entry (the
+// default-profile fallback for an unrecognised device) yields an empty
+// manifest with an explanatory note rather than an error.
+func buildDiscoveryManifest(policy *config.CompiledPolicy, profileName string) *DiscoveryManifest {
+	m := &DiscoveryManifest{Profile: profileName, Endpoints: []DiscoveryEndpoint{}, Credentials: []DiscoveryCredential{}}
+	if policy == nil {
+		m.Notes = append(m.Notes, "gateway has no compiled policy loaded")
+		return m
+	}
+	prof := policy.Profiles[profileName]
+	if prof == nil {
+		m.Notes = append(m.Notes, fmt.Sprintf("profile %q grants no endpoints or credentials", profileName))
+		return m
+	}
+
+	// Endpoints, in a stable name order so the manifest is byte-stable
+	// across calls (agents may diff it; tests assert on it).
+	names := make([]string, 0, len(prof.Endpoints))
+	for name := range prof.Endpoints {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		ep := prof.Endpoints[name]
+		if ep == nil {
+			continue
+		}
+		de := describeEndpoint(ep)
+		de.Credentials = profileEndpointCredentials(prof, name)
+		if len(de.Credentials) == 0 {
+			// Reachable in this profile but no credential dispatches to
+			// it — the agent should know the boundary instead of
+			// flailing with an endpoint it can't authenticate to.
+			de.Credentials = []DiscoveryCredentialRef{}
+		}
+		de.Hint = connectionHint(de)
+		m.Endpoints = append(m.Endpoints, de)
+	}
+
+	// Credentials: what the profile HAS. Endpoints listed per credential
+	// are intersected with the profile's reachable set so the agent sees
+	// the boundary, not the whole config.
+	for _, ent := range prof.Credentials {
+		if ent == nil || ent.Symbol == nil {
+			continue
+		}
+		dc := DiscoveryCredential{Name: ent.Symbol.Name}
+		if ent.Plugin != nil {
+			dc.Type = ent.Plugin.Type
+		}
+		dc.Placeholder = ent.Framework.Str("placeholder")
+		var eps []string
+		for _, target := range config.CredentialEndpointTargets(ent) {
+			if _, ok := prof.Endpoints[target]; ok {
+				eps = append(eps, target)
+			}
+		}
+		sort.Strings(eps)
+		dc.Endpoints = eps
+		m.Credentials = append(m.Credentials, dc)
+	}
+	sort.Slice(m.Credentials, func(i, j int) bool { return m.Credentials[i].Name < m.Credentials[j].Name })
+	return m
+}
+
+// describeEndpoint extracts the connection how-to from a compiled
+// endpoint by type-asserting its plugin Body. Unknown plugin types
+// fall back to the declared Hosts and plugin type — a new endpoint
+// plugin still surfaces in the manifest with its hosts, just without
+// type-specific fields.
+func describeEndpoint(ep *config.CompiledEndpoint) DiscoveryEndpoint {
+	de := DiscoveryEndpoint{Name: ep.Name, Family: ep.Family}
+	if ep.Plugin != nil {
+		de.Type = ep.Plugin.Type
+	}
+	if ep.Tunnel != nil {
+		de.Tunnel = &DiscoveryTunnel{Name: ep.Tunnel.Name}
+		if ep.Tunnel.Plugin != nil {
+			de.Tunnel.Type = ep.Tunnel.Plugin.Type
+		}
+	}
+
+	switch body := ep.Body.(type) {
+	case *endpoints.HTTPSEndpoint:
+		de.Hosts = body.Hosts
+	case *endpoints.ClickhouseHTTPSEndpoint:
+		de.Hosts = body.Hosts
+	case *endpoints.PostgresEndpoint:
+		host, port := splitHostPort(body.Host, 5432)
+		de.Hosts = []string{host}
+		de.Port = port
+		de.SSLMode = body.SSLMode
+	case *endpoints.ClickhouseNativeEndpoint:
+		port := body.Port
+		if port == 0 {
+			port = 9000
+			if body.TLS {
+				port = 9440
+			}
+		}
+		de.Port = port
+		hosts := make([]string, 0, len(body.Hosts))
+		for _, h := range body.Hosts {
+			hp, _ := splitHostPort(h, port)
+			hosts = append(hosts, hp)
+		}
+		de.Hosts = hosts
+	case *endpoints.KubernetesEndpoint:
+		de.Hosts = body.EndpointHosts()
+		if body.Server != "" {
+			// server may be a full URL; surface its path component so
+			// the agent points kubectl at the right apiserver path.
+			if i := strings.Index(body.Server, "/"); i >= 0 && strings.Contains(body.Server, "://") {
+				if u := strings.SplitN(body.Server, "://", 2); len(u) == 2 {
+					if j := strings.Index(u[1], "/"); j >= 0 {
+						de.Path = u[1][j:]
+					}
+				}
+			}
+		}
+	case *endpoints.SSHEndpoint:
+		hosts := make([]string, 0, len(body.Hosts))
+		for _, h := range body.Hosts {
+			hp, port := splitHostPort(h, 22)
+			hosts = append(hosts, hp)
+			de.Port = port
+		}
+		de.Hosts = hosts
+	default:
+		// Unknown plugin: best-effort hosts via the generic accessor.
+		if hoster, ok := ep.Body.(interface{ EndpointHosts() []string }); ok {
+			de.Hosts = hoster.EndpointHosts()
+		} else {
+			de.Hosts = ep.Hosts
+		}
+	}
+	if len(de.Hosts) == 0 {
+		de.Hosts = ep.Hosts
+	}
+	return de
+}
+
+// profileEndpointCredentials returns the credentials the profile can
+// present at endpointName, with placeholder + dispatch discriminators
+// pulled from the profile-scoped dispatch table (the same table
+// runtime.ResolveCredential consults).
+func profileEndpointCredentials(prof *config.CompiledProfile, endpointName string) []DiscoveryCredentialRef {
+	ccs := prof.EndpointCredentials[endpointName]
+	out := make([]DiscoveryCredentialRef, 0, len(ccs))
+	for _, cc := range ccs {
+		if cc == nil || cc.Credential == nil || cc.Credential.Symbol == nil {
+			continue
+		}
+		ref := DiscoveryCredentialRef{Name: cc.Credential.Symbol.Name}
+		if cc.Credential.Plugin != nil {
+			ref.Type = cc.Credential.Plugin.Type
+		}
+		// Split the merged disambiguator map into the placeholder (the
+		// literal the agent sends) and the rest (postgres/clickhouse
+		// user + database the agent connects with).
+		if len(cc.Disambiguators) > 0 {
+			rest := map[string]string{}
+			for k, v := range cc.Disambiguators {
+				if k == "placeholder" {
+					ref.Placeholder = v
+					continue
+				}
+				rest[k] = v
+			}
+			if len(rest) > 0 {
+				ref.Disambiguators = rest
+			}
+		}
+		out = append(out, ref)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// splitHostPort splits a "host:port" string, falling back to def when
+// no port is present. Bare hosts and bracketed IPv6 are both handled.
+func splitHostPort(hp string, def int) (string, int) {
+	if hp == "" {
+		return "", def
+	}
+	host, portStr, err := net.SplitHostPort(hp)
+	if err != nil {
+		return hp, def
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return host, def
+	}
+	return host, port
+}
+
+// connectionHint returns a concrete client invocation for the endpoint
+// where the protocol makes one unambiguous. Empty when there's no
+// single obvious command (the agent still has hosts/port/credential).
+func connectionHint(de DiscoveryEndpoint) string {
+	host := ""
+	if len(de.Hosts) > 0 {
+		host = de.Hosts[0]
+	}
+	if host == "" {
+		return ""
+	}
+	switch de.Type {
+	case "postgres":
+		var b strings.Builder
+		fmt.Fprintf(&b, "psql \"host=%s port=%d", host, de.Port)
+		if user := firstDisambiguator(de, "user"); user != "" {
+			fmt.Fprintf(&b, " user=%s", user)
+		}
+		if db := firstDisambiguator(de, "database"); db != "" {
+			fmt.Fprintf(&b, " dbname=%s", db)
+		} else if de.Database != "" {
+			fmt.Fprintf(&b, " dbname=%s", de.Database)
+		}
+		if de.SSLMode != "" {
+			fmt.Fprintf(&b, " sslmode=%s", de.SSLMode)
+		}
+		b.WriteString("\"")
+		return b.String()
+	case "clickhouse_native":
+		hint := fmt.Sprintf("clickhouse-client --host %s --port %d", host, de.Port)
+		if user := firstDisambiguator(de, "user"); user != "" {
+			hint += " --user " + user
+		}
+		if db := firstDisambiguator(de, "database"); db != "" {
+			hint += " --database " + db
+		}
+		return hint
+	case "kubernetes":
+		return fmt.Sprintf("kubectl --server https://%s%s ...", host, de.Path)
+	case "ssh":
+		user := firstDisambiguator(de, "user")
+		if user != "" {
+			return fmt.Sprintf("ssh %s@%s", user, host)
+		}
+		return fmt.Sprintf("ssh %s", host)
+	case "https", "clickhouse_https":
+		ph := firstPlaceholder(de)
+		if ph != "" {
+			return fmt.Sprintf("curl https://%s/ -H \"Authorization: Bearer %s\"", host, ph)
+		}
+		return fmt.Sprintf("curl https://%s/", host)
+	}
+	return ""
+}
+
+// firstPlaceholder returns the placeholder of the first credential
+// bound at the endpoint that has one.
+func firstPlaceholder(de DiscoveryEndpoint) string {
+	for _, c := range de.Credentials {
+		if c.Placeholder != "" {
+			return c.Placeholder
+		}
+	}
+	return ""
+}
+
+// firstDisambiguator returns the value of key from the first
+// credential at the endpoint that carries it.
+func firstDisambiguator(de DiscoveryEndpoint, key string) string {
+	for _, c := range de.Credentials {
+		if v := c.Disambiguators[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// Markdown renders the manifest as an agent-readable document
+// (llms.txt style). An LLM consumes this directly, so it leads with
+// orientation and keeps each endpoint's how-to self-contained.
+func (m *DiscoveryManifest) Markdown() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Claw Patrol access manifest — profile: %s\n\n", m.Profile)
+	b.WriteString("You are connected through the Claw Patrol gateway. It intercepts your\n")
+	b.WriteString("connections transparently: dial the hosts below as you normally would and\n")
+	b.WriteString("the gateway injects credentials and enforces policy. A credential\n")
+	b.WriteString("`placeholder` is a literal string you send where the secret would go — the\n")
+	b.WriteString("gateway swaps it for the real secret. This manifest is scoped to YOUR\n")
+	b.WriteString("device profile; it lists only what this profile grants.\n\n")
+
+	for _, n := range m.Notes {
+		fmt.Fprintf(&b, "> Note: %s\n\n", n)
+	}
+
+	fmt.Fprintf(&b, "## Endpoints (%d)\n\n", len(m.Endpoints))
+	if len(m.Endpoints) == 0 {
+		b.WriteString("_None reachable for this profile._\n\n")
+	}
+	for _, ep := range m.Endpoints {
+		fmt.Fprintf(&b, "### %s  (%s)\n\n", ep.Name, ep.Type)
+		if len(ep.Hosts) > 0 {
+			fmt.Fprintf(&b, "- Host(s): %s\n", strings.Join(ep.Hosts, ", "))
+		}
+		if ep.Port != 0 {
+			fmt.Fprintf(&b, "- Port: %d\n", ep.Port)
+		}
+		if ep.Database != "" {
+			fmt.Fprintf(&b, "- Database: %s\n", ep.Database)
+		}
+		if ep.SSLMode != "" {
+			fmt.Fprintf(&b, "- SSL mode: %s\n", ep.SSLMode)
+		}
+		if ep.Path != "" {
+			fmt.Fprintf(&b, "- Path: %s\n", ep.Path)
+		}
+		if ep.Tunnel != nil {
+			fmt.Fprintf(&b, "- Tunnel: REQUIRED — `%s` (%s) must be active to reach this endpoint\n", ep.Tunnel.Name, ep.Tunnel.Type)
+		} else {
+			b.WriteString("- Tunnel: none (reachable directly through the gateway)\n")
+		}
+		if len(ep.Credentials) == 0 {
+			b.WriteString("- Credential: NONE bound for this profile — you cannot authenticate here\n")
+		}
+		for _, c := range ep.Credentials {
+			line := fmt.Sprintf("- Credential: %s `%s`", c.Type, c.Name)
+			if c.Placeholder != "" {
+				line += fmt.Sprintf(" — send placeholder `%s`", c.Placeholder)
+			}
+			if len(c.Disambiguators) > 0 {
+				line += " — connect with " + joinDisambiguators(c.Disambiguators)
+			}
+			b.WriteString(line + "\n")
+		}
+		if ep.Hint != "" {
+			fmt.Fprintf(&b, "- Example: `%s`\n", ep.Hint)
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "## Credentials (%d)\n\n", len(m.Credentials))
+	if len(m.Credentials) == 0 {
+		b.WriteString("_None granted to this profile._\n")
+	}
+	for _, c := range m.Credentials {
+		line := fmt.Sprintf("- %s `%s`", c.Type, c.Name)
+		if c.Placeholder != "" {
+			line += fmt.Sprintf(" → placeholder `%s`", c.Placeholder)
+		}
+		if len(c.Endpoints) > 0 {
+			line += " → endpoints: " + strings.Join(c.Endpoints, ", ")
+		} else {
+			line += " → (no reachable endpoint in this profile)"
+		}
+		b.WriteString(line + "\n")
+	}
+	return b.String()
+}
+
+// joinDisambiguators renders a "key=value" set in stable key order.
+func joinDisambiguators(d map[string]string) string {
+	keys := make([]string, 0, len(d))
+	for k := range d {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, d[k]))
+	}
+	return strings.Join(parts, " ")
+}
+
+// wantsJSON decides the response format. An explicit `?format=json`
+// (or `format=markdown`) query param wins; otherwise the Accept header
+// picks. Default is markdown — the primary consumer is an LLM.
+func wantsJSON(r *http.Request) bool {
+	switch strings.ToLower(r.URL.Query().Get("format")) {
+	case "json":
+		return true
+	case "markdown", "md", "text":
+		return false
+	}
+	accept := r.Header.Get("Accept")
+	if strings.Contains(accept, "application/json") && !strings.Contains(accept, "text/markdown") {
+		return true
+	}
+	return false
+}
+
+// writeDiscoveryResponse renders the manifest for profileName in the
+// format the request asked for. Factored out of the TLS-serving path
+// so it can be exercised with httptest without standing up WireGuard.
+func writeDiscoveryResponse(w http.ResponseWriter, r *http.Request, policy *config.CompiledPolicy, profileName string) {
+	m := buildDiscoveryManifest(policy, profileName)
+	if wantsJSON(r) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(m)
+		return
+	}
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	_, _ = w.Write([]byte(m.Markdown()))
+}

--- a/cmd/clawpatrol/discovery.go
+++ b/cmd/clawpatrol/discovery.go
@@ -105,8 +105,12 @@ type DiscoveryManifest struct {
 
 // DiscoveryEndpoint is one reachable endpoint plus the full how-to for
 // connecting to it: protocol/type, host(s)/port(s), database/path
-// where applicable, the credential(s) the profile can present, and
-// whether a tunnel must be active.
+// where applicable, and the credential(s) the profile can present.
+//
+// Deliberately omits any tunnel the endpoint sits behind. The gateway
+// intercepts the agent's connection transparently and brings the tunnel
+// up itself — the agent dials the host below either way and can't act on
+// the tunnel's name or type, so reporting it would only be noise.
 type DiscoveryEndpoint struct {
 	Name        string                   `json:"name"`
 	Type        string                   `json:"type"`   // plugin type: https, postgres, kubernetes, ...
@@ -116,19 +120,10 @@ type DiscoveryEndpoint struct {
 	Database    string                   `json:"database,omitempty"`
 	SSLMode     string                   `json:"sslmode,omitempty"`
 	Path        string                   `json:"path,omitempty"`
-	Tunnel      *DiscoveryTunnel         `json:"tunnel,omitempty"`
 	Credentials []DiscoveryCredentialRef `json:"credentials"`
 	// Hint is a concrete client invocation when the protocol makes one
 	// unambiguous (psql / kubectl / clickhouse-client / ssh / curl).
 	Hint string `json:"hint,omitempty"`
-}
-
-// DiscoveryTunnel reports the tunnel an endpoint dials through. When
-// present the agent must have the named tunnel active to reach the
-// endpoint; the gateway can't recover the upstream otherwise.
-type DiscoveryTunnel struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
 }
 
 // DiscoveryCredentialRef is a credential the profile can present at a
@@ -232,12 +227,6 @@ func describeEndpoint(ep *config.CompiledEndpoint) DiscoveryEndpoint {
 	de := DiscoveryEndpoint{Name: ep.Name, Family: ep.Family}
 	if ep.Plugin != nil {
 		de.Type = ep.Plugin.Type
-	}
-	if ep.Tunnel != nil {
-		de.Tunnel = &DiscoveryTunnel{Name: ep.Tunnel.Name}
-		if ep.Tunnel.Plugin != nil {
-			de.Tunnel.Type = ep.Tunnel.Plugin.Type
-		}
 	}
 
 	switch body := ep.Body.(type) {
@@ -468,11 +457,6 @@ func (m *DiscoveryManifest) Markdown() string {
 		}
 		if ep.Path != "" {
 			fmt.Fprintf(&b, "- Path: %s\n", ep.Path)
-		}
-		if ep.Tunnel != nil {
-			fmt.Fprintf(&b, "- Tunnel: REQUIRED — `%s` (%s) must be active to reach this endpoint\n", ep.Tunnel.Name, ep.Tunnel.Type)
-		} else {
-			b.WriteString("- Tunnel: none (reachable directly through the gateway)\n")
 		}
 		if len(ep.Credentials) == 0 {
 			b.WriteString("- Credential: NONE bound for this profile — you cannot authenticate here\n")

--- a/cmd/clawpatrol/discovery.go
+++ b/cmd/clawpatrol/discovery.go
@@ -477,22 +477,6 @@ func (m *DiscoveryManifest) Markdown() string {
 		b.WriteString("\n")
 	}
 
-	fmt.Fprintf(&b, "## Credentials (%d)\n\n", len(m.Credentials))
-	if len(m.Credentials) == 0 {
-		b.WriteString("_None granted to this profile._\n")
-	}
-	for _, c := range m.Credentials {
-		line := fmt.Sprintf("- %s `%s`", c.Type, c.Name)
-		if c.Placeholder != "" {
-			line += fmt.Sprintf(" → placeholder `%s`", c.Placeholder)
-		}
-		if len(c.Endpoints) > 0 {
-			line += " → endpoints: " + strings.Join(c.Endpoints, ", ")
-		} else {
-			line += " → (no reachable endpoint in this profile)"
-		}
-		b.WriteString(line + "\n")
-	}
 	return b.String()
 }
 

--- a/cmd/clawpatrol/discovery_golden_test.go
+++ b/cmd/clawpatrol/discovery_golden_test.go
@@ -21,8 +21,9 @@ var updateGolden = flag.Bool("update", false, "rewrite discovery golden files")
 // HCL config, renders one profile's manifest through both output paths,
 // and asserts the result byte-for-byte against a committed golden. They
 // cover the distinct config shapes a profile can produce — an empty
-// profile, a simple single-endpoint/single-credential profile, and a
-// profile with multiple credentials bound to one endpoint.
+// profile, a simple single-endpoint/single-credential profile, a
+// profile with multiple credentials bound to one endpoint, and a
+// profile whose endpoint sits behind a tunnel.
 var discoveryGoldenCases = []struct {
 	name    string // golden file stem under testdata/discovery/
 	hcl     string // HCL fixture file under testdata/discovery/
@@ -31,6 +32,7 @@ var discoveryGoldenCases = []struct {
 	{name: "empty", hcl: "empty.hcl", profile: "empty"},
 	{name: "simple", hcl: "simple.hcl", profile: "simple"},
 	{name: "multicred", hcl: "multicred.hcl", profile: "dba"},
+	{name: "tunnel", hcl: "tunnel.hcl", profile: "tunneled"},
 }
 
 func compileDiscoveryFile(t *testing.T, file string) *config.CompiledPolicy {

--- a/cmd/clawpatrol/discovery_golden_test.go
+++ b/cmd/clawpatrol/discovery_golden_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"flag"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+// updateGolden regenerates the .md/.json golden files instead of
+// asserting against them. Run `go test ./cmd/clawpatrol -run
+// TestDiscoveryGolden -update` after an intentional output change, then
+// eyeball the diff before committing.
+var updateGolden = flag.Bool("update", false, "rewrite discovery golden files")
+
+// discoveryGoldenCases are functional end-to-end checks: each loads one
+// HCL config, renders one profile's manifest through both output paths,
+// and asserts the result byte-for-byte against a committed golden. They
+// cover the distinct config shapes a profile can produce — an empty
+// profile, a simple single-endpoint/single-credential profile, and a
+// profile with multiple credentials bound to one endpoint.
+var discoveryGoldenCases = []struct {
+	name    string // golden file stem under testdata/discovery/
+	hcl     string // HCL fixture file under testdata/discovery/
+	profile string // profile to render
+}{
+	{name: "empty", hcl: "empty.hcl", profile: "empty"},
+	{name: "simple", hcl: "simple.hcl", profile: "simple"},
+	{name: "multicred", hcl: "multicred.hcl", profile: "dba"},
+}
+
+func compileDiscoveryFile(t *testing.T, file string) *config.CompiledPolicy {
+	t.Helper()
+	path := filepath.Join("testdata", "discovery", file)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	gw, diags := config.LoadBytes(src, file)
+	if diags.HasErrors() {
+		t.Fatalf("load %s: %v", file, diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile %s: %v", file, err)
+	}
+	return cp
+}
+
+// renderJSON drives the real HTTP response path (?format=json) so the
+// golden captures exactly what an agent receives, trailing newline and
+// all, not a side rendering.
+func renderJSON(t *testing.T, policy *config.CompiledPolicy, profile string) []byte {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "https://clawpatrol/?format=json", nil)
+	writeDiscoveryResponse(rec, req, policy, profile)
+	return rec.Body.Bytes()
+}
+
+func checkGolden(t *testing.T, name, ext string, got []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", "discovery", name+ext)
+	if *updateGolden {
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", path, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run with -update to create)", path, err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("%s mismatch (run with -update to refresh).\n--- got ---\n%s\n--- want ---\n%s", path, got, want)
+	}
+}
+
+func TestDiscoveryGolden(t *testing.T) {
+	for _, tc := range discoveryGoldenCases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := compileDiscoveryFile(t, tc.hcl)
+
+			m := buildDiscoveryManifest(policy, tc.profile)
+			checkGolden(t, tc.name, ".md", []byte(m.Markdown()))
+			checkGolden(t, tc.name, ".json", renderJSON(t, policy, tc.profile))
+		})
+	}
+}

--- a/cmd/clawpatrol/discovery_test.go
+++ b/cmd/clawpatrol/discovery_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+// discoveryFixture declares two profiles whose endpoint/credential
+// grants don't overlap, so the per-profile scoping is observable:
+//
+//	ops → github (https), prod-pg (postgres, tunneled)
+//	ro  → internal (https), metrics (clickhouse_native)
+const discoveryFixture = `gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+tunnel "local_command" "csql" {
+  command     = ["cloud_sql_proxy", "--instances", "p:r:db=tcp:5432"]
+  listen      = "127.0.0.1:5432"
+  ready_probe = "tcp"
+  share       = "singleton"
+  keepalive   = "5m"
+}
+
+endpoint "https" "github"   { hosts = ["api.github.com"] }
+endpoint "https" "internal" { hosts = ["internal.example"] }
+
+endpoint "postgres" "prod-pg" {
+  host    = "main-pg.example:5432"
+  sslmode = "require"
+  tunnel  = local_command.csql
+}
+
+endpoint "clickhouse_native" "metrics" {
+  hosts = ["ch.example"]
+  port  = 9440
+  tls   = true
+}
+
+credential "bearer_token" "gh" {
+  endpoint    = https.github
+  placeholder = "PH_GH"
+}
+credential "bearer_token" "int" {
+  endpoint    = https.internal
+  placeholder = "PH_INT"
+}
+credential "postgres_credential" "pg-rw" {
+  endpoint = postgres.prod-pg
+  user     = "app"
+  database = "prod"
+}
+credential "clickhouse_credential" "ch-ro" {
+  endpoint = clickhouse_native.metrics
+  user     = "ro"
+}
+
+profile "ops" { credentials = [bearer_token.gh, postgres_credential.pg-rw] }
+profile "ro"  { credentials = [bearer_token.int, clickhouse_credential.ch-ro] }
+`
+
+func compileDiscoveryFixture(t *testing.T) *config.CompiledPolicy {
+	t.Helper()
+	gw, diags := config.LoadBytes([]byte(discoveryFixture), "discovery.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cp
+}
+
+func endpointNames(m *DiscoveryManifest) []string {
+	out := make([]string, 0, len(m.Endpoints))
+	for _, e := range m.Endpoints {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+func findEndpoint(m *DiscoveryManifest, name string) *DiscoveryEndpoint {
+	for i := range m.Endpoints {
+		if m.Endpoints[i].Name == name {
+			return &m.Endpoints[i]
+		}
+	}
+	return nil
+}
+
+// TestDiscoveryProfileScoping is the core guarantee: each profile sees
+// only its own endpoints and credentials, never the whole config.
+func TestDiscoveryProfileScoping(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+
+	ops := buildDiscoveryManifest(policy, "ops")
+	if got := endpointNames(ops); strings.Join(got, ",") != "github,prod-pg" {
+		t.Fatalf("ops endpoints = %v, want [github prod-pg]", got)
+	}
+	// ops must NOT see ro's endpoints.
+	if findEndpoint(ops, "internal") != nil || findEndpoint(ops, "metrics") != nil {
+		t.Errorf("ops leaked ro endpoints: %v", endpointNames(ops))
+	}
+	opsCreds := credNames(ops)
+	if opsCreds != "gh,pg-rw" {
+		t.Errorf("ops credentials = %q, want gh,pg-rw", opsCreds)
+	}
+
+	ro := buildDiscoveryManifest(policy, "ro")
+	if got := endpointNames(ro); strings.Join(got, ",") != "internal,metrics" {
+		t.Fatalf("ro endpoints = %v, want [internal metrics]", got)
+	}
+	if findEndpoint(ro, "github") != nil || findEndpoint(ro, "prod-pg") != nil {
+		t.Errorf("ro leaked ops endpoints: %v", endpointNames(ro))
+	}
+	if c := credNames(ro); c != "ch-ro,int" {
+		t.Errorf("ro credentials = %q, want ch-ro,int", c)
+	}
+}
+
+func credNames(m *DiscoveryManifest) string {
+	out := make([]string, 0, len(m.Credentials))
+	for _, c := range m.Credentials {
+		out = append(out, c.Name)
+	}
+	return strings.Join(out, ",")
+}
+
+// TestDiscoveryEndpointDetail checks the per-endpoint connection how-to:
+// host/port/sslmode, the credential placeholder, and SQL disambiguators.
+func TestDiscoveryEndpointDetail(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+	ops := buildDiscoveryManifest(policy, "ops")
+
+	gh := findEndpoint(ops, "github")
+	if gh == nil || gh.Type != "https" {
+		t.Fatalf("github endpoint missing or wrong type: %+v", gh)
+	}
+	if len(gh.Credentials) != 1 || gh.Credentials[0].Placeholder != "PH_GH" {
+		t.Errorf("github credential placeholder = %+v, want PH_GH", gh.Credentials)
+	}
+
+	pg := findEndpoint(ops, "prod-pg")
+	if pg == nil {
+		t.Fatal("prod-pg endpoint missing")
+	}
+	if pg.Type != "postgres" || pg.Port != 5432 || pg.SSLMode != "require" {
+		t.Errorf("prod-pg detail wrong: type=%q port=%d sslmode=%q", pg.Type, pg.Port, pg.SSLMode)
+	}
+	if len(pg.Hosts) != 1 || pg.Hosts[0] != "main-pg.example" {
+		t.Errorf("prod-pg hosts = %v, want [main-pg.example]", pg.Hosts)
+	}
+	if len(pg.Credentials) != 1 {
+		t.Fatalf("prod-pg credentials = %+v", pg.Credentials)
+	}
+	d := pg.Credentials[0].Disambiguators
+	if d["user"] != "app" || d["database"] != "prod" {
+		t.Errorf("prod-pg disambiguators = %v, want user=app database=prod", d)
+	}
+	if !strings.Contains(pg.Hint, "psql") || !strings.Contains(pg.Hint, "dbname=prod") {
+		t.Errorf("prod-pg hint = %q, want psql ... dbname=prod", pg.Hint)
+	}
+}
+
+// TestDiscoveryTunnelReported asserts a tunneled endpoint surfaces the
+// tunnel the agent must have active to reach it.
+func TestDiscoveryTunnelReported(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+	ops := buildDiscoveryManifest(policy, "ops")
+
+	pg := findEndpoint(ops, "prod-pg")
+	if pg == nil || pg.Tunnel == nil {
+		t.Fatalf("prod-pg tunnel not reported: %+v", pg)
+	}
+	if pg.Tunnel.Name != "csql" || pg.Tunnel.Type != "local_command" {
+		t.Errorf("prod-pg tunnel = %+v, want csql/local_command", pg.Tunnel)
+	}
+	// The non-tunneled endpoint must not invent one.
+	if gh := findEndpoint(ops, "github"); gh.Tunnel != nil {
+		t.Errorf("github should have no tunnel, got %+v", gh.Tunnel)
+	}
+	// Markdown spells out the REQUIRED tunnel so an LLM acts on it.
+	md := ops.Markdown()
+	if !strings.Contains(md, "Tunnel: REQUIRED") || !strings.Contains(md, "csql") {
+		t.Errorf("markdown missing tunnel requirement:\n%s", md)
+	}
+}
+
+// TestDiscoveryClickhouseDetail covers the clickhouse_native port/host
+// extraction and its hint.
+func TestDiscoveryClickhouseDetail(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+	ro := buildDiscoveryManifest(policy, "ro")
+	ch := findEndpoint(ro, "metrics")
+	if ch == nil || ch.Type != "clickhouse_native" || ch.Port != 9440 {
+		t.Fatalf("metrics detail wrong: %+v", ch)
+	}
+	if len(ch.Hosts) != 1 || ch.Hosts[0] != "ch.example" {
+		t.Errorf("metrics hosts = %v", ch.Hosts)
+	}
+	if !strings.Contains(ch.Hint, "clickhouse-client") || !strings.Contains(ch.Hint, "--user ro") {
+		t.Errorf("metrics hint = %q", ch.Hint)
+	}
+}
+
+// TestDiscoveryRendersBothFormats checks markdown and JSON come from one
+// representation and reflect the same scoping.
+func TestDiscoveryRendersBothFormats(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+
+	// JSON via ?format=json.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "https://clawpatrol/?format=json", nil)
+	writeDiscoveryResponse(rec, req, policy, "ops")
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("json content-type = %q", ct)
+	}
+	var m DiscoveryManifest
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	if m.Profile != "ops" || strings.Join(endpointNames(&m), ",") != "github,prod-pg" {
+		t.Errorf("json manifest = %+v", m)
+	}
+
+	// Markdown default (no query, no Accept).
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "https://clawpatrol/", nil)
+	writeDiscoveryResponse(rec2, req2, policy, "ops")
+	if ct := rec2.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("markdown content-type = %q", ct)
+	}
+	body := rec2.Body.String()
+	if !strings.Contains(body, "profile: ops") || !strings.Contains(body, "api.github.com") {
+		t.Errorf("markdown body missing expected content:\n%s", body)
+	}
+	if strings.Contains(body, "internal.example") || strings.Contains(body, "ch.example") {
+		t.Errorf("markdown leaked another profile's endpoints:\n%s", body)
+	}
+}
+
+// TestDiscoveryUnknownProfile: a device whose resolved profile isn't in
+// policy gets an empty manifest with a note, not an error or a config
+// dump.
+func TestDiscoveryUnknownProfile(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+	m := buildDiscoveryManifest(policy, "does-not-exist")
+	if len(m.Endpoints) != 0 || len(m.Credentials) != 0 {
+		t.Errorf("unknown profile should be empty, got %+v", m)
+	}
+	if len(m.Notes) == 0 {
+		t.Errorf("unknown profile should carry an explanatory note")
+	}
+}
+
+func TestIsDiscoveryHost(t *testing.T) {
+	cases := map[string]bool{
+		"clawpatrol":      true,
+		"ClawPatrol":      true,
+		"clawpatrol.":     true,
+		"clawpatrol:443":  true,
+		"api.github.com":  false,
+		"":                false,
+		"clawpatrol.evil": false,
+	}
+	for host, want := range cases {
+		if got := isDiscoveryHost(host); got != want {
+			t.Errorf("isDiscoveryHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}

--- a/cmd/clawpatrol/discovery_test.go
+++ b/cmd/clawpatrol/discovery_test.go
@@ -267,6 +267,80 @@ func TestDiscoveryUnknownProfile(t *testing.T) {
 	}
 }
 
+// TestDiscoveryEmptyProfileGuidance: a profile that grants nothing must
+// not hand the agent a bare "none/none" manifest. It explains the empty
+// state and points at the dashboard (gateway.public_url) where the
+// device's profile gets configured. A non-empty profile carries no such
+// pointer — it already has everything actionable.
+func TestDiscoveryEmptyProfileGuidance(t *testing.T) {
+	policy := compileDiscoveryFixture(t)
+
+	// "does-not-exist" resolves to no policy entry → empty manifest.
+	empty := buildDiscoveryManifest(policy, "does-not-exist")
+	if !empty.isEmpty() {
+		t.Fatalf("expected empty manifest, got %+v", empty)
+	}
+	if empty.Dashboard != "https://gw.example.test" {
+		t.Errorf("empty manifest dashboard = %q, want gateway public_url", empty.Dashboard)
+	}
+	md := empty.Markdown()
+	for _, want := range []string{"This profile is empty", "https://gw.example.test", "re-fetch this manifest"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("empty manifest markdown missing %q:\n%s", want, md)
+		}
+	}
+
+	// A populated profile gets neither the dashboard pointer nor the
+	// empty-state guidance.
+	ops := buildDiscoveryManifest(policy, "ops")
+	if ops.Dashboard != "" {
+		t.Errorf("non-empty manifest should not surface dashboard, got %q", ops.Dashboard)
+	}
+	if strings.Contains(ops.Markdown(), "This profile is empty") {
+		t.Errorf("non-empty manifest leaked empty-profile guidance")
+	}
+}
+
+// TestDiscoveryEmptyProfileNoPublicURL: when public_url is unset, the
+// empty-state guidance still renders — minus the URL — rather than
+// printing a dangling "open the dashboard at " line.
+func TestDiscoveryEmptyProfileNoPublicURL(t *testing.T) {
+	const noURL = `gateway {
+  state_dir = "/opt/clawpatrol"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint    = "127.0.0.1:51820"
+  }
+}
+
+endpoint "https" "github" { hosts = ["api.github.com"] }
+credential "bearer_token" "gh" {
+  endpoint    = https.github
+  placeholder = "PH_GH"
+}
+profile "empty" { credentials = [] }
+`
+	gw, diags := config.LoadBytes([]byte(noURL), "nourl.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	m := buildDiscoveryManifest(policy, "empty")
+	if m.Dashboard != "" {
+		t.Errorf("dashboard should be empty when public_url unset, got %q", m.Dashboard)
+	}
+	md := m.Markdown()
+	if !strings.Contains(md, "This profile is empty") {
+		t.Errorf("guidance missing:\n%s", md)
+	}
+	if strings.Contains(md, "open the dashboard at\n") || strings.Contains(md, "dashboard at ") {
+		t.Errorf("dangling dashboard URL line rendered:\n%s", md)
+	}
+}
+
 func TestIsDiscoveryHost(t *testing.T) {
 	cases := map[string]bool{
 		"clawpatrol":      true,

--- a/cmd/clawpatrol/discovery_test.go
+++ b/cmd/clawpatrol/discovery_test.go
@@ -170,27 +170,33 @@ func TestDiscoveryEndpointDetail(t *testing.T) {
 	}
 }
 
-// TestDiscoveryTunnelReported asserts a tunneled endpoint surfaces the
-// tunnel the agent must have active to reach it.
-func TestDiscoveryTunnelReported(t *testing.T) {
+// TestDiscoveryTunnelHidden asserts a tunneled endpoint reads no
+// differently from a directly-reachable one. The gateway brings the
+// tunnel up transparently, so the agent dials the same host either way —
+// the tunnel's name/type would be noise it can't act on. A tunneled
+// endpoint must still surface its host (the one thing the agent needs).
+func TestDiscoveryTunnelHidden(t *testing.T) {
 	policy := compileDiscoveryFixture(t)
 	ops := buildDiscoveryManifest(policy, "ops")
 
 	pg := findEndpoint(ops, "prod-pg")
-	if pg == nil || pg.Tunnel == nil {
-		t.Fatalf("prod-pg tunnel not reported: %+v", pg)
+	if pg == nil {
+		t.Fatal("prod-pg endpoint missing")
 	}
-	if pg.Tunnel.Name != "csql" || pg.Tunnel.Type != "local_command" {
-		t.Errorf("prod-pg tunnel = %+v, want csql/local_command", pg.Tunnel)
+	// The host the agent dials is still reported — that's all it needs.
+	if len(pg.Hosts) != 1 || pg.Hosts[0] != "main-pg.example" {
+		t.Errorf("prod-pg hosts = %v, want [main-pg.example]", pg.Hosts)
 	}
-	// The non-tunneled endpoint must not invent one.
-	if gh := findEndpoint(ops, "github"); gh.Tunnel != nil {
-		t.Errorf("github should have no tunnel, got %+v", gh.Tunnel)
+
+	// No tunnel detail leaks into either render. The JSON has no `tunnel`
+	// key; the markdown has no `Tunnel:` line, REQUIRED or otherwise.
+	js := string(renderJSON(t, policy, "ops"))
+	if strings.Contains(js, "\"tunnel\"") || strings.Contains(js, "csql") || strings.Contains(js, "local_command") {
+		t.Errorf("json leaked tunnel detail:\n%s", js)
 	}
-	// Markdown spells out the REQUIRED tunnel so an LLM acts on it.
 	md := ops.Markdown()
-	if !strings.Contains(md, "Tunnel: REQUIRED") || !strings.Contains(md, "csql") {
-		t.Errorf("markdown missing tunnel requirement:\n%s", md)
+	if strings.Contains(md, "Tunnel") || strings.Contains(md, "csql") {
+		t.Errorf("markdown leaked tunnel detail:\n%s", md)
 	}
 }
 

--- a/cmd/clawpatrol/dnsvip/dnsvip.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip.go
@@ -85,6 +85,33 @@ var (
 // pathological reload loops.
 const MaxID uint32 = 0xFFFE
 
+// DiscoveryHostname is the reserved name the gateway answers locally
+// with a manifest of the caller's profile (see cmd/clawpatrol's
+// discovery endpoint). The allocator hands back a fixed VIP for it so
+// `curl https://clawpatrol/` resolves inside the tunnel; the WG
+// forwarder then routes the :443 SYN to the local discovery handler
+// rather than any upstream.
+const DiscoveryHostname = "clawpatrol"
+
+// discoveryID is the VIP slot reserved for the discovery name. It sits
+// one past MaxID so allocateLocked never hands it to a real hostname,
+// giving the discovery name a stable address (x.x.255.255 v4,
+// ::ffff v6 within the configured CIDRs) without consuming a normal
+// allocation.
+const discoveryID uint32 = MaxID + 1
+
+// isDiscoveryName reports whether hostname is the reserved discovery
+// name (case-insensitive; caller has already trimmed the trailing dot).
+func isDiscoveryName(hostname string) bool {
+	return strings.EqualFold(hostname, DiscoveryHostname)
+}
+
+// DiscoveryVIPs returns the fixed (v4, v6) addresses the discovery
+// name resolves to under this allocator's configured CIDRs.
+func (a *Allocator) DiscoveryVIPs() (netip.Addr, netip.Addr) {
+	return a.vipForID(discoveryID)
+}
+
 type entry struct {
 	ID       uint32
 	Hostname string
@@ -624,6 +651,9 @@ func (a *Allocator) handleQuery(q *dns.Msg, dstIP string) *dns.Msg {
 	for _, qq := range q.Question {
 		host := strings.TrimSuffix(qq.Name, ".")
 		v4, v6 := a.VIPsFor(host)
+		if isDiscoveryName(host) {
+			v4, v6 = a.DiscoveryVIPs()
+		}
 		switch qq.Qtype {
 		case dns.TypeA:
 			if v4.IsValid() {
@@ -658,6 +688,11 @@ func (a *Allocator) handleQuery(q *dns.Msg, dstIP string) *dns.Msg {
 // policy).
 func (a *Allocator) intercepts(hostname string) bool {
 	hostname = strings.ToLower(hostname)
+	if isDiscoveryName(hostname) {
+		// Reserved name: answered locally from a fixed VIP, never
+		// forwarded upstream (the name doesn't exist in public DNS).
+		return true
+	}
 	a.mu.RLock()
 	if _, ok := a.byName[hostname]; ok {
 		a.mu.RUnlock()

--- a/cmd/clawpatrol/dnsvip/dnsvip_test.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip_test.go
@@ -232,6 +232,61 @@ func TestDNSARecordRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDiscoveryNameServedLocally asserts the reserved discovery name
+// resolves to its fixed VIP and is answered authoritatively from the
+// allocator — never forwarded upstream — even with no endpoint policy
+// loaded. The fixed slot also must never collide with a real
+// allocation.
+func TestDiscoveryNameServedLocally(t *testing.T) {
+	db := testDB(t)
+	a, err := New(db, DefaultCIDR4, DefaultCIDR6)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// No RebuildFromPolicy: the discovery name is a built-in, not a
+	// policy-declared host.
+
+	v4, v6 := a.DiscoveryVIPs()
+	if !v4.IsValid() || !v6.IsValid() {
+		t.Fatalf("discovery VIPs invalid: v4=%v v6=%v", v4, v6)
+	}
+	if !DefaultCIDR4.Contains(v4) || !DefaultCIDR6.Contains(v6) {
+		t.Fatalf("discovery VIPs outside CIDRs: v4=%v v6=%v", v4, v6)
+	}
+
+	if !a.intercepts(DiscoveryHostname) {
+		t.Fatalf("discovery name should be intercepted")
+	}
+
+	q := new(dns.Msg)
+	q.SetQuestion(DiscoveryHostname+".", dns.TypeA)
+	resp := a.handleQuery(q, "")
+	if resp == nil || !resp.Authoritative || len(resp.Answer) != 1 {
+		t.Fatalf("discovery A: want 1 authoritative answer, got %v", resp)
+	}
+	if got := resp.Answer[0].(*dns.A).A; !net.IP(v4.AsSlice()).Equal(got) {
+		t.Fatalf("discovery A = %v, want %v", got, v4)
+	}
+
+	q.SetQuestion(DiscoveryHostname+".", dns.TypeAAAA)
+	resp = a.handleQuery(q, "")
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("discovery AAAA: want 1 answer, got %v", resp)
+	}
+	if got := resp.Answer[0].(*dns.AAAA).AAAA; !net.IP(v6.AsSlice()).Equal(got) {
+		t.Fatalf("discovery AAAA = %v, want %v", got, v6)
+	}
+
+	// The reserved slot must not be handed to a real allocation.
+	if err := a.RebuildFromPolicy(fakePolicy(t, []string{"real.example.com:22"})); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	rv4, _ := a.VIPsFor("real.example.com")
+	if rv4 == v4 {
+		t.Fatalf("real allocation collided with reserved discovery VIP %v", v4)
+	}
+}
+
 func TestLookupVIP(t *testing.T) {
 	db := testDB(t)
 	a, err := New(db, DefaultCIDR4, DefaultCIDR6)

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1419,6 +1419,13 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 		// by IP and never sends SNI).
 		if dstIP != "" {
 			c := wrapPeek(raw, prefix)
+			if g.isDiscoveryVIP(dstIP) {
+				// Fixed-IP fallback for `curl https://<discovery-vip>/`
+				// when DNS interception isn't active — no SNI on an IP
+				// literal, so the dst VIP is the only signal.
+				g.serveDiscovery(c, dstIP)
+				return
+			}
 			pip := peerIP(c)
 			profile := g.profileFor(pip)
 			ep, authority, certHost := g.httpsMITMEndpoint(profile, dstIP, dstPort)
@@ -1433,6 +1440,12 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 	}
 	c := wrapPeek(raw, prefix)
 	log.Printf("sni-peek: %s", host)
+	if isDiscoveryHost(host) {
+		// Reserved discovery name: serve the caller's profile manifest
+		// locally and never proxy upstream.
+		g.serveDiscovery(c, discoveryHostname)
+		return
+	}
 	pip := peerIP(c)
 	profile := g.profileFor(pip)
 	ep, authority, certHost := g.httpsMITMEndpoint(profile, host, dstPort)

--- a/cmd/clawpatrol/testdata/discovery/empty.hcl
+++ b/cmd/clawpatrol/testdata/discovery/empty.hcl
@@ -1,0 +1,21 @@
+# Render profile: empty
+#
+# A declared profile that grants no credentials. Other endpoints and
+# credentials exist in the config, so a non-empty manifest here would
+# mean the per-profile scoping leaked. The manifest must come back with
+# zero endpoints and zero credentials (not an error, not a config dump).
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+endpoint "https" "github" { hosts = ["api.github.com"] }
+
+credential "bearer_token" "gh" {
+  endpoint    = https.github
+  placeholder = "PH_GH"
+}
+
+profile "haz-access" { credentials = [bearer_token.gh] }
+profile "empty"      { credentials = [] }

--- a/cmd/clawpatrol/testdata/discovery/empty.json
+++ b/cmd/clawpatrol/testdata/discovery/empty.json
@@ -1,0 +1,5 @@
+{
+  "profile": "empty",
+  "endpoints": [],
+  "credentials": []
+}

--- a/cmd/clawpatrol/testdata/discovery/empty.json
+++ b/cmd/clawpatrol/testdata/discovery/empty.json
@@ -1,5 +1,6 @@
 {
   "profile": "empty",
   "endpoints": [],
-  "credentials": []
+  "credentials": [],
+  "dashboard": "https://gw.example.test"
 }

--- a/cmd/clawpatrol/testdata/discovery/empty.md
+++ b/cmd/clawpatrol/testdata/discovery/empty.md
@@ -11,6 +11,3 @@ device profile; it lists only what this profile grants.
 
 _None reachable for this profile._
 
-## Credentials (0)
-
-_None granted to this profile._

--- a/cmd/clawpatrol/testdata/discovery/empty.md
+++ b/cmd/clawpatrol/testdata/discovery/empty.md
@@ -1,0 +1,16 @@
+# Claw Patrol access manifest — profile: empty
+
+You are connected through the Claw Patrol gateway. It intercepts your
+connections transparently: dial the hosts below as you normally would and
+the gateway injects credentials and enforces policy. A credential
+`placeholder` is a literal string you send where the secret would go — the
+gateway swaps it for the real secret. This manifest is scoped to YOUR
+device profile; it lists only what this profile grants.
+
+## Endpoints (0)
+
+_None reachable for this profile._
+
+## Credentials (0)
+
+_None granted to this profile._

--- a/cmd/clawpatrol/testdata/discovery/empty.md
+++ b/cmd/clawpatrol/testdata/discovery/empty.md
@@ -7,6 +7,24 @@ the gateway injects credentials and enforces policy. A credential
 gateway swaps it for the real secret. This manifest is scoped to YOUR
 device profile; it lists only what this profile grants.
 
+## This profile is empty
+
+Your device is mapped to the `empty` profile, which currently grants no
+endpoints and no credentials. That's why there's nothing actionable
+below. This is a configuration state, not an error — the gateway is
+reachable, your device just hasn't been granted anything yet.
+
+To get value from Claw Patrol, this profile needs endpoints and the
+credentials to reach them bound to it. An operator does that in the
+dashboard by either assigning this device a profile that already grants
+what you need, or adding endpoints and credentials to this one.
+
+Ask the person who runs this gateway to open the dashboard at https://gw.example.test
+and update this device's profile.
+
+Once the profile is configured, re-fetch this manifest (GET
+https://clawpatrol/) and the endpoints and credentials will appear below.
+
 ## Endpoints (0)
 
 _None reachable for this profile._

--- a/cmd/clawpatrol/testdata/discovery/multicred.hcl
+++ b/cmd/clawpatrol/testdata/discovery/multicred.hcl
@@ -1,0 +1,30 @@
+# Render profile: dba
+#
+# Two postgres credentials bound to the SAME endpoint, disambiguated by
+# user/database. The endpoint must list both credentials (sorted by
+# name), the Credentials section must list both pointing back at the one
+# endpoint, and the psql hint must pin to the first credential by sort
+# order (pg-ro). Locks down the multiple-creds-per-endpoint shape.
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+endpoint "postgres" "pg" {
+  host    = "pg.example:5432"
+  sslmode = "require"
+}
+
+credential "postgres_credential" "pg-rw" {
+  endpoint = postgres.pg
+  user     = "writer"
+  database = "app"
+}
+credential "postgres_credential" "pg-ro" {
+  endpoint = postgres.pg
+  user     = "reader"
+  database = "app"
+}
+
+profile "dba" { credentials = [postgres_credential.pg-rw, postgres_credential.pg-ro] }

--- a/cmd/clawpatrol/testdata/discovery/multicred.json
+++ b/cmd/clawpatrol/testdata/discovery/multicred.json
@@ -1,0 +1,50 @@
+{
+  "profile": "dba",
+  "endpoints": [
+    {
+      "name": "pg",
+      "type": "postgres",
+      "family": "sql",
+      "hosts": [
+        "pg.example"
+      ],
+      "port": 5432,
+      "sslmode": "require",
+      "credentials": [
+        {
+          "name": "pg-ro",
+          "type": "postgres_credential",
+          "disambiguators": {
+            "database": "app",
+            "user": "reader"
+          }
+        },
+        {
+          "name": "pg-rw",
+          "type": "postgres_credential",
+          "disambiguators": {
+            "database": "app",
+            "user": "writer"
+          }
+        }
+      ],
+      "hint": "psql \"host=pg.example port=5432 user=reader dbname=app sslmode=require\""
+    }
+  ],
+  "credentials": [
+    {
+      "name": "pg-ro",
+      "type": "postgres_credential",
+      "endpoints": [
+        "pg"
+      ]
+    },
+    {
+      "name": "pg-rw",
+      "type": "postgres_credential",
+      "endpoints": [
+        "pg"
+      ]
+    }
+  ]
+}

--- a/cmd/clawpatrol/testdata/discovery/multicred.md
+++ b/cmd/clawpatrol/testdata/discovery/multicred.md
@@ -1,0 +1,25 @@
+# Claw Patrol access manifest — profile: dba
+
+You are connected through the Claw Patrol gateway. It intercepts your
+connections transparently: dial the hosts below as you normally would and
+the gateway injects credentials and enforces policy. A credential
+`placeholder` is a literal string you send where the secret would go — the
+gateway swaps it for the real secret. This manifest is scoped to YOUR
+device profile; it lists only what this profile grants.
+
+## Endpoints (1)
+
+### pg  (postgres)
+
+- Host(s): pg.example
+- Port: 5432
+- SSL mode: require
+- Tunnel: none (reachable directly through the gateway)
+- Credential: postgres_credential `pg-ro` — connect with database=app user=reader
+- Credential: postgres_credential `pg-rw` — connect with database=app user=writer
+- Example: `psql "host=pg.example port=5432 user=reader dbname=app sslmode=require"`
+
+## Credentials (2)
+
+- postgres_credential `pg-ro` → endpoints: pg
+- postgres_credential `pg-rw` → endpoints: pg

--- a/cmd/clawpatrol/testdata/discovery/multicred.md
+++ b/cmd/clawpatrol/testdata/discovery/multicred.md
@@ -14,7 +14,6 @@ device profile; it lists only what this profile grants.
 - Host(s): pg.example
 - Port: 5432
 - SSL mode: require
-- Tunnel: none (reachable directly through the gateway)
 - Credential: postgres_credential `pg-ro` — connect with database=app user=reader
 - Credential: postgres_credential `pg-rw` — connect with database=app user=writer
 - Example: `psql "host=pg.example port=5432 user=reader dbname=app sslmode=require"`

--- a/cmd/clawpatrol/testdata/discovery/multicred.md
+++ b/cmd/clawpatrol/testdata/discovery/multicred.md
@@ -18,7 +18,3 @@ device profile; it lists only what this profile grants.
 - Credential: postgres_credential `pg-rw` — connect with database=app user=writer
 - Example: `psql "host=pg.example port=5432 user=reader dbname=app sslmode=require"`
 
-## Credentials (2)
-
-- postgres_credential `pg-ro` → endpoints: pg
-- postgres_credential `pg-rw` → endpoints: pg

--- a/cmd/clawpatrol/testdata/discovery/simple.hcl
+++ b/cmd/clawpatrol/testdata/discovery/simple.hcl
@@ -1,0 +1,19 @@
+# Render profile: simple
+#
+# The minimal real profile: one HTTPS endpoint reachable with one bearer
+# credential. Exercises host rendering, the placeholder, the curl hint,
+# and the per-credential Credentials section in both formats.
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+endpoint "https" "github" { hosts = ["api.github.com"] }
+
+credential "bearer_token" "gh" {
+  endpoint    = https.github
+  placeholder = "PH_GH"
+}
+
+profile "simple" { credentials = [bearer_token.gh] }

--- a/cmd/clawpatrol/testdata/discovery/simple.json
+++ b/cmd/clawpatrol/testdata/discovery/simple.json
@@ -1,0 +1,31 @@
+{
+  "profile": "simple",
+  "endpoints": [
+    {
+      "name": "github",
+      "type": "https",
+      "family": "http",
+      "hosts": [
+        "api.github.com"
+      ],
+      "credentials": [
+        {
+          "name": "gh",
+          "type": "bearer_token",
+          "placeholder": "PH_GH"
+        }
+      ],
+      "hint": "curl https://api.github.com/ -H \"Authorization: Bearer PH_GH\""
+    }
+  ],
+  "credentials": [
+    {
+      "name": "gh",
+      "type": "bearer_token",
+      "placeholder": "PH_GH",
+      "endpoints": [
+        "github"
+      ]
+    }
+  ]
+}

--- a/cmd/clawpatrol/testdata/discovery/simple.md
+++ b/cmd/clawpatrol/testdata/discovery/simple.md
@@ -1,0 +1,21 @@
+# Claw Patrol access manifest — profile: simple
+
+You are connected through the Claw Patrol gateway. It intercepts your
+connections transparently: dial the hosts below as you normally would and
+the gateway injects credentials and enforces policy. A credential
+`placeholder` is a literal string you send where the secret would go — the
+gateway swaps it for the real secret. This manifest is scoped to YOUR
+device profile; it lists only what this profile grants.
+
+## Endpoints (1)
+
+### github  (https)
+
+- Host(s): api.github.com
+- Tunnel: none (reachable directly through the gateway)
+- Credential: bearer_token `gh` — send placeholder `PH_GH`
+- Example: `curl https://api.github.com/ -H "Authorization: Bearer PH_GH"`
+
+## Credentials (1)
+
+- bearer_token `gh` → placeholder `PH_GH` → endpoints: github

--- a/cmd/clawpatrol/testdata/discovery/simple.md
+++ b/cmd/clawpatrol/testdata/discovery/simple.md
@@ -12,7 +12,6 @@ device profile; it lists only what this profile grants.
 ### github  (https)
 
 - Host(s): api.github.com
-- Tunnel: none (reachable directly through the gateway)
 - Credential: bearer_token `gh` — send placeholder `PH_GH`
 - Example: `curl https://api.github.com/ -H "Authorization: Bearer PH_GH"`
 

--- a/cmd/clawpatrol/testdata/discovery/simple.md
+++ b/cmd/clawpatrol/testdata/discovery/simple.md
@@ -15,6 +15,3 @@ device profile; it lists only what this profile grants.
 - Credential: bearer_token `gh` — send placeholder `PH_GH`
 - Example: `curl https://api.github.com/ -H "Authorization: Bearer PH_GH"`
 
-## Credentials (1)
-
-- bearer_token `gh` → placeholder `PH_GH` → endpoints: github

--- a/cmd/clawpatrol/testdata/discovery/tunnel.hcl
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.hcl
@@ -1,0 +1,41 @@
+# Render profile: tunneled
+#
+# A profile whose reachable endpoint sits behind a tunnel. Exercises the
+# tunnel-reporting path end-to-end: the endpoint must carry the tunnel's
+# name/type, the markdown must spell out "Tunnel: REQUIRED", and a
+# second, directly-reachable endpoint in the same profile must render
+# "Tunnel: none" so the contrast is locked down. Pairs the local_command
+# tunnel (the one the unit tests use) with a tunneled postgres endpoint.
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+tunnel "local_command" "csql" {
+  command     = ["cloud_sql_proxy", "--instances", "p:r:db=tcp:5432"]
+  listen      = "127.0.0.1:5432"
+  ready_probe = "tcp"
+  share       = "singleton"
+  keepalive   = "5m"
+}
+
+endpoint "https" "github" { hosts = ["api.github.com"] }
+
+endpoint "postgres" "prod-pg" {
+  host    = "main-pg.example:5432"
+  sslmode = "require"
+  tunnel  = local_command.csql
+}
+
+credential "bearer_token" "gh" {
+  endpoint    = https.github
+  placeholder = "PH_GH"
+}
+credential "postgres_credential" "pg-rw" {
+  endpoint = postgres.prod-pg
+  user     = "app"
+  database = "prod"
+}
+
+profile "tunneled" { credentials = [bearer_token.gh, postgres_credential.pg-rw] }

--- a/cmd/clawpatrol/testdata/discovery/tunnel.hcl
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.hcl
@@ -1,11 +1,13 @@
 # Render profile: tunneled
 #
-# A profile whose reachable endpoint sits behind a tunnel. Exercises the
-# tunnel-reporting path end-to-end: the endpoint must carry the tunnel's
-# name/type, the markdown must spell out "Tunnel: REQUIRED", and a
-# second, directly-reachable endpoint in the same profile must render
-# "Tunnel: none" so the contrast is locked down. Pairs the local_command
-# tunnel (the one the unit tests use) with a tunneled postgres endpoint.
+# A profile whose endpoints sit behind tunnels — one per tunnel plugin
+# type (local_command, tailscale, ssh_port_forward,
+# kubernetes_port_forward). The point of covering every type is to lock
+# down that NONE of them leak into the agent-facing manifest: the gateway
+# brings the tunnel up transparently, so each endpoint must render
+# identically to a directly-reachable one (host/port/credential only, no
+# tunnel line). A direct `github` endpoint is kept alongside as the
+# contrast — the tunneled endpoints must read no differently from it.
 gateway {
   state_dir  = "/opt/clawpatrol"
   public_url = "https://gw.example.test"
@@ -20,12 +22,49 @@ tunnel "local_command" "csql" {
   keepalive   = "5m"
 }
 
+tunnel "tailscale" "ts" {
+  hostname = "clawpatrol-tunnel-o11y"
+}
+
+credential "ssh_key" "bastion" {}
+
+tunnel "ssh_port_forward" "bastion-pg" {
+  bastion    = "bastion.example:22"
+  user       = "deploy"
+  credential = ssh_key.bastion
+}
+
+tunnel "kubernetes_port_forward" "kpf" {
+  context = "prod-eks"
+  service = "postgres"
+  port    = 5432
+}
+
 endpoint "https" "github" { hosts = ["api.github.com"] }
 
 endpoint "postgres" "prod-pg" {
   host    = "main-pg.example:5432"
   sslmode = "require"
   tunnel  = local_command.csql
+}
+
+endpoint "clickhouse_native" "metrics" {
+  hosts  = ["ch.example"]
+  port   = 9440
+  tls    = true
+  tunnel = tailscale.ts
+}
+
+endpoint "postgres" "rds-pg" {
+  host    = "rds.example:5432"
+  sslmode = "require"
+  tunnel  = ssh_port_forward.bastion-pg
+}
+
+endpoint "postgres" "k8s-pg" {
+  host    = "k8s-pg.example:5432"
+  sslmode = "require"
+  tunnel  = kubernetes_port_forward.kpf
 }
 
 credential "bearer_token" "gh" {
@@ -37,5 +76,27 @@ credential "postgres_credential" "pg-rw" {
   user     = "app"
   database = "prod"
 }
+credential "clickhouse_credential" "ch-ro" {
+  endpoint = clickhouse_native.metrics
+  user     = "ro"
+}
+credential "postgres_credential" "rds-rw" {
+  endpoint = postgres.rds-pg
+  user     = "app"
+  database = "prod"
+}
+credential "postgres_credential" "k8s-rw" {
+  endpoint = postgres.k8s-pg
+  user     = "app"
+  database = "prod"
+}
 
-profile "tunneled" { credentials = [bearer_token.gh, postgres_credential.pg-rw] }
+profile "tunneled" {
+  credentials = [
+    bearer_token.gh,
+    postgres_credential.pg-rw,
+    clickhouse_credential.ch-ro,
+    postgres_credential.rds-rw,
+    postgres_credential.k8s-rw,
+  ]
+}

--- a/cmd/clawpatrol/testdata/discovery/tunnel.json
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.json
@@ -18,6 +18,46 @@
       "hint": "curl https://api.github.com/ -H \"Authorization: Bearer PH_GH\""
     },
     {
+      "name": "k8s-pg",
+      "type": "postgres",
+      "family": "sql",
+      "hosts": [
+        "k8s-pg.example"
+      ],
+      "port": 5432,
+      "sslmode": "require",
+      "credentials": [
+        {
+          "name": "k8s-rw",
+          "type": "postgres_credential",
+          "disambiguators": {
+            "database": "prod",
+            "user": "app"
+          }
+        }
+      ],
+      "hint": "psql \"host=k8s-pg.example port=5432 user=app dbname=prod sslmode=require\""
+    },
+    {
+      "name": "metrics",
+      "type": "clickhouse_native",
+      "family": "sql",
+      "hosts": [
+        "ch.example"
+      ],
+      "port": 9440,
+      "credentials": [
+        {
+          "name": "ch-ro",
+          "type": "clickhouse_credential",
+          "disambiguators": {
+            "user": "ro"
+          }
+        }
+      ],
+      "hint": "clickhouse-client --host ch.example --port 9440 --user ro"
+    },
+    {
       "name": "prod-pg",
       "type": "postgres",
       "family": "sql",
@@ -26,10 +66,6 @@
       ],
       "port": 5432,
       "sslmode": "require",
-      "tunnel": {
-        "name": "csql",
-        "type": "local_command"
-      },
       "credentials": [
         {
           "name": "pg-rw",
@@ -41,9 +77,37 @@
         }
       ],
       "hint": "psql \"host=main-pg.example port=5432 user=app dbname=prod sslmode=require\""
+    },
+    {
+      "name": "rds-pg",
+      "type": "postgres",
+      "family": "sql",
+      "hosts": [
+        "rds.example"
+      ],
+      "port": 5432,
+      "sslmode": "require",
+      "credentials": [
+        {
+          "name": "rds-rw",
+          "type": "postgres_credential",
+          "disambiguators": {
+            "database": "prod",
+            "user": "app"
+          }
+        }
+      ],
+      "hint": "psql \"host=rds.example port=5432 user=app dbname=prod sslmode=require\""
     }
   ],
   "credentials": [
+    {
+      "name": "ch-ro",
+      "type": "clickhouse_credential",
+      "endpoints": [
+        "metrics"
+      ]
+    },
     {
       "name": "gh",
       "type": "bearer_token",
@@ -53,10 +117,24 @@
       ]
     },
     {
+      "name": "k8s-rw",
+      "type": "postgres_credential",
+      "endpoints": [
+        "k8s-pg"
+      ]
+    },
+    {
       "name": "pg-rw",
       "type": "postgres_credential",
       "endpoints": [
         "prod-pg"
+      ]
+    },
+    {
+      "name": "rds-rw",
+      "type": "postgres_credential",
+      "endpoints": [
+        "rds-pg"
       ]
     }
   ]

--- a/cmd/clawpatrol/testdata/discovery/tunnel.json
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.json
@@ -1,0 +1,63 @@
+{
+  "profile": "tunneled",
+  "endpoints": [
+    {
+      "name": "github",
+      "type": "https",
+      "family": "http",
+      "hosts": [
+        "api.github.com"
+      ],
+      "credentials": [
+        {
+          "name": "gh",
+          "type": "bearer_token",
+          "placeholder": "PH_GH"
+        }
+      ],
+      "hint": "curl https://api.github.com/ -H \"Authorization: Bearer PH_GH\""
+    },
+    {
+      "name": "prod-pg",
+      "type": "postgres",
+      "family": "sql",
+      "hosts": [
+        "main-pg.example"
+      ],
+      "port": 5432,
+      "sslmode": "require",
+      "tunnel": {
+        "name": "csql",
+        "type": "local_command"
+      },
+      "credentials": [
+        {
+          "name": "pg-rw",
+          "type": "postgres_credential",
+          "disambiguators": {
+            "database": "prod",
+            "user": "app"
+          }
+        }
+      ],
+      "hint": "psql \"host=main-pg.example port=5432 user=app dbname=prod sslmode=require\""
+    }
+  ],
+  "credentials": [
+    {
+      "name": "gh",
+      "type": "bearer_token",
+      "placeholder": "PH_GH",
+      "endpoints": [
+        "github"
+      ]
+    },
+    {
+      "name": "pg-rw",
+      "type": "postgres_credential",
+      "endpoints": [
+        "prod-pg"
+      ]
+    }
+  ]
+}

--- a/cmd/clawpatrol/testdata/discovery/tunnel.md
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.md
@@ -1,0 +1,31 @@
+# Claw Patrol access manifest — profile: tunneled
+
+You are connected through the Claw Patrol gateway. It intercepts your
+connections transparently: dial the hosts below as you normally would and
+the gateway injects credentials and enforces policy. A credential
+`placeholder` is a literal string you send where the secret would go — the
+gateway swaps it for the real secret. This manifest is scoped to YOUR
+device profile; it lists only what this profile grants.
+
+## Endpoints (2)
+
+### github  (https)
+
+- Host(s): api.github.com
+- Tunnel: none (reachable directly through the gateway)
+- Credential: bearer_token `gh` — send placeholder `PH_GH`
+- Example: `curl https://api.github.com/ -H "Authorization: Bearer PH_GH"`
+
+### prod-pg  (postgres)
+
+- Host(s): main-pg.example
+- Port: 5432
+- SSL mode: require
+- Tunnel: REQUIRED — `csql` (local_command) must be active to reach this endpoint
+- Credential: postgres_credential `pg-rw` — connect with database=prod user=app
+- Example: `psql "host=main-pg.example port=5432 user=app dbname=prod sslmode=require"`
+
+## Credentials (2)
+
+- bearer_token `gh` → placeholder `PH_GH` → endpoints: github
+- postgres_credential `pg-rw` → endpoints: prod-pg

--- a/cmd/clawpatrol/testdata/discovery/tunnel.md
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.md
@@ -46,10 +46,3 @@ device profile; it lists only what this profile grants.
 - Credential: postgres_credential `rds-rw` — connect with database=prod user=app
 - Example: `psql "host=rds.example port=5432 user=app dbname=prod sslmode=require"`
 
-## Credentials (5)
-
-- clickhouse_credential `ch-ro` → endpoints: metrics
-- bearer_token `gh` → placeholder `PH_GH` → endpoints: github
-- postgres_credential `k8s-rw` → endpoints: k8s-pg
-- postgres_credential `pg-rw` → endpoints: prod-pg
-- postgres_credential `rds-rw` → endpoints: rds-pg

--- a/cmd/clawpatrol/testdata/discovery/tunnel.md
+++ b/cmd/clawpatrol/testdata/discovery/tunnel.md
@@ -7,25 +7,49 @@ the gateway injects credentials and enforces policy. A credential
 gateway swaps it for the real secret. This manifest is scoped to YOUR
 device profile; it lists only what this profile grants.
 
-## Endpoints (2)
+## Endpoints (5)
 
 ### github  (https)
 
 - Host(s): api.github.com
-- Tunnel: none (reachable directly through the gateway)
 - Credential: bearer_token `gh` — send placeholder `PH_GH`
 - Example: `curl https://api.github.com/ -H "Authorization: Bearer PH_GH"`
+
+### k8s-pg  (postgres)
+
+- Host(s): k8s-pg.example
+- Port: 5432
+- SSL mode: require
+- Credential: postgres_credential `k8s-rw` — connect with database=prod user=app
+- Example: `psql "host=k8s-pg.example port=5432 user=app dbname=prod sslmode=require"`
+
+### metrics  (clickhouse_native)
+
+- Host(s): ch.example
+- Port: 9440
+- Credential: clickhouse_credential `ch-ro` — connect with user=ro
+- Example: `clickhouse-client --host ch.example --port 9440 --user ro`
 
 ### prod-pg  (postgres)
 
 - Host(s): main-pg.example
 - Port: 5432
 - SSL mode: require
-- Tunnel: REQUIRED — `csql` (local_command) must be active to reach this endpoint
 - Credential: postgres_credential `pg-rw` — connect with database=prod user=app
 - Example: `psql "host=main-pg.example port=5432 user=app dbname=prod sslmode=require"`
 
-## Credentials (2)
+### rds-pg  (postgres)
 
+- Host(s): rds.example
+- Port: 5432
+- SSL mode: require
+- Credential: postgres_credential `rds-rw` — connect with database=prod user=app
+- Example: `psql "host=rds.example port=5432 user=app dbname=prod sslmode=require"`
+
+## Credentials (5)
+
+- clickhouse_credential `ch-ro` → endpoints: metrics
 - bearer_token `gh` → placeholder `PH_GH` → endpoints: github
+- postgres_credential `k8s-rw` → endpoints: k8s-pg
 - postgres_credential `pg-rw` → endpoints: prod-pg
+- postgres_credential `rds-rw` → endpoints: rds-pg

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -25,6 +25,13 @@ type CompiledPolicy struct {
 	HumanTimeout   int
 	HumanOnTimeout string
 
+	// DashboardURL mirrors gateway.public_url — the canonical URL where
+	// an operator reaches the dashboard to configure device profiles.
+	// Surfaced here so the discovery manifest can point an agent (or its
+	// human) at the dashboard when its profile grants nothing. Empty when
+	// public_url is unset.
+	DashboardURL string
+
 	// Profiles indexed by name. Each holds a per-endpoint rule list,
 	// already family-tagged and priority-sorted.
 	Profiles map[string]*CompiledProfile
@@ -270,6 +277,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		LLMCacheTTL:    d.LLMCacheTTL,
 		HumanTimeout:   d.HumanTimeout,
 		HumanOnTimeout: d.HumanOnTimeout,
+		DashboardURL:   gw.PublicURL(),
 		Profiles:       map[string]*CompiledProfile{},
 		Endpoints:      map[string]*CompiledEndpoint{},
 		Tunnels:        map[string]*CompiledTunnel{},


### PR DESCRIPTION
## Summary

no_merge: true

## PR comment needs response

**Rig**: clawpatrol · **Repo**: denoland/clawpatrol
**PR**: [feat: profile-scoped endpoint/credential discovery endpoint](https://github.com/denoland/clawpatrol/pull/645) (#645, branch `polecat/guzzle-mq6mjqbt`)
**Comment by**: @arnauorriols
**Kind**: review
**Link**: https://github.com/denoland/clawpatrol/pull/645#discussion_r3387245825
**Location**: `cmd/clawpatrol/testdata/discovery/empty.md:1`

### Comment body

~~~
This is not useful for agents. We should tell the agent that their gateway profile is empty, and give some hints suggesting to configure the profile in the gateway so that they can get all the value from clawpatrol. We should tell the agent also where the user can reach the dashboard to change the profile of the device, for example
~~~

## How to address

1. Check out the existing PR branch directly. Do NOT create a new polecat branch:

   ```
   git fetch origin
   git checkout polecat/guzzle-mq6mjqbt
   ```

2. Read the file/line context and the full comment. Then either:
   - Change request: implement, commit, push to `polecat/guzzle-mq6mjqbt`.
   - Question: reply on GitHub. The first line of your reply MUST be `[bot-reply]` so this watcher ignores it next cycle.
     - Threaded review reply: `gh api -X POST repos/denoland/clawpatrol/pulls/645/comments/3387245825/replies -f body=...`
     - Issue comment: `gh pr comment 645 --repo denoland/clawpatrol --body ...`
   - Ambiguous: post a `[bot-reply]` explaining what you would do and ask for confirmation; do not change code.

3. **After pushing a change-request fix, you MUST also post a `[bot-reply]` on this PR summarising what the new commit(s) addressed.** This is non-optional — the human reviewer reads the PR thread, not the commit log, and the next watcher cycle uses `[bot-reply]` as the "comment was acted on" signal. The first line of that comment MUST be `[bot-reply]`. Use:

   ```
   gh pr comment 645 --repo denoland/clawpatrol --body "$(cat <<'EOF'
   [bot-reply]
   Pushed <short-sha> addressing this comment:
   - <one bullet per item you fixed>
   EOF
   )"
   ```

4. Do NOT modify files outside the scope of this comment. After the push AND the `[bot-reply]`, call `gt done` to close the bead and release the polecat, then exit. The sling was `--no-merge`, so `gt done` will not submit to the merge queue — your commits stay on the PR branch.

## Bookkeeping

Dedup label `pr-comment-id-3387245825` (comment id 3387245825). Do not edit this label.

## Changes

```
.github/workflows/ci.yml                           |   6 +
 cmd/clawpatrol/action_file.go                      |  52 +-
 cmd/clawpatrol/action_file_test.go                 |   3 +
 cmd/clawpatrol/agents.go                           |  13 +-
 cmd/clawpatrol/credential_match_test.go            |   5 +-
 cmd/clawpatrol/discovery.go                        | 583 ++++++++++++++++++
 cmd/clawpatrol/discovery_golden_test.go            |  95 +++
 cmd/clawpatrol/discovery_test.go                   | 359 +++++++++++
 cmd/clawpatrol/dnsvip/dnsvip.go                    |  35 ++
 cmd/clawpatrol/dnsvip/dnsvip_test.go               |  55 ++
 cmd/clawpatrol/hitl_async_e2e_test.go              |   2 +-
 cmd/clawpatrol/hitl_async_runtime.go               |   6 +-
 cmd/clawpatrol/hitl_body_sample_test.go            |   3 +-
 cmd/clawpatrol/hitl_operation_api_test.go          |   3 +-
 cmd/clawpatrol/hitl_registry_test.go               |   5 +-
 cmd/clawpatrol/hitl_retry_relay_test.go            |   2 +-
 cmd/clawpatrol/integrations.go                     | 149 +++++
 cmd/clawpatrol/integrations_test.go                | 210 +++++++
 cmd/clawpatrol/main.go                             | 102 +++-
 cmd/clawpatrol/onboard.go                          |  11 +-
 cmd/clawpatrol/raw_ip_mitm_test.go                 |   6 +-
 cmd/clawpatrol/rulegen.go                          | 376 ++++++++++++
 cmd/clawpatrol/rulegen_test.go                     | 152 +++++
 cmd/clawpatrol/run_darwin.go                       |   1 +
 cmd/clawpatrol/run_linux.go                        |   1 +
 cmd/clawpatrol/run_tsnet_darwin.go                 |   1 +
 .../telegram_request_body_redaction_test.go        |   2 +-
 cmd/clawpatrol/telemetry.go                        |  11 +-
 cmd/clawpatrol/test.go                             |   5 +
 cmd/clawpatrol/testdata/discovery/empty.hcl        |  21 +
 cmd/clawpatrol/testdata/discovery/empty.json       |   6 +
 cmd/clawpatrol/testdata/discovery/empty.md         |  31 +
 cmd/clawpatrol/testdata/discovery/multicred.hcl    |  30 +
 cmd/clawpatrol/testdata/discovery/multicred.json   |  50 ++
 cmd/clawpatrol/testdata/discovery/multicred.md     |  20 +
 cmd/clawpatrol/testdata/discovery/simple.hcl       |  19 +
 cmd/clawpatrol/testdata/discovery/simple.json      |  31 +
 cmd/clawpatrol/testdata/discovery/simple.md        |  17 +
 cmd/clawpatrol/testdata/discovery/tunnel.hcl       | 102 ++++
 cmd/clawpatrol/testdata/discovery/tunnel.json      | 141 +++++
 cmd/clawpatrol/testdata/discovery/tunnel.md        |  48 ++
 cmd/clawpatrol/testdata/example.hcl                |  58 +-
 cmd/clawpatrol/testdata/ssh-allow-exec.json        |  15 +
 cmd/clawpatrol/testdata/ssh-allow-shell.json       |  13 +
 cmd/clawpatrol/testdata/ssh-allow-stdin.json       |  14 +
 cmd/clawpatrol/testdata/ssh-deny-forward.json      |  17 +
 cmd/clawpatrol/testdata/ssh-deny-pty.json          |  15 +
 cmd/clawpatrol/testdata/ssh-deny-sftp.json         |  16 +
 cmd/clawpatrol/testdata/ssh-deny-stdin.json        |  16 +
 cmd/clawpatrol/tunnel.go                           |  55 +-
 cmd/clawpatrol/web.go                              | 433 ++++++++++++-
 cmd/clawpatrol/web_auth_test.go                    |  13 +-
 cmd/clawpatrol/web_ca_fingerprint_test.go          |   2 +-
 cmd/clawpatrol/web_config_apply_test.go            | 285 +++++++++
 cmd/clawpatrol/web_dashboard_auth_test.go          |   4 +-
 cmd/clawpatrol/web_fixture_export_test.go          | 164 +++++
 dashboard/src/components/CredentialsTypeGrid.tsx   |   5 +-
 dashboard/src/components/DevicePage.tsx            | 110 +++-
 dashboard/src/components/IntegrationsCards.tsx     |   6 +-
 dashboard/src/components/RequestDetailPage.tsx     | 219 ++++++-
 dashboard/src/lib/api.ts                           |  44 ++
 dashboard/src/lib/credentialLabels.ts              |   2 +
 doc/claude-code-oauth.md                           | 140 +++++
 doc/tailscale.md                                   |  61 +-
 examples/gateway.example.hcl                       |  19 +-
 examples/protocol-https.hcl                        |  30 +-
 internal/config/README.md                          |   2 +-
 internal/config/compile.go                         |  27 +
 internal/config/compile_test.go                    |  12 +-
 internal/config/config.go                          |  11 +
 internal/config/emit.go                            |   3 +
 internal/config/emit_test.go                       |  21 +
 internal/config/extplugin/adapter.go               |   4 +-
 internal/config/extplugin/celenv.go                |  27 +-
 internal/config/extplugin/facet.go                 |   4 +-
 internal/config/facet/composition.go               |  15 +-
 internal/config/match/cel.go                       | 189 ++++--
 internal/config/match/match.go                     |  91 ++-
 internal/config/plugins/all/all.go                 |   1 +
 internal/config/plugins/approvers/human.go         |   8 +-
 internal/config/plugins/approvers/llm.go           |  10 +-
 internal/config/plugins/approvers/llm_test.go      |  51 ++
 .../config/plugins/credentials/anthropic_oauth.go  |  35 +-
 internal/config/plugins/credentials/passthrough.go |  53 ++
 internal/config/plugins/credentials/slack.go       |  27 +-
 .../plugins/credentials/slack_notify_test.go       |  43 +-
 .../plugins/endpoints/clickhouse_native_runtime.go |   8 +-
 internal/config/plugins/endpoints/postgres.go      |  53 +-
 .../plugins/endpoints/postgres_runtime_test.go     |  49 +-
 internal/config/plugins/endpoints/postgres_sql.go  |   6 +-
 internal/config/plugins/endpoints/ssh.go           | 678 +++++++++++++++++----
 internal/config/plugins/endpoints/ssh_e2e_test.go  | 593 ++++++++++++++++++
 internal/config/plugins/endpoints/ssh_test.go      |  69 ++-
 internal/config/plugins/facets/https/https.go      |  25 +-
 internal/config/plugins/facets/https/https_test.go |  94 ++-
 internal/config/plugins/facets/k8s/k8s.go          |   6 +-
 .../plugins/facets/k8s/k8s_composition_test.go     |   4 +-
 .../config/plugins/facets/k8s/k8s_match_test.go    |  20 +-
 internal/config/plugins/facets/sql/sql.go          |   9 +-
 .../config/plugins/facets/sql/sql_match_test.go    |  69 ++-
 internal/config/plugins/facets/ssh/ssh.go          | 241 ++++++++
 .../config/plugins/facets/ssh/ssh_match_test.go    | 207 +++++++
 .../plugins/tunnels/kubernetes_port_forward.go     | 299 +++++++--
 .../tunnels/kubernetes_port_forward_test.go        | 238 ++++++++
 internal/config/plugins/tunnels/tailscale.go       |  88 ++-
 internal/config/plugins/tunnels/tailscale_test.go  |  58 ++
 internal/config/runtime/dispatch.go                | 143 +++--
 internal/config/runtime/dispatch_test.go           | 328 +++++++++-
 internal/config/runtime/runtime.go                 |  18 +-
 internal/config/runtime/tunnel.go                  |  14 +
 internal/config/secret_slot.go                     |  17 +
 internal/config/testdata/full.hcl                  |  64 +-
 internal/config/testdata/full.want.json            | 190 +++---
 internal/tools/docgen/internal/render/render.go    |   3 +
 shared/video/demo2.mp4                             | Bin 0 -> 208096 bytes
 site/doc/clawpatrol-test.md                        |  37 +-
 site/doc/cli.md                                    |   9 +-
 site/doc/config-reference.md                       |  98 ++-
 site/doc/configure-gateway.md                      |   2 +-
 site/doc/credentials.md                            |   2 +-
 site/doc/getting-started.md                        |   7 +
 site/doc/plugins.md                                |  17 +-
 site/doc/rules.md                                  | 313 +++++++---
 site/public/icons/aws.svg                          |  18 +
 site/public/icons/claude-mono.svg                  |   1 +
 site/public/icons/claude.svg                       |   1 +
 site/public/icons/clickhouse.svg                   |   2 +-
 site/public/icons/gcp.svg                          |   1 +
 site/public/icons/github-mono.svg                  |   1 +
 site/public/icons/kubernetes.svg                   |   2 +-
 site/public/icons/postgres-mono.svg                |   2 +
 site/public/icons/tailscale.svg                    |   1 +
 site/public/icons/vultr.svg                        |   1 +
 site/public/icons/wireguard.svg                    |   1 +
 site/public/video                                  |   1 +
 site/src/Landing.tsx                               |  12 +-
 site/src/components/FlowDiagram.tsx                | 170 +++---
 site/src/components/IsometricStack.tsx             | 445 ++++++++++++++
 site/src/docs.css                                  |  21 +-
 site/src/index.css                                 |   1 -
 site/src/lib/examples.ts                           |   2 +-
 site/src/sections/ApproversSection.tsx             | 155 +++--
 site/src/sections/ComparisonSection.tsx            | 328 ++++------
 site/src/sections/CtaSection.tsx                   |  29 +-
 site/src/sections/DemoSection.tsx                  |  64 +-
 site/src/sections/DeploymentSection.tsx            |  58 ++
 site/src/sections/HeroSection.tsx                  |  34 +-
 site/src/sections/ProblemSection.tsx               | 193 ++++--
 site/src/sections/RulesSection.tsx                 |  15 +-
 site/src/sections/RunSection.tsx                   |  44 --
 site/src/sections/TestSection.tsx                  |   6 +-
 site/src/sections/VpnSection.tsx                   | 115 ++++
 site/worker/index.test.ts                          |  24 +
 site/worker/index.ts                               |   7 +
 154 files changed, 9584 insertions(+), 1407 deletions(-)```

---
*Polecat: nitro | Issue: cl-trz6*
