### PR TITLE
feat(pluginsdk): support external HTTP credential plugins

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,6 +10,10 @@ concurrency:
 
 jobs:
   preview:
+    # Demo previews need DEMO_DEPLOY_TOKEN to read/write denoland/clawpatrol-demo.
+    # GitHub does not expose repository secrets to pull_request runs from forks,
+    # so skip this optional preview job there instead of failing fork PR CI.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,10 +10,6 @@ concurrency:
 
 jobs:
   preview:
-    # Demo previews need DEMO_DEPLOY_TOKEN to read/write denoland/clawpatrol-demo.
-    # GitHub does not expose repository secrets to pull_request runs from forks,
-    # so skip this optional preview job there instead of failing fork PR CI.
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/cmd/clawpatrol/extplugin_http_credential_test.go
+++ b/cmd/clawpatrol/extplugin_http_credential_test.go
@@ -157,6 +157,9 @@ rule "allow-api" {
 	if strings.Contains(fmt.Sprint(end.ReqHeaders), "real-external-token") {
 		t.Fatalf("request headers audit leaked injected external credential: %#v", end.ReqHeaders)
 	}
+	if strings.Contains(fmt.Sprint(end.ReqHeaders), "derived-real-external-token") {
+		t.Fatalf("request headers audit leaked derived external credential: %#v", end.ReqHeaders)
+	}
 	if got := end.ReqHeaders["X-Magic"]; got != credentialSampleRedaction {
 		t.Fatalf("X-Magic audit header = %q, want credential redaction marker", got)
 	}
@@ -351,12 +354,13 @@ func main() {
 				if got := req.Headers.Get("Authorization"); !strings.HasPrefix(got, "Bearer PH_") {
 					return nil, fmt.Errorf("authorization = %%q", got)
 				}
+				derived := "derived-" + string(req.CredentialSecret)
 				return &pluginsdk.HTTPInjectResponse{
 					Headers: []pluginsdk.HeaderMutation{
 						{Op: pluginsdk.HeaderSet, Name: "Authorization", Values: []string{"Bearer " + string(req.CredentialSecret)}},
-						{Op: pluginsdk.HeaderSet, Name: "X-Magic", Values: []string{string(req.CredentialSecret)}},
+						{Op: pluginsdk.HeaderSet, Name: "X-Magic", Values: []string{derived}},
 					},
-					Redactions: []string{string(req.CredentialSecret)},
+					Redactions: []string{string(req.CredentialSecret), derived},
 				}, nil
 			},
 		}},

