### PR TITLE
Add OTel GenAI telemetry export with optional message content

### DIFF
--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -1,15 +1,16 @@
 // OpenTelemetry GenAI semantic-convention export for intercepted LLM
-// turns. Targets semconv v1.27.0
+// turns. Targets the GenAI semantic conventions
 // (https://opentelemetry.io/docs/specs/semconv/gen-ai/): one span per
 // model invocation carrying gen_ai.* attributes (system, models, token
 // usage, finish reason) and — only when the operator opts in — the
-// prompt/completion message content as span events.
+// prompt/completion message content as the gen_ai.input.messages /
+// gen_ai.output.messages / gen_ai.system_instructions span attributes.
 //
 // Opt-in is two independent switches (internal/config GenAITelemetry):
 // the `genai_telemetry {}` block presence enables the attribute span;
-// `include_message_content` additionally attaches content events.
-// Disabled is the zero-overhead default — recordGenAITurn returns
-// before parsing anything.
+// `include_message_content` additionally attaches the message-content
+// attributes. Disabled is the zero-overhead default — recordGenAITurn
+// returns before parsing anything.
 
 package main
 
@@ -31,6 +32,22 @@ type genAIMessage struct {
 	Content string
 }
 
+// genAIPart is a single content part within a GenAI message. Only text
+// parts are captured today, so Type is always "text".
+type genAIPart struct {
+	Type    string `json:"type"`
+	Content string `json:"content"`
+}
+
+// genAIChatMessage is one message in the gen_ai.input.messages /
+// gen_ai.output.messages span attributes: a role, its content parts,
+// and (output messages only) the finish reason for that message.
+type genAIChatMessage struct {
+	Role         string      `json:"role"`
+	Parts        []genAIPart `json:"parts"`
+	FinishReason string      `json:"finish_reason,omitempty"`
+}
+
 // genAITurn is one intercepted LLM request/response mapped to OTel
 // GenAI semantic-convention terms.
 type genAITurn struct {
@@ -47,16 +64,18 @@ type genAITurn struct {
 	// stamped at emission time.
 	Start time.Time
 
-	// Messages and Completion populate the content events; filled only
-	// when message-content capture is enabled.
+	// Messages and Completion populate the content attributes; filled
+	// only when message-content capture is enabled.
 	Messages   []genAIMessage
 	Completion string
 }
 
 // emitGenAISpan records one GenAI span on the provided tracer. When
-// includeContent is true, message content is attached as span events
-// per the GenAI content convention. A free function (not a method) so
-// tests can drive it with an in-memory tracer.
+// includeContent is true, message content is attached as the
+// gen_ai.input.messages / gen_ai.output.messages /
+// gen_ai.system_instructions span attributes per the GenAI semantic
+// conventions. A free function (not a method) so tests can drive it
+// with an in-memory tracer.
 func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	if tracer == nil {
 		return
@@ -94,26 +113,63 @@ func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	span.SetAttributes(attrs...)
 
 	if includeContent {
-		for _, m := range t.Messages {
-			role := m.Role
-			if role == "" {
-				role = "user"
-			}
-			span.AddEvent("gen_ai."+role+".message", trace.WithAttributes(
-				attribute.String("gen_ai.system", t.System),
-				attribute.String("content", m.Content),
-			))
-		}
-		if t.Completion != "" {
-			span.AddEvent("gen_ai.choice", trace.WithAttributes(
-				attribute.String("gen_ai.system", t.System),
-				attribute.Int("index", 0),
-				attribute.String("finish_reason", t.FinishReason),
-				attribute.String("content", t.Completion),
-			))
+		if content := genAIContentAttrs(t); len(content) > 0 {
+			span.SetAttributes(content...)
 		}
 	}
 	span.End()
+}
+
+// genAIContentAttrs builds the message-content span attributes for one
+// turn following the GenAI semantic conventions:
+//
+//   - gen_ai.system_instructions — system messages, as content parts
+//   - gen_ai.input.messages      — the user/assistant input messages
+//   - gen_ai.output.messages     — the assistant completion + finish reason
+//
+// Each value is JSON-serialized because OTel attribute values are
+// primitives; the convention models these fields as structured data
+// carried as a JSON string. Returns nil when there is no content.
+func genAIContentAttrs(t genAITurn) []attribute.KeyValue {
+	var sysParts []genAIPart
+	var input []genAIChatMessage
+	for _, m := range t.Messages {
+		if m.Role == "system" {
+			sysParts = append(sysParts, genAIPart{Type: "text", Content: m.Content})
+			continue
+		}
+		role := m.Role
+		if role == "" {
+			role = "user"
+		}
+		input = append(input, genAIChatMessage{
+			Role:  role,
+			Parts: []genAIPart{{Type: "text", Content: m.Content}},
+		})
+	}
+
+	var attrs []attribute.KeyValue
+	if len(sysParts) > 0 {
+		if js, err := json.Marshal(sysParts); err == nil {
+			attrs = append(attrs, attribute.String("gen_ai.system_instructions", string(js)))
+		}
+	}
+	if len(input) > 0 {
+		if js, err := json.Marshal(input); err == nil {
+			attrs = append(attrs, attribute.String("gen_ai.input.messages", string(js)))
+		}
+	}
+	if t.Completion != "" {
+		output := []genAIChatMessage{{
+			Role:         "assistant",
+			Parts:        []genAIPart{{Type: "text", Content: t.Completion}},
+			FinishReason: t.FinishReason,
+		}}
+		if js, err := json.Marshal(output); err == nil {
+			attrs = append(attrs, attribute.String("gen_ai.output.messages", string(js)))
+		}
+	}
+	return attrs
 }
 
 // recordGenAITurn emits a GenAI span for a completed LLM turn when the

--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -11,6 +11,11 @@
 // kind are mapped to GenAI message parts (text, reasoning, tool_call,
 // tool_call_response, plus a generic fallback), not just text.
 //
+// The request's tool catalogue rides gen_ai.tool.definitions: each
+// tool's name and type are on the base span, while its description and
+// JSON-schema parameters are attached only under the content opt-in
+// (a schema can be large and may carry proprietary detail).
+//
 // Opt-in is two independent switches (internal/config GenAITelemetry):
 // the `genai_telemetry {}` block presence enables the attribute span;
 // `include_message_content` additionally attaches the message-content
@@ -70,6 +75,19 @@ type genAIChatMessage struct {
 	FinishReason string      `json:"finish_reason,omitempty"`
 }
 
+// genAIToolDef is one entry in the gen_ai.tool.definitions span
+// attribute: a tool the model was offered for this turn. Type and Name
+// ride the base span; Description and Parameters (the tool's JSON
+// schema) are populated only when message-content capture is opted in,
+// since a schema can be large and may expose proprietary detail.
+// `omitempty` keeps a base-span entry to just {type, name}.
+type genAIToolDef struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
 // genAITurn is one intercepted LLM request/response mapped to OTel
 // GenAI semantic-convention terms.
 type genAITurn struct {
@@ -105,6 +123,11 @@ type genAITurn struct {
 	TopP          *float64 // gen_ai.request.top_p
 	TopK          *int64   // gen_ai.request.top_k
 	StopSequences []string // gen_ai.request.stop_sequences
+
+	// Tools is the request's tool catalogue (gen_ai.tool.definitions).
+	// Name+type are always populated; the schema/description ride only
+	// the content opt-in. Empty when the request offered no tools.
+	Tools []genAIToolDef
 
 	// Start, when non-zero, sets the span start time so its duration
 	// reflects the real upstream round-trip latency. Zero → span is
@@ -172,6 +195,14 @@ func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	}
 	if len(t.StopSequences) > 0 {
 		attrs = append(attrs, attribute.StringSlice("gen_ai.request.stop_sequences", t.StopSequences))
+	}
+	// Tool definitions ride the base span (name+type always; schema and
+	// description only when content capture filled them in). The value is
+	// JSON-serialized since OTel attribute values are primitives.
+	if len(t.Tools) > 0 {
+		if js, err := json.Marshal(t.Tools); err == nil {
+			attrs = append(attrs, attribute.String("gen_ai.tool.definitions", string(js)))
+		}
 	}
 	if t.ResponseModel != "" {
 		attrs = append(attrs, attribute.String("gen_ai.response.model", t.ResponseModel))
@@ -308,6 +339,9 @@ func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respMo
 		turn.TopP = p.TopP
 		turn.TopK = p.TopK
 		turn.StopSequences = p.StopSequences
+		// Tool name+type ride the base span; the schema/description are
+		// gated behind the same content opt-in as message content.
+		turn.Tools = parseClaudeToolDefs(reqBody, includeContent)
 
 		meta := claudeResponseMeta(respBody)
 		turn.ResponseID = meta.ID
@@ -362,6 +396,49 @@ func parseClaudeRequestParams(reqBody []byte) claudeRequestParams {
 		TopK:          req.TopK,
 		StopSequences: req.StopSequences,
 	}
+}
+
+// parseClaudeToolDefs extracts the tool catalogue from an Anthropic
+// /v1/messages request body for the gen_ai.tool.definitions span
+// attribute. A tool's name and type are always captured (they ride the
+// base span); its description and JSON-schema parameters are captured
+// only when includeContent is set, since a schema can be large and may
+// carry proprietary detail. Anthropic custom tools omit a type, so an
+// absent type maps to the GenAI default "function"; built-in tools
+// (e.g. type "web_search_20250305") keep their declared type. A
+// malformed body, or one offering no tools, yields nil.
+func parseClaudeToolDefs(reqBody []byte, includeContent bool) []genAIToolDef {
+	var req struct {
+		Tools []struct {
+			Type        string          `json:"type"`
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"input_schema"`
+		} `json:"tools"`
+	}
+	if json.Unmarshal(reqBody, &req) != nil || len(req.Tools) == 0 {
+		return nil
+	}
+	defs := make([]genAIToolDef, 0, len(req.Tools))
+	for _, tl := range req.Tools {
+		if tl.Name == "" {
+			continue
+		}
+		typ := tl.Type
+		if typ == "" {
+			typ = "function"
+		}
+		d := genAIToolDef{Type: typ, Name: tl.Name}
+		if includeContent {
+			d.Description = tl.Description
+			d.Parameters = rawOrNil(tl.InputSchema)
+		}
+		defs = append(defs, d)
+	}
+	if len(defs) == 0 {
+		return nil
+	}
+	return defs
 }
 
 // claudeResponseMetadata is the non-content response metadata mapped to

--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -1,8 +1,10 @@
 // OpenTelemetry GenAI semantic-convention export for intercepted LLM
 // turns. Targets the GenAI semantic conventions
 // (https://opentelemetry.io/docs/specs/semconv/gen-ai/): one span per
-// model invocation carrying gen_ai.* attributes (system, conversation
-// id, models, token usage, finish reason) and — only when the operator
+// model invocation carrying gen_ai.* attributes (provider name,
+// conversation id, server address, models, request sampling params,
+// token usage incl. the Anthropic cache-token breakdown, response id,
+// finish reason, error type) and — only when the operator
 // opts in — the prompt/completion message content as the
 // gen_ai.input.messages / gen_ai.output.messages /
 // gen_ai.system_instructions span attributes. Content blocks of every
@@ -71,14 +73,38 @@ type genAIChatMessage struct {
 // genAITurn is one intercepted LLM request/response mapped to OTel
 // GenAI semantic-convention terms.
 type genAITurn struct {
-	System         string // gen_ai.system: "anthropic" | "openai"
+	Provider       string // gen_ai.provider.name: "anthropic" | "openai" (replaces the removed gen_ai.system)
 	Operation      string // gen_ai.operation.name: "chat"
 	ConversationID string // gen_ai.conversation.id: correlates a multi-turn session
 	RequestModel   string // gen_ai.request.model
 	ResponseModel  string // gen_ai.response.model
+	ResponseID     string // gen_ai.response.id
 	InputTokens    int64  // gen_ai.usage.input_tokens
 	OutputTokens   int64  // gen_ai.usage.output_tokens
 	FinishReason   string // gen_ai.response.finish_reasons[0]
+	ErrorType      string // error.type: set when the turn carried a provider error
+
+	// Anthropic-specific prompt-cache token breakdown. Both are already
+	// folded into InputTokens for billing; the GenAI convention also
+	// surfaces them separately as gen_ai.usage.cache_read.input_tokens /
+	// gen_ai.usage.cache_creation.input_tokens.
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+
+	// ServerAddress / ServerPort identify the upstream the turn went to
+	// (server.address / server.port). Port is 0 when unknown.
+	ServerAddress string
+	ServerPort    int
+
+	// Request sampling parameters (gen_ai.request.*). Pointers/zero-checks
+	// distinguish "not set in the request" from a real zero value
+	// (temperature 0 is valid and common).
+	Stream        *bool    // gen_ai.request.stream
+	MaxTokens     int64    // gen_ai.request.max_tokens (0 → unset)
+	Temperature   *float64 // gen_ai.request.temperature
+	TopP          *float64 // gen_ai.request.top_p
+	TopK          *int64   // gen_ai.request.top_k
+	StopSequences []string // gen_ai.request.stop_sequences
 
 	// Start, when non-zero, sets the span start time so its duration
 	// reflects the real upstream round-trip latency. Zero → span is
@@ -114,17 +140,44 @@ func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	_, span := tracer.Start(context.Background(), name, startOpts...)
 
 	attrs := []attribute.KeyValue{
-		attribute.String("gen_ai.system", t.System),
+		attribute.String("gen_ai.provider.name", t.Provider),
 		attribute.String("gen_ai.operation.name", t.Operation),
 	}
 	if t.ConversationID != "" {
 		attrs = append(attrs, attribute.String("gen_ai.conversation.id", t.ConversationID))
 	}
+	if t.ServerAddress != "" {
+		attrs = append(attrs, attribute.String("server.address", t.ServerAddress))
+	}
+	if t.ServerPort > 0 {
+		attrs = append(attrs, attribute.Int("server.port", t.ServerPort))
+	}
 	if t.RequestModel != "" {
 		attrs = append(attrs, attribute.String("gen_ai.request.model", t.RequestModel))
 	}
+	if t.Stream != nil {
+		attrs = append(attrs, attribute.Bool("gen_ai.request.stream", *t.Stream))
+	}
+	if t.MaxTokens > 0 {
+		attrs = append(attrs, attribute.Int64("gen_ai.request.max_tokens", t.MaxTokens))
+	}
+	if t.Temperature != nil {
+		attrs = append(attrs, attribute.Float64("gen_ai.request.temperature", *t.Temperature))
+	}
+	if t.TopP != nil {
+		attrs = append(attrs, attribute.Float64("gen_ai.request.top_p", *t.TopP))
+	}
+	if t.TopK != nil {
+		attrs = append(attrs, attribute.Int64("gen_ai.request.top_k", *t.TopK))
+	}
+	if len(t.StopSequences) > 0 {
+		attrs = append(attrs, attribute.StringSlice("gen_ai.request.stop_sequences", t.StopSequences))
+	}
 	if t.ResponseModel != "" {
 		attrs = append(attrs, attribute.String("gen_ai.response.model", t.ResponseModel))
+	}
+	if t.ResponseID != "" {
+		attrs = append(attrs, attribute.String("gen_ai.response.id", t.ResponseID))
 	}
 	if t.InputTokens > 0 {
 		attrs = append(attrs, attribute.Int64("gen_ai.usage.input_tokens", t.InputTokens))
@@ -132,8 +185,17 @@ func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	if t.OutputTokens > 0 {
 		attrs = append(attrs, attribute.Int64("gen_ai.usage.output_tokens", t.OutputTokens))
 	}
+	if t.CacheReadTokens > 0 {
+		attrs = append(attrs, attribute.Int64("gen_ai.usage.cache_read.input_tokens", t.CacheReadTokens))
+	}
+	if t.CacheCreationTokens > 0 {
+		attrs = append(attrs, attribute.Int64("gen_ai.usage.cache_creation.input_tokens", t.CacheCreationTokens))
+	}
 	if t.FinishReason != "" {
 		attrs = append(attrs, attribute.StringSlice("gen_ai.response.finish_reasons", []string{t.FinishReason}))
+	}
+	if t.ErrorType != "" {
+		attrs = append(attrs, attribute.String("error.type", t.ErrorType))
 	}
 	span.SetAttributes(attrs...)
 
@@ -198,13 +260,14 @@ func genAIContentAttrs(t genAITurn) []attribute.KeyValue {
 }
 
 // recordGenAITurn emits a GenAI span for a completed LLM turn when the
-// feature is enabled and the trace exporter is live. system is the
-// gen_ai.system value ("anthropic"/"openai"); convID is the session
-// correlation key emitted as gen_ai.conversation.id (empty when the turn
-// carries no session info). Content is parsed from the bodies only when
-// content capture is opted in, so the disabled and no-content paths stay
-// cheap.
-func (g *Gateway) recordGenAITurn(system, convID, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time) {
+// feature is enabled and the trace exporter is live. provider is the
+// gen_ai.provider.name value ("anthropic"/"openai"); convID is the
+// session correlation key emitted as gen_ai.conversation.id (empty when
+// the turn carries no session info); serverAddr is the upstream host the
+// turn went to (server.address, port 443). Content is parsed from the
+// bodies only when content capture is opted in, so the disabled and
+// no-content paths stay cheap.
+func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time) {
 	cfg := g.cfg.Load()
 	if genaiTracer == nil || !cfg.GenAITelemetryEnabled() {
 		return
@@ -219,18 +282,39 @@ func (g *Gateway) recordGenAITurn(system, convID, reqModel, respModel string, in
 		return
 	}
 	turn := genAITurn{
-		System:         system,
+		Provider:       provider,
 		Operation:      "chat",
 		ConversationID: convID,
+		ServerAddress:  serverAddr,
 		RequestModel:   model,
 		ResponseModel:  respModel,
 		InputTokens:    in,
 		OutputTokens:   out,
 		Start:          start,
 	}
+	// All intercepted LLM endpoints are HTTPS (the MITM only handles TLS).
+	if serverAddr != "" {
+		turn.ServerPort = 443
+	}
 	includeContent := cfg.GenAITelemetryIncludeContent()
-	if system == "anthropic" {
-		// stop_reason is on the response regardless of content capture.
+	if provider == "anthropic" {
+		// Request sampling params and response metadata (id, cache-token
+		// breakdown, error/stop reason) ride the span regardless of
+		// content capture — they carry no prompt/completion text.
+		p := parseClaudeRequestParams(reqBody)
+		turn.Stream = p.Stream
+		turn.MaxTokens = p.MaxTokens
+		turn.Temperature = p.Temperature
+		turn.TopP = p.TopP
+		turn.TopK = p.TopK
+		turn.StopSequences = p.StopSequences
+
+		meta := claudeResponseMeta(respBody)
+		turn.ResponseID = meta.ID
+		turn.CacheReadTokens = meta.CacheReadTokens
+		turn.CacheCreationTokens = meta.CacheCreationTokens
+		turn.ErrorType = meta.ErrorType
+
 		parts, finish := claudeResponseContent(respBody)
 		turn.FinishReason = finish
 		if includeContent {
@@ -239,6 +323,125 @@ func (g *Gateway) recordGenAITurn(system, convID, reqModel, respModel string, in
 		}
 	}
 	emitGenAISpan(genaiTracer, turn, includeContent)
+}
+
+// claudeRequestParams holds the GenAI request sampling parameters parsed
+// from an Anthropic /v1/messages request body. Optional scalar fields are
+// pointers so a real zero (e.g. temperature 0) is distinguished from
+// "absent in the request".
+type claudeRequestParams struct {
+	Stream        *bool
+	MaxTokens     int64
+	Temperature   *float64
+	TopP          *float64
+	TopK          *int64
+	StopSequences []string
+}
+
+// parseClaudeRequestParams pulls the sampling parameters
+// (stream/max_tokens/temperature/top_p/top_k/stop_sequences) from an
+// Anthropic /v1/messages request body for the gen_ai.request.* span
+// attributes. A malformed body yields the zero value (all unset).
+func parseClaudeRequestParams(reqBody []byte) claudeRequestParams {
+	var req struct {
+		Stream        *bool    `json:"stream"`
+		MaxTokens     int64    `json:"max_tokens"`
+		Temperature   *float64 `json:"temperature"`
+		TopP          *float64 `json:"top_p"`
+		TopK          *int64   `json:"top_k"`
+		StopSequences []string `json:"stop_sequences"`
+	}
+	if json.Unmarshal(reqBody, &req) != nil {
+		return claudeRequestParams{}
+	}
+	return claudeRequestParams{
+		Stream:        req.Stream,
+		MaxTokens:     req.MaxTokens,
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		TopK:          req.TopK,
+		StopSequences: req.StopSequences,
+	}
+}
+
+// claudeResponseMetadata is the non-content response metadata mapped to
+// GenAI span attributes: the message id, the Anthropic prompt-cache token
+// breakdown, and the error type when the turn carried a provider error.
+type claudeResponseMetadata struct {
+	ID                  string
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	ErrorType           string
+}
+
+// claudeResponseMeta extracts the response id, prompt-cache token
+// breakdown, and any error type from an Anthropic /v1/messages response,
+// handling both non-streaming JSON and streaming SSE bodies. An error
+// shape ({"type":"error",...} or an SSE `error` event) surfaces only
+// error.type; cache tokens ride the non-streaming usage object or the
+// SSE message_start event.
+func claudeResponseMeta(body []byte) claudeResponseMetadata {
+	// Non-streaming JSON: success carries id+usage; an error response is
+	// {"type":"error","error":{"type":"..."}}.
+	var jr struct {
+		ID    string `json:"id"`
+		Type  string `json:"type"`
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+		Usage struct {
+			CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		} `json:"usage"`
+	}
+	if json.Unmarshal(body, &jr) == nil && (jr.ID != "" || jr.Type == "error") {
+		if jr.Type == "error" {
+			return claudeResponseMetadata{ErrorType: jr.Error.Type}
+		}
+		return claudeResponseMetadata{
+			ID:                  jr.ID,
+			CacheReadTokens:     jr.Usage.CacheReadInputTokens,
+			CacheCreationTokens: jr.Usage.CacheCreationInputTokens,
+		}
+	}
+	// SSE: id + cache tokens ride message_start; an `error` event carries
+	// the same {"type":"error","error":{"type":...}} payload.
+	var meta claudeResponseMetadata
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 || payload[0] != '{' {
+			continue
+		}
+		var ev struct {
+			Type    string `json:"type"`
+			Message struct {
+				ID    string `json:"id"`
+				Usage struct {
+					CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+					CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+			} `json:"message"`
+			Error struct {
+				Type string `json:"type"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(payload, &ev) != nil {
+			continue
+		}
+		switch ev.Type {
+		case "message_start":
+			meta.ID = ev.Message.ID
+			meta.CacheReadTokens = ev.Message.Usage.CacheReadInputTokens
+			meta.CacheCreationTokens = ev.Message.Usage.CacheCreationInputTokens
+		case "error":
+			meta.ErrorType = ev.Error.Type
+		}
+	}
+	return meta
 }
 
 // claudeContentMessages extracts the ordered system/user/assistant/tool

--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -1,0 +1,247 @@
+// OpenTelemetry GenAI semantic-convention export for intercepted LLM
+// turns. Targets semconv v1.27.0
+// (https://opentelemetry.io/docs/specs/semconv/gen-ai/): one span per
+// model invocation carrying gen_ai.* attributes (system, models, token
+// usage, finish reason) and — only when the operator opts in — the
+// prompt/completion message content as span events.
+//
+// Opt-in is two independent switches (internal/config GenAITelemetry):
+// the `genai_telemetry {}` block presence enables the attribute span;
+// `include_message_content` additionally attaches content events.
+// Disabled is the zero-overhead default — recordGenAITurn returns
+// before parsing anything.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// genAIMessage is one input message (system/user/assistant) captured
+// for the GenAI content convention.
+type genAIMessage struct {
+	Role    string
+	Content string
+}
+
+// genAITurn is one intercepted LLM request/response mapped to OTel
+// GenAI semantic-convention terms.
+type genAITurn struct {
+	System        string // gen_ai.system: "anthropic" | "openai"
+	Operation     string // gen_ai.operation.name: "chat"
+	RequestModel  string // gen_ai.request.model
+	ResponseModel string // gen_ai.response.model
+	InputTokens   int64  // gen_ai.usage.input_tokens
+	OutputTokens  int64  // gen_ai.usage.output_tokens
+	FinishReason  string // gen_ai.response.finish_reasons[0]
+
+	// Start, when non-zero, sets the span start time so its duration
+	// reflects the real upstream round-trip latency. Zero → span is
+	// stamped at emission time.
+	Start time.Time
+
+	// Messages and Completion populate the content events; filled only
+	// when message-content capture is enabled.
+	Messages   []genAIMessage
+	Completion string
+}
+
+// emitGenAISpan records one GenAI span on the provided tracer. When
+// includeContent is true, message content is attached as span events
+// per the GenAI content convention. A free function (not a method) so
+// tests can drive it with an in-memory tracer.
+func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
+	if tracer == nil {
+		return
+	}
+	// Span name convention: "{operation} {request.model}".
+	name := t.Operation
+	if t.RequestModel != "" {
+		name = t.Operation + " " + t.RequestModel
+	}
+	startOpts := []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}
+	if !t.Start.IsZero() {
+		startOpts = append(startOpts, trace.WithTimestamp(t.Start))
+	}
+	_, span := tracer.Start(context.Background(), name, startOpts...)
+
+	attrs := []attribute.KeyValue{
+		attribute.String("gen_ai.system", t.System),
+		attribute.String("gen_ai.operation.name", t.Operation),
+	}
+	if t.RequestModel != "" {
+		attrs = append(attrs, attribute.String("gen_ai.request.model", t.RequestModel))
+	}
+	if t.ResponseModel != "" {
+		attrs = append(attrs, attribute.String("gen_ai.response.model", t.ResponseModel))
+	}
+	if t.InputTokens > 0 {
+		attrs = append(attrs, attribute.Int64("gen_ai.usage.input_tokens", t.InputTokens))
+	}
+	if t.OutputTokens > 0 {
+		attrs = append(attrs, attribute.Int64("gen_ai.usage.output_tokens", t.OutputTokens))
+	}
+	if t.FinishReason != "" {
+		attrs = append(attrs, attribute.StringSlice("gen_ai.response.finish_reasons", []string{t.FinishReason}))
+	}
+	span.SetAttributes(attrs...)
+
+	if includeContent {
+		for _, m := range t.Messages {
+			role := m.Role
+			if role == "" {
+				role = "user"
+			}
+			span.AddEvent("gen_ai."+role+".message", trace.WithAttributes(
+				attribute.String("gen_ai.system", t.System),
+				attribute.String("content", m.Content),
+			))
+		}
+		if t.Completion != "" {
+			span.AddEvent("gen_ai.choice", trace.WithAttributes(
+				attribute.String("gen_ai.system", t.System),
+				attribute.Int("index", 0),
+				attribute.String("finish_reason", t.FinishReason),
+				attribute.String("content", t.Completion),
+			))
+		}
+	}
+	span.End()
+}
+
+// recordGenAITurn emits a GenAI span for a completed LLM turn when the
+// feature is enabled and the trace exporter is live. system is the
+// gen_ai.system value ("anthropic"/"openai"). Content is parsed from
+// the bodies only when content capture is opted in, so the disabled and
+// no-content paths stay cheap.
+func (g *Gateway) recordGenAITurn(system, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time) {
+	cfg := g.cfg.Load()
+	if genaiTracer == nil || !cfg.GenAITelemetryEnabled() {
+		return
+	}
+	model := reqModel
+	if model == "" {
+		model = respModel
+	}
+	// Nothing meaningful parsed (e.g. a non-model response that slipped
+	// the path gate) — skip rather than emit an empty span.
+	if model == "" && in == 0 && out == 0 {
+		return
+	}
+	turn := genAITurn{
+		System:        system,
+		Operation:     "chat",
+		RequestModel:  model,
+		ResponseModel: respModel,
+		InputTokens:   in,
+		OutputTokens:  out,
+		Start:         start,
+	}
+	includeContent := cfg.GenAITelemetryIncludeContent()
+	if system == "anthropic" {
+		// stop_reason is on the response regardless of content capture.
+		completion, finish := claudeResponseContent(respBody)
+		turn.FinishReason = finish
+		if includeContent {
+			turn.Messages = claudeContentMessages(reqBody)
+			turn.Completion = completion
+		}
+	}
+	emitGenAISpan(genaiTracer, turn, includeContent)
+}
+
+// claudeContentMessages extracts the ordered system/user/assistant
+// input messages from an Anthropic /v1/messages request body for the
+// GenAI content convention. Reuses messageText so both string and
+// content-block message shapes are flattened to text.
+func claudeContentMessages(reqBody []byte) []genAIMessage {
+	var req struct {
+		System   json.RawMessage `json:"system"`
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if json.Unmarshal(reqBody, &req) != nil {
+		return nil
+	}
+	var out []genAIMessage
+	if sys := messageText(req.System); sys != "" {
+		out = append(out, genAIMessage{Role: "system", Content: sys})
+	}
+	for _, m := range req.Messages {
+		txt := messageText(m.Content)
+		if txt == "" {
+			continue
+		}
+		out = append(out, genAIMessage{Role: m.Role, Content: txt})
+	}
+	return out
+}
+
+// claudeResponseContent extracts the assistant completion text and
+// stop_reason from an Anthropic /v1/messages response, handling both
+// non-streaming JSON and streaming SSE bodies.
+func claudeResponseContent(body []byte) (text, finish string) {
+	// Non-streaming JSON: {"stop_reason":"...","content":[{"type":"text","text":"..."}]}.
+	var jr struct {
+		StopReason string `json:"stop_reason"`
+		Content    []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(body, &jr); err == nil && (len(jr.Content) > 0 || jr.StopReason != "") {
+		var b strings.Builder
+		for _, c := range jr.Content {
+			if c.Text == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(c.Text)
+		}
+		return b.String(), jr.StopReason
+	}
+	// SSE: accumulate content_block_delta text; stop_reason rides the
+	// message_delta event.
+	var b strings.Builder
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 || payload[0] != '{' {
+			continue
+		}
+		var ev struct {
+			Type  string `json:"type"`
+			Delta struct {
+				Type       string `json:"type"`
+				Text       string `json:"text"`
+				StopReason string `json:"stop_reason"`
+			} `json:"delta"`
+		}
+		if json.Unmarshal(payload, &ev) != nil {
+			continue
+		}
+		switch ev.Type {
+		case "content_block_delta":
+			b.WriteString(ev.Delta.Text)
+		case "message_delta":
+			if ev.Delta.StopReason != "" {
+				finish = ev.Delta.StopReason
+			}
+		}
+	}
+	return b.String(), finish
+}

--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -3,9 +3,11 @@
 // (https://opentelemetry.io/docs/specs/semconv/gen-ai/): one span per
 // model invocation carrying gen_ai.* attributes (system, conversation
 // id, models, token usage, finish reason) and — only when the operator
-// opts in — the
-// prompt/completion message content as the gen_ai.input.messages /
-// gen_ai.output.messages / gen_ai.system_instructions span attributes.
+// opts in — the prompt/completion message content as the
+// gen_ai.input.messages / gen_ai.output.messages /
+// gen_ai.system_instructions span attributes. Content blocks of every
+// kind are mapped to GenAI message parts (text, reasoning, tool_call,
+// tool_call_response, plus a generic fallback), not just text.
 //
 // Opt-in is two independent switches (internal/config GenAITelemetry):
 // the `genai_telemetry {}` block presence enables the attribute span;
@@ -26,18 +28,35 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// genAIMessage is one input message (system/user/assistant) captured
-// for the GenAI content convention.
+// genAIMessage is one input message (system/user/assistant/tool)
+// captured for the GenAI content convention, carrying its content parts
+// (text, tool_call, tool_call_response, reasoning, …).
 type genAIMessage struct {
-	Role    string
-	Content string
+	Role  string
+	Parts []genAIPart
 }
 
-// genAIPart is a single content part within a GenAI message. Only text
-// parts are captured today, so Type is always "text".
+// genAIPart is a single content part within a GenAI message, following
+// the GenAI message-part conventions. The fields are a superset across
+// the part types we emit; `omitempty` keeps each serialized part to the
+// keys its type actually defines:
+//
+//   - text               → {type, content}
+//   - reasoning          → {type, content}            (Anthropic "thinking")
+//   - tool_call          → {type, id, name, arguments}
+//   - tool_call_response → {type, id, response}
+//   - any other block    → {type}                     (generic part)
+//
+// Mapping every Anthropic block to one of these — rather than flattening
+// to text and dropping the rest — means tool calls, tool results, and
+// reasoning are captured too.
 type genAIPart struct {
-	Type    string `json:"type"`
-	Content string `json:"content"`
+	Type      string          `json:"type"`
+	Content   string          `json:"content,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	Response  json.RawMessage `json:"response,omitempty"`
 }
 
 // genAIChatMessage is one message in the gen_ai.input.messages /
@@ -66,10 +85,11 @@ type genAITurn struct {
 	// stamped at emission time.
 	Start time.Time
 
-	// Messages and Completion populate the content attributes; filled
-	// only when message-content capture is enabled.
-	Messages   []genAIMessage
-	Completion string
+	// Messages and Output populate the content attributes; filled only
+	// when message-content capture is enabled. Messages are the input
+	// (request) messages; Output is the assistant response's parts.
+	Messages []genAIMessage
+	Output   []genAIPart
 }
 
 // emitGenAISpan records one GenAI span on the provided tracer. When
@@ -139,18 +159,18 @@ func genAIContentAttrs(t genAITurn) []attribute.KeyValue {
 	var sysParts []genAIPart
 	var input []genAIChatMessage
 	for _, m := range t.Messages {
+		if len(m.Parts) == 0 {
+			continue
+		}
 		if m.Role == "system" {
-			sysParts = append(sysParts, genAIPart{Type: "text", Content: m.Content})
+			sysParts = append(sysParts, m.Parts...)
 			continue
 		}
 		role := m.Role
 		if role == "" {
 			role = "user"
 		}
-		input = append(input, genAIChatMessage{
-			Role:  role,
-			Parts: []genAIPart{{Type: "text", Content: m.Content}},
-		})
+		input = append(input, genAIChatMessage{Role: role, Parts: m.Parts})
 	}
 
 	var attrs []attribute.KeyValue
@@ -164,10 +184,10 @@ func genAIContentAttrs(t genAITurn) []attribute.KeyValue {
 			attrs = append(attrs, attribute.String("gen_ai.input.messages", string(js)))
 		}
 	}
-	if t.Completion != "" {
+	if len(t.Output) > 0 {
 		output := []genAIChatMessage{{
 			Role:         "assistant",
-			Parts:        []genAIPart{{Type: "text", Content: t.Completion}},
+			Parts:        t.Output,
 			FinishReason: t.FinishReason,
 		}}
 		if js, err := json.Marshal(output); err == nil {
@@ -211,20 +231,21 @@ func (g *Gateway) recordGenAITurn(system, convID, reqModel, respModel string, in
 	includeContent := cfg.GenAITelemetryIncludeContent()
 	if system == "anthropic" {
 		// stop_reason is on the response regardless of content capture.
-		completion, finish := claudeResponseContent(respBody)
+		parts, finish := claudeResponseContent(respBody)
 		turn.FinishReason = finish
 		if includeContent {
 			turn.Messages = claudeContentMessages(reqBody)
-			turn.Completion = completion
+			turn.Output = parts
 		}
 	}
 	emitGenAISpan(genaiTracer, turn, includeContent)
 }
 
-// claudeContentMessages extracts the ordered system/user/assistant
+// claudeContentMessages extracts the ordered system/user/assistant/tool
 // input messages from an Anthropic /v1/messages request body for the
-// GenAI content convention. Reuses messageText so both string and
-// content-block message shapes are flattened to text.
+// GenAI content convention. Every content block is mapped to a GenAI
+// message part (see claudeBlockPart), so tool calls, tool results, and
+// reasoning are captured alongside text rather than dropped.
 func claudeContentMessages(reqBody []byte) []genAIMessage {
 	var req struct {
 		System   json.RawMessage `json:"system"`
@@ -237,47 +258,163 @@ func claudeContentMessages(reqBody []byte) []genAIMessage {
 		return nil
 	}
 	var out []genAIMessage
-	if sys := messageText(req.System); sys != "" {
-		out = append(out, genAIMessage{Role: "system", Content: sys})
+	if sys := claudeMessageParts(req.System); len(sys) > 0 {
+		out = append(out, genAIMessage{Role: "system", Parts: sys})
 	}
 	for _, m := range req.Messages {
-		txt := messageText(m.Content)
-		if txt == "" {
+		parts := claudeMessageParts(m.Content)
+		if len(parts) == 0 {
 			continue
 		}
-		out = append(out, genAIMessage{Role: m.Role, Content: txt})
+		out = append(out, genAIMessage{Role: m.Role, Parts: parts})
 	}
 	return out
 }
 
-// claudeResponseContent extracts the assistant completion text and
-// stop_reason from an Anthropic /v1/messages response, handling both
-// non-streaming JSON and streaming SSE bodies.
-func claudeResponseContent(body []byte) (text, finish string) {
-	// Non-streaming JSON: {"stop_reason":"...","content":[{"type":"text","text":"..."}]}.
-	var jr struct {
-		StopReason string `json:"stop_reason"`
-		Content    []struct {
-			Type string `json:"type"`
+// claudeMessageParts converts an Anthropic message Content — either a
+// plain string or an array of typed blocks — into GenAI message parts.
+func claudeMessageParts(c json.RawMessage) []genAIPart {
+	if len(c) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(c, &s) == nil {
+		if s == "" {
+			return nil
+		}
+		return []genAIPart{{Type: "text", Content: s}}
+	}
+	var blocks []json.RawMessage
+	if json.Unmarshal(c, &blocks) != nil {
+		return nil
+	}
+	var parts []genAIPart
+	for _, raw := range blocks {
+		if p, ok := claudeBlockPart(raw); ok {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+// claudeBlockPart maps a single Anthropic content block to a GenAI
+// message part following the part-type conventions. Known block types
+// become their semantic part (text, reasoning, tool_call,
+// tool_call_response); any other block type (image, document,
+// redacted_thinking, web_search_tool_result, …) becomes a generic part
+// that preserves the type so it is recorded rather than silently
+// dropped. Raw binary payloads (e.g. base64 image data) are
+// intentionally not captured. ok is false for blocks with no type and
+// for empty text/reasoning blocks that carry nothing worth recording.
+func claudeBlockPart(raw json.RawMessage) (genAIPart, bool) {
+	var hdr struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(raw, &hdr) != nil || hdr.Type == "" {
+		return genAIPart{}, false
+	}
+	switch hdr.Type {
+	case "text":
+		var b struct {
 			Text string `json:"text"`
-		} `json:"content"`
+		}
+		_ = json.Unmarshal(raw, &b)
+		if b.Text == "" {
+			return genAIPart{}, false
+		}
+		return genAIPart{Type: "text", Content: b.Text}, true
+	case "thinking":
+		var b struct {
+			Thinking string `json:"thinking"`
+		}
+		_ = json.Unmarshal(raw, &b)
+		if b.Thinking == "" {
+			return genAIPart{}, false
+		}
+		return genAIPart{Type: "reasoning", Content: b.Thinking}, true
+	case "tool_use", "server_tool_use":
+		var b struct {
+			ID    string          `json:"id"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		}
+		_ = json.Unmarshal(raw, &b)
+		return genAIPart{Type: "tool_call", ID: b.ID, Name: b.Name, Arguments: rawOrNil(b.Input)}, true
+	case "tool_result":
+		var b struct {
+			ToolUseID string          `json:"tool_use_id"`
+			Content   json.RawMessage `json:"content"`
+		}
+		_ = json.Unmarshal(raw, &b)
+		return genAIPart{Type: "tool_call_response", ID: b.ToolUseID, Response: rawOrNil(b.Content)}, true
+	default:
+		return genAIPart{Type: hdr.Type}, true
+	}
+}
+
+// rawOrNil normalizes an absent or literal-null RawMessage to nil so it
+// is omitted from the serialized part.
+func rawOrNil(r json.RawMessage) json.RawMessage {
+	if len(r) == 0 || string(bytes.TrimSpace(r)) == "null" {
+		return nil
+	}
+	return r
+}
+
+// claudeResponseContent extracts the assistant response parts and
+// stop_reason from an Anthropic /v1/messages response, handling both
+// non-streaming JSON and streaming SSE bodies. Every content block
+// (text, tool_use, thinking, …) is mapped to a GenAI message part via
+// claudeBlockPart, so the response is captured beyond just its text.
+func claudeResponseContent(body []byte) (parts []genAIPart, finish string) {
+	// Non-streaming JSON: {"stop_reason":"...","content":[ <blocks> ]}.
+	var jr struct {
+		StopReason string          `json:"stop_reason"`
+		Content    json.RawMessage `json:"content"`
 	}
 	if err := json.Unmarshal(body, &jr); err == nil && (len(jr.Content) > 0 || jr.StopReason != "") {
-		var b strings.Builder
-		for _, c := range jr.Content {
-			if c.Text == "" {
-				continue
+		var blocks []json.RawMessage
+		if json.Unmarshal(jr.Content, &blocks) == nil {
+			for _, raw := range blocks {
+				if p, ok := claudeBlockPart(raw); ok {
+					parts = append(parts, p)
+				}
 			}
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(c.Text)
 		}
-		return b.String(), jr.StopReason
+		return parts, jr.StopReason
 	}
-	// SSE: accumulate content_block_delta text; stop_reason rides the
-	// message_delta event.
-	var b strings.Builder
+	// SSE: reconstruct each block from its start + delta events.
+	return claudeResponseSSEParts(body)
+}
+
+// claudeResponseSSEParts reconstructs the assistant response parts and
+// stop_reason from an Anthropic streaming (SSE) response. Blocks are
+// tracked by index across content_block_start / content_block_delta
+// events: text and thinking deltas accumulate their content, and
+// tool_use input_json_delta fragments accumulate the arguments JSON.
+// stop_reason rides the message_delta event.
+func claudeResponseSSEParts(body []byte) (parts []genAIPart, finish string) {
+	type sseBlock struct {
+		typ  string
+		id   string
+		name string
+		text strings.Builder
+		args strings.Builder
+	}
+	blocks := map[int]*sseBlock{}
+	var order []int
+	// get returns the block at index i, defaulting unseen indices to a
+	// text block (some streams omit content_block_start, e.g. a plain
+	// text-only response).
+	get := func(i int) *sseBlock {
+		b := blocks[i]
+		if b == nil {
+			b = &sseBlock{typ: "text"}
+			blocks[i] = b
+			order = append(order, i)
+		}
+		return b
+	}
 	for _, line := range bytes.Split(body, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
@@ -288,24 +425,68 @@ func claudeResponseContent(body []byte) (text, finish string) {
 			continue
 		}
 		var ev struct {
-			Type  string `json:"type"`
+			Type         string `json:"type"`
+			Index        int    `json:"index"`
+			ContentBlock struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"content_block"`
 			Delta struct {
-				Type       string `json:"type"`
-				Text       string `json:"text"`
-				StopReason string `json:"stop_reason"`
+				Type        string `json:"type"`
+				Text        string `json:"text"`
+				Thinking    string `json:"thinking"`
+				PartialJSON string `json:"partial_json"`
+				StopReason  string `json:"stop_reason"`
 			} `json:"delta"`
 		}
 		if json.Unmarshal(payload, &ev) != nil {
 			continue
 		}
 		switch ev.Type {
+		case "content_block_start":
+			b := get(ev.Index)
+			if ev.ContentBlock.Type != "" {
+				b.typ = ev.ContentBlock.Type
+			}
+			b.id = ev.ContentBlock.ID
+			b.name = ev.ContentBlock.Name
 		case "content_block_delta":
-			b.WriteString(ev.Delta.Text)
+			b := get(ev.Index)
+			switch ev.Delta.Type {
+			case "text_delta":
+				b.text.WriteString(ev.Delta.Text)
+			case "thinking_delta":
+				b.text.WriteString(ev.Delta.Thinking)
+			case "input_json_delta":
+				b.args.WriteString(ev.Delta.PartialJSON)
+			}
 		case "message_delta":
 			if ev.Delta.StopReason != "" {
 				finish = ev.Delta.StopReason
 			}
 		}
 	}
-	return b.String(), finish
+	for _, i := range order {
+		b := blocks[i]
+		switch b.typ {
+		case "text":
+			if b.text.Len() > 0 {
+				parts = append(parts, genAIPart{Type: "text", Content: b.text.String()})
+			}
+		case "thinking":
+			if b.text.Len() > 0 {
+				parts = append(parts, genAIPart{Type: "reasoning", Content: b.text.String()})
+			}
+		case "tool_use", "server_tool_use":
+			p := genAIPart{Type: "tool_call", ID: b.id, Name: b.name}
+			if b.args.Len() > 0 {
+				p.Arguments = json.RawMessage(b.args.String())
+			}
+			parts = append(parts, p)
+		default:
+			parts = append(parts, genAIPart{Type: b.typ})
+		}
+	}
+	return parts, finish
 }

--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -1,8 +1,9 @@
 // OpenTelemetry GenAI semantic-convention export for intercepted LLM
 // turns. Targets the GenAI semantic conventions
 // (https://opentelemetry.io/docs/specs/semconv/gen-ai/): one span per
-// model invocation carrying gen_ai.* attributes (system, models, token
-// usage, finish reason) and — only when the operator opts in — the
+// model invocation carrying gen_ai.* attributes (system, conversation
+// id, models, token usage, finish reason) and — only when the operator
+// opts in — the
 // prompt/completion message content as the gen_ai.input.messages /
 // gen_ai.output.messages / gen_ai.system_instructions span attributes.
 //
@@ -51,13 +52,14 @@ type genAIChatMessage struct {
 // genAITurn is one intercepted LLM request/response mapped to OTel
 // GenAI semantic-convention terms.
 type genAITurn struct {
-	System        string // gen_ai.system: "anthropic" | "openai"
-	Operation     string // gen_ai.operation.name: "chat"
-	RequestModel  string // gen_ai.request.model
-	ResponseModel string // gen_ai.response.model
-	InputTokens   int64  // gen_ai.usage.input_tokens
-	OutputTokens  int64  // gen_ai.usage.output_tokens
-	FinishReason  string // gen_ai.response.finish_reasons[0]
+	System         string // gen_ai.system: "anthropic" | "openai"
+	Operation      string // gen_ai.operation.name: "chat"
+	ConversationID string // gen_ai.conversation.id: correlates a multi-turn session
+	RequestModel   string // gen_ai.request.model
+	ResponseModel  string // gen_ai.response.model
+	InputTokens    int64  // gen_ai.usage.input_tokens
+	OutputTokens   int64  // gen_ai.usage.output_tokens
+	FinishReason   string // gen_ai.response.finish_reasons[0]
 
 	// Start, when non-zero, sets the span start time so its duration
 	// reflects the real upstream round-trip latency. Zero → span is
@@ -94,6 +96,9 @@ func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	attrs := []attribute.KeyValue{
 		attribute.String("gen_ai.system", t.System),
 		attribute.String("gen_ai.operation.name", t.Operation),
+	}
+	if t.ConversationID != "" {
+		attrs = append(attrs, attribute.String("gen_ai.conversation.id", t.ConversationID))
 	}
 	if t.RequestModel != "" {
 		attrs = append(attrs, attribute.String("gen_ai.request.model", t.RequestModel))
@@ -174,10 +179,12 @@ func genAIContentAttrs(t genAITurn) []attribute.KeyValue {
 
 // recordGenAITurn emits a GenAI span for a completed LLM turn when the
 // feature is enabled and the trace exporter is live. system is the
-// gen_ai.system value ("anthropic"/"openai"). Content is parsed from
-// the bodies only when content capture is opted in, so the disabled and
-// no-content paths stay cheap.
-func (g *Gateway) recordGenAITurn(system, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time) {
+// gen_ai.system value ("anthropic"/"openai"); convID is the session
+// correlation key emitted as gen_ai.conversation.id (empty when the turn
+// carries no session info). Content is parsed from the bodies only when
+// content capture is opted in, so the disabled and no-content paths stay
+// cheap.
+func (g *Gateway) recordGenAITurn(system, convID, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time) {
 	cfg := g.cfg.Load()
 	if genaiTracer == nil || !cfg.GenAITelemetryEnabled() {
 		return
@@ -192,13 +199,14 @@ func (g *Gateway) recordGenAITurn(system, reqModel, respModel string, in, out in
 		return
 	}
 	turn := genAITurn{
-		System:        system,
-		Operation:     "chat",
-		RequestModel:  model,
-		ResponseModel: respModel,
-		InputTokens:   in,
-		OutputTokens:  out,
-		Start:         start,
+		System:         system,
+		Operation:      "chat",
+		ConversationID: convID,
+		RequestModel:   model,
+		ResponseModel:  respModel,
+		InputTokens:    in,
+		OutputTokens:   out,
+		Start:          start,
 	}
 	includeContent := cfg.GenAITelemetryIncludeContent()
 	if system == "anthropic" {

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -31,7 +31,7 @@ func attrMap(kvs []attribute.KeyValue) map[string]attribute.Value {
 func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
 	sr, tp := newRecordingTracer(t)
 	turn := genAITurn{
-		System:         "anthropic",
+		Provider:       "anthropic",
 		Operation:      "chat",
 		ConversationID: "s_abc123",
 		RequestModel:   "claude-3-5-sonnet-20241022",
@@ -53,8 +53,8 @@ func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
 		t.Errorf("span name = %q", s.Name())
 	}
 	m := attrMap(s.Attributes())
-	if m["gen_ai.system"].AsString() != "anthropic" {
-		t.Errorf("gen_ai.system = %q", m["gen_ai.system"].AsString())
+	if m["gen_ai.provider.name"].AsString() != "anthropic" {
+		t.Errorf("gen_ai.provider.name = %q", m["gen_ai.provider.name"].AsString())
 	}
 	if m["gen_ai.operation.name"].AsString() != "chat" {
 		t.Errorf("gen_ai.operation.name = %q", m["gen_ai.operation.name"].AsString())
@@ -83,7 +83,7 @@ func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
 func TestEmitGenAISpanWithContent(t *testing.T) {
 	sr, tp := newRecordingTracer(t)
 	turn := genAITurn{
-		System:       "anthropic",
+		Provider:     "anthropic",
 		Operation:    "chat",
 		RequestModel: "claude-3-5-sonnet-20241022",
 		FinishReason: "end_turn",
@@ -146,7 +146,7 @@ func TestEmitGenAISpanNilTracerNoPanic(t *testing.T) {
 			t.Fatalf("emitGenAISpan(nil) panicked: %v", r)
 		}
 	}()
-	emitGenAISpan(nil, genAITurn{System: "anthropic", Operation: "chat"}, true)
+	emitGenAISpan(nil, genAITurn{Provider: "anthropic", Operation: "chat"}, true)
 }
 
 func TestClaudeContentMessages(t *testing.T) {
@@ -335,7 +335,7 @@ gateway {
 	g := &Gateway{}
 	g.cfg.Store(gw)
 
-	g.recordGenAITurn("anthropic", "s_abc123", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 1, 2,
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 1, 2,
 		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"yo"}]}`),
 		time.Time{})
@@ -365,7 +365,7 @@ gateway {
 	g := &Gateway{}
 	g.cfg.Store(gw)
 
-	g.recordGenAITurn("anthropic", "s_abc123", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"messages":[{"role":"user","content":"hi there"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"secret"}]}`),
 		time.Time{})
@@ -375,8 +375,8 @@ gateway {
 		t.Fatalf("got %d spans, want 1", len(spans))
 	}
 	m := attrMap(spans[0].Attributes())
-	if m["gen_ai.system"].AsString() != "anthropic" {
-		t.Errorf("gen_ai.system = %q", m["gen_ai.system"].AsString())
+	if m["gen_ai.provider.name"].AsString() != "anthropic" {
+		t.Errorf("gen_ai.provider.name = %q", m["gen_ai.provider.name"].AsString())
 	}
 	if m["gen_ai.conversation.id"].AsString() != "s_abc123" {
 		t.Errorf("gen_ai.conversation.id = %q, want s_abc123", m["gen_ai.conversation.id"].AsString())
@@ -414,7 +414,7 @@ gateway {
 	g := &Gateway{}
 	g.cfg.Store(gw)
 
-	g.recordGenAITurn("anthropic", "s_abc123", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"system":"be terse","messages":[{"role":"user","content":"hi there"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"hello back"}]}`),
 		time.Time{})
@@ -450,5 +450,181 @@ gateway {
 	}
 	if len(output) != 1 || output[0].Parts[0].Content != "hello back" || output[0].FinishReason != "end_turn" {
 		t.Errorf("gen_ai.output.messages = %+v", output)
+	}
+}
+
+func TestParseClaudeRequestParams(t *testing.T) {
+	stream := true
+	temp := 0.0 // a real zero must round-trip, not read as "unset".
+	topP := 0.95
+	topK := int64(40)
+	p := parseClaudeRequestParams([]byte(`{
+		"model":"claude-3-5-sonnet-20241022",
+		"max_tokens":1024,
+		"stream":true,
+		"temperature":0.0,
+		"top_p":0.95,
+		"top_k":40,
+		"stop_sequences":["STOP","END"]
+	}`))
+	if p.Stream == nil || *p.Stream != stream {
+		t.Errorf("stream = %v, want %v", p.Stream, stream)
+	}
+	if p.MaxTokens != 1024 {
+		t.Errorf("max_tokens = %d, want 1024", p.MaxTokens)
+	}
+	if p.Temperature == nil || *p.Temperature != temp {
+		t.Errorf("temperature = %v, want %v", p.Temperature, temp)
+	}
+	if p.TopP == nil || *p.TopP != topP {
+		t.Errorf("top_p = %v, want %v", p.TopP, topP)
+	}
+	if p.TopK == nil || *p.TopK != topK {
+		t.Errorf("top_k = %v, want %v", p.TopK, topK)
+	}
+	if !reflect.DeepEqual(p.StopSequences, []string{"STOP", "END"}) {
+		t.Errorf("stop_sequences = %v", p.StopSequences)
+	}
+
+	// Absent optional fields stay unset (nil), distinguishable from zero.
+	empty := parseClaudeRequestParams([]byte(`{"model":"x","max_tokens":10}`))
+	if empty.Stream != nil || empty.Temperature != nil || empty.TopP != nil || empty.TopK != nil {
+		t.Errorf("absent optionals should be nil, got %+v", empty)
+	}
+	if len(empty.StopSequences) != 0 {
+		t.Errorf("stop_sequences should be empty, got %v", empty.StopSequences)
+	}
+}
+
+func TestClaudeResponseMetaJSON(t *testing.T) {
+	meta := claudeResponseMeta([]byte(`{
+		"id":"msg_01ABC",
+		"model":"claude-3-5-sonnet-20241022",
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":5,"output_tokens":7,"cache_read_input_tokens":100,"cache_creation_input_tokens":40}
+	}`))
+	if meta.ID != "msg_01ABC" {
+		t.Errorf("id = %q, want msg_01ABC", meta.ID)
+	}
+	if meta.CacheReadTokens != 100 {
+		t.Errorf("cache_read = %d, want 100", meta.CacheReadTokens)
+	}
+	if meta.CacheCreationTokens != 40 {
+		t.Errorf("cache_creation = %d, want 40", meta.CacheCreationTokens)
+	}
+	if meta.ErrorType != "" {
+		t.Errorf("error_type = %q, want empty", meta.ErrorType)
+	}
+}
+
+func TestClaudeResponseMetaError(t *testing.T) {
+	meta := claudeResponseMeta([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"slow down"}}`))
+	if meta.ErrorType != "overloaded_error" {
+		t.Errorf("error_type = %q, want overloaded_error", meta.ErrorType)
+	}
+	if meta.ID != "" {
+		t.Errorf("id = %q, want empty on error", meta.ID)
+	}
+}
+
+func TestClaudeResponseMetaSSE(t *testing.T) {
+	body := []byte(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_stream1","usage":{"input_tokens":3,"cache_read_input_tokens":12,"cache_creation_input_tokens":8}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}
+`)
+	meta := claudeResponseMeta(body)
+	if meta.ID != "msg_stream1" {
+		t.Errorf("id = %q, want msg_stream1", meta.ID)
+	}
+	if meta.CacheReadTokens != 12 || meta.CacheCreationTokens != 8 {
+		t.Errorf("cache tokens = read %d / create %d, want 12 / 8", meta.CacheReadTokens, meta.CacheCreationTokens)
+	}
+}
+
+func TestClaudeResponseMetaSSEError(t *testing.T) {
+	body := []byte(`event: error
+data: {"type":"error","error":{"type":"overloaded_error","message":"slow down"}}
+`)
+	if meta := claudeResponseMeta(body); meta.ErrorType != "overloaded_error" {
+		t.Errorf("error_type = %q, want overloaded_error", meta.ErrorType)
+	}
+}
+
+// TestRecordGenAITurnRichAttributes drives the full recordGenAITurn path
+// and asserts every newly added GenAI attribute lands on the span:
+// provider name, server address/port, request sampling params, response
+// id, and the Anthropic prompt-cache token breakdown.
+func TestRecordGenAITurnRichAttributes(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry {}
+}
+`), "rich.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com",
+		"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		[]byte(`{"model":"claude-3-5-sonnet-20241022","max_tokens":2048,"stream":false,"temperature":0.7,"top_p":0.9,"top_k":50,"stop_sequences":["STOP"],"messages":[{"role":"user","content":"hi"}]}`),
+		[]byte(`{"id":"msg_01XYZ","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":256,"cache_creation_input_tokens":64},"content":[{"type":"text","text":"hello"}]}`),
+		time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+
+	if m["gen_ai.provider.name"].AsString() != "anthropic" {
+		t.Errorf("provider.name = %q", m["gen_ai.provider.name"].AsString())
+	}
+	if m["server.address"].AsString() != "api.anthropic.com" {
+		t.Errorf("server.address = %q", m["server.address"].AsString())
+	}
+	if got := m["server.port"].AsInt64(); got != 443 {
+		t.Errorf("server.port = %d, want 443", got)
+	}
+	if got := m["gen_ai.request.max_tokens"].AsInt64(); got != 2048 {
+		t.Errorf("request.max_tokens = %d, want 2048", got)
+	}
+	if m["gen_ai.request.stream"].AsBool() != false {
+		t.Errorf("request.stream = %v, want false", m["gen_ai.request.stream"].AsBool())
+	}
+	if got := m["gen_ai.request.temperature"].AsFloat64(); got != 0.7 {
+		t.Errorf("request.temperature = %v, want 0.7", got)
+	}
+	if got := m["gen_ai.request.top_p"].AsFloat64(); got != 0.9 {
+		t.Errorf("request.top_p = %v, want 0.9", got)
+	}
+	if got := m["gen_ai.request.top_k"].AsInt64(); got != 50 {
+		t.Errorf("request.top_k = %d, want 50", got)
+	}
+	if ss := m["gen_ai.request.stop_sequences"].AsStringSlice(); len(ss) != 1 || ss[0] != "STOP" {
+		t.Errorf("request.stop_sequences = %v", ss)
+	}
+	if m["gen_ai.response.id"].AsString() != "msg_01XYZ" {
+		t.Errorf("response.id = %q", m["gen_ai.response.id"].AsString())
+	}
+	if got := m["gen_ai.usage.cache_read.input_tokens"].AsInt64(); got != 256 {
+		t.Errorf("cache_read.input_tokens = %d, want 256", got)
+	}
+	if got := m["gen_ai.usage.cache_creation.input_tokens"].AsInt64(); got != 64 {
+		t.Errorf("cache_creation.input_tokens = %d, want 64", got)
 	}
 }

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -31,15 +31,16 @@ func attrMap(kvs []attribute.KeyValue) map[string]attribute.Value {
 func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
 	sr, tp := newRecordingTracer(t)
 	turn := genAITurn{
-		System:        "anthropic",
-		Operation:     "chat",
-		RequestModel:  "claude-3-5-sonnet-20241022",
-		ResponseModel: "claude-3-5-sonnet-20241022",
-		InputTokens:   42,
-		OutputTokens:  17,
-		FinishReason:  "end_turn",
-		Messages:      []genAIMessage{{Role: "user", Content: "secret prompt"}},
-		Completion:    "secret completion",
+		System:         "anthropic",
+		Operation:      "chat",
+		ConversationID: "s_abc123",
+		RequestModel:   "claude-3-5-sonnet-20241022",
+		ResponseModel:  "claude-3-5-sonnet-20241022",
+		InputTokens:    42,
+		OutputTokens:   17,
+		FinishReason:   "end_turn",
+		Messages:       []genAIMessage{{Role: "user", Content: "secret prompt"}},
+		Completion:     "secret completion",
 	}
 	emitGenAISpan(tp.Tracer("test"), turn, false)
 
@@ -57,6 +58,9 @@ func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
 	}
 	if m["gen_ai.operation.name"].AsString() != "chat" {
 		t.Errorf("gen_ai.operation.name = %q", m["gen_ai.operation.name"].AsString())
+	}
+	if m["gen_ai.conversation.id"].AsString() != "s_abc123" {
+		t.Errorf("gen_ai.conversation.id = %q, want s_abc123", m["gen_ai.conversation.id"].AsString())
 	}
 	if m["gen_ai.request.model"].AsString() != "claude-3-5-sonnet-20241022" {
 		t.Errorf("gen_ai.request.model = %q", m["gen_ai.request.model"].AsString())
@@ -225,7 +229,7 @@ gateway {
 	g := &Gateway{}
 	g.cfg.Store(gw)
 
-	g.recordGenAITurn("anthropic", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 1, 2,
+	g.recordGenAITurn("anthropic", "s_abc123", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 1, 2,
 		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"yo"}]}`),
 		time.Time{})
