### PR TITLE
feat: HTTP middleware chain on endpoints (anthropic_system_prompt as v1 type)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2004,6 +2004,49 @@ func bufferHTTPBodyForMatchTruncated(req *http.Request, capBytes int) (body []by
 	return b, false
 }
 
+// applyRequestMiddleware runs the endpoint's ordered request-side
+// middleware chain against req. It reads the full request body (the
+// match path re-attached the stream, so a fresh read here yields the
+// complete body), hands it to each middleware's RewriteHTTPRequest in
+// declared order, and re-attaches the result with a corrected
+// Content-Length. Any middleware error aborts the chain and is
+// returned; the caller fails the request closed with a 502.
+//
+// CEL rule predicates matched against the pre-middleware body — this
+// runs after matching, so a middleware-injected system prompt is the
+// body the upstream receives, not the body the policy evaluated. The
+// caller gates on len(ep.Middleware) > 0 so endpoints without a
+// middleware never pay this full-body read.
+func (g *Gateway) applyRequestMiddleware(req *http.Request, ep *config.CompiledEndpoint) error {
+	var body []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return fmt.Errorf("reading request body: %w", err)
+		}
+		body = b
+	}
+	for _, mw := range ep.Middleware {
+		r, ok := mw.Body.(runtime.HTTPMiddleware)
+		if !ok {
+			// The registry checker rejects middleware plugins whose
+			// Body doesn't satisfy HTTPMiddleware at init time, so this
+			// is defensive — skip rather than fail a live request.
+			continue
+		}
+		out, err := r.RewriteHTTPRequest(req.Context(), req, body)
+		if err != nil {
+			return fmt.Errorf("middleware %q: %w", mw.Name, err)
+		}
+		body = out
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+	return nil
+}
+
 // mitmHTTPS handles an SNI-matched TLS connection for an HTTPS-family
 // endpoint (https, kubernetes). It mints a leaf cert, terminates TLS,
 // then loops reading HTTP requests and dispatching each through the
@@ -2457,6 +2500,37 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 			ev.Ms = time.Since(start).Milliseconds()
 			g.emitEnd(ev)
 			return
+		}
+
+		// Request-side middleware chain. Runs after credential
+		// injection (so a middleware sees the real auth headers) and
+		// after the WS early-return (middlewares are HTTP-body
+		// transforms; WS frames have their own credential rewrite
+		// path). Each middleware in the endpoint's ordered list may
+		// mutate the body; an error fails the request closed with a
+		// 502 and no upstream call. Endpoints with no middleware skip
+		// the body read entirely.
+		if len(ep.Middleware) > 0 {
+			if err := g.applyRequestMiddleware(req, ep); err != nil {
+				log.Printf("middleware %s %s %s: %v", host, req.Method, req.URL.Path, err)
+				if hitlRetryConsumedOperation != nil {
+					if transitionErr := g.transitionConsumedHITLRetryGrant(context.Background(), *hitlRetryConsumedOperation, HITLOperationStateUpstreamFailed, err.Error()); transitionErr != nil {
+						log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, HITLOperationStateUpstreamFailed, transitionErr)
+					}
+				}
+				if asyncOp.ID != "" {
+					if _, trErr := g.transitionAsyncHITLOperation(req.Context(), asyncOp, HITLOperationStateUpstreamFailed, err.Error()); trErr != nil {
+						log.Printf("hitl async operation upstream failed %s: %v", asyncOp.ID, trErr)
+					}
+				}
+				_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+				ev.Status = 502
+				ev.Action = "error"
+				ev.Reason = err.Error()
+				ev.Ms = time.Since(start).Milliseconds()
+				g.emitEnd(ev)
+				return
+			}
 		}
 
 		trackKind := trackKindFor(host)

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -40,6 +40,11 @@ type CompiledPolicy struct {
 	// in their Tunnel field — same instance as the entry here.
 	Tunnels map[string]*CompiledTunnel
 
+	// Middlewares contains every declared middleware, keyed by name.
+	// Endpoints store ordered *CompiledMiddleware pointers in their
+	// Middleware field — the same instances as the entries here.
+	Middlewares map[string]*CompiledMiddleware
+
 	// Approvers / Credentials surface the same entities from the
 	// Policy struct under a runtime-friendly typed alias — they're
 	// pointers into the same Entity records, no copies.
@@ -126,6 +131,13 @@ type CompiledEndpoint struct {
 	// Populated from the endpoint plugin's optional EndpointTunnel()
 	// accessor.
 	Tunnel *CompiledTunnel
+
+	// Middleware is the resolved, ordered request-side hook chain this
+	// endpoint runs after credential injection and before the upstream
+	// forward. Empty for endpoints with no `middleware = [...]` attr.
+	// The dispatcher walks it in order; each entry's Body is type-
+	// asserted to runtime.HTTPMiddleware at request time.
+	Middleware []*CompiledMiddleware
 }
 
 // RequiresVIP reports whether DNS-VIP allocation should claim this
@@ -202,6 +214,20 @@ type CompiledTunnel struct {
 // log it.
 const KeepaliveAlwaysSentinel = time.Duration(-1)
 
+// CompiledMiddleware is the runtime-friendly view of one middleware
+// block. Endpoints hold an ordered slice of these via
+// CompiledEndpoint.Middleware; the dispatcher type-asserts Body to
+// runtime.HTTPMiddleware and calls RewriteHTTPRequest per request.
+type CompiledMiddleware struct {
+	Name   string
+	Plugin *Plugin
+	// Body is whatever the middleware plugin's Build returned — the
+	// decoded config instance (e.g. *middlewares.AnthropicSystemPrompt)
+	// carrying the runtime methods. Runtime callers type-assert it to
+	// runtime.HTTPMiddleware.
+	Body any
+}
+
 // CompiledCredential expands a credential's `endpoint = X` /
 // `endpoints = [...]` binding into a per-endpoint entry. The
 // Disambiguators map carries the merged dispatch discriminators
@@ -273,6 +299,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		Profiles:       map[string]*CompiledProfile{},
 		Endpoints:      map[string]*CompiledEndpoint{},
 		Tunnels:        map[string]*CompiledTunnel{},
+		Middlewares:    map[string]*CompiledMiddleware{},
 		Approvers:      p.Approvers,
 		Credentials:    p.Credentials,
 	}
@@ -282,6 +309,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	if err := compileTunnels(cp, p); err != nil {
 		return nil, err
 	}
+
+	// Compile middlewares before endpoints so endpoint compilation can
+	// resolve `middleware = [...]` refs to *CompiledMiddleware pointers.
+	compileMiddlewares(cp, p)
 
 	// Compile every endpoint once into a CompiledEndpoint with the
 	// (placeholder) rule list. Credentials attach in the next pass —
@@ -536,6 +567,16 @@ func compileEndpoint(name string, ent *Entity, cp *CompiledPolicy) (*CompiledEnd
 			return nil, fmt.Errorf("tunnel %q routes endpoint %q but it has no hostnames in `hosts` (only IP literals); tunneled endpoints rely on DNS-VIP interception, which needs a name to intercept", tn, name)
 		}
 	}
