### PR TITLE
run: apply Claude Code OAuth shim on the passwordless-sudo path (cl-ulck)

### DIFF
--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -377,31 +377,81 @@ func applyEnvPushdownVars(vars []pushdownEnvVar) {
 // `.credentials.json` — that login wins once we drop the bearer, so we
 // leave it untouched.
 func installClaudeCodeOAuthShim(cmd []string) {
-	if len(cmd) == 0 || filepath.Base(cmd[0]) != "claude" {
+	res := planClaudeCodeOAuthShim(cmd, os.Getenv, defaultClawpatrolDir(), -1, -1)
+	if res.warn {
+		warnClaudeCodeRemoteControlDisabled()
 		return
 	}
-	bearer := os.Getenv("ANTHROPIC_AUTH_TOKEN")
-	if bearer == "" {
+	if !res.applied {
 		return
+	}
+	// Redirect Claude Code's credential read onto our synthesized file
+	// (only when we own the dir; an operator-set one is already exported).
+	// Unsetting ANTHROPIC_AUTH_TOKEN drops Claude Code out of precedence #2
+	// so the synthesized credentials.json (precedence #6) wins.
+	if res.configDir != "" {
+		_ = os.Setenv("CLAUDE_CONFIG_DIR", res.configDir)
+	}
+	if res.unsetAuthToken {
+		_ = os.Unsetenv("ANTHROPIC_AUTH_TOKEN")
+	}
+}
+
+// claudeShimResult is the decision + side effects of one shim
+// evaluation. The file write (credentials.json) has already happened
+// when applied is true; the caller is responsible only for reflecting
+// the env changes (configDir / unsetAuthToken) onto whatever env
+// representation it uses — os.Setenv for the live process, or a
+// []string slice for the privileged sudo child.
+type claudeShimResult struct {
+	applied        bool   // shim fired: credentials.json was (re)written
+	warn           bool   // not opted in — caller should print the notice
+	configDir      string // non-empty → set CLAUDE_CONFIG_DIR to this
+	unsetAuthToken bool   // drop ANTHROPIC_AUTH_TOKEN from the child env
+}
+
+// planClaudeCodeOAuthShim is the shared core of the `clawpatrol run
+// claude` OAuth shim. It reads env via get, decides whether the shim
+// applies, and (when it does) writes the synthesized credentials.json —
+// chowning it to chownUID/chownGID when chownUID >= 0, so the privileged
+// sudo path can materialize a file the dropped-to-user child can read.
+// It returns the env mutations for the caller to apply; it deliberately
+// does NOT touch process env, so it works equally for os.Getenv and for
+// a captured []string env.
+//
+// clawDir is the `.clawpatrol` directory to carve the managed config dir
+// out of (the user's, not root's, on the sudo path).
+func planClaudeCodeOAuthShim(cmd []string, get func(string) string, clawDir string, chownUID, chownGID int) claudeShimResult {
+	if len(cmd) == 0 || filepath.Base(cmd[0]) != "claude" {
+		return claudeShimResult{}
+	}
+	bearer := get("ANTHROPIC_AUTH_TOKEN")
+	if bearer == "" {
+		return claudeShimResult{}
 	}
 	// Opt-in only. Writing credentials + repointing CLAUDE_CONFIG_DIR can
 	// shadow the worker's ~/.claude and touch files we don't own, so we
 	// never do it silently — tell the operator how to enable it instead.
-	if os.Getenv("CLAWPATROL_CLAUDE_OAUTH_SHIM") != "1" {
-		warnClaudeCodeRemoteControlDisabled()
-		return
+	if get("CLAWPATROL_CLAUDE_OAUTH_SHIM") != "1" {
+		return claudeShimResult{warn: true}
 	}
 	// Honor an operator-set CLAUDE_CONFIG_DIR so Claude Code keeps its
 	// settings/MCP/project state living there; otherwise carve out a
 	// clawpatrol-managed dir that leaves the worker's ~/.claude untouched.
-	dir := os.Getenv("CLAUDE_CONFIG_DIR")
+	dir := get("CLAUDE_CONFIG_DIR")
 	managed := dir == ""
 	if managed {
-		dir = filepath.Join(defaultClawpatrolDir(), "claude-config")
+		dir = filepath.Join(clawDir, "claude-config")
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		fmt.Fprintf(os.Stderr, "[clawpatrol] claude oauth shim: mkdir %s: %v\n", dir, err)
-		return
+		return claudeShimResult{}
+	}
+	if chownUID >= 0 && managed {
+		// We created the managed dir (possibly as root on the sudo path);
+		// hand it to the user who will read it. Best-effort: the file
+		// chown below is what actually matters for the read.
+		_ = os.Chown(dir, chownUID, chownGID)
 	}
 	credPath := filepath.Join(dir, ".credentials.json")
 	// Don't clobber a real /login that already lives in an operator-set
@@ -409,22 +459,23 @@ func installClaudeCodeOAuthShim(cmd []string) {
 	// own. (We always (re)write our own managed dir: it's clawpatrol's.)
 	if !managed {
 		if _, err := os.Stat(credPath); err == nil {
-			_ = os.Unsetenv("ANTHROPIC_AUTH_TOKEN")
-			return
+			return claudeShimResult{applied: true, unsetAuthToken: true}
 		}
 	}
 	if err := writeClaudeCodeCredentials(credPath, bearer); err != nil {
 		fmt.Fprintf(os.Stderr, "[clawpatrol] claude oauth shim: write credentials: %v\n", err)
-		return
+		return claudeShimResult{}
 	}
-	// Redirect Claude Code's credential read onto our synthesized file
-	// (only when we own the dir; an operator-set one is already exported).
-	// Unsetting ANTHROPIC_AUTH_TOKEN drops Claude Code out of precedence #2
-	// so the synthesized credentials.json (precedence #6) wins.
+	if chownUID >= 0 {
+		// credentials.json is mode 0600 — without this chown the
+		// dropped-to-user `claude` couldn't read its own credentials.
+		_ = os.Chown(credPath, chownUID, chownGID)
+	}
+	res := claudeShimResult{applied: true, unsetAuthToken: true}
 	if managed {
-		_ = os.Setenv("CLAUDE_CONFIG_DIR", dir)
+		res.configDir = dir
 	}
-	_ = os.Unsetenv("ANTHROPIC_AUTH_TOKEN")
+	return res
 }
 
 // warnClaudeCodeRemoteControlDisabled tells the operator why

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -323,6 +323,15 @@ func runWholeMachineDirect(cmd []string) {
 			fmt.Fprintf(os.Stderr, "[clawpatrol] env pushdown: %v (continuing without injected credentials)\n", err)
 		}
 	}
+	// Apply the Claude Code OAuth shim against the live process env, now
+	// that the pushdown has injected ANTHROPIC_AUTH_TOKEN above. Without
+	// this, `clawpatrol run claude` on a whole-machine device leaves the
+	// bearer set and never writes the synthesized .credentials.json, so
+	// Claude Code stays in API-key mode and OAuth-only features (e.g.
+	// /remote-control) stay gated — the same bug the sudo/userns paths
+	// already guard against. The command runs as the invoking user here
+	// (no privilege drop), so the process-env shim is sufficient.
+	installClaudeCodeOAuthShim(cmd)
 	bin, err := exec.LookPath(cmd[0])
 	if err != nil {
 		fail("%s: %v", cmd[0], err)

--- a/cmd/clawpatrol/run_sudo_linux.go
+++ b/cmd/clawpatrol/run_sudo_linux.go
@@ -77,9 +77,12 @@ func runViaSudo(cmd []string) {
 	}
 
 	// sudo resets the environment, but the command must run with this
-	// user's env. Capture it — after the OAuth shim, so CLAUDE_CONFIG_DIR
-	// is included — into a 0600 file the helper reads and deletes.
-	installClaudeCodeOAuthShim(cmd)
+	// user's env. Capture it into a 0600 file the helper reads and deletes.
+	// The Claude Code OAuth shim is NOT applied here: the gateway
+	// env-pushdown that feeds it ANTHROPIC_AUTH_TOKEN isn't in this
+	// (unprivileged, pre-session) env yet. The privileged helper applies it
+	// against the fully-built child env instead — see
+	// applyClaudeCodeOAuthShimSudo in runRunPrivileged.
 	envFile, err := writePrivilegedEnvFile(os.Environ())
 	if err != nil {
 		fail("env file: %v", err)
@@ -185,6 +188,12 @@ func runRunPrivileged(args []string) {
 	// The control vars below are consumed by runRunChild and stripped
 	// before it execs the actual command.
 	childEnv := buildPrivilegedEnv(*envFile, *caPath, pushVars)
+	// Apply the `clawpatrol run claude` OAuth shim here, not in the
+	// unprivileged runViaSudo parent: the gateway env-pushdown that
+	// supplies ANTHROPIC_AUTH_TOKEN is merged just above (buildPrivilegedEnv),
+	// so the parent's env never had the token to shim. Evaluate against the
+	// built child env instead.
+	childEnv = applyClaudeCodeOAuthShimSudo(childEnv, cmd, uid, gid)
 	childEnv = append(childEnv,
 		runChildEnv+"=1",
 		runTunAddrEnv+"="+tunAddr.String(),
@@ -324,6 +333,55 @@ func buildPrivilegedEnv(envFile, caPath string, pushVars []pushdownEnvVar) []str
 		have[ev.Name] = true
 	}
 	return env
+}
+
+// applyClaudeCodeOAuthShimSudo reflects the `clawpatrol run claude` OAuth
+// shim onto the privileged child's environment slice.
+//
+// The userns/darwin paths run the shim against the live process env right
+// before exec (installClaudeCodeOAuthShim). The sudo path can't: the
+// gateway env-pushdown that supplies ANTHROPIC_AUTH_TOKEN is merged here,
+// in the root helper (buildPrivilegedEnv), long after the unprivileged
+// parent captured its env — so at capture time there was no token to shim
+// and the shim silently no-op'd, leaving the child in bearer mode (Claude
+// Code precedence #2) instead of subscription OAuth (#6). We instead
+// evaluate the shim against the built childEnv: derive the managed config
+// dir from the child's (the user's) HOME, and chown the synthesized
+// credentials to the target uid/gid so the dropped-to-user command can
+// read them.
+func applyClaudeCodeOAuthShimSudo(env, cmd []string, uid, gid int) []string {
+	get := func(k string) string {
+		pre := k + "="
+		v := ""
+		for _, kv := range env {
+			if strings.HasPrefix(kv, pre) {
+				v = kv[len(pre):] // last wins, matching exec env semantics
+			}
+		}
+		return v
+	}
+	clawDir := filepath.Join(get("HOME"), ".clawpatrol")
+	res := planClaudeCodeOAuthShim(cmd, get, clawDir, uid, gid)
+	if res.warn {
+		warnClaudeCodeRemoteControlDisabled()
+	}
+	if !res.applied {
+		return env
+	}
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if res.unsetAuthToken && strings.HasPrefix(kv, "ANTHROPIC_AUTH_TOKEN=") {
+			continue
+		}
+		if res.configDir != "" && strings.HasPrefix(kv, "CLAUDE_CONFIG_DIR=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	if res.configDir != "" {
+		out = append(out, "CLAUDE_CONFIG_DIR="+res.configDir)
+	}
+	return out
 }
 
 // dropToUser permanently drops the process to uid/gid (real, effective,

--- a/cmd/clawpatrol/run_sudo_linux_test.go
+++ b/cmd/clawpatrol/run_sudo_linux_test.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// envVal returns the (last-wins) value of key in a NAME=VALUE slice, and
+// whether it was present at all.
+func envVal(env []string, key string) (string, bool) {
+	pre := key + "="
+	val, ok := "", false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, pre) {
+			val, ok = kv[len(pre):], true
+		}
+	}
+	return val, ok
+}
+
+// TestApplyClaudeCodeOAuthShimSudo is the regression test for cl-ulck:
+// on the passwordless-sudo run path the OAuth shim must fire against the
+// privileged child's built env (where the gateway pushdown has injected
+// ANTHROPIC_AUTH_TOKEN), strip the bearer, point CLAUDE_CONFIG_DIR at a
+// managed dir under the *child's* HOME, and write a synthesized
+// credentials.json the dropped-to-user command can read.
+func TestApplyClaudeCodeOAuthShimSudo(t *testing.T) {
+	home := t.TempDir()
+	// The managed dir is carved out of $HOME/.clawpatrol, which already
+	// exists on a joined host (ca.crt lives there).
+	if err := os.MkdirAll(filepath.Join(home, ".clawpatrol"), 0o700); err != nil {
+		t.Fatalf("seed .clawpatrol: %v", err)
+	}
+	env := []string{
+		"HOME=" + home,
+		"PATH=/usr/bin",
+		"ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-clawpatrol-placeholder-do-not-use",
+		"CLAWPATROL_CLAUDE_OAUTH_SHIM=1",
+	}
+
+	got := applyClaudeCodeOAuthShimSudo(env, []string{"claude"}, os.Getuid(), os.Getgid())
+
+	if _, ok := envVal(got, "ANTHROPIC_AUTH_TOKEN"); ok {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN should be stripped from child env, got %v", got)
+	}
+	cfgDir, ok := envVal(got, "CLAUDE_CONFIG_DIR")
+	if !ok {
+		t.Fatalf("CLAUDE_CONFIG_DIR should be set, got %v", got)
+	}
+	wantDir := filepath.Join(home, ".clawpatrol", "claude-config")
+	if cfgDir != wantDir {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q, want %q", cfgDir, wantDir)
+	}
+	// Unrelated vars survive.
+	if v, _ := envVal(got, "PATH"); v != "/usr/bin" {
+		t.Errorf("PATH not preserved: %q", v)
+	}
+
+	path := filepath.Join(cfgDir, ".credentials.json")
+	creds := readShimCreds(t, path)
+	if !hasScope(creds.ClaudeAiOauth.Scopes, "user:sessions:claude_code") {
+		t.Errorf("scopes missing user:sessions:claude_code: %v", creds.ClaudeAiOauth.Scopes)
+	}
+	if creds.ClaudeAiOauth.AccessToken == "" {
+		t.Errorf("accessToken empty")
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("credentials.json mode = %o, want 0600", mode)
+	}
+}
+
+// TestApplyClaudeCodeOAuthShimSudo_NotOptedIn: without the opt-in, the
+// child env is returned untouched (bearer kept, no managed dir, no file)
+// — default behavior must be unchanged.
+func TestApplyClaudeCodeOAuthShimSudo_NotOptedIn(t *testing.T) {
+	home := t.TempDir()
+	env := []string{
+		"HOME=" + home,
+		"ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-clawpatrol-placeholder-do-not-use",
+	}
+
+	got := applyClaudeCodeOAuthShimSudo(env, []string{"claude"}, os.Getuid(), os.Getgid())
+
+	if v, ok := envVal(got, "ANTHROPIC_AUTH_TOKEN"); !ok || v == "" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN should be kept when not opted in, got %v", got)
+	}
+	if _, ok := envVal(got, "CLAUDE_CONFIG_DIR"); ok {
+		t.Errorf("CLAUDE_CONFIG_DIR should not be set when not opted in")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".clawpatrol", "claude-config", ".credentials.json")); err == nil {
+		t.Errorf("credentials.json should not be written when not opted in")
+	}
+}
+
+// TestApplyClaudeCodeOAuthShimSudo_OperatorConfigDir: when the operator
+// set CLAUDE_CONFIG_DIR, the shim writes the synthesized credentials INTO
+// that dir and leaves the env var pointing at it (rather than carving out
+// a managed dir), still stripping the bearer.
+func TestApplyClaudeCodeOAuthShimSudo_OperatorConfigDir(t *testing.T) {
+	home := t.TempDir()
+	cfg := t.TempDir()
+	env := []string{
+		"HOME=" + home,
+		"ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-clawpatrol-placeholder-do-not-use",
+		"CLAWPATROL_CLAUDE_OAUTH_SHIM=1",
+		"CLAUDE_CONFIG_DIR=" + cfg,
+	}
+
+	got := applyClaudeCodeOAuthShimSudo(env, []string{"claude"}, os.Getuid(), os.Getgid())
+
+	if _, ok := envVal(got, "ANTHROPIC_AUTH_TOKEN"); ok {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN should be stripped, got %v", got)
+	}
+	if v, _ := envVal(got, "CLAUDE_CONFIG_DIR"); v != cfg {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q, want operator's %q", v, cfg)
+	}
+	creds := readShimCreds(t, filepath.Join(cfg, ".credentials.json"))
+	if !hasScope(creds.ClaudeAiOauth.Scopes, "user:sessions:claude_code") {
+		t.Errorf("scopes missing user:sessions:claude_code: %v", creds.ClaudeAiOauth.Scopes)
+	}
+}

--- a/doc/claude-code-oauth.md
+++ b/doc/claude-code-oauth.md
@@ -129,6 +129,27 @@ added must re-run the dashboard OAuth flow once).
   memory, and MCP servers are *not* visible — set `CLAUDE_CONFIG_DIR`
   yourself if you need them.
 
+## Where the shim runs across the Linux run paths
+
+`clawpatrol run` has two Linux sandboxing paths, and the shim must run
+*after* the gateway env-pushdown has injected `ANTHROPIC_AUTH_TOKEN` —
+otherwise it sees no bearer and silently no-ops:
+
+- **Unprivileged user-namespace path** (`run_linux.go`): the parent
+  applies the pushdown then calls `installClaudeCodeOAuthShim` against its
+  own process env, and the child inherits the result. Straightforward.
+- **Passwordless-sudo path** (`run_sudo_linux.go`, the default when
+  passwordless `sudo` is available): the pushdown is fetched and merged
+  *root-side*, in the privileged helper, long after the unprivileged
+  parent captured its environment. So the shim runs there too —
+  `applyClaudeCodeOAuthShimSudo` evaluates against the built child env,
+  derives the managed config dir from the *child's* `HOME`, and `chown`s
+  the synthesized `.credentials.json` to the target uid/gid so the
+  dropped-to-user `claude` can read it. Running the shim in the
+  unprivileged parent instead (as an earlier version did) left it a
+  no-op: the token wasn't in the env yet, so the child fell back to
+  bearer mode and OAuth-only features stayed gated.
+
 ## Caveat: macOS Keychain
 
 On macOS, an interactive `claude /login` stores credentials in the

--- a/doc/claude-code-oauth.md
+++ b/doc/claude-code-oauth.md
@@ -131,13 +131,21 @@ added must re-run the dashboard OAuth flow once).
 
 ## Where the shim runs across the Linux run paths
 