@@ -255,7 +259,7 @@ gateway {
 	g := &Gateway{}
 	g.cfg.Store(gw)
 
-	g.recordGenAITurn("anthropic", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+	g.recordGenAITurn("anthropic", "s_abc123", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"messages":[{"role":"user","content":"hi there"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"secret"}]}`),
 		time.Time{})
@@ -267,6 +271,9 @@ gateway {
 	m := attrMap(spans[0].Attributes())
 	if m["gen_ai.system"].AsString() != "anthropic" {
 		t.Errorf("gen_ai.system = %q", m["gen_ai.system"].AsString())
+	}
+	if m["gen_ai.conversation.id"].AsString() != "s_abc123" {
+		t.Errorf("gen_ai.conversation.id = %q, want s_abc123", m["gen_ai.conversation.id"].AsString())
 	}
 	if got := m["gen_ai.usage.input_tokens"].AsInt64(); got != 10 {
 		t.Errorf("input_tokens = %d, want 10", got)
@@ -301,7 +308,7 @@ gateway {
 	g := &Gateway{}
 	g.cfg.Store(gw)
 
-	g.recordGenAITurn("anthropic", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+	g.recordGenAITurn("anthropic", "s_abc123", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"system":"be terse","messages":[{"role":"user","content":"hi there"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"hello back"}]}`),
 		time.Time{})

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -496,6 +496,143 @@ func TestParseClaudeRequestParams(t *testing.T) {
 	}
 }
 
