### PR TITLE
onboard: assign profile on claim; fix --whole-machine completion output

### DIFF
--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -348,6 +348,14 @@ func (r *onboardRegistry) ClaimIP(deviceCode, ip, hostnameOverride string) (stri
 	} else if s.hostname != "" {
 		r.hostnameByIP[ip] = s.hostname
 	}
+	// Carry the operator-picked profile onto the claimed IP. The
+	// whole-machine Tailscale path reaches the gateway only via claim
+	// (its tailnet IP isn't known at approve time, and unlike the
+	// per-host daemon it never hits /api/peer/tsnet/register), so
+	// without this the device lands in no profile despite --profile.
+	if s.profile != "" {
+		r.profileByIP[ip] = s.profile
+	}
 	r.upsertLocked(ip)
 	return s.owner, true
 }

--- a/cmd/clawpatrol/onboard_profile_test.go
+++ b/cmd/clawpatrol/onboard_profile_test.go
@@ -166,6 +166,40 @@ func TestOnboardClaimSeedsAgentsRegistry(t *testing.T) {
 	t.Fatalf("agents registry has no entry for 10.55.0.9 after claim")
 }
 
+// The claim path (whole-machine Tailscale, where the device's tailnet
+// IP is only known post-`tailscale up`) must carry the operator-picked
+// profile onto the claimed IP — it never goes through approve's
+// AssignProfile or the register-promotion that the other modes use.
+func TestOnboardClaimAssignsProfile(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.cfg.Load().Policy = onboardProfileTestPolicy()
+	w.g.agents = NewAgentRegistry()
+	w.g.agents.onboard = w.g.onboard
+	h := w.handler()
+	code := startOnboardSession(t, h, "?hostname=dev1&profile=prod")
+
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code="+url.QueryEscape(code), nil)
+	approveReq.AddCookie(authTestSessionCookie(t, w))
+	approveRR := httptest.NewRecorder()
+	h.ServeHTTP(approveRR, approveReq)
+	if approveRR.Code != http.StatusOK {
+		t.Fatalf("approve status = %d; body = %q", approveRR.Code, approveRR.Body.String())
+	}
+
+	dc := w.onboard.byUserCode(code).deviceCode
+	claimReq := httptest.NewRequest(http.MethodPost,
+		"/api/onboard/claim?device_code="+url.QueryEscape(dc)+"&ip=100.64.0.9&hostname=dev1", nil)
+	claimRR := httptest.NewRecorder()
+	h.ServeHTTP(claimRR, claimReq)
+	if claimRR.Code != http.StatusOK {
+		t.Fatalf("claim status = %d; body = %q", claimRR.Code, claimRR.Body.String())
+	}
+
+	if got := w.g.onboard.ProfileForIP("100.64.0.9"); got != "prod" {
+		t.Fatalf("ProfileForIP(100.64.0.9) = %q, want prod (claim must carry --profile)", got)
+	}
+}
+
 // The tsnet placeholder seeded at approve time must be promoted to
 // the real tailnet IP on the daemon's first register call: agents
 // entry replaced, profile and hostname carried over, devices row

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -214,6 +214,9 @@ func runJoin(args []string) {
 		if err := applyWholeMachineExitNode(exitNode); err != nil {
 			fail("%v", err)
 		}
+		// Closing message printed here (not in onboardViaDeviceFlow) so
+		// it lands after the exit-node setup and the "DNS pinned…" line.
+		printWholeMachineDone("tailscale exit-node")
 	}
 }
 
@@ -810,6 +813,22 @@ func printChecklist(items []string) {
 	}
 }
 