--- a/cmd/clawpatrol/extplugin_http_credential_test.go
+++ b/cmd/clawpatrol/extplugin_http_credential_test.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all" // register built-in plugins
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+type externalHTTPTestSecretStore map[string]string
+
+func (s externalHTTPTestSecretStore) Get(name string) (runtime.Secret, error) {
+	v, ok := s[name]
+	if !ok {
+		return runtime.Secret{}, fmt.Errorf("unexpected secret lookup %q", name)
+	}
+	return runtime.Secret{Bytes: []byte(v)}, nil
+}
+
+func TestExternalCredentialInjectsAuthorizationThroughBuiltInHTTPS(t *testing.T) {
+	typeName := fmt.Sprintf("ext_https_cred_%d", time.Now().UnixNano())
+	pluginPath := buildExternalHTTPTestPlugin(t, typeName)
+
+	mgr := extplugin.New(nil)
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() {
+		mgr.Stop()
+		config.SetPluginLoader(nil)
+	})
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+plugin "extcredtest" { source = %q }
+
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+endpoint "https" "api" {
+  hosts = ["api.example.test"]
+}
+credential %q "external" {
+  endpoint    = https.api
+  placeholder = "PH_external"
+}
+profile "default" { credentials = [%s.external] }
+rule "allow-api" {
+  endpoint = https.api
+  verdict  = "allow"
+}
+`, pluginPath, typeName, typeName)), "external-http-credential-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ep := policy.Endpoints["api"]
+	if ep == nil {
+		t.Fatalf("missing api endpoint")
+	}
+	if _, ok := policy.Credentials["external"].Body.(runtime.HTTPCredentialRuntime); !ok {
+		t.Fatalf("external credential body does not implement HTTPCredentialRuntime")
+	}
+
+	upstreamAuth := make(chan string, 1)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	upstreamAddr := upstream.Listener.Addr().String()
+	tr := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upstreamAddr)
+		},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: false,
+	}
+	defer tr.CloseIdleConnections()
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	defer close(sink.ch)
+	events, cancelEvents := sink.Subscribe()
+	defer cancelEvents()
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{certs: certs, sink: sink, secrets: externalHTTPTestSecretStore{"external": "real-external-token"}}
+	g.cfg.Store(gw)
+	g.policy.Store(policy)
+	g.transports.Store(ep, tr)
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.mitmHTTPS(serverConn, "api.example.test", ep)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: "api.example.test"})
+	defer func() { _ = clientTLS.Close() }()
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.test/v1/test", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer PH_external")
+	if err := req.Write(clientTLS); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(clientTLS), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	select {
+	case got := <-upstreamAuth:
+		if got != "Bearer real-external-token" {
+			t.Fatalf("upstream Authorization = %q, want real token", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for upstream request")
+	}
+
+	var end Event
+	select {
+	case end = <-endEvent(events):
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for terminal audit event")
+	}
+	if strings.Contains(fmt.Sprint(end.ReqHeaders), "real-external-token") {
+		t.Fatalf("request headers audit leaked injected external credential: %#v", end.ReqHeaders)
+	}
+	if got := end.ReqHeaders["X-Magic"]; got != credentialSampleRedaction {
+		t.Fatalf("X-Magic audit header = %q, want credential redaction marker", got)
+	}
+
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
+	}
+}
+
+func TestExternalCredentialPlaceholderDispatchThroughBuiltInHTTPS(t *testing.T) {
+	typeName := fmt.Sprintf("ext_https_cred_%d", time.Now().UnixNano())
+	pluginPath := buildExternalHTTPTestPlugin(t, typeName)
+
+	mgr := extplugin.New(nil)
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() {
+		mgr.Stop()
+		config.SetPluginLoader(nil)
+	})
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+plugin "extcredtest" { source = %q }
+
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+endpoint "https" "api" {
+  hosts = ["api.example.test"]
+}
+credential %q "one" {
+  endpoint    = https.api
+  placeholder = "PH_one"
+}
+credential %q "two" {
+  endpoint    = https.api
+  placeholder = "PH_two"
+}
+profile "default" { credentials = [%s.one, %s.two] }
+rule "allow-api" {
+  endpoint = https.api
+  verdict  = "allow"
+}
+`, pluginPath, typeName, typeName, typeName, typeName)), "external-http-placeholder-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ep := policy.Endpoints["api"]
+
+	upstreamAuth := make(chan string, 1)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	upstreamAddr := upstream.Listener.Addr().String()
+	tr := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upstreamAddr)
+		},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: false,
+	}
+	defer tr.CloseIdleConnections()
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	defer close(sink.ch)
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{certs: certs, sink: sink, secrets: externalHTTPTestSecretStore{
+		"one": "real-token-one",
+		"two": "real-token-two",
+	}}
+	g.cfg.Store(gw)
+	g.policy.Store(policy)
+	g.transports.Store(ep, tr)
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.mitmHTTPS(serverConn, "api.example.test", ep)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: "api.example.test"})
+	defer func() { _ = clientTLS.Close() }()
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.test/v1/test", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer PH_two")
+	if err := req.Write(clientTLS); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(clientTLS), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	select {
+	case got := <-upstreamAuth:
+		if got != "Bearer real-token-two" {
+			t.Fatalf("upstream Authorization = %q, want second credential token", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for upstream request")
+	}
+
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
+	}
+}
+
+func buildExternalHTTPTestPlugin(t *testing.T, typeName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	moduleRoot := moduleRootForTest(t)
+	goMod := fmt.Sprintf(`module extcredtest
+
+go 1.26.3
+
+require github.com/denoland/clawpatrol v0.0.0
+
+replace github.com/denoland/clawpatrol => %s
+`, moduleRoot)
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	rootSum, err := os.ReadFile(filepath.Join(moduleRoot, "go.sum"))
+	if err != nil {
+		t.Fatalf("read root go.sum: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), rootSum, 0644); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	mainGo := fmt.Sprintf(`package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name: "extcredtest",
+		Credentials: []pluginsdk.CredentialDef{{
+			TypeName: %q,
+			Disambiguators: []string{"placeholder"},
+			HTTPInject: true,
+			Build: func(req pluginsdk.BuildRequest) (any, error) {
+				return pluginsdk.CredentialBuildResult{
+					Canonical: map[string]string{"instance": req.InstanceName},
+					Metadata: pluginsdk.CredentialMetadata{
+						SecretSlots: []pluginsdk.SecretSlot{{Label: "External token"}},
+						EnvVars: []pluginsdk.EnvVar{{Name: "EXTERNAL_TOKEN", Value: "PH_external", Description: "placeholder"}},
+						HTTPInject: true,
+					},
+				}, nil
+			},
+			InjectHTTP: func(_ context.Context, req pluginsdk.HTTPInjectRequest) (*pluginsdk.HTTPInjectResponse, error) {
+				if len(req.CredentialSecret) == 0 {
+					return nil, fmt.Errorf("empty credential secret")
+				}
+				if len(req.CredentialCanonicalConfig) == 0 {
+					return nil, fmt.Errorf("empty canonical config")
+				}
+				if got := req.Headers.Get("Authorization"); !strings.HasPrefix(got, "Bearer PH_") {
+					return nil, fmt.Errorf("authorization = %%q", got)
+				}
+				return &pluginsdk.HTTPInjectResponse{
+					Headers: []pluginsdk.HeaderMutation{
+						{Op: pluginsdk.HeaderSet, Name: "Authorization", Values: []string{"Bearer " + string(req.CredentialSecret)}},
+						{Op: pluginsdk.HeaderSet, Name: "X-Magic", Values: []string{string(req.CredentialSecret)}},
+					},
+					Redactions: []string{string(req.CredentialSecret)},
+				}, nil
+			},
+		}},
+	})
+}
+`, typeName)
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainGo), 0644); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+	bin := filepath.Join(dir, "extcredtest")
+	cmd := exec.Command("go", "build", "-mod=mod", "-o", bin, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build external test plugin: %v\n%s", err, string(out))
+	}
+	return bin
+}
+
+func moduleRootForTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(wd, "go.mod")); err == nil {
+			return filepath.ToSlash(wd)
+		}
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			t.Fatalf("could not find module root")
+		}
+		wd = parent
+	}
+}

--- a/cmd/clawpatrol/integrations_test.go
+++ b/cmd/clawpatrol/integrations_test.go
@@ -114,8 +114,13 @@ func TestFetchEnvPushdownErrors(t *testing.T) {
 // flat list.
 func TestEnvPushdownVarsServerDriven(t *testing.T) {
 	prev := envPushdownGatewayFetcher
+	prevDaemon := envPushdownDaemonFetcher
 	envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
-	t.Cleanup(func() { envPushdownGatewayFetcher = prev })
+	envPushdownDaemonFetcher = nil
+	t.Cleanup(func() {
+		envPushdownGatewayFetcher = prev
+		envPushdownDaemonFetcher = prevDaemon
+	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -162,8 +167,13 @@ func TestEnvPushdownVarsErrorReturnsCAOnly(t *testing.T) {
 	// the host's running NE happens to have to say, instead of the
 	// gateway-URL-missing error this test exercises.
 	prev := envPushdownGatewayFetcher
+	prevDaemon := envPushdownDaemonFetcher
 	envPushdownGatewayFetcher = fetchEnvPushdownFromGateway
-	t.Cleanup(func() { envPushdownGatewayFetcher = prev })
+	envPushdownDaemonFetcher = nil
+	t.Cleanup(func() {
+		envPushdownGatewayFetcher = prev
+		envPushdownDaemonFetcher = prevDaemon
+	})
 
 	dir := t.TempDir()
 	caPath := filepath.Join(dir, "ca.crt")

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2417,8 +2417,11 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 						}
 					case wantsHTTP:
 						reqBodySecretRedactions = appendCredentialSecretRedactions(reqBodySecretRedactions, sec)
+						// Match existing request-signing behavior: an injection failure is logged,
+						// then the request continues with the agent's placeholder. The upstream
+						// service should reject that placeholder without exposing gateway secrets.
 						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
-							log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
+							log.Printf("inject %s: %v; forwarding without injection", cc.Credential.Symbol.Name, err)
 						}
 						if rp, ok := injector.(runtime.HTTPCredentialRedactionProvider); ok {
 							for _, secret := range rp.ConsumeHTTPRedactions(req) {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2420,6 +2420,11 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
 							log.Printf("inject %s: %v", cc.Credential.Symbol.Name, err)
 						}
+						if rp, ok := injector.(runtime.HTTPCredentialRedactionProvider); ok {
+							for _, secret := range rp.ConsumeHTTPRedactions(req) {
+								reqBodySecretRedactions = appendCredentialSecretRedaction(reqBodySecretRedactions, secret)
+							}
+						}
 					}
 					if wantsWS && isWSUpgrade(req) {
 						wsSec := sec
@@ -2598,7 +2603,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 			}
 		}
 		ev.Status = resp.StatusCode
-		ev.ReqHeaders = flatHeaders(req.Header)
+		ev.ReqHeaders = flatHeadersRedacted(req.Header, reqBodySecretRedactions)
 		ev.In = reqS.n
 		ev.Out = respS.n
 		ev.ReqSha = reqS.sha()

--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -798,23 +798,22 @@ func normalizeOAuthExchangeInput(input string) string {
 		return ""
 	}
 
-	// Operators often paste the callback URL after providers redirect to a
-	// loopback URI (for example localhost:8900/callback?code=...&state=...).
-	// Also accept raw query strings, regardless of parameter order.
-	rawQuery := strings.TrimPrefix(s, "?")
-	if strings.Contains(rawQuery, "=") && !strings.Contains(rawQuery, "://") && !strings.Contains(rawQuery, "/") {
-		if vals, err := url.ParseQuery(rawQuery); err == nil {
+	// Operators often paste the whole callback URL after providers
+	// redirect to a loopback URI (for example
+	// localhost:8900/callback?code=...&state=...) or just its raw query
+	// string, with parameters in any order. Try the query-shaped
+	// interpretations first, then fall back to a bare code.
+	if !strings.Contains(s, "?") {
+		if vals, err := url.ParseQuery(strings.TrimPrefix(s, "?")); err == nil {
 			if code := strings.TrimSpace(vals.Get("code")); code != "" {
 				return code
 			}
 		}
-	}
-
-	// Treat anything carrying a code query parameter as URL/query-shaped even
-	// when the browser omitted the scheme in the copied text.
-	if strings.Contains(s, "?code=") || strings.Contains(s, "&code=") {
+	} else {
 		candidate := s
 		if !strings.Contains(candidate, "://") && !strings.HasPrefix(candidate, "/") {
+			// Browsers omit the scheme when the URL is copied from the
+			// address bar; url.Parse needs one to find the query.
 			candidate = "http://" + candidate
 		}
 		if u, err := url.Parse(candidate); err == nil {
@@ -823,13 +822,10 @@ func normalizeOAuthExchangeInput(input string) string {
 			}
 		}
 	}
-	if strings.HasPrefix(s, "code=") || strings.HasPrefix(s, "?code=") {
-		if vals, err := url.ParseQuery(strings.TrimPrefix(s, "?")); err == nil {
-			if code := strings.TrimSpace(vals.Get("code")); code != "" {
-				return code
-			}
-		}
-	}
+
+	// Otherwise treat the input as a bare code. Codes never contain
+	// fragment/query metacharacters, so anything after one is junk the
+	// browser appended (e.g. "#" anchors) and gets truncated.
 	if i := strings.IndexAny(s, "#&?"); i > 0 {
 		s = s[:i]
 	}
@@ -1224,28 +1220,28 @@ type dynamicMCPRefreshSource struct {
 	current *oauth2.Token
 }
 
-func (n *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if n.current.Valid() {
-		return n.current, nil
+func (d *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.current.Valid() {
+		return d.current, nil
 	}
-	if n.current.RefreshToken == "" {
+	if d.current.RefreshToken == "" {
 		return nil, fmt.Errorf("dynamic_mcp refresh: no refresh_token")
 	}
-	if n.cfg.ClientID == "" {
+	if d.cfg.ClientID == "" {
 		return nil, fmt.Errorf("dynamic_mcp refresh: no client_id (dynamic registration was never persisted)")
 	}
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", n.current.RefreshToken)
-	form.Set("client_id", n.cfg.ClientID)
+	form.Set("refresh_token", d.current.RefreshToken)
+	form.Set("client_id", d.cfg.ClientID)
 	// See anthropicRefreshSource.Token: oauth2 has no ctx on Token(),
-	// so we bound the upstream round-trip here so n.mu stays available
+	// so we bound the upstream round-trip here so d.mu stays available
 	// even if the MCP token endpoint hangs.
 	ctx, cancel := context.WithTimeout(context.Background(), oauthUpstreamTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", d.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("dynamic_mcp refresh: build request: %w", err)
 	}
@@ -1275,12 +1271,12 @@ func (n *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
 		TokenType:    tr.TokenType,
 	}
 	if t.RefreshToken == "" {
-		t.RefreshToken = n.current.RefreshToken
+		t.RefreshToken = d.current.RefreshToken
 	}
 	if tr.ExpiresIn > 0 {
 		t.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
 	}
-	n.current = t
+	d.current = t
 	return t, nil
 }
 

--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -56,11 +56,12 @@ type oauthState struct {
 	displayName string // human-readable name (e.g. github login)
 	avatarURL   string // dashboard pfp
 	// clientID is the dynamically-registered OAuth client_id for flows
-	// that use RFC 7591 (notion_mcp). Static-ClientID flows (github,
-	// anthropic, codex) leave this empty and use cfg.ClientID. Persisted
-	// in the credentials table alongside the tokens so refresh works
-	// across gateway restarts.
+	// that use RFC 7591 (notion_mcp/dynamic_mcp). Static-ClientID flows
+	// (github, anthropic, codex) leave this empty and use cfg.ClientID.
+	// Persisted in the credentials table alongside the tokens so refresh
+	// works across gateway restarts.
 	clientID string
+	flow     string
 	db       *sql.DB
 	mu       sync.Mutex
 }
@@ -218,7 +219,7 @@ func (r *OAuthRegistry) Set(ctx context.Context, id string, tok *oauth2.Token) e
 
 // SetWithClient is Set + a dynamically registered client_id. Pass empty
 // clientID for static-ClientID flows; pass the per-credential client_id
-// for RFC 7591 dynamic registration flows (notion_mcp). The clientID is
+// for RFC 7591 dynamic registration flows (notion_mcp/dynamic_mcp). The clientID is
 // stamped onto the in-memory state and persisted alongside the tokens so
 // refresh continues to work after restart.
 //
@@ -335,6 +336,7 @@ func newState(it *OAuthIntegration, db *sql.DB) *oauthState {
 		header: header,
 		prefix: prefix,
 		id:     it.ID,
+		flow:   it.Flow,
 		db:     db,
 	}
 }
@@ -347,11 +349,13 @@ func (s *oauthState) setToken(tok *oauth2.Token) {
 		// (returns "Invalid request format" otherwise). Stdlib oauth2
 		// only sends form-urlencoded.
 		base = &anthropicRefreshSource{cfg: s.cfg, current: tok}
-	case isNotionMCPTokenURL(s.cfg.Endpoint.TokenURL):
-		// Notion's MCP token endpoint refreshes via form-urlencoded body
-		// and expects the dynamically registered client_id (no static
-		// ClientSecret — PKCE-only public client).
-		base = &notionMCPRefreshSource{cfg: s.cfg, current: tok}
+	case s.flow == "dynamic_mcp" || s.flow == "notion_mcp":
+		// Hosted MCP token endpoints refresh via form-urlencoded body and
+		// expect the dynamically registered client_id (no static
+		// ClientSecret — PKCE-only public client). The flow, not the
+		// provider hostname, selects this behavior so external credential
+		// plugins can supply their own MCP OAuth endpoints.
+		base = &dynamicMCPRefreshSource{cfg: s.cfg, current: tok}
 	default:
 		base = s.cfg.TokenSource(context.Background(), tok)
 	}
@@ -535,7 +539,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 		}
 		s := newState(it, r.db)
 		// Restore the dynamically-registered client_id BEFORE setToken
-		// so the refresh source (notion_mcp) picks it up via s.cfg.
+		// so the refresh source (notion_mcp/dynamic_mcp) picks it up via s.cfg.
 		if clientID.Valid && clientID.String != "" {
 			s.clientID = clientID.String
 			s.cfg.ClientID = clientID.String
@@ -566,7 +570,7 @@ type oauthSession struct {
 	id       string
 	created  time.Time
 	// dynClientID is the RFC 7591 client_id this session registered at
-	// start time (notion_mcp). Empty for static-ClientID flows. Stamped
+	// start time (notion_mcp/dynamic_mcp). Empty for static-ClientID flows. Stamped
 	// onto the credential row at exchange time so refresh can replay it.
 	dynClientID string
 }
@@ -646,8 +650,8 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 		w.startOpenAIDeviceFlow(rw, r, id, flow)
 		return
 	}
-	if flow.Flow == "notion_mcp" {
-		w.startNotionMCPFlow(rw, r, id, flow)
+	if flow.Flow == "notion_mcp" || flow.Flow == "dynamic_mcp" {
+		w.startDynamicMCPFlow(rw, r, id, flow)
 		return
 	}
 
@@ -677,14 +681,18 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state})
 }
 
-// startNotionMCPFlow drives the mcp.notion.com auth-code flow with RFC
-// 7591 dynamic client registration. Notion accepts arbitrary redirect
-// URIs at registration, so we register the dashboard's own
-// /oauth/callback page — the page auto-exchanges via /api/oauth/exchange
-// when it loads, with copy-paste from the URL bar as a fallback.
-func (w *webMux) startNotionMCPFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
-	redirectURI := w.dashboardRedirectURI(r, "/oauth/callback")
-	clientID, err := registerOAuthClient(r.Context(), flow.OAuth.RegisterURL, redirectURI)
+// startDynamicMCPFlow drives auth-code OAuth flows with RFC 7591
+// dynamic client registration. Plugins may pin a provider-accepted
+// redirect URI (Amplitude uses a localhost loopback URI); otherwise we
+// register the dashboard's own /oauth/callback page, which
+// auto-exchanges via /api/oauth/exchange when it loads, with copy-paste
+// from the URL bar as a fallback.
+func (w *webMux) startDynamicMCPFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
+	redirectURI := strings.TrimSpace(flow.OAuth.RedirectURI)
+	if redirectURI == "" {
+		redirectURI = w.dashboardRedirectURI(r, "/oauth/callback")
+	}
+	clientID, err := registerOAuthClient(r.Context(), flow.OAuth.RegisterURL, redirectURI, flow.OAuth.Scopes)
 	if err != nil {
 		http.Error(rw, "dynamic client registration: "+err.Error(), http.StatusBadGateway)
 		return
@@ -740,14 +748,18 @@ func (w *webMux) dashboardRedirectURI(r *http.Request, path string) string {
 // registerOAuthClient performs RFC 7591 dynamic client registration
 // against `registerURL`, asking for a public PKCE client bound to the
 // given redirect URI. Returns the issued client_id.
-func registerOAuthClient(ctx context.Context, registerURL, redirectURI string) (string, error) {
-	body, _ := json.Marshal(map[string]any{
+func registerOAuthClient(ctx context.Context, registerURL, redirectURI string, scopes []string) (string, error) {
+	bodyMap := map[string]any{
 		"client_name":                "clawpatrol",
 		"redirect_uris":              []string{redirectURI},
 		"grant_types":                []string{"authorization_code", "refresh_token"},
 		"response_types":             []string{"code"},
 		"token_endpoint_auth_method": "none",
-	})
+	}
+	if len(scopes) > 0 {
+		bodyMap["scope"] = strings.Join(scopes, " ")
+	}
+	body, _ := json.Marshal(bodyMap)
 	req, err := http.NewRequestWithContext(ctx, "POST", registerURL, bytes.NewReader(body))
 	if err != nil {
 		return "", err
@@ -1155,32 +1167,28 @@ func isAnthropicTokenURL(u string) bool {
 	return strings.Contains(u, "anthropic.com/")
 }
 
-func isNotionMCPTokenURL(u string) bool {
-	return strings.Contains(u, "mcp.notion.com/")
-}
-
-// notionMCPRefreshSource refreshes Notion MCP OAuth tokens via the
+// dynamicMCPRefreshSource refreshes hosted MCP OAuth tokens via the
 // form-urlencoded body the spec mandates. The client_id is read from
 // cfg.ClientID, which the registry restores from the persisted
 // credentials.client_id column on boot. Stateful: holds the current
 // token (with refresh_token) and rotates it on each refresh.
-type notionMCPRefreshSource struct {
+type dynamicMCPRefreshSource struct {
 	mu      sync.Mutex
 	cfg     *oauth2.Config
 	current *oauth2.Token
 }
 
-func (n *notionMCPRefreshSource) Token() (*oauth2.Token, error) {
+func (n *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.current.Valid() {
 		return n.current, nil
 	}
 	if n.current.RefreshToken == "" {
-		return nil, fmt.Errorf("notion_mcp refresh: no refresh_token")
+		return nil, fmt.Errorf("dynamic_mcp refresh: no refresh_token")
 	}
 	if n.cfg.ClientID == "" {
-		return nil, fmt.Errorf("notion_mcp refresh: no client_id (dynamic registration was never persisted)")
+		return nil, fmt.Errorf("dynamic_mcp refresh: no client_id (dynamic registration was never persisted)")
 	}
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
@@ -1193,18 +1201,18 @@ func (n *notionMCPRefreshSource) Token() (*oauth2.Token, error) {
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("notion_mcp refresh: build request: %w", err)
+		return nil, fmt.Errorf("dynamic_mcp refresh: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("notion_mcp refresh: %w", err)
+		return nil, fmt.Errorf("dynamic_mcp refresh: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, oauthResponseLimit))
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("notion_mcp refresh %d: %s", resp.StatusCode, string(respBytes))
+		return nil, fmt.Errorf("dynamic_mcp refresh %d: %s", resp.StatusCode, string(respBytes))
 	}
 	var tr struct {
 		AccessToken  string `json:"access_token"`
@@ -1319,7 +1327,7 @@ func (w *webMux) apiOAuthRevoke(rw http.ResponseWriter, r *http.Request) {
 
 // oauthCallbackHTML is served at GET /oauth/callback for
 // dynamic-registration flows that redirect back to the dashboard
-// (notion_mcp). The inline JS extracts ?code & ?state, POSTs them to
+// (notion_mcp/dynamic_mcp). The inline JS extracts ?code & ?state, POSTs them to
 // /api/oauth/exchange so the original ConnectModal sees the credential
 // connect itself, and shows the code prominently as a copy-paste
 // fallback if the auto-exchange fails (e.g. dashboard secret expired,

--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -219,8 +219,8 @@ func (r *OAuthRegistry) Set(ctx context.Context, id string, tok *oauth2.Token) e
 
 // SetWithClient is Set + a dynamically registered client_id. Pass empty
 // clientID for static-ClientID flows; pass the per-credential client_id
-// for RFC 7591 dynamic registration flows (notion_mcp/dynamic_mcp). The clientID is
-// stamped onto the in-memory state and persisted alongside the tokens so
+// for RFC 7591 dynamic registration flows (notion_mcp/dynamic_mcp). The
+// clientID is stamped onto the in-memory state and persisted alongside the tokens so
 // refresh continues to work after restart.
 //
 // The userinfo fetch (fetchOAuthProfile) runs OUTSIDE the registry lock
@@ -539,7 +539,7 @@ func (r *OAuthRegistry) loadFromDB() error {
 		}
 		s := newState(it, r.db)
 		// Restore the dynamically-registered client_id BEFORE setToken
-		// so the refresh source (notion_mcp/dynamic_mcp) picks it up via s.cfg.
+		// so dynamic MCP refresh sources pick it up via s.cfg.
 		if clientID.Valid && clientID.String != "" {
 			s.clientID = clientID.String
 			s.cfg.ClientID = clientID.String
@@ -570,8 +570,9 @@ type oauthSession struct {
 	id       string
 	created  time.Time
 	// dynClientID is the RFC 7591 client_id this session registered at
-	// start time (notion_mcp/dynamic_mcp). Empty for static-ClientID flows. Stamped
-	// onto the credential row at exchange time so refresh can replay it.
+	// start time (dynamic MCP flows). Empty for static-ClientID flows.
+	// Stamped onto the credential row at exchange time so refresh can
+	// replay it.
 	dynClientID string
 }
 
@@ -787,6 +788,40 @@ func registerOAuthClient(ctx context.Context, registerURL, redirectURI string, s
 	return rr.ClientID, nil
 }
 
+func normalizeOAuthExchangeInput(input string) string {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return ""
+	}
+
+	// Operators often paste the callback URL after providers redirect to a
+	// loopback URI (for example localhost:8900/callback?code=...&state=...).
+	// Treat anything carrying a code query parameter as URL/query-shaped even
+	// when the browser omitted the scheme in the copied text.
+	if strings.Contains(s, "?code=") || strings.Contains(s, "&code=") {
+		candidate := s
+		if !strings.Contains(candidate, "://") && !strings.HasPrefix(candidate, "/") {
+			candidate = "http://" + candidate
+		}
+		if u, err := url.Parse(candidate); err == nil {
+			if code := strings.TrimSpace(u.Query().Get("code")); code != "" {
+				return code
+			}
+		}
+	}
+	if strings.HasPrefix(s, "code=") || strings.HasPrefix(s, "?code=") {
+		if vals, err := url.ParseQuery(strings.TrimPrefix(s, "?")); err == nil {
+			if code := strings.TrimSpace(vals.Get("code")); code != "" {
+				return code
+			}
+		}
+	}
+	if i := strings.IndexAny(s, "#&?"); i > 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
 func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(rw, "POST", http.StatusMethodNotAllowed)
@@ -800,13 +835,10 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, err.Error(), 400)
 		return
 	}
-	body.Code = strings.TrimSpace(body.Code)
+	body.Code = normalizeOAuthExchangeInput(body.Code)
 	if body.Code == "" || body.State == "" {
 		http.Error(rw, "missing code/state", 400)
 		return
-	}
-	if i := strings.IndexAny(body.Code, "#&?"); i > 0 {
-		body.Code = body.Code[:i]
 	}
 
 	w.mu.Lock()
@@ -1196,7 +1228,7 @@ func (n *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
 	form.Set("client_id", n.cfg.ClientID)
 	// See anthropicRefreshSource.Token: oauth2 has no ctx on Token(),
 	// so we bound the upstream round-trip here so n.mu stays available
-	// even if Notion's token endpoint hangs.
+	// even if the MCP token endpoint hangs.
 	ctx, cancel := context.WithTimeout(context.Background(), oauthUpstreamTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))

--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -793,23 +793,25 @@ func registerOAuthClient(ctx context.Context, registerURL, redirectURI string, s
 }
 
 func normalizeOAuthExchangeInput(input string) string {
+	code, _ := parseOAuthExchangeInput(input)
+	return code
+}
+
+func parseOAuthExchangeInput(input string) (code, oauthErr string) {
 	s := strings.TrimSpace(input)
 	if s == "" {
-		return ""
+		return "", ""
 	}
 
 	// Operators often paste the whole callback URL after providers
 	// redirect to a loopback URI (for example
 	// localhost:8900/callback?code=...&state=...) or just its raw query
-	// string, with parameters in any order. Try the query-shaped
-	// interpretations first, then fall back to a bare code.
-	if !strings.Contains(s, "?") {
-		if vals, err := url.ParseQuery(strings.TrimPrefix(s, "?")); err == nil {
-			if code := strings.TrimSpace(vals.Get("code")); code != "" {
-				return code
-			}
-		}
-	} else {
+	// string, with parameters in any order. Try query-shaped inputs
+	// first, then fall back to a bare opaque code.
+	if code, oauthErr, ok := parseOAuthRawQuery(s); ok {
+		return code, oauthErr
+	}
+	if strings.Contains(s, "?") {
 		candidate := s
 		if !strings.Contains(candidate, "://") && !strings.HasPrefix(candidate, "/") {
 			// Browsers omit the scheme when the URL is copied from the
@@ -817,19 +819,41 @@ func normalizeOAuthExchangeInput(input string) string {
 			candidate = "http://" + candidate
 		}
 		if u, err := url.Parse(candidate); err == nil {
-			if code := strings.TrimSpace(u.Query().Get("code")); code != "" {
-				return code
+			if code, oauthErr := oauthCodeOrError(u.Query()); code != "" || oauthErr != "" {
+				return code, oauthErr
 			}
 		}
 	}
 
-	// Otherwise treat the input as a bare code. Codes never contain
-	// fragment/query metacharacters, so anything after one is junk the
-	// browser appended (e.g. "#" anchors) and gets truncated.
-	if i := strings.IndexAny(s, "#&?"); i > 0 {
+	// Otherwise treat the input as a bare code. Preserve '&' and '=' because
+	// opaque provider codes may contain them; only strip fragment/query suffixes.
+	if i := strings.IndexAny(s, "#?"); i > 0 {
 		s = s[:i]
 	}
-	return strings.TrimSpace(s)
+	return strings.TrimSpace(s), ""
+}
+
+func parseOAuthRawQuery(input string) (code, oauthErr string, ok bool) {
+	raw := strings.TrimPrefix(input, "?")
+	vals, err := url.ParseQuery(raw)
+	if err != nil {
+		return "", "", false
+	}
+	code, oauthErr = oauthCodeOrError(vals)
+	return code, oauthErr, code != "" || oauthErr != ""
+}
+
+func oauthCodeOrError(vals url.Values) (code, oauthErr string) {
+	if code := strings.TrimSpace(vals.Get("code")); code != "" {
+		return code, ""
+	}
+	if errCode := strings.TrimSpace(vals.Get("error")); errCode != "" {
+		if desc := strings.TrimSpace(vals.Get("error_description")); desc != "" {
+			return "", fmt.Sprintf("%s: %s", errCode, desc)
+		}
+		return "", errCode
+	}
+	return "", ""
 }
 
 func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
@@ -845,7 +869,12 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, err.Error(), 400)
 		return
 	}
-	body.Code = normalizeOAuthExchangeInput(body.Code)
+	var oauthErr string
+	body.Code, oauthErr = parseOAuthExchangeInput(body.Code)
+	if oauthErr != "" {
+		http.Error(rw, "oauth error: "+oauthErr, 400)
+		return
+	}
 	if body.Code == "" || body.State == "" {
 		http.Error(rw, "missing code/state", 400)
 		return

--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -706,7 +706,11 @@ func (w *webMux) startDynamicMCPFlow(rw http.ResponseWriter, r *http.Request, id
 		ClientID:    clientID,
 		Scopes:      flow.OAuth.Scopes,
 		RedirectURL: redirectURI,
-		Endpoint:    oauth2.Endpoint{AuthURL: flow.OAuth.AuthURL, TokenURL: flow.OAuth.TokenURL},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   flow.OAuth.AuthURL,
+			TokenURL:  flow.OAuth.TokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
 	}
 	authURL := cfg.AuthCodeURL(state,
 		oauth2.SetAuthURLParam("code_challenge", challenge),
@@ -796,6 +800,16 @@ func normalizeOAuthExchangeInput(input string) string {
 
 	// Operators often paste the callback URL after providers redirect to a
 	// loopback URI (for example localhost:8900/callback?code=...&state=...).
+	// Also accept raw query strings, regardless of parameter order.
+	rawQuery := strings.TrimPrefix(s, "?")
+	if strings.Contains(rawQuery, "=") && !strings.Contains(rawQuery, "://") && !strings.Contains(rawQuery, "/") {
+		if vals, err := url.ParseQuery(rawQuery); err == nil {
+			if code := strings.TrimSpace(vals.Get("code")); code != "" {
+				return code
+			}
+		}
+	}
+
 	// Treat anything carrying a code query parameter as URL/query-shaped even
 	// when the browser omitted the scheme in the copied text.
 	if strings.Contains(s, "?code=") || strings.Contains(s, "&code=") {

--- a/cmd/clawpatrol/oauth_dynamic_mcp_test.go
+++ b/cmd/clawpatrol/oauth_dynamic_mcp_test.go
@@ -30,6 +30,8 @@ func TestNormalizeOAuthExchangeInput(t *testing.T) {
 		{name: "absolute path callback", in: "/callback?code=path-code&state=s", want: "path-code"},
 		{name: "raw query", in: "code=query-code&state=s", want: "query-code"},
 		{name: "raw query with state first", in: "state=s&code=query-code", want: "query-code"},
+		{name: "raw query with leading question mark", in: "?code=query-code&state=s", want: "query-code"},
+		{name: "raw query with slash in code", in: "code=ab/cd&state=s", want: "ab/cd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/clawpatrol/oauth_dynamic_mcp_test.go
+++ b/cmd/clawpatrol/oauth_dynamic_mcp_test.go
@@ -25,6 +25,7 @@ func TestNormalizeOAuthExchangeInput(t *testing.T) {
 	}{
 		{name: "raw code", in: "abc123", want: "abc123"},
 		{name: "raw code with suffix", in: "abc123?ignored=1", want: "abc123"},
+		{name: "raw opaque code with ampersand and equals", in: "abc=def&ghi=jkl", want: "abc=def&ghi=jkl"},
 		{name: "https callback url", in: "https://gateway.example/oauth/callback?code=url-code&state=s", want: "url-code"},
 		{name: "localhost callback without scheme", in: "localhost:8900/callback?code=loopback-code&state=s", want: "loopback-code"},
 		{name: "absolute path callback", in: "/callback?code=path-code&state=s", want: "path-code"},
@@ -39,6 +40,16 @@ func TestNormalizeOAuthExchangeInput(t *testing.T) {
 				t.Fatalf("normalizeOAuthExchangeInput(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseOAuthExchangeInputReportsCallbackError(t *testing.T) {
+	code, oauthErr := parseOAuthExchangeInput("?error=access_denied&error_description=user+cancelled")
+	if code != "" {
+		t.Fatalf("code = %q, want empty", code)
+	}
+	if oauthErr != "access_denied: user cancelled" {
+		t.Fatalf("oauthErr = %q, want callback error", oauthErr)
 	}
 }
 

--- a/cmd/clawpatrol/oauth_dynamic_mcp_test.go
+++ b/cmd/clawpatrol/oauth_dynamic_mcp_test.go
@@ -29,6 +29,7 @@ func TestNormalizeOAuthExchangeInput(t *testing.T) {
 		{name: "localhost callback without scheme", in: "localhost:8900/callback?code=loopback-code&state=s", want: "loopback-code"},
 		{name: "absolute path callback", in: "/callback?code=path-code&state=s", want: "path-code"},
 		{name: "raw query", in: "code=query-code&state=s", want: "query-code"},
+		{name: "raw query with state first", in: "state=s&code=query-code", want: "query-code"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -136,6 +137,58 @@ func TestDynamicMCPRefreshSourceSendsClientID(t *testing.T) {
 	}
 }
 
+func TestDynamicMCPCodeExchangeSendsClientIDInParams(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			failOAuthTestHandler(t, w, "Authorization = %q, want no client-auth header", got)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			failOAuthTestHandler(t, w, "parse form: %v", err)
+			return
+		}
+		if got := r.Form.Get("grant_type"); got != "authorization_code" {
+			failOAuthTestHandler(t, w, "grant_type = %q, want authorization_code", got)
+			return
+		}
+		if got := r.Form.Get("client_id"); got != "dyn-client" {
+			failOAuthTestHandler(t, w, "client_id = %q, want dyn-client", got)
+			return
+		}
+		if got := r.Form.Get("code"); got != "auth-code" {
+			failOAuthTestHandler(t, w, "code = %q, want auth-code", got)
+			return
+		}
+		if got := r.Form.Get("code_verifier"); got != "verifier" {
+			failOAuthTestHandler(t, w, "code_verifier = %q, want verifier", got)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	sess := &oauthSession{
+		verifier: "verifier",
+		state:    "state",
+		cfg: &oauth2.Config{
+			ClientID:    "dyn-client",
+			RedirectURL: "http://localhost:8900/callback",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  ts.URL,
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+		},
+	}
+	tok, err := exchangeOAuthCode(t.Context(), sess, "auth-code", "state")
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if tok.AccessToken != "access" || tok.RefreshToken != "refresh" {
+		t.Fatalf("token = %#v", tok)
+	}
+}
+
 func TestStartDynamicMCPFlowUsesConfiguredRedirectURI(t *testing.T) {
 	registerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var got struct {
@@ -186,6 +239,15 @@ func TestStartDynamicMCPFlowUsesConfiguredRedirectURI(t *testing.T) {
 	}
 	if got := authURL.Query().Get("redirect_uri"); got != "http://localhost:8900/callback" {
 		t.Fatalf("auth_url redirect_uri = %q, want localhost callback", got)
+	}
+	w.mu.Lock()
+	sess := w.sessions[body.State]
+	w.mu.Unlock()
+	if sess == nil {
+		t.Fatalf("missing session for state %q", body.State)
+	}
+	if got := sess.cfg.Endpoint.AuthStyle; got != oauth2.AuthStyleInParams {
+		t.Fatalf("token endpoint AuthStyle = %v, want AuthStyleInParams", got)
 	}
 }
 

--- a/cmd/clawpatrol/oauth_dynamic_mcp_test.go
+++ b/cmd/clawpatrol/oauth_dynamic_mcp_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestDynamicMCPRefreshSelectedByFlowForAnyTokenURL(t *testing.T) {
+	var sawRefresh bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRefresh = true
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want no client-auth header", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if got := r.Form.Get("client_id"); got != "external-dynamic-client" {
+			t.Fatalf("client_id = %q, want external-dynamic-client", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	state := newState(&OAuthIntegration{
+		ID:   "external-mcp",
+		Flow: "dynamic_mcp",
+		OAuth: OAuthConfig{
+			ClientID: "external-dynamic-client",
+			TokenURL: ts.URL,
+		},
+	}, nil)
+	state.setToken(&oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Hour),
+	})
+
+	tok, err := state.source.Token()
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if !sawRefresh {
+		t.Fatalf("token server was not called")
+	}
+	if tok.AccessToken != "new-access" || tok.RefreshToken != "new-refresh" {
+		t.Fatalf("token = %#v, want refreshed access/refresh", tok)
+	}
+}
+
+func TestDynamicMCPRefreshSourceSendsClientID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Fatalf("grant_type = %q, want refresh_token", got)
+		}
+		if got := r.Form.Get("client_id"); got != "dyn-client" {
+			t.Fatalf("client_id = %q, want dyn-client", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != "old-refresh" {
+			t.Fatalf("refresh_token = %q, want old-refresh", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	src := &dynamicMCPRefreshSource{
+		cfg: &oauth2.Config{
+			ClientID: "dyn-client",
+			Endpoint: oauth2.Endpoint{TokenURL: ts.URL},
+		},
+		current: &oauth2.Token{
+			AccessToken:  "old-access",
+			RefreshToken: "old-refresh",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(-time.Hour),
+		},
+	}
+
+	tok, err := src.Token()
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if tok.AccessToken != "new-access" || tok.RefreshToken != "new-refresh" {
+		t.Fatalf("token = %#v, want refreshed access/refresh", tok)
+	}
+}
+
+func TestStartDynamicMCPFlowUsesConfiguredRedirectURI(t *testing.T) {
+	registerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got struct {
+			RedirectURIs []string `json:"redirect_uris"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode register body: %v", err)
+		}
+		if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "http://localhost:8900/callback" {
+			t.Fatalf("redirect_uris = %#v, want localhost callback", got.RedirectURIs)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"client-loopback"}`))
+	}))
+	defer registerServer.Close()
+
+	w := &webMux{sessions: map[string]*oauthSession{}}
+	req := httptest.NewRequest(http.MethodPost, "http://100.66.146.96:8080/api/oauth/start", nil)
+	rr := httptest.NewRecorder()
+	w.startDynamicMCPFlow(rr, req, "amplitude", &OAuthIntegration{
+		OAuth: OAuthConfig{
+			AuthURL:     "https://mcp.eu.amplitude.com/authorize",
+			TokenURL:    "https://mcp.eu.amplitude.com/token",
+			RegisterURL: registerServer.URL,
+			RedirectURI: "http://localhost:8900/callback",
+			Scopes:      []string{"mcp:read", "offline_access"},
+		},
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		AuthURL string `json:"auth_url"`
+		State   string `json:"state"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.State == "" {
+		t.Fatalf("state is empty")
+	}
+	authURL, err := url.Parse(body.AuthURL)
+	if err != nil {
+		t.Fatalf("parse auth_url: %v", err)
+	}
+	if got := authURL.Query().Get("redirect_uri"); got != "http://localhost:8900/callback" {
+		t.Fatalf("auth_url redirect_uri = %q, want localhost callback", got)
+	}
+}
+
+func TestRegisterOAuthClientIncludesScopes(t *testing.T) {
+	var got map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"client-123"}`))
+	}))
+	defer ts.Close()
+
+	clientID, err := registerOAuthClient(t.Context(), ts.URL, "https://gateway.example/oauth/callback", []string{"mcp:read", "offline_access"})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if clientID != "client-123" {
+		t.Fatalf("clientID = %q, want client-123", clientID)
+	}
+	if got["scope"] != "mcp:read offline_access" {
+		t.Fatalf("scope = %#v, want joined scopes", got["scope"])
+	}
+	if got["token_endpoint_auth_method"] != "none" {
+		t.Fatalf("token_endpoint_auth_method = %#v, want none", got["token_endpoint_auth_method"])
+	}
+}

--- a/cmd/clawpatrol/oauth_dynamic_mcp_test.go
+++ b/cmd/clawpatrol/oauth_dynamic_mcp_test.go
@@ -11,18 +11,49 @@ import (
 	"golang.org/x/oauth2"
 )
 
+func failOAuthTestHandler(t *testing.T, w http.ResponseWriter, format string, args ...any) {
+	t.Helper()
+	t.Errorf(format, args...)
+	http.Error(w, "test handler assertion failed", http.StatusInternalServerError)
+}
+
+func TestNormalizeOAuthExchangeInput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "raw code", in: "abc123", want: "abc123"},
+		{name: "raw code with suffix", in: "abc123?ignored=1", want: "abc123"},
+		{name: "https callback url", in: "https://gateway.example/oauth/callback?code=url-code&state=s", want: "url-code"},
+		{name: "localhost callback without scheme", in: "localhost:8900/callback?code=loopback-code&state=s", want: "loopback-code"},
+		{name: "absolute path callback", in: "/callback?code=path-code&state=s", want: "path-code"},
+		{name: "raw query", in: "code=query-code&state=s", want: "query-code"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeOAuthExchangeInput(tt.in); got != tt.want {
+				t.Fatalf("normalizeOAuthExchangeInput(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDynamicMCPRefreshSelectedByFlowForAnyTokenURL(t *testing.T) {
 	var sawRefresh bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawRefresh = true
 		if got := r.Header.Get("Authorization"); got != "" {
-			t.Fatalf("Authorization = %q, want no client-auth header", got)
+			failOAuthTestHandler(t, w, "Authorization = %q, want no client-auth header", got)
+			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("parse form: %v", err)
+			failOAuthTestHandler(t, w, "parse form: %v", err)
+			return
 		}
 		if got := r.Form.Get("client_id"); got != "external-dynamic-client" {
-			t.Fatalf("client_id = %q, want external-dynamic-client", got)
+			failOAuthTestHandler(t, w, "client_id = %q, want external-dynamic-client", got)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
@@ -59,19 +90,24 @@ func TestDynamicMCPRefreshSelectedByFlowForAnyTokenURL(t *testing.T) {
 func TestDynamicMCPRefreshSourceSendsClientID(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
+			failOAuthTestHandler(t, w, "method = %s, want POST", r.Method)
+			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("parse form: %v", err)
+			failOAuthTestHandler(t, w, "parse form: %v", err)
+			return
 		}
 		if got := r.Form.Get("grant_type"); got != "refresh_token" {
-			t.Fatalf("grant_type = %q, want refresh_token", got)
+			failOAuthTestHandler(t, w, "grant_type = %q, want refresh_token", got)
+			return
 		}
 		if got := r.Form.Get("client_id"); got != "dyn-client" {
-			t.Fatalf("client_id = %q, want dyn-client", got)
+			failOAuthTestHandler(t, w, "client_id = %q, want dyn-client", got)
+			return
 		}
 		if got := r.Form.Get("refresh_token"); got != "old-refresh" {
-			t.Fatalf("refresh_token = %q, want old-refresh", got)
+			failOAuthTestHandler(t, w, "refresh_token = %q, want old-refresh", got)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
@@ -106,10 +142,12 @@ func TestStartDynamicMCPFlowUsesConfiguredRedirectURI(t *testing.T) {
 			RedirectURIs []string `json:"redirect_uris"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode register body: %v", err)
+			failOAuthTestHandler(t, w, "decode register body: %v", err)
+			return
 		}
 		if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "http://localhost:8900/callback" {
-			t.Fatalf("redirect_uris = %#v, want localhost callback", got.RedirectURIs)
+			failOAuthTestHandler(t, w, "redirect_uris = %#v, want localhost callback", got.RedirectURIs)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"client_id":"client-loopback"}`))
@@ -155,10 +193,12 @@ func TestRegisterOAuthClientIncludesScopes(t *testing.T) {
 	var got map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
+			failOAuthTestHandler(t, w, "method = %s, want POST", r.Method)
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode body: %v", err)
+			failOAuthTestHandler(t, w, "decode body: %v", err)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"client_id":"client-123"}`))

