### PR TITLE
dashboard: fix copy buttons in non-secure contexts

### DIFF
--- a/dashboard/src/components/AddDeviceModal.tsx
+++ b/dashboard/src/components/AddDeviceModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { listProfiles, type Whoami } from "../lib/api";
 import { Button } from "./Button";
 import { Modal } from "./Modal";
+import { copyText } from "../lib/clipboard";
 
 // shellArg quotes s for copy-paste into a POSIX shell when it
 // contains anything beyond plain word characters.
@@ -105,28 +106,9 @@ export function AddDeviceModal({
 function Step({ n, label, cmd }: { n: number; label: string; cmd: string }) {
   const [copied, setCopied] = useState(false);
   async function copy() {
-    const flash = () => {
+    if (await copyText(cmd)) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    };
-    try {
-      await navigator.clipboard.writeText(cmd);
-      flash();
-      return;
-    } catch {
-      // Fall through to the legacy path below. Reasons writeText can
-      // throw: non-secure context, page not focused, browser policy.
-    }
-    const ta = document.createElement("textarea");
-    ta.value = cmd;
-    ta.style.position = "fixed";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.select();
-    try {
-      if (document.execCommand("copy")) flash();
-    } finally {
-      document.body.removeChild(ta);
     }
   }
   return (

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -9,7 +9,7 @@ import {
   type FacetSchema,
   type RulePreview,
 } from "../lib/api";
-import { headersToJSON } from "../lib/clipboard";
+import { copyText, headersToJSON } from "../lib/clipboard";
 import { formatFacetValue, useFacets } from "../lib/facets";
 import { fmtDateTime } from "../lib/format";
 import { Button } from "./Button";
@@ -300,8 +300,7 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   }, [ev.id]);
 
   async function copyHCL() {
-    await navigator.clipboard.writeText(hcl);
-    setMsg("HCL copied.");
+    setMsg((await copyText(hcl)) ? "HCL copied." : "Copy failed.");
   }
 
   async function applyRule() {

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -300,7 +300,13 @@ function RulePreviewModal({ ev, onClose }: { ev: EventRecord; onClose: () => voi
   }, [ev.id]);
 
   async function copyHCL() {
-    setMsg((await copyText(hcl)) ? "HCL copied." : "Copy failed.");
+    if (await copyText(hcl)) {
+      setErr(null);
+      setMsg("HCL copied.");
+    } else {
+      setMsg(null);
+      setErr("Copy failed.");
+    }
   }
 
   async function applyRule() {

--- a/dashboard/src/lib/clipboard.ts
+++ b/dashboard/src/lib/clipboard.ts
@@ -18,15 +18,63 @@ export function headersToJSON(headers: Record<string, string | string[]>): strin
 }
 
 // copyText writes text to the system clipboard. Returns true on
-// success, false otherwise (insecure context, denied permission,
-// or no Clipboard API). Callers use the return value to decide
+// success, false otherwise (denied permission, or both the async and
+// legacy paths unavailable). Callers use the return value to decide
 // whether to flash a confirmation indicator.
+//
+// The async Clipboard API only exists in a secure context (https or
+// localhost). The dashboard is routinely reached over plain http on a
+// tailnet hostname, where navigator.clipboard is undefined — so we
+// fall through to the legacy execCommand path rather than silently
+// failing.
 export async function copyText(text: string): Promise<boolean> {
-  if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Focus/permission/policy rejection — fall through to the
+      // legacy path, which works in more situations than its
+      // reputation suggests.
+    }
+  }
+  return legacyCopy(text);
+}
+
+// legacyCopy copies via a temporary <textarea> + document.execCommand.
+// Deprecated but still implemented everywhere and the only option in a
+// non-secure context.
+function legacyCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  // readonly stops the mobile keyboard from popping; selection still
+  // works. Off-screen + transparent so it never flashes visibly.
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.top = "0";
+  ta.style.left = "0";
+  ta.style.opacity = "0";
+  // A modal <dialog> opened via showModal() puts everything outside it
+  // in the inert, top-layer-blocked subtree. A textarea appended to
+  // <body> would be inert — unselectable — so execCommand copies an
+  // empty selection. Mount inside the topmost open dialog when there is
+  // one so the node is live and selectable; otherwise <body> is fine.
+  const dialogs = document.querySelectorAll<HTMLDialogElement>("dialog[open]");
+  const host = dialogs.length ? dialogs[dialogs.length - 1] : document.body;
+  const prevFocus = document.activeElement as HTMLElement | null;
+  host.appendChild(ta);
   try {
-    await navigator.clipboard.writeText(text);
-    return true;
+    ta.focus();
+    ta.select();
+    ta.setSelectionRange(0, ta.value.length);
+    return document.execCommand("copy");
   } catch {
     return false;
+  } finally {
+    ta.remove();
+    // Restore focus to whatever the user had (the copy button), so the
+    // transient textarea doesn't steal it.
+    prevFocus?.focus?.();
   }
 }


### PR DESCRIPTION
The async Clipboard API (`navigator.clipboard`) only exists in a
secure context — https or localhost. The dashboard is routinely
reached over plain http on a tailnet hostname, where
`navigator.clipboard` is undefined, so the copy buttons silently did
nothing. The Add-device join/install command was the reported case.

* Give the shared `copyText()` helper a legacy `execCommand` fallback
  for when the Clipboard API is unavailable or rejects.
* Mount the temporary `<textarea>` inside the topmost open `<dialog>`
  rather than `<body>`. A modal dialog (`showModal()`) makes
  everything outside its top layer inert and therefore unselectable,
  so a textarea on `<body>` copied an empty selection.
* Route `AddDeviceModal` through `copyText()`, dropping its duplicated
  inline clipboard logic.
* Route `RequestDetailPage`'s "copy HCL" through `copyText()` too; it
  previously awaited `writeText()` with no fallback and no catch, so
  it threw (and showed no confirmation) in the same contexts.