### PR TITLE
site: add Tunnels docs page

### DIFF
--- a/site/doc/architecture.md
+++ b/site/doc/architecture.md
@@ -35,7 +35,7 @@ Five actors take part in a clawpatrol deployment:
   operator controls — to keep the picture clean, but the deployment
   shape is independent of the binary: the same gateway also runs on
   `localhost` next to the agent for single-machine setups, or
-  anywhere reachable by the device’s WireGuard config.
+  anywhere reachable by the device’s transport config.
 - **Upstream.** The API or service the agent is calling
   (api.anthropic.com, api.github.com, an internal Kubernetes API
   server, a Postgres database, a ClickHouse cluster, an SSH

--- a/site/doc/architecture.md
+++ b/site/doc/architecture.md
@@ -19,13 +19,16 @@ Five actors take part in a clawpatrol deployment:
 - **Device.** The machine the agent runs on. The device hosts a
   small clawpatrol client (CLI binary on Linux; system extension
   inside `Clawpatrol.app` on macOS) that captures the agent’s
-  outbound flows and feeds them into the tunnel.
-- **Tunnel.** A WireGuard underlay between the device and the
-  gateway. The tunnel carries L3 packets — every byte the agent
-  emits travels inside it. The agent never sees a proxy URL or a
-  CA bundle.
+  outbound flows and feeds them into the transport.
+- **Transport.** A WireGuard or Tailscale connection between the
+  device and the gateway, configured by the `gateway { wireguard
+  { ... } }` or `gateway { tailscale { ... } }` block (see
+  [Configure the gateway › Transports](/docs/configure-gateway/#transports-wireguard-tailscale-or-both)).
+  The transport carries L3 packets — every byte the agent emits
+  travels inside it. The agent never sees a proxy URL or a CA
+  bundle.
 - **Gateway.** The clawpatrol process. A single Go binary that
-  terminates the tunnel, decides per flow whether to intercept or
+  terminates the transport, decides per flow whether to intercept or
   pass through, and runs the policy plugins that inject real
   credentials, gate requests, and emit events. The diagram below
   draws the gateway on its own machine — typically a small VM the
@@ -45,7 +48,7 @@ The gateway is drawn on a separate machine; the device runs only
 the client — it does not run policy logic, does not hold
 credentials, and does not know upstream secrets.
 
-<svg viewBox="0 0 920 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="clawpatrol process diagram: device captures agent flows, tunnels them via WireGuard to the gateway, which either runs them through endpoint, rule, and credential plugins or splices them transparently to the upstream">
+<svg viewBox="0 0 920 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="clawpatrol process diagram: device captures agent flows, transports them via WireGuard or Tailscale to the gateway, which either runs them through endpoint, rule, and credential plugins or splices them transparently to the upstream">
   <defs>
     <marker id="ar-proc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
       <path d="M0,0 L10,5 L0,10 z" fill="#2a342f"/>
@@ -70,7 +73,7 @@ credentials, and does not know upstream secrets.
   <text class="sm-proc" x="180" y="106">capture</text>
   <line class="arr-proc" x1="120" y1="90" x2="140" y2="90" marker-end="url(#ar-proc)"/>
   <line class="arr-proc" x1="240" y1="90" x2="335" y2="90" marker-end="url(#ar-proc)"/>
-  <text class="sm-proc" x="287" y="82">tunnel (WireGuard)</text>
+  <text class="sm-proc" x="287" y="82">transport</text>
   <rect class="f-proc" x="335" y="20" width="565" height="320" rx="6"/>
   <text class="ttl-proc" x="345" y="14">gateway</text>
   <rect class="b-proc" x="345" y="70" width="100" height="40" rx="4"/>
@@ -197,7 +200,7 @@ PPID-filtered. Reference: `run_darwin.go`,
 
 ## Network traffic processing
 
-Once a flow reaches the gateway over the tunnel, the gateway
+Once a flow reaches the gateway over the transport, the gateway
 inspects the destination port (and, for some families, the SNI or
 the resolved hostname) to pick a handler. A **family** is the
 protocol class an endpoint plugin advertises so the rule engine

--- a/site/doc/toc.json
+++ b/site/doc/toc.json
@@ -4,6 +4,7 @@
   "configure-gateway",
   "credentials",
   "rules",
+  "tunnels",
   "clawpatrol-test",
   "plugins",
   "architecture",

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -26,9 +26,11 @@ for a tunnel when:
 - **Upstream lives on a tailnet.** MagicDNS-only hostnames and
   tailnet-internal IPs aren't reachable from the gateway's normal
   netns; embedded tsnet joins the tailnet in-process.
-- **You bounce through a bastion.** SSH jump host pattern — the
-  upstream is only routable from the bastion, and the gateway
-  opens one SSH session per tunnel and forwards through it.
+- **The upstream is only reachable from a jump host.** A common
+  pattern: a public-facing SSH server (the "bastion") sits in
+  front of a private database or service that has no public route.
+  The gateway opens one SSH session to the bastion and forwards
+  every dial through it (`ssh -L` semantics).
 
 ## How endpoints reference a tunnel
 

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -240,10 +240,10 @@ is zero — tear down as soon as the last endpoint goes idle.
 
 ## Chaining tunnels with `via`
 
-Set `via = <other-tunnel>` on a tunnel block to dial its
+Set `via = <other-tunnel>` on a tunnel block to route its
 underlying TCP connection through another tunnel instead of
-`net.Dial`. The canonical case is `kubectl port-forward →
-ssh-server pod → ssh -L to RDS`:
+dialing directly from the gateway host. The canonical case is
+`kubectl port-forward → ssh-server pod → ssh -L to RDS`:
 
 ```hcl
 tunnel "kubernetes_port_forward" "ssh-jump-pod" {

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -1,0 +1,283 @@
+# Tunnels
+
+A tunnel block tells the gateway how to reach an upstream that
+isn't directly routable from its own network namespace. An
+[endpoint](/docs/glossary/#endpoint) declares the wire protocol;
+a tunnel declares the path the gateway dials over. Operators
+write them as top-level blocks in `gateway.hcl`:
+
+```hcl
+tunnel "<type>" "<name>" { ... }
+```
+
+> **Not the same "tunnel" as in [Architecture](/docs/architecture/).**
+> That page uses "tunnel" for the WireGuard underlay carrying
+> agent traffic *into* the gateway. The blocks on this page are
+> the opposite direction — how the gateway reaches *out* to
+> upstreams. Same word, two layers.
+
+## When you need a tunnel
+
+The gateway dials upstreams from its own netns by default. If the
+upstream is publicly resolvable and the gateway can route to it,
+no tunnel block is needed — the endpoint alone is enough. Reach
+for a tunnel when:
+
+- **Upstream is in a private VPC or cluster.** RDS behind an EKS
+  VPC, an internal API behind a corporate VPN — the gateway needs
+  someone else's network presence to reach it.
+- **The vendor ships a sidecar proxy.** Cloud SQL's
+  `cloud-sql-proxy`, AWS SSM port forwarding, and friends — they
+  run locally, expose a port, and encapsulate auth.
+- **Upstream lives on a tailnet.** MagicDNS-only hostnames and
+  tailnet-internal IPs aren't reachable from the gateway's normal
+  netns; embedded tsnet joins the tailnet in-process.
+- **You bounce through a bastion.** SSH jump host pattern — the
+  upstream is only routable from the bastion, and the gateway
+  opens one SSH session per tunnel and forwards through it.
+
+## How endpoints reference a tunnel
+
+`tunnel = <name>` is a framework attribute on the endpoint block,
+the same shape as `credential = <name>`:
+
+```hcl
+tunnel "local_command" "csql-staging" {
+  command = ["cloud-sql-proxy", "--auto-iam-authn",
+    "denosr-staging:us-east4:main-pg14?port=5433"]
+  listen      = "127.0.0.1:5433"
+  ready_probe = "tcp"
+}
+
+endpoint "postgres" "pg-staging" {
+  host   = "main-pg14.denosr-staging.internal:5432"
+  tunnel = local_command.csql-staging
+}
+```
+
+Three load-time consequences worth knowing:
+
+1. **Tunneled endpoints reach the upstream via DNS-VIP.** The
+   gateway intercepts the agent's DNS query for the endpoint's
+   hostname and returns an allocated VIP; when the agent dials
+   the VIP, the dispatcher routes it into the endpoint runtime,
+   which then asks the tunnel to dial. Pure-IP `hosts = [...]`
+   on a tunneled endpoint is a compile error — there's no DNS
+   for the gateway to intercept. See
+   [Architecture › DNS interception → VIP](/docs/architecture/#dns-interception--vip).
+2. **The endpoint's `host` is what the *tunnel* will dial.** Some
+   tunnels honour it (`ssh_port_forward` opens a TCP channel to
+   that host:port through the bastion). Some ignore it
+   (`local_command`, `kubernetes_port_forward` already encode the
+   upstream in their own config and dial a fixed local listener).
+   The hostname is still mandatory so the DNS-VIP path has a name
+   to allocate against.
+3. **One tunnel can serve many endpoints.** A single
+   `local_command` running `cloud-sql-proxy` (`share =
+   "singleton"`) is shared across every endpoint that names it.
+   See [share and keepalive](#share-and-keepalive) below.
+
+## Built-in tunnel types
+
+Each subsection shows one terse HCL example. The full per-field
+schema lives in
+[Config Reference › tunnel blocks](/docs/config-reference/#tunnel-blocks).
+
+### `local_command` — wrap a vendor proxy
+
+Spawns an arbitrary command that exposes a local listener;
+`Tunnel.Dial` always dials the configured `listen` address. Right
+fit for cloud-sql-proxy, AWS SSM port forwarding, or any
+"we already have a CLI for this upstream" case.
+
+```hcl
+tunnel "local_command" "csql-staging" {
+  command = [
+    "/usr/local/bin/cloud-sql-proxy", "--auto-iam-authn",
+    "--credentials-file", "/opt/clawpatrol/secrets/avocet.json",
+    "denosr-staging:us-east4:main-pg14?port=5433",
+  ]
+  listen        = "127.0.0.1:5433"
+  ready_probe   = "tcp"
+  ready_timeout = "30s"
+  share         = "singleton"
+  keepalive     = "10m"
+}
+```
+
+See [config reference](/docs/config-reference/#tunnel-localcommand).
+
+### `kubernetes_port_forward` — kubectl into a cluster
+
+Shells out to `kubectl port-forward` against an existing pod, a
+service, a label-selected pod, or a templated jump pod the
+gateway creates on demand. Template mode is the workhorse for the
+"socat sidecar inside EKS so the gateway can reach RDS in the
+VPC" pattern.
+
+```hcl
+tunnel "kubernetes_port_forward" "pg-deployng-dev-jump" {
+  server       = "https://....eks.amazonaws.com"
+  cluster_name = "deployng-dev"
+  region       = "us-east-2"
+  credential   = aws_credential.avocet-aws
+  ca_cert      = "<<file:eks-dev-ca.pem>>"
+  port         = 5432
+  share        = "singleton"
+  keepalive    = "10m"
+  template     = <<-EOT
+    apiVersion: v1
+    kind: Pod
+    metadata: { generateName: clawpatrol-rds-jump- }
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: socat
+        image: alpine/socat:1.8.0.0
+        args:
+        - TCP-LISTEN:5432,fork,reuseaddr
+        - TCP:deployng-dev.<rds-host>.rds.amazonaws.com:5432
+        ports: [{ containerPort: 5432 }]
+  EOT
+}
+```
+
+The plugin authenticates to the apiserver in one of two modes:
+either kubectl uses whatever the host's `KUBECONFIG` /
+`~/.kube/config` selects (with optional `context = ...` to pin a
+named context), or — when `server` is set — the plugin writes a
+self-contained per-tunnel kubeconfig with a bearer minted from
+the bound credential. The second mode is the right one for EKS:
+pair it with an `aws_credential` and the plugin re-mints the
+short-lived STS-presigned bearer on every kubectl call.
+
+Template-created pods are stamped with `clawpatrol.dev/managed-by`
+and `clawpatrol.dev/tunnel=<name>` labels. A startup sweep
+deletes any leftover pods carrying those labels (a previous
+daemon crash that skipped graceful teardown), so jump pods don't
+accumulate. Set `cleanup = "keep"` to opt out.
+
+See [config reference](/docs/config-reference/#tunnel-kubernetesportforward).
+
+### `ssh_port_forward` — through a bastion
+
+Opens one SSH session to a bastion and forwards every
+`Tunnel.Dial` through it (`ssh -L` semantics, all in-process).
+Multiple concurrent dials share the same session.
+
+```hcl
+tunnel "ssh_port_forward" "deploy-bastion" {
+  bastion    = "bastion.deploy.example:22"
+  user       = "root"
+  credential = ssh_key.deploy-bastion
+}
+
+endpoint "postgres" "pg-internal" {
+  host   = "pg.internal:5432"
+  tunnel = ssh_port_forward.deploy-bastion
+}
+```
+
+The upstream address is resolved on the bastion side — exactly
+what you want when the upstream is only reachable from the
+bastion's network. Pair with [`via`](#chaining-tunnels-with-via)
+to reach a bastion that itself lives behind another tunnel.
+
+See [config reference](/docs/config-reference/#tunnel-sshportforward).
+
+### `tailscale` — embed a tsnet node
+
+Joins the tailnet in-process via `tsnet.Server`; every dial
+routes through it, so MagicDNS hostnames and tailnet-internal
+IPs resolve correctly. The canonical case is an internal service
+published on the tailnet that the gateway can't reach from its
+host netns.
+
+```hcl
+credential "tailscale_auth" "deno-tailnet" {}
+
+tunnel "tailscale" "deno-tailnet-tunnel" {
+  credential = tailscale_auth.deno-tailnet
+}
+
+endpoint "clickhouse_native" "clickhouse-o11y" {
+  hosts  = ["clickhouse-o11y.tail9a48e.ts.net"]
+  tls    = true
+  tunnel = tailscale.deno-tailnet-tunnel
+}
+```
+
+Three auth shapes are supported. A bound `credential
+"tailscale_auth"` keeps the node identity in the gateway's secret
+store and surfaces a one-time interactive login URL on the
+dashboard's Connect button — best fit when you want the tsnet
+node to show up under a real user identity. An inline
+`authkey = "..."` (with `CLAWPATROL_TUNNEL_<NAME>_AUTHKEY` env
+fallback) is the pre-minted-key path. `oauth_client_secret = "..."`
+mints fresh short-lived device keys on every join, so nothing
+expires out from under you.
+
+See [config reference](/docs/config-reference/#tunnel-tailscale).
+
+## share and keepalive
+
+Two knobs control how many runtime instances of a tunnel block
+exist and how long they live. They sit on every tunnel type:
+
+- `share = "singleton"` (default for `local_command`,
+  `ssh_port_forward`, `tailscale`): one instance per tunnel name,
+  shared across every endpoint and every connection.
+- `share = "per_endpoint"` (default for
+  `kubernetes_port_forward`): one instance per (tunnel, endpoint)
+  pair. Right when each endpoint needs its own ephemeral local
+  port — two endpoints can't share one `kubectl port-forward`
+  listener.
+- `share = "per_conn"`: one instance per inbound connection, torn
+  down when the conn closes. Niche; useful when the tunnel's
+  state should track a single request.
+
+`keepalive = "<duration>"` is the idle window after refcount hits
+zero before the manager calls Close. `keepalive = "always"` pins
+the tunnel up for the policy lifetime (no idle teardown). Default
+is zero — tear down as soon as the last endpoint goes idle.
+
+## Chaining tunnels with `via`
+
+Set `via = <other-tunnel>` on a tunnel block to dial its
+transport through another tunnel instead of `net.Dial`. The
+canonical case is `kubectl port-forward → ssh-server pod →
+ssh -L to RDS`:
+
+```hcl
+tunnel "kubernetes_port_forward" "ssh-jump-pod" {
+  context = "..."
+  pod     = "ssh-server"
+  port    = 22
+}
+
+tunnel "ssh_port_forward" "rds-via-jump" {
+  user       = "root"
+  credential = ssh_key.jump-pod
+  via        = kubernetes_port_forward.ssh-jump-pod
+  # `bastion` omitted — the via tunnel handles addressing
+}
+```
+
+The manager opens, refcounts, and tears down the `via` chain
+automatically. Cycles in the `via` graph fail at compile time.
+
+## Credentials on tunnels
+
+The `credential = X` attribute on a tunnel block authenticates
+the *tunnel's own transport* — the bastion login for
+`ssh_port_forward`, the EKS bearer for
+`kubernetes_port_forward` with `server` set, the tailnet node
+identity for `tailscale`. It's distinct from the credential the
+endpoint will inject into the agent's request once the tunnel is
+up; that one lives on a separate `credential` block bound to the
+endpoint.
+
+So a postgres-behind-EKS deployment carries two credentials in
+play: an `aws_credential` on the tunnel (mints the EKS bearer
+for kubectl) and a `postgres_credential` on the endpoint (the
+SCRAM password the gateway replays to RDS).

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -10,12 +10,6 @@ write them as top-level blocks in `gateway.hcl`:
 tunnel "<type>" "<name>" { ... }
 ```
 
-> **Not the same "tunnel" as in [Architecture](/docs/architecture/).**
-> That page uses "tunnel" for the WireGuard underlay carrying
-> agent traffic *into* the gateway. The blocks on this page are
-> the opposite direction — how the gateway reaches *out* to
-> upstreams. Same word, two layers.
-
 ## When you need a tunnel
 
 The gateway dials upstreams from its own netns by default. If the

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -61,13 +61,14 @@ Three load-time consequences worth knowing:
    on a tunneled endpoint is a compile error — there's no DNS
    for the gateway to intercept. See
    [Architecture › DNS interception → VIP](/docs/architecture/#dns-interception--vip).
-2. **The endpoint's `host` is what the *tunnel* will dial.** Some
-   tunnels honour it (`ssh_port_forward` opens a TCP channel to
-   that host:port through the bastion). Some ignore it
-   (`local_command`, `kubernetes_port_forward` already encode the
-   upstream in their own config and dial a fixed local listener).
-   The hostname is still mandatory so the DNS-VIP path has a name
-   to allocate against.
+2. **The endpoint's `host` is what gets the VIP allocated.**
+   Whether the tunnel then dials that address depends on the type.
+   `ssh_port_forward` and `tailscale` honour it (the bastion /
+   tsnet resolves the upstream from inside the remote network).
+   `local_command` and `kubernetes_port_forward` ignore it — they
+   already encode the upstream in their own config and dial a
+   fixed local listener. The hostname is mandatory regardless, so
+   DNS-VIP has a name to allocate against.
 3. **One tunnel can serve many endpoints.** A single
    `local_command` running `cloud-sql-proxy` (`share =
    "singleton"`) is shared across every endpoint that names it.
@@ -240,9 +241,9 @@ is zero — tear down as soon as the last endpoint goes idle.
 ## Chaining tunnels with `via`
 
 Set `via = <other-tunnel>` on a tunnel block to dial its
-transport through another tunnel instead of `net.Dial`. The
-canonical case is `kubectl port-forward → ssh-server pod →
-ssh -L to RDS`:
+underlying TCP connection through another tunnel instead of
+`net.Dial`. The canonical case is `kubectl port-forward →
+ssh-server pod → ssh -L to RDS`:
 
 ```hcl
 tunnel "kubernetes_port_forward" "ssh-jump-pod" {

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -26,11 +26,11 @@ for a tunnel when:
 - **Upstream lives on a tailnet.** MagicDNS-only hostnames and
   tailnet-internal IPs aren't reachable from the gateway's normal
   netns; embedded tsnet joins the tailnet in-process.
-- **The upstream is only reachable from a jump host.** A common
-  pattern: a public-facing SSH server (the "bastion") sits in
-  front of a private database or service that has no public route.
-  The gateway opens one SSH session to the bastion and forwards
-  every dial through it (`ssh -L` semantics).
+- **The upstream is only reachable from an SSH jump host.** A
+  common pattern: a public-facing SSH server (the "bastion") sits
+  in front of a private database or service that has no public
+  route. The gateway opens one SSH session to the bastion and
+  forwards every dial through it (`ssh -L` semantics).
 
 ## How endpoints reference a tunnel
 


### PR DESCRIPTION
## Summary

- Adds `site/doc/tunnels.md` — a top-level concepts page covering tunnel blocks (the upstream-side ones, distinct from the WG underlay)
- Slots `tunnels` into `toc.json` after `rules`

The page covers:
- When you actually need a tunnel (private VPC, vendor proxy, tailnet, bastion)
- How endpoints reference a tunnel via `tunnel = X`, including the implicit DNS-VIP requirement and the no-IP-literal compile error
- One short HCL example per built-in type (`local_command`, `kubernetes_port_forward`, `ssh_port_forward`, `tailscale`), each linking out to the existing config-reference entry rather than re-listing fields
- `share` and `keepalive` semantics with the per-type defaults
- `via` chaining (the `kubectl port-forward → ssh pod → ssh -L` pattern)
- The two-credential split — `credential` on the tunnel authenticates the tunnel's own transport, separate from the credential bound to the endpoint

## Test plan
- [ ] `cd site && npm run build` succeeds and produces `dist/docs/tunnels/index.html`
- [ ] Tunnels link appears in the docs sidebar between Rules and `clawpatrol-test`
- [ ] In-page links to `/docs/architecture/#dns-interception--vip` and the `/docs/config-reference/#tunnel-*` anchors resolve