+// Tool definitions: name+type are captured even without content; the
+// description and JSON schema appear only when content capture is on.
+// An absent Anthropic type defaults to "function"; a built-in tool's
+// declared type is kept.
+func TestParseClaudeToolDefs(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-3-5-sonnet-20241022",
+		"tools":[
+			{"name":"get_weather","description":"Look up the weather","input_schema":{"type":"object","properties":{"location":{"type":"string"}}}},
+			{"type":"web_search_20250305","name":"web_search"}
+		]
+	}`)
+
+	// Without content: name+type only, no description/parameters.
+	base := parseClaudeToolDefs(body, false)
+	want := []genAIToolDef{
+		{Type: "function", Name: "get_weather"},
+		{Type: "web_search_20250305", Name: "web_search"},
+	}
+	if !reflect.DeepEqual(base, want) {
+		t.Errorf("base defs = %+v, want %+v", base, want)
+	}
+
+	// With content: description + JSON-schema parameters ride along.
+	full := parseClaudeToolDefs(body, true)
+	if len(full) != 2 {
+		t.Fatalf("got %d defs, want 2", len(full))
+	}
+	if full[0].Description != "Look up the weather" {
+		t.Errorf("description = %q", full[0].Description)
+	}
+	if !reflect.DeepEqual(full[0].Parameters, json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}}}`)) {
+		t.Errorf("parameters = %s", full[0].Parameters)
+	}
+	// A tool with no schema leaves Parameters nil even under content.
+	if full[1].Parameters != nil {
+		t.Errorf("schemaless tool parameters = %s, want nil", full[1].Parameters)
+	}
+
+	// No tools / malformed → nil.
+	if got := parseClaudeToolDefs([]byte(`{"model":"x"}`), true); got != nil {
+		t.Errorf("no tools = %+v, want nil", got)
+	}
+	if got := parseClaudeToolDefs([]byte(`not json`), true); got != nil {
+		t.Errorf("malformed = %+v, want nil", got)
+	}
+}
+
+// gen_ai.tool.definitions rides the base span even with content off,
+// carrying name+type but neither description nor schema.
+func TestRecordGenAITurnToolDefsNoContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry {}
+}
+`), "tools.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		[]byte(`{"messages":[{"role":"user","content":"hi"}],"tools":[{"name":"get_weather","description":"secret","input_schema":{"type":"object"}}]}`),
+		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}]}`),
+		time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	var defs []genAIToolDef
+	if err := json.Unmarshal([]byte(m["gen_ai.tool.definitions"].AsString()), &defs); err != nil {
+		t.Fatalf("gen_ai.tool.definitions: %v (raw %q)", err, m["gen_ai.tool.definitions"].AsString())
+	}
+	want := []genAIToolDef{{Type: "function", Name: "get_weather"}}
+	if !reflect.DeepEqual(defs, want) {
+		t.Errorf("tool defs = %+v, want %+v (description/schema must stay off without content)", defs, want)
+	}
+}
+
+// With content on, gen_ai.tool.definitions also carries the description
+// and JSON schema.
+func TestRecordGenAITurnToolDefsWithContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry { include_message_content = true }
+}
+`), "tools-content.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		[]byte(`{"messages":[{"role":"user","content":"hi"}],"tools":[{"name":"get_weather","description":"Look up the weather","input_schema":{"type":"object","properties":{"location":{"type":"string"}}}}]}`),
+		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}]}`),
+		time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	var defs []genAIToolDef
+	if err := json.Unmarshal([]byte(m["gen_ai.tool.definitions"].AsString()), &defs); err != nil {
+		t.Fatalf("gen_ai.tool.definitions: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Name != "get_weather" || defs[0].Type != "function" {
+		t.Fatalf("tool defs = %+v", defs)
+	}
+	if defs[0].Description != "Look up the weather" {
+		t.Errorf("description = %q", defs[0].Description)
+	}
+	if !reflect.DeepEqual(defs[0].Parameters, json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}}}`)) {
+		t.Errorf("parameters = %s", defs[0].Parameters)
+	}
+}
+
 func TestClaudeResponseMetaJSON(t *testing.T) {
 	meta := claudeResponseMeta([]byte(`{
 		"id":"msg_01ABC",

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -119,6 +119,11 @@ func TestEmitGenAISpanWithContent(t *testing.T) {
 }
 
 func TestEmitGenAISpanNilTracerNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("emitGenAISpan(nil) panicked: %v", r)
+		}
+	}()
 	emitGenAISpan(nil, genAITurn{System: "anthropic", Operation: "chat"}, true)
 }
 

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -39,8 +39,8 @@ func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
 		InputTokens:    42,
 		OutputTokens:   17,
 		FinishReason:   "end_turn",
