### PR TITLE
run: stop leaking resolv.conf bind-mounts to the host (sudo path)

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -900,13 +900,12 @@ func childResolvConf() string {
 
 // bindResolv writes body to a temp file and bind-mounts it over
 // /etc/resolv.conf in the calling mount namespace. The temp file is
-// unlinked on every error path so a child whose CreateTemp succeeded
-// but WriteString / Mount failed doesn't strand a file in /tmp.
-//
-// On the success path the file stays on disk because the bind mount
-// holds a reference to its inode — unlinking before the namespace
-// tears down would replace /etc/resolv.conf with an empty path.
-// Kernel reclaims it when the mount goes away (mount namespace exit).
+// unlinked on every path — including success: once the bind-mount is
+// in place it holds a reference to the inode, so removing the source
+// directory entry leaves /etc/resolv.conf intact (it points at the
+// inode, not the path) while ensuring we don't strand one
+// /tmp/clawpatrol-resolv-* file per `clawpatrol run`. The kernel
+// reclaims the inode when the mount goes away on namespace exit.
 func bindResolv(body string) error {
 	tmp, err := os.CreateTemp("", "clawpatrol-resolv-*")
 	if err != nil {
@@ -925,5 +924,8 @@ func bindResolv(body string) error {
 		_ = os.Remove(tmp.Name())
 		return fmt.Errorf("bind-mount resolv: %w", err)
 	}
+	// Mount holds the inode; drop the now-redundant /tmp path so it
+	// doesn't accumulate across runs.
+	_ = os.Remove(tmp.Name())
 	return nil
 }

--- a/cmd/clawpatrol/run_sudo_linux.go
+++ b/cmd/clawpatrol/run_sudo_linux.go
@@ -223,7 +223,18 @@ func runRunPrivileged(args []string) {
 	child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
 	child.ExtraFiles = []*os.File{cSock, tunUpR}
 	child.SysProcAttr = &syscall.SysProcAttr{
-		Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWNS,
+		Cloneflags: syscall.CLONE_NEWNET,
+		// Create the mount namespace via Unshareflags rather than
+		// Cloneflags: Go follows an Unshareflags CLONE_NEWNS with a
+		// recursive MS_PRIVATE remount of `/`. Without that the new
+		// mount namespace inherits the host's shared propagation, so
+		// the resolv.conf bind-mount runRunChild does propagates back
+		// to the host /etc/resolv.conf and stacks up one overmount per
+		// `clawpatrol run` (and pins the /tmp temp file forever). The
+		// unprivileged userns path doesn't need this — a userns-owned
+		// mount namespace is already private. Real root here can
+		// unshare the mount namespace directly.
+		Unshareflags: syscall.CLONE_NEWNS,
 	}
 	if err := child.Start(); err != nil {
 		fail("clone child: %v", err)


### PR DESCRIPTION
On a passwordless-sudo host, `clawpatrol run` leaked a bind-mount onto
the host's `/etc/resolv.conf` on every invocation. They stacked
without bound — observed 110 overmounts on the host mount table —
along with a stranded `/tmp/clawpatrol-resolv-*` file per run.

Cause: the sudo path cloned the wrapped command into a new mount
namespace via `Cloneflags: CLONE_NEWNS`, which inherits the host's
shared mount propagation. The `/etc/resolv.conf` bind-mount that
`runRunChild` sets up then propagated back to the host namespace and
was never torn down. The unprivileged userns path was unaffected
because a userns-owned mount namespace is already private.

* Create the mount namespace via `Unshareflags` instead of
  `Cloneflags`, so Go follows the unshare with its recursive
  `MS_PRIVATE` remount of `/` and the bind-mount stays confined to the
  sandbox.
* Remove the resolv.conf temp file after the bind-mount succeeds — the
  mount pins the inode, so `/etc/resolv.conf` is unaffected and the
  `/tmp` entry stops accumulating.

Verified on a Linux box: after the fix, host `/etc/resolv.conf`
overmounts stay at 0 and the temp-file count stays flat across repeated
runs (both grew by one per run before), while resolv.conf is still
bind-mounted once inside the sandbox and resolves correctly.