-`clawpatrol run` has two Linux sandboxing paths, and the shim must run
+`clawpatrol run` has three Linux run paths, and the shim must run
 *after* the gateway env-pushdown has injected `ANTHROPIC_AUTH_TOKEN` —
 otherwise it sees no bearer and silently no-ops:
 
 - **Unprivileged user-namespace path** (`run_linux.go`): the parent
   applies the pushdown then calls `installClaudeCodeOAuthShim` against its
   own process env, and the child inherits the result. Straightforward.
+- **Whole-machine path** (`runWholeMachineDirect` in `run_linux.go`, taken
+  on a `--whole-machine` device where the host already routes all traffic
+  through the gateway): there is no sandbox — the command is exec'd
+  directly as the invoking user. The pushdown is fetched straight from the
+  gateway and the shim runs against the live process env right after, same
+  as the userns path. Omitting the shim here (as the original
+  whole-machine direct-exec did) left `clawpatrol run claude` in bearer
+  mode on whole-machine devices even with the opt-in set.
 - **Passwordless-sudo path** (`run_sudo_linux.go`, the default when
   passwordless `sudo` is available): the pushdown is fetched and merged
   *root-side*, in the privileged helper, long after the unprivileged


### PR DESCRIPTION
## Problem

`CLAWPATROL_CLAUDE_OAUTH_SHIM=1` silently broke credential injection on the **passwordless-sudo run path** (now the default after #663): enabling it left Claude Code unable to use the injected OAuth credential — it behaved as API-key/bearer auth, so OAuth-only features like `/remote-control` stayed gated.

## Root cause

`runViaSudo` called `installClaudeCodeOAuthShim` **before** the gateway env-pushdown had injected `ANTHROPIC_AUTH_TOKEN`. The pushdown is fetched and merged *root-side* in `runRunPrivileged` (`buildPrivilegedEnv`), long after the unprivileged parent captured its environment. So the shim saw no bearer and returned an early no-op — never writing `.credentials.json`, never setting `CLAUDE_CONFIG_DIR`, never stripping the token. The pushdown then injected `ANTHROPIC_AUTH_TOKEN` into the child anyway, pinning Claude Code to bearer mode (precedence #2) instead of subscription OAuth (#6).

The in-code comment at `run_sudo_linux.go` ("capture … after the OAuth shim, so `CLAUDE_CONFIG_DIR` is included") documented the intended-but-broken behavior.

The Linux userns path and both darwin paths already apply the pushdown **before** the shim, so they were unaffected.

## Fix

- Extract the shim core into `planClaudeCodeOAuthShim`, shared by the process-env path (`installClaudeCodeOAuthShim`) and a new sudo slice-env path.
- `applyClaudeCodeOAuthShimSudo` runs in `runRunPrivileged` against the fully-built child env (where the pushdown has injected the bearer), derives the managed config dir from the **child's** `HOME`, and `chown`s the synthesized `.credentials.json` to the target uid/gid so the dropped-to-user `claude` can read it.
- Remove the dead call in `runViaSudo`; fix the stale comment.
- Document the per-run-path ordering requirement in `doc/claude-code-oauth.md`.

## Tests

New `run_sudo_linux_test.go` covers the sudo env transform: opt-in (token stripped, `CLAUDE_CONFIG_DIR` set, creds written 0600 with `user:sessions:claude_code`), not-opted-in (env untouched), and operator-set `CLAUDE_CONFIG_DIR`. Existing `installClaudeCodeOAuthShim` tests unchanged and green. `gofmt`/`go vet` clean.

Note: `TestEnvPushdownVars{ServerDriven,ErrorReturnsCAOnly}` fail on the base commit too (env-sensitive httptest fetch, untouched by this PR) — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)