-		Messages:       []genAIMessage{{Role: "user", Content: "secret prompt"}},
-		Completion:     "secret completion",
+		Messages:       []genAIMessage{{Role: "user", Parts: []genAIPart{{Type: "text", Content: "secret prompt"}}}},
+		Output:         []genAIPart{{Type: "text", Content: "secret completion"}},
 	}
 	emitGenAISpan(tp.Tracer("test"), turn, false)
 
@@ -88,10 +88,10 @@ func TestEmitGenAISpanWithContent(t *testing.T) {
 		RequestModel: "claude-3-5-sonnet-20241022",
 		FinishReason: "end_turn",
 		Messages: []genAIMessage{
-			{Role: "system", Content: "you are helpful"},
-			{Role: "user", Content: "hello there"},
+			{Role: "system", Parts: []genAIPart{{Type: "text", Content: "you are helpful"}}},
+			{Role: "user", Parts: []genAIPart{{Type: "text", Content: "hello there"}}},
 		},
-		Completion: "general kenobi",
+		Output: []genAIPart{{Type: "text", Content: "general kenobi"}},
 	}
 	emitGenAISpan(tp.Tracer("test"), turn, true)
 
@@ -161,29 +161,98 @@ func TestClaudeContentMessages(t *testing.T) {
 	}`)
 	msgs := claudeContentMessages(body)
 	want := []genAIMessage{
-		{Role: "system", Content: "be terse"},
-		{Role: "user", Content: "first"},
-		{Role: "assistant", Content: "reply"},
-		{Role: "user", Content: "second"},
+		{Role: "system", Parts: []genAIPart{{Type: "text", Content: "be terse"}}},
+		{Role: "user", Parts: []genAIPart{{Type: "text", Content: "first"}}},
+		{Role: "assistant", Parts: []genAIPart{{Type: "text", Content: "reply"}}},
+		{Role: "user", Parts: []genAIPart{{Type: "text", Content: "second"}}},
 	}
-	if len(msgs) != len(want) {
-		t.Fatalf("got %d messages, want %d: %+v", len(msgs), len(want), msgs)
+	if !reflect.DeepEqual(msgs, want) {
+		t.Errorf("claudeContentMessages = %+v, want %+v", msgs, want)
 	}
-	for i := range want {
-		if msgs[i] != want[i] {
-			t.Errorf("message[%d] = %+v, want %+v", i, msgs[i], want[i])
-		}
+}
+
+// TestClaudeContentMessagesAllBlockTypes covers the reviewer's request:
+// every block kind in a request — not just text — is mapped to a GenAI
+// message part. tool_use → tool_call, tool_result → tool_call_response,
+// thinking → reasoning, and an unknown block (image) → a generic part
+// that preserves the type without carrying its raw payload.
+func TestClaudeContentMessagesAllBlockTypes(t *testing.T) {
+	body := []byte(`{
+		"system":[{"type":"text","text":"sys one"},{"type":"text","text":"sys two"}],
+		"messages":[
+			{"role":"user","content":[
+				{"type":"text","text":"look at this"},
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}
+			]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"let me check the weather"},
+				{"type":"text","text":"calling a tool"},
+				{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"location":"Paris"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"toolu_1","content":"rainy, 57F"}
+			]}
+		]
+	}`)
+	msgs := claudeContentMessages(body)
+	want := []genAIMessage{
+		{Role: "system", Parts: []genAIPart{
+			{Type: "text", Content: "sys one"},
+			{Type: "text", Content: "sys two"},
+		}},
+		{Role: "user", Parts: []genAIPart{
+			{Type: "text", Content: "look at this"},
+			{Type: "image"},
+		}},
+		{Role: "assistant", Parts: []genAIPart{
+			{Type: "reasoning", Content: "let me check the weather"},
+			{Type: "text", Content: "calling a tool"},
+			{Type: "tool_call", ID: "toolu_1", Name: "get_weather", Arguments: json.RawMessage(`{"location":"Paris"}`)},
+		}},
+		{Role: "user", Parts: []genAIPart{
+			{Type: "tool_call_response", ID: "toolu_1", Response: json.RawMessage(`"rainy, 57F"`)},
+		}},
+	}
+	if !reflect.DeepEqual(msgs, want) {
+		t.Errorf("claudeContentMessages = %#v\nwant %#v", msgs, want)
 	}
 }
 
 func TestClaudeResponseContentJSON(t *testing.T) {
 	body := []byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"line one"},{"type":"text","text":"line two"}]}`)
