### PR TITLE
onboarding: surface profile assignment at approval time

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -195,6 +195,14 @@ func (r *AgentRegistry) Seed(ip string) {
 		}
 	}
 	r.agents[ip] = a
+	// Kick off the whois fill the same way trackUA does on first sight.
+	// Without this, pre-seeding the entry here means the agent-miss
+	// branch in trackUA never fires for this IP, so OS / tailnet login
+	// would never populate. Skip placeholder IDs (tsnet-<host>) — they
+	// aren't real addresses; promotion re-seeds under the tailnet IP.
+	if !strings.HasPrefix(ip, tsnetPlaceholderPrefix) {
+		go r.fillIdentity(ip)
+	}
 }
 
 func (r *AgentRegistry) track(remoteAddr, host string, in, out int64) {

--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -299,6 +300,14 @@ func (r *AgentRegistry) fillIdentity(ip string) {
 		return
 	}
 	if who.Node != nil {
+		// An ephemeral `--login` join-bootstrap node is not a managed
+		// device — its API calls during onboarding get tracked like
+		// any tailnet peer, but it's discarded the instant join
+		// completes. Drop it once whois reveals what it is.
+		if strings.HasPrefix(who.Node.Hostinfo.Hostname(), bootstrapHostnamePrefix) {
+			delete(r.agents, ip)
+			return
+		}
 		// Onboard-supplied hostname (via /api/onboard/claim or
 		// /api/peer/tsnet/register) takes priority. The whois response
 		// reflects whatever the tsnet node registered with (the daemon's
@@ -945,6 +954,12 @@ func (w *webMux) agentsList() []*Agent {
 	if w.g.agents != nil {
 		snap = w.g.agents.snapshot()
 	}
+	// Hide ephemeral `--login` join-bootstrap nodes — fillIdentity drops
+	// them once whois resolves, but filter here too so they never flash
+	// into the list in the window before that lands.
+	snap = slices.DeleteFunc(snap, func(a *Agent) bool {
+		return strings.HasPrefix(a.Hostname, bootstrapHostnamePrefix)
+	})
 	// External IPs: the underlay v4/v6 each WG peer is dialing in from.
 	// Show these in place of the server-side /32 (routing artefact).
 	// Live endpoint observed via wg-go IpcGet — persist into the devices

--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -289,7 +289,16 @@ func (r *AgentRegistry) fillIdentity(ip string) {
 	addrPort := netip.AddrPortFrom(addr, 0)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	who, err := r.lc.WhoIs(ctx, addrPort.String())
+	// Snapshot the LocalClient under the lock — SetLocalClient swaps it
+	// in once tsnet is up, and Seed now spawns fillIdentity at boot
+	// (via seedAgentsFromDevices) which can race that write.
+	r.mu.Lock()
+	lc := r.lc
+	r.mu.Unlock()
+	if lc == nil {
+		return
+	}
+	who, err := lc.WhoIs(ctx, addrPort.String())
 	if err != nil || who == nil {
 		return
 	}

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -185,6 +186,23 @@ func (r *onboardRegistry) assignProfileMemOnly(ip, profile string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.profileByIP[ip] = profile
+}
+
+// seedPlaceholder records hostname/owner for a tsnet placeholder ID,
+// in memory only (upsertLocked refuses placeholder IDs), so the
+// agents-registry Seed at approve time renders a recognizable device
+// row before the daemon's first register call promotes the
+// placeholder to a real devices row. ForgetIP at promotion clears
+// these entries.
+func (r *onboardRegistry) seedPlaceholder(id, hostname, owner string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if hostname != "" {
+		r.hostnameByIP[id] = hostname
+	}
+	if owner != "" {
+		r.ownerByIP[id] = owner
+	}
 }
 
 // AgentIPFor returns the device IP that traffic from ip should be
@@ -716,11 +734,25 @@ func (w *webMux) apiOnboardLookup(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "unknown or expired code", 404)
 		return
 	}
+	// Profile names + the preselection for the approval page's picker.
+	// The suggestion is the CLI's `join --profile` value when it names
+	// a real profile, else the same fallback apiOnboardApprove uses —
+	// so what the picker shows is exactly what an unmodified approve
+	// would assign. After approval s.profile holds the final choice,
+	// so the page can render the assignment.
+	policy := w.g.cfg.Load().Policy
+	profiles := orderedProfileNames(policy)
+	suggested := s.profile
+	if !slices.Contains(profiles, suggested) {
+		suggested = defaultProfileName(policy)
+	}
 	writeJSON(rw, map[string]any{
-		"user_code":      s.userCode,
-		"approved":       s.approved,
-		"created_at":     s.created.Unix(),
-		"ca_fingerprint": w.caFingerprint(),
+		"user_code":         s.userCode,
+		"approved":          s.approved,
+		"created_at":        s.created.Unix(),
+		"ca_fingerprint":    w.caFingerprint(),
+		"profiles":          profiles,
+		"suggested_profile": suggested,
 	})
 }
 
@@ -750,18 +782,37 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	}
 	// Operator picks which profile this device joins. Priority:
 	// dashboard query param → CLI suggestion stashed at /start time →
-	// profile named "default" → first profile in source order.
+	// profile named "default" → first profile in source order. An
+	// explicit query param naming a nonexistent profile is a hard
+	// error (a typo'd `join --profile` auto-approve should fall back
+	// to browser approval, not land the device in a ghost profile); a
+	// bogus stashed suggestion just degrades to the default.
+	policy := w.g.cfg.Load().Policy
+	profiles := orderedProfileNames(policy)
 	profile := r.URL.Query().Get("profile")
+	// A policy with zero profiles has nothing to validate against —
+	// keep accepting whatever the caller sent, as before.
+	if len(profiles) > 0 {
+		if profile != "" && !slices.Contains(profiles, profile) {
+			http.Error(rw, fmt.Sprintf("unknown profile %q", profile), http.StatusBadRequest)
+			return
+		}
+		if profile == "" && !slices.Contains(profiles, s.profile) {
+			// Bogus or absent CLI suggestion — degrade to the default
+			// instead of hard-failing the approval.
+			profile = defaultProfileName(policy)
+		}
+	}
 	if profile == "" {
 		profile = s.profile
 	}
 	if profile == "" {
-		profile = defaultProfileName(w.g.cfg.Load().Policy)
+		profile = defaultProfileName(policy)
 	}
 	w.onboard.mu.Lock()
 	if s.approved {
 		w.onboard.mu.Unlock()
-		writeJSON(rw, map[string]any{"already": true})
+		writeJSON(rw, map[string]any{"already": true, "profile": s.profile})
 		return
 	}
 	s.approved = true
@@ -824,9 +875,12 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			// /api/peer/tsnet/register on the daemon's first boot.
 			s2 := w.onboard.byDeviceCode(dc)
 			parentID := tsnetPlaceholderPrefix + dc
+			hostname := ""
 			if s2 != nil && s2.hostname != "" {
-				parentID = tsnetPlaceholderPrefix + s2.hostname
+				hostname = s2.hostname
+				parentID = tsnetPlaceholderPrefix + hostname
 			}
+			w.onboard.seedPlaceholder(parentID, hostname, owner)
 			if profile != "" {
 				w.onboard.assignProfileMemOnly(parentID, profile)
 			}
@@ -837,9 +891,17 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			} else {
 				log.Printf("api-token mint for %s: %v", parentID, perr)
 			}
+			// Seed the agents registry under the placeholder so the
+			// dashboard shows the just-approved device (and lets the
+			// operator re-assign its profile) before the daemon's
+			// first register call. The register promotion deletes
+			// this entry and re-seeds under the real tailnet IP.
+			if w.g.agents != nil {
+				w.g.agents.Seed(parentID)
+			}
 		}
 	}()
-	writeJSON(rw, map[string]any{"approved": true})
+	writeJSON(rw, map[string]any{"approved": true, "profile": profile})
 }
 
 // apiOnboardClaim is hit by the CLI right after `tailscale up`