--- a/cmd/clawpatrol/sample_redact.go
+++ b/cmd/clawpatrol/sample_redact.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/denoland/clawpatrol/internal/config/runtime"
@@ -29,6 +30,8 @@ func appendCredentialSecretRedaction(dst []string, secret string) []string {
 }
 
 func redactCredentialSample(sample string, secrets []string) string {
+	secrets = append([]string(nil), secrets...)
+	sort.SliceStable(secrets, func(i, j int) bool { return len(secrets[i]) > len(secrets[j]) })
 	for _, secret := range secrets {
 		if secret == "" {
 			continue

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -2775,12 +2775,16 @@ var sensitiveHeader = regexp.MustCompile(
 )
 
 func flatHeaders(h http.Header) map[string]string {
+	return flatHeadersRedacted(h, nil)
+}
+
+func flatHeadersRedacted(h http.Header, redactions []string) map[string]string {
 	out := make(map[string]string, len(h))
 	for k, v := range h {
 		if sensitiveHeader.MatchString(k) {
 			out[k] = "***"
 		} else {
-			out[k] = strings.Join(v, ", ")
+			out[k] = redactCredentialSample(strings.Join(v, ", "), redactions)
 		}
 	}
 	return out

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -854,8 +854,11 @@ func (b *dynamicOAuthHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request
 const injectHTTPTimeout = 30 * time.Second
 
 func injectHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) error {
-	if body == nil || body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
+	if body == nil {
 		return nil
+	}
+	if body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
+		return fmt.Errorf("extplugin: credential %q InjectHTTP unavailable: plugin client is not connected", body.instanceName)
 	}
 	ctx, cancel := context.WithTimeout(ctx, injectHTTPTimeout)
 	defer cancel()

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -115,7 +115,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 			credSec = secret.Bytes
 			credExtra = secret.Extras
 		}
-		if cb, ok := c.Body.(*dynamicCredentialBody); ok {
+		if cb, ok := credentialBaseOf(c.Body); ok {
 			credCanon = cb.canonicalJSON
 		}
 	}
@@ -752,14 +752,199 @@ func (t *remoteTunnel) Close() error {
 }
 
 // =====================================================================
-// Credential body (storage only — runtime credential injection
-// happens inside the plugin's endpoint code, not via RPC)
+// Credential adapter
 // =====================================================================
 
-// dynamicCredentialBody is what gets stored on Entity.Body for
-// credentials registered by external plugins. It carries the
-// canonical JSON returned by the plugin's Build so endpoint adapters
-// can forward it on ConnInit.
+type credentialAdapter struct {
+	client   *Client
+	typeName string
+}
+
+type credentialMetadata struct {
+	disambiguators []string
+	secretSlots    []config.SecretSlot
+	envVars        []config.EnvVar
+	oauth          *config.OAuthIntegration
+	httpInject     bool
+}
+
+// dynamicCredentialBody is the per-instance base Body for credentials
+// registered by external plugins. It carries the canonical JSON and
+// metadata returned by the plugin's Build so endpoint adapters can
+// forward it on ConnInit and dashboard/env/OAuth surfaces can discover
+// the credential's capabilities.
 type dynamicCredentialBody struct {
+	adapter       *credentialAdapter
+	instanceName  string
 	canonicalJSON []byte
+	metadata      credentialMetadata
+
+	redactionsMu sync.Mutex
+	redactions   map[*http.Request][]string
+}
+
+func (b *dynamicCredentialBody) SecretSlots() []config.SecretSlot {
+	if b == nil || len(b.metadata.secretSlots) == 0 {
+		return nil
+	}
+	return append([]config.SecretSlot(nil), b.metadata.secretSlots...)
+}
+
+func (b *dynamicCredentialBody) EnvVars() []config.EnvVar {
+	if b == nil || len(b.metadata.envVars) == 0 {
+		return nil
+	}
+	return append([]config.EnvVar(nil), b.metadata.envVars...)
+}
+
+type dynamicOAuthCredentialBody struct{ *dynamicCredentialBody }
+
+func (b *dynamicOAuthCredentialBody) OAuthFlow() *config.OAuthIntegration {
+	return cloneOAuthIntegration(b.dynamicCredentialBody.metadata.oauth)
+}
+
+type dynamicHTTPCredentialBody struct{ *dynamicCredentialBody }
+
+type dynamicOAuthHTTPCredentialBody struct{ *dynamicCredentialBody }
+
+func (b *dynamicOAuthHTTPCredentialBody) OAuthFlow() *config.OAuthIntegration {
+	return cloneOAuthIntegration(b.dynamicCredentialBody.metadata.oauth)
+}
+
+func (b *dynamicHTTPCredentialBody) InjectHTTP(ctx context.Context, req *http.Request, sec runtime.Secret) error {
+	return injectHTTPWithExternalCredential(ctx, b.dynamicCredentialBody, req, sec)
+}
+
+func (b *dynamicOAuthHTTPCredentialBody) InjectHTTP(ctx context.Context, req *http.Request, sec runtime.Secret) error {
+	return injectHTTPWithExternalCredential(ctx, b.dynamicCredentialBody, req, sec)
+}
+
+func (b *dynamicHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request) []string {
+	return consumeHTTPRedactions(b.dynamicCredentialBody, req)
+}
+
+func (b *dynamicOAuthHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request) []string {
+	return consumeHTTPRedactions(b.dynamicCredentialBody, req)
+}
+
+func injectHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) error {
+	if body == nil || body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
+		return nil
+	}
+	out, err := body.adapter.client.credential.InjectHTTP(ctx, &pb.InjectHTTPRequest{
+		CredentialTypeName:      body.adapter.typeName,
+		CredentialInstance:      body.instanceName,
+		CredentialCanonicalJson: body.canonicalJSON,
+		CredentialSecret:        sec.Bytes,
+		CredentialExtras:        sec.Extras,
+		Method:                  req.Method,
+		Url:                     req.URL.String(),
+		Host:                    req.Host,
+		Headers:                 headersToProto(req.Header),
+	})
+	if err != nil {
+		return fmt.Errorf("extplugin: credential %s.%s InjectHTTP: %w", body.adapter.typeName, body.instanceName, err)
+	}
+	body.recordHTTPRedactions(req, out.GetRedactions())
+	applyHeaderMutations(req.Header, out.GetHeaders())
+	return nil
+}
+
+func (b *dynamicCredentialBody) recordHTTPRedactions(req *http.Request, redactions []string) {
+	if b == nil || req == nil || len(redactions) == 0 {
+		return
+	}
+	b.redactionsMu.Lock()
+	defer b.redactionsMu.Unlock()
+	if b.redactions == nil {
+		b.redactions = map[*http.Request][]string{}
+	}
+	b.redactions[req] = append([]string(nil), redactions...)
+}
+
+func consumeHTTPRedactions(b *dynamicCredentialBody, req *http.Request) []string {
+	if b == nil || req == nil {
+		return nil
+	}
+	b.redactionsMu.Lock()
+	defer b.redactionsMu.Unlock()
+	out := append([]string(nil), b.redactions[req]...)
+	delete(b.redactions, req)
+	return out
+}
+
+func credentialBaseOf(v any) (*dynamicCredentialBody, bool) {
+	switch b := v.(type) {
+	case *dynamicCredentialBody:
+		return b, b != nil
+	case *dynamicHTTPCredentialBody:
+		return b.dynamicCredentialBody, b != nil && b.dynamicCredentialBody != nil
+	case *dynamicOAuthCredentialBody:
+		return b.dynamicCredentialBody, b != nil && b.dynamicCredentialBody != nil
+	case *dynamicOAuthHTTPCredentialBody:
+		return b.dynamicCredentialBody, b != nil && b.dynamicCredentialBody != nil
+	default:
+		return nil, false
+	}
+}
+
+func wrapCredentialBody(b *dynamicCredentialBody) any {
+	if b == nil {
+		return b
+	}
+	switch {
+	case b.metadata.oauth != nil && b.metadata.httpInject:
+		return &dynamicOAuthHTTPCredentialBody{dynamicCredentialBody: b}
+	case b.metadata.oauth != nil:
+		return &dynamicOAuthCredentialBody{dynamicCredentialBody: b}
+	case b.metadata.httpInject:
+		return &dynamicHTTPCredentialBody{dynamicCredentialBody: b}
+	default:
+		return b
+	}
+}
+
+func headersToProto(in http.Header) map[string]*pb.HTTPHeaderValues {
+	out := make(map[string]*pb.HTTPHeaderValues, len(in))
+	for k, vals := range in {
+		out[k] = &pb.HTTPHeaderValues{Values: append([]string(nil), vals...)}
+	}
+	return out
+}
+
+func applyHeaderMutations(h http.Header, mutations []*pb.HeaderMutation) {
+	for _, m := range mutations {
+		if m == nil || m.Name == "" {
+			continue
+		}
+		switch m.Op {
+		case pb.HeaderMutation_ADD:
+			for _, v := range m.Values {
+				h.Add(m.Name, v)
+			}
+		case pb.HeaderMutation_DEL:
+			h.Del(m.Name)
+		default:
+			h.Del(m.Name)
+			for _, v := range m.Values {
+				h.Add(m.Name, v)
+			}
+		}
+	}
+}
+
+func cloneOAuthIntegration(in *config.OAuthIntegration) *config.OAuthIntegration {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.OAuth.Scopes = append([]string(nil), in.OAuth.Scopes...)
+	out.OptionalScopes = make([]config.OptionalScopeGroup, len(in.OptionalScopes))
+	for i, g := range in.OptionalScopes {
+		out.OptionalScopes[i] = config.OptionalScopeGroup{
+			Title:  g.Title,
+			Scopes: append([]config.OptionalScope(nil), g.Scopes...),
+		}
+	}
+	return &out
 }

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/denoland/clawpatrol/internal/config"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
@@ -845,10 +846,19 @@ func (b *dynamicOAuthHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request
 	return consumeHTTPRedactions(b.dynamicCredentialBody, req)
 }
 
+// injectHTTPTimeout bounds the plugin InjectHTTP round trip. Plugins
+// may perform network token exchanges at request time, so a hung or
+// slow plugin must degrade to a logged inject error instead of
+// wedging the proxied request for as long as the agent keeps the
+// connection open.
+const injectHTTPTimeout = 30 * time.Second
+
 func injectHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) error {
 	if body == nil || body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
 		return nil
 	}