-	text, finish := claudeResponseContent(body)
-	if text != "line one\nline two" {
-		t.Errorf("text = %q", text)
+	parts, finish := claudeResponseContent(body)
+	want := []genAIPart{
+		{Type: "text", Content: "line one"},
+		{Type: "text", Content: "line two"},
+	}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %+v, want %+v", parts, want)
 	}
 	if finish != "end_turn" {
 		t.Errorf("finish = %q", finish)
+	}
+}
+
+// TestClaudeResponseContentJSONToolUse asserts a non-streaming response
+// carrying a tool call (and reasoning) is captured as tool_call /
+// reasoning parts, not dropped.
+func TestClaudeResponseContentJSONToolUse(t *testing.T) {
+	body := []byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"tool_use","content":[
+		{"type":"thinking","thinking":"need the weather"},
+		{"type":"text","text":"let me check"},
+		{"type":"tool_use","id":"toolu_9","name":"get_weather","input":{"location":"Paris"}}
+	]}`)
+	parts, finish := claudeResponseContent(body)
+	want := []genAIPart{
+		{Type: "reasoning", Content: "need the weather"},
+		{Type: "text", Content: "let me check"},
+		{Type: "tool_call", ID: "toolu_9", Name: "get_weather", Arguments: json.RawMessage(`{"location":"Paris"}`)},
+	}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v\nwant %#v", parts, want)
+	}
+	if finish != "tool_use" {
+		t.Errorf("finish = %q, want tool_use", finish)
 	}
 }
 
@@ -200,12 +269,49 @@ data: {"type":"content_block_delta","delta":{"type":"text_delta","text":", world
 event: message_delta
 data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}
 `)
