### PR TITLE
run: use passwordless sudo for setup so the wrapped command can sudo

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2769,6 +2769,11 @@ func main() {
 		// internal: re-exec'd from inside the agent netns to host the
 		// auto-expose worker. Hidden from usage.
 		runRelayWorker(os.Args[2:])
+	case "__run-privileged":
+		// internal: re-exec'd via sudo by `clawpatrol run` on hosts with
+		// passwordless sudo, to set up the netns as real root (so the
+		// wrapped command can sudo). Hidden from usage.
+		runRunPrivileged(os.Args[2:])
 	case "env":
 		runEnv(os.Args[2:])
 	case "validate":

--- a/cmd/clawpatrol/relay_other.go
+++ b/cmd/clawpatrol/relay_other.go
@@ -14,3 +14,7 @@ func runRelaySupervisor(_ []string) {
 func runRelayWorker(_ []string) {
 	fail("relay-worker is linux-only")
 }
+
+func runRunPrivileged(_ []string) {
+	fail("__run-privileged is linux-only")
+}

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -51,7 +51,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -406,16 +405,16 @@ func runRunChild() {
 	// Privileged (sudo) path: this child was cloned by a root parent and
 	// is itself root in the netns. Drop to the invoking user before
 	// exec, so the command runs unprivileged (and can sudo on its own).
-	// Lock the OS thread so the per-thread credential change and the
-	// execve land on the same thread. Unprivileged userns path: just
-	// shed the ambient caps the parent granted for TUN setup.
+	// dropToUser changes credentials on every OS thread, so the execve
+	// below runs as the user regardless of which thread it lands on.
+	// Unprivileged userns path: just shed the ambient caps the parent
+	// granted for TUN setup.
 	if uidStr := os.Getenv(runDropUIDEnv); uidStr != "" {
 		uid, err1 := strconv.Atoi(uidStr)
 		gid, err2 := strconv.Atoi(os.Getenv(runDropGIDEnv))
 		if err1 != nil || err2 != nil {
 			fail("internal: bad drop uid/gid")
 		}
-		runtime.LockOSThread()
 		if err := dropToUser(uid, gid); err != nil {
 			fail("drop privileges: %v", err)
 		}

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -51,6 +51,8 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -68,6 +70,12 @@ const (
 	// netns can configure `ip addr add` without round-tripping
 	// the value through the SCM_RIGHTS conn.
 	runTunAddrEnv = "CLAWPATROL_TUN_ADDR"
+	// runDropUIDEnv / runDropGIDEnv are set by the privileged (sudo)
+	// parent (run_sudo_linux.go) to tell runRunChild to drop from root
+	// to the invoking user before exec'ing the command. Absent on the
+	// unprivileged userns path, where the child already runs as the user.
+	runDropUIDEnv = "CLAWPATROL_RUN_DROP_UID"
+	runDropGIDEnv = "CLAWPATROL_RUN_DROP_GID"
 	tunIfName     = "wg0"
 	// runTunMTU is the TUN MTU inside the child's netns. Set to the
 	// max IPv4 packet size — the daemon's transport handles real
@@ -100,6 +108,15 @@ func runRun(args []string) {
 	// root, unlike the unprivileged-userns path below).
 	if isWholeMachineJoin() {
 		runWholeMachineDirect(cmd)
+		return
+	}
+
+	// With passwordless sudo we can set the netns up as real root
+	// instead of an unprivileged user namespace, so the wrapped command
+	// keeps real uids and `sudo` works inside it. Opt out with
+	// CLAWPATROL_NO_SUDO.
+	if sudoSetupAvailable() {
+		runViaSudo(cmd)
 		return
 	}
 
@@ -386,7 +403,23 @@ func runRunChild() {
 			unix.PR_SET_PTRACER, ptraceAny, 0, 0, 0, 0)
 	}
 
-	if err := clearAmbientCaps(); err != nil {
+	// Privileged (sudo) path: this child was cloned by a root parent and
+	// is itself root in the netns. Drop to the invoking user before
+	// exec, so the command runs unprivileged (and can sudo on its own).
+	// Lock the OS thread so the per-thread credential change and the
+	// execve land on the same thread. Unprivileged userns path: just
+	// shed the ambient caps the parent granted for TUN setup.
+	if uidStr := os.Getenv(runDropUIDEnv); uidStr != "" {
+		uid, err1 := strconv.Atoi(uidStr)
+		gid, err2 := strconv.Atoi(os.Getenv(runDropGIDEnv))
+		if err1 != nil || err2 != nil {
+			fail("internal: bad drop uid/gid")
+		}
+		runtime.LockOSThread()
+		if err := dropToUser(uid, gid); err != nil {
+			fail("drop privileges: %v", err)
+		}
+	} else if err := clearAmbientCaps(); err != nil {
 		fail("clear ambient caps: %v", err)
 	}
 
@@ -394,9 +427,36 @@ func runRunChild() {
 	if err != nil {
 		fail("lookpath %s: %v", argv[0], err)
 	}
-	if err := syscall.Exec(bin, argv, os.Environ()); err != nil {
+	// Strip the internal re-exec coordination vars so the command
+	// doesn't inherit them (and can't tell how it was launched).
+	if err := syscall.Exec(bin, argv, strippedRunEnv()); err != nil {
 		fail("exec %s: %v", bin, err)
 	}
+}
+
+// strippedRunEnv returns the process environment with clawpatrol's
+// internal run-coordination variables removed, so the wrapped command
+// doesn't inherit them.
+func strippedRunEnv() []string {
+	drop := map[string]bool{
+		runChildEnv:   true,
+		runTunAddrEnv: true,
+		runDropUIDEnv: true,
+		runDropGIDEnv: true,
+	}
+	env := os.Environ()
+	out := env[:0]
+	for _, kv := range env {
+		name := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			name = kv[:i]
+		}
+		if drop[name] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // --- daemon client protocol ------------------------------------------

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -439,10 +439,11 @@ func runRunChild() {
 // doesn't inherit them.
 func strippedRunEnv() []string {
 	drop := map[string]bool{
-		runChildEnv:   true,
-		runTunAddrEnv: true,
-		runDropUIDEnv: true,
-		runDropGIDEnv: true,
+		runChildEnv:        true,
+		runTunAddrEnv:      true,
+		runDropUIDEnv:      true,
+		runDropGIDEnv:      true,
+		runNoAutoExposeEnv: true,
 	}
 	env := os.Environ()
 	out := env[:0]

--- a/cmd/clawpatrol/run_sudo_linux.go
+++ b/cmd/clawpatrol/run_sudo_linux.go
@@ -272,11 +272,16 @@ func runRunPrivileged(args []string) {
 }
 
 // sudoTargetIDs returns the uid/gid sudo recorded for the invoking user.
+// Both must be non-root (we only ever drop privileges, never retarget to
+// root or the root group). sudo resets the environment and sets these
+// from the real invoker by default, so the unprivileged caller can't
+// spoof them — barring an unusual sudoers that env_keeps SUDO_UID/GID,
+// and even then the worst case is dropping to another non-root identity.
 func sudoTargetIDs() (uid, gid int, ok bool) {
 	us, gs := os.Getenv("SUDO_UID"), os.Getenv("SUDO_GID")
 	u, err1 := strconv.Atoi(us)
 	g, err2 := strconv.Atoi(gs)
-	if err1 != nil || err2 != nil || u <= 0 || g < 0 {
+	if err1 != nil || err2 != nil || u <= 0 || g <= 0 {
 		return 0, 0, false
 	}
 	return u, g, true
@@ -325,6 +330,12 @@ func buildPrivilegedEnv(envFile, caPath string, pushVars []pushdownEnvVar) []str
 // and saved), restoring the user's supplementary groups, and verifies
 // the drop took. Groups before gid before uid, so each step still has
 // the privilege it needs.
+//
+// Uses the syscall package's setid family deliberately: the Go runtime
+// broadcasts those across every OS thread (unlike x/sys/unix.Setgroups,
+// which is a per-thread raw syscall). A uniform, all-threads drop means
+// no runtime thread is left holding root's credentials, so it doesn't
+// matter which thread the subsequent execve runs on.
 func dropToUser(uid, gid int) error {
 	groups := []int{gid}
 	if u, err := user.LookupId(strconv.Itoa(uid)); err == nil {
@@ -340,17 +351,17 @@ func dropToUser(uid, gid int) error {
 			}
 		}
 	}
-	if err := unix.Setgroups(groups); err != nil {
+	if err := syscall.Setgroups(groups); err != nil {
 		return fmt.Errorf("setgroups: %w", err)
 	}
-	if err := unix.Setresgid(gid, gid, gid); err != nil {
+	if err := syscall.Setresgid(gid, gid, gid); err != nil {
 		return fmt.Errorf("setresgid: %w", err)
 	}
-	if err := unix.Setresuid(uid, uid, uid); err != nil {
+	if err := syscall.Setresuid(uid, uid, uid); err != nil {
 		return fmt.Errorf("setresuid: %w", err)
 	}
-	if unix.Getuid() != uid || unix.Geteuid() != uid {
-		return fmt.Errorf("uid still %d/%d after drop, want %d", unix.Getuid(), unix.Geteuid(), uid)
+	if syscall.Getuid() != uid || syscall.Geteuid() != uid {
+		return fmt.Errorf("uid still %d/%d after drop, want %d", syscall.Getuid(), syscall.Geteuid(), uid)
 	}
 	return nil
 }

--- a/cmd/clawpatrol/run_sudo_linux.go
+++ b/cmd/clawpatrol/run_sudo_linux.go
@@ -1,0 +1,356 @@
+//go:build linux
+
+package main
+
+// Privileged `clawpatrol run` setup on a host with passwordless sudo.
+//
+// The default path (run_linux.go) runs the wrapped command in an
+// unprivileged user namespace to obtain CAP_NET_ADMIN / CAP_SYS_ADMIN
+// without root. The trade-off is that the userns has no mapped root, so
+// `sudo` (and anything needing real root) can't work inside it.
+//
+// When the host already grants passwordless sudo, we don't need the
+// userns: get the caps from real root instead. A small helper, re-exec'd
+// once via sudo, creates the net+mnt namespace as root (no userns),
+// attaches the TUN to the per-host daemon exactly as the userns child
+// does, then drops back to the invoking user and execs the command. The
+// command therefore runs with real uids in a namespace where root
+// exists — so `sudo` works — while its traffic still routes through the
+// gateway (credentials/policy are unaffected; that's enforced gateway-
+// side, not by the sandbox).
+//
+// Privilege escalation fundamentally requires the setuid `sudo` binary —
+// there's no syscall that grants root from sudoers — so we exec sudo
+// exactly once and do everything else with syscalls.
+//
+// Opt out with CLAWPATROL_NO_SUDO to force the unprivileged userns path.
+//
+// Limitation: the auto-expose relay (port mirroring) is not wired into
+// this path yet; listeners the command opens aren't published to the
+// host. Use the userns path (CLAWPATROL_NO_SUDO=1) if you need that.
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// sudoSetupAvailable reports whether runRun should set the namespace up
+// via passwordless sudo (real root) rather than an unprivileged user
+// namespace. Gated off by CLAWPATROL_NO_SUDO.
+func sudoSetupAvailable() bool {
+	if os.Getenv("CLAWPATROL_NO_SUDO") != "" {
+		return false
+	}
+	if os.Geteuid() == 0 {
+		// Already root — the userns path refuses this anyway; not our case.
+		return false
+	}
+	// `sudo -n true` exits non-zero (without prompting) when a password
+	// would be required, and errors when sudo is absent.
+	return exec.Command("sudo", "-n", "true").Run() == nil
+}
+
+// runViaSudo ensures the per-host daemon is up (as this user), then
+// launches the privileged setup helper under sudo and waits on it.
+func runViaSudo(cmd []string) {
+	// The helper connects to the daemon but must never spawn one (a
+	// root-spawned daemon would own state in the wrong home). Ensure
+	// it's running here, as this user. The daemon is persistent
+	// (5-minute idle exit), so the brief gap until the helper connects
+	// is safe.
+	if c, err := daemonConnect(); err != nil {
+		fail("daemon connect: %v", err)
+	} else {
+		_ = c.Close()
+	}
+
+	// sudo resets the environment, but the command must run with this
+	// user's env. Capture it — after the OAuth shim, so CLAUDE_CONFIG_DIR
+	// is included — into a 0600 file the helper reads and deletes.
+	installClaudeCodeOAuthShim(cmd)
+	envFile, err := writePrivilegedEnvFile(os.Environ())
+	if err != nil {
+		fail("env file: %v", err)
+	}
+	defer func() { _ = os.Remove(envFile) }()
+
+	self, err := os.Executable()
+	if err != nil {
+		fail("self path: %v", err)
+	}
+	args := []string{
+		"--", self, "__run-privileged",
+		"--sock", daemonControlSockPath(),
+		"--env-file", envFile,
+		"--ca", filepath.Join(defaultClawpatrolDir(), "ca.crt"),
+		"--",
+	}
+	args = append(args, cmd...)
+	c := exec.Command("sudo", args...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := c.Start(); err != nil {
+		fail("sudo: %v", err)
+	}
+	sigCh := make(chan os.Signal, 4)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		for s := range sigCh {
+			if c.Process != nil {
+				_ = c.Process.Signal(s)
+			}
+		}
+	}()
+	if err := c.Wait(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		fail("run: %v", err)
+	}
+}
+
+// writePrivilegedEnvFile writes env entries NUL-separated to a 0600
+// file under the user's runtime dir for the helper to read.
+func writePrivilegedEnvFile(env []string) (string, error) {
+	f, err := os.CreateTemp(daemonRuntimeDir(), "run-env-*")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(strings.Join(env, "\x00")); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// runRunPrivileged is the `__run-privileged` subcommand: re-exec'd via
+// sudo by runViaSudo, runs as root. It creates the net+mnt namespace,
+// attaches the TUN to the daemon, drops to the invoking user, and execs
+// the command.
+func runRunPrivileged(args []string) {
+	if os.Geteuid() != 0 {
+		fail("internal: __run-privileged must run as root (via sudo)")
+	}
+	fs := flag.NewFlagSet("__run-privileged", flag.ExitOnError)
+	sock := fs.String("sock", "", "daemon control socket path")
+	envFile := fs.String("env-file", "", "NUL-separated env for the command")
+	caPath := fs.String("ca", "", "CA path for cert env vars")
+	_ = fs.Parse(args)
+	cmd := fs.Args()
+	if len(cmd) == 0 {
+		fail("internal: __run-privileged got no command")
+	}
+
+	uid, gid, ok := sudoTargetIDs()
+	if !ok {
+		fail("internal: missing/!invalid SUDO_UID/SUDO_GID — invoke via sudo")
+	}
+
+	// 1. Daemon session. The daemon is already running as the user;
+	// dial it directly (never spawn — that would run as root).
+	ctrl, ok := daemonDialAndHello(*sock)
+	if !ok {
+		fail("daemon not reachable at %s", *sock)
+	}
+	br, tunAddr, pushVars, warn, err := daemonClientStartSession(ctrl)
+	if err != nil {
+		fail("daemon START: %v", err)
+	}
+	if warn != "" {
+		fmt.Fprintf(os.Stderr, "clawpatrol: daemon: %s\n", warn)
+	}
+	uc, _ := ctrl.(*net.UnixConn)
+	if uc == nil {
+		fail("control conn is %T, not *net.UnixConn", ctrl)
+	}
+	defer func() { _ = ctrl.Close() }()
+
+	// 2. Build the command's environment: the invoking user's env (from
+	// the file) plus the cert / push-down vars. The command never sees
+	// SUDO_* — we set its env explicitly — and the daemon control conn
+	// stays with us (this root parent), never inherited by the command.
+	// The control vars below are consumed by runRunChild and stripped
+	// before it execs the actual command.
+	childEnv := buildPrivilegedEnv(*envFile, *caPath, pushVars)
+	childEnv = append(childEnv,
+		runChildEnv+"=1",
+		runTunAddrEnv+"="+tunAddr.String(),
+		runDropUIDEnv+"="+strconv.Itoa(uid),
+		runDropGIDEnv+"="+strconv.Itoa(gid),
+		runNoAutoExposeEnv+"=1", // auto-expose isn't wired into the sudo path yet
+	)
+
+	// 3. IPC channels for the child: TUN fd handoff + tun-up signal.
+	sp, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		fail("socketpair: %v", err)
+	}
+	pSock := os.NewFile(uintptr(sp[0]), "parent-sock")
+	cSock := os.NewFile(uintptr(sp[1]), "child-sock")
+	defer func() { _ = pSock.Close() }()
+	tunUpR, tunUpW, err := os.Pipe()
+	if err != nil {
+		fail("pipe: %v", err)
+	}
+
+	// 4. Spawn the command as a child cloned into a fresh net+mnt
+	// namespace. No user namespace: this parent is real root, so the
+	// child is created with full caps, opens its TUN, configures
+	// routing/DNS, then drops to the invoking user and execs the
+	// command (runRunChild handles the drop when runDropUIDEnv is set).
+	// The command thus runs as that user in a namespace where root
+	// exists — sudo works — and can't tell it was launched via sudo
+	// (clean env, normal uid, parent is clawpatrol, no stray fds).
+	self, err := os.Executable()
+	if err != nil {
+		fail("self path: %v", err)
+	}
+	child := exec.Command(self, append([]string{"run"}, cmd...)...)
+	child.Env = childEnv
+	child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
+	child.ExtraFiles = []*os.File{cSock, tunUpR}
+	child.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWNS,
+	}
+	if err := child.Start(); err != nil {
+		fail("clone child: %v", err)
+	}
+	_ = cSock.Close()
+	_ = tunUpR.Close()
+
+	// 5. Receive the TUN fd from the child, hand it to the daemon, wait
+	// ATTACHED.
+	tunFd, err := recvFD(pSock)
+	if err != nil {
+		_ = child.Process.Kill()
+		fail("recv tun fd: %v", err)
+	}
+	if err := sendFDUnixConn(uc, tunFd); err != nil {
+		_ = child.Process.Kill()
+		fail("send tun fd to daemon: %v", err)
+	}
+	_ = unix.Close(tunFd)
+	if err := daemonClientWaitAttached(ctrl, br); err != nil {
+		_ = child.Process.Kill()
+		fail("daemon ATTACHED: %v", err)
+	}
+
+	// 6. Signal the child that the bridge is up.
+	_, _ = tunUpW.Write([]byte{1})
+	_ = tunUpW.Close()
+
+	// 7. Forward signals and wait. We hold the daemon control conn for
+	// the command's lifetime; the deferred Close tears the session down.
+	sigCh := make(chan os.Signal, 4)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		for s := range sigCh {
+			_ = child.Process.Signal(s)
+		}
+	}()
+	waitErr := child.Wait()
+	if waitErr != nil {
+		var ee *exec.ExitError
+		if errors.As(waitErr, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		fail("wait: %v", waitErr)
+	}
+}
+
+// sudoTargetIDs returns the uid/gid sudo recorded for the invoking user.
+func sudoTargetIDs() (uid, gid int, ok bool) {
+	us, gs := os.Getenv("SUDO_UID"), os.Getenv("SUDO_GID")
+	u, err1 := strconv.Atoi(us)
+	g, err2 := strconv.Atoi(gs)
+	if err1 != nil || err2 != nil || u <= 0 || g < 0 {
+		return 0, 0, false
+	}
+	return u, g, true
+}
+
+// buildPrivilegedEnv reconstructs the command's environment: the user's
+// captured env (from envFile, which it deletes) plus the cert-bundle and
+// gateway push-down vars, the latter skipped when the user set
+// CLAWPATROL_NO_ENV and never overriding a var the user already set.
+func buildPrivilegedEnv(envFile, caPath string, pushVars []pushdownEnvVar) []string {
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		fail("read env file: %v", err)
+	}
+	_ = os.Remove(envFile)
+
+	var env []string
+	have := map[string]bool{}
+	noEnv := false
+	for _, kv := range strings.Split(string(data), "\x00") {
+		if kv == "" {
+			continue
+		}
+		env = append(env, kv)
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			have[kv[:i]] = true
+			if kv == "CLAWPATROL_NO_ENV=1" {
+				noEnv = true
+			}
+		}
+	}
+	if noEnv {
+		return env
+	}
+	for _, ev := range append(caPathPushdownVars(caPath), pushVars...) {
+		if have[ev.Name] {
+			continue
+		}
+		env = append(env, ev.Name+"="+ev.Value)
+		have[ev.Name] = true
+	}
+	return env
+}
+
+// dropToUser permanently drops the process to uid/gid (real, effective,
+// and saved), restoring the user's supplementary groups, and verifies
+// the drop took. Groups before gid before uid, so each step still has
+// the privilege it needs.
+func dropToUser(uid, gid int) error {
+	groups := []int{gid}
+	if u, err := user.LookupId(strconv.Itoa(uid)); err == nil {
+		if gidStrs, err := u.GroupIds(); err == nil && len(gidStrs) > 0 {
+			groups = groups[:0]
+			for _, gs := range gidStrs {
+				if g, err := strconv.Atoi(gs); err == nil {
+					groups = append(groups, g)
+				}
+			}
+			if len(groups) == 0 {
+				groups = []int{gid}
+			}
+		}
+	}
+	if err := unix.Setgroups(groups); err != nil {
+		return fmt.Errorf("setgroups: %w", err)
+	}
+	if err := unix.Setresgid(gid, gid, gid); err != nil {
+		return fmt.Errorf("setresgid: %w", err)
+	}
+	if err := unix.Setresuid(uid, uid, uid); err != nil {
+		return fmt.Errorf("setresuid: %w", err)
+	}
+	if unix.Getuid() != uid || unix.Geteuid() != uid {
+		return fmt.Errorf("uid still %d/%d after drop, want %d", unix.Getuid(), unix.Geteuid(), uid)
+	}
+	return nil
+}


### PR DESCRIPTION
`clawpatrol run` uses an unprivileged user namespace to get
CAP_NET_ADMIN/CAP_SYS_ADMIN without root; the cost is that the userns
has no mapped root, so `sudo` (and anything needing real root) can't
work inside the wrapped command. When the host already grants
passwordless sudo, the userns isn't needed — get the caps from real
root instead, and the command keeps real uids (so its own `sudo`
works). Credentials/policy are unaffected — those are enforced
gateway-side, not by the sandbox.

* `sudoSetupAvailable()`: when `sudo -n true` succeeds and
  `CLAWPATROL_NO_SUDO` is unset, `runRun` takes the privileged path
  (after the whole-machine check, before the root check).
* `runViaSudo` ensures the per-host daemon is up (as the user),
  captures the user's env to a 0600 file, and re-execs
  `__run-privileged` once via sudo. Escalation inherently needs the
  setuid sudo binary — no syscall grants root from sudoers — so sudo
  is exec'd exactly once; everything after is syscalls.
* `runRunPrivileged` (root) is a supervisor: dials the daemon, clones
  the command as a child into a fresh net+mnt namespace (no userns)
  via the existing `runRunChild`, hands the TUN to the daemon, and
  waits — holding the daemon control conn for the session's lifetime.
  `runRunChild`, when `CLAWPATROL_RUN_DROP_{UID,GID}` are set, drops
  from root to the invoking user (`dropToUser`, all-threads setid)
  before exec.

The command runs as the invoking user, in a namespace where real root
exists (so `sudo` works), and can't tell it was launched via sudo:
clean env (no `SUDO_*`, no internal `CLAWPATROL_RUN_*`; built
explicitly), normal uid, parent is `clawpatrol` (not `sudo`), no stray
inherited fds. `CLAWPATROL_NO_SUDO=1` forces the unprivileged userns
path.

**Validated live** on a fresh Linux VM (passwordless sudo, per-process
WG join to a local gateway): `clawpatrol run -- id` → invoking user
with full groups; `clawpatrol run -- sudo id` → root; env shows no
`SUDO_*`/`CLAWPATROL_RUN_*`; parent is clawpatrol; no leaked daemon fd;
`CLAWPATROL_NO_SUDO=1` falls back to the userns (sudo blocked, as
before). Routing behaves identically to the userns path.

Reviewed by an agent; addressed the privilege-drop thread-uniformity
finding (all-threads setid) and hardened `sudoTargetIDs`.

Limitation: the auto-expose relay (port mirroring) isn't wired into
this path yet — listeners the command opens aren't published to the
host. Use `CLAWPATROL_NO_SUDO=1` if you need that. Follow-up.