+	// Resolve the ordered `middleware = [...]` reflist into shared
+	// *CompiledMiddleware pointers. Declaration order is preserved —
+	// the dispatcher runs them in list order.
+	for _, mwName := range ent.Framework.RefList("middleware") {
+		cm, ok := cp.Middlewares[mwName]
+		if !ok {
+			return nil, fmt.Errorf("middleware %q not declared", mwName)
+		}
+		ce.Middleware = append(ce.Middleware, cm)
+	}
 	return ce, nil
 }
 
@@ -650,6 +691,21 @@ type TunnelCommon struct {
 // the concrete plugin type.
 type TunnelCommonRead interface {
 	TunnelCommon() TunnelCommon
+}
+
+// compileMiddlewares lowers every middleware block into a
+// *CompiledMiddleware keyed by name. Middlewares carry no cross-refs
+// (no via chain, no credential binding in v1), so this is a flat
+// pass; endpoint compilation links them in via the `middleware = [...]`
+// reflist.
+func compileMiddlewares(cp *CompiledPolicy, p *Policy) {
+	for name, ent := range p.Middlewares {
+		cp.Middlewares[name] = &CompiledMiddleware{
+			Name:   name,
+			Plugin: ent.Plugin,
+			Body:   ent.Body,
+		}
+	}
 }
 
 // compileTunnels lowers every tunnel block into a *CompiledTunnel,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -454,6 +454,7 @@ type Policy struct {
 	Endpoints   map[string]*Entity
 	Rules       map[string]*Entity
 	Tunnels     map[string]*Entity
+	Middlewares map[string]*Entity
 
 	Profiles map[string]*Profile
 
@@ -813,6 +814,7 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 		Endpoints:   make(map[string]*Entity),
 		Rules:       make(map[string]*Entity),
 		Tunnels:     make(map[string]*Entity),
+		Middlewares: make(map[string]*Entity),
 		Profiles:    make(map[string]*Profile),
 	}
 
@@ -1056,6 +1058,7 @@ func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 			{Type: "rule", LabelNames: []string{"name"}},
 			{Type: "profile", LabelNames: []string{"name"}},
 			{Type: "tunnel", LabelNames: []string{"type", "name"}},
+			{Type: "middleware", LabelNames: []string{"type", "name"}},
 		},
 	}
 	content, diags := body.Content(schema)
@@ -1130,15 +1133,16 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 		p.Order = append(p.Order, sym.Name)
 	}
 
-	// Decode order: credentials and tunnels first (no cross-deps on
-	// other kinds), then endpoints (which reference both), then rules
-	// (which reference endpoints), then approvers (referenced by
-	// rules but with no body-level dep on them at decode time).
+	// Decode order: credentials, tunnels and middlewares first (no
+	// cross-deps on other kinds), then endpoints (which reference
+	// them), then rules (which reference endpoints), then approvers
+	// (referenced by rules but with no body-level dep on them at
+	// decode time).
 	// Symbol-table-backed ref resolution doesn't actually require this
 	// ordering — symbols are populated in pass 1 — but matching decode
 	// order to compile order keeps Order[] stable across the file's
 	// declaration sequence and avoids surprising readers.
-	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule} {
+	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindMiddleware, KindEndpoint, KindRule} {
 		for _, sym := range table.byKind[kind] {
 			plugin := Lookup(sym.Kind, sym.Type)
 			if plugin == nil {
@@ -1190,6 +1194,8 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 				p.Credentials[sym.Name] = ent
 			case KindTunnel:
 				p.Tunnels[sym.Name] = ent
+			case KindMiddleware:
+				p.Middlewares[sym.Name] = ent
 			case KindEndpoint:
 				p.Endpoints[sym.Name] = ent
 			case KindRule:
@@ -1201,6 +1207,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 
 	diags = append(diags, validateCredentialBindings(p)...)
 	diags = append(diags, validateProfileDisambiguators(p, table)...)
+	diags = append(diags, validateMiddlewareEndpointCompat(p)...)
 
 	_ = configDir // file-include resolution will use this in a follow-up
 	return diags
@@ -1224,6 +1231,55 @@ func validateCredentialBindings(p *Policy) hcl.Diagnostics {
 				Detail:   "Use exactly one of `endpoint = X` (singular) or `endpoints = [X, Y, ...]` (list).",
 				Subject:  &ent.Symbol.Block.DefRange,
 			})
+		}
+	}
+	return diags
+}
+
+// MiddlewareEndpointCompat is the optional interface a middleware
+// plugin's body implements to assert it is compatible with the hosts
+// of an endpoint it's attached to. The loader calls CheckEndpointHosts
+// once per (endpoint, middleware) binding; a non-nil error becomes an
+// hcl.Diagnostic pinned to the endpoint block. `anthropic_system_prompt`
+// uses it to reject attachment to endpoints that don't intercept
+// api.anthropic.com — same compatibility-check shape as the rest of
+// the loader's validation.
+type MiddlewareEndpointCompat interface {
+	CheckEndpointHosts(hosts []string) error
+}
+
+// validateMiddlewareEndpointCompat walks every endpoint's resolved
+// `middleware = [...]` list and runs each middleware's optional
+// host-family compatibility check against the endpoint's hosts. A
+// middleware type that doesn't implement MiddlewareEndpointCompat is
+// compatible with any endpoint.
+func validateMiddlewareEndpointCompat(p *Policy) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	for epName, ep := range p.Endpoints {
+		mws := ep.Framework.RefList("middleware")
+		if len(mws) == 0 {
+			continue
+		}
+		hosts := extractHosts(ep.Body)
+		for _, mwName := range mws {
+			mwEnt, ok := p.Middlewares[mwName]
+			if !ok {
+				// Unresolved reference is already reported by the
+				// framework ref resolver; skip.
+				continue
+			}
+			compat, ok := mwEnt.Body.(MiddlewareEndpointCompat)
+			if !ok {
+				continue
+			}
+			if err := compat.CheckEndpointHosts(hosts); err != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("Middleware %q incompatible with endpoint %q", mwName, epName),
+					Detail:   err.Error(),
+					Subject:  &ep.Symbol.Block.DefRange,
+				})
+			}
 		}
 	}
 	return diags