-	text, finish := claudeResponseContent(body)
-	if text != "Hello, world" {
-		t.Errorf("text = %q, want %q", text, "Hello, world")
+	parts, finish := claudeResponseContent(body)
+	want := []genAIPart{{Type: "text", Content: "Hello, world"}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %+v, want %+v", parts, want)
 	}
 	if finish != "end_turn" {
 		t.Errorf("finish = %q, want end_turn", finish)
+	}
+}
+
+// TestClaudeResponseContentSSEToolUse asserts a streamed response with a
+// tool call reconstructs the tool_call part (id, name, and arguments
+// accumulated from input_json_delta fragments) plus any text/reasoning
+// blocks, indexed correctly.
+func TestClaudeResponseContentSSEToolUse(t *testing.T) {
+	body := []byte(`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"on it"}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_5","name":"get_weather"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
+`)
+	parts, finish := claudeResponseContent(body)
+	want := []genAIPart{
+		{Type: "text", Content: "on it"},
+		{Type: "tool_call", ID: "toolu_5", Name: "get_weather", Arguments: json.RawMessage(`{"location":"Paris"}`)},
+	}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v\nwant %#v", parts, want)
+	}
+	if finish != "tool_use" {
+		t.Errorf("finish = %q, want tool_use", finish)
 	}
 }
 

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -93,28 +95,44 @@ func TestEmitGenAISpanWithContent(t *testing.T) {
 	if len(spans) != 1 {
 		t.Fatalf("got %d spans, want 1", len(spans))
 	}
-	events := spans[0].Events()
-	if len(events) != 3 { // system message, user message, choice
-		t.Fatalf("got %d events, want 3: %+v", len(events), events)
+	// Content rides span attributes now, not events.
+	if n := len(spans[0].Events()); n != 0 {
+		t.Errorf("got %d events, want 0 (content is on attributes)", n)
 	}
-	if events[0].Name != "gen_ai.system.message" {
-		t.Errorf("event[0].Name = %q", events[0].Name)
+	m := attrMap(spans[0].Attributes())
+
+	// System message → gen_ai.system_instructions (separate from input).
+	var sysParts []genAIPart
+	if err := json.Unmarshal([]byte(m["gen_ai.system_instructions"].AsString()), &sysParts); err != nil {
+		t.Fatalf("gen_ai.system_instructions: %v (raw %q)", err, m["gen_ai.system_instructions"].AsString())
 	}
-	if events[1].Name != "gen_ai.user.message" {
-		t.Errorf("event[1].Name = %q", events[1].Name)
+	wantSys := []genAIPart{{Type: "text", Content: "you are helpful"}}
+	if !reflect.DeepEqual(sysParts, wantSys) {
+		t.Errorf("gen_ai.system_instructions = %+v, want %+v", sysParts, wantSys)
 	}
-	if got := attrMap(events[1].Attributes)["content"].AsString(); got != "hello there" {
-		t.Errorf("user message content = %q", got)
+
+	// Non-system messages → gen_ai.input.messages.
+	var input []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.input.messages"].AsString()), &input); err != nil {
+		t.Fatalf("gen_ai.input.messages: %v (raw %q)", err, m["gen_ai.input.messages"].AsString())
 	}
-	if events[2].Name != "gen_ai.choice" {
-		t.Errorf("event[2].Name = %q", events[2].Name)
+	wantInput := []genAIChatMessage{
+		{Role: "user", Parts: []genAIPart{{Type: "text", Content: "hello there"}}},
 	}
-	choice := attrMap(events[2].Attributes)
-	if got := choice["content"].AsString(); got != "general kenobi" {
-		t.Errorf("choice content = %q", got)
+	if !reflect.DeepEqual(input, wantInput) {
+		t.Errorf("gen_ai.input.messages = %+v, want %+v", input, wantInput)
 	}
-	if got := choice["finish_reason"].AsString(); got != "end_turn" {
-		t.Errorf("choice finish_reason = %q", got)
+
+	// Completion → gen_ai.output.messages with finish reason.
+	var output []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.output.messages"].AsString()), &output); err != nil {
+		t.Fatalf("gen_ai.output.messages: %v (raw %q)", err, m["gen_ai.output.messages"].AsString())
+	}
+	wantOutput := []genAIChatMessage{
+		{Role: "assistant", Parts: []genAIPart{{Type: "text", Content: "general kenobi"}}, FinishReason: "end_turn"},
+	}
+	if !reflect.DeepEqual(output, wantOutput) {
+		t.Errorf("gen_ai.output.messages = %+v, want %+v", output, wantOutput)
 	}
 }
 
@@ -292,11 +310,32 @@ gateway {
 	if len(spans) != 1 {
 		t.Fatalf("got %d spans, want 1", len(spans))
 	}
-	events := spans[0].Events()
-	if len(events) != 3 { // system + user message + choice
-		t.Fatalf("got %d events, want 3: %+v", len(events), events)
+	if n := len(spans[0].Events()); n != 0 {
+		t.Errorf("got %d events, want 0 (content is on attributes)", n)
 	}
-	if got := attrMap(events[2].Attributes)["content"].AsString(); got != "hello back" {
-		t.Errorf("completion content = %q", got)
+	m := attrMap(spans[0].Attributes())
+
+	var sysParts []genAIPart
+	if err := json.Unmarshal([]byte(m["gen_ai.system_instructions"].AsString()), &sysParts); err != nil {
+		t.Fatalf("gen_ai.system_instructions: %v", err)
+	}
+	if len(sysParts) != 1 || sysParts[0].Content != "be terse" {
+		t.Errorf("gen_ai.system_instructions = %+v", sysParts)
+	}
+
+	var input []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.input.messages"].AsString()), &input); err != nil {
+		t.Fatalf("gen_ai.input.messages: %v", err)
+	}
+	if len(input) != 1 || input[0].Role != "user" || len(input[0].Parts) != 1 || input[0].Parts[0].Content != "hi there" {
+		t.Errorf("gen_ai.input.messages = %+v", input)
+	}
+
+	var output []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.output.messages"].AsString()), &output); err != nil {
+		t.Fatalf("gen_ai.output.messages: %v", err)
+	}
+	if len(output) != 1 || output[0].Parts[0].Content != "hello back" || output[0].FinishReason != "end_turn" {
+		t.Errorf("gen_ai.output.messages = %+v", output)
 	}
 }

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+func newRecordingTracer(t *testing.T) (*tracetest.SpanRecorder, *sdktrace.TracerProvider) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	return sr, tp
+}
+
+func attrMap(kvs []attribute.KeyValue) map[string]attribute.Value {
+	m := make(map[string]attribute.Value, len(kvs))
+	for _, kv := range kvs {
+		m[string(kv.Key)] = kv.Value
+	}
+	return m
+}
+
+func TestEmitGenAISpanAttributesNoContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	turn := genAITurn{
+		System:        "anthropic",
+		Operation:     "chat",
+		RequestModel:  "claude-3-5-sonnet-20241022",
+		ResponseModel: "claude-3-5-sonnet-20241022",
+		InputTokens:   42,
+		OutputTokens:  17,
+		FinishReason:  "end_turn",
+		Messages:      []genAIMessage{{Role: "user", Content: "secret prompt"}},
+		Completion:    "secret completion",
+	}
+	emitGenAISpan(tp.Tracer("test"), turn, false)
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	s := spans[0]
+	if s.Name() != "chat claude-3-5-sonnet-20241022" {
+		t.Errorf("span name = %q", s.Name())
+	}
+	m := attrMap(s.Attributes())
+	if m["gen_ai.system"].AsString() != "anthropic" {
+		t.Errorf("gen_ai.system = %q", m["gen_ai.system"].AsString())
+	}
+	if m["gen_ai.operation.name"].AsString() != "chat" {
+		t.Errorf("gen_ai.operation.name = %q", m["gen_ai.operation.name"].AsString())
+	}
+	if m["gen_ai.request.model"].AsString() != "claude-3-5-sonnet-20241022" {
+		t.Errorf("gen_ai.request.model = %q", m["gen_ai.request.model"].AsString())
+	}
+	if got := m["gen_ai.usage.input_tokens"].AsInt64(); got != 42 {
+		t.Errorf("gen_ai.usage.input_tokens = %d, want 42", got)
+	}
+	if got := m["gen_ai.usage.output_tokens"].AsInt64(); got != 17 {
+		t.Errorf("gen_ai.usage.output_tokens = %d, want 17", got)
+	}
+	if fr := m["gen_ai.response.finish_reasons"].AsStringSlice(); len(fr) != 1 || fr[0] != "end_turn" {
+		t.Errorf("gen_ai.response.finish_reasons = %v", fr)
+	}
+	// Content flag off: no events, and no message content anywhere.
+	if len(s.Events()) != 0 {
+		t.Errorf("got %d events with content off, want 0", len(s.Events()))
+	}
+}
+
+func TestEmitGenAISpanWithContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	turn := genAITurn{
+		System:       "anthropic",
+		Operation:    "chat",
+		RequestModel: "claude-3-5-sonnet-20241022",
+		FinishReason: "end_turn",
+		Messages: []genAIMessage{
+			{Role: "system", Content: "you are helpful"},
+			{Role: "user", Content: "hello there"},
+		},
+		Completion: "general kenobi",
+	}
+	emitGenAISpan(tp.Tracer("test"), turn, true)
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	events := spans[0].Events()
+	if len(events) != 3 { // system message, user message, choice
+		t.Fatalf("got %d events, want 3: %+v", len(events), events)
+	}
+	if events[0].Name != "gen_ai.system.message" {
+		t.Errorf("event[0].Name = %q", events[0].Name)
+	}
+	if events[1].Name != "gen_ai.user.message" {
+		t.Errorf("event[1].Name = %q", events[1].Name)
+	}
+	if got := attrMap(events[1].Attributes)["content"].AsString(); got != "hello there" {
+		t.Errorf("user message content = %q", got)
+	}
+	if events[2].Name != "gen_ai.choice" {
+		t.Errorf("event[2].Name = %q", events[2].Name)
+	}
+	choice := attrMap(events[2].Attributes)
+	if got := choice["content"].AsString(); got != "general kenobi" {
+		t.Errorf("choice content = %q", got)
+	}
+	if got := choice["finish_reason"].AsString(); got != "end_turn" {
+		t.Errorf("choice finish_reason = %q", got)
+	}
+}
+
+func TestEmitGenAISpanNilTracerNoPanic(t *testing.T) {
+	emitGenAISpan(nil, genAITurn{System: "anthropic", Operation: "chat"}, true)
+}
+
+func TestClaudeContentMessages(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-3-5-sonnet-20241022",
+		"system":"be terse",
+		"messages":[
+			{"role":"user","content":"first"},
+			{"role":"assistant","content":[{"type":"text","text":"reply"}]},
+			{"role":"user","content":[{"type":"text","text":"second"}]}
+		]
+	}`)
+	msgs := claudeContentMessages(body)
+	want := []genAIMessage{
+		{Role: "system", Content: "be terse"},
+		{Role: "user", Content: "first"},
+		{Role: "assistant", Content: "reply"},
+		{Role: "user", Content: "second"},
+	}
+	if len(msgs) != len(want) {
+		t.Fatalf("got %d messages, want %d: %+v", len(msgs), len(want), msgs)
+	}
+	for i := range want {
+		if msgs[i] != want[i] {
+			t.Errorf("message[%d] = %+v, want %+v", i, msgs[i], want[i])
+		}
+	}
+}
+
+func TestClaudeResponseContentJSON(t *testing.T) {
+	body := []byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"line one"},{"type":"text","text":"line two"}]}`)
+	text, finish := claudeResponseContent(body)
+	if text != "line one\nline two" {
+		t.Errorf("text = %q", text)
+	}
+	if finish != "end_turn" {
+		t.Errorf("finish = %q", finish)
+	}
+}
+
+func TestClaudeResponseContentSSE(t *testing.T) {
+	body := []byte(`event: message_start
+data: {"type":"message_start","message":{"model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":5}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","delta":{"type":"text_delta","text":", world"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}
+`)
+	text, finish := claudeResponseContent(body)
+	if text != "Hello, world" {
+		t.Errorf("text = %q, want %q", text, "Hello, world")
+	}
+	if finish != "end_turn" {
+		t.Errorf("finish = %q, want end_turn", finish)
+	}
+}
+
+func TestRecordGenAITurnDisabled(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	// No genai_telemetry block → disabled.
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+`), "off.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+
+	g.recordGenAITurn("anthropic", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 1, 2,
+		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"yo"}]}`),
+		time.Time{})
+
+	if n := len(sr.Ended()); n != 0 {
+		t.Fatalf("got %d spans with telemetry disabled, want 0", n)
+	}
+}
+
+func TestRecordGenAITurnEnabledNoContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry {}
+}
+`), "base.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+
+	g.recordGenAITurn("anthropic", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		[]byte(`{"messages":[{"role":"user","content":"hi there"}]}`),
+		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"secret"}]}`),
+		time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	if m["gen_ai.system"].AsString() != "anthropic" {
+		t.Errorf("gen_ai.system = %q", m["gen_ai.system"].AsString())
+	}
+	if got := m["gen_ai.usage.input_tokens"].AsInt64(); got != 10 {
+		t.Errorf("input_tokens = %d, want 10", got)
+	}
+	// finish_reason rides the base span (no content flag needed).
+	if fr := m["gen_ai.response.finish_reasons"].AsStringSlice(); len(fr) != 1 || fr[0] != "end_turn" {
+		t.Errorf("finish_reasons = %v", fr)
+	}
+	// Content off → no events, prompt/completion text never captured.
+	if n := len(spans[0].Events()); n != 0 {
+		t.Errorf("got %d events with content disabled, want 0", n)
+	}
+}
+
+func TestRecordGenAITurnEnabledWithContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry { include_message_content = true }
+}
+`), "content.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+
+	g.recordGenAITurn("anthropic", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		[]byte(`{"system":"be terse","messages":[{"role":"user","content":"hi there"}]}`),
+		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"hello back"}]}`),
+		time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	events := spans[0].Events()
+	if len(events) != 3 { // system + user message + choice
+		t.Fatalf("got %d events, want 3: %+v", len(events), events)
+	}
+	if got := attrMap(events[2].Attributes)["content"].AsString(); got != "hello back" {
+		t.Errorf("completion content = %q", got)
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1021,7 +1021,7 @@ func codexRequestModel(body []byte) string {
 // trackLLMUsage parses LLM API request/response bodies for session id,
 // title, model, and token usage. Only fires on actual model-invocation
 // endpoints; ignores heartbeat / event_logging / mcp / oauth probes.
-func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody []byte, sessionHint string, reqStart time.Time) {
+func (g *Gateway) trackLLMUsage(c net.Conn, kind, host, path string, reqBody, respBody []byte, sessionHint string, reqStart time.Time) {
 	ip := g.agentIPFor(c)
 	switch kind {
 	case "claude_usage":
@@ -1041,7 +1041,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if sid == "" && title != "" {
 			sid = shortHash(title)
 		}
-		g.recordGenAITurn("anthropic", sid, reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("anthropic", sid, host, reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart)
 		if sid == "" {
 			return // heartbeat/probe with no session info
 		}
@@ -1058,7 +1058,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
-		g.recordGenAITurn("openai", sid, model, model, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("openai", sid, host, model, model, in, out, reqBody, respBody, reqStart)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	case "codex_ws_usage":
 		// chatgpt.com Codex backend. Two transports:
@@ -1079,7 +1079,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if sid == "" {
 			sid = shortHash(codexResponsesRequestFirstTitle(reqBody))
 		}
-		g.recordGenAITurn("openai", sid, model, model, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("openai", sid, host, model, model, in, out, reqBody, respBody, reqStart)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	}
 }
@@ -2579,7 +2579,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 					_ = zr.Close()
 				}
 			}
-			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint, rtStart)
+			g.trackLLMUsage(c, trackKind, host, req.URL.Path, trackedReqBody, body, sessionHint, rtStart)
 		}
 
 		if hitlRetryConsumedOperation != nil {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1021,7 +1021,7 @@ func codexRequestModel(body []byte) string {
 // trackLLMUsage parses LLM API request/response bodies for session id,
 // title, model, and token usage. Only fires on actual model-invocation
 // endpoints; ignores heartbeat / event_logging / mcp / oauth probes.
-func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody []byte, sessionHint string) {
+func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody []byte, sessionHint string, reqStart time.Time) {
 	ip := g.agentIPFor(c)
 	switch kind {
 	case "claude_usage":
@@ -1034,6 +1034,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" {
 			model = respModel
 		}
+		g.recordGenAITurn("anthropic", reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart)
 		// Prefer Claude Code's session id from metadata; fall back to
 		// hash of first real user message. Skip if neither.
 		sid := reqInfo.SessionID
@@ -1057,6 +1058,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
+		g.recordGenAITurn("openai", model, model, in, out, reqBody, respBody, reqStart)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	case "codex_ws_usage":
 		// chatgpt.com Codex backend. Two transports:
@@ -1073,6 +1075,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
+		g.recordGenAITurn("openai", model, model, in, out, reqBody, respBody, reqStart)
 		sid := shortHash(sessionHint)
 		if sid == "" {
 			sid = shortHash(codexResponsesRequestFirstTitle(reqBody))
@@ -2576,7 +2579,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 					_ = zr.Close()
 				}
 			}
-			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint)
+			g.trackLLMUsage(c, trackKind, req.URL.Path, trackedReqBody, body, sessionHint, rtStart)
 		}
 
 		if hitlRetryConsumedOperation != nil {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1034,16 +1034,16 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" {
 			model = respModel
 		}
