### PR TITLE
run: fix DNS in passwordless-sudo path (resolv.conf perms)

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -917,6 +917,19 @@ func bindResolv(body string) error {
 		_ = os.Remove(tmp.Name())
 		return fmt.Errorf("write resolv temp file: %w", err)
 	}
+	// os.CreateTemp makes the file 0600. In the sudo path bindResolv
+	// runs as root (before the drop to the invoking user), so a 0600
+	// file ends up root-owned and the unprivileged command can't read
+	// the resolv.conf bind-mounted over /etc/resolv.conf — every name
+	// lookup then fails with "could not resolve host" while raw-IP
+	// traffic still works. Make it world-readable like a normal
+	// /etc/resolv.conf; it holds only a nameserver line, nothing
+	// sensitive.
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("chmod resolv temp file: %w", err)
+	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmp.Name())
 		return fmt.Errorf("close resolv temp file: %w", err)


### PR DESCRIPTION
`clawpatrol run` over the passwordless-sudo path could not resolve any
hostname (`curl: (6) Could not resolve host`), while raw-IP traffic
(`http://1.1.1.1`) worked and `CLAWPATROL_NO_SUDO=1` worked. The
divergence was the resolv.conf file mode, not its contents or the
environment.

`bindResolv` creates the resolv.conf temp file with `os.CreateTemp`,
which is mode 0600. In the sudo path it runs as root, before the drop
to the invoking user, so the file the gateway bind-mounts over
`/etc/resolv.conf` is root-owned and unreadable by the unprivileged
command — every name lookup fails while raw-IP traffic is unaffected.
The userns path was fine because there the temp file is created as the
invoking user.

* `chmod` the resolv.conf temp file to 0644, like a normal
  `/etc/resolv.conf`. It holds only a `nameserver` line, nothing
  sensitive.

Verified on a Linux box: in the sudo path `clawpatrol run cat
/etc/resolv.conf` now returns the gateway nameserver and
`clawpatrol run curl https://google.com` resolves and connects.