### PR TITLE
daemon: stable runtime dir so only one daemon runs per identity

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -55,6 +55,9 @@ const (
 	daemonHelloTimeout = 2 * time.Second
 	daemonSpawnTimeout = 30 * time.Second
 	daemonMagicLine    = "CLAWPATROL/1\n"
+	// daemonLogMaxBytes caps the persistent daemon.log: when a respawn
+	// finds the file larger than this it truncates instead of appending.
+	daemonLogMaxBytes = 2 << 20 // 2 MiB
 )
 
 // daemonTransport is the per-host network identity shared by every
@@ -88,15 +91,29 @@ type daemonTransport interface {
 	Close() error
 }
 
-// daemonRuntimeDir resolves the per-user runtime directory holding the
-// daemon's coordination state (control socket, spawn lock, log). Prefer
-// XDG_RUNTIME_DIR (tmpfs, per-user, no NFS pitfalls); fall back to
-// /tmp/clawpatrol-<uid> when unset (containers, minimal images).
+// daemonRuntimeDir resolves the directory holding the daemon's
+// coordination state (control socket, spawn lock, log). It MUST be a
+// stable, env-independent path: the whole point of the daemon is to be
+// a per-identity singleton that multiplexes every `clawpatrol run`
+// over the one tailnet key in daemonStateDir(), so the socket/lock have
+// to live at the same place no matter how the invoking process was
+// launched.
+//
+// It used to key on $XDG_RUNTIME_DIR (→ /run/user/<uid>/clawpatrol),
+// falling back to /tmp/clawpatrol-<uid> when unset. But pam_systemd
+// sets XDG_RUNTIME_DIR only for login sessions: an interactive shell
+// had it, while `ssh host cmd`, cron, and system services did not. The
+// two contexts therefore resolved different runtime dirs and spawned
+// *two* daemons that both bound the single tailnet identity and fought
+// over it — connections landed on whichever daemon a given invocation
+// happened to reach, so traffic intermittently went nowhere.
+//
+// Co-locate with the auth-key under daemonStateDir() so "one key in the
+// state dir" deterministically means "one daemon". AF_UNIX sockets work
+// fine on the persistent FS, and the existing stale-socket handling in
+// daemonConnect copes with a leftover socket after a reboot.
 func daemonRuntimeDir() string {
-	if d := os.Getenv("XDG_RUNTIME_DIR"); d != "" {
-		return filepath.Join(d, "clawpatrol")
-	}
-	return filepath.Join("/tmp", fmt.Sprintf("clawpatrol-%d", os.Getuid()))
+	return filepath.Join(daemonStateDir(), "run")
 }
 
 func daemonControlSockPath() string { return filepath.Join(daemonRuntimeDir(), "control.sock") }
@@ -214,8 +231,17 @@ func daemonSpawn(_ string) error {
 	}
 	defer func() { _ = pr.Close() }()
 
-	logf, err := os.OpenFile(daemonLogPath(),
-		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	// Truncate when starting if the log has grown past the cap. The
+	// daemon idle-exits and respawns often, and the log now lives on
+	// the persistent state dir (not tmpfs that a reboot would clear),
+	// so plain O_APPEND would grow without bound. A start-time size
+	// check keeps recent history across a handful of restarts while
+	// bounding total size.
+	logFlags := os.O_CREATE | os.O_APPEND | os.O_WRONLY
+	if fi, err := os.Stat(daemonLogPath()); err == nil && fi.Size() > daemonLogMaxBytes {
+		logFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	}
+	logf, err := os.OpenFile(daemonLogPath(), logFlags, 0o600)
 	if err != nil {
 		_ = pw.Close()
 		return err

--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -32,6 +32,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -58,6 +59,10 @@ const (
 	// daemonLogMaxBytes caps the persistent daemon.log: when a respawn
 	// finds the file larger than this it truncates instead of appending.
 	daemonLogMaxBytes = 2 << 20 // 2 MiB
+	// afUnixMaxPath is the AF_UNIX sun_path capacity on Linux (108
+	// bytes including the trailing NUL). The control socket path must
+	// fit; daemonRuntimeDir falls back to a short path when it wouldn't.
+	afUnixMaxPath = 108
 )
 
 // daemonTransport is the per-host network identity shared by every
@@ -112,8 +117,22 @@ type daemonTransport interface {
 // state dir" deterministically means "one daemon". AF_UNIX sockets work
 // fine on the persistent FS, and the existing stale-socket handling in
 // daemonConnect copes with a leftover socket after a reboot.
+//
+// Fallback for an unusually long $HOME / $XDG_STATE_HOME: the control
+// socket path must fit AF_UNIX's sun_path limit. When the state-dir
+// path would overflow it, use a short /tmp path keyed on a hash of the
+// (stable) state dir — still deterministic across invocation contexts,
+// so the one-daemon-per-identity guarantee holds, just not env-derived.
 func daemonRuntimeDir() string {
-	return filepath.Join(daemonStateDir(), "run")
+	dir := filepath.Join(daemonStateDir(), "run")
+	// +1 for the NUL terminator counted against sun_path.
+	if len(filepath.Join(dir, "control.sock"))+1 <= afUnixMaxPath {
+		return dir
+	}
+	sum := sha256.Sum256([]byte(daemonStateDir()))
+	// Hardcoded /tmp (not os.TempDir(), which honours $TMPDIR and could
+	// vary by context) keeps the fallback path env-independent too.
+	return filepath.Join("/tmp", fmt.Sprintf("clawpatrol-%d-%x", os.Getuid(), sum[:6]))
 }
 
 func daemonControlSockPath() string { return filepath.Join(daemonRuntimeDir(), "control.sock") }


### PR DESCRIPTION
`clawpatrol run` intermittently failed — DNS not resolving, or
connections hanging entirely — depending on how the invoking shell was
launched. The same command worked from one shell and failed from
another.

Root cause: `daemonRuntimeDir()` keyed the control socket / spawn lock
/ log on `$XDG_RUNTIME_DIR`, falling back to `/tmp/clawpatrol-<uid>`
when unset. `pam_systemd` sets `XDG_RUNTIME_DIR` only for login
sessions, so an interactive shell resolved
`/run/user/<uid>/clawpatrol` while `ssh host cmd`, cron, and system
services resolved `/tmp/clawpatrol-<uid>`. The two contexts spawned
*separate* daemons that both bound the single tailnet identity in
`daemonStateDir()` and fought over it — a given `clawpatrol run`
attached to whichever daemon matched its environment, so tunnel
traffic intermittently went nowhere.

* Resolve the runtime dir from `daemonStateDir()` (a `run` subdir)
  instead of `$XDG_RUNTIME_DIR`, co-locating the socket / lock / log
  with the auth-key so "one key in the state dir" deterministically
  means "one daemon", regardless of how the process was launched.
  AF_UNIX sockets work on the persistent FS, and `daemonConnect`
  already removes a stale socket left by a reboot.
* Truncate `daemon.log` at spawn when it exceeds 2 MiB. The log now
  lives on persistent storage rather than tmpfs that a reboot would
  clear, so plain `O_APPEND` across frequent idle-respawns would grow
  it without bound.

Verified on a Linux box: with the fix, interactive and
non-interactive invocations share one daemon in the new dir and 16
alternating runs across both session types all succeed (previously
intermittent).