-		g.recordGenAITurn("anthropic", reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart)
 		// Prefer Claude Code's session id from metadata; fall back to
-		// hash of first real user message. Skip if neither.
+		// hash of first real user message. Skip usage if neither.
 		sid := reqInfo.SessionID
 		title := reqInfo.Title
-		if sid == "" {
-			if title == "" {
-				return // heartbeat/probe with no session info
-			}
+		if sid == "" && title != "" {
 			sid = shortHash(title)
+		}
+		g.recordGenAITurn("anthropic", sid, reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart)
+		if sid == "" {
+			return // heartbeat/probe with no session info
 		}
 		g.agents.recordLLMUsage(ip, "claude", sid, title, model, in, out)
 	case "openai_usage":
@@ -1058,7 +1058,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
-		g.recordGenAITurn("openai", model, model, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("openai", sid, model, model, in, out, reqBody, respBody, reqStart)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	case "codex_ws_usage":
 		// chatgpt.com Codex backend. Two transports:
@@ -1075,11 +1075,11 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, path string, reqBody, respBody
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
-		g.recordGenAITurn("openai", model, model, in, out, reqBody, respBody, reqStart)
 		sid := shortHash(sessionHint)
 		if sid == "" {
 			sid = shortHash(codexResponsesRequestFirstTitle(reqBody))
 		}
+		g.recordGenAITurn("openai", sid, model, model, in, out, reqBody, respBody, reqStart)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	}
 }

--- a/cmd/clawpatrol/otel.go
+++ b/cmd/clawpatrol/otel.go
@@ -22,6 +22,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Module-globals so main.go's hooks can call cheap helpers without
@@ -32,6 +33,13 @@ var (
 	mVerdicts    metric.Int64Counter
 	mReqDuration metric.Float64Histogram
 )
+
+// genaiTracer is the tracer used to emit OTel GenAI semantic-convention
+// spans for intercepted LLM turns. Set by StartOtel when the trace
+// exporter is configured; nil otherwise, in which case recordGenAITurn
+// no-ops. Threading a tracer through every call site would be noisier
+// than this module-global, matching the metric handles above.
+var genaiTracer trace.Tracer
 
 func StartOtel(g *Gateway) (func(context.Context) error, error) {
 	noop := func(context.Context) error { return nil }
@@ -92,6 +100,7 @@ func StartOtel(g *Gateway) (func(context.Context) error, error) {
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 			propagation.TraceContext{}, propagation.Baggage{},
 		))