--- a/internal/config/dump.go
+++ b/internal/config/dump.go
@@ -157,6 +157,9 @@ func dumpPolicy(p *Policy) map[string]any {
 	if v := dumpEntityMap(p.Tunnels); v != nil {
 		out["tunnels"] = v
 	}
+	if v := dumpEntityMap(p.Middlewares); v != nil {
+		out["middlewares"] = v
+	}
 	if v := dumpProfiles(p.Profiles); v != nil {
 		out["profiles"] = v
 	}

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -20,6 +20,7 @@ type RefIndex struct {
 	approverTyp map[string]string
 	tunnelType  map[string]string
 	endpointTyp map[string]string
+	mwType      map[string]string
 }
 
 func newRefIndex(p *Policy) *RefIndex {
@@ -28,6 +29,7 @@ func newRefIndex(p *Policy) *RefIndex {
 		approverTyp: map[string]string{},
 		tunnelType:  map[string]string{},
 		endpointTyp: map[string]string{},
+		mwType:      map[string]string{},
 	}
 	if p == nil {
 		return r
@@ -50,6 +52,11 @@ func newRefIndex(p *Policy) *RefIndex {
 	for n, e := range p.Endpoints {
 		if e != nil && e.Plugin != nil {
 			r.endpointTyp[n] = e.Plugin.Type
+		}
+	}
+	for n, e := range p.Middlewares {
+		if e != nil && e.Plugin != nil {
+			r.mwType[n] = e.Plugin.Type
 		}
 	}
 	// Built-in approvers (e.g. dashboard) carry the synthetic "builtin"
@@ -83,6 +90,10 @@ func (r *RefIndex) Ref(kind Kind, name string) string {
 		}
 	case KindEndpoint:
 		if t := r.endpointTyp[name]; t != "" {
+			return t + "." + name
+		}
+	case KindMiddleware:
+		if t := r.mwType[name]; t != "" {
 			return t + "." + name
 		}
 	case KindRule, KindProfile:
@@ -159,13 +170,14 @@ func Emit(gw *Gateway) ([]byte, error) {
 	defer func() { emitRI = nil }()
 
 	// Per-kind groups in a deterministic order: approvers → credentials
-	// → tunnels → endpoints → rules → profiles. Within a group, walk
+	// → tunnels → middlewares → endpoints → rules → profiles. Within a group, walk
 	// p.Order (source order) and filter to that kind, falling back to
 	// alphabetical for entries Order doesn't cover (defensive — every
 	// loaded entry is in Order in practice).
 	emitGroup(body, p, KindApprover)
 	emitGroup(body, p, KindCredential)
 	emitGroup(body, p, KindTunnel)
+	emitGroup(body, p, KindMiddleware)
 	emitGroup(body, p, KindEndpoint)
 	emitGroup(body, p, KindRule)
 	emitGroup(body, p, KindProfile)
@@ -346,6 +358,12 @@ func leftoverNames(p *Policy, kind Kind, emitted map[string]bool) []string {
 				out = append(out, n)
 			}
 		}
+	case KindMiddleware:
+		for n := range p.Middlewares {
+			if !emitted[n] {
+				out = append(out, n)
+			}
+		}
 	case KindProfile:
 		for n := range p.Profiles {
 			if !emitted[n] {
@@ -389,6 +407,12 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 			return false
 		}
 		emitEntityBlock(body, "tunnel", ent, name)
+	case KindMiddleware:
+		ent, ok := p.Middlewares[name]
+		if !ok {
+			return false
+		}
+		emitEntityBlock(body, "middleware", ent, name)
 	case KindProfile:
 		pr, ok := p.Profiles[name]
 		if !ok {

--- a/internal/config/file_include.go
+++ b/internal/config/file_include.go
@@ -25,7 +25,7 @@ import (
 // have field-precise positions at this layer.
 func expandFileIncludes(p *Policy, configDir string) hcl.Diagnostics {
 	var diags hcl.Diagnostics
-	for _, group := range []map[string]*Entity{p.Endpoints, p.Credentials, p.Approvers, p.Rules, p.Tunnels} {
+	for _, group := range []map[string]*Entity{p.Endpoints, p.Credentials, p.Approvers, p.Rules, p.Tunnels, p.Middlewares} {
 		for name, ent := range group {
 			fi, ok := ent.Body.(FileIncludable)
 			if !ok {

--- a/internal/config/middleware_test.go
+++ b/internal/config/middleware_test.go
@@ -1,0 +1,170 @@
+package config_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// middlewareSrc declares an Anthropic endpoint with two ordered
+// system-prompt middlewares attached. Reused across the resolve /
+// ordering tests.
+const middlewareSrc = `
+middleware "anthropic_system_prompt" "first" {
+  text = "FIRST"
+}
+middleware "anthropic_system_prompt" "second" {
+  text = "SECOND"
+}
+endpoint "https" "anthropic" {
+  hosts      = ["api.anthropic.com"]
+  middleware = [anthropic_system_prompt.first, anthropic_system_prompt.second]
+}
+credential "bearer_token" "key" {
+  endpoint = https.anthropic
+}
+profile "p" { credentials = [bearer_token.key] }
+`
+
+// TestMiddlewareResolveAndOrder verifies the new `middleware` block
+// parses, the endpoint's `middleware = [...]` reflist resolves to
+// shared CompiledMiddleware pointers, and declaration order is
+// preserved on the compiled endpoint.
+func TestMiddlewareResolveAndOrder(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+middlewareSrc), "mw.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if len(gw.Policy.Middlewares) != 2 {
+		t.Fatalf("expected 2 middlewares, got %d", len(gw.Policy.Middlewares))
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ce := cp.Endpoints["anthropic"]
+	if ce == nil {
+		t.Fatal("missing anthropic endpoint")
+	}
+	if len(ce.Middleware) != 2 {
+		t.Fatalf("endpoint has %d middlewares, want 2", len(ce.Middleware))
+	}
+	if ce.Middleware[0].Name != "first" || ce.Middleware[1].Name != "second" {
+		t.Errorf("middleware order = [%s, %s], want [first, second]",
+			ce.Middleware[0].Name, ce.Middleware[1].Name)
+	}
+	// Pointers are shared with cp.Middlewares.
+	if ce.Middleware[0] != cp.Middlewares["first"] {
+		t.Error("endpoint middleware is not the same instance as cp.Middlewares")
+	}
+}
+
+// TestMiddlewareOrderedExecution runs the compiled middleware chain
+// against a Messages body and asserts both transforms applied in
+// declared order (FIRST appended before SECOND).
+func TestMiddlewareOrderedExecution(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+middlewareSrc), "mw.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ce := cp.Endpoints["anthropic"]
+
+	body := []byte(`{"system":"BASE","messages":[]}`)
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", strings.NewReader(string(body)))
+	for _, mw := range ce.Middleware {
+		r, ok := mw.Body.(runtime.HTTPMiddleware)
+		if !ok {
+			t.Fatalf("middleware %q body does not satisfy HTTPMiddleware", mw.Name)
+		}
+		body, err = r.RewriteHTTPRequest(context.Background(), req, body)
+		if err != nil {
+			t.Fatalf("middleware %q: %v", mw.Name, err)
+		}
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		t.Fatalf("result not JSON: %v", err)
+	}
+	want := "BASE\n\nFIRST\n\nSECOND"
+	if obj["system"] != want {
+		t.Errorf("system = %q, want %q (ordered application)", obj["system"], want)
+	}
+}
+
+// TestMiddlewareHostCompatDiagnostic verifies the load-time
+// compatibility check: attaching anthropic_system_prompt to an
+// endpoint that doesn't intercept api.anthropic.com is a clear error.
+func TestMiddlewareHostCompatDiagnostic(t *testing.T) {
+	src := `
+middleware "anthropic_system_prompt" "inject" {
+  text = "x"
+}
+endpoint "https" "openai" {
+  hosts      = ["api.openai.com"]
+  middleware = [anthropic_system_prompt.inject]
+}
+credential "bearer_token" "key" {
+  endpoint = https.openai
+}
+profile "p" { credentials = [bearer_token.key] }
+`
+	_, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "mw.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("expected a host-compatibility diagnostic, got none")
+	}
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Summary, "incompatible with endpoint") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected incompatibility diagnostic, got: %v", diags)
+	}
+}
+
+// TestMiddlewareRoundTrip verifies a config with middleware blocks
+// survives Emit → Load unchanged in structure (block parses back and
+// the endpoint re-resolves its middleware list).
+func TestMiddlewareRoundTrip(t *testing.T) {
+	gw, diags := config.LoadBytes([]byte(testGatewayPrefix+middlewareSrc), "mw.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	out, err := config.Emit(gw)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	gw2, diags := config.LoadBytes(out, "mw-roundtrip.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("reload emitted config: %v\n--- emitted ---\n%s", diags, out)
+	}
+	cp, err := config.Compile(gw2)
+	if err != nil {
+		t.Fatalf("compile reloaded: %v", err)
+	}
+	ce := cp.Endpoints["anthropic"]
+	if ce == nil || len(ce.Middleware) != 2 {
+		t.Fatalf("round-trip lost middleware wiring: %+v", ce)
+	}
+	if mw := gw2.Policy.Middlewares["first"]; mw == nil {
+		t.Error("round-trip lost middleware block 'first'")
+	} else if asp, ok := mw.Body.(interface {
+		FileIncludeFields() []config.FileIncludeField
+	}); ok {
+		if got := asp.FileIncludeFields()[0].Get(); got != "FIRST" {
+			t.Errorf("round-trip text = %q, want FIRST", got)
+		}
+	}
+}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -4,9 +4,9 @@
 // state_dir / tailscale {} / ...) live at the top of the file and
 // decode via
 // gohcl into the Gateway struct. Policy blocks (defaults / approver /
-// credential / endpoint / rule / profile) are dispatched to
-// plugins by their first label; each plugin owns its body schema, the
-// in-memory record it builds, and (later) the runtime that handles
+// credential / endpoint / middleware / rule / profile) are dispatched
+// to plugins by their first label; each plugin owns its body schema,
+// the in-memory record it builds, and (later) the runtime that handles
 // requests for it.
 package config
 
@@ -34,13 +34,14 @@ const (
 	KindApprover   Kind = "approver"
 	KindProfile    Kind = "profile"
 	KindTunnel     Kind = "tunnel"
+	KindMiddleware Kind = "middleware"
 )
 
 // LabelCount returns how many labels a block of this kind carries
 // (excluding the kind keyword itself).
 func (k Kind) LabelCount() int {
 	switch k {
-	case KindEndpoint, KindCredential, KindApprover, KindTunnel:
+	case KindEndpoint, KindCredential, KindApprover, KindTunnel, KindMiddleware:
 		return 2 // first = type, second = name
 	case KindRule, KindProfile:
 		return 1 // name
@@ -109,6 +110,7 @@ type Plugin struct {
 	//   KindApprover   → runtime.ApproverRuntime
 	//   KindRule       → runtime.RuleMatcherFactory
 	//   KindTunnel     → runtime.TunnelRuntime
+	//   KindMiddleware → runtime.HTTPMiddleware
 	// nil means "schema-only; runtime not implemented" — request-time
 	// dispatch reports a clear diagnostic when it tries to use one.
 	Runtime any
@@ -181,6 +183,12 @@ type FrameworkAttrSpec struct {
 var frameworkAttrsByKind = map[Kind][]FrameworkAttrSpec{
 	KindEndpoint: {
 		{Name: "tunnel", Kind: KindTunnel, Optional: true},
+		// `middleware = [type.name, ...]` is an ordered list of
+		// request-side hooks the dispatcher runs after credential
+		// injection. List shape (vs tunnel's singular) because
+		// same-stage composition is the point — every middleware in
+		// the list runs in declared order.
+		{Name: "middleware", Kind: KindMiddleware, Optional: true, List: true},
 	},
 	// credential→endpoint binding lives on the credential block. A
 	// credential names either a single endpoint or a list of them

--- a/internal/config/plugins/all/all.go
+++ b/internal/config/plugins/all/all.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/k8s"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/ssh"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/middlewares"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/rules"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/tunnels"
 )

--- a/internal/config/plugins/middlewares/anthropic_system_prompt.go
+++ b/internal/config/plugins/middlewares/anthropic_system_prompt.go
@@ -1,0 +1,184 @@
+// Package middlewares holds the built-in HTTP middleware plugins —
+// request-side hooks attached to endpoints via `middleware = [...]`
+// that see the request after credential injection and may mutate the
+// body before the upstream forward. The seam mirrors the credential
+// plugin layout: each type lives in its own file, registers via
+// init(), and co-locates its HCL schema with its runtime methods.
+package middlewares
+
+// anthropic_system_prompt: appends a configured text block to the
+// `system` field of Anthropic `/v1/messages` requests. The first
+// consumer is clawpatrol tool-discovery (telling the model which
+// gateway-mediated tools it can reach), but the value is literal text
+// in v1 — dynamic templating is deferred.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// anthropicMessagesPath is the only request shape this middleware
+// transforms. Other methods / paths pass through unchanged.
+const anthropicMessagesPath = "/v1/messages"
+
+// anthropicHost is the upstream host this middleware understands. The
+// load-time host-compat check rejects attachment to endpoints that
+// don't intercept it.
+const anthropicHost = "api.anthropic.com"
+
+// AnthropicSystemPrompt is a request middleware that appends Text to
+// the `system` field of Anthropic `/v1/messages` requests.
+type AnthropicSystemPrompt struct {
+	// Text is the literal block appended to the request's system
+	// prompt. Supports `<<file:NAME>>` inlining so operators can keep
+	// large discovery prompts in a sidecar file.
+	Text string `hcl:"text"`
+}
+
+// RewriteHTTPRequest is part of the clawpatrol plugin API. It appends
+// the configured Text to the `system` field of an Anthropic Messages
+// request body, handling all three legal `system` shapes (absent,
+// bare string, content-block array). Non-Messages requests pass
+// through untouched. A `system` field in an unrecognized shape fails
+// the request closed (returns an error), so a malformed body can't
+// silently bypass the injection.
+func (m *AnthropicSystemPrompt) RewriteHTTPRequest(_ context.Context, req *http.Request, body []byte) ([]byte, error) {
+	// Gate on the Messages endpoint. The host is already constrained
+	// to api.anthropic.com by the load-time compatibility check, so we
+	// only need to discriminate method + path here.
+	if req == nil || req.Method != http.MethodPost || req.URL == nil || req.URL.Path != anthropicMessagesPath {
+		return body, nil
+	}
+	if m.Text == "" {
+		return body, nil
+	}
+
+	// Decode into an order-preserving map of raw values so every field
+	// other than `system` round-trips byte-for-byte (no number-
+	// precision loss). Only the system field is rewritten.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, fmt.Errorf("anthropic_system_prompt: request body is not a JSON object: %w", err)
+	}
+
+	newSystem, err := appendSystem(obj["system"], m.Text)
+	if err != nil {
+		return nil, err
+	}
+	obj["system"] = newSystem
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic_system_prompt: re-encoding request body: %w", err)
+	}
+	return out, nil
+}
+
+// appendSystem returns the new `system` value with text appended,
+// dispatching on the existing value's shape:
+//
+//   - absent / null → system = text (a bare string)
+//   - string        → system = original + "\n\n" + text
+//   - array         → append {"type":"text","text": text} content block
+//
+// An unrecognized shape (number, bool, object) returns an error so the
+// caller fails closed.
+func appendSystem(cur json.RawMessage, text string) (json.RawMessage, error) {
+	if len(cur) == 0 || string(cur) == "null" {
+		return mustJSON(text), nil
+	}
+
+	// String shape.
+	var s string
+	if err := json.Unmarshal(cur, &s); err == nil {
+		return mustJSON(s + "\n\n" + text), nil
+	}
+
+	// Content-block array shape.
+	var arr []json.RawMessage
+	if err := json.Unmarshal(cur, &arr); err == nil {
+		block := mustJSON(map[string]string{"type": "text", "text": text})
+		arr = append(arr, block)
+		out, err := json.Marshal(arr)
+		if err != nil {
+			return nil, fmt.Errorf("anthropic_system_prompt: re-encoding system array: %w", err)
+		}
+		return out, nil
+	}
+
+	return nil, fmt.Errorf("anthropic_system_prompt: unrecognized `system` shape %s (want string or content-block array)", truncateForError(cur))
+}
+
+// mustJSON marshals v, which is only ever a string or a small map here
+// — both infallible — so the error is dropped to keep call sites
+// readable. A marshal failure would be a programmer error, not config.
+func mustJSON(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+// truncateForError clips a raw JSON snippet for inclusion in a
+// diagnostic so a huge body doesn't flood the log.
+func truncateForError(b []byte) string {
+	const max = 64
+	s := strings.TrimSpace(string(b))
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}
+
+// CheckEndpointHosts is part of the clawpatrol plugin API. It rejects
+// attaching this middleware to an endpoint that doesn't intercept
+// api.anthropic.com — the transform only makes sense for the Anthropic
+// Messages API. Mirrors the loader's other compatibility diagnostics.
+func (m *AnthropicSystemPrompt) CheckEndpointHosts(hosts []string) error {
+	for _, h := range hosts {
+		host := h
+		if i := strings.IndexByte(host, ':'); i >= 0 {
+			host = host[:i]
+		}
+		if strings.EqualFold(host, anthropicHost) {
+			return nil
+		}
+	}
+	return fmt.Errorf("anthropic_system_prompt middleware requires an endpoint whose hosts include %q; got %v", anthropicHost, hosts)
+}
+
+// FileIncludeFields is part of the clawpatrol plugin API. It lets the
+// loader inline `<<file:NAME>>` markers in Text so a large discovery
+// prompt can live in a sidecar file next to the policy.
+func (m *AnthropicSystemPrompt) FileIncludeFields() []config.FileIncludeField {
+	return []config.FileIncludeField{
+		{Get: func() string { return m.Text }, Set: func(v string) { m.Text = v }},
+	}
+}
+
+func init() {
+	var _ runtime.HTTPMiddleware = (*AnthropicSystemPrompt)(nil)
+	var _ config.MiddlewareEndpointCompat = (*AnthropicSystemPrompt)(nil)
+	var _ config.FileIncludable = (*AnthropicSystemPrompt)(nil)
+	config.Register(&config.Plugin{
+		Kind:    config.KindMiddleware,
+		Type:    "anthropic_system_prompt",
+		New:     func() any { return &AnthropicSystemPrompt{} },
+		Runtime: (*AnthropicSystemPrompt)(nil),
+		Build: func(decoded any, _ string, _ *config.BuildCtx) (any, hcl.Diagnostics) {
+			return decoded, nil
+		},
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			v := body.(*AnthropicSystemPrompt)
+			b.SetAttributeValue("text", cty.StringVal(v.Text))
+		},
+	})
+}

--- a/internal/config/plugins/middlewares/anthropic_system_prompt_test.go
+++ b/internal/config/plugins/middlewares/anthropic_system_prompt_test.go
@@ -1,0 +1,175 @@
+package middlewares
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// rewrite is a test helper: it builds a POST /v1/messages request with
+// the given JSON body, runs the middleware, and returns the decoded
+// result object.
+func rewrite(t *testing.T, m *AnthropicSystemPrompt, body string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", strings.NewReader(body))
+	out, err := m.RewriteHTTPRequest(context.Background(), req, []byte(body))
+	if err != nil {
+		t.Fatalf("RewriteHTTPRequest: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("result not JSON: %v (%s)", err, out)
+	}
+	return obj
+}
+
+// TestAppendSystemAbsent: a request with no `system` field gets the
+// injected text as a bare string.
+func TestAppendSystemAbsent(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS: gateway"}
+	obj := rewrite(t, m, `{"model":"claude","messages":[]}`)
+	sys, ok := obj["system"].(string)
+	if !ok {
+		t.Fatalf("system is %T, want string", obj["system"])
+	}
+	if sys != "TOOLS: gateway" {
+		t.Errorf("system = %q, want injected text", sys)
+	}
+	// Other fields preserved.
+	if obj["model"] != "claude" {
+		t.Errorf("model field lost: %v", obj["model"])
+	}
+}
+
+// TestAppendSystemString: a string `system` gets the injected text
+// appended after a blank-line separator.
+func TestAppendSystemString(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS: gateway"}
+	obj := rewrite(t, m, `{"system":"You are helpful.","messages":[]}`)
+	sys, ok := obj["system"].(string)
+	if !ok {
+		t.Fatalf("system is %T, want string", obj["system"])
+	}
+	if sys != "You are helpful.\n\nTOOLS: gateway" {
+		t.Errorf("system = %q, want original + injected", sys)
+	}
+}
+
+// TestAppendSystemArray: a content-block array `system` gets a new
+// text block appended at the end; existing blocks are untouched.
+func TestAppendSystemArray(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS: gateway"}
+	obj := rewrite(t, m, `{"system":[{"type":"text","text":"base","cache_control":{"type":"ephemeral"}}],"messages":[]}`)
+	arr, ok := obj["system"].([]any)
+	if !ok {
+		t.Fatalf("system is %T, want array", obj["system"])
+	}
+	if len(arr) != 2 {
+		t.Fatalf("system array len = %d, want 2", len(arr))
+	}
+	// First block preserved verbatim (including cache_control).
+	first := arr[0].(map[string]any)
+	if first["text"] != "base" {
+		t.Errorf("first block text = %v, want base", first["text"])
+	}
+	if first["cache_control"] == nil {
+		t.Errorf("first block lost cache_control")
+	}
+	// Second block is the injected text.
+	second := arr[1].(map[string]any)
+	if second["type"] != "text" || second["text"] != "TOOLS: gateway" {
+		t.Errorf("appended block = %v, want {type:text, text:injected}", second)
+	}
+}
+
+// TestNonMessagesPassThrough: a request to a different path is returned
+// byte-for-byte unchanged.
+func TestNonMessagesPassThrough(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS"}
+	body := `{"system":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/complete", strings.NewReader(body))
+	out, err := m.RewriteHTTPRequest(context.Background(), req, []byte(body))
+	if err != nil {
+		t.Fatalf("RewriteHTTPRequest: %v", err)
+	}
+	if string(out) != body {
+		t.Errorf("non-Messages body mutated: %s", out)
+	}
+}
+
+// TestGetPassThrough: a GET (no body transform) passes through.
+func TestGetPassThrough(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS"}
+	req := httptest.NewRequest(http.MethodGet, "https://api.anthropic.com/v1/messages", nil)
+	out, err := m.RewriteHTTPRequest(context.Background(), req, []byte(nil))
+	if err != nil {
+		t.Fatalf("RewriteHTTPRequest: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("GET body should stay empty, got %s", out)
+	}
+}
+
+// TestFailClosedBadShape: a `system` field in an unrecognized shape
+// (number) fails the request closed rather than silently passing it
+// upstream without the injection.
+func TestFailClosedBadShape(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS"}
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", strings.NewReader(`{"system":42}`))
+	_, err := m.RewriteHTTPRequest(context.Background(), req, []byte(`{"system":42}`))
+	if err == nil {
+		t.Fatal("expected error on numeric system shape, got nil")
+	}
+}
+
+// TestFailClosedBadJSON: a body that isn't a JSON object fails closed.
+func TestFailClosedBadJSON(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "TOOLS"}
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", strings.NewReader(`not json`))
+	_, err := m.RewriteHTTPRequest(context.Background(), req, []byte(`not json`))
+	if err == nil {
+		t.Fatal("expected error on non-JSON body, got nil")
+	}
+}
+
+// TestEmptyTextPassThrough: an empty Text is a no-op even on a
+// Messages request (defensive — the loader requires text, but a
+// zero-value instance shouldn't mangle bodies).
+func TestEmptyTextPassThrough(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: ""}
+	body := `{"system":"x","messages":[]}`
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", strings.NewReader(body))
+	out, err := m.RewriteHTTPRequest(context.Background(), req, []byte(body))
+	if err != nil {
+		t.Fatalf("RewriteHTTPRequest: %v", err)
+	}
+	if string(out) != body {
+		t.Errorf("empty-text body mutated: %s", out)
+	}
+}
+
+// TestCheckEndpointHosts: the host-family compatibility check accepts
+// endpoints that intercept api.anthropic.com (with or without a port)
+// and rejects others.
+func TestCheckEndpointHosts(t *testing.T) {
+	m := &AnthropicSystemPrompt{Text: "x"}
+	cases := []struct {
+		hosts []string
+		ok    bool
+	}{
+		{[]string{"api.anthropic.com"}, true},
+		{[]string{"api.anthropic.com:443"}, true},
+		{[]string{"other.com", "API.ANTHROPIC.COM"}, true}, // case-insensitive
+		{[]string{"api.openai.com"}, false},
+		{nil, false},
+	}
+	for _, c := range cases {
+		err := m.CheckEndpointHosts(c.hosts)
+		if (err == nil) != c.ok {
+			t.Errorf("CheckEndpointHosts(%v) err=%v, want ok=%v", c.hosts, err, c.ok)
+		}
+	}
+}

--- a/internal/config/runtime/checker.go
+++ b/internal/config/runtime/checker.go
@@ -69,6 +69,10 @@ func checkRuntime(p *config.Plugin) []string {
 		if _, ok := p.Runtime.(TunnelRuntime); !ok {
 			return []string{fmt.Sprintf("Runtime %T does not satisfy TunnelRuntime", p.Runtime)}
 		}
+	case config.KindMiddleware:
+		if _, ok := p.Runtime.(HTTPMiddleware); !ok {
+			return []string{fmt.Sprintf("Runtime %T does not satisfy HTTPMiddleware", p.Runtime)}
+		}
 	}
 	return nil
 }

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -51,6 +51,28 @@ type HTTPRequestSigner interface {
 	SignHTTPRequest(ctx context.Context, req *http.Request, sec Secret, endpoint any) error
 }
 
+// HTTPMiddleware is the middleware-plugin contract for request-side
+// body rewriting. The dispatcher calls RewriteHTTPRequest after
+// credential injection and before the upstream forward, once per
+// middleware in an endpoint's ordered `middleware = [...]` list. The
+// hook sees the full request body (read and buffered by the host) and
+// returns the body to forward; it may inspect req to gate on method /
+// path / headers and pass the body through unchanged when the request
+// isn't one it transforms.
+//
+// Returning (nil, err) fails the request closed: the dispatcher emits
+// a 502 + error event and does NOT forward upstream. This is the
+// see-the-request, optionally-mutate, optionally-short-circuit seam —
+// mirrors HTTPCredentialRuntime, but for body transforms rather than
+// auth injection. Middlewares are endpoint-attached (not rule- or
+// credential-attached) so the transform binds to the protocol surface.
+//
+// Implementations live next to their config plugin
+// (config/plugins/middlewares) so schema and runtime stay co-located.
+type HTTPMiddleware interface {
+	RewriteHTTPRequest(ctx context.Context, req *http.Request, body []byte) ([]byte, error)
+}
+
 // WebSocketCredentialRuntime is the credential-plugin contract for
 // server-bound WebSocket text payloads that carry token placeholders.
 // The gateway calls this after decoding/unmasking a complete text frame

--- a/internal/config/symbols.go
+++ b/internal/config/symbols.go
@@ -66,6 +66,7 @@ var blockKinds = map[string]Kind{
 	"approver":   KindApprover,
 	"profile":    KindProfile,
 	"tunnel":     KindTunnel,
+	"middleware": KindMiddleware,
 }
 
 // buildSymbols is pass 1. It walks the parsed file's policy blocks,

--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -49,6 +49,7 @@ func (r *renderer) run() (string, error) {
 		config.KindEndpoint,
 		config.KindRule,
 		config.KindTunnel,
+		config.KindMiddleware,
 	} {
 		r.writeKind(kind)
 	}
@@ -373,7 +374,7 @@ func skipPublicConfigReferenceField(pkgName, typeName, fieldName string) bool {
 func (r *renderer) fieldRefs(pkgName, typeName string) map[string]string {
 	out := map[string]string{}
 	for _, kind := range []config.Kind{
-		config.KindApprover, config.KindCredential, config.KindTunnel, config.KindEndpoint, config.KindRule,
+		config.KindApprover, config.KindCredential, config.KindTunnel, config.KindEndpoint, config.KindRule, config.KindMiddleware,
 	} {
 		for _, p := range config.AllPlugins(kind) {
 			rt := pluginStructType(p)

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -685,3 +685,24 @@ Configures the tunnel runtime.
 tunnel "tailscale" "example" {}
 ```
 
+## `middleware` blocks
+
+Block syntax: `middleware "<type>" "<name>" { ... }`
+
+Registered types: [`anthropic_system_prompt`](#middleware-anthropicsystemprompt).
+
+### `middleware "anthropic_system_prompt" "<name>"`
+
+A request middleware that appends Text to
+the `system` field of Anthropic `/v1/messages` requests.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | `string` | yes | The literal block appended to the request's system prompt. Supports `<<file:NAME>>` inlining so operators can keep large discovery prompts in a sidecar file. |
+
+```hcl
+middleware "anthropic_system_prompt" "example" {
+  text = "example"
+}
+```
+

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -222,6 +222,64 @@ Rules attached to this endpoint are written exactly the way they
 would be against any in-process HTTPS endpoint:
 `http.method == "POST"`, `http.body.contains("…")`, etc.
 
+## Request middleware
+
+A **middleware** is a request-side hook attached to an endpoint that
+can rewrite the request body after credential injection and before the
+upstream forward. Where a credential plugin *injects auth* and a rule
+*decides allow/deny*, a middleware *transforms the request* — the
+see-the-request, optionally-mutate seam.
+
+Declare a `middleware "<type>" "<name>" { … }` block and attach it to
+an endpoint with the ordered `middleware = [...]` attribute:
+
+```hcl
+middleware "anthropic_system_prompt" "tool_discovery" {
+  text = "You can reach these gateway-mediated tools: …"
+}
+
+endpoint "https" "anthropic_api" {
+  hosts      = ["api.anthropic.com"]
+  credential = bearer_token.prod
+  middleware = [anthropic_system_prompt.tool_discovery]
+}
+```
+
+- The first label (`anthropic_system_prompt`) is the **type**; the
+  second (`tool_discovery`) is the **instance** name. References use
+  the `type.name` form, the same as credentials and tunnels.
+- `endpoint.middleware` is an **ordered list**. Unlike the credential
+  binding ("first non-error wins"), *every* middleware in the list
+  runs, in declared order — same-stage composition.
+- A middleware that returns an error **fails the request closed**: the
+  gateway returns `502` and a dashboard error event, and never calls
+  upstream.
+- CEL rule conditions match the **pre-middleware** body — the rule
+  decides on the request the agent sent; the middleware shapes the
+  request the upstream receives.
+
+### `anthropic_system_prompt`
+
+The one built-in middleware type. It appends `text` to the `system`
+field of Anthropic `/v1/messages` requests, handling all three legal
+shapes:
+
+- **absent** → `system` is set to the text.
+- **string** → the text is appended after a blank line.
+- **content-block array** → a `{"type":"text","text": …}` block is
+  appended.
+
+A `system` field in any other shape fails closed. `text` accepts a
+literal string or a [`<<file:NAME>>`](configure-gateway) include so a
+large prompt can live in a sidecar file. Attaching this type to an
+endpoint whose `hosts` don't include `api.anthropic.com` is a
+load-time error.
+
+> Middlewares are a **built-in** kind today (request side only).
+> Response-side rewriting, sibling types for other providers
+> (OpenAI `instructions`, Gemini `systemInstruction`), and an
+> external-plugin middleware surface are planned but not yet shipped.
+
 ## Validating a plugin config
 
 `clawpatrol validate` runs the same load path the daemon does, so


### PR DESCRIPTION
## What

Introduces an **HTTP middleware** seam to clawpatrol: an ordered,
endpoint-attached chain of typed request-side hooks that run after
credential injection and before the upstream forward. Each hook can
mutate the request body; an error fails the request closed (502, no
upstream call). Ships one concrete type alongside the plumbing.

Resolves `cl-whtr`.

## The seam

- **New `middleware "<type>" "<name>" { … }` block** (two-label kind,
  parallel to `credential`/`tunnel`) plus an ordered
  `endpoint.middleware = [type.name, ...]` attribute. Every middleware
  in the list runs, in declared order.
- **`runtime.HTTPMiddleware`** interface (request side only):
  `RewriteHTTPRequest(ctx, req, body) ([]byte, error)`.
- **Load-time host-family compatibility check**: a middleware body may
  implement `MiddlewareEndpointCompat` to reject attachment to
  incompatible endpoints as a clear diagnostic.
- **Dispatcher loop** in `mitmHTTPSWithCertHost`, after credential
  injection and the WebSocket early-return, before usage tracking.
  Fail-closed 502 + dashboard error event on middleware error.

CEL rule predicates match the **pre-middleware** body — the rule
decides on the request the agent sent; the middleware shapes what the
upstream receives.

## First concrete type: `anthropic_system_prompt`

Appends configured `text` to the `system` field of Anthropic
`/v1/messages` requests, handling all three legal shapes (absent →
set; string → append after blank line; content-block array → append
text block). Unknown shape fails closed. `text` supports `<<file:NAME>>`
inlining. Compile-time check requires the endpoint to intercept
`api.anthropic.com`.

## Wiring

`plugin.go`, `symbols.go`, `config.go` (Policy.Middlewares, decode
order, `validateMiddlewareEndpointCompat`), `compile.go`
(`CompiledMiddleware`, `CompiledEndpoint.Middleware`,
`compileMiddlewares`), `emit.go`, `dump.go`, `file_include.go`,
`runtime/runtime.go`, `runtime/checker.go`, `plugins/all/all.go`.

## Docs

New "Request middleware" section in `site/doc/plugins.md`; regenerated
`site/doc/config-reference.md` (docgen).

## Out of scope (deferred)

Response-side middleware, OpenAI/Gemini sibling types, dynamic
discovery text, external-plugin middleware, unifying with the approver
chain. See the bead for rationale.

## Tests

- Plugin unit tests: three `system` shapes, non-Messages / GET
  pass-through, fail-closed on bad shape and bad JSON, host-compat.
- Config integration: reflist resolve + order, ordered execution
  end-to-end, host-compat diagnostic, Emit → Load round-trip.

`go test ./internal/...` and `go test ./cmd/clawpatrol/` pass; gofmt
and `go vet` clean; docgen drift test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)