+	ctx, cancel := context.WithTimeout(ctx, injectHTTPTimeout)
+	defer cancel()
 	out, err := body.adapter.client.credential.InjectHTTP(ctx, &pb.InjectHTTPRequest{
 		CredentialTypeName:      body.adapter.typeName,
 		CredentialInstance:      body.instanceName,
@@ -945,6 +955,11 @@ func applyHeaderMutations(h http.Header, mutations []*pb.HeaderMutation) {
 			continue
 		}
 		switch m.Op {
+		case pb.HeaderMutation_SET:
+			h.Del(m.Name)
+			for _, v := range m.Values {
+				h.Add(m.Name, v)
+			}
 		case pb.HeaderMutation_ADD:
 			for _, v := range m.Values {
 				h.Add(m.Name, v)
@@ -952,10 +967,8 @@ func applyHeaderMutations(h http.Header, mutations []*pb.HeaderMutation) {
 		case pb.HeaderMutation_DEL:
 			h.Del(m.Name)
 		default:
-			h.Del(m.Name)
-			for _, v := range m.Values {
-				h.Add(m.Name, v)
-			}
+			// Ops this gateway build doesn't know (a newer plugin
+			// proto) are skipped rather than guessed at as SET.
 		}
 	}
 }

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -800,7 +800,10 @@ func (b *dynamicCredentialBody) EnvVars() []config.EnvVar {
 type dynamicOAuthCredentialBody struct{ *dynamicCredentialBody }
 
 func (b *dynamicOAuthCredentialBody) OAuthFlow() *config.OAuthIntegration {
-	return cloneOAuthIntegration(b.dynamicCredentialBody.metadata.oauth)
+	if b == nil || b.dynamicCredentialBody == nil {
+		return nil
+	}
+	return cloneOAuthIntegration(b.metadata.oauth)
 }
 
 type dynamicHTTPCredentialBody struct{ *dynamicCredentialBody }
@@ -808,22 +811,37 @@ type dynamicHTTPCredentialBody struct{ *dynamicCredentialBody }
 type dynamicOAuthHTTPCredentialBody struct{ *dynamicCredentialBody }
 
 func (b *dynamicOAuthHTTPCredentialBody) OAuthFlow() *config.OAuthIntegration {
-	return cloneOAuthIntegration(b.dynamicCredentialBody.metadata.oauth)
+	if b == nil || b.dynamicCredentialBody == nil {
+		return nil
+	}
+	return cloneOAuthIntegration(b.metadata.oauth)
 }
 
 func (b *dynamicHTTPCredentialBody) InjectHTTP(ctx context.Context, req *http.Request, sec runtime.Secret) error {
+	if b == nil {
+		return nil
+	}
 	return injectHTTPWithExternalCredential(ctx, b.dynamicCredentialBody, req, sec)
 }
 
 func (b *dynamicOAuthHTTPCredentialBody) InjectHTTP(ctx context.Context, req *http.Request, sec runtime.Secret) error {
+	if b == nil {
+		return nil
+	}
 	return injectHTTPWithExternalCredential(ctx, b.dynamicCredentialBody, req, sec)
 }
 
 func (b *dynamicHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request) []string {
+	if b == nil {
+		return nil
+	}
 	return consumeHTTPRedactions(b.dynamicCredentialBody, req)
 }
 
 func (b *dynamicOAuthHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request) []string {
+	if b == nil {
+		return nil
+	}
 	return consumeHTTPRedactions(b.dynamicCredentialBody, req)
 }
 
@@ -878,11 +896,20 @@ func credentialBaseOf(v any) (*dynamicCredentialBody, bool) {
 	case *dynamicCredentialBody:
 		return b, b != nil
 	case *dynamicHTTPCredentialBody:
-		return b.dynamicCredentialBody, b != nil && b.dynamicCredentialBody != nil
+		if b == nil || b.dynamicCredentialBody == nil {
+			return nil, false
+		}
+		return b.dynamicCredentialBody, true
 	case *dynamicOAuthCredentialBody:
-		return b.dynamicCredentialBody, b != nil && b.dynamicCredentialBody != nil
+		if b == nil || b.dynamicCredentialBody == nil {
+			return nil, false
+		}
+		return b.dynamicCredentialBody, true
 	case *dynamicOAuthHTTPCredentialBody:
-		return b.dynamicCredentialBody, b != nil && b.dynamicCredentialBody != nil
+		if b == nil || b.dynamicCredentialBody == nil {
+			return nil, false
+		}
+		return b.dynamicCredentialBody, true
 	default:
 		return nil, false
 	}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/denoland/clawpatrol/internal/config/facet"
 	"github.com/denoland/clawpatrol/internal/config/match"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"golang.org/x/net/http/httpguts"
 )
 
 // =====================================================================
@@ -851,7 +852,10 @@ func (b *dynamicOAuthHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request
 // slow plugin must degrade to a logged inject error instead of
 // wedging the proxied request for as long as the agent keeps the
 // connection open.
-const injectHTTPTimeout = 30 * time.Second
+const (
+	injectHTTPTimeout          = 30 * time.Second
+	maxHTTPRedactionMapEntries = 1024
+)
 
 func injectHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) error {
 	if body == nil {
@@ -889,6 +893,12 @@ func (b *dynamicCredentialBody) recordHTTPRedactions(req *http.Request, redactio
 	defer b.redactionsMu.Unlock()
 	if b.redactions == nil {
 		b.redactions = map[*http.Request][]string{}
+	}
+	if len(b.redactions) >= maxHTTPRedactionMapEntries {
+		for stale := range b.redactions {
+			delete(b.redactions, stale)
+			break
+		}
 	}
 	b.redactions[req] = append([]string(nil), redactions...)
 }
@@ -954,7 +964,7 @@ func headersToProto(in http.Header) map[string]*pb.HTTPHeaderValues {
 
 func applyHeaderMutations(h http.Header, mutations []*pb.HeaderMutation) {
 	for _, m := range mutations {
-		if m == nil || m.Name == "" {
+		if !validHeaderMutation(m) {
 			continue
 		}
 		switch m.Op {
@@ -974,6 +984,21 @@ func applyHeaderMutations(h http.Header, mutations []*pb.HeaderMutation) {
 			// proto) are skipped rather than guessed at as SET.
 		}
 	}
+}
+
+func validHeaderMutation(m *pb.HeaderMutation) bool {
+	if m == nil || !httpguts.ValidHeaderFieldName(m.Name) {
+		return false
+	}
+	if m.Op == pb.HeaderMutation_DEL {
+		return true
+	}
+	for _, v := range m.Values {
+		if !httpguts.ValidHeaderFieldValue(v) {
+			return false
+		}
+	}
+	return true
 }
 
 func cloneOAuthIntegration(in *config.OAuthIntegration) *config.OAuthIntegration {

--- a/internal/config/extplugin/credential_test.go
+++ b/internal/config/extplugin/credential_test.go
@@ -229,16 +229,14 @@ func newCredentialPluginTestClient(t *testing.T, srv *credentialPluginTestServer
 	pb.RegisterPluginServer(gs, srv)
 	pb.RegisterCredentialServer(gs, srv)
 	go func() { _ = gs.Serve(lis) }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	conn, err := grpc.DialContext(ctx, "bufnet",
+	conn, err := grpc.NewClient("passthrough:///bufnet",
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
-	cancel()
 	if err != nil {
 		gs.Stop()
 		_ = lis.Close()
-		t.Fatalf("DialContext: %v", err)
+		t.Fatalf("NewClient: %v", err)
 	}
 	client := &Client{
 		name:       "extcredtest",

--- a/internal/config/extplugin/credential_test.go
+++ b/internal/config/extplugin/credential_test.go
@@ -1,0 +1,255 @@
+package extplugin
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all" // register built-in plugins
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+type credentialPluginTestServer struct {
+	pb.UnimplementedPluginServer
+	pb.UnimplementedCredentialServer
+
+	typeName string
+	metadata *pb.CredentialMetadata
+	seen     chan *pb.InjectHTTPRequest
+}
+
+func (s *credentialPluginTestServer) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildResponse, error) {
+	if req.Kind != "credential" || req.TypeName != s.typeName {
+		return nil, fmt.Errorf("unexpected build request: %s %s", req.Kind, req.TypeName)
+	}
+	metadata := s.metadata
+	if metadata == nil {
+		metadata = &pb.CredentialMetadata{
+			SecretSlots: []*pb.SecretSlotDecl{{Label: "External token", Description: "stored by gateway"}},
+			EnvVars:     []*pb.EnvVarDecl{{Name: "EXTERNAL_TOKEN", Value: "PH_external", Description: "placeholder"}},
+			Oauth: &pb.OAuthIntegrationDecl{
+				Type:   "oauth2",
+				Header: "Authorization",
+				Prefix: "Bearer ",
+				Flow:   "dynamic_mcp",
+				Oauth: &pb.OAuthConfigDecl{
+					AuthUrl:     "https://auth.example.test/authorize",
+					TokenUrl:    "https://auth.example.test/token",
+					RegisterUrl: "https://auth.example.test/register",
+					Scopes:      []string{"mcp:read"},
+				},
+			},
+			HttpInject: true,
+		}
+	}
+	return &pb.BuildResponse{
+		CanonicalJson:      []byte(`{"built":"yes"}`),
+		CredentialMetadata: metadata,
+	}, nil
+}
+
+func (s *credentialPluginTestServer) InjectHTTP(_ context.Context, req *pb.InjectHTTPRequest) (*pb.InjectHTTPResponse, error) {
+	s.seen <- req
+	return &pb.InjectHTTPResponse{Headers: []*pb.HeaderMutation{{
+		Op:     pb.HeaderMutation_SET,
+		Name:   "Authorization",
+		Values: []string{"Bearer " + string(req.CredentialSecret)},
+	}}}, nil
+}
+
+func TestExternalCredentialMetadataAndInjectHTTPAdapter(t *testing.T) {
+	typeName := fmt.Sprintf("extplugin_test_cred_%d", time.Now().UnixNano())
+	server := &credentialPluginTestServer{typeName: typeName, seen: make(chan *pb.InjectHTTPRequest, 1)}
+	client, cleanup := newCredentialPluginTestClient(t, server)
+	defer cleanup()
+
+	diags := RegisterManifest(client, &pb.ManifestResponse{
+		Name: "extcredtest",
+		Credentials: []*pb.CredentialDecl{{
+			TypeName:       typeName,
+			Schema:         &pb.Schema{},
+			Disambiguators: []string{"placeholder"},
+			HttpInject:     true,
+		}},
+	})
+	if diags.HasErrors() {
+		t.Fatalf("RegisterManifest: %v", diags)
+	}
+	plug := config.Lookup(config.KindCredential, typeName)
+	if plug == nil {
+		t.Fatalf("credential plugin %q was not registered", typeName)
+	}
+	if got := plug.Disambiguators; len(got) != 1 || got[0] != "placeholder" {
+		t.Fatalf("Disambiguators = %#v", got)
+	}
+
+	hcl := fmt.Sprintf(`
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+endpoint "https" "api" {
+  hosts = ["api.example.test"]
+}
+credential %q "external" {
+  endpoint    = https.api
+  placeholder = "PH_external"
+}
+profile "default" { credentials = [%s.external] }
+`, typeName, typeName)
+	gw, diags := config.LoadBytes([]byte(hcl), "extplugin-credential-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("LoadBytes: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	ent := policy.Credentials["external"]
+	if ent == nil {
+		t.Fatalf("compiled credential missing")
+	}
+	base, ok := credentialBaseOf(ent.Body)
+	if !ok {
+		t.Fatalf("credential body type = %T, want dynamic external body", ent.Body)
+	}
+	if !strings.Contains(string(base.canonicalJSON), `"built":"yes"`) {
+		t.Fatalf("canonical json = %s", string(base.canonicalJSON))
+	}
+	if slots := ent.Body.(config.SecretSlotsProvider).SecretSlots(); len(slots) != 1 || slots[0].Label != "External token" {
+		t.Fatalf("secret slots = %#v", slots)
+	}
+	if env := ent.Body.(config.EnvPushdownProvider).EnvVars(); len(env) != 1 || env[0].Name != "EXTERNAL_TOKEN" || env[0].Value != "PH_external" {
+		t.Fatalf("env vars = %#v", env)
+	}
+	oauthProvider, ok := ent.Body.(config.OAuthFlowProvider)
+	if !ok {
+		t.Fatalf("credential body does not implement OAuthFlowProvider")
+	}
+	if flow := oauthProvider.OAuthFlow(); flow == nil || flow.Flow != "dynamic_mcp" || flow.OAuth.TokenURL != "https://auth.example.test/token" {
+		t.Fatalf("oauth flow = %#v", flow)
+	}
+	injector, ok := ent.Body.(runtime.HTTPCredentialRuntime)
+	if !ok {
+		t.Fatalf("credential body does not implement HTTPCredentialRuntime")
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.test/v1", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Host = "api.example.test"
+	req.Header.Set("Authorization", "Bearer PH_external")
+	if err := injector.InjectHTTP(context.Background(), req, runtime.Secret{Bytes: []byte("real-token")}); err != nil {
+		t.Fatalf("InjectHTTP: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer real-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	select {
+	case got := <-server.seen:
+		if got.CredentialTypeName != typeName || got.CredentialInstance != "external" {
+			t.Fatalf("InjectHTTP credential = %s/%s", got.CredentialTypeName, got.CredentialInstance)
+		}
+		if string(got.CredentialSecret) != "real-token" {
+			t.Fatalf("CredentialSecret = %q", string(got.CredentialSecret))
+		}
+		if got.Headers["Authorization"].Values[0] != "Bearer PH_external" {
+			t.Fatalf("headers = %#v", got.Headers)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for InjectHTTP RPC")
+	}
+}
+
+func TestExternalCredentialWithoutHTTPInjectRemainsSchemaOnly(t *testing.T) {
+	typeName := fmt.Sprintf("extplugin_test_schema_cred_%d", time.Now().UnixNano())
+	server := &credentialPluginTestServer{typeName: typeName, metadata: &pb.CredentialMetadata{}, seen: make(chan *pb.InjectHTTPRequest, 1)}
+	client, cleanup := newCredentialPluginTestClient(t, server)
+	defer cleanup()
+
+	diags := RegisterManifest(client, &pb.ManifestResponse{
+		Name: "extschemaonlytest",
+		Credentials: []*pb.CredentialDecl{{
+			TypeName: typeName,
+			Schema:   &pb.Schema{},
+		}},
+	})
+	if diags.HasErrors() {
+		t.Fatalf("RegisterManifest: %v", diags)
+	}
+
+	hcl := fmt.Sprintf(`
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+endpoint "https" "api" {
+  hosts = ["api.example.test"]
+}
+credential %q "external" {
+  endpoint = https.api
+}
+profile "default" { credentials = [%s.external] }
+`, typeName, typeName)
+	gw, diags := config.LoadBytes([]byte(hcl), "extplugin-schema-only-credential-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("LoadBytes: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	ent := policy.Credentials["external"]
+	if ent == nil {
+		t.Fatalf("compiled credential missing")
+	}
+	if _, ok := ent.Body.(runtime.HTTPCredentialRuntime); ok {
+		t.Fatalf("schema-only external credential unexpectedly implements HTTPCredentialRuntime")
+	}
+	if _, ok := ent.Body.(config.OAuthFlowProvider); ok {
+		t.Fatalf("schema-only external credential unexpectedly implements OAuthFlowProvider")
+	}
+}
+
+func newCredentialPluginTestClient(t *testing.T, srv *credentialPluginTestServer) (*Client, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	pb.RegisterPluginServer(gs, srv)
+	pb.RegisterCredentialServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	conn, err := grpc.DialContext(ctx, "bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	cancel()
+	if err != nil {
+		gs.Stop()
+		_ = lis.Close()
+		t.Fatalf("DialContext: %v", err)
+	}
+	client := &Client{
+		name:       "extcredtest",
+		conn:       conn,
+		pluginCli:  pb.NewPluginClient(conn),
+		credential: pb.NewCredentialClient(conn),
+	}
+	cleanup := func() {
+		_ = conn.Close()
+		gs.Stop()
+		_ = lis.Close()
+	}
+	return client, cleanup
+}

--- a/internal/config/extplugin/credential_test.go
+++ b/internal/config/extplugin/credential_test.go
@@ -222,6 +222,43 @@ profile "default" { credentials = [%s.external] }
 	}
 }
 
+func TestValidateCredentialMetadataShapeRejectsDuplicateAndEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		meta credentialMetadata
+	}{
+		{name: "duplicate named secret slots", meta: credentialMetadata{secretSlots: []config.SecretSlot{{Name: "token"}, {Name: "token"}}}},
+		{name: "multiple unnamed secret slots", meta: credentialMetadata{secretSlots: []config.SecretSlot{{Label: "Token"}, {Label: "Other"}}}},
+		{name: "empty env var name", meta: credentialMetadata{envVars: []config.EnvVar{{Value: "PH_token"}}}},
+		{name: "duplicate env var names", meta: credentialMetadata{envVars: []config.EnvVar{{Name: "TOKEN"}, {Name: "TOKEN"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diags := validateCredentialMetadataShape("p", "t", tt.meta); !diags.HasErrors() {
+				t.Fatalf("validateCredentialMetadataShape returned no errors")
+			}
+		})
+	}
+}
+
+func TestApplyHeaderMutationsRejectsInvalidHeaders(t *testing.T) {
+	h := http.Header{}
+	applyHeaderMutations(h, []*pb.HeaderMutation{
+		{Op: pb.HeaderMutation_SET, Name: "X-Good", Values: []string{"ok"}},
+		{Op: pb.HeaderMutation_SET, Name: "X-Bad\r\nInjected", Values: []string{"oops"}},
+		{Op: pb.HeaderMutation_SET, Name: "X-Bad-Value", Values: []string{"oops\r\nInjected: 1"}},
+	})
+	if got := h.Get("X-Good"); got != "ok" {
+		t.Fatalf("X-Good = %q, want ok", got)
+	}
+	if got := h.Get("X-Bad"); got != "" {
+		t.Fatalf("X-Bad = %q, want empty", got)
+	}
+	if got := h.Get("X-Bad-Value"); got != "" {
+		t.Fatalf("X-Bad-Value = %q, want empty", got)
+	}
+}
+
 func newCredentialPluginTestClient(t *testing.T, srv *credentialPluginTestServer) (*Client, func()) {
 	t.Helper()
 	lis := bufconn.Listen(1 << 20)

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -86,12 +86,13 @@ func (m *Manager) Start(ctx context.Context, source string) (*Client, *pb.Manife
 		return nil, nil, fmt.Errorf("plugin %q: unexpected client type %T", source, raw)
 	}
 	c := &Client{
-		source:    source,
-		gp:        cli,
-		conn:      conn,
-		pluginCli: pb.NewPluginClient(conn),
-		endpoint:  pb.NewEndpointClient(conn),
-		tunnel:    pb.NewTunnelClient(conn),
+		source:     source,
+		gp:         cli,
+		conn:       conn,
+		pluginCli:  pb.NewPluginClient(conn),
+		credential: pb.NewCredentialClient(conn),
+		endpoint:   pb.NewEndpointClient(conn),
+		tunnel:     pb.NewTunnelClient(conn),
 	}
 	manifest, err := c.pluginCli.Manifest(ctx, &pb.ManifestRequest{})
 	if err != nil {
@@ -251,14 +252,15 @@ func (m *Manager) Stop() {
 // Client is the gateway-side handle to one running plugin subprocess.
 // Adapters use it to issue RPCs.
 type Client struct {
-	name      string
-	source    string
-	manifest  *pb.ManifestResponse
-	gp        *plugin.Client
-	conn      *grpc.ClientConn
-	pluginCli pb.PluginClient
-	endpoint  pb.EndpointClient
-	tunnel    pb.TunnelClient
+	name       string
+	source     string
+	manifest   *pb.ManifestResponse
+	gp         *plugin.Client
+	conn       *grpc.ClientConn
+	pluginCli  pb.PluginClient
+	credential pb.CredentialClient
+	endpoint   pb.EndpointClient
+	tunnel     pb.TunnelClient
 }
 
 // Name returns the plugin's manifest name (lower-case identifier).
@@ -274,6 +276,9 @@ func (c *Client) Manifest() *pb.ManifestResponse { return c.manifest }
 
 // PluginRPC exposes the Build RPC; used by the registration helper.
 func (c *Client) PluginRPC() pb.PluginClient { return c.pluginCli }
+
+// CredentialRPC exposes InjectHTTP for credential adapters.
+func (c *Client) CredentialRPC() pb.CredentialClient { return c.credential }
 
 // EndpointRPC exposes HandleConn for endpoint adapters.
 func (c *Client) EndpointRPC() pb.EndpointClient { return c.endpoint }

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -188,7 +188,56 @@ func (x Diagnostic_Severity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Diagnostic_Severity.Descriptor instead.
 func (Diagnostic_Severity) EnumDescriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{11, 0}
+	return file_plugin_proto_rawDescGZIP(), []int{18, 0}
+}
+
+type HeaderMutation_Op int32
+
+const (
+	HeaderMutation_SET HeaderMutation_Op = 0
+	HeaderMutation_ADD HeaderMutation_Op = 1
+	HeaderMutation_DEL HeaderMutation_Op = 2
+)
+
+// Enum value maps for HeaderMutation_Op.
+var (
+	HeaderMutation_Op_name = map[int32]string{
+		0: "SET",
+		1: "ADD",
+		2: "DEL",
+	}
+	HeaderMutation_Op_value = map[string]int32{
+		"SET": 0,
+		"ADD": 1,
+		"DEL": 2,
+	}
+)
+
+func (x HeaderMutation_Op) Enum() *HeaderMutation_Op {
+	p := new(HeaderMutation_Op)
+	*p = x
+	return p
+}
+
+func (x HeaderMutation_Op) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (HeaderMutation_Op) Descriptor() protoreflect.EnumDescriptor {
+	return file_plugin_proto_enumTypes[3].Descriptor()
+}
+
+func (HeaderMutation_Op) Type() protoreflect.EnumType {
+	return &file_plugin_proto_enumTypes[3]
+}
+
+func (x HeaderMutation_Op) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use HeaderMutation_Op.Descriptor instead.
+func (HeaderMutation_Op) EnumDescriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{21, 0}
 }
 
 type ManifestRequest struct {
@@ -549,17 +598,523 @@ func (x *SchemaField) GetRequired() bool {
 	return false
 }
 
-type CredentialDecl struct {
+type SecretSlotDecl struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TypeName      string                 `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
-	Schema        *Schema                `protobuf:"bytes,2,opt,name=schema,proto3" json:"schema,omitempty"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Label         string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+	Multiline     bool                   `protobuf:"varint,3,opt,name=multiline,proto3" json:"multiline,omitempty"`
+	Description   string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *SecretSlotDecl) Reset() {
+	*x = SecretSlotDecl{}
+	mi := &file_plugin_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SecretSlotDecl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SecretSlotDecl) ProtoMessage() {}
+
+func (x *SecretSlotDecl) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SecretSlotDecl.ProtoReflect.Descriptor instead.
+func (*SecretSlotDecl) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SecretSlotDecl) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SecretSlotDecl) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+func (x *SecretSlotDecl) GetMultiline() bool {
+	if x != nil {
+		return x.Multiline
+	}
+	return false
+}
+
+func (x *SecretSlotDecl) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+type EnvVarDecl struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Description   string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnvVarDecl) Reset() {
+	*x = EnvVarDecl{}
+	mi := &file_plugin_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnvVarDecl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnvVarDecl) ProtoMessage() {}
+
+func (x *EnvVarDecl) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnvVarDecl.ProtoReflect.Descriptor instead.
+func (*EnvVarDecl) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *EnvVarDecl) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *EnvVarDecl) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *EnvVarDecl) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+type OptionalScopeDecl struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Label         string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OptionalScopeDecl) Reset() {
+	*x = OptionalScopeDecl{}
+	mi := &file_plugin_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OptionalScopeDecl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OptionalScopeDecl) ProtoMessage() {}
+
+func (x *OptionalScopeDecl) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OptionalScopeDecl.ProtoReflect.Descriptor instead.
+func (*OptionalScopeDecl) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *OptionalScopeDecl) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *OptionalScopeDecl) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+type OptionalScopeGroupDecl struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Title         string                 `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
+	Scopes        []*OptionalScopeDecl   `protobuf:"bytes,2,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OptionalScopeGroupDecl) Reset() {
+	*x = OptionalScopeGroupDecl{}
+	mi := &file_plugin_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OptionalScopeGroupDecl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OptionalScopeGroupDecl) ProtoMessage() {}
+
+func (x *OptionalScopeGroupDecl) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OptionalScopeGroupDecl.ProtoReflect.Descriptor instead.
+func (*OptionalScopeGroupDecl) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *OptionalScopeGroupDecl) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *OptionalScopeGroupDecl) GetScopes() []*OptionalScopeDecl {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
+type OAuthConfigDecl struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ClientSecret  string                 `protobuf:"bytes,2,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty"`
+	AuthUrl       string                 `protobuf:"bytes,3,opt,name=auth_url,json=authUrl,proto3" json:"auth_url,omitempty"`
+	TokenUrl      string                 `protobuf:"bytes,4,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty"`
+	DeviceUrl     string                 `protobuf:"bytes,5,opt,name=device_url,json=deviceUrl,proto3" json:"device_url,omitempty"`
+	RegisterUrl   string                 `protobuf:"bytes,6,opt,name=register_url,json=registerUrl,proto3" json:"register_url,omitempty"`
+	RedirectUri   string                 `protobuf:"bytes,7,opt,name=redirect_uri,json=redirectUri,proto3" json:"redirect_uri,omitempty"`
+	Scopes        []string               `protobuf:"bytes,8,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	RefreshToken  string                 `protobuf:"bytes,9,opt,name=refresh_token,json=refreshToken,proto3" json:"refresh_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OAuthConfigDecl) Reset() {
+	*x = OAuthConfigDecl{}
+	mi := &file_plugin_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OAuthConfigDecl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OAuthConfigDecl) ProtoMessage() {}
+
+func (x *OAuthConfigDecl) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OAuthConfigDecl.ProtoReflect.Descriptor instead.
+func (*OAuthConfigDecl) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *OAuthConfigDecl) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetClientSecret() string {
+	if x != nil {
+		return x.ClientSecret
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetAuthUrl() string {
+	if x != nil {
+		return x.AuthUrl
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetTokenUrl() string {
+	if x != nil {
+		return x.TokenUrl
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetDeviceUrl() string {
+	if x != nil {
+		return x.DeviceUrl
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetRegisterUrl() string {
+	if x != nil {
+		return x.RegisterUrl
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetRedirectUri() string {
+	if x != nil {
+		return x.RedirectUri
+	}
+	return ""
+}
+
+func (x *OAuthConfigDecl) GetScopes() []string {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
+func (x *OAuthConfigDecl) GetRefreshToken() string {
+	if x != nil {
+		return x.RefreshToken
+	}
+	return ""
+}
+
+type OAuthIntegrationDecl struct {
+	state          protoimpl.MessageState    `protogen:"open.v1"`
+	Type           string                    `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Header         string                    `protobuf:"bytes,2,opt,name=header,proto3" json:"header,omitempty"`
+	Prefix         string                    `protobuf:"bytes,3,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Flow           string                    `protobuf:"bytes,4,opt,name=flow,proto3" json:"flow,omitempty"`
+	Oauth          *OAuthConfigDecl          `protobuf:"bytes,5,opt,name=oauth,proto3" json:"oauth,omitempty"`
+	OptionalScopes []*OptionalScopeGroupDecl `protobuf:"bytes,6,rep,name=optional_scopes,json=optionalScopes,proto3" json:"optional_scopes,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *OAuthIntegrationDecl) Reset() {
+	*x = OAuthIntegrationDecl{}
+	mi := &file_plugin_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OAuthIntegrationDecl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OAuthIntegrationDecl) ProtoMessage() {}
+
+func (x *OAuthIntegrationDecl) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OAuthIntegrationDecl.ProtoReflect.Descriptor instead.
+func (*OAuthIntegrationDecl) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *OAuthIntegrationDecl) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *OAuthIntegrationDecl) GetHeader() string {
+	if x != nil {
+		return x.Header
+	}
+	return ""
+}
+
+func (x *OAuthIntegrationDecl) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+func (x *OAuthIntegrationDecl) GetFlow() string {
+	if x != nil {
+		return x.Flow
+	}
+	return ""
+}
+
+func (x *OAuthIntegrationDecl) GetOauth() *OAuthConfigDecl {
+	if x != nil {
+		return x.Oauth
+	}
+	return nil
+}
+
+func (x *OAuthIntegrationDecl) GetOptionalScopes() []*OptionalScopeGroupDecl {
+	if x != nil {
+		return x.OptionalScopes
+	}
+	return nil
+}
+
+type CredentialMetadata struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Disambiguators []string               `protobuf:"bytes,1,rep,name=disambiguators,proto3" json:"disambiguators,omitempty"`
+	SecretSlots    []*SecretSlotDecl      `protobuf:"bytes,2,rep,name=secret_slots,json=secretSlots,proto3" json:"secret_slots,omitempty"`
+	EnvVars        []*EnvVarDecl          `protobuf:"bytes,3,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty"`
+	Oauth          *OAuthIntegrationDecl  `protobuf:"bytes,4,opt,name=oauth,proto3" json:"oauth,omitempty"`
+	HttpInject     bool                   `protobuf:"varint,5,opt,name=http_inject,json=httpInject,proto3" json:"http_inject,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CredentialMetadata) Reset() {
+	*x = CredentialMetadata{}
+	mi := &file_plugin_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CredentialMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CredentialMetadata) ProtoMessage() {}
+
+func (x *CredentialMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CredentialMetadata.ProtoReflect.Descriptor instead.
+func (*CredentialMetadata) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *CredentialMetadata) GetDisambiguators() []string {
+	if x != nil {
+		return x.Disambiguators
+	}
+	return nil
+}
+
+func (x *CredentialMetadata) GetSecretSlots() []*SecretSlotDecl {
+	if x != nil {
+		return x.SecretSlots
+	}
+	return nil
+}
+
+func (x *CredentialMetadata) GetEnvVars() []*EnvVarDecl {
+	if x != nil {
+		return x.EnvVars
+	}
+	return nil
+}
+
+func (x *CredentialMetadata) GetOauth() *OAuthIntegrationDecl {
+	if x != nil {
+		return x.Oauth
+	}
+	return nil
+}
+
+func (x *CredentialMetadata) GetHttpInject() bool {
+	if x != nil {
+		return x.HttpInject
+	}
+	return false
+}
+
+type CredentialDecl struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	TypeName string                 `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Schema   *Schema                `protobuf:"bytes,2,opt,name=schema,proto3" json:"schema,omitempty"`
+	// Declares static capabilities for registration/validation.
+	// BuildResponse.credential_metadata may refine instance-specific
+	// env vars, slots, and OAuth URLs, but registration-time
+	// disambiguators are authoritative for validation.
+	Disambiguators []string `protobuf:"bytes,3,rep,name=disambiguators,proto3" json:"disambiguators,omitempty"`
+	HttpInject     bool     `protobuf:"varint,4,opt,name=http_inject,json=httpInject,proto3" json:"http_inject,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
 func (x *CredentialDecl) Reset() {
 	*x = CredentialDecl{}
-	mi := &file_plugin_proto_msgTypes[6]
+	mi := &file_plugin_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -571,7 +1126,7 @@ func (x *CredentialDecl) String() string {
 func (*CredentialDecl) ProtoMessage() {}
 
 func (x *CredentialDecl) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[6]
+	mi := &file_plugin_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -584,7 +1139,7 @@ func (x *CredentialDecl) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CredentialDecl.ProtoReflect.Descriptor instead.
 func (*CredentialDecl) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{6}
+	return file_plugin_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CredentialDecl) GetTypeName() string {
@@ -601,6 +1156,20 @@ func (x *CredentialDecl) GetSchema() *Schema {
 	return nil
 }
 
+func (x *CredentialDecl) GetDisambiguators() []string {
+	if x != nil {
+		return x.Disambiguators
+	}
+	return nil
+}
+
+func (x *CredentialDecl) GetHttpInject() bool {
+	if x != nil {
+		return x.HttpInject
+	}
+	return false
+}
+
 type TunnelDecl struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TypeName      string                 `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
@@ -611,7 +1180,7 @@ type TunnelDecl struct {
 
 func (x *TunnelDecl) Reset() {
 	*x = TunnelDecl{}
-	mi := &file_plugin_proto_msgTypes[7]
+	mi := &file_plugin_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -623,7 +1192,7 @@ func (x *TunnelDecl) String() string {
 func (*TunnelDecl) ProtoMessage() {}
 
 func (x *TunnelDecl) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[7]
+	mi := &file_plugin_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -636,7 +1205,7 @@ func (x *TunnelDecl) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelDecl.ProtoReflect.Descriptor instead.
 func (*TunnelDecl) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{7}
+	return file_plugin_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TunnelDecl) GetTypeName() string {
@@ -669,7 +1238,7 @@ type EndpointDecl struct {
 
 func (x *EndpointDecl) Reset() {
 	*x = EndpointDecl{}
-	mi := &file_plugin_proto_msgTypes[8]
+	mi := &file_plugin_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -681,7 +1250,7 @@ func (x *EndpointDecl) String() string {
 func (*EndpointDecl) ProtoMessage() {}
 
 func (x *EndpointDecl) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[8]
+	mi := &file_plugin_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -694,7 +1263,7 @@ func (x *EndpointDecl) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointDecl.ProtoReflect.Descriptor instead.
 func (*EndpointDecl) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{8}
+	return file_plugin_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *EndpointDecl) GetTypeName() string {
@@ -747,7 +1316,7 @@ type BuildRequest struct {
 
 func (x *BuildRequest) Reset() {
 	*x = BuildRequest{}
-	mi := &file_plugin_proto_msgTypes[9]
+	mi := &file_plugin_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -759,7 +1328,7 @@ func (x *BuildRequest) String() string {
 func (*BuildRequest) ProtoMessage() {}
 
 func (x *BuildRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[9]
+	mi := &file_plugin_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -772,7 +1341,7 @@ func (x *BuildRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildRequest.ProtoReflect.Descriptor instead.
 func (*BuildRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{9}
+	return file_plugin_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *BuildRequest) GetKind() string {
@@ -810,13 +1379,16 @@ type BuildResponse struct {
 	// ConnInit / OpenTunnelRequest.
 	CanonicalJson []byte        `protobuf:"bytes,1,opt,name=canonical_json,json=canonicalJson,proto3" json:"canonical_json,omitempty"`
 	Diagnostics   []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Used when kind == "credential". Instance-specific metadata
+	// derived from config, e.g. region-specific env vars/OAuth URLs.
+	CredentialMetadata *CredentialMetadata `protobuf:"bytes,3,opt,name=credential_metadata,json=credentialMetadata,proto3" json:"credential_metadata,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *BuildResponse) Reset() {
 	*x = BuildResponse{}
-	mi := &file_plugin_proto_msgTypes[10]
+	mi := &file_plugin_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -828,7 +1400,7 @@ func (x *BuildResponse) String() string {
 func (*BuildResponse) ProtoMessage() {}
 
 func (x *BuildResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[10]
+	mi := &file_plugin_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -841,7 +1413,7 @@ func (x *BuildResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildResponse.ProtoReflect.Descriptor instead.
 func (*BuildResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{10}
+	return file_plugin_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BuildResponse) GetCanonicalJson() []byte {
@@ -858,6 +1430,13 @@ func (x *BuildResponse) GetDiagnostics() []*Diagnostic {
 	return nil
 }
 
+func (x *BuildResponse) GetCredentialMetadata() *CredentialMetadata {
+	if x != nil {
+		return x.CredentialMetadata
+	}
+	return nil
+}
+
 type Diagnostic struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Severity      Diagnostic_Severity    `protobuf:"varint,1,opt,name=severity,proto3,enum=clawpatrol.plugin.v1.Diagnostic_Severity" json:"severity,omitempty"`
@@ -869,7 +1448,7 @@ type Diagnostic struct {
 
 func (x *Diagnostic) Reset() {
 	*x = Diagnostic{}
-	mi := &file_plugin_proto_msgTypes[11]
+	mi := &file_plugin_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -881,7 +1460,7 @@ func (x *Diagnostic) String() string {
 func (*Diagnostic) ProtoMessage() {}
 
 func (x *Diagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[11]
+	mi := &file_plugin_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -894,7 +1473,7 @@ func (x *Diagnostic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Diagnostic.ProtoReflect.Descriptor instead.
 func (*Diagnostic) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{11}
+	return file_plugin_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Diagnostic) GetSeverity() Diagnostic_Severity {
@@ -918,6 +1497,291 @@ func (x *Diagnostic) GetDetail() string {
 	return ""
 }
 
+type HTTPHeaderValues struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Values        []string               `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HTTPHeaderValues) Reset() {
+	*x = HTTPHeaderValues{}
+	mi := &file_plugin_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HTTPHeaderValues) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HTTPHeaderValues) ProtoMessage() {}
+
+func (x *HTTPHeaderValues) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HTTPHeaderValues.ProtoReflect.Descriptor instead.
+func (*HTTPHeaderValues) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *HTTPHeaderValues) GetValues() []string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type InjectHTTPRequest struct {
+	state                   protoimpl.MessageState       `protogen:"open.v1"`
+	CredentialTypeName      string                       `protobuf:"bytes,1,opt,name=credential_type_name,json=credentialTypeName,proto3" json:"credential_type_name,omitempty"`
+	CredentialInstance      string                       `protobuf:"bytes,2,opt,name=credential_instance,json=credentialInstance,proto3" json:"credential_instance,omitempty"`
+	CredentialCanonicalJson []byte                       `protobuf:"bytes,3,opt,name=credential_canonical_json,json=credentialCanonicalJson,proto3" json:"credential_canonical_json,omitempty"`
+	CredentialSecret        []byte                       `protobuf:"bytes,4,opt,name=credential_secret,json=credentialSecret,proto3" json:"credential_secret,omitempty"`
+	CredentialExtras        map[string]string            `protobuf:"bytes,5,rep,name=credential_extras,json=credentialExtras,proto3" json:"credential_extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Method                  string                       `protobuf:"bytes,6,opt,name=method,proto3" json:"method,omitempty"`
+	Url                     string                       `protobuf:"bytes,7,opt,name=url,proto3" json:"url,omitempty"`
+	Host                    string                       `protobuf:"bytes,8,opt,name=host,proto3" json:"host,omitempty"`
+	Headers                 map[string]*HTTPHeaderValues `protobuf:"bytes,9,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Optional, capped by gateway. Not required by current external
+	// credentials but reserved for future read-only inspection.
+	BodyPrefix    []byte `protobuf:"bytes,10,opt,name=body_prefix,json=bodyPrefix,proto3" json:"body_prefix,omitempty"`
+	BodyTruncated bool   `protobuf:"varint,11,opt,name=body_truncated,json=bodyTruncated,proto3" json:"body_truncated,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InjectHTTPRequest) Reset() {
+	*x = InjectHTTPRequest{}
+	mi := &file_plugin_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InjectHTTPRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InjectHTTPRequest) ProtoMessage() {}
+
+func (x *InjectHTTPRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InjectHTTPRequest.ProtoReflect.Descriptor instead.
+func (*InjectHTTPRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *InjectHTTPRequest) GetCredentialTypeName() string {
+	if x != nil {
+		return x.CredentialTypeName
+	}
+	return ""
+}
+
+func (x *InjectHTTPRequest) GetCredentialInstance() string {
+	if x != nil {
+		return x.CredentialInstance
+	}
+	return ""
+}
+
+func (x *InjectHTTPRequest) GetCredentialCanonicalJson() []byte {
+	if x != nil {
+		return x.CredentialCanonicalJson
+	}
+	return nil
+}
+
+func (x *InjectHTTPRequest) GetCredentialSecret() []byte {
+	if x != nil {
+		return x.CredentialSecret
+	}
+	return nil
+}
+
+func (x *InjectHTTPRequest) GetCredentialExtras() map[string]string {
+	if x != nil {
+		return x.CredentialExtras
+	}
+	return nil
+}
+
+func (x *InjectHTTPRequest) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *InjectHTTPRequest) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *InjectHTTPRequest) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *InjectHTTPRequest) GetHeaders() map[string]*HTTPHeaderValues {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+func (x *InjectHTTPRequest) GetBodyPrefix() []byte {
+	if x != nil {
+		return x.BodyPrefix
+	}
+	return nil
+}
+
+func (x *InjectHTTPRequest) GetBodyTruncated() bool {
+	if x != nil {
+		return x.BodyTruncated
+	}
+	return false
+}
+
+type HeaderMutation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Op            HeaderMutation_Op      `protobuf:"varint,1,opt,name=op,proto3,enum=clawpatrol.plugin.v1.HeaderMutation_Op" json:"op,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Values        []string               `protobuf:"bytes,3,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HeaderMutation) Reset() {
+	*x = HeaderMutation{}
+	mi := &file_plugin_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeaderMutation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeaderMutation) ProtoMessage() {}
+
+func (x *HeaderMutation) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeaderMutation.ProtoReflect.Descriptor instead.
+func (*HeaderMutation) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *HeaderMutation) GetOp() HeaderMutation_Op {
+	if x != nil {
+		return x.Op
+	}
+	return HeaderMutation_SET
+}
+
+func (x *HeaderMutation) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *HeaderMutation) GetValues() []string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type InjectHTTPResponse struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Headers []*HeaderMutation      `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty"`
+	// Extra runtime-derived sensitive values, such as a gateway-minted
+	// short-lived bearer token, that should be redacted from logs if
+	// encountered.
+	Redactions    []string `protobuf:"bytes,2,rep,name=redactions,proto3" json:"redactions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InjectHTTPResponse) Reset() {
+	*x = InjectHTTPResponse{}
+	mi := &file_plugin_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InjectHTTPResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InjectHTTPResponse) ProtoMessage() {}
+
+func (x *InjectHTTPResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InjectHTTPResponse.ProtoReflect.Descriptor instead.
+func (*InjectHTTPResponse) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *InjectHTTPResponse) GetHeaders() []*HeaderMutation {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+func (x *InjectHTTPResponse) GetRedactions() []string {
+	if x != nil {
+		return x.Redactions
+	}
+	return nil
+}
+
 type ConnMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -938,7 +1802,7 @@ type ConnMessage struct {
 
 func (x *ConnMessage) Reset() {
 	*x = ConnMessage{}
-	mi := &file_plugin_proto_msgTypes[12]
+	mi := &file_plugin_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -950,7 +1814,7 @@ func (x *ConnMessage) String() string {
 func (*ConnMessage) ProtoMessage() {}
 
 func (x *ConnMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[12]
+	mi := &file_plugin_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -963,7 +1827,7 @@ func (x *ConnMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnMessage.ProtoReflect.Descriptor instead.
 func (*ConnMessage) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{12}
+	return file_plugin_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ConnMessage) GetKind() isConnMessage_Kind {
@@ -1124,7 +1988,7 @@ type StreamRead struct {
 
 func (x *StreamRead) Reset() {
 	*x = StreamRead{}
-	mi := &file_plugin_proto_msgTypes[13]
+	mi := &file_plugin_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1136,7 +2000,7 @@ func (x *StreamRead) String() string {
 func (*StreamRead) ProtoMessage() {}
 
 func (x *StreamRead) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[13]
+	mi := &file_plugin_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1149,7 +2013,7 @@ func (x *StreamRead) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamRead.ProtoReflect.Descriptor instead.
 func (*StreamRead) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{13}
+	return file_plugin_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *StreamRead) GetHandle() string {
@@ -1180,7 +2044,7 @@ type StreamChunk struct {
 
 func (x *StreamChunk) Reset() {
 	*x = StreamChunk{}
-	mi := &file_plugin_proto_msgTypes[14]
+	mi := &file_plugin_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1192,7 +2056,7 @@ func (x *StreamChunk) String() string {
 func (*StreamChunk) ProtoMessage() {}
 
 func (x *StreamChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[14]
+	mi := &file_plugin_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1205,7 +2069,7 @@ func (x *StreamChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamChunk.ProtoReflect.Descriptor instead.
 func (*StreamChunk) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{14}
+	return file_plugin_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *StreamChunk) GetHandle() string {
@@ -1241,7 +2105,7 @@ type StreamCancel struct {
 
 func (x *StreamCancel) Reset() {
 	*x = StreamCancel{}
-	mi := &file_plugin_proto_msgTypes[15]
+	mi := &file_plugin_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1253,7 +2117,7 @@ func (x *StreamCancel) String() string {
 func (*StreamCancel) ProtoMessage() {}
 
 func (x *StreamCancel) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[15]
+	mi := &file_plugin_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1266,7 +2130,7 @@ func (x *StreamCancel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamCancel.ProtoReflect.Descriptor instead.
 func (*StreamCancel) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{15}
+	return file_plugin_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *StreamCancel) GetHandle() string {
@@ -1310,7 +2174,7 @@ type EvaluateAction struct {
 
 func (x *EvaluateAction) Reset() {
 	*x = EvaluateAction{}
-	mi := &file_plugin_proto_msgTypes[16]
+	mi := &file_plugin_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1322,7 +2186,7 @@ func (x *EvaluateAction) String() string {
 func (*EvaluateAction) ProtoMessage() {}
 
 func (x *EvaluateAction) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[16]
+	mi := &file_plugin_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1335,7 +2199,7 @@ func (x *EvaluateAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateAction.ProtoReflect.Descriptor instead.
 func (*EvaluateAction) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{16}
+	return file_plugin_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *EvaluateAction) GetCallId() string {
@@ -1385,7 +2249,7 @@ type ActionVerdict struct {
 
 func (x *ActionVerdict) Reset() {
 	*x = ActionVerdict{}
-	mi := &file_plugin_proto_msgTypes[17]
+	mi := &file_plugin_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1397,7 +2261,7 @@ func (x *ActionVerdict) String() string {
 func (*ActionVerdict) ProtoMessage() {}
 
 func (x *ActionVerdict) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[17]
+	mi := &file_plugin_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1410,7 +2274,7 @@ func (x *ActionVerdict) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActionVerdict.ProtoReflect.Descriptor instead.
 func (*ActionVerdict) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{17}
+	return file_plugin_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ActionVerdict) GetCallId() string {
@@ -1473,7 +2337,7 @@ type ConnInit struct {
 
 func (x *ConnInit) Reset() {
 	*x = ConnInit{}
-	mi := &file_plugin_proto_msgTypes[18]
+	mi := &file_plugin_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1485,7 +2349,7 @@ func (x *ConnInit) String() string {
 func (*ConnInit) ProtoMessage() {}
 
 func (x *ConnInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[18]
+	mi := &file_plugin_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1498,7 +2362,7 @@ func (x *ConnInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnInit.ProtoReflect.Descriptor instead.
 func (*ConnInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{18}
+	return file_plugin_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ConnInit) GetEndpointTypeName() string {
@@ -1608,7 +2472,7 @@ type ConnData struct {
 
 func (x *ConnData) Reset() {
 	*x = ConnData{}
-	mi := &file_plugin_proto_msgTypes[19]
+	mi := &file_plugin_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1620,7 +2484,7 @@ func (x *ConnData) String() string {
 func (*ConnData) ProtoMessage() {}
 
 func (x *ConnData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[19]
+	mi := &file_plugin_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1633,7 +2497,7 @@ func (x *ConnData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnData.ProtoReflect.Descriptor instead.
 func (*ConnData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{19}
+	return file_plugin_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ConnData) GetPayload() []byte {
@@ -1653,7 +2517,7 @@ type ConnClose struct {
 
 func (x *ConnClose) Reset() {
 	*x = ConnClose{}
-	mi := &file_plugin_proto_msgTypes[20]
+	mi := &file_plugin_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1665,7 +2529,7 @@ func (x *ConnClose) String() string {
 func (*ConnClose) ProtoMessage() {}
 
 func (x *ConnClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[20]
+	mi := &file_plugin_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1678,7 +2542,7 @@ func (x *ConnClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnClose.ProtoReflect.Descriptor instead.
 func (*ConnClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{20}
+	return file_plugin_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ConnClose) GetReason() string {
@@ -1709,7 +2573,7 @@ type ConnEvent struct {
 
 func (x *ConnEvent) Reset() {
 	*x = ConnEvent{}
-	mi := &file_plugin_proto_msgTypes[21]
+	mi := &file_plugin_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1721,7 +2585,7 @@ func (x *ConnEvent) String() string {
 func (*ConnEvent) ProtoMessage() {}
 
 func (x *ConnEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[21]
+	mi := &file_plugin_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1734,7 +2598,7 @@ func (x *ConnEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnEvent.ProtoReflect.Descriptor instead.
 func (*ConnEvent) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{21}
+	return file_plugin_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ConnEvent) GetAction() string {
@@ -1800,7 +2664,7 @@ type OpenTunnelRequest struct {
 
 func (x *OpenTunnelRequest) Reset() {
 	*x = OpenTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[22]
+	mi := &file_plugin_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1812,7 +2676,7 @@ func (x *OpenTunnelRequest) String() string {
 func (*OpenTunnelRequest) ProtoMessage() {}
 
 func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[22]
+	mi := &file_plugin_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1825,7 +2689,7 @@ func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelRequest.ProtoReflect.Descriptor instead.
 func (*OpenTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{22}
+	return file_plugin_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *OpenTunnelRequest) GetTunnelTypeName() string {
@@ -1872,7 +2736,7 @@ type OpenTunnelResponse struct {
 
 func (x *OpenTunnelResponse) Reset() {
 	*x = OpenTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[23]
+	mi := &file_plugin_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1884,7 +2748,7 @@ func (x *OpenTunnelResponse) String() string {
 func (*OpenTunnelResponse) ProtoMessage() {}
 
 func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[23]
+	mi := &file_plugin_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1897,7 +2761,7 @@ func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelResponse.ProtoReflect.Descriptor instead.
 func (*OpenTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{23}
+	return file_plugin_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *OpenTunnelResponse) GetHandle() string {
@@ -1916,7 +2780,7 @@ type CloseTunnelRequest struct {
 
 func (x *CloseTunnelRequest) Reset() {
 	*x = CloseTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[24]
+	mi := &file_plugin_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1928,7 +2792,7 @@ func (x *CloseTunnelRequest) String() string {
 func (*CloseTunnelRequest) ProtoMessage() {}
 
 func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[24]
+	mi := &file_plugin_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1941,7 +2805,7 @@ func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelRequest.ProtoReflect.Descriptor instead.
 func (*CloseTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{24}
+	return file_plugin_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *CloseTunnelRequest) GetHandle() string {
@@ -1959,7 +2823,7 @@ type CloseTunnelResponse struct {
 
 func (x *CloseTunnelResponse) Reset() {
 	*x = CloseTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[25]
+	mi := &file_plugin_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1971,7 +2835,7 @@ func (x *CloseTunnelResponse) String() string {
 func (*CloseTunnelResponse) ProtoMessage() {}
 
 func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[25]
+	mi := &file_plugin_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1984,7 +2848,7 @@ func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelResponse.ProtoReflect.Descriptor instead.
 func (*CloseTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{25}
+	return file_plugin_proto_rawDescGZIP(), []int{36}
 }
 
 type DialMessage struct {
@@ -2001,7 +2865,7 @@ type DialMessage struct {
 
 func (x *DialMessage) Reset() {
 	*x = DialMessage{}
-	mi := &file_plugin_proto_msgTypes[26]
+	mi := &file_plugin_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2013,7 +2877,7 @@ func (x *DialMessage) String() string {
 func (*DialMessage) ProtoMessage() {}
 
 func (x *DialMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[26]
+	mi := &file_plugin_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2026,7 +2890,7 @@ func (x *DialMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialMessage.ProtoReflect.Descriptor instead.
 func (*DialMessage) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{26}
+	return file_plugin_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DialMessage) GetKind() isDialMessage_Kind {
@@ -2096,7 +2960,7 @@ type DialInit struct {
 
 func (x *DialInit) Reset() {
 	*x = DialInit{}
-	mi := &file_plugin_proto_msgTypes[27]
+	mi := &file_plugin_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2108,7 +2972,7 @@ func (x *DialInit) String() string {
 func (*DialInit) ProtoMessage() {}
 
 func (x *DialInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[27]
+	mi := &file_plugin_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2121,7 +2985,7 @@ func (x *DialInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialInit.ProtoReflect.Descriptor instead.
 func (*DialInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{27}
+	return file_plugin_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *DialInit) GetTunnelHandle() string {
@@ -2154,7 +3018,7 @@ type DialData struct {
 
 func (x *DialData) Reset() {
 	*x = DialData{}
-	mi := &file_plugin_proto_msgTypes[28]
+	mi := &file_plugin_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2166,7 +3030,7 @@ func (x *DialData) String() string {
 func (*DialData) ProtoMessage() {}
 
 func (x *DialData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[28]
+	mi := &file_plugin_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2179,7 +3043,7 @@ func (x *DialData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialData.ProtoReflect.Descriptor instead.
 func (*DialData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{28}
+	return file_plugin_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *DialData) GetPayload() []byte {
@@ -2198,7 +3062,7 @@ type DialClose struct {
 
 func (x *DialClose) Reset() {
 	*x = DialClose{}
-	mi := &file_plugin_proto_msgTypes[29]
+	mi := &file_plugin_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2210,7 +3074,7 @@ func (x *DialClose) String() string {
 func (*DialClose) ProtoMessage() {}
 
 func (x *DialClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[29]
+	mi := &file_plugin_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2223,7 +3087,7 @@ func (x *DialClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialClose.ProtoReflect.Descriptor instead.
 func (*DialClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{29}
+	return file_plugin_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *DialClose) GetReason() string {
@@ -2260,10 +3124,54 @@ const file_plugin_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vtype_string\x18\x02 \x01(\tR\n" +
 	"typeString\x12\x1a\n" +
-	"\brequired\x18\x03 \x01(\bR\brequired\"c\n" +
+	"\brequired\x18\x03 \x01(\bR\brequired\"z\n" +
+	"\x0eSecretSlotDecl\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05label\x18\x02 \x01(\tR\x05label\x12\x1c\n" +
+	"\tmultiline\x18\x03 \x01(\bR\tmultiline\x12 \n" +
+	"\vdescription\x18\x04 \x01(\tR\vdescription\"X\n" +
+	"\n" +
+	"EnvVarDecl\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\"9\n" +
+	"\x11OptionalScopeDecl\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05label\x18\x02 \x01(\tR\x05label\"o\n" +
+	"\x16OptionalScopeGroupDecl\x12\x14\n" +
+	"\x05title\x18\x01 \x01(\tR\x05title\x12?\n" +
+	"\x06scopes\x18\x02 \x03(\v2'.clawpatrol.plugin.v1.OptionalScopeDeclR\x06scopes\"\xad\x02\n" +
+	"\x0fOAuthConfigDecl\x12\x1b\n" +
+	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12#\n" +
+	"\rclient_secret\x18\x02 \x01(\tR\fclientSecret\x12\x19\n" +
+	"\bauth_url\x18\x03 \x01(\tR\aauthUrl\x12\x1b\n" +
+	"\ttoken_url\x18\x04 \x01(\tR\btokenUrl\x12\x1d\n" +
+	"\n" +
+	"device_url\x18\x05 \x01(\tR\tdeviceUrl\x12!\n" +
+	"\fregister_url\x18\x06 \x01(\tR\vregisterUrl\x12!\n" +
+	"\fredirect_uri\x18\a \x01(\tR\vredirectUri\x12\x16\n" +
+	"\x06scopes\x18\b \x03(\tR\x06scopes\x12#\n" +
+	"\rrefresh_token\x18\t \x01(\tR\frefreshToken\"\x82\x02\n" +
+	"\x14OAuthIntegrationDecl\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
+	"\x06header\x18\x02 \x01(\tR\x06header\x12\x16\n" +
+	"\x06prefix\x18\x03 \x01(\tR\x06prefix\x12\x12\n" +
+	"\x04flow\x18\x04 \x01(\tR\x04flow\x12;\n" +
+	"\x05oauth\x18\x05 \x01(\v2%.clawpatrol.plugin.v1.OAuthConfigDeclR\x05oauth\x12U\n" +
+	"\x0foptional_scopes\x18\x06 \x03(\v2,.clawpatrol.plugin.v1.OptionalScopeGroupDeclR\x0eoptionalScopes\"\xa5\x02\n" +
+	"\x12CredentialMetadata\x12&\n" +
+	"\x0edisambiguators\x18\x01 \x03(\tR\x0edisambiguators\x12G\n" +
+	"\fsecret_slots\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.SecretSlotDeclR\vsecretSlots\x12;\n" +
+	"\benv_vars\x18\x03 \x03(\v2 .clawpatrol.plugin.v1.EnvVarDeclR\aenvVars\x12@\n" +
+	"\x05oauth\x18\x04 \x01(\v2*.clawpatrol.plugin.v1.OAuthIntegrationDeclR\x05oauth\x12\x1f\n" +
+	"\vhttp_inject\x18\x05 \x01(\bR\n" +
+	"httpInject\"\xac\x01\n" +
 	"\x0eCredentialDecl\x12\x1b\n" +
 	"\ttype_name\x18\x01 \x01(\tR\btypeName\x124\n" +
-	"\x06schema\x18\x02 \x01(\v2\x1c.clawpatrol.plugin.v1.SchemaR\x06schema\"_\n" +
+	"\x06schema\x18\x02 \x01(\v2\x1c.clawpatrol.plugin.v1.SchemaR\x06schema\x12&\n" +
+	"\x0edisambiguators\x18\x03 \x03(\tR\x0edisambiguators\x12\x1f\n" +
+	"\vhttp_inject\x18\x04 \x01(\bR\n" +
+	"httpInject\"_\n" +
 	"\n" +
 	"TunnelDecl\x12\x1b\n" +
 	"\ttype_name\x18\x01 \x01(\tR\btypeName\x124\n" +
@@ -2279,10 +3187,11 @@ const file_plugin_proto_rawDesc = "" +
 	"\ttype_name\x18\x02 \x01(\tR\btypeName\x12#\n" +
 	"\rinstance_name\x18\x03 \x01(\tR\finstanceName\x12\x1f\n" +
 	"\vconfig_json\x18\x04 \x01(\fR\n" +
-	"configJson\"z\n" +
+	"configJson\"\xd5\x01\n" +
 	"\rBuildResponse\x12%\n" +
 	"\x0ecanonical_json\x18\x01 \x01(\fR\rcanonicalJson\x12B\n" +
-	"\vdiagnostics\x18\x02 \x03(\v2 .clawpatrol.plugin.v1.DiagnosticR\vdiagnostics\"\xa9\x01\n" +
+	"\vdiagnostics\x18\x02 \x03(\v2 .clawpatrol.plugin.v1.DiagnosticR\vdiagnostics\x12Y\n" +
+	"\x13credential_metadata\x18\x03 \x01(\v2(.clawpatrol.plugin.v1.CredentialMetadataR\x12credentialMetadata\"\xa9\x01\n" +
 	"\n" +
 	"Diagnostic\x12E\n" +
 	"\bseverity\x18\x01 \x01(\x0e2).clawpatrol.plugin.v1.Diagnostic.SeverityR\bseverity\x12\x18\n" +
@@ -2290,7 +3199,42 @@ const file_plugin_proto_rawDesc = "" +
 	"\x06detail\x18\x03 \x01(\tR\x06detail\"\"\n" +
 	"\bSeverity\x12\t\n" +
 	"\x05ERROR\x10\x00\x12\v\n" +
-	"\aWARNING\x10\x01\"\xd0\x04\n" +
+	"\aWARNING\x10\x01\"*\n" +
+	"\x10HTTPHeaderValues\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\"\xca\x05\n" +
+	"\x11InjectHTTPRequest\x120\n" +
+	"\x14credential_type_name\x18\x01 \x01(\tR\x12credentialTypeName\x12/\n" +
+	"\x13credential_instance\x18\x02 \x01(\tR\x12credentialInstance\x12:\n" +
+	"\x19credential_canonical_json\x18\x03 \x01(\fR\x17credentialCanonicalJson\x12+\n" +
+	"\x11credential_secret\x18\x04 \x01(\fR\x10credentialSecret\x12j\n" +
+	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntryR\x10credentialExtras\x12\x16\n" +
+	"\x06method\x18\x06 \x01(\tR\x06method\x12\x10\n" +
+	"\x03url\x18\a \x01(\tR\x03url\x12\x12\n" +
+	"\x04host\x18\b \x01(\tR\x04host\x12N\n" +
+	"\aheaders\x18\t \x03(\v24.clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntryR\aheaders\x12\x1f\n" +
+	"\vbody_prefix\x18\n" +
+	" \x01(\fR\n" +
+	"bodyPrefix\x12%\n" +
+	"\x0ebody_truncated\x18\v \x01(\bR\rbodyTruncated\x1aC\n" +
+	"\x15CredentialExtrasEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1ab\n" +
+	"\fHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
+	"\x05value\x18\x02 \x01(\v2&.clawpatrol.plugin.v1.HTTPHeaderValuesR\x05value:\x028\x01\"\x96\x01\n" +
+	"\x0eHeaderMutation\x127\n" +
+	"\x02op\x18\x01 \x01(\x0e2'.clawpatrol.plugin.v1.HeaderMutation.OpR\x02op\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +
+	"\x06values\x18\x03 \x03(\tR\x06values\"\x1f\n" +
+	"\x02Op\x12\a\n" +
+	"\x03SET\x10\x00\x12\a\n" +
+	"\x03ADD\x10\x01\x12\a\n" +
+	"\x03DEL\x10\x02\"t\n" +
+	"\x12InjectHTTPResponse\x12>\n" +
+	"\aheaders\x18\x01 \x03(\v2$.clawpatrol.plugin.v1.HeaderMutationR\aheaders\x12\x1e\n" +
+	"\n" +
+	"redactions\x18\x02 \x03(\tR\n" +
+	"redactions\"\xd0\x04\n" +
 	"\vConnMessage\x124\n" +
 	"\x04init\x18\x01 \x01(\v2\x1e.clawpatrol.plugin.v1.ConnInitH\x00R\x04init\x124\n" +
 	"\x04data\x18\x02 \x01(\v2\x1e.clawpatrol.plugin.v1.ConnDataH\x00R\x04data\x127\n" +
@@ -2400,7 +3344,11 @@ const file_plugin_proto_rawDesc = "" +
 	"\rTLS_TERMINATE\x10\x012\xb5\x01\n" +
 	"\x06Plugin\x12Y\n" +
 	"\bManifest\x12%.clawpatrol.plugin.v1.ManifestRequest\x1a&.clawpatrol.plugin.v1.ManifestResponse\x12P\n" +
-	"\x05Build\x12\".clawpatrol.plugin.v1.BuildRequest\x1a#.clawpatrol.plugin.v1.BuildResponse2b\n" +
+	"\x05Build\x12\".clawpatrol.plugin.v1.BuildRequest\x1a#.clawpatrol.plugin.v1.BuildResponse2m\n" +
+	"\n" +
+	"Credential\x12_\n" +
+	"\n" +
+	"InjectHTTP\x12'.clawpatrol.plugin.v1.InjectHTTPRequest\x1a(.clawpatrol.plugin.v1.InjectHTTPResponse2b\n" +
 	"\bEndpoint\x12V\n" +
 	"\n" +
 	"HandleConn\x12!.clawpatrol.plugin.v1.ConnMessage\x1a!.clawpatrol.plugin.v1.ConnMessage(\x010\x012\x9f\x02\n" +
@@ -2422,92 +3370,120 @@ func file_plugin_proto_rawDescGZIP() []byte {
 	return file_plugin_proto_rawDescData
 }
 
-var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_plugin_proto_goTypes = []any{
-	(FacetKind)(0),              // 0: clawpatrol.plugin.v1.FacetKind
-	(TLSMode)(0),                // 1: clawpatrol.plugin.v1.TLSMode
-	(Diagnostic_Severity)(0),    // 2: clawpatrol.plugin.v1.Diagnostic.Severity
-	(*ManifestRequest)(nil),     // 3: clawpatrol.plugin.v1.ManifestRequest
-	(*ManifestResponse)(nil),    // 4: clawpatrol.plugin.v1.ManifestResponse
-	(*FacetDecl)(nil),           // 5: clawpatrol.plugin.v1.FacetDecl
-	(*FacetFieldDecl)(nil),      // 6: clawpatrol.plugin.v1.FacetFieldDecl
-	(*Schema)(nil),              // 7: clawpatrol.plugin.v1.Schema
-	(*SchemaField)(nil),         // 8: clawpatrol.plugin.v1.SchemaField
-	(*CredentialDecl)(nil),      // 9: clawpatrol.plugin.v1.CredentialDecl
-	(*TunnelDecl)(nil),          // 10: clawpatrol.plugin.v1.TunnelDecl
-	(*EndpointDecl)(nil),        // 11: clawpatrol.plugin.v1.EndpointDecl
-	(*BuildRequest)(nil),        // 12: clawpatrol.plugin.v1.BuildRequest
-	(*BuildResponse)(nil),       // 13: clawpatrol.plugin.v1.BuildResponse
-	(*Diagnostic)(nil),          // 14: clawpatrol.plugin.v1.Diagnostic
-	(*ConnMessage)(nil),         // 15: clawpatrol.plugin.v1.ConnMessage
-	(*StreamRead)(nil),          // 16: clawpatrol.plugin.v1.StreamRead
-	(*StreamChunk)(nil),         // 17: clawpatrol.plugin.v1.StreamChunk
-	(*StreamCancel)(nil),        // 18: clawpatrol.plugin.v1.StreamCancel
-	(*EvaluateAction)(nil),      // 19: clawpatrol.plugin.v1.EvaluateAction
-	(*ActionVerdict)(nil),       // 20: clawpatrol.plugin.v1.ActionVerdict
-	(*ConnInit)(nil),            // 21: clawpatrol.plugin.v1.ConnInit
-	(*ConnData)(nil),            // 22: clawpatrol.plugin.v1.ConnData
-	(*ConnClose)(nil),           // 23: clawpatrol.plugin.v1.ConnClose
-	(*ConnEvent)(nil),           // 24: clawpatrol.plugin.v1.ConnEvent
-	(*OpenTunnelRequest)(nil),   // 25: clawpatrol.plugin.v1.OpenTunnelRequest
-	(*OpenTunnelResponse)(nil),  // 26: clawpatrol.plugin.v1.OpenTunnelResponse
-	(*CloseTunnelRequest)(nil),  // 27: clawpatrol.plugin.v1.CloseTunnelRequest
-	(*CloseTunnelResponse)(nil), // 28: clawpatrol.plugin.v1.CloseTunnelResponse
-	(*DialMessage)(nil),         // 29: clawpatrol.plugin.v1.DialMessage
-	(*DialInit)(nil),            // 30: clawpatrol.plugin.v1.DialInit
-	(*DialData)(nil),            // 31: clawpatrol.plugin.v1.DialData
-	(*DialClose)(nil),           // 32: clawpatrol.plugin.v1.DialClose
-	nil,                         // 33: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                         // 34: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                         // 35: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(FacetKind)(0),                 // 0: clawpatrol.plugin.v1.FacetKind
+	(TLSMode)(0),                   // 1: clawpatrol.plugin.v1.TLSMode
+	(Diagnostic_Severity)(0),       // 2: clawpatrol.plugin.v1.Diagnostic.Severity
+	(HeaderMutation_Op)(0),         // 3: clawpatrol.plugin.v1.HeaderMutation.Op
+	(*ManifestRequest)(nil),        // 4: clawpatrol.plugin.v1.ManifestRequest
+	(*ManifestResponse)(nil),       // 5: clawpatrol.plugin.v1.ManifestResponse
+	(*FacetDecl)(nil),              // 6: clawpatrol.plugin.v1.FacetDecl
+	(*FacetFieldDecl)(nil),         // 7: clawpatrol.plugin.v1.FacetFieldDecl
+	(*Schema)(nil),                 // 8: clawpatrol.plugin.v1.Schema
+	(*SchemaField)(nil),            // 9: clawpatrol.plugin.v1.SchemaField
+	(*SecretSlotDecl)(nil),         // 10: clawpatrol.plugin.v1.SecretSlotDecl
+	(*EnvVarDecl)(nil),             // 11: clawpatrol.plugin.v1.EnvVarDecl
+	(*OptionalScopeDecl)(nil),      // 12: clawpatrol.plugin.v1.OptionalScopeDecl
+	(*OptionalScopeGroupDecl)(nil), // 13: clawpatrol.plugin.v1.OptionalScopeGroupDecl
+	(*OAuthConfigDecl)(nil),        // 14: clawpatrol.plugin.v1.OAuthConfigDecl
+	(*OAuthIntegrationDecl)(nil),   // 15: clawpatrol.plugin.v1.OAuthIntegrationDecl
+	(*CredentialMetadata)(nil),     // 16: clawpatrol.plugin.v1.CredentialMetadata
+	(*CredentialDecl)(nil),         // 17: clawpatrol.plugin.v1.CredentialDecl
+	(*TunnelDecl)(nil),             // 18: clawpatrol.plugin.v1.TunnelDecl
+	(*EndpointDecl)(nil),           // 19: clawpatrol.plugin.v1.EndpointDecl
+	(*BuildRequest)(nil),           // 20: clawpatrol.plugin.v1.BuildRequest
+	(*BuildResponse)(nil),          // 21: clawpatrol.plugin.v1.BuildResponse
+	(*Diagnostic)(nil),             // 22: clawpatrol.plugin.v1.Diagnostic
+	(*HTTPHeaderValues)(nil),       // 23: clawpatrol.plugin.v1.HTTPHeaderValues
+	(*InjectHTTPRequest)(nil),      // 24: clawpatrol.plugin.v1.InjectHTTPRequest
+	(*HeaderMutation)(nil),         // 25: clawpatrol.plugin.v1.HeaderMutation
+	(*InjectHTTPResponse)(nil),     // 26: clawpatrol.plugin.v1.InjectHTTPResponse
+	(*ConnMessage)(nil),            // 27: clawpatrol.plugin.v1.ConnMessage
+	(*StreamRead)(nil),             // 28: clawpatrol.plugin.v1.StreamRead
+	(*StreamChunk)(nil),            // 29: clawpatrol.plugin.v1.StreamChunk
+	(*StreamCancel)(nil),           // 30: clawpatrol.plugin.v1.StreamCancel
+	(*EvaluateAction)(nil),         // 31: clawpatrol.plugin.v1.EvaluateAction
+	(*ActionVerdict)(nil),          // 32: clawpatrol.plugin.v1.ActionVerdict
+	(*ConnInit)(nil),               // 33: clawpatrol.plugin.v1.ConnInit
+	(*ConnData)(nil),               // 34: clawpatrol.plugin.v1.ConnData
+	(*ConnClose)(nil),              // 35: clawpatrol.plugin.v1.ConnClose
+	(*ConnEvent)(nil),              // 36: clawpatrol.plugin.v1.ConnEvent
+	(*OpenTunnelRequest)(nil),      // 37: clawpatrol.plugin.v1.OpenTunnelRequest
+	(*OpenTunnelResponse)(nil),     // 38: clawpatrol.plugin.v1.OpenTunnelResponse
+	(*CloseTunnelRequest)(nil),     // 39: clawpatrol.plugin.v1.CloseTunnelRequest
+	(*CloseTunnelResponse)(nil),    // 40: clawpatrol.plugin.v1.CloseTunnelResponse
+	(*DialMessage)(nil),            // 41: clawpatrol.plugin.v1.DialMessage
+	(*DialInit)(nil),               // 42: clawpatrol.plugin.v1.DialInit
+	(*DialData)(nil),               // 43: clawpatrol.plugin.v1.DialData
+	(*DialClose)(nil),              // 44: clawpatrol.plugin.v1.DialClose
+	nil,                            // 45: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 46: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 47: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 48: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 49: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
-	9,  // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
-	10, // 1: clawpatrol.plugin.v1.ManifestResponse.tunnels:type_name -> clawpatrol.plugin.v1.TunnelDecl
-	11, // 2: clawpatrol.plugin.v1.ManifestResponse.endpoints:type_name -> clawpatrol.plugin.v1.EndpointDecl
-	5,  // 3: clawpatrol.plugin.v1.ManifestResponse.facets:type_name -> clawpatrol.plugin.v1.FacetDecl
-	6,  // 4: clawpatrol.plugin.v1.FacetDecl.fields:type_name -> clawpatrol.plugin.v1.FacetFieldDecl
+	17, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
+	18, // 1: clawpatrol.plugin.v1.ManifestResponse.tunnels:type_name -> clawpatrol.plugin.v1.TunnelDecl
+	19, // 2: clawpatrol.plugin.v1.ManifestResponse.endpoints:type_name -> clawpatrol.plugin.v1.EndpointDecl
+	6,  // 3: clawpatrol.plugin.v1.ManifestResponse.facets:type_name -> clawpatrol.plugin.v1.FacetDecl
+	7,  // 4: clawpatrol.plugin.v1.FacetDecl.fields:type_name -> clawpatrol.plugin.v1.FacetFieldDecl
 	0,  // 5: clawpatrol.plugin.v1.FacetFieldDecl.kind:type_name -> clawpatrol.plugin.v1.FacetKind
-	8,  // 6: clawpatrol.plugin.v1.Schema.fields:type_name -> clawpatrol.plugin.v1.SchemaField
-	7,  // 7: clawpatrol.plugin.v1.CredentialDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
-	7,  // 8: clawpatrol.plugin.v1.TunnelDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
-	7,  // 9: clawpatrol.plugin.v1.EndpointDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
-	1,  // 10: clawpatrol.plugin.v1.EndpointDecl.tls_mode:type_name -> clawpatrol.plugin.v1.TLSMode
-	14, // 11: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
-	2,  // 12: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	21, // 13: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
-	22, // 14: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
-	23, // 15: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
-	24, // 16: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
-	19, // 17: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
-	20, // 18: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
-	16, // 19: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
-	17, // 20: clawpatrol.plugin.v1.ConnMessage.stream_chunk:type_name -> clawpatrol.plugin.v1.StreamChunk
-	18, // 21: clawpatrol.plugin.v1.ConnMessage.stream_cancel:type_name -> clawpatrol.plugin.v1.StreamCancel
-	33, // 22: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	34, // 23: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	35, // 24: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
-	30, // 25: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
-	31, // 26: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
-	32, // 27: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
-	3,  // 28: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
-	12, // 29: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
-	15, // 30: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
-	25, // 31: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
-	29, // 32: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
-	27, // 33: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
-	4,  // 34: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	13, // 35: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	15, // 36: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	26, // 37: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	29, // 38: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	28, // 39: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	34, // [34:40] is the sub-list for method output_type
-	28, // [28:34] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	9,  // 6: clawpatrol.plugin.v1.Schema.fields:type_name -> clawpatrol.plugin.v1.SchemaField
+	12, // 7: clawpatrol.plugin.v1.OptionalScopeGroupDecl.scopes:type_name -> clawpatrol.plugin.v1.OptionalScopeDecl
+	14, // 8: clawpatrol.plugin.v1.OAuthIntegrationDecl.oauth:type_name -> clawpatrol.plugin.v1.OAuthConfigDecl
+	13, // 9: clawpatrol.plugin.v1.OAuthIntegrationDecl.optional_scopes:type_name -> clawpatrol.plugin.v1.OptionalScopeGroupDecl
+	10, // 10: clawpatrol.plugin.v1.CredentialMetadata.secret_slots:type_name -> clawpatrol.plugin.v1.SecretSlotDecl
+	11, // 11: clawpatrol.plugin.v1.CredentialMetadata.env_vars:type_name -> clawpatrol.plugin.v1.EnvVarDecl
+	15, // 12: clawpatrol.plugin.v1.CredentialMetadata.oauth:type_name -> clawpatrol.plugin.v1.OAuthIntegrationDecl
+	8,  // 13: clawpatrol.plugin.v1.CredentialDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
+	8,  // 14: clawpatrol.plugin.v1.TunnelDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
+	8,  // 15: clawpatrol.plugin.v1.EndpointDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
+	1,  // 16: clawpatrol.plugin.v1.EndpointDecl.tls_mode:type_name -> clawpatrol.plugin.v1.TLSMode
+	22, // 17: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
+	16, // 18: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
+	2,  // 19: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
+	45, // 20: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	46, // 21: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	3,  // 22: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
+	25, // 23: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
+	33, // 24: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
+	34, // 25: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
+	35, // 26: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
+	36, // 27: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
+	31, // 28: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
+	32, // 29: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
+	28, // 30: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
+	29, // 31: clawpatrol.plugin.v1.ConnMessage.stream_chunk:type_name -> clawpatrol.plugin.v1.StreamChunk
+	30, // 32: clawpatrol.plugin.v1.ConnMessage.stream_cancel:type_name -> clawpatrol.plugin.v1.StreamCancel
+	47, // 33: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	48, // 34: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	49, // 35: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	42, // 36: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
+	43, // 37: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
+	44, // 38: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
+	23, // 39: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	4,  // 40: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
+	20, // 41: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
+	24, // 42: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
+	27, // 43: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
+	37, // 44: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
+	41, // 45: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
+	39, // 46: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
+	5,  // 47: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	21, // 48: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	26, // 49: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	27, // 50: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	38, // 51: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	41, // 52: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	40, // 53: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	47, // [47:54] is the sub-list for method output_type
+	40, // [40:47] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -2515,7 +3491,7 @@ func file_plugin_proto_init() {
 	if File_plugin_proto != nil {
 		return
 	}
-	file_plugin_proto_msgTypes[12].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[23].OneofWrappers = []any{
 		(*ConnMessage_Init)(nil),
 		(*ConnMessage_Data)(nil),
 		(*ConnMessage_Close)(nil),
@@ -2526,7 +3502,7 @@ func file_plugin_proto_init() {
 		(*ConnMessage_StreamChunk)(nil),
 		(*ConnMessage_StreamCancel)(nil),
 	}
-	file_plugin_proto_msgTypes[26].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[37].OneofWrappers = []any{
 		(*DialMessage_Init)(nil),
 		(*DialMessage_Data)(nil),
 		(*DialMessage_Close)(nil),
@@ -2536,10 +3512,10 @@ func file_plugin_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   33,
+			NumEnums:      4,
+			NumMessages:   46,
 			NumExtensions: 0,
-			NumServices:   3,
+			NumServices:   4,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -97,9 +97,68 @@ message SchemaField {
   bool required = 3;
 }
 
+message SecretSlotDecl {
+  string name = 1;
+  string label = 2;
+  bool multiline = 3;
+  string description = 4;
+}
+
+message EnvVarDecl {
+  string name = 1;
+  string value = 2;
+  string description = 3;
+}
+
+message OptionalScopeDecl {
+  string id = 1;
+  string label = 2;
+}
+
+message OptionalScopeGroupDecl {
+  string title = 1;
+  repeated OptionalScopeDecl scopes = 2;
+}
+
+message OAuthConfigDecl {
+  string client_id = 1;
+  string client_secret = 2;
+  string auth_url = 3;
+  string token_url = 4;
+  string device_url = 5;
+  string register_url = 6;
+  string redirect_uri = 7;
+  repeated string scopes = 8;
+  string refresh_token = 9;
+}
+
+message OAuthIntegrationDecl {
+  string type = 1;
+  string header = 2;
+  string prefix = 3;
+  string flow = 4;
+  OAuthConfigDecl oauth = 5;
+  repeated OptionalScopeGroupDecl optional_scopes = 6;
+}
+
+message CredentialMetadata {
+  repeated string disambiguators = 1;
+  repeated SecretSlotDecl secret_slots = 2;
+  repeated EnvVarDecl env_vars = 3;
+  OAuthIntegrationDecl oauth = 4;
+  bool http_inject = 5;
+}
+
 message CredentialDecl {
   string type_name = 1;
   Schema schema = 2;
+
+  // Declares static capabilities for registration/validation.
+  // BuildResponse.credential_metadata may refine instance-specific
+  // env vars, slots, and OAuth URLs, but registration-time
+  // disambiguators are authoritative for validation.
+  repeated string disambiguators = 3;
+  bool http_inject = 4;
 }
 
 message TunnelDecl {
@@ -143,6 +202,10 @@ message BuildResponse {
   // ConnInit / OpenTunnelRequest.
   bytes canonical_json = 1;
   repeated Diagnostic diagnostics = 2;
+
+  // Used when kind == "credential". Instance-specific metadata
+  // derived from config, e.g. region-specific env vars/OAuth URLs.
+  CredentialMetadata credential_metadata = 3;
 }
 
 message Diagnostic {
@@ -153,6 +216,59 @@ message Diagnostic {
   Severity severity = 1;
   string summary = 2;
   string detail = 3;
+}
+
+// =====================================================================
+// Credential runtime
+// =====================================================================
+
+service Credential {
+  // InjectHTTP lets an external credential type participate in the
+  // built-in HTTPS endpoint's request-time credential injection path.
+  rpc InjectHTTP(InjectHTTPRequest) returns (InjectHTTPResponse);
+}
+
+message HTTPHeaderValues {
+  repeated string values = 1;
+}
+
+message InjectHTTPRequest {
+  string credential_type_name = 1;
+  string credential_instance = 2;
+  bytes credential_canonical_json = 3;
+
+  bytes credential_secret = 4;
+  map<string, string> credential_extras = 5;
+
+  string method = 6;
+  string url = 7;
+  string host = 8;
+  map<string, HTTPHeaderValues> headers = 9;
+
+  // Optional, capped by gateway. Not required by current external
+  // credentials but reserved for future read-only inspection.
+  bytes body_prefix = 10;
+  bool body_truncated = 11;
+}
+
+message HeaderMutation {
+  enum Op {
+    SET = 0;
+    ADD = 1;
+    DEL = 2;
+  }
+  Op op = 1;
+  string name = 2;
+  repeated string values = 3;
+}
+
+message InjectHTTPResponse {
+  repeated HeaderMutation headers = 1;
+
+  // Extra runtime-derived sensitive values, such as a gateway-minted
+  // short-lived bearer token, that should be redacted from logs if
+  // encountered.
+  repeated string redactions = 2;
 }
 
 // =====================================================================

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -190,6 +190,112 @@ var Plugin_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
+	Credential_InjectHTTP_FullMethodName = "/clawpatrol.plugin.v1.Credential/InjectHTTP"
+)
+
+// CredentialClient is the client API for Credential service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+type CredentialClient interface {
+	// InjectHTTP lets an external credential type participate in the
+	// built-in HTTPS endpoint's request-time credential injection path.
+	InjectHTTP(ctx context.Context, in *InjectHTTPRequest, opts ...grpc.CallOption) (*InjectHTTPResponse, error)
+}
+
+type credentialClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewCredentialClient(cc grpc.ClientConnInterface) CredentialClient {
+	return &credentialClient{cc}
+}
+
+func (c *credentialClient) InjectHTTP(ctx context.Context, in *InjectHTTPRequest, opts ...grpc.CallOption) (*InjectHTTPResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InjectHTTPResponse)
+	err := c.cc.Invoke(ctx, Credential_InjectHTTP_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CredentialServer is the server API for Credential service.
+// All implementations must embed UnimplementedCredentialServer
+// for forward compatibility.
+type CredentialServer interface {
+	// InjectHTTP lets an external credential type participate in the
+	// built-in HTTPS endpoint's request-time credential injection path.
+	InjectHTTP(context.Context, *InjectHTTPRequest) (*InjectHTTPResponse, error)
+	mustEmbedUnimplementedCredentialServer()
+}
+
+// UnimplementedCredentialServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedCredentialServer struct{}
+
+func (UnimplementedCredentialServer) InjectHTTP(context.Context, *InjectHTTPRequest) (*InjectHTTPResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InjectHTTP not implemented")
+}
+func (UnimplementedCredentialServer) mustEmbedUnimplementedCredentialServer() {}
+func (UnimplementedCredentialServer) testEmbeddedByValue()                    {}
+
+// UnsafeCredentialServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to CredentialServer will
+// result in compilation errors.
+type UnsafeCredentialServer interface {
+	mustEmbedUnimplementedCredentialServer()
+}
+
+func RegisterCredentialServer(s grpc.ServiceRegistrar, srv CredentialServer) {
+	// If the following call panics, it indicates UnimplementedCredentialServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&Credential_ServiceDesc, srv)
+}
+
+func _Credential_InjectHTTP_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InjectHTTPRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CredentialServer).InjectHTTP(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Credential_InjectHTTP_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CredentialServer).InjectHTTP(ctx, req.(*InjectHTTPRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// Credential_ServiceDesc is the grpc.ServiceDesc for Credential service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var Credential_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.Credential",
+	HandlerType: (*CredentialServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "InjectHTTP",
+			Handler:    _Credential_InjectHTTP_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "plugin.proto",
+}
+
+const (
 	Endpoint_HandleConn_FullMethodName = "/clawpatrol.plugin.v1.Endpoint/HandleConn"
 )
 

--- a/internal/config/extplugin/register.go
+++ b/internal/config/extplugin/register.go
@@ -3,6 +3,7 @@ package extplugin
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/denoland/clawpatrol/internal/config"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
@@ -153,7 +154,11 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 				if resp.CredentialMetadata.HttpInject && !decl.HttpInject {
 					return nil, fail("plugin %q credential %q: build metadata declared HTTP injection but manifest did not", pluginName, decl.TypeName)
 				}
-				meta = mergeCredentialMetadata(manifestMeta, credentialMetadataFromProto(resp.CredentialMetadata))
+				instanceMeta := credentialMetadataFromProto(resp.CredentialMetadata)
+				if d := validateCredentialMetadataShape(pluginName, decl.TypeName, instanceMeta); d.HasErrors() {
+					return nil, d
+				}
+				meta = mergeCredentialMetadata(manifestMeta, instanceMeta)
 			}
 			b.metadata = meta
 			return wrapCredentialBody(b), nil
@@ -260,12 +265,46 @@ func mergeCredentialMetadata(base, instance credentialMetadata) credentialMetada
 	out := base
 	out.secretSlots = instance.secretSlots
 	out.envVars = instance.envVars
+	// OAuth is intentionally instance-scoped Build metadata: region, scopes,
+	// URLs, and flow can differ across two HCL blocks of the same type.
 	out.oauth = instance.oauth
 	// HTTP injection is a registration-time capability. Build metadata
 	// can restate it but cannot enable it for a type whose manifest did
 	// not declare it.
 	out.httpInject = base.httpInject
 	return out
+}
+
+func validateCredentialMetadataShape(pluginName, typeName string, meta credentialMetadata) hcl.Diagnostics {
+	seenSlots := map[string]bool{}
+	unnamedSlots := 0
+	for _, slot := range meta.secretSlots {
+		name := strings.TrimSpace(slot.Name)
+		if name == "" {
+			unnamedSlots++
+			if unnamedSlots > 1 {
+				return fail("plugin %q credential %q: build metadata declared multiple unnamed secret slots", pluginName, typeName)
+			}
+			continue
+		}
+		if seenSlots[name] {
+			return fail("plugin %q credential %q: build metadata declared duplicate secret slot %q", pluginName, typeName, name)
+		}
+		seenSlots[name] = true
+	}
+
+	seenEnv := map[string]bool{}
+	for _, ev := range meta.envVars {
+		name := strings.TrimSpace(ev.Name)
+		if name == "" {
+			return fail("plugin %q credential %q: build metadata declared empty env var name", pluginName, typeName)
+		}
+		if seenEnv[name] {
+			return fail("plugin %q credential %q: build metadata declared duplicate env var %q", pluginName, typeName, name)
+		}
+		seenEnv[name] = true
+	}
+	return nil
 }
 
 func validateBuildDisambiguators(pluginName, typeName string, supported, got []string) hcl.Diagnostics {

--- a/internal/config/extplugin/register.go
+++ b/internal/config/extplugin/register.go
@@ -107,11 +107,16 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 	if err != nil {
 		return fail("plugin %q credential %q: %v", pluginName, decl.TypeName, err)
 	}
+	adapter := &credentialAdapter{client: client, typeName: decl.TypeName}
+	manifestMeta := credentialMetadataFromDecl(decl)
 
 	plug := &config.Plugin{
-		Kind: config.KindCredential,
-		Type: decl.TypeName,
-		New:  func() any { return &dynamicCredentialBody{} },
+		Kind:           config.KindCredential,
+		Type:           decl.TypeName,
+		Disambiguators: append([]string(nil), decl.Disambiguators...),
+		New: func() any {
+			return &dynamicCredentialBody{adapter: adapter, metadata: manifestMeta}
+		},
 		DecodeBody: func(body hcl.Body, ctx *hcl.EvalContext, target any) hcl.Diagnostics {
 			b := target.(*dynamicCredentialBody)
 			val, d := hcldec.Decode(body, spec, ctx)
@@ -127,6 +132,7 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 		},
 		Build: func(decoded any, name string, _ *config.BuildCtx) (any, hcl.Diagnostics) {
 			b := decoded.(*dynamicCredentialBody)
+			b.instanceName = name
 			resp, err := client.PluginRPC().Build(context.Background(), &pb.BuildRequest{
 				Kind: "credential", TypeName: decl.TypeName, InstanceName: name, ConfigJson: b.canonicalJSON,
 			})
@@ -139,12 +145,135 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 			if len(resp.CanonicalJson) > 0 {
 				b.canonicalJSON = resp.CanonicalJson
 			}
-			return b, nil
+			meta := manifestMeta
+			if resp.CredentialMetadata != nil {
+				if d := validateBuildDisambiguators(pluginName, decl.TypeName, decl.Disambiguators, resp.CredentialMetadata.Disambiguators); d.HasErrors() {
+					return nil, d
+				}
+				if resp.CredentialMetadata.HttpInject && !decl.HttpInject {
+					return nil, fail("plugin %q credential %q: build metadata declared HTTP injection but manifest did not", pluginName, decl.TypeName)
+				}
+				meta = mergeCredentialMetadata(manifestMeta, credentialMetadataFromProto(resp.CredentialMetadata))
+			}
+			b.metadata = meta
+			return wrapCredentialBody(b), nil
 		},
 		Emit: func(_ any, _ string, _ *hclwrite.Body) {},
 	}
 	if d := registerOrCollide(plug, pluginName, "credential"); d != nil {
 		return d
+	}
+	return nil
+}
+
+func credentialMetadataFromDecl(decl *pb.CredentialDecl) credentialMetadata {
+	if decl == nil {
+		return credentialMetadata{}
+	}
+	return credentialMetadata{
+		disambiguators: append([]string(nil), decl.Disambiguators...),
+		httpInject:     decl.HttpInject,
+	}
+}
+
+func credentialMetadataFromProto(in *pb.CredentialMetadata) credentialMetadata {
+	if in == nil {
+		return credentialMetadata{}
+	}
+	out := credentialMetadata{
+		disambiguators: append([]string(nil), in.Disambiguators...),
+		httpInject:     in.HttpInject,
+	}
+	for _, s := range in.SecretSlots {
+		if s == nil {
+			continue
+		}
+		out.secretSlots = append(out.secretSlots, config.SecretSlot{
+			Name:        s.Name,
+			Label:       s.Label,
+			Multiline:   s.Multiline,
+			Description: s.Description,
+		})
+	}
+	for _, ev := range in.EnvVars {
+		if ev == nil {
+			continue
+		}
+		out.envVars = append(out.envVars, config.EnvVar{
+			Name:        ev.Name,
+			Value:       ev.Value,
+			Description: ev.Description,
+		})
+	}
+	if in.Oauth != nil {
+		out.oauth = oauthIntegrationFromProto(in.Oauth)
+	}
+	return out
+}
+
+func oauthIntegrationFromProto(in *pb.OAuthIntegrationDecl) *config.OAuthIntegration {
+	if in == nil {
+		return nil
+	}
+	out := &config.OAuthIntegration{
+		Type:   in.Type,
+		Header: in.Header,
+		Prefix: in.Prefix,
+		Flow:   in.Flow,
+	}
+	if in.Oauth != nil {
+		out.OAuth = config.OAuthConfig{
+			ClientID:     in.Oauth.ClientId,
+			ClientSecret: in.Oauth.ClientSecret,
+			AuthURL:      in.Oauth.AuthUrl,
+			TokenURL:     in.Oauth.TokenUrl,
+			DeviceURL:    in.Oauth.DeviceUrl,
+			RegisterURL:  in.Oauth.RegisterUrl,
+			RedirectURI:  in.Oauth.RedirectUri,
+			Scopes:       append([]string(nil), in.Oauth.Scopes...),
+			RefreshToken: in.Oauth.RefreshToken,
+		}
+	}
+	for _, g := range in.OptionalScopes {
+		if g == nil {
+			continue
+		}
+		group := config.OptionalScopeGroup{Title: g.Title}
+		for _, s := range g.Scopes {
+			if s == nil {
+				continue
+			}
+			group.Scopes = append(group.Scopes, config.OptionalScope{ID: s.Id, Label: s.Label})
+		}
+		out.OptionalScopes = append(out.OptionalScopes, group)
+	}
+	return out
+}
+
+func mergeCredentialMetadata(base, instance credentialMetadata) credentialMetadata {
+	out := base
+	out.secretSlots = instance.secretSlots
+	out.envVars = instance.envVars
+	out.oauth = instance.oauth
+	// HTTP injection is a registration-time capability. Build metadata
+	// can restate it but cannot enable it for a type whose manifest did
+	// not declare it.
+	out.httpInject = base.httpInject
+	return out
+}
+
+func validateBuildDisambiguators(pluginName, typeName string, supported, got []string) hcl.Diagnostics {
+	if len(got) == 0 {
+		return nil
+	}
+	allowed := map[string]bool{}
+	for _, s := range supported {
+		allowed[s] = true
+	}
+	for _, s := range got {
+		if !allowed[s] {
+			return fail("plugin %q credential %q: build metadata declared unsupported disambiguator %q", pluginName, typeName, s)
+		}
 	}
 	return nil
 }

--- a/internal/config/extplugin/register.go
+++ b/internal/config/extplugin/register.go
@@ -250,6 +250,12 @@ func oauthIntegrationFromProto(in *pb.OAuthIntegrationDecl) *config.OAuthIntegra
 	return out
 }
 
+// mergeCredentialMetadata combines registration-time (base) and
+// Build-time (instance) credential metadata. The per-instance
+// surfaces — secret slots, env vars, OAuth — are wholesale REPLACED
+// by the instance metadata, not appended: the manifest declaration
+// cannot carry them, so whatever Build returned is the complete set
+// for that instance.
 func mergeCredentialMetadata(base, instance credentialMetadata) credentialMetadata {
 	out := base
 	out.secretSlots = instance.secretSlots

--- a/internal/config/plugins/approvers/llm.go
+++ b/internal/config/plugins/approvers/llm.go
@@ -98,8 +98,10 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
 	}
 	if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
+		discardHTTPRedactions(injector, hreq)
 		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential inject: " + err.Error()}, nil
 	}
+	discardHTTPRedactions(injector, hreq)
 	c := &http.Client{Timeout: 30 * time.Second}
 	resp, err := c.Do(hreq)
 	if err != nil {
@@ -117,6 +119,12 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	verdict, reason := parseJudgeVerdict(text)
 	by := "llm:" + a.Model
 	return runtime.ApproveVerdict{Decision: verdict, Reason: reason, By: by}, nil
+}
+
+func discardHTTPRedactions(injector runtime.HTTPCredentialRuntime, req *http.Request) {
+	if rp, ok := injector.(runtime.HTTPCredentialRedactionProvider); ok {
+		_ = rp.ConsumeHTTPRedactions(req)
+	}
 }
 
 func buildJudgePrompt(req runtime.ApproveRequest, policyText string) string {
@@ -306,8 +314,10 @@ func (a *LLMApprover) Summarize(ctx context.Context, req runtime.ApproveRequest)
 		return nil, fmt.Errorf("secret fetch: %w", err)
 	}
 	if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
+		discardHTTPRedactions(injector, hreq)
 		return nil, fmt.Errorf("credential inject: %w", err)
 	}
+	discardHTTPRedactions(injector, hreq)
 	c := &http.Client{Timeout: 30 * time.Second}
 	resp, err := c.Do(hreq)
 	if err != nil {

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -30,6 +30,15 @@ type HTTPCredentialRuntime interface {
 	InjectHTTP(ctx context.Context, req *http.Request, sec Secret) error
 }
 
+// HTTPCredentialRedactionProvider is an optional companion to
+// HTTPCredentialRuntime for injectors that derive additional sensitive
+// values at request time. The gateway calls ConsumeHTTPRedactions after
+// InjectHTTP and adds the returned values to request audit redaction.
+// Implementations should forget the values they return for req.
+type HTTPCredentialRedactionProvider interface {
+	ConsumeHTTPRedactions(req *http.Request) []string
+}
+
 // HTTPRequestSigner is the credential-plugin contract for HTTP auth
 // shapes whose signature spans the *whole request* (method, URL,
 // headers, body) and need parameters that live on the endpoint, not

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -26,6 +26,13 @@ import (
 //
 // Implementations live next to their config plugin so the schema and
 // runtime stay co-located, mirroring unclaw's plugin layout.
+//
+// Callers MUST check whether the injector also implements
+// HTTPCredentialRedactionProvider and, if so, call
+// ConsumeHTTPRedactions(req) after InjectHTTP returns — including on
+// inject error. Skipping the consume strands the injector's
+// per-request redaction state for the lifetime of the credential
+// instance.
 type HTTPCredentialRuntime interface {
 	InjectHTTP(ctx context.Context, req *http.Request, sec Secret) error
 }

--- a/pluginsdk/example/magic_token.go
+++ b/pluginsdk/example/magic_token.go
@@ -1,6 +1,12 @@
 package main
 
-import "github.com/denoland/clawpatrol/pluginsdk"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+)
 
 // magicToken is the credential type the example plugin's endpoints
 // consume. The token bytes themselves live in the gateway's secret
@@ -13,7 +19,9 @@ type magicToken struct {
 
 func magicTokenDef() pluginsdk.CredentialDef {
 	return pluginsdk.CredentialDef{
-		TypeName: "example_magic_token",
+		TypeName:       "example_magic_token",
+		Disambiguators: []string{"placeholder"},
+		HTTPInject:     true,
 		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
 			{Name: "header_name", TypeString: "string"},
 		}},
@@ -25,7 +33,35 @@ func magicTokenDef() pluginsdk.CredentialDef {
 			if c.HeaderName == "" {
 				c.HeaderName = "X-Magic"
 			}
-			return c, nil
+			return pluginsdk.CredentialBuildResult{
+				Canonical: c,
+				Metadata: pluginsdk.CredentialMetadata{
+					SecretSlots: []pluginsdk.SecretSlot{{Label: "Magic token", Description: "Stored by the gateway and injected into the configured header."}},
+					EnvVars:     []pluginsdk.EnvVar{{Name: "EXAMPLE_MAGIC_TOKEN", Value: "PH_example_magic", Description: "Example placeholder token for built-in HTTPS injection."}},
+					HTTPInject:  true,
+				},
+			}, nil
+		},
+		InjectHTTP: func(_ context.Context, req pluginsdk.HTTPInjectRequest) (*pluginsdk.HTTPInjectResponse, error) {
+			headerName := "X-Magic"
+			if len(req.CredentialCanonicalConfig) > 0 {
+				var c magicToken
+				if err := json.Unmarshal(req.CredentialCanonicalConfig, &c); err == nil && c.HeaderName != "" {
+					headerName = c.HeaderName
+				}
+			}
+			if http.CanonicalHeaderKey(headerName) == "Authorization" {
+				return &pluginsdk.HTTPInjectResponse{Headers: []pluginsdk.HeaderMutation{{
+					Op:     pluginsdk.HeaderSet,
+					Name:   headerName,
+					Values: []string{"Bearer " + string(req.CredentialSecret)},
+				}}}, nil
+			}
+			return &pluginsdk.HTTPInjectResponse{Headers: []pluginsdk.HeaderMutation{{
+				Op:     pluginsdk.HeaderSet,
+				Name:   headerName,
+				Values: []string{string(req.CredentialSecret)},
+			}}}, nil
 		},
 	}
 }

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -188,7 +188,9 @@ type HeaderMutationOp string
 const (
 	// HeaderSet replaces all existing values for the named request header.
 	HeaderSet HeaderMutationOp = "set"
-	// HeaderAdd appends values to the named request header.
+	// HeaderAdd appends values to the named request header. Use HeaderSet for
+	// Authorization and other replacement-style auth headers so the agent's
+	// placeholder header is removed before the real value is forwarded.
 	HeaderAdd HeaderMutationOp = "add"
 	// HeaderDel removes the named request header.
 	HeaderDel HeaderMutationOp = "del"

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -186,8 +186,11 @@ type CredentialBuildResult struct {
 type HeaderMutationOp string
 
 const (
+	// HeaderSet replaces all existing values for the named request header.
 	HeaderSet HeaderMutationOp = "set"
+	// HeaderAdd appends values to the named request header.
 	HeaderAdd HeaderMutationOp = "add"
+	// HeaderDel removes the named request header.
 	HeaderDel HeaderMutationOp = "del"
 )
 

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -222,7 +222,10 @@ type HTTPInjectRequest struct {
 // HTTPInjectResponse is the header-only mutation set returned by an
 // external credential InjectHTTP callback.
 type HTTPInjectResponse struct {
-	Headers    []HeaderMutation
+	Headers []HeaderMutation
+	// Redactions lists exact derived secret strings the gateway should mask from
+	// audit samples. Include any exchanged JWTs, HMAC signatures, or other values
+	// derived from CredentialSecret that are injected into non-sensitive headers.
 	Redactions []string
 }
 

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
 
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 )
@@ -108,20 +109,148 @@ type StreamValue struct {
 	R io.Reader
 }
 
+// SecretSlot describes one dashboard secret input an external
+// credential type exposes to operators.
+type SecretSlot struct {
+	Name        string
+	Label       string
+	Multiline   bool
+	Description string
+}
+
+// EnvVar is one environment variable pushed to agent processes. The
+// Value should be a placeholder, not a real secret.
+type EnvVar struct {
+	Name        string
+	Value       string
+	Description string
+}
+
+// OptionalScopeGroup is one dashboard OAuth scope-picker section.
+type OptionalScopeGroup struct {
+	Title  string
+	Scopes []OptionalScope
+}
+
+// OptionalScope is one toggleable OAuth scope.
+type OptionalScope struct {
+	ID    string
+	Label string
+}
+
+// OAuthConfig describes the OAuth client/endpoint configuration for
+// an external credential's gateway-owned OAuth flow.
+type OAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	AuthURL      string
+	TokenURL     string
+	DeviceURL    string
+	RegisterURL  string
+	RedirectURI  string
+	Scopes       []string
+	RefreshToken string
+}
+
+// OAuthIntegration describes how an OAuth access token is acquired and
+// injected for an external credential.
+type OAuthIntegration struct {
+	Type           string
+	Header         string
+	Prefix         string
+	Flow           string
+	OAuth          OAuthConfig
+	OptionalScopes []OptionalScopeGroup
+}
+
+// CredentialMetadata is the instance-specific metadata a credential
+// Build callback may return alongside its canonical config.
+type CredentialMetadata struct {
+	Disambiguators []string
+	SecretSlots    []SecretSlot
+	EnvVars        []EnvVar
+	OAuth          *OAuthIntegration
+	HTTPInject     bool
+}
+
+// CredentialBuildResult lets a Build callback return both canonical
+// config and instance-specific metadata. Returning a plain value keeps
+// the legacy behavior and treats that value as canonical config.
+type CredentialBuildResult struct {
+	Canonical any
+	Metadata  CredentialMetadata
+}
+
+// HeaderMutationOp is a request-header operation returned by an
+// external credential InjectHTTP callback.
+type HeaderMutationOp string
+
+const (
+	HeaderSet HeaderMutationOp = "set"
+	HeaderAdd HeaderMutationOp = "add"
+	HeaderDel HeaderMutationOp = "del"
+)
+
+// HeaderMutation mutates an outbound HTTP request header.
+type HeaderMutation struct {
+	Op     HeaderMutationOp
+	Name   string
+	Values []string
+}
+
+// HTTPInjectRequest is sent to an external credential just before the
+// built-in HTTPS endpoint forwards a request upstream.
+type HTTPInjectRequest struct {
+	CredentialTypeName        string
+	CredentialInstance        string
+	CredentialCanonicalConfig []byte
+	CredentialSecret          []byte
+	CredentialExtras          map[string]string
+
+	Method  string
+	URL     string
+	Host    string
+	Headers http.Header
+
+	BodyPrefix    []byte
+	BodyTruncated bool
+}
+
+// HTTPInjectResponse is the header-only mutation set returned by an
+// external credential InjectHTTP callback.
+type HTTPInjectResponse struct {
+	Headers    []HeaderMutation
+	Redactions []string
+}
+
 // CredentialDef declares one credential type. The plugin's endpoints
-// receive the credential's secret bytes via Conn.CredentialSecret;
-// there is no per-request RPC for credential injection in v1, since
-// "plugin owns the whole conn" means the plugin's endpoint code
-// applies the credential however the protocol requires.
+// still receive the credential's secret bytes via Conn.CredentialSecret,
+// and credentials with HTTPInject=true can also participate in the
+// built-in HTTPS endpoint's request-time injection path.
 type CredentialDef struct {
 	TypeName string
 	Schema   Schema
+
+	// Disambiguators names registration-time supported dispatch
+	// discriminator fields, e.g. "placeholder" for HTTP bearer-style
+	// credentials. The gateway validates credential/profile HCL against
+	// this list.
+	Disambiguators []string
+
+	// HTTPInject declares that this credential can inject into the
+	// built-in HTTPS endpoint via InjectHTTP.
+	HTTPInject bool
+
 	// Build is optional. When set, the gateway invokes it once per
 	// HCL block at config-load time. The plugin can validate the
-	// decoded body, fill defaults, and return a canonical form that
-	// later rides on Conn.CredentialCanonicalJSON. When nil, the
-	// SDK echoes the request body unchanged.
+	// decoded body, fill defaults, and return either a canonical form
+	// or CredentialBuildResult. When nil, the SDK echoes the request
+	// body unchanged.
 	Build func(req BuildRequest) (any, error)
+
+	// InjectHTTP is called for credentials bound to a built-in HTTPS
+	// endpoint when HTTPInject is true.
+	InjectHTTP func(ctx context.Context, req HTTPInjectRequest) (*HTTPInjectResponse, error)
 }
 
 // TunnelDef declares one tunnel type. Open returns an opaque handle

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -174,7 +176,7 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 			return nil, fmt.Errorf("%w: credential %q", ErrNoSuchType, req.TypeName)
 		}
 		if def.Build != nil {
-			built, err = def.Build(br)
+			built, err = invokeBuild("credential", req.TypeName, req.InstanceName, def.Build, br)
 		}
 	case "tunnel":
 		def, ok := s.tunnels[req.TypeName]
@@ -182,7 +184,7 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 			return nil, fmt.Errorf("%w: tunnel %q", ErrNoSuchType, req.TypeName)
 		}
 		if def.Build != nil {
-			built, err = def.Build(br)
+			built, err = invokeBuild("tunnel", req.TypeName, req.InstanceName, def.Build, br)
 		}
 	case "endpoint":
 		def, ok := s.endpoints[req.TypeName]
@@ -190,7 +192,7 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 			return nil, fmt.Errorf("%w: endpoint %q", ErrNoSuchType, req.TypeName)
 		}
 		if def.Build != nil {
-			built, err = def.Build(br)
+			built, err = invokeBuild("endpoint", req.TypeName, req.InstanceName, def.Build, br)
 		}
 	default:
 		return nil, fmt.Errorf("pluginsdk: unknown build kind %q", req.Kind)
@@ -237,6 +239,15 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 		resp.CanonicalJson = req.ConfigJson
 	}
 	return resp, nil
+}
+
+func invokeBuild(kind, typeName, instanceName string, fn func(BuildRequest) (any, error), req BuildRequest) (built any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("%s.%s %q Build", kind, typeName, instanceName), r)
+		}
+	}()
+	return fn(req)
 }
 
 func credentialMetadataToProto(m CredentialMetadata) *pb.CredentialMetadata {
@@ -316,11 +327,20 @@ func (s *server) InjectHTTP(ctx context.Context, req *pb.InjectHTTPRequest) (*pb
 		BodyPrefix:                req.BodyPrefix,
 		BodyTruncated:             req.BodyTruncated,
 	}
-	out, err := def.InjectHTTP(ctx, in)
+	out, err := invokeInjectHTTP(ctx, req.CredentialTypeName, req.CredentialInstance, def.InjectHTTP, in)
 	if err != nil {
 		return nil, err
 	}
 	return httpInjectResponseToProto(out), nil
+}
+
+func invokeInjectHTTP(ctx context.Context, typeName, instanceName string, fn func(context.Context, HTTPInjectRequest) (*HTTPInjectResponse, error), req HTTPInjectRequest) (out *HTTPInjectResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("credential.%s %q InjectHTTP", typeName, instanceName), r)
+		}
+	}()
+	return fn(ctx, req)
 }
 
 func headersFromProto(in map[string]*pb.HTTPHeaderValues) http.Header {
@@ -610,7 +630,7 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		}
 	}()
 
-	handleErr := def.HandleConn(ctx, conn)
+	handleErr := invokeHandleConn(ctx, def, conn)
 	_ = conn.Close()
 	closer()
 	<-recvErr
@@ -628,6 +648,49 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		}})
 	}
 	return handleErr
+}
+
+func invokeHandleConn(ctx context.Context, def EndpointDef, conn *Conn) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("endpoint.%s HandleConn", def.TypeName), r)
+		}
+	}()
+	if def.HandleConn == nil {
+		return fmt.Errorf("pluginsdk: endpoint %q has no HandleConn callback", def.TypeName)
+	}
+	return def.HandleConn(ctx, conn)
+}
+
+func invokeTunnelOpen(ctx context.Context, def TunnelDef, req TunnelOpenRequest) (handle any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("tunnel.%s %q Open", def.TypeName, req.TunnelInstance), r)
+		}
+	}()
+	return def.Open(ctx, req)
+}
+
+func invokeTunnelClose(ctx context.Context, def TunnelDef, handle any) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("tunnel.%s Close", def.TypeName), r)
+		}
+	}()
+	return def.Close(ctx, handle)
+}
+
+func invokeTunnelDial(ctx context.Context, def TunnelDef, req TunnelDialRequest, conn net.Conn) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("tunnel.%s Dial", def.TypeName), r)
+		}
+	}()
+	return def.Dial(ctx, req, conn)
+}
+
+func callbackPanicError(where string, r any) error {
+	return fmt.Errorf("pluginsdk: panic in %s: %v\n%s", where, r, debug.Stack())
 }
 
 // streamReg holds one StreamValue's reader plus a cancel sentinel
@@ -719,7 +782,7 @@ func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb
 		err    error
 	)
 	if def.Open != nil {
-		handle, err = def.Open(ctx, openReq)
+		handle, err = invokeTunnelOpen(ctx, def, openReq)
 		if err != nil {
 			return nil, fmt.Errorf("plugin tunnel %q open: %w", req.TunnelInstance, err)
 		}
@@ -738,7 +801,7 @@ func (s *server) CloseTunnel(ctx context.Context, req *pb.CloseTunnelRequest) (*
 	}
 	th := v.(*tunnelHandle)
 	if th.def.Close != nil {
-		if err := th.def.Close(ctx, th.handle); err != nil {
+		if err := invokeTunnelClose(ctx, th.def, th.handle); err != nil {
 			return nil, err
 		}
 	}
@@ -818,7 +881,7 @@ func (s *server) Dial(stream pb.Tunnel_DialServer) error {
 		}
 	}()
 
-	dialErr := th.def.Dial(ctx, TunnelDialRequest{
+	dialErr := invokeTunnelDial(ctx, th.def, TunnelDialRequest{
 		Handle:  th.handle,
 		Network: initMsg.Init.Network,
 		Addr:    initMsg.Init.Addr,

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"sync/atomic"
 
@@ -47,6 +48,7 @@ type grpcServer struct {
 
 func (g *grpcServer) GRPCServer(_ *plugin.GRPCBroker, s *grpc.Server) error {
 	pb.RegisterPluginServer(s, g.srv)
+	pb.RegisterCredentialServer(s, g.srv)
 	pb.RegisterEndpointServer(s, g.srv)
 	pb.RegisterTunnelServer(s, g.srv)
 	return nil
@@ -60,6 +62,7 @@ func (g *grpcServer) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, _ *grpc
 // server is the in-process dispatcher behind the three gRPC services.
 type server struct {
 	pb.UnimplementedPluginServer
+	pb.UnimplementedCredentialServer
 	pb.UnimplementedEndpointServer
 	pb.UnimplementedTunnelServer
 
@@ -100,8 +103,10 @@ func (s *server) Manifest(_ context.Context, _ *pb.ManifestRequest) (*pb.Manifes
 	}
 	for _, c := range s.plug.Credentials {
 		resp.Credentials = append(resp.Credentials, &pb.CredentialDecl{
-			TypeName: c.TypeName,
-			Schema:   schemaToProto(c.Schema),
+			TypeName:       c.TypeName,
+			Schema:         schemaToProto(c.Schema),
+			Disambiguators: append([]string(nil), c.Disambiguators...),
+			HttpInject:     c.HTTPInject,
 		})
 	}
 	for _, t := range s.plug.Tunnels {
@@ -201,8 +206,22 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 		return resp, nil //nolint:nilerr // Build errors are returned as diagnostics in the successful gRPC response.
 	}
 
-	if built != nil {
-		j, jerr := json.Marshal(built)
+	canonical := built
+	if req.Kind == "credential" {
+		switch r := built.(type) {
+		case CredentialBuildResult:
+			canonical = r.Canonical
+			resp.CredentialMetadata = credentialMetadataToProto(r.Metadata)
+		case *CredentialBuildResult:
+			if r != nil {
+				canonical = r.Canonical
+				resp.CredentialMetadata = credentialMetadataToProto(r.Metadata)
+			}
+		}
+	}
+
+	if canonical != nil {
+		j, jerr := json.Marshal(canonical)
 		if jerr != nil {
 			resp.Diagnostics = []*pb.Diagnostic{{
 				Severity: pb.Diagnostic_ERROR,
@@ -218,6 +237,124 @@ func (s *server) Build(_ context.Context, req *pb.BuildRequest) (*pb.BuildRespon
 		resp.CanonicalJson = req.ConfigJson
 	}
 	return resp, nil
+}
+
+func credentialMetadataToProto(m CredentialMetadata) *pb.CredentialMetadata {
+	out := &pb.CredentialMetadata{
+		Disambiguators: append([]string(nil), m.Disambiguators...),
+		HttpInject:     m.HTTPInject,
+	}
+	for _, s := range m.SecretSlots {
+		out.SecretSlots = append(out.SecretSlots, &pb.SecretSlotDecl{
+			Name:        s.Name,
+			Label:       s.Label,
+			Multiline:   s.Multiline,
+			Description: s.Description,
+		})
+	}
+	for _, ev := range m.EnvVars {
+		out.EnvVars = append(out.EnvVars, &pb.EnvVarDecl{
+			Name:        ev.Name,
+			Value:       ev.Value,
+			Description: ev.Description,
+		})
+	}
+	if m.OAuth != nil {
+		out.Oauth = oauthIntegrationToProto(*m.OAuth)
+	}
+	return out
+}
+
+func oauthIntegrationToProto(in OAuthIntegration) *pb.OAuthIntegrationDecl {
+	out := &pb.OAuthIntegrationDecl{
+		Type:   in.Type,
+		Header: in.Header,
+		Prefix: in.Prefix,
+		Flow:   in.Flow,
+		Oauth: &pb.OAuthConfigDecl{
+			ClientId:     in.OAuth.ClientID,
+			ClientSecret: in.OAuth.ClientSecret,
+			AuthUrl:      in.OAuth.AuthURL,
+			TokenUrl:     in.OAuth.TokenURL,
+			DeviceUrl:    in.OAuth.DeviceURL,
+			RegisterUrl:  in.OAuth.RegisterURL,
+			RedirectUri:  in.OAuth.RedirectURI,
+			Scopes:       append([]string(nil), in.OAuth.Scopes...),
+			RefreshToken: in.OAuth.RefreshToken,
+		},
+	}
+	for _, g := range in.OptionalScopes {
+		pg := &pb.OptionalScopeGroupDecl{Title: g.Title}
+		for _, s := range g.Scopes {
+			pg.Scopes = append(pg.Scopes, &pb.OptionalScopeDecl{Id: s.ID, Label: s.Label})
+		}
+		out.OptionalScopes = append(out.OptionalScopes, pg)
+	}
+	return out
+}
+
+// InjectHTTP dispatches a built-in HTTPS credential injection call to
+// the credential definition's callback.
+func (s *server) InjectHTTP(ctx context.Context, req *pb.InjectHTTPRequest) (*pb.InjectHTTPResponse, error) {
+	def, ok := s.credentials[req.CredentialTypeName]
+	if !ok {
+		return nil, fmt.Errorf("%w: credential %q", ErrNoSuchType, req.CredentialTypeName)
+	}
+	if def.InjectHTTP == nil {
+		return nil, fmt.Errorf("pluginsdk: credential %q has no InjectHTTP callback", req.CredentialTypeName)
+	}
+	in := HTTPInjectRequest{
+		CredentialTypeName:        req.CredentialTypeName,
+		CredentialInstance:        req.CredentialInstance,
+		CredentialCanonicalConfig: req.CredentialCanonicalJson,
+		CredentialSecret:          req.CredentialSecret,
+		CredentialExtras:          req.CredentialExtras,
+		Method:                    req.Method,
+		URL:                       req.Url,
+		Host:                      req.Host,
+		Headers:                   headersFromProto(req.Headers),
+		BodyPrefix:                req.BodyPrefix,
+		BodyTruncated:             req.BodyTruncated,
+	}
+	out, err := def.InjectHTTP(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return httpInjectResponseToProto(out), nil
+}
+
+func headersFromProto(in map[string]*pb.HTTPHeaderValues) http.Header {
+	out := http.Header{}
+	for k, v := range in {
+		if v == nil {
+			continue
+		}
+		out[k] = append([]string(nil), v.Values...)
+	}
+	return out
+}
+
+func httpInjectResponseToProto(in *HTTPInjectResponse) *pb.InjectHTTPResponse {
+	out := &pb.InjectHTTPResponse{}
+	if in == nil {
+		return out
+	}
+	for _, h := range in.Headers {
+		op := pb.HeaderMutation_SET
+		switch h.Op {
+		case HeaderAdd:
+			op = pb.HeaderMutation_ADD
+		case HeaderDel:
+			op = pb.HeaderMutation_DEL
+		}
+		out.Headers = append(out.Headers, &pb.HeaderMutation{
+			Op:     op,
+			Name:   h.Name,
+			Values: append([]string(nil), h.Values...),
+		})
+	}
+	out.Redactions = append([]string(nil), in.Redactions...)
+	return out
 }
 
 // HandleConn pumps the gateway-provided agent connection to the

--- a/pluginsdk/server_test.go
+++ b/pluginsdk/server_test.go
@@ -1,0 +1,160 @@
+package pluginsdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+func TestServerCredentialMetadataAndInjectHTTP(t *testing.T) {
+	var sawInject bool
+	srv := newServer(&Plugin{
+		Name:    "testplugin",
+		Version: "0.1.0",
+		Credentials: []CredentialDef{{
+			TypeName:       "example_bearer",
+			Disambiguators: []string{"placeholder"},
+			HTTPInject:     true,
+			Build: func(req BuildRequest) (any, error) {
+				return CredentialBuildResult{
+					Canonical: map[string]string{"instance": req.InstanceName},
+					Metadata: CredentialMetadata{
+						SecretSlots: []SecretSlot{{Label: "Bearer token", Description: "stored by gateway"}},
+						EnvVars:     []EnvVar{{Name: "EXAMPLE_TOKEN", Value: "PH_example", Description: "placeholder"}},
+						OAuth: &OAuthIntegration{
+							Type:   "oauth2",
+							Header: "Authorization",
+							Prefix: "Bearer ",
+							Flow:   "dynamic_mcp",
+							OAuth: OAuthConfig{
+								AuthURL:     "https://auth.example.test/authorize",
+								TokenURL:    "https://auth.example.test/token",
+								RegisterURL: "https://auth.example.test/register",
+								Scopes:      []string{"mcp:read"},
+							},
+						},
+						HTTPInject: true,
+					},
+				}, nil
+			},
+			InjectHTTP: func(_ context.Context, req HTTPInjectRequest) (*HTTPInjectResponse, error) {
+				sawInject = true
+				if req.CredentialTypeName != "example_bearer" {
+					t.Fatalf("CredentialTypeName = %q", req.CredentialTypeName)
+				}
+				if req.CredentialInstance != "example" {
+					t.Fatalf("CredentialInstance = %q", req.CredentialInstance)
+				}
+				if string(req.CredentialSecret) != "real-token" {
+					t.Fatalf("CredentialSecret = %q", string(req.CredentialSecret))
+				}
+				if got := req.Headers.Get("Authorization"); got != "Bearer PH_example" {
+					t.Fatalf("Authorization header = %q", got)
+				}
+				return &HTTPInjectResponse{
+					Headers:    []HeaderMutation{{Op: HeaderSet, Name: "Authorization", Values: []string{"Bearer real-token"}}},
+					Redactions: []string{"real-token"},
+				}, nil
+			},
+		}},
+	})
+
+	manifest, err := srv.Manifest(context.Background(), &pb.ManifestRequest{})
+	if err != nil {
+		t.Fatalf("Manifest: %v", err)
+	}
+	if len(manifest.Credentials) != 1 {
+		t.Fatalf("credentials = %d, want 1", len(manifest.Credentials))
+	}
+	decl := manifest.Credentials[0]
+	if !decl.HttpInject {
+		t.Fatalf("HttpInject = false, want true")
+	}
+	if got := decl.Disambiguators; len(got) != 1 || got[0] != "placeholder" {
+		t.Fatalf("Disambiguators = %#v", got)
+	}
+
+	built, err := srv.Build(context.Background(), &pb.BuildRequest{
+		Kind:         "credential",
+		TypeName:     "example_bearer",
+		InstanceName: "example",
+		ConfigJson:   []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(built.Diagnostics) > 0 {
+		t.Fatalf("Build diagnostics = %#v", built.Diagnostics)
+	}
+	var canonical map[string]string
+	if err := json.Unmarshal(built.CanonicalJson, &canonical); err != nil {
+		t.Fatalf("canonical json: %v", err)
+	}
+	if canonical["instance"] != "example" {
+		t.Fatalf("canonical = %#v", canonical)
+	}
+	meta := built.CredentialMetadata
+	if meta == nil {
+		t.Fatalf("missing credential metadata")
+	}
+	if !meta.HttpInject || len(meta.SecretSlots) != 1 || len(meta.EnvVars) != 1 || meta.Oauth == nil {
+		t.Fatalf("metadata = %#v", meta)
+	}
+	if got := meta.Oauth.Flow; got != "dynamic_mcp" {
+		t.Fatalf("oauth flow = %q", got)
+	}
+
+	out, err := srv.InjectHTTP(context.Background(), &pb.InjectHTTPRequest{
+		CredentialTypeName:      "example_bearer",
+		CredentialInstance:      "example",
+		CredentialCanonicalJson: built.CanonicalJson,
+		CredentialSecret:        []byte("real-token"),
+		Method:                  http.MethodGet,
+		Url:                     "https://api.example.test/v1",
+		Host:                    "api.example.test",
+		Headers: map[string]*pb.HTTPHeaderValues{
+			"Authorization": {Values: []string{"Bearer PH_example"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InjectHTTP: %v", err)
+	}
+	if !sawInject {
+		t.Fatalf("InjectHTTP callback was not called")
+	}
+	if len(out.Headers) != 1 || out.Headers[0].Op != pb.HeaderMutation_SET || out.Headers[0].Values[0] != "Bearer real-token" {
+		t.Fatalf("header mutations = %#v", out.Headers)
+	}
+	if len(out.Redactions) != 1 || out.Redactions[0] != "real-token" {
+		t.Fatalf("redactions = %#v", out.Redactions)
+	}
+}
+
+func TestServerCredentialBuildPlainCanonicalRemainsBackwardCompatible(t *testing.T) {
+	srv := newServer(&Plugin{
+		Name: "testplugin",
+		Credentials: []CredentialDef{{
+			TypeName: "legacy_credential",
+			Build: func(BuildRequest) (any, error) {
+				return map[string]string{"legacy": "ok"}, nil
+			},
+		}},
+	})
+	built, err := srv.Build(context.Background(), &pb.BuildRequest{Kind: "credential", TypeName: "legacy_credential", ConfigJson: []byte(`{}`)})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if built.CredentialMetadata != nil && (built.CredentialMetadata.HttpInject || len(built.CredentialMetadata.EnvVars) > 0) {
+		t.Fatalf("unexpected metadata for legacy build: %#v", built.CredentialMetadata)
+	}
+	var canonical map[string]string
+	if err := json.Unmarshal(built.CanonicalJson, &canonical); err != nil {
+		t.Fatalf("canonical json: %v", err)
+	}
+	if canonical["legacy"] != "ok" {
+		t.Fatalf("canonical = %#v", canonical)
+	}
+}

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -145,11 +145,32 @@ before calling `InjectHTTP`. `InjectHTTP` is intentionally
 header-only; external credentials cannot rewrite the destination URL
 or request body through this hook.
 
+At runtime the built-in HTTPS endpoint keeps the privilege split:
+
+1. The wrapped process sees only metadata and placeholders from
+   `EnvVars` (for example `EXAMPLE_TOKEN=PH_example`).
+2. The gateway resolves the matched credential and fetches its
+   gateway-held secret.
+3. The gateway calls the external plugin's `InjectHTTP` callback
+   with request metadata and that secret.
+4. The plugin returns header mutations and any derived strings that
+   should be redacted from audit samples.
+
 OAuth credentials can set `CredentialMetadata.OAuth` instead of
 secret slots. The gateway owns the OAuth lifecycle and stores or
 refreshes tokens under the credential instance name; the external
 credential receives the current access token as `CredentialSecret`
-when HTTPS injection runs.
+when HTTPS injection runs. Dynamic MCP OAuth providers should set
+`Flow: "dynamic_mcp"`; the gateway will use public-client PKCE
+exchange and refresh behavior selected by that flow, not by a
+hardcoded provider hostname.
+
+External credentials that need provider-specific exchange logic (for
+example exchanging a durable service-account token for a short-lived
+JWT) should do that inside `InjectHTTP`. Validate any provider base
+URLs before sending long-lived secrets: plugin HCL is operator
+configuration, but the plugin process is still the component that
+knows which upstream hosts are allowed to receive its secret material.
 
 ### Endpoints own the connection
 

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -156,6 +156,14 @@ At runtime the built-in HTTPS endpoint keeps the privilege split:
 4. The plugin returns header mutations and any derived strings that
    should be redacted from audit samples.
 
+Redactions are part of the security contract. The gateway automatically
+redacts the raw credential secret it fetched, and audit samples also
+mask obviously sensitive header names such as `Authorization`. If your
+plugin injects any derived secret (for example an exchanged JWT or HMAC
+signature), return the exact derived string in `HTTPInjectResponse.Redactions`.
+Otherwise a derived value placed in a non-sensitive header such as
+`X-Signature` may appear verbatim in request audit samples.
+
 OAuth credentials can set `CredentialMetadata.OAuth` instead of
 secret slots. The gateway owns the OAuth lifecycle and stores or
 refreshes tokens under the credential instance name; the external

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -95,6 +95,62 @@ func main() {
 Build with `go build` like any Go binary; deploy by setting
 `source = "<path>"` in the gateway HCL.
 
+### External credential metadata and HTTPS injection
+
+External credential plugins are trusted gateway components. The
+gateway may send them credential secret bytes over the local plugin
+RPC channel when a request is about to leave through the built-in
+HTTPS endpoint. Only load plugin binaries you trust, and protect the
+paths they are loaded from the same way you protect the gateway
+binary.
+
+A credential can return `pluginsdk.CredentialBuildResult` from
+`Build` to publish dashboard secret slots, env pushdown placeholders,
+OAuth flow metadata, and HTTPS injection support while keeping its
+canonical config opaque to the gateway:
+
+```go
+pluginsdk.CredentialDef{
+    TypeName:       "example_bearer",
+    Disambiguators: []string{"placeholder"},
+    HTTPInject:     true,
+    Build: func(req pluginsdk.BuildRequest) (any, error) {
+        return pluginsdk.CredentialBuildResult{
+            Canonical: map[string]any{},
+            Metadata: pluginsdk.CredentialMetadata{
+                SecretSlots: []pluginsdk.SecretSlot{{Label: "Bearer token"}},
+                EnvVars: []pluginsdk.EnvVar{{
+                    Name:  "EXAMPLE_TOKEN",
+                    Value: "PH_example",
+                }},
+                HTTPInject: true,
+            },
+        }, nil
+    },
+    InjectHTTP: func(ctx context.Context, req pluginsdk.HTTPInjectRequest) (*pluginsdk.HTTPInjectResponse, error) {
+        return &pluginsdk.HTTPInjectResponse{Headers: []pluginsdk.HeaderMutation{{
+            Op:     pluginsdk.HeaderSet,
+            Name:   "Authorization",
+            Values: []string{"Bearer " + string(req.CredentialSecret)},
+        }}}, nil
+    },
+}
+```
+
+`Disambiguators` declares which credential/profile attrs are valid
+for multi-credential dispatch. For HTTP credentials the conventional
+field is `placeholder`: the agent sends a placeholder-looking token,
+and the built-in HTTPS endpoint selects the matching credential
+before calling `InjectHTTP`. `InjectHTTP` is intentionally
+header-only; external credentials cannot rewrite the destination URL
+or request body through this hook.
+
+OAuth credentials can set `CredentialMetadata.OAuth` instead of
+secret slots. The gateway owns the OAuth lifecycle and stores or
+refreshes tokens under the credential instance name; the external
+credential receives the current access token as `CredentialSecret`
+when HTTPS injection runs.
+
 ### Endpoints own the connection
 
 For each accepted agent connection on a plugin endpoint, the

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -165,9 +165,14 @@ when HTTPS injection runs. Dynamic MCP OAuth providers should set
 exchange and refresh behavior selected by that flow, not by a
 hardcoded provider hostname.
 
-External credentials that need provider-specific exchange logic (for
-example exchanging a durable service-account token for a short-lived
-JWT) should do that inside `InjectHTTP`. Validate any provider base
+`InjectHTTP` is one gateway→plugin RPC round trip per proxied
+request. External credentials that need provider-specific exchange
+logic (for example exchanging a durable service-account token for a
+short-lived JWT) should do that inside `InjectHTTP`, but must cache
+the derived token in plugin memory and reuse it until expiry — do
+not mint a fresh token on every request. The gateway bounds each
+`InjectHTTP` call with a 30s deadline; a plugin that exceeds it is
+logged and the request is forwarded without injection. Validate any provider base
 URLs before sending long-lived secrets: plugin HCL is operator
 configuration, but the plugin process is still the component that
 knows which upstream hosts are allowed to receive its secret material.

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -143,7 +143,9 @@ field is `placeholder`: the agent sends a placeholder-looking token,
 and the built-in HTTPS endpoint selects the matching credential
 before calling `InjectHTTP`. `InjectHTTP` is intentionally
 header-only; external credentials cannot rewrite the destination URL
-or request body through this hook.
+or request body through this hook. Use `HeaderSet` for auth headers
+such as `Authorization`; `HeaderAdd` appends and may leave the
+agent's placeholder value in place.
 
 At runtime the built-in HTTPS endpoint keeps the privilege split:
 
@@ -165,10 +167,13 @@ Otherwise a derived value placed in a non-sensitive header such as
 `X-Signature` may appear verbatim in request audit samples.
 
 OAuth credentials can set `CredentialMetadata.OAuth` instead of
-secret slots. The gateway owns the OAuth lifecycle and stores or
-refreshes tokens under the credential instance name; the external
-credential receives the current access token as `CredentialSecret`
-when HTTPS injection runs. Dynamic MCP OAuth providers should set
+secret slots. OAuth metadata is intentionally Build-time and
+instance-scoped, so two HCL blocks of the same credential type can
+select different regions, URLs, scopes, or flows. The gateway owns the
+OAuth lifecycle and stores or refreshes tokens under the credential
+instance name; the external credential receives the current access
+token as `CredentialSecret` when HTTPS injection runs. Dynamic MCP
+OAuth providers should set
 `Flow: "dynamic_mcp"`; the gateway will use public-client PKCE
 exchange and refresh behavior selected by that flow, not by a
 hardcoded provider hostname.


### PR DESCRIPTION
## Summary

This PR adds generic support for **external HTTP credential plugins**.

External plugins can now expose the same credential capabilities that previously required built-in Go code:

- dashboard secret slots
- agent environment pushdown placeholders
- OAuth flow metadata
- request-time HTTP header injection through the built-in HTTPS endpoint
- plugin-returned redactions for derived/injected secrets

The goal is to let provider-specific integrations live out of tree while keeping Claw Patrol's upstream runtime generic.

## Motivation

Some credentials need more than static bearer/header injection, but they should not all become built-ins.

Two motivating examples:

1. **Amplitude MCP OAuth**
   - declares a dynamic MCP OAuth flow
   - pushes placeholders expected by the `amp` CLI
   - lets the gateway OAuth registry own token storage/refresh
   - injects the current access token into Amplitude MCP HTTPS requests

2. **Customer.io service accounts**
   - stores a durable service-account token only on the gateway
   - exchanges it gateway-side for short-lived JWTs
   - injects the JWT into Customer.io HTTPS requests
   - keeps raw service-account material out of agent env/files

This PR adds the generic SDK/runtime surface needed for both without adding Amplitude or Customer.io provider logic to core.

## Architecture walkthrough

Visual explainer:

https://clawpatrol-external-credentials.vercel.app

It covers the config-load path, request-time injection path, OAuth path, security model, and the two reference POCs.

## What changed

### Plugin SDK

`pluginsdk.CredentialDef` can now declare HTTP injection support and return instance-specific metadata from `Build` via `pluginsdk.CredentialBuildResult`:

- `SecretSlots`
- `EnvVars`
- `OAuth`
- `Disambiguators`
- `HTTPInject`

External credentials can also implement:

```go
InjectHTTP(ctx context.Context, req pluginsdk.HTTPInjectRequest) (*pluginsdk.HTTPInjectResponse, error)
```

The request includes credential identity, canonical config, gateway-held secret bytes/extras, and HTTP request metadata. The response returns header mutations plus redaction strings.

### External plugin adapter

The external-plugin adapter maps plugin metadata onto the existing internal credential interfaces:

- secret slot provider
- env pushdown provider
- OAuth flow provider
- HTTP credential runtime
- HTTP redaction provider

This lets the rest of the gateway continue to use the same abstractions as built-in credentials.

### HTTPS credential dispatch

The built-in HTTPS endpoint can now route placeholder-matched requests to external HTTP credentials.

At request time the gateway:

1. detects the credential placeholder
2. fetches the gateway-held secret
3. calls the external plugin's `InjectHTTP` RPC
4. applies returned header mutations
5. consumes returned redactions for audit/sample redaction

### OAuth improvements

Dynamic MCP OAuth is now selected by the credential flow (`dynamic_mcp`) rather than provider-hostname-specific checks. This makes external MCP OAuth providers possible.

This branch also fixes a few dynamic-MCP edge cases discovered during closeout review:

- authorization-code exchange uses public-client form params instead of first attempting HTTP Basic auth
- manual callback parsing accepts raw query strings even when `state` appears before `code`
- loopback callback URLs can be pasted directly into the dashboard exchange field

### Documentation

`site/doc/plugins.md` now documents external credential metadata, HTTPS injection, runtime privilege split, dynamic MCP flow selection, and provider-specific exchange guidance.

## Security model

External credential plugins are **trusted gateway-side code**.

The security boundary remains:

- wrapped agents receive placeholders only
- real secrets stay on the gateway
- the gateway sends credential secret bytes only to trusted local plugin processes
- provider-specific exchange/injection logic happens on the gateway side
- returned derived secrets can be redacted from request samples/audit views

`InjectHTTP` is intentionally header-only. External credential plugins cannot rewrite the destination URL or request body through this hook.

## Reference POCs

Two external plugins were built and exercised against this branch:

- Customer.io service-account credential plugin  
  https://github.com/dhruvkelawala/clawpatrol-customerio-plugin

- Amplitude MCP OAuth credential plugin  
  https://github.com/dhruvkelawala/clawpatrol-amplitude-plugin

They demonstrate two different external credential patterns:

1. dashboard secret slot + plugin-owned token exchange + HTTP injection
2. plugin-provided OAuth metadata + gateway OAuth registry + HTTP injection

Both were tested end-to-end through Claw Patrol gateway mode with real CLIs while keeping provider credentials gateway-held.

## Validation

Core branch:

```bash
XDG_RUNTIME_DIR=/proc go test -count=1 ./...
cd dashboard
deno task build
deno task lint
deno task format:check
```

External plugin POCs:

```bash
cd clawpatrol-customerio-plugin
go test -count=1 ./...
go build -o clawpatrol-customerio-plugin .

cd clawpatrol-amplitude-plugin
go test -count=1 ./...
go build -o clawpatrol-amplitude-plugin .
```

Structured autoreview was run on:

- the Customer.io plugin
- the Amplitude plugin
- this implementation branch

Accepted findings from review were fixed before opening this PR.

## Notes for reviewers

- This intentionally avoids provider-specific upstream code.
- The POC repositories are referenced as validation/examples, not as dependencies of Claw Patrol.
- External plugins should be treated like gateway extensions: operators should load only trusted binaries and protect plugin install paths like the gateway binary itself.
