### PR TITLE
feat(credentials): add Amplitude OAuth credential

### DIFF
--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -347,11 +347,11 @@ func (s *oauthState) setToken(tok *oauth2.Token) {
 		// (returns "Invalid request format" otherwise). Stdlib oauth2
 		// only sends form-urlencoded.
 		base = &anthropicRefreshSource{cfg: s.cfg, current: tok}
-	case isNotionMCPTokenURL(s.cfg.Endpoint.TokenURL):
-		// Notion's MCP token endpoint refreshes via form-urlencoded body
-		// and expects the dynamically registered client_id (no static
+	case isDynamicMCPTokenURL(s.cfg.Endpoint.TokenURL):
+		// Hosted MCP token endpoints refresh via form-urlencoded body and
+		// expect the dynamically registered client_id (no static
 		// ClientSecret — PKCE-only public client).
-		base = &notionMCPRefreshSource{cfg: s.cfg, current: tok}
+		base = &dynamicMCPRefreshSource{cfg: s.cfg, current: tok}
 	default:
 		base = s.cfg.TokenSource(context.Background(), tok)
 	}
@@ -535,7 +535,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 		}
 		s := newState(it, r.db)
 		// Restore the dynamically-registered client_id BEFORE setToken
-		// so the refresh source (notion_mcp) picks it up via s.cfg.
+		// so dynamic MCP refresh sources pick it up via s.cfg.
 		if clientID.Valid && clientID.String != "" {
 			s.clientID = clientID.String
 			s.cfg.ClientID = clientID.String
@@ -566,8 +566,9 @@ type oauthSession struct {
 	id       string
 	created  time.Time
 	// dynClientID is the RFC 7591 client_id this session registered at
-	// start time (notion_mcp). Empty for static-ClientID flows. Stamped
-	// onto the credential row at exchange time so refresh can replay it.
+	// start time (dynamic MCP flows). Empty for static-ClientID flows.
+	// Stamped onto the credential row at exchange time so refresh can
+	// replay it.
 	dynClientID string
 }
 
@@ -646,8 +647,8 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		w.startOpenAIDeviceFlow(rw, r, id, flow)
 		return
 	}
-	if flow.Flow == "notion_mcp" {
-		w.startNotionMCPFlow(rw, r, id, flow)
+	if flow.Flow == "notion_mcp" || flow.Flow == "dynamic_mcp" {
+		w.startDynamicMCPFlow(rw, r, id, flow)
 		return
 	}
 
@@ -677,14 +678,18 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state})
 }
 
