### PR TITLE
onboard: propagate profile reassignment across the IP alias group

### DIFF
--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -500,6 +500,17 @@ func (r *onboardRegistry) ForgetIP(ip string) {
 	delete(r.profileByIP, ip)
 	delete(r.extV4ByIP, ip)
 	delete(r.extV6ByIP, ip)
+	// Drop the IP from the alias graph too — both as an alias and as a
+	// canonical. Otherwise a stale alias outlives the device and, after
+	// IP reuse, AssignProfile's alias fan-out could re-stamp a profile
+	// onto an address now belonging to a different peer.
+	delete(r.canonicalByAlias, ip)
+	for alias, canonical := range r.canonicalByAlias {
+		if canonical == ip {
+			delete(r.canonicalByAlias, alias)
+			delete(r.profileByIP, alias)
+		}
+	}
 	if r.db != nil {
 		_, _ = r.db.Exec("DELETE FROM devices WHERE id = ?", ip)
 	}

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -189,13 +189,29 @@ func (r *onboardRegistry) RegisterIPAlias(alias, canonical string) {
 	r.canonicalByAlias[alias] = canonical
 }
 
-// AssignProfile records that a peer IP belongs to a named profile.
-// Persists to the devices row.
+// AssignProfile records that a peer IP belongs to a named profile, and
+// propagates it across the IP's whole alias group. A Tailscale peer
+// reaches the gateway on both its 100.x IPv4 and its fd7a: IPv6 ULA;
+// RegisterIPAlias links the two but only copies the profile once. So a
+// later reassignment (e.g. an operator changing the profile from the
+// dashboard) of one address must update the others, or profileFor
+// resolves traffic on the un-updated address to the stale (often
+// "default") profile while the dashboard shows the new one. Persists
+// the canonical devices row; aliases are in-memory only.
 func (r *onboardRegistry) AssignProfile(ip, profile string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.profileByIP[ip] = profile
-	r.upsertLocked(ip)
+	canonical := ip
+	if c := r.canonicalByAlias[ip]; c != "" {
+		canonical = c
+	}
+	r.profileByIP[canonical] = profile
+	for alias, c := range r.canonicalByAlias {
+		if c == canonical {
+			r.profileByIP[alias] = profile
+		}
+	}
+	r.upsertLocked(canonical)
 }
 
 // seedPlaceholder records hostname/owner/profile for a tsnet

--- a/cmd/clawpatrol/onboard_alias_test.go
+++ b/cmd/clawpatrol/onboard_alias_test.go
@@ -71,3 +71,38 @@ func TestClaimAliasResolve(t *testing.T) {
 		t.Fatal("empty ip must not claim")
 	}
 }
+
+// AssignProfile must propagate across an IP's alias group. A Tailscale
+// peer's IPv6 ULA is aliased to its IPv4; reassigning the profile on
+// either address (e.g. from the dashboard) must update the whole group,
+// or traffic on the un-updated address resolves to the stale profile
+// while the dashboard shows the new one.
+func TestAssignProfilePropagatesAcrossAlias(t *testing.T) {
+	r := newOnboardRegistry()
+	const v4 = "100.106.145.49"
+	const v6 = "fd7a:115c:a1e0::1234"
+
+	// Initial assignment + alias (mirrors join: v4 gets a profile, the
+	// v6 ULA is linked and copies it).
+	r.AssignProfile(v4, "default")
+	r.RegisterIPAlias(v6, v4)
+	if got := r.ProfileForIP(v6); got != "default" {
+		t.Fatalf("after alias: ProfileForIP(v6) = %q, want default", got)
+	}
+
+	// Operator reassigns via the dashboard (apiAgentProfile → AssignProfile
+	// on the canonical v4). The v6 alias must follow.
+	r.AssignProfile(v4, "avocet2")
+	if got := r.ProfileForIP(v4); got != "avocet2" {
+		t.Fatalf("ProfileForIP(v4) = %q, want avocet2", got)
+	}
+	if got := r.ProfileForIP(v6); got != "avocet2" {
+		t.Fatalf("ProfileForIP(v6) = %q, want avocet2 (alias must follow reassignment)", got)
+	}
+
+	// Reassigning via the alias address must update the canonical too.
+	r.AssignProfile(v6, "default")
+	if got := r.ProfileForIP(v4); got != "default" {
+		t.Fatalf("ProfileForIP(v4) = %q, want default (canonical must follow alias reassignment)", got)
+	}
+}


### PR DESCRIPTION
A device shown as `avocet2` in the dashboard was serving its manifest
as `profile: default`. Confirmed against the gateway: the devices table
had `100.106.145.49 | minesweeper-per-tare | avocet2`, but
`curl https://clawpatrol.internal/manifest` from that box returned
`# Claw Patrol access manifest — profile: default`.

Root cause: a Tailscale peer reaches the gateway on both its 100.x IPv4
and its fd7a: IPv6 ULA. `RegisterIPAlias` links them but copies the
profile only once, at alias-registration time. `AssignProfile` then
updated only the one IP, so reassigning the profile from the dashboard
(or anywhere) left the other-family alias stale — and `profileFor`
resolves the device's traffic (which arrives on the v6 ULA in
whole-machine mode) to the old `default` profile. A security-scoping
bug: the device's effective access didn't match what the dashboard
showed.

`AssignProfile` now resolves the canonical IP and applies the profile
to it and every alias pointing at it. New test covers reassignment
propagating both canonical→alias and alias→canonical.

Server-side, so the gateway needs this build for the propagation to
take effect.