+// printWholeMachineDone prints the closing message for a --whole-machine
+// join. Unlike per-process mode there's no `clawpatrol run` — all host
+// traffic already routes through the gateway, so tools run directly.
+// But the credential env (placeholders + SSL_CERT_FILE) only landed in
+// the shell rc, which the current shell hasn't sourced yet, so point
+// the operator at `clawpatrol env` / a fresh shell. via names the
+// routing mechanism (interface, "system extension", "exit-node").
+func printWholeMachineDone(via string) {
+	fmt.Println()
+	fmt.Printf("Installed! All host traffic now routes through the gateway (%s).\n", via)
+	fmt.Println("Run your tools directly — no `clawpatrol run` needed. This shell hasn't")
+	fmt.Println("loaded the injected credentials yet; start a new shell or run:")
+	fmt.Println()
+	fmt.Println(`    eval "$(clawpatrol env)"`)
+}
+
 // setupSummaryItems lowers a joinSetup into the human-facing one-liners
 // the join / login output blocks render. CA-trust failures and skipped
 // shell-rc updates surface as their own items so the operator sees what
@@ -1170,16 +1189,16 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		items := setupSummaryItems(*setup)
 		items = append(items, "✓ joined gateway")
 		printChecklist(items)
-		fmt.Println()
 		if !wholeMachine {
+			fmt.Println()
 			fmt.Println("Installed! Try: clawpatrol run claude")
 		} else if runtime.GOOS == "darwin" {
-			fmt.Println("Installed! All host traffic routes via the system extension.")
+			printWholeMachineDone("system extension")
 		} else {
 			if err := wgQuickUp(iface, authKey); err != nil {
 				return true, fmt.Errorf("wg-quick up: %w", err)
 			}
-			fmt.Printf("Installed! All host traffic routes via the gateway (%s).\n", iface)
+			printWholeMachineDone(iface)
 		}
 		if persistErr != nil {
 			fmt.Fprintf(os.Stderr, "⚠ persist user wg conf: %v\n", persistErr)
@@ -1269,8 +1288,15 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		items := setupSummaryItems(*setup)
 		items = append(items, "✓ joined gateway")
 		printChecklist(items)
-		fmt.Println()
-		fmt.Println("Installed! Try: clawpatrol run claude")
+		if wholeMachine {
+			// Reached here only on darwin — Linux whole-machine falls
+			// through to the system-tailscale path below. The NE routes
+			// all host traffic, so the command runs directly.
+			printWholeMachineDone("system extension")
+		} else {
+			fmt.Println()
+			fmt.Println("Installed! Try: clawpatrol run claude")
+		}
 		return false, nil
 	}
 
@@ -1403,9 +1429,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 	items := setupSummaryItems(*setup)
 	items = append(items, "✓ joined gateway")
 	printChecklist(items)
-	fmt.Println()
-	fmt.Println("Installed! Try: clawpatrol run claude")
-
+	// The closing message is printed by runJoin, after it sets the
+	// exit-node and pins DNS — otherwise "DNS pinned…" would land after
+	// "Installed!". (Linux whole-machine Tailscale only.)
 	return false, nil
 }
 


### PR DESCRIPTION
Found while testing a `clawpatrol join --login --whole-machine --profile avocet2`.

* **Profile not assigned (the bug).** Whole-machine **Tailscale**
  devices landed in no profile despite `--profile`. Their tailnet IP
  is only known after `tailscale up`, so they register via
  `/api/onboard/claim` — not approve's `AssignProfile` (WireGuard) or
  the register-promotion (per-host daemon) — and `ClaimIP` never
  carried the session's resolved profile onto the claimed IP. Fixed;
  covered by a new test. (Server-side, so the **gateway** needs this
  build for the assignment to happen.)
* **`--whole-machine` completion output:**
  - No longer suggests `clawpatrol run claude` — whole-machine routes
    all host traffic, so tools run directly. A shared
    `printWholeMachineDone` is used by every whole-machine path (WG
    interface, macOS NE, Tailscale exit-node).
  - Now tells the operator the current shell hasn't sourced the
    injected credentials yet (the shell rc was updated) — run
    `eval "$(clawpatrol env)"` or open a new shell.
  - For Linux whole-machine Tailscale the closing prints in `runJoin`
    after the exit-node setup + DNS pin, so `DNS pinned…` no longer
    appears *after* `Installed!`.