-// startNotionMCPFlow drives the mcp.notion.com auth-code flow with RFC
-// 7591 dynamic client registration. Notion accepts arbitrary redirect
-// URIs at registration, so we register the dashboard's own
-// /oauth/callback page — the page auto-exchanges via /api/oauth/exchange
-// when it loads, with copy-paste from the URL bar as a fallback.
-func (w *webMux) startNotionMCPFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
-	redirectURI := w.dashboardRedirectURI(r, "/oauth/callback")
-	clientID, err := registerOAuthClient(r.Context(), flow.OAuth.RegisterURL, redirectURI)
+// startDynamicMCPFlow drives auth-code OAuth flows with RFC 7591
+// dynamic client registration. Plugins may pin a provider-accepted
+// redirect URI (Amplitude uses a localhost loopback URI); otherwise we
+// register the dashboard's own /oauth/callback page, which
+// auto-exchanges via /api/oauth/exchange when it loads, with copy-paste
+// from the URL bar as a fallback.
+func (w *webMux) startDynamicMCPFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
+	redirectURI := strings.TrimSpace(flow.OAuth.RedirectURI)
+	if redirectURI == "" {
+		redirectURI = w.dashboardRedirectURI(r, "/oauth/callback")
+	}
+	clientID, err := registerOAuthClient(r.Context(), flow.OAuth.RegisterURL, redirectURI, flow.OAuth.Scopes)
 	if err != nil {
 		http.Error(rw, "dynamic client registration: "+err.Error(), http.StatusBadGateway)
 		return
@@ -740,14 +745,52 @@ func (w *webMux) dashboardRedirectURI(r *http.Request, path string) string {
 // registerOAuthClient performs RFC 7591 dynamic client registration
 // against `registerURL`, asking for a public PKCE client bound to the
 // given redirect URI. Returns the issued client_id.
-func registerOAuthClient(ctx context.Context, registerURL, redirectURI string) (string, error) {
-	body, _ := json.Marshal(map[string]any{
+func normalizeOAuthExchangeInput(rawCode, rawState string) (code, state string, err error) {
+	code = strings.TrimSpace(rawCode)
+	state = strings.TrimSpace(rawState)
+	if code == "" {
+		return "", state, nil
+	}
+	if strings.HasPrefix(code, "http://") || strings.HasPrefix(code, "https://") {
+		u, err := url.Parse(code)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid OAuth callback URL: %w", err)
+		}
+		q := u.Query()
+		if oauthErr := q.Get("error"); oauthErr != "" {
+			desc := q.Get("error_description")
+			if desc != "" {
+				return "", "", fmt.Errorf("OAuth callback error: %s: %s", oauthErr, desc)
+			}
+			return "", "", fmt.Errorf("OAuth callback error: %s", oauthErr)
+		}
+		code = strings.TrimSpace(q.Get("code"))
+		if gotState := strings.TrimSpace(q.Get("state")); gotState != "" {
+			if state != "" && state != gotState {
+				return "", "", fmt.Errorf("OAuth state mismatch in pasted callback URL")
+			}
+			state = gotState
+		}
+		return code, state, nil
+	}
+	if i := strings.IndexAny(code, "#&?"); i > 0 {
+		code = code[:i]
+	}
+	return strings.TrimSpace(code), state, nil
+}
+
+func registerOAuthClient(ctx context.Context, registerURL, redirectURI string, scopes []string) (string, error) {
+	bodyMap := map[string]any{
 		"client_name":                "clawpatrol",
 		"redirect_uris":              []string{redirectURI},
 		"grant_types":                []string{"authorization_code", "refresh_token"},
 		"response_types":             []string{"code"},
 		"token_endpoint_auth_method": "none",
-	})
+	}
+	if len(scopes) > 0 {
+		bodyMap["scope"] = strings.Join(scopes, " ")
+	}
+	body, _ := json.Marshal(bodyMap)
 	req, err := http.NewRequestWithContext(ctx, "POST", registerURL, bytes.NewReader(body))
 	if err != nil {
 		return "", err
@@ -788,13 +831,16 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, err.Error(), 400)
 		return
 	}
-	body.Code = strings.TrimSpace(body.Code)
+	code, state, err := normalizeOAuthExchangeInput(body.Code, body.State)
+	if err != nil {
+		http.Error(rw, err.Error(), 400)
+		return
+	}
+	body.Code = code
+	body.State = state
 	if body.Code == "" || body.State == "" {
 		http.Error(rw, "missing code/state", 400)
 		return
-	}
-	if i := strings.IndexAny(body.Code, "#&?"); i > 0 {
-		body.Code = body.Code[:i]
 	}
 
 	w.mu.Lock()
@@ -1155,32 +1201,34 @@ func isAnthropicTokenURL(u string) bool {
 	return strings.Contains(u, "anthropic.com/")
 }
 
-func isNotionMCPTokenURL(u string) bool {
-	return strings.Contains(u, "mcp.notion.com/")
+func isDynamicMCPTokenURL(u string) bool {
+	return strings.Contains(u, "mcp.notion.com/") ||
+		strings.Contains(u, "mcp.amplitude.com/") ||
+		strings.Contains(u, "mcp.eu.amplitude.com/")
 }
 
-// notionMCPRefreshSource refreshes Notion MCP OAuth tokens via the
+// dynamicMCPRefreshSource refreshes hosted MCP OAuth tokens via the
 // form-urlencoded body the spec mandates. The client_id is read from
 // cfg.ClientID, which the registry restores from the persisted
 // credentials.client_id column on boot. Stateful: holds the current
 // token (with refresh_token) and rotates it on each refresh.
-type notionMCPRefreshSource struct {
+type dynamicMCPRefreshSource struct {
 	mu      sync.Mutex
 	cfg     *oauth2.Config
 	current *oauth2.Token
 }
 
-func (n *notionMCPRefreshSource) Token() (*oauth2.Token, error) {
+func (n *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.current.Valid() {
 		return n.current, nil
 	}
 	if n.current.RefreshToken == "" {
-		return nil, fmt.Errorf("notion_mcp refresh: no refresh_token")
+		return nil, fmt.Errorf("dynamic_mcp refresh: no refresh_token")
 	}
 	if n.cfg.ClientID == "" {
-		return nil, fmt.Errorf("notion_mcp refresh: no client_id (dynamic registration was never persisted)")
+		return nil, fmt.Errorf("dynamic_mcp refresh: no client_id (dynamic registration was never persisted)")
 	}
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
@@ -1188,23 +1236,23 @@ func (n *notionMCPRefreshSource) Token() (*oauth2.Token, error) {
 	form.Set("client_id", n.cfg.ClientID)
 	// See anthropicRefreshSource.Token: oauth2 has no ctx on Token(),
 	// so we bound the upstream round-trip here so n.mu stays available
-	// even if Notion's token endpoint hangs.
+	// even if the MCP token endpoint hangs.
 	ctx, cancel := context.WithTimeout(context.Background(), oauthUpstreamTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("notion_mcp refresh: build request: %w", err)
+		return nil, fmt.Errorf("dynamic_mcp refresh: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("notion_mcp refresh: %w", err)
+		return nil, fmt.Errorf("dynamic_mcp refresh: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, oauthResponseLimit))
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("notion_mcp refresh %d: %s", resp.StatusCode, string(respBytes))
+		return nil, fmt.Errorf("dynamic_mcp refresh %d: %s", resp.StatusCode, string(respBytes))
 	}
 	var tr struct {
 		AccessToken  string `json:"access_token"`

--- a/cmd/clawpatrol/oauth_dynamic_mcp_test.go
+++ b/cmd/clawpatrol/oauth_dynamic_mcp_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestIsDynamicMCPTokenURLIncludesAmplitudeAndNotion(t *testing.T) {
+	for _, u := range []string{
+		"https://mcp.notion.com/token",
+		"https://mcp.amplitude.com/token",
+		"https://mcp.eu.amplitude.com/token",
+	} {
+		if !isDynamicMCPTokenURL(u) {
+			t.Fatalf("isDynamicMCPTokenURL(%q) = false", u)
+		}
+	}
+	if isDynamicMCPTokenURL("https://api.example.com/token") {
+		t.Fatalf("isDynamicMCPTokenURL matched unrelated URL")
+	}
+}
+
+func TestDynamicMCPRefreshSourceSendsClientID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Fatalf("grant_type = %q, want refresh_token", got)
+		}
+		if got := r.Form.Get("client_id"); got != "dyn-client" {
+			t.Fatalf("client_id = %q, want dyn-client", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != "old-refresh" {
+			t.Fatalf("refresh_token = %q, want old-refresh", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	src := &dynamicMCPRefreshSource{
+		cfg: &oauth2.Config{
+			ClientID: "dyn-client",
+			Endpoint: oauth2.Endpoint{TokenURL: ts.URL},
+		},
+		current: &oauth2.Token{
+			AccessToken:  "old-access",
+			RefreshToken: "old-refresh",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(-time.Hour),
+		},
+	}
+
+	tok, err := src.Token()
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if tok.AccessToken != "new-access" || tok.RefreshToken != "new-refresh" {
+		t.Fatalf("token = %#v, want refreshed access/refresh", tok)
+	}
+}
+
+func TestStartDynamicMCPFlowUsesConfiguredRedirectURI(t *testing.T) {
+	registerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got struct {
+			RedirectURIs []string `json:"redirect_uris"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode register body: %v", err)
+		}
+		if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "http://localhost:8900/callback" {
+			t.Fatalf("redirect_uris = %#v, want localhost callback", got.RedirectURIs)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"client-loopback"}`))
+	}))
+	defer registerServer.Close()
+
+	w := &webMux{sessions: map[string]*oauthSession{}}
+	req := httptest.NewRequest(http.MethodPost, "http://100.66.146.96:8080/api/oauth/start", nil)
+	rr := httptest.NewRecorder()
+	w.startDynamicMCPFlow(rr, req, "amplitude", &OAuthIntegration{
+		OAuth: OAuthConfig{
+			AuthURL:     "https://mcp.eu.amplitude.com/authorize",
+			TokenURL:    "https://mcp.eu.amplitude.com/token",
+			RegisterURL: registerServer.URL,
+			RedirectURI: "http://localhost:8900/callback",
+			Scopes:      []string{"mcp:read", "offline_access"},
+		},
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		AuthURL string `json:"auth_url"`
+		State   string `json:"state"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.State == "" {
+		t.Fatalf("state is empty")
+	}
+	authURL, err := url.Parse(body.AuthURL)
+	if err != nil {
+		t.Fatalf("parse auth_url: %v", err)
+	}
+	if got := authURL.Query().Get("redirect_uri"); got != "http://localhost:8900/callback" {
+		t.Fatalf("auth_url redirect_uri = %q, want localhost callback", got)
+	}
+}
+
+func TestNormalizeOAuthExchangeInputAcceptsCallbackURL(t *testing.T) {
+	code, state, err := normalizeOAuthExchangeInput("http://localhost:8900/callback?code=abc123&state=s1", "s1")
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if code != "abc123" || state != "s1" {
+		t.Fatalf("code/state = %q/%q, want abc123/s1", code, state)
+	}
+}
+
+func TestNormalizeOAuthExchangeInputRejectsCallbackURLStateMismatch(t *testing.T) {
+	_, _, err := normalizeOAuthExchangeInput("http://localhost:8900/callback?code=abc123&state=other", "s1")
+	if err == nil {
+		t.Fatalf("normalize succeeded, want state mismatch")
+	}
+}
+
+func TestNormalizeOAuthExchangeInputKeepsPlainCodeCompatibility(t *testing.T) {
+	code, state, err := normalizeOAuthExchangeInput("abc123&state=s1", "s1")
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if code != "abc123" || state != "s1" {
+		t.Fatalf("code/state = %q/%q, want abc123/s1", code, state)
+	}
+}
+
+func TestRegisterOAuthClientIncludesScopes(t *testing.T) {
+	var got map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"client-123"}`))
+	}))
+	defer ts.Close()
+
+	clientID, err := registerOAuthClient(t.Context(), ts.URL, "https://gateway.example/oauth/callback", []string{"mcp:read", "offline_access"})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if clientID != "client-123" {
+		t.Fatalf("clientID = %q, want client-123", clientID)
+	}
+	if got["scope"] != "mcp:read offline_access" {
+		t.Fatalf("scope = %#v, want joined scopes", got["scope"])
+	}
+	if got["token_endpoint_auth_method"] != "none" {
+		t.Fatalf("token_endpoint_auth_method = %#v, want none", got["token_endpoint_auth_method"])
+	}
+}

--- a/internal/config/plugins/credentials/amplitude_oauth.go
+++ b/internal/config/plugins/credentials/amplitude_oauth.go
@@ -1,0 +1,122 @@
+package credentials
+
+// amplitude_oauth: OAuth bearer for Amplitude's hosted MCP server.
+// The amp CLI reads AMPLITUDE_ACCESS_TOKEN / AMPLITUDE_OAUTH_TOKEN and
+// AMPLITUDE_REGION; the gateway rewrites the Authorization header at
+// MITM time and refreshes tokens through the OAuth registry.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+const (
+	amplitudeOAuthScopes      = "mcp:read mcp:write offline_access"
+	amplitudeOAuthRedirectURI = "http://localhost:8900/callback"
+)
+
+// AmplitudeOAuth is part of the clawpatrol plugin API.
+type AmplitudeOAuth struct {
+	// Region selects Amplitude's MCP host. Valid values are "us" and
+	// "eu". Empty defaults to "us" to match amplitude-cli.
+	Region string `hcl:"region,optional"`
+}
+
+// InjectHTTP is part of the clawpatrol plugin API.
+func (a *AmplitudeOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
+	if len(sec.Bytes) == 0 {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+string(sec.Bytes))
+	return nil
+}
+
+// EnvVars is part of the clawpatrol plugin API.
+func (a *AmplitudeOAuth) EnvVars() []config.EnvVar {
+	region := a.normalizedRegion()
+	return []config.EnvVar{
+		{Name: "AMPLITUDE_ACCESS_TOKEN", Value: phAmplitude, Description: "Amplitude CLI OAuth access token placeholder"},
+		{Name: "AMPLITUDE_OAUTH_TOKEN", Value: phAmplitude, Description: "Amplitude CLI OAuth access token placeholder"},
+		{Name: "AMPLITUDE_REGION", Value: region, Description: "Amplitude region for MCP host selection"},
+	}
+}
+
+// OAuthFlow returns Amplitude MCP's dynamic-client OAuth flow. Amplitude
+// only allows insecure redirect URIs for localhost, so we register the
+// same loopback callback shape as amplitude-cli. The dashboard falls
+// back to copy-pasting the code from the browser URL; the gateway stores
+// the issued client_id beside the token so refresh works after restart.
+func (a *AmplitudeOAuth) OAuthFlow() *config.OAuthIntegration {
+	base := amplitudeMCPBaseURL(a.normalizedRegion())
+	return &config.OAuthIntegration{
+		Type:   "oauth2",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+		Flow:   "dynamic_mcp",
+		OAuth: config.OAuthConfig{
+			AuthURL:     base + "/authorize",
+			TokenURL:    base + "/token",
+			RegisterURL: base + "/register",
+			RedirectURI: amplitudeOAuthRedirectURI,
+			Scopes:      strings.Fields(amplitudeOAuthScopes),
+		},
+	}
+}
+
+func (a *AmplitudeOAuth) normalizedRegion() string {
+	switch strings.ToLower(strings.TrimSpace(a.Region)) {
+	case "eu":
+		return "eu"
+	default:
+		return "us"
+	}
+}
+
+func amplitudeMCPBaseURL(region string) string {
+	if strings.EqualFold(region, "eu") {
+		return "https://mcp.eu.amplitude.com"
+	}
+	return "https://mcp.amplitude.com"
+}
+
+func buildAmplitudeOAuth(decoded any, _ string, _ *config.BuildCtx) (any, hcl.Diagnostics) {
+	a := decoded.(*AmplitudeOAuth)
+	a.Region = strings.ToLower(strings.TrimSpace(a.Region))
+	if a.Region == "" {
+		a.Region = "us"
+	}
+	if a.Region != "us" && a.Region != "eu" {
+		return a, hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid Amplitude region",
+			Detail:   `region must be "us" or "eu"`,
+		}}
+	}
+	return a, nil
+}
+
+func init() {
+	var _ runtime.HTTPCredentialRuntime = (*AmplitudeOAuth)(nil)
+	config.Register(&config.Plugin{
+		Kind:           config.KindCredential,
+		Type:           "amplitude_oauth",
+		Disambiguators: []string{"placeholder"},
+		New:            newer[AmplitudeOAuth](),
+		Runtime:        (*AmplitudeOAuth)(nil),
+		Build:          buildAmplitudeOAuth,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			v := body.(*AmplitudeOAuth)
+			if v.Region != "" && v.Region != "us" {
+				b.SetAttributeValue("region", cty.StringVal(v.Region))
+			}
+		},
+	})
+}

--- a/internal/config/plugins/credentials/amplitude_oauth_test.go
+++ b/internal/config/plugins/credentials/amplitude_oauth_test.go
@@ -1,0 +1,68 @@
+package credentials
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func TestAmplitudeOAuthInjectHTTPUsesBearer(t *testing.T) {
+	plugin := &AmplitudeOAuth{}
+	req, err := http.NewRequest("GET", "https://mcp.eu.amplitude.com/mcp", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err := plugin.InjectHTTP(req.Context(), req, runtime.Secret{Bytes: []byte("real.amplitude.token")}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer real.amplitude.token" {
+		t.Fatalf("Authorization = %q, want Bearer real.amplitude.token", got)
+	}
+}
+
+func TestAmplitudeOAuthEnvVarsIncludeAmpPlaceholdersAndRegion(t *testing.T) {
+	vars := (&AmplitudeOAuth{Region: "eu"}).EnvVars()
+	got := map[string]string{}
+	for _, v := range vars {
+		got[v.Name] = v.Value
+	}
+	if got["AMPLITUDE_ACCESS_TOKEN"] != phAmplitude {
+		t.Fatalf("AMPLITUDE_ACCESS_TOKEN = %q, want %q", got["AMPLITUDE_ACCESS_TOKEN"], phAmplitude)
+	}
+	if got["AMPLITUDE_OAUTH_TOKEN"] != phAmplitude {
+		t.Fatalf("AMPLITUDE_OAUTH_TOKEN = %q, want %q", got["AMPLITUDE_OAUTH_TOKEN"], phAmplitude)
+	}
+	if got["AMPLITUDE_REGION"] != "eu" {
+		t.Fatalf("AMPLITUDE_REGION = %q, want eu", got["AMPLITUDE_REGION"])
+	}
+}
+
+func TestAmplitudeOAuthFlowUsesEUHostedMCP(t *testing.T) {
+	flow := (&AmplitudeOAuth{Region: "eu"}).OAuthFlow()
+	if flow.Flow != "dynamic_mcp" {
+		t.Fatalf("Flow = %q, want dynamic_mcp", flow.Flow)
+	}
+	if flow.OAuth.AuthURL != "https://mcp.eu.amplitude.com/authorize" {
+		t.Fatalf("AuthURL = %q", flow.OAuth.AuthURL)
+	}
+	if flow.OAuth.TokenURL != "https://mcp.eu.amplitude.com/token" {
+		t.Fatalf("TokenURL = %q", flow.OAuth.TokenURL)
+	}
+	if flow.OAuth.RegisterURL != "https://mcp.eu.amplitude.com/register" {
+		t.Fatalf("RegisterURL = %q", flow.OAuth.RegisterURL)
+	}
+	if flow.OAuth.RedirectURI != "http://localhost:8900/callback" {
+		t.Fatalf("RedirectURI = %q", flow.OAuth.RedirectURI)
+	}
+	wantScopes := []string{"mcp:read", "mcp:write", "offline_access"}
+	if len(flow.OAuth.Scopes) != len(wantScopes) {
+		t.Fatalf("Scopes = %#v, want %#v", flow.OAuth.Scopes, wantScopes)
+	}
+	for i, want := range wantScopes {
+		if flow.OAuth.Scopes[i] != want {
+			t.Fatalf("Scopes[%d] = %q, want %q", i, flow.OAuth.Scopes[i], want)
+		}
+	}
+}

--- a/internal/config/plugins/credentials/util.go
+++ b/internal/config/plugins/credentials/util.go
@@ -46,13 +46,14 @@ func ensureBeta(h http.Header, beta string) {
 	h.Set("anthropic-beta", cur+","+beta)
 }
 
-// Per-provider env-var placeholders. Chosen to look like real tokens
-// so the agent CLI's startup validation accepts them; the gateway
-// overwrites the slot at MITM time so the placeholder bytes never
-// reach the upstream.
+// Per-provider env-var placeholders. Most are chosen to look like real
+// tokens so agent CLIs with startup validation accept them; the gateway
+// overwrites the slot at MITM time so the placeholder bytes never reach
+// the upstream.
 const (
-	phClaude = "sk-ant-oat01-clawpatrol-placeholder-do-not-use"
-	phOpenAI = "sk-clawpatrol-placeholder-do-not-use"
-	phGitHub = "ghp_clawpatrol_placeholder_do_not_use"
-	phGemini = "AIzaClawpatrolPlaceholderDoNotUse00000000"
+	phClaude    = "sk-ant-oat01-clawpatrol-placeholder-do-not-use"
+	phOpenAI    = "sk-clawpatrol-placeholder-do-not-use"
+	phGitHub    = "ghp_clawpatrol_placeholder_do_not_use"
+	phGemini    = "AIzaClawpatrolPlaceholderDoNotUse00000000"
+	phAmplitude = "PH_amplitude_oauth"
 )

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -174,7 +174,17 @@ approver "llm_approver" "example" {
 
 Block syntax: `credential "<type>" "<name>" { ... }`
 
-Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`passthrough`](#credential-passthrough), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh_key`](#credential-sshkey), [`tailscale_auth`](#credential-tailscaleauth), [`telegram_bot_token`](#credential-telegrambottoken).
+Registered types: [`amplitude_oauth`](#credential-amplitudeoauth), [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`passthrough`](#credential-passthrough), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh_key`](#credential-sshkey), [`tailscale_auth`](#credential-tailscaleauth), [`telegram_bot_token`](#credential-telegrambottoken).
+
+### `credential "amplitude_oauth" "<name>"`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `region` | `string` | no | Selects Amplitude's MCP host. Valid values are "us" and "eu". Empty defaults to "us" to match amplitude-cli. |
+
+```hcl
+credential "amplitude_oauth" "example" {}
+```
 
 ### `credential "anthropic_manual_key" "<name>"`
 


### PR DESCRIPTION
## Summary

Adds a built-in `amplitude_oauth` credential for Amplitude's hosted MCP server and the `amp` CLI.

The credential:

- injects `Authorization: Bearer <gateway OAuth token>` for Amplitude MCP requests
- pushes `AMPLITUDE_ACCESS_TOKEN`, `AMPLITUDE_OAUTH_TOKEN`, and `AMPLITUDE_REGION` placeholders for `amp`
- supports `region = "us" | "eu"`
- uses Amplitude MCP dynamic client registration (`/register`) with PKCE
- refreshes tokens through the gateway OAuth registry with the persisted dynamic `client_id`

## OAuth callback model

Amplitude is stricter than Notion MCP about redirect URIs: it rejects `http://<tailnet-ip>:8080/oauth/callback` and only allows insecure HTTP for localhost. To keep this working without requiring operators to expose the dashboard over HTTPS, this credential pins the redirect URI to the same loopback shape used by `amplitude-cli`:

```text
http://localhost:8900/callback
```

The browser may land on a connection-failed localhost page, but the dashboard's existing copy/paste exchange flow can complete the connection. I also made the exchange handler accept a pasted full callback URL, not only the raw code, to make that fallback less fragile.

I would appreciate maintainer guidance on whether this should stay credential-specific, or whether Claw Patrol should grow a first-class callback model for dynamic OAuth providers, e.g. provider-declared callback strategy, `gateway.public_url` preference, Funnel HTTPS fallback, or dashboard-assisted loopback handling.

## Validation

- `XDG_RUNTIME_DIR=/proc go test ./cmd/clawpatrol ./internal/config/plugins/credentials ./internal/tools/docgen`
- `XDG_RUNTIME_DIR=/proc go test ./...`
- `go build ./cmd/clawpatrol`
- Live Amplitude EU dynamic registration probe accepted `http://localhost:8900/callback`
- Tested on a gateway: dashboard connect succeeded, then `clawpatrol run -- amp auth status` and `clawpatrol run -- amp events list` succeeded with placeholder env vars; direct `amp` with the placeholder failed as expected.
