### PR TITLE
daemon: auto-recover WG tunnel + DNS after a gateway restart

### DIFF
--- a/cmd/clawpatrol/daemon_transport_wg_linux.go
+++ b/cmd/clawpatrol/daemon_transport_wg_linux.go
@@ -49,6 +49,19 @@ const (
 	// so the first user flow doesn't race the initial handshake. See
 	// macos/netstack/wgnetstack.go for the same rationale.
 	wgClientKeepalive = 10
+	// wgWatchdogPoll is how often the handshake-recovery watchdog samples
+	// the peer's last_handshake_time_sec + tx_bytes. The watchdog only
+	// acts once the handshake is older than wgWatchdogStuckTimeout, so a
+	// few seconds between polls is plenty and stays cheap.
+	wgWatchdogPoll = 5 * time.Second
+	// wgWatchdogStuckTimeout mirrors wireguard's RejectAfterTime (180s):
+	// below this a stale last_handshake is normal (no rekey was due), so
+	// rebuilding the peer would only add churn. Past it, with traffic
+	// still being staged, the handshake is genuinely wedged.
+	wgWatchdogStuckTimeout = 3 * time.Minute
+	// wgWatchdogResetCooldown holds off back-to-back rebuilds so a fresh
+	// initiation has time to complete before the watchdog fires again.
+	wgWatchdogResetCooldown = time.Minute
 )
 
 type wgTransport struct {
@@ -56,6 +69,10 @@ type wgTransport struct {
 	tun         *wgClientTun
 	localAddr   netip.Addr
 	bootWarning string
+
+	// stopWatchdog cancels the handshake-recovery watchdog goroutine.
+	// Set by startWGTransport, invoked by Close.
+	stopWatchdog context.CancelFunc
 }
 
 func (t *wgTransport) LocalAddr() netip.Addr { return t.localAddr }
@@ -97,6 +114,9 @@ func (t *wgTransport) Dial(ctx context.Context, network, addr string) (net.Conn,
 }
 
 func (t *wgTransport) Close() error {
+	if t.stopWatchdog != nil {
+		t.stopWatchdog()
+	}
 	if t.dev != nil {
 		t.dev.Close()
 	}
@@ -142,7 +162,16 @@ func startWGTransport() (daemonTransport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("netTUN: %w", err)
 	}
-	logger := device.NewLogger(device.LogLevelError, "[clawpatrol daemon wg] ")
+	// forceReset lets the watchdog short-circuit its poll cadence the
+	// instant wireguard-go logs the keypair-derivation failure, so the
+	// stuck handshake state machine is rebuilt within milliseconds
+	// rather than after the next stuck-timeout poll. Buffered to one so
+	// concurrent failures coalesce into a single wake-up.
+	forceReset := make(chan struct{}, 1)
+	logger := wrapWGLogger(
+		device.NewLogger(device.LogLevelError, "[clawpatrol daemon wg] "),
+		forceReset,
+	)
 	dev := device.NewDevice(tun, conn.NewDefaultBind(), logger)
 
 	if err := dev.IpcSet(buildDaemonWGIpc(cfg)); err != nil {
@@ -173,11 +202,44 @@ func startWGTransport() (daemonTransport, error) {
 		log.Printf("daemon: wg handshake established")
 	}
 
+	// Start the handshake-recovery watchdog. Without it, a gateway
+	// restart (which drops the gateway's in-memory peer/session state)
+	// leaves the device holding a dead session: it keeps encrypting with
+	// the old keypair until RejectAfterTime, then re-initiates — but the
+	// wireguard-go state machine can wedge in handshakeInitiationCreated
+	// and never recover, black-holing every flow (including tunnelled
+	// DNS) until the daemon is killed and the peer rebuilt by hand. The
+	// watchdog automates that rebuild: poll the handshake age, and when
+	// it goes stale while traffic is still being staged, re-IpcSet the
+	// peer to force a clean fresh initiation.
+	watchdogCtx, stopWatchdog := context.WithCancel(context.Background())
+	ticker := time.NewTicker(wgWatchdogPoll)
+	go func() {
+		defer ticker.Stop()
+		runWGWatchdogLoop(watchdogCtx, wgWatchdogConfig{
+			stats: func() *wgPeerStats {
+				uapi, err := dev.IpcGet()
+				if err != nil {
+					return nil
+				}
+				return parsePeerStats(uapi)
+			},
+			reset:         func() error { return dev.IpcSet(buildDaemonWGIpc(cfg)) },
+			log:           logger,
+			forceReset:    forceReset,
+			tick:          ticker.C,
+			stuckTimeout:  wgWatchdogStuckTimeout,
+			resetCooldown: wgWatchdogResetCooldown,
+			now:           time.Now,
+		})
+	}()
+
 	return &wgTransport{
-		dev:         dev,
-		tun:         tun,
-		localAddr:   clientIP,
-		bootWarning: bootWarning,
+		dev:          dev,
+		tun:          tun,
+		localAddr:    clientIP,
+		bootWarning:  bootWarning,
+		stopWatchdog: stopWatchdog,
 	}, nil
 }
 

--- a/cmd/clawpatrol/daemon_transport_wg_linux_test.go
+++ b/cmd/clawpatrol/daemon_transport_wg_linux_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package main
+
+import "testing"
+
+// The gateway-restart DNS black-hole (cl-pmcy) was caused by the
+// handshake-recovery watchdog being implemented but never wired into
+// the WG transport's lifecycle. Guard that Close still tears the
+// watchdog down so a started watchdog can't outlive its transport.
+func TestWGTransportCloseStopsWatchdog(t *testing.T) {
+	stopped := false
+	tr := &wgTransport{
+		stopWatchdog: func() { stopped = true },
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !stopped {
+		t.Fatal("Close did not stop the watchdog")
+	}
+}
+
+// A transport with no watchdog (e.g. a future code path that skips it)
+// must not panic on Close.
+func TestWGTransportCloseNilWatchdog(t *testing.T) {
+	tr := &wgTransport{}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close with nil watchdog: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

When the gateway is restarted, devices with an open tunnel stop resolving DNS and do **not** self-recover. The only known fix is to kill the device-side daemon, after which DNS comes back.

## Root cause

A gateway restart drops all in-memory WireGuard peer/session state. The device keeps its locally-configured peer and its old keypair, treating it as valid until `RejectAfterTime` (180s), so it keeps encrypting with a session the gateway can no longer decrypt and `last_handshake_time_sec` freezes. When the keypair finally expires and the device re-initiates, the wireguard-go handshake state machine can wedge in `handshakeInitiationCreated` ("Failed to derive keypair") with no path out — black-holing every flow, including tunnelled DNS (UDP/53 forwarded through the tunnel), until the daemon is killed and the peer is rebuilt from scratch.

A recovery watchdog (`runWGWatchdogLoop`) already existed for exactly this stuck-handshake class — it rebuilds the peer to force a clean re-handshake, which is precisely what a manual daemon restart does. But it was never started in production (only referenced from tests).

## Fix

Wire the watchdog into the WG transport lifecycle in `startWGTransport`:

- Poll the peer's handshake age; when it goes stale (> 3m, mirroring `RejectAfterTime`) while traffic is still being staged, `IpcSet` the peer to force a clean fresh initiation.
- Wrap the device logger so the "Failed to derive keypair" log line short-circuits the poll cadence and recovery starts within milliseconds.
- Tear the watchdog down on transport `Close` so it can't outlive its transport.

Tunnelled DNS self-heals once the tunnel re-handshakes (the UDP forwarder's flows carry a 30s read deadline and re-dial), so no DNS-specific change is needed.

## No regression

Healthy tunnels rekey well within the 3m stuck-timeout (REKEY_AFTER_TIME 120s, keepalive 10s), so `last_handshake` stays fresh and the watchdog never fires during normal operation. It only acts on a genuinely wedged handshake (stale age **and** advancing tx) or the explicit keypair-derivation signal.

Scope: WireGuard mode only — the transport in the repro. tsnet mode has tailscale's own reconnect logic.

## Tests

- Added `daemon_transport_wg_linux_test.go` covering the watchdog teardown on `Close` (and nil-safety).
- Existing `wg_watchdog_test.go` covers the loop behaviour.
- Full `cmd/clawpatrol` suite green; `gofmt`/`go vet` clean.