### PR TITLE
run: on a --whole-machine device, exec directly instead of spawning the daemon

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -85,9 +85,6 @@ func runRun(args []string) {
 	}
 
 	warnIfOnGatewayHost()
-	if os.Geteuid() == 0 {
-		fail("run as your normal user; clawpatrol run uses unprivileged user namespaces which root cannot enter on this distro")
-	}
 
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	noAutoExpose := fs.Bool("no-auto-expose", false, "disable the seccomp relay (mirrors TCP listeners inside the netns back to the host AND forwards wrapped-cmd connections to 127.0.0.1 out to host loopback services)")
@@ -95,6 +92,19 @@ func runRun(args []string) {
 	cmd := fs.Args()
 	if len(cmd) == 0 {
 		fail("usage: clawpatrol run [--no-auto-expose] -- <cmd> [args...]")
+	}
+
+	// Whole-machine join: the host already routes all traffic through
+	// the gateway, so there's no per-process daemon/sandbox. Inject the
+	// credential env and exec the command directly (this also works as
+	// root, unlike the unprivileged-userns path below).
+	if isWholeMachineJoin() {
+		runWholeMachineDirect(cmd)
+		return
+	}
+
+	if os.Geteuid() == 0 {
+		fail("run as your normal user; clawpatrol run uses unprivileged user namespaces which root cannot enter on this distro")
 	}
 	if *noAutoExpose {
 		_ = os.Setenv(runNoAutoExposeEnv, "1")
@@ -107,7 +117,7 @@ func runRun(args []string) {
 	// none is alive. Hello handshake happens inside daemonConnect.
 	ctrl, err := daemonConnect()
 	if err != nil {
-		fail("daemon connect: %v", err)
+		fail("daemon connect: %v\n  (if this machine was joined with --whole-machine, run the command directly — `clawpatrol run` isn't needed; traffic already routes through the gateway)", err)
 	}
 	defer func() { _ = ctrl.Close() }()
 
@@ -279,6 +289,31 @@ func runRun(args []string) {
 			os.Exit(ee.ExitCode())
 		}
 		fail("wait: %v", waitErr)
+	}
+}
+
+// runWholeMachineDirect handles `clawpatrol run <cmd>` on a
+// --whole-machine device. The host already routes all traffic through
+// the gateway, so there's no per-process namespace/daemon: just inject
+// the credential env and exec the command. Env is fetched straight
+// from the gateway — the daemon fetcher would try to spawn the
+// per-host daemon, which whole-machine mode doesn't run.
+func runWholeMachineDirect(cmd []string) {
+	if os.Getenv("CLAWPATROL_NO_ENV") != "1" {
+		caDir := defaultClawpatrolDir()
+		if vars, err := envPushdownGatewayFetcher(caDir); err == nil {
+			applyEnvPushdownVars(vars)
+		} else {
+			fmt.Fprintf(os.Stderr, "[clawpatrol] env pushdown: %v (continuing without injected credentials)\n", err)
+		}
+	}
+	bin, err := exec.LookPath(cmd[0])
+	if err != nil {
+		fail("%s: %v", cmd[0], err)
+	}
+	fmt.Fprintln(os.Stderr, "[clawpatrol] whole-machine join — traffic already routes through the gateway; running directly (no sandbox)")
+	if err := syscall.Exec(bin, cmd, os.Environ()); err != nil {
+		fail("exec %s: %v", bin, err)
 	}
 }
 

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -362,7 +362,29 @@ func preJoinFetchCA(gateway, caDir string, cli *http.Client) (joinSetup, error) 
 // — and worse, the `clawpatrol env` it eval's on every new
 // terminal would dial the gateway's tailnet IP, which the
 // parent shell can't reach (only the NE can).
+// wholeMachineMarkerName is a sentinel file written under the
+// clawpatrol dir by a --whole-machine join. `clawpatrol run` checks for
+// it: in whole-machine mode the host already routes all traffic through
+// the gateway, so there's no per-process daemon/sandbox to attach to.
+const wholeMachineMarkerName = "whole-machine"
+
+// isWholeMachineJoin reports whether this device was joined with
+// --whole-machine (the marker is written by finishJoinSetup).
+func isWholeMachineJoin() bool {
+	_, err := os.Stat(filepath.Join(defaultClawpatrolDir(), wholeMachineMarkerName))
+	return err == nil
+}
+
 func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine bool) {
+	if wholeMachine && s.caPath != "" {
+		// Record the mode so `clawpatrol run` can short-circuit to a
+		// direct exec instead of trying to spawn the per-host daemon.
+		// Written next to the rest of the join state (mode, gateway,
+		// …). `clawpatrol run` reads defaultClawpatrolDir(), the same
+		// dir the daemon assumes — so, like the other state files, the
+		// marker is only found when join used the default --ca-dir.
+		_ = os.WriteFile(filepath.Join(filepath.Dir(s.caPath), wholeMachineMarkerName), []byte("1\n"), 0o600)
+	}
 	if s.caPath == "" {
 		return
 	}


### PR DESCRIPTION
On a whole-machine-joined box, `clawpatrol run claude` failed with:

```
clawpatrol: daemon connect: spawn daemon: daemon ready: EOF (read "")
```

It tried to bring up the per-process userns/daemon, which whole-machine
mode doesn't run. But whole-machine already routes all host traffic
through the gateway, so `clawpatrol run` only needs to inject the
credential env and exec the command.

* A `--whole-machine` join writes a `whole-machine` marker file
  (`finishJoinSetup`); `isWholeMachineJoin()` checks for it.
* `runRun` short-circuits to `runWholeMachineDirect` when the marker is
  present: fetch env-pushdown straight from the gateway (the daemon
  fetcher would re-trigger the failing daemon spawn), apply it, and
  `syscall.Exec` the command. Works as root too, unlike the userns path.
* The daemon-connect failure message now hints that a whole-machine box
  doesn't need `clawpatrol run` — for older joins predating the marker.

Note: like the rest of the join↔run state (the daemon already hardcodes
`defaultClawpatrolDir()`), the marker is only found when join used the
default `--ca-dir`; a custom `--ca-dir` is an existing unsupported
configuration for `clawpatrol run`, not newly broken here.