+		genaiTracer = tp.Tracer("clawpatrol")
 		tpShutdown = tp.Shutdown
 		_, span := tp.Tracer("clawpatrol").Start(context.Background(), "gateway.boot")
 		span.SetAttributes(attribute.String("event", "startup"))

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -99,15 +99,18 @@ gateway {
   # per intercepted LLM turn following the GenAI semantic conventions
   # (gen_ai.* — provider name, server address, request/response model,
   # request sampling params, token usage incl. the Anthropic cache-token
-  # breakdown, response id, finish reason, error type). Requires the
-  # OTLP exporter to be configured via the
+  # breakdown, response id, finish reason, error type, and the request's
+  # tool catalogue as gen_ai.tool.definitions — name and type per tool).
+  # Requires the OTLP exporter to be configured via the
   # standard OTEL_EXPORTER_OTLP_ENDPOINT env var; without it there is
   # nothing to export to. Remove the block to disable (zero overhead).
   #
   # include_message_content additionally attaches the prompt and
   # completion text as the gen_ai.input.messages / gen_ai.output.messages
-  # / gen_ai.system_instructions span attributes. Default false — content
-  # can be large and sensitive, so it ships only when you explicitly opt in.
+  # / gen_ai.system_instructions span attributes, and enriches
+  # gen_ai.tool.definitions with each tool's description and JSON schema.
+  # Default false — content can be large and sensitive, so it ships only
+  # when you explicitly opt in.
   #
   # genai_telemetry {
   #   include_message_content = false

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -97,8 +97,10 @@ gateway {
 
   # OpenTelemetry GenAI telemetry. Block presence emits one OTel span
   # per intercepted LLM turn following the GenAI semantic conventions
-  # (gen_ai.* — system, request/response model, token usage, finish
-  # reason). Requires the OTLP exporter to be configured via the
+  # (gen_ai.* — provider name, server address, request/response model,
+  # request sampling params, token usage incl. the Anthropic cache-token
+  # breakdown, response id, finish reason, error type). Requires the
+  # OTLP exporter to be configured via the
   # standard OTEL_EXPORTER_OTLP_ENDPOINT env var; without it there is
   # nothing to export to. Remove the block to disable (zero overhead).
   #

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -94,6 +94,21 @@ gateway {
   #   # requires tsnet whois identity.
   #   operators = ["alice@example.com", "*@example.com"]
   # }
+
+  # OpenTelemetry GenAI telemetry. Block presence emits one OTel span
+  # per intercepted LLM turn following the GenAI semantic conventions
+  # (gen_ai.* — system, request/response model, token usage, finish
+  # reason). Requires the OTLP exporter to be configured via the
+  # standard OTEL_EXPORTER_OTLP_ENDPOINT env var; without it there is
+  # nothing to export to. Remove the block to disable (zero overhead).
+  #
+  # include_message_content additionally attaches the prompt and
+  # completion text as GenAI content events. Default false — content can
+  # be large and sensitive, so it ships only when you explicitly opt in.
+  #
+  # genai_telemetry {
+  #   include_message_content = false
+  # }
 }
 
 defaults {

--- a/examples/gateway.example.hcl
+++ b/examples/gateway.example.hcl
@@ -103,8 +103,9 @@ gateway {
   # nothing to export to. Remove the block to disable (zero overhead).
   #
   # include_message_content additionally attaches the prompt and
-  # completion text as GenAI content events. Default false — content can
-  # be large and sensitive, so it ships only when you explicitly opt in.
+  # completion text as the gen_ai.input.messages / gen_ai.output.messages
+  # / gen_ai.system_instructions span attributes. Default false — content
+  # can be large and sensitive, so it ships only when you explicitly opt in.
   #
   # genai_telemetry {
   #   include_message_content = false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,11 +214,13 @@ type GenAITelemetryBlock struct {
 	// IncludeMessageContent additionally captures and exports the
 	// prompt/completion message content via the GenAI content
 	// convention (the gen_ai.input.messages, gen_ai.output.messages,
-	// and gen_ai.system_instructions span attributes). Default false:
-	// message content can be large and sensitive, so it is only
-	// captured when an operator explicitly opts in. Independent of the
-	// base span export — the gen_ai.* attribute span emits regardless
-	// of this flag.
+	// and gen_ai.system_instructions span attributes), and enriches
+	// gen_ai.tool.definitions with each tool's description and JSON
+	// schema. Default false: message content can be large and
+	// sensitive, so it is only captured when an operator explicitly
+	// opts in. Independent of the base span export — the gen_ai.*
+	// attribute span emits regardless of this flag, including
+	// gen_ai.tool.definitions with each tool's name and type.
 	IncludeMessageContent bool `hcl:"include_message_content,optional"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,6 +188,14 @@ type GatewaySettings struct {
 	// today's hardcoded behavior.
 	Limits *LimitsBlock `hcl:"limits,block"`
 
+	// GenAITelemetry, if present, enables export of OpenTelemetry GenAI
+	// semantic-convention spans (gen_ai.*) for intercepted LLM
+	// requests. Requires the OTLP exporter to be configured
+	// (OTEL_EXPORTER_OTLP_ENDPOINT); without it there is nothing to
+	// export to. The block is opt-in: when absent, no gen_ai.* spans
+	// are emitted and there is no added per-request overhead.
+	GenAITelemetry *GenAITelemetryBlock `hcl:"genai_telemetry,block"`
+
 	// WireGuard, if present, enables the embedded userspace WireGuard
 	// server. Required block when running WG-mode deployments.
 	WireGuard *WireGuardBlock `hcl:"wireguard,block"`
@@ -196,6 +204,21 @@ type GatewaySettings struct {
 	// Tailscale control plane (OAuth key minting, exit-node routing).
 	// Both transports may be enabled simultaneously.
 	Tailscale *TailscaleBlock `hcl:"tailscale,block"`
+}
+
+// GenAITelemetryBlock is the body of the `genai_telemetry { ... }`
+// sub-block inside `gateway { ... }`. Presence of the block enables
+// emission of OpenTelemetry GenAI semantic-convention spans for
+// intercepted LLM requests (gen_ai.* attributes — semconv v1.27.0).
+type GenAITelemetryBlock struct {
+	// IncludeMessageContent additionally captures and exports the
+	// prompt/completion message content via the GenAI content
+	// convention (span events: gen_ai.{role}.message and
+	// gen_ai.choice). Default false: message content can be large and
+	// sensitive, so it is only captured when an operator explicitly
+	// opts in. Independent of the base span export — the gen_ai.*
+	// attribute span emits regardless of this flag.
+	IncludeMessageContent bool `hcl:"include_message_content,optional"`
 }
 
 // WireGuardBlock is the body of the `wireguard { ... }` sub-block
@@ -385,6 +408,19 @@ func (g *Gateway) LogPath() string { return g.settings().LogPath }
 
 // Telemetry returns the pointer-bool telemetry opt-in. nil = default on.
 func (g *Gateway) Telemetry() *bool { return g.settings().Telemetry }
+
+// GenAITelemetryEnabled reports whether OTel GenAI semantic-convention
+// span export is opted in (the `genai_telemetry {}` block is present).
+func (g *Gateway) GenAITelemetryEnabled() bool {
+	return g != nil && g.Settings != nil && g.Settings.GenAITelemetry != nil
+}
+
+// GenAITelemetryIncludeContent reports whether message content
+// (prompts/completions) should be captured on GenAI spans. Always
+// false unless GenAI telemetry is enabled and the operator opted in.
+func (g *Gateway) GenAITelemetryIncludeContent() bool {
+	return g.GenAITelemetryEnabled() && g.Settings.GenAITelemetry.IncludeMessageContent
+}
 
 // SessionKeep returns the raw session-retention string, or empty.
 func (g *Gateway) SessionKeep() string { return g.settings().SessionKeep }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,11 +213,12 @@ type GatewaySettings struct {
 type GenAITelemetryBlock struct {
 	// IncludeMessageContent additionally captures and exports the
 	// prompt/completion message content via the GenAI content
-	// convention (span events: gen_ai.{role}.message and
-	// gen_ai.choice). Default false: message content can be large and
-	// sensitive, so it is only captured when an operator explicitly
-	// opts in. Independent of the base span export — the gen_ai.*
-	// attribute span emits regardless of this flag.
+	// convention (the gen_ai.input.messages, gen_ai.output.messages,
+	// and gen_ai.system_instructions span attributes). Default false:
+	// message content can be large and sensitive, so it is only
+	// captured when an operator explicitly opts in. Independent of the
+	// base span export — the gen_ai.* attribute span emits regardless
+	// of this flag.
 	IncludeMessageContent bool `hcl:"include_message_content,optional"`
 }
 

--- a/internal/config/genai_telemetry_test.go
+++ b/internal/config/genai_telemetry_test.go
@@ -1,0 +1,75 @@
+package config
+
+import "testing"
+
+func TestGenAITelemetryAccessorsAbsent(t *testing.T) {
+	// No genai_telemetry block → disabled, content off.
+	gw, diags := LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+`), "genai-absent.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if gw.GenAITelemetryEnabled() {
+		t.Error("GenAITelemetryEnabled() = true with no block, want false")
+	}
+	if gw.GenAITelemetryIncludeContent() {
+		t.Error("GenAITelemetryIncludeContent() = true with no block, want false")
+	}
+}
+
+func TestGenAITelemetryEnabledNoContent(t *testing.T) {
+	// Empty block → base export on, content still off (the safe default).
+	gw, diags := LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry {}
+}
+`), "genai-base.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if !gw.GenAITelemetryEnabled() {
+		t.Error("GenAITelemetryEnabled() = false with block present, want true")
+	}
+	if gw.GenAITelemetryIncludeContent() {
+		t.Error("GenAITelemetryIncludeContent() = true without opt-in, want false")
+	}
+}
+
+func TestGenAITelemetryContentOptIn(t *testing.T) {
+	gw, diags := LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry { include_message_content = true }
+}
+`), "genai-content.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	if !gw.GenAITelemetryEnabled() {
+		t.Error("GenAITelemetryEnabled() = false, want true")
+	}
+	if !gw.GenAITelemetryIncludeContent() {
+		t.Error("GenAITelemetryIncludeContent() = false with opt-in, want true")
+	}
+}
+
+func TestGenAITelemetryNilReceiverSafe(t *testing.T) {
+	var g *Gateway
+	if g.GenAITelemetryEnabled() || g.GenAITelemetryIncludeContent() {
+		t.Error("nil receiver should report disabled")
+	}
+	g = &Gateway{}
+	if g.GenAITelemetryEnabled() || g.GenAITelemetryIncludeContent() {
+		t.Error("nil Settings should report disabled")
+	}
+}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -83,7 +83,7 @@ intercepted LLM requests (gen_ai.* attributes — semconv v1.27.0).
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `include_message_content` | `bool` | no | Additionally captures and exports the prompt/completion message content via the GenAI content convention (the gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions span attributes). Default false: message content can be large and sensitive, so it is only captured when an operator explicitly opts in. Independent of the base span export — the gen_ai.* attribute span emits regardless of this flag. |
+| `include_message_content` | `bool` | no | Additionally captures and exports the prompt/completion message content via the GenAI content convention (the gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions span attributes), and enriches gen_ai.tool.definitions with each tool's description and JSON schema. Default false: message content can be large and sensitive, so it is only captured when an operator explicitly opts in. Independent of the base span export — the gen_ai.* attribute span emits regardless of this flag, including gen_ai.tool.definitions with each tool's name and type. |
 
 **Nested block `wireguard {}`:**
 

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -83,7 +83,7 @@ intercepted LLM requests (gen_ai.* attributes — semconv v1.27.0).
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `include_message_content` | `bool` | no | Additionally captures and exports the prompt/completion message content via the GenAI content convention (span events: gen_ai.{role}.message and gen_ai.choice). Default false: message content can be large and sensitive, so it is only captured when an operator explicitly opts in. Independent of the base span export — the gen_ai.* attribute span emits regardless of this flag. |
+| `include_message_content` | `bool` | no | Additionally captures and exports the prompt/completion message content via the GenAI content convention (the gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions span attributes). Default false: message content can be large and sensitive, so it is only captured when an operator explicitly opts in. Independent of the base span export — the gen_ai.* attribute span emits regardless of this flag. |
 
 **Nested block `wireguard {}`:**
 

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -49,6 +49,7 @@ The gateway block carries operational settings — listen addresses, the WireGua
 | `telemetry` | `bool` | no | Opts in/out of the update-checker / anonymous usage ping (doc/telemetry.md). nil = default on; explicit `telemetry = false` silences the goroutine. Env vars CLAWPATROL_TELEMETRY=0 and DO_NOT_TRACK=1 also work. |
 | `session_keep` | `string` | no | The hard retention floor for the sessions table. Sessions whose last_at is older than this get deleted by the background sweeper. Default 720h (30d), "0" / "off" disables. time.ParseDuration format. |
 | `limits` | `block` | no | Limits, if present, overrides the two gateway-wide body-size limits (rules-engine body buffer and persisted action body storage). nil uses the DefaultBody*Limit constants, which match today's hardcoded behavior. |
+| `genai_telemetry` | `block` | no | GenAITelemetry, if present, enables export of OpenTelemetry GenAI semantic-convention spans (gen_ai.*) for intercepted LLM requests. Requires the OTLP exporter to be configured (OTEL_EXPORTER_OTLP_ENDPOINT); without it there is nothing to export to. The block is opt-in: when absent, no gen_ai.* spans are emitted and there is no added per-request overhead. |
 | `wireguard` | `block` | no | WireGuard, if present, enables the embedded userspace WireGuard server. Required block when running WG-mode deployments. |
 | `tailscale` | `block` | no | Tailscale, if present, enables the embedded tsnet node and the Tailscale control plane (OAuth key minting, exit-node routing). Both transports may be enabled simultaneously. |
 
@@ -72,6 +73,17 @@ constants, which equal today's hardcoded behavior.
 |-----------|------|----------|-------------|
 | `body_buffer` | `string` | no |  |
 | `body_storage` | `string` | no |  |
+
+**Nested block `genai_telemetry {}`:**
+
+The body of the `genai_telemetry { ... }`
+sub-block inside `gateway { ... }`. Presence of the block enables
+emission of OpenTelemetry GenAI semantic-convention spans for
+intercepted LLM requests (gen_ai.* attributes — semconv v1.27.0).
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `include_message_content` | `bool` | no | Additionally captures and exports the prompt/completion message content via the GenAI content convention (span events: gen_ai.{role}.message and gen_ai.choice). Default false: message content can be large and sensitive, so it is only captured when an operator explicitly opts in. Independent of the base span export — the gen_ai.* attribute span emits regardless of this flag. |
 
 **Nested block `wireguard {}`:**
 


### PR DESCRIPTION
## Summary

Adds an opt-in OpenTelemetry export that maps intercepted LLM traffic to the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (semconv v1.27.0), so LLM calls flowing through the gateway show up in standard OTel/GenAI observability tooling.

For each intercepted turn the gateway emits a `chat {model}` span carrying:

- `gen_ai.system` (`anthropic` / `openai`)
- `gen_ai.operation.name`
- `gen_ai.request.model` / `gen_ai.response.model`
- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`
- `gen_ai.response.finish_reasons`

Span duration reflects the real upstream round-trip latency.

## Config

Two independent switches under the `gateway {}` block:

```hcl
genai_telemetry {
  include_message_content = false
}
```

- **Block presence** enables base span export. It reuses the existing OTLP exporter, so `OTEL_EXPORTER_OTLP_ENDPOINT` must be set.
- **`include_message_content`** additionally attaches prompt/completion content as GenAI content events (`gen_ai.{role}.message`, `gen_ai.choice`). Defaults **off** — content can be large and sensitive — and is independent of the base toggle.

When the block is absent the export path returns before parsing anything, so disabled behavior is unchanged with no added per-request overhead.

## Scope

Base attribute spans emit for all intercepted providers (Anthropic, OpenAI, codex). Message-content extraction is implemented for Anthropic (both non-streaming JSON and SSE); OpenAI/codex content extraction is left as a follow-up.

## Tests

- `internal/config`: block parsing + accessor behavior (absent / enabled / content opt-in / nil-safe).
- `cmd/clawpatrol`: span attributes, content-event gating, Claude request/response content parsers (JSON + SSE), and end-to-end `recordGenAITurn` for disabled / enabled / content-on paths using an in-memory span recorder.