### PR TITLE
gateway: advertise dnsvip CIDRs as Tailscale subnet routes

### DIFF
--- a/cmd/clawpatrol/dnsvip/dnsvip.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip.go
@@ -114,6 +114,14 @@ func (a *Allocator) InternalVIPs() (netip.Addr, netip.Addr) {
 	return a.vipForID(internalID)
 }
 
+// CIDRs returns the (v4, v6) prefixes this allocator hands VIPs out
+// of. The gateway advertises them as Tailscale subnet routes so
+// exit-node-routed clients can reach VIPs at all (see
+// advertiseExitRoutes in cmd/clawpatrol).
+func (a *Allocator) CIDRs() (netip.Prefix, netip.Prefix) {
+	return a.cidr4, a.cidr6
+}
+
 type entry struct {
 	ID       uint32
 	Hostname string

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3149,6 +3149,14 @@ func runGateway(args []string) {
 	if err != nil {
 		log.Fatalf("listen: %v", err)
 	}
+	if tsnetServer != nil {
+		// Advertise exit routes plus the dnsvip CIDRs as subnet routes;
+		// without the latter, exit-node clients can't reach any v4 VIP
+		// (the local inbound filter shrinks a /0 advertisement to
+		// public space only). See advertiseExitRoutes.
+		vip4, vip6 := g.dnsvip.CIDRs()
+		go advertiseExitRoutes(tsnetServer, vip4, vip6)
+	}
 	if ln != nil {
 		log.Printf("gateway listening on %s, %d endpoints across %d profiles",
 			ln.Addr(), len(policy.Endpoints), len(policy.Profiles))

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -153,9 +153,9 @@ func openListener(cfg *config.Gateway, stateDir string) (*tsnet.Server, net.List
 		return nil, nil, err
 	}
 	_ = bringUp.Close()
-	// Advertise exit routes so whole-machine and per-process tsnet
-	// clients can use this node as a Tailscale exit node.
-	go advertiseExitRoutes(s)
+	// Route advertisement (exit routes + VIP subnet routes) happens in
+	// runGateway via advertiseExitRoutes once the dnsvip allocator's
+	// CIDRs are known.
 	return s, ln, nil
 }
 
@@ -238,7 +238,28 @@ func tsnetCertDomain(s *tsnet.Server) string {
 // node (advertises 0.0.0.0/0 and ::/0). Whole-machine clients on the
 // same tailnet can then route all traffic through this gateway; exit
 // flows are intercepted via RegisterFallbackTCPHandler in runGateway.
-func advertiseExitRoutes(s *tsnet.Server) {
+//
+// The dnsvip CIDRs are advertised alongside as plain subnet routes.
+// The exit-node /0 advertisements alone do NOT make the v4 VIPs
+// reachable: tailscaled derives the inbound packet filter's accept
+// set (localNets) locally from AdvertiseRoutes, and a /0 route is
+// deliberately shrunk to "the internet" (guest-wifi semantics) by
+// subtracting removeFromDefaultRoute — which contains 10.0.0.0/8 and
+// therefore the v4 VIP range. Inbound exit-node flows to a v4 VIP
+// were dropped by the filter's "destination not allowed" check before
+// any clawpatrol handler ran, for every client kind (tsnet
+// `clawpatrol run` and whole-machine alike). The v6 list strips only
+// link-local/multicast/fd7a:115c:a1e0::/48, so fd78:: VIPs always
+// passed — which is why v6-capable clients masked the bug. See
+// ipn/ipnlocal updateFilterLocked + shrinkDefaultRoute.
+//
+// Advertising the VIP CIDRs as non-default routes puts them in
+// localNets verbatim, so VIP-bound flows reach
+// RegisterFallbackTCPHandler / the UDP catch-all like any other
+// intercepted traffic. This is purely node-local: it does not require
+// the routes to be approved in the tailnet (clients route VIPs via
+// the exit-node /0, not via subnet routes). (#653)
+func advertiseExitRoutes(s *tsnet.Server, vipCIDRs ...netip.Prefix) {
 	lc, err := s.LocalClient()
 	if err != nil {
 		log.Printf("tsnet: LocalClient for exit routes: %v", err)
@@ -248,13 +269,18 @@ func advertiseExitRoutes(s *tsnet.Server) {
 		netip.MustParsePrefix("0.0.0.0/0"),
 		netip.MustParsePrefix("::/0"),
 	}
+	for _, p := range vipCIDRs {
+		if p.IsValid() {
+			routes = append(routes, p)
+		}
+	}
 	if _, err := lc.EditPrefs(context.Background(), &ipn.MaskedPrefs{
 		AdvertiseRoutesSet: true,
 		Prefs:              ipn.Prefs{AdvertiseRoutes: routes},
 	}); err != nil {
 		log.Printf("tsnet: advertise exit routes: %v", err)
 	} else {
-		log.Printf("tsnet: advertised exit routes (0.0.0.0/0, ::/0)")
+		log.Printf("tsnet: advertised exit routes (%s)", routes)
 	}
 }
 

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -89,22 +89,48 @@ the tailnet ACL must **auto-approve the gateway as an exit node
 for the client tag**. Without it, the pref is accepted locally
 but every outbound dial silently times out.
 
+Besides the two `/0` exit routes, the gateway advertises the dnsvip
+VIP ranges (`10.78.0.0/16` / `fd78::/64` — the per-endpoint virtual
+IPs that `clawpatrol.internal`, SSH hosts, ClickHouse native, etc.
+resolve to) as plain subnet routes. This is what makes the v4 VIPs
+reachable at all: tailscaled derives its inbound packet filter's
+accept set locally from the advertised routes, and a bare `/0`
+advertisement is deliberately shrunk to public address space
+("guest wifi" semantics — `10.0.0.0/8` and friends are stripped), so
+without the explicit VIP-range advertisement the gateway itself
+silently drops exit-node flows to v4 VIPs. The effect is node-local;
+the VIP routes do **not** need to be approved in the admin console
+for VIP traffic to work (clients reach VIPs through the exit-node
+`/0`, not through subnet routing). Approving or auto-approving them
+merely keeps the gateway's machine entry free of "pending route
+approval" noise.
+
 Add to your tailnet ACL JSON:
 
 ```jsonc
 {
   "autoApprovers": {
-    "exitNode": ["tag:client"]    // must match tailscale.tags below
+    "exitNode": ["tag:client"],   // must match tailscale.tags below
+    "routes": {
+      // dnsvip VIP ranges (optional tidiness, see above); approver
+      // is the GATEWAY node's tag (the tag on the authkey the
+      // gateway itself joined with).
+      "10.78.0.0/16": ["tag:gateway"],
+      "fd78::/64":    ["tag:gateway"]
+    }
   },
   "tagOwners": {
-    "tag:client": ["autogroup:admin"]
+    "tag:client":  ["autogroup:admin"],
+    "tag:gateway": ["autogroup:admin"]
   }
 }
 ```
 
-The gateway already advertises `0.0.0.0/0` + `::/0` via
-`advertiseExitRoutes`, so no operator action is needed in the
-Tailscale admin console — the ACL above is the whole prereq.
+If your ACL is not the permissive default (`accept *:*`), the rules
+must also allow client tags to send to the VIP ranges, e.g.
+`{"action": "accept", "src": ["tag:client"], "dst":
+["10.78.0.0/16:*", "fd78::/64:*"]}` — `autogroup:internet` does not
+include them.
 
 ## Operator setup
 


### PR DESCRIPTION
Fixes #653.

* Root cause (corrected after an A/B test on the live gateway — see
  the issue thread): tailscaled derives the inbound packet filter's
  accept set (`localNets`) locally from `AdvertiseRoutes`. A bare
  `/0` exit advertisement is deliberately shrunk to public address
  space ("guest wifi" semantics, `removeFromDefaultRoute` in
  `ipn/ipnlocal`), which strips `10.0.0.0/8` — and with it the
  `10.78.0.0/16` VIP range. Inbound exit-node flows to a v4 VIP were
  dropped by the filter's "destination not allowed" check before any
  clawpatrol handler ran, for every client kind.
* The v6 strip list leaves generic ULA intact, so `fd78::` VIPs
  always worked — masking the bug on v6-capable (whole-machine)
  clients. `clawpatrol run` sessions are v4-only and always hit it.
* Fix: advertise the dnsvip CIDRs as plain subnet routes alongside
  `0.0.0.0/0` + `::/0`. Non-default advertised routes enter
  `localNets` verbatim. The effect is node-local; tailnet route
  approval is NOT required (clients route VIPs via the exit-node
  `/0`), though auto-approving avoids "pending approval" noise in
  the admin console.
* The advertisement call moves from `openListener` to `runGateway`,
  where the dnsvip allocator's CIDRs are in scope; `Allocator` gains
  a `CIDRs()` accessor. `doc/tailscale.md` documents the mechanism.

Verified by binary A/B on a live two-client setup (per-process tsnet
+ whole-machine): base build — v4 VIP times out from both clients,
v6 VIP works; base build + only this change — v4 VIP returns 200
from both in ~0.3s, with the routes still unapproved in the admin
console. Unrelated RFC1918 destinations remain dropped.