@@ -876,6 +938,11 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Printf("onboard claim: %s → %s (hostname=%q)", host, owner, hostname)
+	// Seed the agents registry so the dashboard shows the device as
+	// soon as the claim lands, before it sends any traffic.
+	if w.g.agents != nil {
+		w.g.agents.Seed(host)
+	}
 	// Mirror profile mapping onto the peer's IPv6 ULA — whole-machine
 	// tsnet traffic frequently arrives on fd7a:115c:a1e0::/48 not the
 	// 100.x IPv4 that claim() registered.

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -114,6 +114,27 @@ func newOnboardRegistry() *onboardRegistry {
 // upsertLocked so they don't surface as ghost devices rows.
 const tsnetPlaceholderPrefix = "tsnet-"
 
+// resolveProfileFromList picks the profile to assign given an ordered
+// profile list and a suggestion (a CLI `join --profile` value). The
+// suggestion wins when it names a real profile; otherwise the gateway
+// default applies — the profile named "default" if present, else the
+// first in source order. With no profiles declared there is nothing to
+// validate against, so the suggestion is returned verbatim. Shared by
+// apiOnboardLookup (picker preselection) and apiOnboardApprove
+// (assignment) so the picker shows exactly what approve would pick.
+func resolveProfileFromList(profiles []string, suggestion string) string {
+	if slices.Contains(profiles, suggestion) {
+		return suggestion
+	}
+	if len(profiles) == 0 {
+		return suggestion
+	}
+	if slices.Contains(profiles, "default") {
+		return "default"
+	}
+	return profiles[0]
+}
+
 // SetExternalIPs records the underlay endpoint addresses (v4 and/or v6)
 // observed for the wg peer at ip. Mirrors unclaw's approvedIpv4 /
 // approvedIpv6 model — the dashboard shows these in place of the wg /32,
@@ -177,24 +198,15 @@ func (r *onboardRegistry) AssignProfile(ip, profile string) {
 	r.upsertLocked(ip)
 }
 
-// assignProfileMemOnly records the profile mapping in memory without
-// upserting a devices row. Used for the tsnet "tsnet-<hostname>"
-// placeholder between approve time and the first daemon register
-// call. upsertLocked refuses to persist IDs with the placeholder
-// prefix so this is safe.
-func (r *onboardRegistry) assignProfileMemOnly(ip, profile string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.profileByIP[ip] = profile
-}
-
-// seedPlaceholder records hostname/owner for a tsnet placeholder ID,
-// in memory only (upsertLocked refuses placeholder IDs), so the
-// agents-registry Seed at approve time renders a recognizable device
-// row before the daemon's first register call promotes the
-// placeholder to a real devices row. ForgetIP at promotion clears
-// these entries.
-func (r *onboardRegistry) seedPlaceholder(id, hostname, owner string) {
+// seedPlaceholder records hostname/owner/profile for a tsnet
+// placeholder ID, in memory only (upsertLocked refuses placeholder
+// IDs), so the agents-registry Seed at approve time renders a
+// recognizable device row before the daemon's first register call
+// promotes the placeholder to a real devices row. Done in one
+// critical section so a concurrent register promotion never observes
+// a half-seeded placeholder. ForgetIP at promotion clears these
+// entries (their values are carried across to the real tailnet IP).
+func (r *onboardRegistry) seedPlaceholder(id, hostname, owner, profile string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if hostname != "" {
@@ -202,6 +214,9 @@ func (r *onboardRegistry) seedPlaceholder(id, hostname, owner string) {
 	}
 	if owner != "" {
 		r.ownerByIP[id] = owner
+	}
+	if profile != "" {
+		r.profileByIP[id] = profile
 	}
 }
 
@@ -354,6 +369,19 @@ func (r *onboardRegistry) OwnerForIP(ip string) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.ownerByIP[ip]
+}
+
+// SetOwner records an approver for a peer IP outside the onboard
+// device-code flow — used by the tsnet register promotion to carry
+// the owner seeded on the placeholder across to the real tailnet IP.
+func (r *onboardRegistry) SetOwner(ip, owner string) {
+	if ip == "" || owner == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ownerByIP[ip] = owner
+	r.upsertLocked(ip)
 }
 
 func (r *onboardRegistry) HostnameForIP(ip string) string {
@@ -734,22 +762,30 @@ func (w *webMux) apiOnboardLookup(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "unknown or expired code", 404)
 		return
 	}
+	w.onboard.mu.Lock()
+	userCode := s.userCode
+	approved := s.approved
+	created := s.created
+	stored := s.profile
+	w.onboard.mu.Unlock()
+
 	// Profile names + the preselection for the approval page's picker.
-	// The suggestion is the CLI's `join --profile` value when it names
-	// a real profile, else the same fallback apiOnboardApprove uses —
-	// so what the picker shows is exactly what an unmodified approve
-	// would assign. After approval s.profile holds the final choice,
-	// so the page can render the assignment.
-	policy := w.g.cfg.Load().Policy
-	profiles := orderedProfileNames(policy)
-	suggested := s.profile
-	if !slices.Contains(profiles, suggested) {
-		suggested = defaultProfileName(policy)
+	// Before approval the suggestion is the CLI's `join --profile`
+	// value when it names a real profile, else the same fallback
+	// apiOnboardApprove uses — so the picker shows exactly what an
+	// unmodified approve would assign. After approval s.profile holds
+	// the final choice; report it verbatim so the page renders the
+	// real assignment even if that profile was since removed from the
+	// policy.
+	profiles := orderedProfileNames(w.g.cfg.Load().Policy)
+	suggested := stored
+	if !approved {
+		suggested = resolveProfileFromList(profiles, stored)
 	}
 	writeJSON(rw, map[string]any{
-		"user_code":         s.userCode,
-		"approved":          s.approved,
-		"created_at":        s.created.Unix(),
+		"user_code":         userCode,
+		"approved":          approved,
+		"created_at":        created.Unix(),
 		"ca_fingerprint":    w.caFingerprint(),
 		"profiles":          profiles,
 		"suggested_profile": suggested,
@@ -787,27 +823,24 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	// error (a typo'd `join --profile` auto-approve should fall back
 	// to browser approval, not land the device in a ghost profile); a
 	// bogus stashed suggestion just degrades to the default.
-	policy := w.g.cfg.Load().Policy
-	profiles := orderedProfileNames(policy)
+	profiles := orderedProfileNames(w.g.cfg.Load().Policy)
 	profile := r.URL.Query().Get("profile")
-	// A policy with zero profiles has nothing to validate against —
-	// keep accepting whatever the caller sent, as before.
-	if len(profiles) > 0 {
-		if profile != "" && !slices.Contains(profiles, profile) {
+	if profile != "" {
+		// An explicit query param naming a nonexistent profile is a
+		// hard error: a typo'd `join --profile` auto-approve should
+		// fall back to browser approval, not land the device in a
+		// ghost profile. (A policy with zero profiles has nothing to
+		// validate against — accept whatever the caller sent.)
+		if len(profiles) > 0 && !slices.Contains(profiles, profile) {
 			http.Error(rw, fmt.Sprintf("unknown profile %q", profile), http.StatusBadRequest)
 			return
 		}
-		if profile == "" && !slices.Contains(profiles, s.profile) {
-			// Bogus or absent CLI suggestion — degrade to the default
-			// instead of hard-failing the approval.
-			profile = defaultProfileName(policy)
-		}
-	}
-	if profile == "" {
-		profile = s.profile
-	}
-	if profile == "" {
-		profile = defaultProfileName(policy)
+	} else {
+		// No operator override — fall back to the CLI's stashed
+		// suggestion when it names a real profile, else the default.
+		// A bogus suggestion degrades to the default rather than
+		// failing. With zero profiles this stays the raw suggestion.
+		profile = resolveProfileFromList(profiles, s.profile)
 	}
 	w.onboard.mu.Lock()
 	if s.approved {
@@ -880,10 +913,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 				hostname = s2.hostname
 				parentID = tsnetPlaceholderPrefix + hostname
 			}
-			w.onboard.seedPlaceholder(parentID, hostname, owner)
-			if profile != "" {
-				w.onboard.assignProfileMemOnly(parentID, profile)
-			}
+			w.onboard.seedPlaceholder(parentID, hostname, owner, profile)
 			if token, perr := mintAndPersistPeerAPIToken(w.g.db, parentID); perr == nil {
 				w.onboard.mu.Lock()
 				s.apiToken = token
@@ -997,9 +1027,15 @@ func (w *webMux) apiPeerTsnetRegister(rw http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(parentIP, tsnetPlaceholderPrefix) {
 		// First call — promote the synthetic placeholder to a real
 		// devices row keyed on the tailnet IP. Rebind the api-token,
-		// drop the placeholder from in-memory state, copy across the
-		// profile picked at approve time.
+		// drop the placeholder from in-memory state, carry across the
+		// per-IP state seeded at approve time (profile, owner, and the
+		// hostname unless the daemon supplied a fresher one). Capture
+		// before ForgetIP clears the placeholder entries.
 		profile := w.g.onboard.ProfileForIP(parentIP)
+		owner := w.g.onboard.OwnerForIP(parentIP)
+		if hostname == "" {
+			hostname = w.g.onboard.HostnameForIP(parentIP)
+		}
 		_, _ = w.g.db.Exec("UPDATE peer_api_tokens SET peer_ip=? WHERE peer_ip=?", tsnetIP, parentIP)
 		w.g.onboard.ForgetIP(parentIP)
 		if w.g.agents != nil {
@@ -1007,6 +1043,9 @@ func (w *webMux) apiPeerTsnetRegister(rw http.ResponseWriter, r *http.Request) {
 		}
 		if profile != "" {
 			w.g.onboard.AssignProfile(tsnetIP, profile)
+		}
+		if owner != "" {
+			w.g.onboard.SetOwner(tsnetIP, owner)
 		}
 		if hostname != "" {
 			w.g.onboard.SetHostname(tsnetIP, hostname)

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -852,6 +852,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	s.owner = owner
 	s.profile = profile
 	hostname := s.hostname
+	wholeMachine := s.wholeMachine
 	w.onboard.mu.Unlock()
 
 	// Recycle the wg /32 already bound to (owner, hostname) so a rejoin
@@ -862,7 +863,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		key, loginServer, peerIP, err := newOnboarder(w.ts).MintKey(ctx, reuseIP, s.wholeMachine)
+		key, loginServer, peerIP, err := newOnboarder(w.ts).MintKey(ctx, reuseIP, wholeMachine)
 		w.onboard.mu.Lock()
 		if err != nil {
 			s.err = err.Error()
@@ -899,7 +900,7 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			} else {
 				log.Printf("api-token mint for %s: %v", peerIP, perr)
 			}
-		} else if loginServer == "" && !s.wholeMachine {
+		} else if loginServer == "" && !wholeMachine {
 			// Tsnet daemon mode: no devices row yet — the tailnet IP
 			// only exists once the per-host daemon joins, which happens
 			// later when the operator runs `clawpatrol run`. Hold the
@@ -914,20 +915,24 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 				parentID = tsnetPlaceholderPrefix + hostname
 			}
 			w.onboard.seedPlaceholder(parentID, hostname, owner, profile)
+			// Seed the agents registry under the placeholder so the
+			// dashboard shows the just-approved device (and lets the
+			// operator re-assign its profile) before the daemon's
+			// first register call. The register promotion deletes this
+			// entry and re-seeds under the real tailnet IP. Seed BEFORE
+			// minting the token: /api/peer/tsnet/register authenticates
+			// with that token, so doing it first guarantees a register
+			// can't slip in and promote between mint and Seed, which
+			// would leave the re-seeded placeholder as an orphan ghost.
+			if w.g.agents != nil {
+				w.g.agents.Seed(parentID)
+			}
 			if token, perr := mintAndPersistPeerAPIToken(w.g.db, parentID); perr == nil {
 				w.onboard.mu.Lock()
 				s.apiToken = token
 				w.onboard.mu.Unlock()
 			} else {
 				log.Printf("api-token mint for %s: %v", parentID, perr)
-			}
-			// Seed the agents registry under the placeholder so the
-			// dashboard shows the just-approved device (and lets the
-			// operator re-assign its profile) before the daemon's
-			// first register call. The register promotion deletes
-			// this entry and re-seeds under the real tailnet IP.
-			if w.g.agents != nil {
-				w.g.agents.Seed(parentID)
 			}
 		}
 	}()

--- a/cmd/clawpatrol/onboard_profile_test.go
+++ b/cmd/clawpatrol/onboard_profile_test.go
@@ -181,8 +181,7 @@ func TestTsnetRegisterPromotesSeededPlaceholder(t *testing.T) {
 	h := w.handler()
 
 	const placeholder = tsnetPlaceholderPrefix + "myhost"
-	w.g.onboard.seedPlaceholder(placeholder, "myhost", "op@example.com")
-	w.g.onboard.assignProfileMemOnly(placeholder, "prod")
+	w.g.onboard.seedPlaceholder(placeholder, "myhost", "op@example.com", "prod")
 	w.g.agents.Seed(placeholder)
 
 	var seeded *Agent
@@ -228,6 +227,9 @@ func TestTsnetRegisterPromotesSeededPlaceholder(t *testing.T) {
 	}
 	if got := w.g.onboard.HostnameForIP("100.64.0.7"); got != "myhost" {
 		t.Errorf("HostnameForIP(100.64.0.7) = %q, want myhost", got)
+	}
+	if got := w.g.onboard.OwnerForIP("100.64.0.7"); got != "op@example.com" {
+		t.Errorf("OwnerForIP(100.64.0.7) = %q, want op@example.com (owner must carry across promotion)", got)
 	}
 	if !w.g.onboard.HasDevice("100.64.0.7") {
 		t.Errorf("devices row for 100.64.0.7 missing after register promotion")

--- a/cmd/clawpatrol/onboard_profile_test.go
+++ b/cmd/clawpatrol/onboard_profile_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// onboardProfileTestPolicy returns a policy with two profiles and no
+// profile literally named "default", so the fallback is the first
+// profile in source order ("staging").
+func onboardProfileTestPolicy() *config.Policy {
+	return &config.Policy{
+		Profiles: map[string]*config.Profile{
+			"staging": {Name: "staging"},
+			"prod":    {Name: "prod"},
+		},
+		Order: []string{"staging", "prod"},
+	}
+}
+
+func startOnboardSession(t *testing.T, h http.Handler, startQuery string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/start"+startQuery, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("start status = %d; body = %q", rr.Code, rr.Body.String())
+	}
+	var start struct {
+		UserCode string `json:"user_code"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&start); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	if start.UserCode == "" {
+		t.Fatalf("start response missing user_code")
+	}
+	return start.UserCode
+}
+
+func TestOnboardLookupIncludesProfilesAndSuggestion(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.cfg.Load().Policy = onboardProfileTestPolicy()
+	h := w.handler()
+
+	for _, tc := range []struct {
+		startQuery    string
+		wantSuggested string
+	}{
+		{"?hostname=dev1&profile=prod", "prod"},
+		{"?hostname=dev2", "staging"},                     // no suggestion → first profile
+		{"?hostname=dev3&profile=nonexistent", "staging"}, // bogus suggestion → fallback
+	} {
+		code := startOnboardSession(t, h, tc.startQuery)
+		req := httptest.NewRequest(http.MethodGet, "/api/onboard/lookup?code="+url.QueryEscape(code), nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("lookup(%s) status = %d; body = %q", tc.startQuery, rr.Code, rr.Body.String())
+		}
+		var lookup struct {
+			Profiles  []string `json:"profiles"`
+			Suggested string   `json:"suggested_profile"`
+		}
+		if err := json.NewDecoder(rr.Body).Decode(&lookup); err != nil {
+			t.Fatalf("decode lookup response: %v", err)
+		}
+		if len(lookup.Profiles) != 2 || lookup.Profiles[0] != "staging" || lookup.Profiles[1] != "prod" {
+			t.Errorf("lookup(%s) profiles = %v, want [staging prod]", tc.startQuery, lookup.Profiles)
+		}
+		if lookup.Suggested != tc.wantSuggested {
+			t.Errorf("lookup(%s) suggested_profile = %q, want %q", tc.startQuery, lookup.Suggested, tc.wantSuggested)
+		}
+	}
+}
+
+func TestOnboardApproveRejectsUnknownProfile(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.cfg.Load().Policy = onboardProfileTestPolicy()
+	h := w.handler()
+	code := startOnboardSession(t, h, "?hostname=dev1")
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/onboard/approve?code="+url.QueryEscape(code)+"&profile=nonexistent", nil)
+	req.AddCookie(authTestSessionCookie(t, w))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("approve status = %d, want 400; body = %q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOnboardApproveResolvesAndReportsProfile(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.cfg.Load().Policy = onboardProfileTestPolicy()
+	h := w.handler()
+
+	for _, tc := range []struct {
+		startQuery   string
+		approveQuery string
+		want         string
+	}{
+		{"?hostname=dev1&profile=prod", "", "prod"},                    // CLI suggestion honored
+		{"?hostname=dev2&profile=prod", "&profile=staging", "staging"}, // operator override wins
+		{"?hostname=dev3", "", "staging"},                              // nothing specified → fallback
+	} {
+		code := startOnboardSession(t, h, tc.startQuery)
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/onboard/approve?code="+url.QueryEscape(code)+tc.approveQuery, nil)
+		req.AddCookie(authTestSessionCookie(t, w))
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("approve(%s%s) status = %d; body = %q", tc.startQuery, tc.approveQuery, rr.Code, rr.Body.String())
+		}
+		var resp struct {
+			Approved bool   `json:"approved"`
+			Profile  string `json:"profile"`
+		}
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode approve response: %v", err)
+		}
+		if !resp.Approved || resp.Profile != tc.want {
+			t.Errorf("approve(%s%s) = %+v, want approved with profile %q", tc.startQuery, tc.approveQuery, resp, tc.want)
+		}
+	}
+}
+
+// A claim must make the device visible on the dashboard immediately,
+// before any traffic flows.
+func TestOnboardClaimSeedsAgentsRegistry(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.cfg.Load().Policy = onboardProfileTestPolicy()
+	w.g.agents = NewAgentRegistry()
+	w.g.agents.onboard = w.g.onboard
+	h := w.handler()
+	code := startOnboardSession(t, h, "?hostname=dev1")
+
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code="+url.QueryEscape(code), nil)
+	approveReq.AddCookie(authTestSessionCookie(t, w))
+	approveRR := httptest.NewRecorder()
+	h.ServeHTTP(approveRR, approveReq)
+	if approveRR.Code != http.StatusOK {
+		t.Fatalf("approve status = %d; body = %q", approveRR.Code, approveRR.Body.String())
+	}
+
+	dc := w.onboard.byUserCode(code).deviceCode
+	claimReq := httptest.NewRequest(http.MethodPost,
+		"/api/onboard/claim?device_code="+url.QueryEscape(dc)+"&ip=10.55.0.9&hostname=dev1", nil)
+	claimRR := httptest.NewRecorder()
+	h.ServeHTTP(claimRR, claimReq)
+	if claimRR.Code != http.StatusOK {
+		t.Fatalf("claim status = %d; body = %q", claimRR.Code, claimRR.Body.String())
+	}
+
+	for _, a := range w.g.agents.snapshot() {
+		if a.IP == "10.55.0.9" {
+			return
+		}
+	}
+	t.Fatalf("agents registry has no entry for 10.55.0.9 after claim")
+}
+
+// The tsnet placeholder seeded at approve time must be promoted to
+// the real tailnet IP on the daemon's first register call: agents
+// entry replaced, profile and hostname carried over, devices row
+// created.
+func TestTsnetRegisterPromotesSeededPlaceholder(t *testing.T) {
+	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
+	w.g.cfg.Load().Policy = onboardProfileTestPolicy()
+	w.g.agents = NewAgentRegistry()
+	w.g.agents.onboard = w.g.onboard
+	if err := w.g.onboard.Load(w.g.db); err != nil {
+		t.Fatalf("onboard load: %v", err)
+	}
+	h := w.handler()
+
+	const placeholder = tsnetPlaceholderPrefix + "myhost"
+	w.g.onboard.seedPlaceholder(placeholder, "myhost", "op@example.com")
+	w.g.onboard.assignProfileMemOnly(placeholder, "prod")
+	w.g.agents.Seed(placeholder)
+
+	var seeded *Agent
+	for _, a := range w.g.agents.snapshot() {
+		if a.IP == placeholder {
+			seeded = a
+		}
+	}
+	if seeded == nil {
+		t.Fatalf("placeholder %q not in agents registry after Seed", placeholder)
+	}
+	if seeded.Hostname != "myhost" || seeded.User != "op@example.com" || seeded.Profile != "prod" {
+		t.Fatalf("seeded placeholder = hostname %q user %q profile %q, want myhost/op@example.com/prod",
+			seeded.Hostname, seeded.User, seeded.Profile)
+	}
+
+	token, err := mintAndPersistPeerAPIToken(w.g.db, placeholder)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/peer/tsnet/register?ip=100.64.0.7&hostname=myhost", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("register status = %d, want 204; body = %q", rr.Code, rr.Body.String())
+	}
+
+	var promoted *Agent
+	for _, a := range w.g.agents.snapshot() {
+		if a.IP == placeholder {
+			t.Errorf("placeholder %q still in agents registry after register", placeholder)
+		}
+		if a.IP == "100.64.0.7" {
+			promoted = a
+		}
+	}
+	if promoted == nil {
+		t.Fatalf("registered IP 100.64.0.7 not in agents registry")
+	}
+	if got := w.g.onboard.ProfileForIP("100.64.0.7"); got != "prod" {
+		t.Errorf("ProfileForIP(100.64.0.7) = %q, want prod", got)
+	}
+	if got := w.g.onboard.HostnameForIP("100.64.0.7"); got != "myhost" {
+		t.Errorf("HostnameForIP(100.64.0.7) = %q, want myhost", got)
+	}
+	if !w.g.onboard.HasDevice("100.64.0.7") {
+		t.Errorf("devices row for 100.64.0.7 missing after register promotion")
+	}
+}

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -992,7 +992,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			case 200:
 				autoApproved = true
 				fmt.Println()
-				fmt.Println("Auto-approved via tailnet operator identity.")
+				fmt.Println("✓ auto-approved as tailnet operator")
 			case 403:
 				// Not an operator — quietly fall through to the
 				// browser-approval path. No warning: this is the
@@ -1009,33 +1009,29 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 
 	if !autoApproved {
 		fmt.Println()
-		fmt.Println("Verify code in browser:")
+		fmt.Printf("  Approve this device on the dashboard. Code: %s\n", start.UserCode)
 		fmt.Println()
-		fmt.Printf("    %s\n", start.UserCode)
-		fmt.Println()
-		fmt.Println(start.VerifyURL)
-		// One-line CA fingerprint after the verify URL. The
-		// dashboard's approval page shows the same value next to
-		// the user_code — operator visually confirms they match
-		// before clicking approve, blocking an on-path swap of the
-		// CA the CLI just fetched over plain HTTP.
-		if setup != nil && setup.caFingerprint != "" {
-			fmt.Println()
-			fmt.Printf("CA fingerprint: %s\n", setup.caFingerprint)
-		}
+		fmt.Printf("    %s\n", start.VerifyURL)
 		fmt.Println()
 		// Tailnet-only verify URLs (100.64.0.0/10 IP or *.ts.net
 		// host) are unreachable from the machine running
 		// `clawpatrol join` until approval lands — that's the whole
-		// point of needing approval. Print a QR code so the operator
-		// can scan from a phone or another already-tailnet-connected
-		// device. Skip tryOpen on that path: a local browser can't
-		// reach the URL anyway, and the spawned xdg-open / open
-		// process just produces a meaningless tab.
+		// point of needing approval. Print a QR so the operator can
+		// scan from a phone or another tailnet-connected device. Skip
+		// tryOpen there: a local browser can't reach the URL anyway.
 		if isTailnetOnlyURL(start.VerifyURL) {
-			printVerifyQR(start.VerifyURL)
+			printQR(start.VerifyURL)
 		} else {
 			tryOpen(start.VerifyURL)
+		}
+		// CA fingerprint last, so it sits right next to the approve
+		// action. The dashboard's approval page shows the same value
+		// beside the user_code — the operator visually confirms they
+		// match before clicking approve, blocking an on-path swap of
+		// the CA the CLI just fetched over plain HTTP.
+		if setup != nil && setup.caFingerprint != "" {
+			fmt.Printf("  CA fingerprint (must match the dashboard): %s\n", setup.caFingerprint)
+			fmt.Println()
 		}
 	}
 
@@ -1103,7 +1099,11 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		}
 		return false, fmt.Errorf("timed out waiting for approval")
 	}
-	fmt.Println("Approved.")
+	// On the auto-approve path we already printed the operator
+	// confirmation; don't repeat it here.
+	if !autoApproved {
+		fmt.Println("✓ approved")
+	}
 	// Approval click ⇒ operator visually confirmed the CA
 	// fingerprint on the dashboard matched what the CLI
 	// printed. Only now is it safe to push the fetched CA
@@ -1462,15 +1462,6 @@ func isTailnetOnlyURL(u string) bool {
 // inside it is unreachable except from a tailnet member.
 var tailscaleCGNAT = netip.MustParsePrefix("100.64.0.0/10")
 
-// printVerifyQR writes a terminal QR code encoding url to stdout.
-// Used when the verify URL is tailnet-only — the operator scans with a
-// phone or another already-onboarded device that can actually reach
-// the gateway.
-//
-// GenerateHalfBlock packs two QR rows per terminal line via the
-// ▀ / ▄ / █ / space unicode chars. Half the vertical space of the
-// ANSI-colored block-per-cell variant, and renders cleanly when the
-// operator pipes the join output to a file or pastes it into chat.
 // approveBaseFromVerifyURL returns the scheme://host origin of the
 // onboard verify URL — the dashboard origin whose /api/onboard/approve
 // is the same handler the dashboard Approve button POSTs to. Falls back
@@ -1486,20 +1477,12 @@ func approveBaseFromVerifyURL(verifyURL, fallback string) string {
 	return u.Scheme + "://" + u.Host
 }
 
-func printVerifyQR(url string) {
-	fmt.Println("Tailnet-only URL — scan from a device with tailnet access:")
-	fmt.Println()
-	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
-	fmt.Println()
-}
-
-// printLoginQR renders a QR for the interactive tailnet login URL. The
-// box running `clawpatrol join` is frequently headless, so scanning
-// from a phone is the path of least resistance. Unlike the verify URL
-// this is a public login.tailscale.com link, reachable anywhere.
-func printLoginQR(url string) {
-	fmt.Println("No browser? Scan to log in from another device:")
-	fmt.Println()
+// printQR renders url as a scannable terminal QR, no caption — the URL
+// is always printed directly above the call site and a QR is plainly a
+// QR. GenerateHalfBlock packs two QR rows per line via ▀/▄/█/space,
+// half the height of the block-per-cell variant, and renders cleanly
+// when the join output is piped to a file or pasted into chat.
+func printQR(url string) {
 	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
 	fmt.Println()
 }

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -372,13 +372,17 @@ func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine bool) {
 		}
 		return
 	}
-	if !skipTrust {
+	switch {
+	case s.caInstalled:
+		// Already installed during the tailnet device flow
+		// (onboardViaDeviceFlow). Don't run it — or print it — twice.
+	case !skipTrust:
 		if err := installCATrust(s.caPath); err != nil {
 			s.caHint = manualTrustHint(s.caPath)
 		} else {
 			s.caInstalled = true
 		}
-	} else {
+	default:
 		s.caHint = manualTrustHint(s.caPath)
 	}
 	if wholeMachine {
@@ -814,16 +818,14 @@ func isTerminal(f *os.File) bool {
 	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
-// printTreeItems prints a list as ├-prefixed sub-items with the final
-// entry marked └ (bottom-corner). Same box-drawing family so the glyphs
-// align visually instead of mixing the heavier ⎿ corner.
-func printTreeItems(items []string) {
-	for i, line := range items {
-		prefix := "├ "
-		if i == len(items)-1 {
-			prefix = "└ "
-		}
-		fmt.Println(prefix + line)
+// printChecklist prints each line on its own row. Lines already carry
+// their own status marker ("✓ " success, "! " needs-attention) from the
+// caller / setupSummaryItems, so this is a plain printer — no tree
+// glyphs, which previously made the items read as sub-steps of whatever
+// progress line preceded them.
+func printChecklist(items []string) {
+	for _, line := range items {
+		fmt.Println(line)
 	}
 }
 
@@ -836,12 +838,12 @@ func setupSummaryItems(s joinSetup) []string {
 	var out []string
 	switch {
 	case s.caInstalled:
-		out = append(out, "CA installed in system trust")
+		out = append(out, "✓ CA installed in system trust")
 	case s.caHint != "":
-		out = append(out, "CA at "+s.caPath+" — trust manually: "+s.caHint)
+		out = append(out, "! CA not trusted yet — install manually: "+s.caHint)
 	}
 	if s.shellRC {
-		out = append(out, `Shell rc: eval "$(clawpatrol env)"`)
+		out = append(out, `✓ shell rc updated (eval "$(clawpatrol env)")`)
 	}
 	return out
 }
@@ -1056,7 +1058,14 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		_ = runAsRoot("wg-quick", "down", "clawpatrol").Run()
 	}
 
-	stopSpin := startSpinner("Waiting for approval")
+	// After an operator self-approve the device is already approved;
+	// the poll just collects the minted credentials. Don't claim we're
+	// "waiting for approval" in that case.
+	spinLabel := "Waiting for approval"
+	if autoApproved {
+		spinLabel = "Completing join"
+	}
+	stopSpin := startSpinner(spinLabel)
 	authKey, loginServer, apiToken := "", "", ""
 	var tailnetGWHost, tailnetControlURL, gatewayIP, caPEM string
 	// Track the most recent transport error so a poll loop that never
@@ -1177,14 +1186,13 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		if runtime.GOOS == "darwin" {
 			macErr = macHelperInstall(wholeMachine)
 		}
-		items := []string{}
+		items := setupSummaryItems(*setup)
 		if wgIP := wgAddressFromConf(authKey); wgIP != "" {
-			items = append(items, "Joined as "+wgIP)
+			items = append(items, "✓ joined as "+wgIP)
 		} else {
-			items = append(items, "Joined")
+			items = append(items, "✓ joined")
 		}
-		items = append(items, setupSummaryItems(*setup)...)
-		printTreeItems(items)
+		printChecklist(items)
 		fmt.Println()
 		if !wholeMachine {
 			fmt.Println("Installed! Try: clawpatrol run claude")
@@ -1289,9 +1297,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				return false, fmt.Errorf("write auth-key: %w", err)
 			}
 		}
-		items := []string{"Joined (tsnet mode — persistent daemon node joins tailnet on first `clawpatrol run`)"}
-		items = append(items, setupSummaryItems(*setup)...)
-		printTreeItems(items)
+		items := setupSummaryItems(*setup)
+		items = append(items, "✓ joined — the daemon joins the tailnet on your first `clawpatrol run`")
+		printChecklist(items)
 		fmt.Println()
 		fmt.Println("Installed! Try: clawpatrol run claude")
 		return false, nil
@@ -1431,9 +1439,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		}
 	}
 
-	items := []string{"Joined tailnet as " + tailIP}
-	items = append(items, setupSummaryItems(*setup)...)
-	printTreeItems(items)
+	items := setupSummaryItems(*setup)
+	items = append(items, "✓ joined tailnet as "+tailIP)
+	printChecklist(items)
 	fmt.Println()
 	fmt.Println("Installed! Try: clawpatrol run -- claude")
 
@@ -1482,14 +1490,18 @@ func approveBaseFromVerifyURL(verifyURL, fallback string) string {
 	return u.Scheme + "://" + u.Host
 }
 
-// printQR renders url as a scannable terminal QR, no caption — the URL
-// is always printed directly above the call site and a QR is plainly a
-// QR. Callers control surrounding blank lines. GenerateHalfBlock packs
+// printQR renders url as a scannable terminal QR, indented to line up
+// under the URL printed above it. No caption — a QR is plainly a QR,
+// and callers control surrounding blank lines. GenerateHalfBlock packs
 // two QR rows per line via ▀/▄/█/space, half the height of the
 // block-per-cell variant, and renders cleanly when the join output is
 // piped to a file or pasted into chat.
 func printQR(url string) {
-	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
+	var buf bytes.Buffer
+	qrterminal.GenerateHalfBlock(url, qrterminal.M, &buf)
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		fmt.Println("    " + line)
+	}
 }
 
 func tryOpen(u string) {

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -975,7 +975,16 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		if profile != "" {
 			aq.Set("profile", profile)
 		}
-		approveURL := gateway + "/api/onboard/approve?" + aq.Encode()
+		// Approve must hit the same origin the dashboard's Approve
+		// button POSTs from — the operator-gated dashboard/API, where
+		// the bootstrap node's tailnet whois identity is checked. The
+		// `gateway` arg is the join URL, which for a funnel-enabled
+		// gateway is the public :443 Funnel whose allowlist excludes
+		// /api/onboard/approve (it would 404). verify_url already
+		// points at that dashboard origin (the tailnet :8080 API in
+		// tsnet mode), so derive the approve base from it.
+		approveBase := approveBaseFromVerifyURL(start.VerifyURL, gateway)
+		approveURL := approveBase + "/api/onboard/approve?" + aq.Encode()
 		if ar, aerr := cli.Post(approveURL, "application/json", nil); aerr == nil {
 			body, _ := io.ReadAll(io.LimitReader(ar.Body, 1024))
 			_ = ar.Body.Close()
@@ -1462,8 +1471,34 @@ var tailscaleCGNAT = netip.MustParsePrefix("100.64.0.0/10")
 // ▀ / ▄ / █ / space unicode chars. Half the vertical space of the
 // ANSI-colored block-per-cell variant, and renders cleanly when the
 // operator pipes the join output to a file or pastes it into chat.
+// approveBaseFromVerifyURL returns the scheme://host origin of the
+// onboard verify URL — the dashboard origin whose /api/onboard/approve
+// is the same handler the dashboard Approve button POSTs to. Falls back
+// to the join URL when verify_url is absent or unparseable.
+func approveBaseFromVerifyURL(verifyURL, fallback string) string {
+	if verifyURL == "" {
+		return fallback
+	}
+	u, err := neturl.Parse(verifyURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fallback
+	}
+	return u.Scheme + "://" + u.Host
+}
+
 func printVerifyQR(url string) {
 	fmt.Println("Tailnet-only URL — scan from a device with tailnet access:")
+	fmt.Println()
+	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
+	fmt.Println()
+}
+
+// printLoginQR renders a QR for the interactive tailnet login URL. The
+// box running `clawpatrol join` is frequently headless, so scanning
+// from a phone is the path of least resistance. Unlike the verify URL
+// this is a public login.tailscale.com link, reachable anywhere.
+func printLoginQR(url string) {
+	fmt.Println("No browser? Scan to log in from another device:")
 	fmt.Println()
 	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
 	fmt.Println()

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -1021,16 +1021,21 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		// tryOpen there: a local browser can't reach the URL anyway.
 		if isTailnetOnlyURL(start.VerifyURL) {
 			printQR(start.VerifyURL)
+			fmt.Println()
 		} else {
 			tryOpen(start.VerifyURL)
 		}
-		// CA fingerprint last, so it sits right next to the approve
-		// action. The dashboard's approval page shows the same value
-		// beside the user_code — the operator visually confirms they
-		// match before clicking approve, blocking an on-path swap of
-		// the CA the CLI just fetched over plain HTTP.
+		// CA fingerprint, with the why. This machine just downloaded
+		// the gateway's CA certificate over plain HTTP, so an on-path
+		// attacker could have swapped it. The dashboard's approve page
+		// shows the fingerprint the gateway actually has — matching
+		// them by eye before approving is what rules that swap out.
 		if setup != nil && setup.caFingerprint != "" {
-			fmt.Printf("  CA fingerprint (must match the dashboard): %s\n", setup.caFingerprint)
+			fmt.Println("  Before approving, check this fingerprint matches the one shown")
+			fmt.Println("  on the dashboard — it confirms the gateway certificate this")
+			fmt.Println("  machine downloaded wasn't tampered with in transit:")
+			fmt.Println()
+			fmt.Printf("    %s\n", setup.caFingerprint)
 			fmt.Println()
 		}
 	}
@@ -1479,12 +1484,12 @@ func approveBaseFromVerifyURL(verifyURL, fallback string) string {
 
 // printQR renders url as a scannable terminal QR, no caption — the URL
 // is always printed directly above the call site and a QR is plainly a
-// QR. GenerateHalfBlock packs two QR rows per line via ▀/▄/█/space,
-// half the height of the block-per-cell variant, and renders cleanly
-// when the join output is piped to a file or pasted into chat.
+// QR. Callers control surrounding blank lines. GenerateHalfBlock packs
+// two QR rows per line via ▀/▄/█/space, half the height of the
+// block-per-cell variant, and renders cleanly when the join output is
+// piped to a file or pasted into chat.
 func printQR(url string) {
 	qrterminal.GenerateHalfBlock(url, qrterminal.M, os.Stdout)
-	fmt.Println()
 }
 
 func tryOpen(u string) {

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -372,19 +372,7 @@ func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine bool) {
 		}
 		return
 	}
-	switch {
-	case s.caInstalled:
-		// Already installed during the tailnet device flow
-		// (onboardViaDeviceFlow). Don't run it — or print it — twice.
-	case !skipTrust:
-		if err := installCATrust(s.caPath); err != nil {
-			s.caHint = manualTrustHint(s.caPath)
-		} else {
-			s.caInstalled = true
-		}
-	default:
-		s.caHint = manualTrustHint(s.caPath)
-	}
+	s.installTrust(skipTrust)
 	if wholeMachine {
 		if err := installShellRC(); err == nil {
 			s.shellRC = true
@@ -671,8 +659,36 @@ func fetchCA(ip, dst string) error {
 	return nil
 }
 
+// installTrust installs the fetched CA into the system trust store
+// behind a live step ("* Installing CA in system trust" → "✓ CA
+// installed in system trust" / "! CA not trusted yet — …") and records
+// the outcome on s. Idempotent: a no-op once s.caInstalled is set (the
+// WireGuard path installs early, before the mode-specific branch).
+func (s *joinSetup) installTrust(skipTrust bool) {
+	if s.caInstalled {
+		return
+	}
+	if skipTrust {
+		s.caHint = manualTrustHint(s.caPath)
+		fmt.Println("! CA fetched but not trusted (--no-trust) — install manually: " + s.caHint)
+		return
+	}
+	// Erase-on-done only when sudo won't prompt — an interactive
+	// password prompt prints inside the step and breaks the cursor
+	// math. sudo -n returns non-zero (without prompting) when a
+	// password would be needed, and errors when sudo is absent.
+	erasable := exec.Command("sudo", "-n", "true").Run() == nil
+	finish := beginStep("Installing CA in system trust", nil, erasable)
+	if err := installCATrust(s.caPath); err != nil {
+		s.caHint = manualTrustHint(s.caPath)
+		finish("! CA not trusted yet — install manually: " + s.caHint)
+	} else {
+		s.caInstalled = true
+		finish("✓ CA installed in system trust")
+	}
+}
+
 func installCATrust(caPath string) error {
-	fmt.Println("Installing CA certificate into system trust store (requires sudo)...")
 	switch runtime.GOOS {
 	case "darwin":
 		return exec.Command("sudo", "security", "add-trusted-cert",
@@ -775,41 +791,6 @@ func fail(format string, a ...any) {
 	os.Exit(2)
 }
 
-// startSpinner paints a braille spinner + label on the current line and
-// returns a stop function that clears the line. Tick is 80ms — fast
-// enough to feel alive while the device-flow poll loop sits on its
-// 3-second interval. Writes only land on stderr-attached TTYs; if stdout
-// isn't a terminal (CI, piped logs) the spinner suppresses itself so it
-// doesn't scribble control codes into log files.
-func startSpinner(label string) func() {
-	if !isTerminal(os.Stdout) {
-		return func() {}
-	}
-	frames := []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
-	stop := make(chan struct{})
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		i := 0
-		t := time.NewTicker(80 * time.Millisecond)
-		defer t.Stop()
-		for {
-			select {
-			case <-stop:
-				fmt.Printf("\r\033[K")
-				return
-			case <-t.C:
-				fmt.Printf("\r%c %s", frames[i%len(frames)], label)
-				i++
-			}
-		}
-	}()
-	return func() {
-		close(stop)
-		<-done
-	}
-}
-
 func isTerminal(f *os.File) bool {
 	fi, err := f.Stat()
 	if err != nil {
@@ -834,14 +815,12 @@ func printChecklist(items []string) {
 // shell-rc updates surface as their own items so the operator sees what
 // they need to do manually; success cases stay quiet to keep the block
 // short.
+// setupSummaryItems returns the trailing checklist items that aren't
+// already reported by their own live step. CA trust is handled by
+// joinSetup.installTrust at install time, so it's intentionally not
+// repeated here.
 func setupSummaryItems(s joinSetup) []string {
 	var out []string
-	switch {
-	case s.caInstalled:
-		out = append(out, "✓ CA installed in system trust")
-	case s.caHint != "":
-		out = append(out, "! CA not trusted yet — install manually: "+s.caHint)
-	}
 	if s.shellRC {
 		out = append(out, `✓ shell rc updated (eval "$(clawpatrol env)")`)
 	}
@@ -987,58 +966,29 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		// tsnet mode), so derive the approve base from it.
 		approveBase := approveBaseFromVerifyURL(start.VerifyURL, gateway)
 		approveURL := approveBase + "/api/onboard/approve?" + aq.Encode()
-		if ar, aerr := cli.Post(approveURL, "application/json", nil); aerr == nil {
+		fmt.Println()
+		finish := beginStep("Approving as tailnet operator", nil, true)
+		ar, aerr := cli.Post(approveURL, "application/json", nil)
+		switch {
+		case aerr != nil:
+			finish("")
+			fmt.Fprintf(os.Stderr, "⚠ auto-approve request failed: %v — approve on the dashboard instead.\n", aerr)
+		case ar.StatusCode == 200:
+			_ = ar.Body.Close()
+			autoApproved = true
+			finish("✓ auto-approved as tailnet operator")
+		case ar.StatusCode == 403:
+			// Not an operator — clear the pending line and fall through
+			// to dashboard approval. Normal for any non-allowlisted user.
+			_ = ar.Body.Close()
+			finish("")
+		default:
 			body, _ := io.ReadAll(io.LimitReader(ar.Body, 1024))
 			_ = ar.Body.Close()
-			switch ar.StatusCode {
-			case 200:
-				autoApproved = true
-				fmt.Println()
-				fmt.Println("✓ auto-approved as tailnet operator")
-			case 403:
-				// Not an operator — quietly fall through to the
-				// browser-approval path. No warning: this is the
-				// normal case for any user not on the allowlist.
-			default:
-				fmt.Fprintf(os.Stderr,
-					"⚠ auto-approve unexpected status %d: %s\n  Falling back to dashboard approval.\n",
-					ar.StatusCode, strings.TrimSpace(string(body)))
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "⚠ auto-approve POST failed: %v; falling back to dashboard approval.\n", aerr)
-		}
-	}
-
-	if !autoApproved {
-		fmt.Println()
-		fmt.Printf("  Approve this device on the dashboard. Code: %s\n", start.UserCode)
-		fmt.Println()
-		fmt.Printf("    %s\n", start.VerifyURL)
-		fmt.Println()
-		// Tailnet-only verify URLs (100.64.0.0/10 IP or *.ts.net
-		// host) are unreachable from the machine running
-		// `clawpatrol join` until approval lands — that's the whole
-		// point of needing approval. Print a QR so the operator can
-		// scan from a phone or another tailnet-connected device. Skip
-		// tryOpen there: a local browser can't reach the URL anyway.
-		if isTailnetOnlyURL(start.VerifyURL) {
-			printQR(start.VerifyURL)
-			fmt.Println()
-		} else {
-			tryOpen(start.VerifyURL)
-		}
-		// CA fingerprint, with the why. This machine just downloaded
-		// the gateway's CA certificate over plain HTTP, so an on-path
-		// attacker could have swapped it. The dashboard's approve page
-		// shows the fingerprint the gateway actually has — matching
-		// them by eye before approving is what rules that swap out.
-		if setup != nil && setup.caFingerprint != "" {
-			fmt.Println("  Before approving, check this fingerprint matches the one shown")
-			fmt.Println("  on the dashboard — it confirms the gateway certificate this")
-			fmt.Println("  machine downloaded wasn't tampered with in transit:")
-			fmt.Println()
-			fmt.Printf("    %s\n", setup.caFingerprint)
-			fmt.Println()
+			finish("")
+			fmt.Fprintf(os.Stderr,
+				"⚠ auto-approve unexpected status %d: %s — approve on the dashboard instead.\n",
+				ar.StatusCode, strings.TrimSpace(string(body)))
 		}
 	}
 
@@ -1052,20 +1002,43 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	// In whole-machine mode the clawpatrol WireGuard tunnel already routes
 	// all traffic — including these poll requests. When the admin approves,
 	// MintKey evicts our old peer from the gateway device, killing the
-	// tunnel mid-poll and hanging the spinner indefinitely. Bring it down
-	// before polling so requests go over the regular internet.
+	// tunnel mid-poll and hanging the join indefinitely. Bring it down
+	// before polling so requests go over the regular internet — and before
+	// the approve step below, so wg-quick's own output doesn't land inside
+	// that step's block.
 	if wholeMachine {
 		_ = runAsRoot("wg-quick", "down", "clawpatrol").Run()
 	}
 
-	// After an operator self-approve the device is already approved;
-	// the poll just collects the minted credentials. Don't claim we're
-	// "waiting for approval" in that case.
-	spinLabel := "Waiting for approval"
-	if autoApproved {
-		spinLabel = "Completing join"
+	// Manual approval: show the approve step and leave it up until the
+	// poll loop sees the device approved, then collapse it to "✓ approved".
+	// No spinner — the step block is the indicator. (Auto-approve already
+	// printed its own "✓ auto-approved …".)
+	var finishApprove func(string)
+	if !autoApproved {
+		// Tailnet-only verify URLs (100.64.0.0/10 IP or *.ts.net host)
+		// are unreachable from the joining machine until approval lands,
+		// so show a QR to scan from a phone / tailnet device. For a
+		// publicly reachable URL, skip the QR and just open a browser.
+		tailnetOnly := isTailnetOnlyURL(start.VerifyURL)
+		detail := linkDetail(start.VerifyURL, tailnetOnly)
+		if !tailnetOnly {
+			tryOpen(start.VerifyURL)
+		}
+		// CA fingerprint with the why: this machine downloaded the CA
+		// over plain HTTP, so an on-path attacker could have swapped it.
+		// The dashboard shows the fingerprint the gateway actually has;
+		// matching them by eye before approving rules that swap out.
+		if setup != nil && setup.caFingerprint != "" {
+			detail = append(detail,
+				"",
+				"  before approving, confirm this CA fingerprint matches the dashboard:",
+				"  "+setup.caFingerprint)
+		}
+		fmt.Println()
+		finishApprove = beginStep("Approve this device on the dashboard — code "+start.UserCode, detail, true)
 	}
-	stopSpin := startSpinner(spinLabel)
+
 	authKey, loginServer, apiToken := "", "", ""
 	var tailnetGWHost, tailnetControlURL, gatewayIP, caPEM string
 	// Track the most recent transport error so a poll loop that never
@@ -1102,21 +1075,17 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			break
 		}
 		if e := pv["error"]; e != "" && e != "authorization_pending" && e != "slow_down" {
-			stopSpin()
 			return false, fmt.Errorf("poll: %s (%s)", e, pv["detail"])
 		}
 	}
-	stopSpin()
 	if authKey == "" {
 		if lastPollErr != nil {
 			return false, fmt.Errorf("timed out waiting for approval (last poll error: %w)", lastPollErr)
 		}
 		return false, fmt.Errorf("timed out waiting for approval")
 	}
-	// On the auto-approve path we already printed the operator
-	// confirmation; don't repeat it here.
-	if !autoApproved {
-		fmt.Println("✓ approved")
+	if finishApprove != nil {
+		finishApprove("✓ approved")
 	}
 	// Approval click ⇒ operator visually confirmed the CA
 	// fingerprint on the dashboard matched what the CLI
@@ -1187,11 +1156,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			macErr = macHelperInstall(wholeMachine)
 		}
 		items := setupSummaryItems(*setup)
-		if wgIP := wgAddressFromConf(authKey); wgIP != "" {
-			items = append(items, "✓ joined as "+wgIP)
-		} else {
-			items = append(items, "✓ joined")
-		}
+		items = append(items, "✓ joined gateway")
 		printChecklist(items)
 		fmt.Println()
 		if !wholeMachine {
@@ -1235,15 +1200,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				if fp, ferr := caFingerprintFromPEM([]byte(caPEM)); ferr == nil {
 					setup.caFingerprint = fp
 				}
-				if !skipTrust {
-					if ierr := installCATrust(setup.caPath); ierr == nil {
-						setup.caInstalled = true
-					} else {
-						setup.caHint = manualTrustHint(setup.caPath)
-					}
-				} else {
-					setup.caHint = manualTrustHint(setup.caPath)
-				}
+				setup.installTrust(skipTrust)
 			}
 		}
 		if err := os.WriteFile(filepath.Join(clawDir, "mode"), []byte("tailscale\n"), 0o600); err != nil {
@@ -1298,7 +1255,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			}
 		}
 		items := setupSummaryItems(*setup)
-		items = append(items, "✓ joined — the daemon joins the tailnet on your first `clawpatrol run`")
+		items = append(items, "✓ joined gateway")
 		printChecklist(items)
 		fmt.Println()
 		fmt.Println("Installed! Try: clawpatrol run claude")
@@ -1419,15 +1376,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 					[]byte(peer.TailscaleIPs[0]+"\n"), 0o600)
 				if _, serr := os.Stat(setup.caPath); serr != nil {
 					if ferr := fetchCA(peer.TailscaleIPs[0], setup.caPath); ferr == nil {
-						if !skipTrust {
-							if ierr := installCATrust(setup.caPath); ierr != nil {
-								setup.caHint = manualTrustHint(setup.caPath)
-							} else {
-								setup.caInstalled = true
-							}
-						} else {
-							setup.caHint = manualTrustHint(setup.caPath)
-						}
+						setup.installTrust(skipTrust)
 					}
 				}
 			}
@@ -1440,10 +1389,10 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	}
 
 	items := setupSummaryItems(*setup)
-	items = append(items, "✓ joined tailnet as "+tailIP)
+	items = append(items, "✓ joined gateway")
 	printChecklist(items)
 	fmt.Println()
-	fmt.Println("Installed! Try: clawpatrol run -- claude")
+	fmt.Println("Installed! Try: clawpatrol run claude")
 
 	return false, nil
 }
@@ -1490,17 +1439,59 @@ func approveBaseFromVerifyURL(verifyURL, fallback string) string {
 	return u.Scheme + "://" + u.Host
 }
 
-// printQR renders url as a scannable terminal QR, indented to line up
-// under the URL printed above it. No caption — a QR is plainly a QR,
-// and callers control surrounding blank lines. GenerateHalfBlock packs
-// two QR rows per line via ▀/▄/█/space, half the height of the
-// block-per-cell variant, and renders cleanly when the join output is
-// piped to a file or pasted into chat.
-func printQR(url string) {
+// qrLines renders url as half-block QR rows, each indented two spaces
+// so it sits under a step's "* " headline. GenerateHalfBlock packs two
+// QR rows per line via ▀/▄/█/space — half the height of the
+// block-per-cell variant, and it renders cleanly when the join output
+// is piped to a file or pasted into chat.
+func qrLines(url string) []string {
 	var buf bytes.Buffer
 	qrterminal.GenerateHalfBlock(url, qrterminal.M, &buf)
+	var out []string
 	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
-		fmt.Println("    " + line)
+		out = append(out, "  "+line)
+	}
+	return out
+}
+
+// linkDetail returns the indented detail lines for a step that points
+// the operator at a URL: the URL itself, and — when qr is true — a
+// blank line plus a scannable QR beneath it. Shared by the
+// tailnet-login and dashboard-approval steps so the URL + QR layout
+// stays identical everywhere it appears.
+func linkDetail(url string, qr bool) []string {
+	out := []string{"  " + url}
+	if qr {
+		out = append(out, "")
+		out = append(out, qrLines(url)...)
+	}
+	return out
+}
+
+// beginStep prints a pending step — a "* "-prefixed headline plus any
+// already-indented detail lines — and returns a finish func. On a TTY
+// (and when erasable) finish erases the whole block and reprints it as
+// a single status line ("✓ …" done, "! …" needs-attention, or "" to
+// just clear it); off a TTY it appends the status line below instead.
+//
+// Nothing else may write to stdout between begin and finish or the
+// erase line-count drifts. erasable must be false when the step shells
+// out to something that writes to the terminal (an interactive sudo
+// password prompt), since that output would land inside the block.
+func beginStep(headline string, detail []string, erasable bool) func(status string) {
+	fmt.Println("* " + headline)
+	for _, l := range detail {
+		fmt.Println(l)
+	}
+	n := 1 + len(detail)
+	erase := erasable && isTerminal(os.Stdout)
+	return func(status string) {
+		if erase {
+			fmt.Printf("\033[%dA\033[J", n)
+		}
+		if status != "" {
+			fmt.Println(status)
+		}
 	}
 }
 

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -966,13 +966,25 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		// tsnet mode), so derive the approve base from it.
 		approveBase := approveBaseFromVerifyURL(start.VerifyURL, gateway)
 		approveURL := approveBase + "/api/onboard/approve?" + aq.Encode()
-		fmt.Println()
 		finish := beginStep("Approving as tailnet operator", nil, true)
-		ar, aerr := cli.Post(approveURL, "application/json", nil)
+		// Bound the self-approve POST. It dials the gateway's tailnet IP,
+		// which hangs indefinitely if this machine logged into a tailnet
+		// that doesn't include the gateway (e.g. the wrong account at the
+		// Tailscale login prompt). On timeout / error, fall back to
+		// dashboard approval rather than wedging the whole join.
+		actx, acancel := context.WithTimeout(context.Background(), 15*time.Second)
+		var ar *http.Response
+		areq, aerr := http.NewRequestWithContext(actx, http.MethodPost, approveURL, nil)
+		if aerr == nil {
+			ar, aerr = cli.Do(areq)
+		}
 		switch {
 		case aerr != nil:
 			finish("")
-			fmt.Fprintf(os.Stderr, "⚠ auto-approve request failed: %v — approve on the dashboard instead.\n", aerr)
+			fmt.Fprintf(os.Stderr,
+				"⚠ couldn't reach the gateway over the tailnet to self-approve\n"+
+					"  (is this machine logged into the tailnet that has %s?)\n"+
+					"  — approve on the dashboard instead.\n", gateway)
 		case ar.StatusCode == 200:
 			_ = ar.Body.Close()
 			autoApproved = true
@@ -990,6 +1002,7 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				"⚠ auto-approve unexpected status %d: %s — approve on the dashboard instead.\n",
 				ar.StatusCode, strings.TrimSpace(string(body)))
 		}
+		acancel()
 	}
 
 	// 2. poll
@@ -1035,7 +1048,6 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 				"  before approving, confirm this CA fingerprint matches the dashboard:",
 				"  "+setup.caFingerprint)
 		}
-		fmt.Println()
 		finishApprove = beginStep("Approve this device on the dashboard — code "+start.UserCode, detail, true)
 	}
 

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -220,10 +220,20 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 	defer cancel()
 
 	var finish func(string)
+	lastState := "unknown"
+	// settle resolves the pending step (if shown) with line, else prints
+	// line on its own.
+	settle := func(line string) {
+		if finish != nil {
+			finish(line)
+		} else {
+			fmt.Println(line)
+		}
+	}
 	for {
 		select {
 		case <-deadline.Done():
-			return fmt.Errorf("tailnet bootstrap: timed out waiting for login")
+			return fmt.Errorf("tailnet bootstrap: timed out waiting for login (last state: %s)", lastState)
 		default:
 		}
 		st, err := lc.StatusWithoutPeers(deadline)
@@ -233,6 +243,7 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
+		lastState = st.BackendState
 		if finish == nil && st.AuthURL != "" {
 			// The box running `clawpatrol join` is usually headless
 			// (SSH session, no browser). Show the login URL + a QR so
@@ -242,14 +253,16 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			finish = beginStep("Log in to the tailnet to reach the gateway", linkDetail(st.AuthURL, true), true)
 			tryOpen(st.AuthURL) // best-effort local browser if one exists
 		}
-		if st.BackendState == "Running" {
-			if finish != nil {
-				finish("✓ logged in to the tailnet")
-			} else {
-				// Cached login — Running before any AuthURL appeared.
-				fmt.Println("✓ logged in to the tailnet")
-			}
+		switch st.BackendState {
+		case "Running":
+			settle("✓ logged in to the tailnet")
 			return nil
+		case "NeedsMachineAuth":
+			// Authenticated but the tailnet gates new devices on admin
+			// approval — it'll never reach Running on its own. Fail with
+			// a reason instead of waiting out the 10-minute deadline.
+			settle("! tailnet requires admin approval for this device")
+			return fmt.Errorf("tailnet bootstrap: device needs admin approval — approve it in the Tailscale admin console (Machines), then re-run")
 		}
 		time.Sleep(500 * time.Millisecond)
 	}

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -244,7 +244,6 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 				"",
 			}
 			detail = append(detail, linkDetail(st.AuthURL, true)...)
-			fmt.Println()
 			finish = beginStep("Log in to the tailnet to reach the gateway", detail, true)
 			tryOpen(st.AuthURL) // best-effort local browser if one exists
 		}

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -220,10 +220,9 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 	defer cancel()
 
 	fmt.Println()
-	fmt.Println("Reaching the gateway requires Tailscale tailnet access.")
-	fmt.Println("Opening browser for one-time interactive login.")
-	fmt.Println("(These credentials are discarded as soon as join completes —")
-	fmt.Println(" the agent's persistent identity is the gateway-minted tag.)")
+	fmt.Println("  Tailnet access is needed to reach the gateway. Log in once below.")
+	fmt.Println("  These credentials are discarded when join completes — the agent's")
+	fmt.Println("  identity is the gateway-minted tag.")
 
 	printed := false
 	for {
@@ -243,16 +242,17 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			fmt.Println()
 			fmt.Printf("    %s\n", st.AuthURL)
 			fmt.Println()
-			// The box running `clawpatrol join` often has no browser
-			// (headless VM, SSH session). Print a QR alongside so the
-			// operator can scan it from a phone — this is a public
-			// login.tailscale.com URL, reachable from any device.
-			printLoginQR(st.AuthURL)
+			// The box running `clawpatrol join` is usually headless
+			// (SSH session, no browser). Show a QR right under the URL
+			// so the operator can scan from a phone — it's a public
+			// login.tailscale.com link, reachable from any device. Also
+			// best-effort open a local browser if one exists.
+			printQR(st.AuthURL)
 			tryOpen(st.AuthURL)
 			printed = true
 		}
 		if st.BackendState == "Running" {
-			fmt.Println("Tailnet login complete.")
+			fmt.Println("✓ tailnet login complete")
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -73,6 +73,13 @@ func (s *ramStateStore) WriteState(k ipn.StateKey, v []byte) error {
 
 // tailnetBootstrap is a transient tsnet.Server that exists only for
 // the duration of `clawpatrol join`. Use Client() to talk to the
+// bootstrapHostnamePrefix names the ephemeral tsnet node a `--login`
+// join spins up to reach the gateway over the tailnet. The gateway
+// filters agents whose whois hostname carries this prefix out of the
+// device list — the node is discarded the instant join completes and
+// is never a managed device.
+const bootstrapHostnamePrefix = "clawpatrol-bootstrap-"
+
 // gateway over the tailnet, then call Close to log the node out and
 // reclaim the log dir.
 type tailnetBootstrap struct {
@@ -151,7 +158,7 @@ func bootstrapTailnetForJoin(ctx context.Context) (*tailnetBootstrap, error) {
 		cleanup()
 		return nil, fmt.Errorf("tailnet bootstrap: random: %w", err)
 	}
-	hostname := "clawpatrol-bootstrap-" + hex.EncodeToString(suffix)
+	hostname := bootstrapHostnamePrefix + hex.EncodeToString(suffix)
 
 	s := &tsnet.Server{
 		// Dir still hosts tsnet's log buffer (tailscaled.log.conf
@@ -236,6 +243,11 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			fmt.Println()
 			fmt.Printf("    %s\n", st.AuthURL)
 			fmt.Println()
+			// The box running `clawpatrol join` often has no browser
+			// (headless VM, SSH session). Print a QR alongside so the
+			// operator can scan it from a phone — this is a public
+			// login.tailscale.com URL, reachable from any device.
+			printLoginQR(st.AuthURL)
 			tryOpen(st.AuthURL)
 			printed = true
 		}

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -219,12 +219,7 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 	deadline, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	fmt.Println()
-	fmt.Println("  Tailnet access is needed to reach the gateway. Log in once below.")
-	fmt.Println("  These credentials are discarded when join completes — the agent's")
-	fmt.Println("  identity is the gateway-minted tag.")
-
-	printed := false
+	var finish func(string)
 	for {
 		select {
 		case <-deadline.Done():
@@ -238,22 +233,28 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
-		if !printed && st.AuthURL != "" {
-			fmt.Println()
-			fmt.Printf("    %s\n", st.AuthURL)
-			fmt.Println()
+		if finish == nil && st.AuthURL != "" {
 			// The box running `clawpatrol join` is usually headless
-			// (SSH session, no browser). Show a QR right under the URL
-			// so the operator can scan from a phone — it's a public
-			// login.tailscale.com link, reachable from any device. Also
-			// best-effort open a local browser if one exists.
-			printQR(st.AuthURL)
+			// (SSH session, no browser). Show the login URL + a QR so
+			// the operator can scan from a phone — it's a public
+			// login.tailscale.com link, reachable from any device. The
+			// whole block collapses to "✓ logged in" once auth lands.
+			detail := []string{
+				"  log in once; these credentials are discarded when join completes",
+				"",
+			}
+			detail = append(detail, linkDetail(st.AuthURL, true)...)
 			fmt.Println()
-			tryOpen(st.AuthURL)
-			printed = true
+			finish = beginStep("Log in to the tailnet to reach the gateway", detail, true)
+			tryOpen(st.AuthURL) // best-effort local browser if one exists
 		}
 		if st.BackendState == "Running" {
-			fmt.Println("✓ tailnet login complete")
+			if finish != nil {
+				finish("✓ logged in to the tailnet")
+			} else {
+				// Cached login — Running before any AuthURL appeared.
+				fmt.Println("✓ logged in to the tailnet")
+			}
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -239,12 +239,7 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			// the operator can scan from a phone — it's a public
 			// login.tailscale.com link, reachable from any device. The
 			// whole block collapses to "✓ logged in" once auth lands.
-			detail := []string{
-				"  log in once; these credentials are discarded when join completes",
-				"",
-			}
-			detail = append(detail, linkDetail(st.AuthURL, true)...)
-			finish = beginStep("Log in to the tailnet to reach the gateway", detail, true)
+			finish = beginStep("Log in to the tailnet to reach the gateway", linkDetail(st.AuthURL, true), true)
 			tryOpen(st.AuthURL) // best-effort local browser if one exists
 		}
 		if st.BackendState == "Running" {

--- a/cmd/clawpatrol/setup_tailnet_login.go
+++ b/cmd/clawpatrol/setup_tailnet_login.go
@@ -248,6 +248,7 @@ func awaitTailnetAuth(ctx context.Context, lc *local.Client) error {
 			// login.tailscale.com link, reachable from any device. Also
 			// best-effort open a local browser if one exists.
 			printQR(st.AuthURL)
+			fmt.Println()
 			tryOpen(st.AuthURL)
 			printed = true
 		}

--- a/cmd/clawpatrol/setup_test.go
+++ b/cmd/clawpatrol/setup_test.go
@@ -34,3 +34,29 @@ func TestIsTailnetOnlyURL(t *testing.T) {
 		})
 	}
 }
+
+// approveBaseFromVerifyURL must return the dashboard origin of the
+// verify URL so auto-approve POSTs to the operator-gated API (where
+// the bootstrap node's whois identity is checked), not the public
+// Funnel join URL whose allowlist 404s /api/onboard/approve.
+func TestApproveBaseFromVerifyURL(t *testing.T) {
+	const fallback = "https://clawpatrol-gateway.tail9a48e.ts.net"
+	cases := []struct {
+		name      string
+		verifyURL string
+		want      string
+	}{
+		{"tailnet dashboard url", "http://100.79.206.14:8080/#/onboard/NDVL-4343", "http://100.79.206.14:8080"},
+		{"public dashboard url", "https://gw.example.com/#/onboard/X", "https://gw.example.com"},
+		{"empty falls back", "", fallback},
+		{"garbage falls back", "::not-a-url::", fallback},
+		{"missing host falls back", "http:///#/onboard/X", fallback},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := approveBaseFromVerifyURL(c.verifyURL, fallback); got != c.want {
+				t.Errorf("approveBaseFromVerifyURL(%q) = %q; want %q", c.verifyURL, got, c.want)
+			}
+		})
+	}
+}

--- a/dashboard/src/components/AddDeviceModal.tsx
+++ b/dashboard/src/components/AddDeviceModal.tsx
@@ -1,17 +1,51 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { listProfiles, type Whoami } from "../lib/api";
 import { Button } from "./Button";
 import { Modal } from "./Modal";
 
+// shellArg quotes s for copy-paste into a POSIX shell when it
+// contains anything beyond plain word characters.
+function shellArg(s: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s)) return s;
+  return "'" + s.replaceAll("'", "'\\''") + "'";
+}
+
 export function AddDeviceModal({
-  publicURL,
+  whoami,
   onClose,
 }: {
-  publicURL?: string;
+  whoami?: Whoami | null;
   onClose: () => void;
 }) {
-  const url = publicURL || window.location.origin;
+  const url = whoami?.public_url || window.location.origin;
+  const [profiles, setProfiles] = useState<string[]>([]);
+  const [profile, setProfile] = useState("");
+
+  useEffect(() => {
+    listProfiles()
+      .then((p) => {
+        setProfiles(p);
+        // Mirror the gateway's default-profile pick: "default" if it
+        // exists, else the first profile in source order.
+        setProfile(p.includes("default") ? "default" : (p[0] ?? ""));
+      })
+      .catch(() => setProfiles([]));
+  }, []);
+
+  // An operator authenticated over the tailnet can mint joins that
+  // auto-approve: --login joins with their identity and the gateway's
+  // operator gate accepts the self-approval. Password sessions can't
+  // promise that, so the plain browser-approval join is suggested.
+  const login = whoami?.auth_method === "tailscale";
+
   const installCmd = "curl -fsSL https://clawpatrol.dev/install.sh | sh";
-  const joinCmd = `clawpatrol join ${url}`;
+  const joinCmd = [
+    "clawpatrol",
+    "join",
+    ...(login ? ["--login"] : []),
+    ...(profile ? ["--profile", shellArg(profile)] : []),
+    url,
+  ].join(" ");
 
   return (
     <Modal title="Add device" onClose={onClose}>
@@ -19,8 +53,30 @@ export function AddDeviceModal({
         <h3 className="text-sm leading-none tracking-tight text-text font-mono">
           Run the following on the new device:
         </h3>
+        {profiles.length > 1 && (
+          <div className="space-y-1">
+            <label className="text-sm text-text-muted font-sans block">
+              Profile for the new device
+            </label>
+            <select
+              value={profile}
+              onChange={(e) => setProfile(e.target.value)}
+              className="w-full font-mono text-xs text-text bg-canvas border-1.5 border-navy px-2 py-1.5"
+            >
+              {profiles.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
         <Step n={1} label="Install" cmd={installCmd} />
-        <Step n={2} label="Join" cmd={joinCmd} />
+        <Step
+          n={2}
+          label={login ? "Join (auto-approves via your tailnet identity)" : "Join"}
+          cmd={joinCmd}
+        />
       </div>
     </Modal>
   );

--- a/dashboard/src/components/AddDeviceModal.tsx
+++ b/dashboard/src/components/AddDeviceModal.tsx
@@ -21,8 +21,8 @@ export function AddDeviceModal({
   const [profiles, setProfiles] = useState<string[]>([]);
   const [profile, setProfile] = useState("");
   // Per-process `clawpatrol run` is the default; --whole-machine
-  // installs system Tailscale and pins the gateway as the host-wide
-  // exit node.
+  // installs system Tailscale and routes all of the machine's network
+  // traffic through clawpatrol.
   const [mode, setMode] = useState<"run" | "whole-machine">("run");
 
   useEffect(() => {
@@ -84,7 +84,9 @@ export function AddDeviceModal({
               className="w-full font-mono text-xs text-text bg-canvas border-1.5 border-navy px-2 py-1.5"
             >
               <option value="run">clawpatrol run (per-process, default)</option>
-              <option value="whole-machine">--whole-machine (host-wide exit node)</option>
+              <option value="whole-machine">
+                --whole-machine (route all of this machine's traffic through clawpatrol)
+              </option>
             </select>
           </label>
         </div>

--- a/dashboard/src/components/AddDeviceModal.tsx
+++ b/dashboard/src/components/AddDeviceModal.tsx
@@ -20,6 +20,10 @@ export function AddDeviceModal({
   const url = whoami?.public_url || window.location.origin;
   const [profiles, setProfiles] = useState<string[]>([]);
   const [profile, setProfile] = useState("");
+  // Per-process `clawpatrol run` is the default; --whole-machine
+  // installs system Tailscale and pins the gateway as the host-wide
+  // exit node.
+  const [mode, setMode] = useState<"run" | "whole-machine">("run");
 
   useEffect(() => {
     listProfiles()
@@ -43,34 +47,48 @@ export function AddDeviceModal({
     "clawpatrol",
     "join",
     ...(login ? ["--login"] : []),
+    ...(mode === "whole-machine" ? ["--whole-machine"] : []),
     ...(profile ? ["--profile", shellArg(profile)] : []),
     url,
   ].join(" ");
 
   return (
     <Modal title="Add device" onClose={onClose}>
-      <div className="p-4 space-y-6">
+      <div className="p-4 space-y-5">
         <h3 className="text-sm leading-none tracking-tight text-text font-mono">
           Run the following on the new device:
         </h3>
-        {profiles.length > 1 && (
-          <div className="space-y-1">
-            <label className="text-sm text-text-muted font-sans block">
-              Profile for the new device
+
+        <div className="space-y-3">
+          {profiles.length > 1 && (
+            <label className="block space-y-1">
+              <span className="text-xs text-text-muted font-sans">Profile</span>
+              <select
+                value={profile}
+                onChange={(e) => setProfile(e.target.value)}
+                className="w-full font-mono text-xs text-text bg-canvas border-1.5 border-navy px-2 py-1.5"
+              >
+                {profiles.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
             </label>
+          )}
+          <label className="block space-y-1">
+            <span className="text-xs text-text-muted font-sans">Mode</span>
             <select
-              value={profile}
-              onChange={(e) => setProfile(e.target.value)}
+              value={mode}
+              onChange={(e) => setMode(e.target.value as "run" | "whole-machine")}
               className="w-full font-mono text-xs text-text bg-canvas border-1.5 border-navy px-2 py-1.5"
             >
-              {profiles.map((p) => (
-                <option key={p} value={p}>
-                  {p}
-                </option>
-              ))}
+              <option value="run">clawpatrol run (per-process, default)</option>
+              <option value="whole-machine">--whole-machine (host-wide exit node)</option>
             </select>
-          </div>
-        )}
+          </label>
+        </div>
+
         <Step n={1} label="Install" cmd={installCmd} />
         <Step
           n={2}
@@ -111,20 +129,20 @@ function Step({ n, label, cmd }: { n: number; label: string; cmd: string }) {
   }
   return (
     <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        <span className="w-6 h-6 squircle-md bg-navy-100 text-xs font-semibold font-mono flex items-center justify-center shrink-0">
-          {n}
-        </span>
-        <span className="text-sm text-text-muted font-sans">{label}</span>
-      </div>
-      <div className="relative">
-        <pre className="bg-navy rounded px-4 py-4 text-xs font-mono text-canvas overflow-x-auto whitespace-pre">
-          {cmd}
-        </pre>
-        <Button variant="outline" onClick={copy} className="absolute top-2.5 right-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="w-6 h-6 squircle-md bg-navy-100 text-xs font-semibold font-mono flex items-center justify-center shrink-0">
+            {n}
+          </span>
+          <span className="text-sm text-text-muted font-sans truncate">{label}</span>
+        </div>
+        <Button variant="outline" onClick={copy} className="shrink-0">
           {copied ? "copied" : "copy"}
         </Button>
       </div>
+      <pre className="bg-navy rounded px-4 py-4 text-xs font-mono text-canvas overflow-x-auto whitespace-pre">
+        {cmd}
+      </pre>
     </div>
   );
 }

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -94,10 +94,13 @@ export function AgentsTable({
               <Td
                 className="text-xs text-text-muted tabular-nums truncate"
                 title={
-                  [a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") || `wg ${a.ip}`
+                  [a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") ||
+                  (a.ip.startsWith("tsnet-") ? "approved, waiting for first connect" : `wg ${a.ip}`)
                 }
               >
-                {a.external_ipv4 || a.external_ipv6 || a.ip}
+                {a.external_ipv4 ||
+                  a.external_ipv6 ||
+                  (a.ip.startsWith("tsnet-") ? "pending first connect" : a.ip)}
               </Td>
             </tr>
           );

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -55,11 +55,17 @@ export function AgentsTable({
           const dotTitle = flagged
             ? `${needs.length} integration${needs.length === 1 ? "" : "s"} need setup: ${needs.join(", ")}`
             : "";
+          // Placeholder rows for devices approved but not yet connected
+          // (the gateway keys them "tsnet-<host>" until first register).
+          const pending = a.ip.startsWith("tsnet-");
           return (
             <tr
               key={a.ip}
-              onClick={() => onSelect?.(a.ip)}
-              className="border-b border-canvas-muted cursor-pointer hover:bg-canvas-muted transition-colors"
+              onClick={pending ? undefined : () => onSelect?.(a.ip)}
+              className={
+                "border-b border-canvas-muted transition-colors " +
+                (pending ? "opacity-70" : "cursor-pointer hover:bg-canvas-muted")
+              }
             >
               <Td>
                 <div className="flex items-center gap-1.5 min-w-0">
@@ -95,12 +101,10 @@ export function AgentsTable({
                 className="text-xs text-text-muted tabular-nums truncate"
                 title={
                   [a.external_ipv4, a.external_ipv6].filter(Boolean).join(" / ") ||
-                  (a.ip.startsWith("tsnet-") ? "approved, waiting for first connect" : `wg ${a.ip}`)
+                  (pending ? "approved, waiting for first connect" : `wg ${a.ip}`)
                 }
               >
-                {a.external_ipv4 ||
-                  a.external_ipv6 ||
-                  (a.ip.startsWith("tsnet-") ? "pending first connect" : a.ip)}
+                {a.external_ipv4 || a.external_ipv6 || (pending ? "pending first connect" : a.ip)}
               </Td>
             </tr>
           );

--- a/dashboard/src/components/AgentsTable.tsx
+++ b/dashboard/src/components/AgentsTable.tsx
@@ -61,10 +61,13 @@ export function AgentsTable({
           return (
             <tr
               key={a.ip}
-              onClick={pending ? undefined : () => onSelect?.(a.ip)}
+              onClick={() => onSelect?.(a.ip)}
               className={
-                "border-b border-canvas-muted transition-colors " +
-                (pending ? "opacity-70" : "cursor-pointer hover:bg-canvas-muted")
+                "border-b border-canvas-muted cursor-pointer hover:bg-canvas-muted transition-colors " +
+                // Dim pending rows as a cue, but keep them clickable —
+                // the detail page is where the operator re-assigns the
+                // profile before the device first connects.
+                (pending ? "opacity-70" : "")
               }
             >
               <Td>

--- a/dashboard/src/components/DevicesPage.tsx
+++ b/dashboard/src/components/DevicesPage.tsx
@@ -33,9 +33,7 @@ export function DevicesPage({
           <AgentsTable agents={agents} integrations={integrations} onSelect={onSelect} />
         </div>
       </section>
-      {showAdd && (
-        <AddDeviceModal publicURL={whoami?.public_url} onClose={() => setShowAdd(false)} />
-      )}
+      {showAdd && <AddDeviceModal whoami={whoami} onClose={() => setShowAdd(false)} />}
     </Main>
   );
 }

--- a/dashboard/src/components/OnboardPage.tsx
+++ b/dashboard/src/components/OnboardPage.tsx
@@ -10,32 +10,46 @@ export function OnboardPage({ code }: { code: string }) {
     user_code?: string;
     approved?: boolean;
     ca_fingerprint?: string;
+    profiles?: string[];
+    suggested_profile?: string;
   } | null>(null);
+  const [profile, setProfile] = useState("");
+  const [assigned, setAssigned] = useState("");
 
   useEffect(() => {
     fetch("/api/onboard/lookup?code=" + encodeURIComponent(code))
       .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
-      .then((d) => setInfo(d))
+      .then((d) => {
+        setInfo(d);
+        setProfile(d.suggested_profile || "");
+        // For an already-approved code the suggestion IS the
+        // assignment (the gateway stores the final choice).
+        if (d.approved) setAssigned(d.suggested_profile || "");
+      })
       .catch((e) => setErr(String(e)));
   }, [code]);
 
   async function approve() {
     setStatus("approving");
     try {
-      const r = await fetch("/api/onboard/approve?code=" + encodeURIComponent(code), {
-        method: "POST",
-      });
+      let url = "/api/onboard/approve?code=" + encodeURIComponent(code);
+      if (profile) url += "&profile=" + encodeURIComponent(profile);
+      const r = await fetch(url, { method: "POST" });
       if (!r.ok) {
         setErr(await r.text());
         setStatus("error");
         return;
       }
+      const d = await r.json().catch(() => ({}));
+      setAssigned(d.profile || profile);
       setStatus("approved");
     } catch (e) {
       setErr(String(e));
       setStatus("error");
     }
   }
+
+  const profiles = info?.profiles ?? [];
 
   return (
     <Main centered>
@@ -61,6 +75,30 @@ export function OnboardPage({ code }: { code: string }) {
                 only approve if you typed this code on the new machine.
               </div>
 
+              {!info.approved && status !== "approved" && profiles.length > 0 && (
+                <div>
+                  <label className="font-mono text-2xs uppercase tracking-wider text-text-subtle block">
+                    profile
+                  </label>
+                  {profiles.length === 1 ? (
+                    <div className="font-mono text-sm text-text mt-1">{profiles[0]}</div>
+                  ) : (
+                    <select
+                      value={profile}
+                      onChange={(e) => setProfile(e.target.value)}
+                      disabled={status === "approving"}
+                      className="mt-1 w-full font-mono text-sm text-text bg-canvas border-1.5 border-navy px-2 py-1.5"
+                    >
+                      {profiles.map((p) => (
+                        <option key={p} value={p}>
+                          {p}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              )}
+
               {info.ca_fingerprint && (
                 <details className="text-[0.6875rem] text-[#737373]">
                   <summary className="cursor-pointer hover:text-[#171717]">
@@ -80,7 +118,14 @@ export function OnboardPage({ code }: { code: string }) {
               {status === "approving" && <div className="text-xs text-text-muted">approving…</div>}
               {(status === "approved" || info.approved) && (
                 <div className="text-xs text-success-600">
-                  ✓ approved — return to the CLI on the new device
+                  ✓ approved
+                  {assigned ? (
+                    <>
+                      {" — profile "}
+                      <span className="font-mono">{assigned}</span>
+                    </>
+                  ) : null}
+                  {" — return to the CLI on the new device"}
                 </div>
               )}
             </div>


### PR DESCRIPTION
Fixes #655, plus a ground-up cleanup of the `clawpatrol join` output that surfaced while testing this end to end on a real client.

## Onboarding: profile assignment (the #655 work)

* `/api/onboard/lookup` returns the policy's profile names plus a `suggested_profile` (the CLI's `join --profile` value when it names a real profile, else the same default `apiOnboardApprove` would pick), so the approval page renders an accurate picker.
* Approval page shows a profile picker preset to the suggestion (static text when there's exactly one profile); the choice is sent as `?profile=`.
* `apiOnboardApprove` validates the profile: an explicit query param naming a nonexistent profile is a 400 (a typo'd `--login` auto-approve then falls back to dashboard approval instead of landing in a ghost profile); a bogus stashed suggestion degrades to the default. Zero-profile policies keep the old accept-anything behavior. Responses carry the resolved profile.
* "Add device" dialog builds a smarter copy-pastable command: `--login` when the dashboard session is a tailnet operator, a `--profile` picker (shown when there's more than one profile, preset to the gateway default), and a Mode selector — per-process `clawpatrol run` (default) or `--whole-machine` ("route all of this machine's traffic through clawpatrol").
* Just-approved devices appear in the devices list immediately, before any traffic: tsnet daemon joins seed the agents registry under a `tsnet-<host>` placeholder at approve time (mem-only; `upsertLocked` refuses placeholder rows), and the register promotion carries profile/owner/hostname across to the real tailnet IP. The claim path seeds on claim.

## `--login` auto-approve

* Fixed the auto-approve 404: it was POSTing to the public Funnel join URL (whose allowlist excludes `/api/onboard/approve`). It now targets the dashboard origin from `verify_url` (the operator-gated tailnet `:8080` API), where the bootstrap node's whois identity is actually checked.
* Time-boxed that POST (15s) and added a clear fallback — a wrong-tailnet login no longer hangs the join forever; it falls through to dashboard approval with a hint.
* `awaitTailnetAuth` fails fast on `NeedsMachineAuth` ("tailnet requires admin approval for this device") and reports the last backend state on timeout, instead of waiting out the 10-minute deadline silently.
* The ephemeral `--login` bootstrap node (`clawpatrol-bootstrap-*`) no longer shows up as a managed device — it's dropped on whois resolution and filtered from the devices list.

## `clawpatrol join` output, reworked

Every step is now a live `*` pending block that, on a TTY, collapses to a single `✓`/`!` line when it completes — no spinners. A finished join is a clean column:

```
✓ logged in to the tailnet
✓ auto-approved as tailnet operator
✓ CA installed in system trust
✓ joined gateway

Installed! Try: clawpatrol run claude
```

* `beginStep(headline, detail, erasable)` prints the pending block and returns a finish func that erases it (cursor-up + clear) and reprints one status line; off a TTY it appends instead, so piped logs stay clean. `linkDetail(url, qr)` builds the shared URL+QR detail used by the login and approve steps.
* Login and approve show the URL with an indented QR beneath it (scan from a phone — the joining box is usually headless). CA trust install runs behind a step (erases only when sudo is non-interactive). The CA fingerprint check (WireGuard mode) explains *why* it matters.
* Consistent wording: `✓ joined gateway` across all paths, `clawpatrol run claude` everywhere.

## Review / correctness

Ran a multi-agent review over the branch; fixed the real findings: a data race on `AgentRegistry.lc` (now triggered at boot by `Seed`→`fillIdentity`), the approver being dropped at register promotion, an unsynchronized `s.profile`/`s.wholeMachine` read, and a placeholder ghost-row race (seed the agent before minting the token register authenticates with).

New tests cover the lookup profile/suggestion shapes, approve validation + resolution priority, claim-time seeding, the placeholder→register promotion (profile/owner/hostname carry-over + cleanup), and `approveBaseFromVerifyURL`.

A walkthrough of the expected join output across OS / transport / `--login` / approval / `--whole-machine` / sudo is in [this comment](https://github.com/denoland/clawpatrol/pull/657#issuecomment-4674817018).

## Known limitations (pre-existing, not addressed here)

* The tsnet placeholder's profile/owner are in-memory only, so a gateway restart in the approve→register gap loses them.
* An abandoned approval leaves a "pending" device row and a non-expiring peer api-token with no GC.
* The default-profile rule lives in three places (Go `defaultProfileName`, the lookup suggestion, and the dashboard); a gateway-served default would unify them.
