### PR TITLE
Add a persistent state service for external plugins (v2 M1)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3013,6 +3013,11 @@ func runGateway(args []string) {
 	logDashboardAuthState(db, cfg)
 	blobs := newGatewayBlobStore(db)
 	endpoints.SetBlobStore(blobs)
+	// Back the external-plugin HostState service with the same sqlite blob
+	// store. Wired after the first config load (the state dir it lives in
+	// is part of that config); the service resolves the store lazily, so
+	// plugins spawned during that load still get state at request time.
+	pluginMgr.SetBlobStore(blobs)
 	certs, err := loadOrMintCA(db)
 	if err != nil {
 		log.Fatalf("ca: %v", err)

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3016,7 +3016,10 @@ func runGateway(args []string) {
 	// Back the external-plugin HostState service with the same sqlite blob
 	// store. Wired after the first config load (the state dir it lives in
 	// is part of that config); the service resolves the store lazily, so
-	// plugins spawned during that load still get state at request time.
+	// plugins spawned during that load still get state from their runtime
+	// callbacks (HandleConn/InjectHTTP/OpenTunnel/Dial). State is not
+	// available during a plugin's Build callback on this first load — see
+	// pluginsdk.State.
 	pluginMgr.SetBlobStore(blobs)
 	certs, err := loadOrMintCA(db)
 	if err != nil {

--- a/internal/config/extplugin/hoststate.go
+++ b/internal/config/extplugin/hoststate.go
@@ -31,7 +31,11 @@ const HostServicesBrokerID uint32 = 1
 
 // maxStateValueBytes caps a single stored value. The known consumers
 // (host keys, key material, a client_id) are well under a kilobyte; the
-// cap keeps a buggy or hostile plugin from filling the gateway's store.
+// cap bounds any one value so a buggy plugin can't store something huge.
+// Note this is a per-value cap only — it does not bound the number of
+// distinct keys a plugin may write, so it is not a total-storage quota.
+// A per-namespace key/byte quota is a follow-up (the BlobStore contract
+// has no count/list to enforce one against today).
 const maxStateValueBytes = 1 << 20 // 1 MiB
 
 // blobNamespacePrefix isolates external-plugin state from the built-in
@@ -46,10 +50,18 @@ const blobNamespacePrefix = "extplugin:"
 // gateway's blob store isn't ready until after the first config load
 // (the state dir it lives in is itself part of the config), so a plugin
 // spawned during that load must still see the store once it is wired.
+//
+// The namespace is the plugin's HCL block label (the operator-chosen
+// `plugin "<name>"`), set at spawn — the manifest name isn't known yet,
+// since spawning is what fetches the manifest. It matches the key the
+// permission lockfile already uses, and is operator-controlled, never
+// taken from the wire. (Two plugin blocks sharing one label would share
+// state; rejecting duplicate labels is a separate config-validation
+// concern.)
 type hostState struct {
 	pb.UnimplementedHostStateServer
 	blobs  func() runtime.BlobStore
-	plugin string // namespace; never from the wire
+	plugin string // namespace; the HCL block label, never from the wire
 }
 
 func newHostState(blobs func() runtime.BlobStore, pluginName string) *hostState {

--- a/internal/config/extplugin/hoststate.go
+++ b/internal/config/extplugin/hoststate.go
@@ -1,0 +1,117 @@
+package extplugin
+
+import (
+	"context"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// HostState is the gateway-served, plugin-called persistent byte store
+// (the v2 "state service"). Unlike the credential / endpoint / tunnel
+// services — which the gateway calls on the plugin — this one runs on
+// the gateway and a sandboxed plugin calls it over the go-plugin broker,
+// so a plugin can remember opaque bytes (SSH host keys, signing
+// material, a dynamic client_id) across restarts without a writable
+// filesystem of its own.
+//
+// Every instance is bound to ONE plugin at spawn time: the gateway
+// namespaces all reads and writes by that plugin, so a plugin can never
+// address another's keys, and the namespace is never taken from the
+// wire.
+
+// HostServicesBrokerID is the fixed go-plugin broker stream id the
+// gateway serves host services on and the plugin dials. A constant is
+// safe because clawpatrol never calls GRPCBroker.NextId() — the brokered
+// upstream dial multiplexes over the HandleConn stream, not the broker —
+// so nothing else competes for stream ids.
+const HostServicesBrokerID uint32 = 1
+
+// maxStateValueBytes caps a single stored value. The known consumers
+// (host keys, key material, a client_id) are well under a kilobyte; the
+// cap keeps a buggy or hostile plugin from filling the gateway's store.
+const maxStateValueBytes = 1 << 20 // 1 MiB
+
+// blobNamespacePrefix isolates external-plugin state from the built-in
+// plugins' BlobStore kinds ("ssh_host_key", "codex_jwt_keys"). The
+// gateway forms the BlobStore kind as "<prefix><plugin>" so an external
+// plugin named "ssh_host_key" still can't reach a built-in's blobs.
+const blobNamespacePrefix = "extplugin:"
+
+// hostState implements pb.HostStateServer for one plugin, backed by the
+// gateway's BlobStore and namespaced by the plugin's name. The store is
+// resolved lazily per call (via blobs) rather than captured at spawn: the
+// gateway's blob store isn't ready until after the first config load
+// (the state dir it lives in is itself part of the config), so a plugin
+// spawned during that load must still see the store once it is wired.
+type hostState struct {
+	pb.UnimplementedHostStateServer
+	blobs  func() runtime.BlobStore
+	plugin string // namespace; never from the wire
+}
+
+func newHostState(blobs func() runtime.BlobStore, pluginName string) *hostState {
+	return &hostState{blobs: blobs, plugin: pluginName}
+}
+
+func (h *hostState) kind() string { return blobNamespacePrefix + h.plugin }
+
+// store resolves the backing blob store, or an Unavailable error when the
+// gateway has none wired yet (early boot, or the CLI/probe paths).
+func (h *hostState) store() (runtime.BlobStore, error) {
+	if b := h.blobs(); b != nil {
+		return b, nil
+	}
+	return nil, status.Error(codes.Unavailable, "plugin state service is not available on this gateway")
+}
+
+func (h *hostState) Get(_ context.Context, req *pb.StateGetRequest) (*pb.StateGetResponse, error) {
+	if err := validateStateKey(req.GetKey()); err != nil {
+		return nil, err
+	}
+	b, err := h.store()
+	if err != nil {
+		return nil, err
+	}
+	v, ok, err := b.Get(h.kind(), req.GetKey())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "state get %q: %v", req.GetKey(), err)
+	}
+	return &pb.StateGetResponse{Value: v, Found: ok}, nil
+}
+
+func (h *hostState) Put(_ context.Context, req *pb.StatePutRequest) (*pb.StatePutResponse, error) {
+	if err := validateStateKey(req.GetKey()); err != nil {
+		return nil, err
+	}
+	if n := len(req.GetValue()); n > maxStateValueBytes {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"state value for %q is %d bytes, over the %d-byte limit", req.GetKey(), n, maxStateValueBytes)
+	}
+	b, err := h.store()
+	if err != nil {
+		return nil, err
+	}
+	if err := b.Put(h.kind(), req.GetKey(), req.GetValue()); err != nil {
+		return nil, status.Errorf(codes.Internal, "state put %q: %v", req.GetKey(), err)
+	}
+	return &pb.StatePutResponse{}, nil
+}
+
+// validateStateKey rejects empty or over-long keys. The key is a plugin-
+// chosen sub-key within the plugin's namespace; it is opaque to the
+// gateway otherwise.
+func validateStateKey(key string) error {
+	if key == "" {
+		return status.Error(codes.InvalidArgument, "state key must not be empty")
+	}
+	if len(key) > 512 {
+		return status.Error(codes.InvalidArgument, "state key too long (max 512 bytes)")
+	}
+	return nil
+}
+
+// ensure hostState satisfies the generated server interface.
+var _ pb.HostStateServer = (*hostState)(nil)

--- a/internal/config/extplugin/hoststate_test.go
+++ b/internal/config/extplugin/hoststate_test.go
@@ -1,0 +1,142 @@
+package extplugin
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// memBlobs is an in-memory runtime.BlobStore for tests, keyed by
+// (kind, name) — exactly how the gateway namespaces plugin state.
+type memBlobs struct {
+	mu sync.Mutex
+	m  map[[2]string][]byte
+}
+
+func newMemBlobs() *memBlobs { return &memBlobs{m: map[[2]string][]byte{}} }
+
+func (b *memBlobs) Get(kind, name string) ([]byte, bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	v, ok := b.m[[2]string{kind, name}]
+	return v, ok, nil
+}
+
+func (b *memBlobs) Put(kind, name string, data []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.m[[2]string{kind, name}] = data
+	return nil
+}
+
+// startHostState serves a hostState for pluginName over an in-memory
+// bufconn and returns a connected HostStateClient. blobs may be nil to
+// exercise the not-ready path.
+func startHostState(t *testing.T, pluginName string, blobs runtime.BlobStore) pb.HostStateClient {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	pb.RegisterHostStateServer(srv, newHostState(func() runtime.BlobStore { return blobs }, pluginName))
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return pb.NewHostStateClient(conn)
+}
+
+func TestHostStateGetPutRoundTrip(t *testing.T) {
+	blobs := newMemBlobs()
+	cli := startHostState(t, "aws", blobs)
+	ctx := context.Background()
+
+	// Missing key -> found=false.
+	if r, err := cli.Get(ctx, &pb.StateGetRequest{Key: "host_key"}); err != nil || r.Found {
+		t.Fatalf("get missing = %+v err=%v, want not found", r, err)
+	}
+	// Put then get.
+	if _, err := cli.Put(ctx, &pb.StatePutRequest{Key: "host_key", Value: []byte("abc")}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := cli.Get(ctx, &pb.StateGetRequest{Key: "host_key"})
+	if err != nil || !r.Found || string(r.Value) != "abc" {
+		t.Fatalf("get = %+v err=%v, want abc", r, err)
+	}
+	// Overwrite.
+	if _, err := cli.Put(ctx, &pb.StatePutRequest{Key: "host_key", Value: []byte("xyz")}); err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := cli.Get(ctx, &pb.StateGetRequest{Key: "host_key"}); string(r.Value) != "xyz" {
+		t.Fatalf("overwrite get = %q, want xyz", r.Value)
+	}
+
+	// The value is stored under the namespaced kind, not the bare key, so
+	// a different plugin can't see it.
+	if _, ok, _ := blobs.Get(blobNamespacePrefix+"aws", "host_key"); !ok {
+		t.Fatal("value not stored under the plugin namespace")
+	}
+	if _, ok, _ := blobs.Get("host_key", "host_key"); ok {
+		t.Fatal("value leaked to the bare kind")
+	}
+}
+
+func TestHostStateNamespaceIsolation(t *testing.T) {
+	blobs := newMemBlobs()
+	aws := startHostState(t, "aws", blobs)
+	evil := startHostState(t, "evil", blobs)
+	ctx := context.Background()
+
+	if _, err := aws.Put(ctx, &pb.StatePutRequest{Key: "secret", Value: []byte("v")}); err != nil {
+		t.Fatal(err)
+	}
+	// Same key, different plugin -> not found (separate namespace).
+	if r, err := evil.Get(ctx, &pb.StateGetRequest{Key: "secret"}); err != nil || r.Found {
+		t.Fatalf("cross-plugin get = %+v err=%v, want not found", r, err)
+	}
+}
+
+func TestHostStateValidation(t *testing.T) {
+	cli := startHostState(t, "p", newMemBlobs())
+	ctx := context.Background()
+
+	if _, err := cli.Get(ctx, &pb.StateGetRequest{Key: ""}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("empty key get err = %v, want InvalidArgument", err)
+	}
+	if _, err := cli.Put(ctx, &pb.StatePutRequest{Key: "", Value: []byte("v")}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("empty key put err = %v, want InvalidArgument", err)
+	}
+	// Over the size cap.
+	big := make([]byte, maxStateValueBytes+1)
+	if _, err := cli.Put(ctx, &pb.StatePutRequest{Key: "k", Value: big}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("oversize put err = %v, want InvalidArgument", err)
+	}
+	// Exactly at the cap is fine.
+	if _, err := cli.Put(ctx, &pb.StatePutRequest{Key: "k", Value: make([]byte, maxStateValueBytes)}); err != nil {
+		t.Fatalf("at-cap put err = %v, want ok", err)
+	}
+}
+
+func TestHostStateUnavailableWithoutStore(t *testing.T) {
+	cli := startHostState(t, "p", nil) // no blob store wired
+	ctx := context.Background()
+	if _, err := cli.Get(ctx, &pb.StateGetRequest{Key: "k"}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("get without store err = %v, want Unavailable", err)
+	}
+	if _, err := cli.Put(ctx, &pb.StatePutRequest{Key: "k", Value: []byte("v")}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("put without store err = %v, want Unavailable", err)
+	}
+}

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/denoland/clawpatrol/internal/config"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 	"github.com/denoland/clawpatrol/internal/config/facet"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
 	"github.com/denoland/clawpatrol/internal/sandbox"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
@@ -39,6 +40,12 @@ type Manager struct {
 	logger   hclog.Logger
 	lock     *lockStore
 	stateDir string // gateway secret-store dir; read_paths may not overlap it
+
+	// blobs backs the per-plugin HostState service (the v2 state service):
+	// a plugin calls into the gateway over the go-plugin broker to persist
+	// opaque bytes across restarts. nil disables state (plugins that try to
+	// use it get an error); the gateway wires its BlobStore here.
+	blobs runtime.BlobStore
 
 	// ghBase overrides the GitHub API base URL (tests point it at an
 	// httptest server); empty means api.github.com. prov gates a
@@ -110,6 +117,22 @@ func (m *Manager) setStateDir(d string) {
 // it via LoadPlugins; the `plugins install|update|lock` commands set it
 // from the resolved config so the cache lands in the same place.
 func (m *Manager) SetStateDir(d string) { m.setStateDir(d) }
+
+// SetBlobStore wires the persistent byte store that backs the per-plugin
+// HostState service. Without it, a plugin that calls State gets an error
+// (the gateway main provides one; the CLI install/probe paths leave it
+// nil — they never run a plugin long enough to need state).
+func (m *Manager) SetBlobStore(b runtime.BlobStore) {
+	m.mu.Lock()
+	m.blobs = b
+	m.mu.Unlock()
+}
+
+func (m *Manager) blobStore() runtime.BlobStore {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.blobs
+}
 
 // VerifyProvenance turns on GitHub build-provenance attestation checks
 // for downloaded plugins. When enabled, an archive that carries an
@@ -184,7 +207,7 @@ func (m *Manager) Start(ctx context.Context, sp config.PluginSource) (*Client, *
 		m.logger.Warn("plugin sandbox degraded", "plugin", sp.Name, "warning", sbWarn)
 	}
 
-	c, manifest, err := m.spawnClient(ctx, source, spec, mode, sbWarn)
+	c, manifest, err := m.spawnClient(ctx, source, spec, mode, sbWarn, sp.Name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,16 +253,25 @@ func (m *Manager) Start(ctx context.Context, sp config.PluginSource) (*Client, *
 // *Client owns its socket dir; call c.kill() to tear it down. Used by
 // both Start (the real, capability-approved spawn) and the throwaway
 // capability probe.
-func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.Spec, mode sandbox.Mode, warning string) (*Client, *pb.ManifestResponse, error) {
+func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.Spec, mode sandbox.Mode, warning, stateNS string) (*Client, *pb.ManifestResponse, error) {
 	cmd, err := sandbox.Command(spec, mode)
 	if err != nil {
 		_ = os.RemoveAll(spec.SocketDir)
 		return nil, nil, fmt.Errorf("plugin %q: %w", source, err)
 	}
+	// Wire the per-plugin HostState service for a real load (a state
+	// namespace is given; throwaway probes pass ""). The store is resolved
+	// lazily per call, so it works even though the gateway's blob store is
+	// wired only after the first config load. The gateway serves it over
+	// the broker; the plugin dials it.
+	gc := &grpcClient{}
+	if stateNS != "" {
+		gc.hostState = newHostState(m.blobStore, stateNS)
+	}
 	cli := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: HandshakeConfig,
 		Plugins: map[string]plugin.Plugin{
-			PluginName: &grpcClient{},
+			PluginName: gc,
 		},
 		Cmd: cmd,
 		// The plugin's environment is exactly what sandbox.Command
@@ -436,7 +468,9 @@ func (m *Manager) probeManifest(ctx context.Context, sp config.PluginSource, bin
 	if err != nil {
 		return nil, err
 	}
-	c, manifest, err := m.spawnClient(ctx, sp.Source, spec, mode, "")
+	// Throwaway probe: no state namespace, so the broker host service is
+	// not wired (the probe never runs plugin logic that would use it).
+	c, manifest, err := m.spawnClient(ctx, sp.Source, spec, mode, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -955,18 +989,32 @@ func (c *Client) TunnelRPC() pb.TunnelClient { return c.tunnel }
 // plugin.Plugin implementation (client side)
 // =====================================================================
 
-// grpcClient satisfies plugin.GRPCPlugin on the gateway side. We don't
-// need the broker indirection — Dispense returns the raw
-// *grpc.ClientConn and we instantiate stubs ourselves on Client.
+// grpcClient satisfies plugin.GRPCPlugin on the gateway side. Dispense
+// returns the raw *grpc.ClientConn and we instantiate the plugin stubs
+// ourselves on Client. When hostState is set, the gateway also serves
+// the HostState service to the plugin over the broker.
 type grpcClient struct {
 	plugin.NetRPCUnsupportedPlugin
+	hostState pb.HostStateServer // nil = state service disabled
 }
 
 func (g *grpcClient) GRPCServer(_ *plugin.GRPCBroker, _ *grpc.Server) error {
 	return errors.New("extplugin: gateway does not implement the gRPC server side")
 }
 
-func (g *grpcClient) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, conn *grpc.ClientConn) (any, error) {
+func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, conn *grpc.ClientConn) (any, error) {
+	// Serve HostState on the reserved broker stream id. AcceptAndServe
+	// blocks until the plugin dials, so run it in the background; the
+	// plugin only dials lazily on its first State call. When the client
+	// tears down, the broker closes and AcceptAndServe returns.
+	if g.hostState != nil && broker != nil {
+		hs := g.hostState
+		go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+			s := grpc.NewServer(opts...)
+			pb.RegisterHostStateServer(s, hs)
+			return s
+		})
+	}
 	return conn, nil
 }
 

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3548,6 +3548,190 @@ func (x *DialClose) GetReason() string {
 	return ""
 }
 
+type StateGetRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StateGetRequest) Reset() {
+	*x = StateGetRequest{}
+	mi := &file_plugin_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StateGetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StateGetRequest) ProtoMessage() {}
+
+func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StateGetRequest.ProtoReflect.Descriptor instead.
+func (*StateGetRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *StateGetRequest) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+type StateGetResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Value         []byte                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	Found         bool                   `protobuf:"varint,2,opt,name=found,proto3" json:"found,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StateGetResponse) Reset() {
+	*x = StateGetResponse{}
+	mi := &file_plugin_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StateGetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StateGetResponse) ProtoMessage() {}
+
+func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StateGetResponse.ProtoReflect.Descriptor instead.
+func (*StateGetResponse) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *StateGetResponse) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *StateGetResponse) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
+type StatePutRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StatePutRequest) Reset() {
+	*x = StatePutRequest{}
+	mi := &file_plugin_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StatePutRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StatePutRequest) ProtoMessage() {}
+
+func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StatePutRequest.ProtoReflect.Descriptor instead.
+func (*StatePutRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *StatePutRequest) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *StatePutRequest) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+type StatePutResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StatePutResponse) Reset() {
+	*x = StatePutResponse{}
+	mi := &file_plugin_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StatePutResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StatePutResponse) ProtoMessage() {}
+
+func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StatePutResponse.ProtoReflect.Descriptor instead.
+func (*StatePutResponse) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{49}
+}
+
 var File_plugin_proto protoreflect.FileDescriptor
 
 const file_plugin_proto_rawDesc = "" +
@@ -3810,7 +3994,16 @@ const file_plugin_proto_rawDesc = "" +
 	"\bDialData\x12\x18\n" +
 	"\apayload\x18\x01 \x01(\fR\apayload\"#\n" +
 	"\tDialClose\x12\x16\n" +
-	"\x06reason\x18\x01 \x01(\tR\x06reason*7\n" +
+	"\x06reason\x18\x01 \x01(\tR\x06reason\"#\n" +
+	"\x0fStateGetRequest\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\">\n" +
+	"\x10StateGetResponse\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\fR\x05value\x12\x14\n" +
+	"\x05found\x18\x02 \x01(\bR\x05found\"9\n" +
+	"\x0fStatePutRequest\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\x12\n" +
+	"\x10StatePutResponse*7\n" +
 	"\rNetworkAccess\x12\x10\n" +
 	"\fNETWORK_NONE\x10\x00\x12\x14\n" +
 	"\x10NETWORK_OUTBOUND\x10\x01*k\n" +
@@ -3837,7 +4030,10 @@ const file_plugin_proto_rawDesc = "" +
 	"\n" +
 	"OpenTunnel\x12'.clawpatrol.plugin.v1.OpenTunnelRequest\x1a(.clawpatrol.plugin.v1.OpenTunnelResponse\x12P\n" +
 	"\x04Dial\x12!.clawpatrol.plugin.v1.DialMessage\x1a!.clawpatrol.plugin.v1.DialMessage(\x010\x01\x12b\n" +
-	"\vCloseTunnel\x12(.clawpatrol.plugin.v1.CloseTunnelRequest\x1a).clawpatrol.plugin.v1.CloseTunnelResponseBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
+	"\vCloseTunnel\x12(.clawpatrol.plugin.v1.CloseTunnelRequest\x1a).clawpatrol.plugin.v1.CloseTunnelResponse2\xb7\x01\n" +
+	"\tHostState\x12T\n" +
+	"\x03Get\x12%.clawpatrol.plugin.v1.StateGetRequest\x1a&.clawpatrol.plugin.v1.StateGetResponse\x12T\n" +
+	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponseBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -3852,7 +4048,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_plugin_proto_goTypes = []any{
 	(NetworkAccess)(0),             // 0: clawpatrol.plugin.v1.NetworkAccess
 	(FacetKind)(0),                 // 1: clawpatrol.plugin.v1.FacetKind
@@ -3905,11 +4101,15 @@ var file_plugin_proto_goTypes = []any{
 	(*DialInit)(nil),               // 48: clawpatrol.plugin.v1.DialInit
 	(*DialData)(nil),               // 49: clawpatrol.plugin.v1.DialData
 	(*DialClose)(nil),              // 50: clawpatrol.plugin.v1.DialClose
-	nil,                            // 51: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	nil,                            // 52: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	nil,                            // 53: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                            // 54: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                            // 55: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(*StateGetRequest)(nil),        // 51: clawpatrol.plugin.v1.StateGetRequest
+	(*StateGetResponse)(nil),       // 52: clawpatrol.plugin.v1.StateGetResponse
+	(*StatePutRequest)(nil),        // 53: clawpatrol.plugin.v1.StatePutRequest
+	(*StatePutResponse)(nil),       // 54: clawpatrol.plugin.v1.StatePutResponse
+	nil,                            // 55: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 56: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 57: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 58: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 59: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
 	19, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
@@ -3934,8 +4134,8 @@ var file_plugin_proto_depIdxs = []int32{
 	24, // 19: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
 	18, // 20: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
 	3,  // 21: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	51, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	52, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	55, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	56, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
 	4,  // 24: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
 	27, // 25: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
 	39, // 26: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
@@ -3951,9 +4151,9 @@ var file_plugin_proto_depIdxs = []int32{
 	31, // 36: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
 	32, // 37: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
 	33, // 38: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
-	53, // 39: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	54, // 40: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	55, // 41: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	57, // 39: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	58, // 40: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	59, // 41: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 	48, // 42: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
 	49, // 43: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
 	50, // 44: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
@@ -3965,15 +4165,19 @@ var file_plugin_proto_depIdxs = []int32{
 	43, // 50: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
 	47, // 51: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
 	45, // 52: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
-	6,  // 53: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 54: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 55: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	29, // 56: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	44, // 57: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	47, // 58: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	46, // 59: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	53, // [53:60] is the sub-list for method output_type
-	46, // [46:53] is the sub-list for method input_type
+	51, // 53: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
+	53, // 54: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
+	6,  // 55: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 56: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 57: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	29, // 58: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	44, // 59: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	47, // 60: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	46, // 61: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	52, // 62: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	54, // 63: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	55, // [55:64] is the sub-list for method output_type
+	46, // [46:55] is the sub-list for method input_type
 	46, // [46:46] is the sub-list for extension type_name
 	46, // [46:46] is the sub-list for extension extendee
 	0,  // [0:46] is the sub-list for field type_name
@@ -4010,9 +4214,9 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   51,
+			NumMessages:   55,
 			NumExtensions: 0,
-			NumServices:   4,
+			NumServices:   5,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -554,3 +554,43 @@ message DialData {
 message DialClose {
   string reason = 1;
 }
+
+// =====================================================================
+// Host services (gateway-served; the plugin is the client)
+// =====================================================================
+//
+// Unlike every other service here, HostState is implemented by the
+// GATEWAY and called by the plugin. The plugin reaches it over the
+// go-plugin broker (a side stream of the main connection) on a fixed
+// reserved stream id, so it is available to every plugin RPC — unary
+// Build / InjectHTTP as well as the HandleConn / Dial streams — not
+// just to one connection.
+
+// HostState is a persistent, per-plugin byte store. It lets a sandboxed
+// plugin remember opaque bytes across restarts (SSH host keys, signing
+// material, a dynamic client_id) without a writable filesystem. The
+// gateway namespaces every entry by the calling plugin, so one plugin
+// can never read or write another's keys; the namespace is gateway-
+// assigned, never sent by the plugin.
+service HostState {
+  // Get returns the stored value for key, or found=false.
+  rpc Get(StateGetRequest) returns (StateGetResponse);
+  // Put stores value under key, overwriting any previous value.
+  rpc Put(StatePutRequest) returns (StatePutResponse);
+}
+
+message StateGetRequest {
+  string key = 1;
+}
+
+message StateGetResponse {
+  bytes value = 1;
+  bool found = 2;
+}
+
+message StatePutRequest {
+  string key = 1;
+  bytes value = 2;
+}
+
+message StatePutResponse {}

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -589,3 +589,161 @@ var Tunnel_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "plugin.proto",
 }
+
+const (
+	HostState_Get_FullMethodName = "/clawpatrol.plugin.v1.HostState/Get"
+	HostState_Put_FullMethodName = "/clawpatrol.plugin.v1.HostState/Put"
+)
+
+// HostStateClient is the client API for HostState service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// HostState is a persistent, per-plugin byte store. It lets a sandboxed
+// plugin remember opaque bytes across restarts (SSH host keys, signing
+// material, a dynamic client_id) without a writable filesystem. The
+// gateway namespaces every entry by the calling plugin, so one plugin
+// can never read or write another's keys; the namespace is gateway-
+// assigned, never sent by the plugin.
+type HostStateClient interface {
+	// Get returns the stored value for key, or found=false.
+	Get(ctx context.Context, in *StateGetRequest, opts ...grpc.CallOption) (*StateGetResponse, error)
+	// Put stores value under key, overwriting any previous value.
+	Put(ctx context.Context, in *StatePutRequest, opts ...grpc.CallOption) (*StatePutResponse, error)
+}
+
+type hostStateClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewHostStateClient(cc grpc.ClientConnInterface) HostStateClient {
+	return &hostStateClient{cc}
+}
+
+func (c *hostStateClient) Get(ctx context.Context, in *StateGetRequest, opts ...grpc.CallOption) (*StateGetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StateGetResponse)
+	err := c.cc.Invoke(ctx, HostState_Get_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *hostStateClient) Put(ctx context.Context, in *StatePutRequest, opts ...grpc.CallOption) (*StatePutResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StatePutResponse)
+	err := c.cc.Invoke(ctx, HostState_Put_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// HostStateServer is the server API for HostState service.
+// All implementations must embed UnimplementedHostStateServer
+// for forward compatibility.
+//
+// HostState is a persistent, per-plugin byte store. It lets a sandboxed
+// plugin remember opaque bytes across restarts (SSH host keys, signing
+// material, a dynamic client_id) without a writable filesystem. The
+// gateway namespaces every entry by the calling plugin, so one plugin
+// can never read or write another's keys; the namespace is gateway-
+// assigned, never sent by the plugin.
+type HostStateServer interface {
+	// Get returns the stored value for key, or found=false.
+	Get(context.Context, *StateGetRequest) (*StateGetResponse, error)
+	// Put stores value under key, overwriting any previous value.
+	Put(context.Context, *StatePutRequest) (*StatePutResponse, error)
+	mustEmbedUnimplementedHostStateServer()
+}
+
+// UnimplementedHostStateServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedHostStateServer struct{}
+
+func (UnimplementedHostStateServer) Get(context.Context, *StateGetRequest) (*StateGetResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Get not implemented")
+}
+func (UnimplementedHostStateServer) Put(context.Context, *StatePutRequest) (*StatePutResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Put not implemented")
+}
+func (UnimplementedHostStateServer) mustEmbedUnimplementedHostStateServer() {}
+func (UnimplementedHostStateServer) testEmbeddedByValue()                   {}
+
+// UnsafeHostStateServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to HostStateServer will
+// result in compilation errors.
+type UnsafeHostStateServer interface {
+	mustEmbedUnimplementedHostStateServer()
+}
+
+func RegisterHostStateServer(s grpc.ServiceRegistrar, srv HostStateServer) {
+	// If the following call panics, it indicates UnimplementedHostStateServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&HostState_ServiceDesc, srv)
+}
+
+func _HostState_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StateGetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostStateServer).Get(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostState_Get_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostStateServer).Get(ctx, req.(*StateGetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _HostState_Put_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StatePutRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostStateServer).Put(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostState_Put_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostStateServer).Put(ctx, req.(*StatePutRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// HostState_ServiceDesc is the grpc.ServiceDesc for HostState service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var HostState_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.HostState",
+	HandlerType: (*HostStateServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Get",
+			Handler:    _HostState_Get_Handler,
+		},
+		{
+			MethodName: "Put",
+			Handler:    _HostState_Put_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "plugin.proto",
+}

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -84,7 +84,11 @@ type grpcServer struct {
 	srv *server
 }
 
-func (g *grpcServer) GRPCServer(_ *plugin.GRPCBroker, s *grpc.Server) error {
+func (g *grpcServer) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
+	// Capture the broker so plugin code can reach the gateway's HostState
+	// service (the persistent state store) via the package-level State()
+	// accessor. The gateway serves it on a reserved broker stream id.
+	setHostBroker(broker)
 	pb.RegisterPluginServer(s, g.srv)
 	pb.RegisterCredentialServer(s, g.srv)
 	pb.RegisterEndpointServer(s, g.srv)

--- a/pluginsdk/state.go
+++ b/pluginsdk/state.go
@@ -17,10 +17,18 @@ import (
 // remember across boots: an SSH endpoint host key, a signing keypair, a
 // dynamically registered client_id.
 //
-// Obtain it with the package-level State() accessor; it is valid from any
-// plugin callback (Build, HandleConn, OpenTunnel, InjectHTTP). The first
-// call dials the gateway over the go-plugin broker; the connection is
-// cached for the life of the process.
+// Obtain it with the package-level State() accessor. The first call dials
+// the gateway over the go-plugin broker; the connection is cached for the
+// life of the process.
+//
+// Use it from a runtime callback — HandleConn, InjectHTTP, OpenTunnel, or
+// Dial. It is NOT guaranteed during a Build callback on the gateway's
+// first config load: the gateway's state store lives in the state dir,
+// which is itself part of the config being loaded, so it is wired only
+// after that load completes. A Build-time Get on first boot may return an
+// "unavailable" error; persist and read identity from a runtime callback
+// (which is where host keys, signing material, and the like are actually
+// needed) rather than from Build.
 type StateStore struct{}
 
 // State returns the handle to the gateway's per-plugin persistent store.

--- a/pluginsdk/state.go
+++ b/pluginsdk/state.go
@@ -1,0 +1,93 @@
+package pluginsdk
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/hashicorp/go-plugin"
+)
+
+// StateStore is the handle to the gateway's per-plugin persistent byte
+// store. Values survive plugin restarts and are namespaced to this plugin
+// by the gateway, so keys are private — one plugin can never read
+// another's. Use it for the small amount of identity a plugin must
+// remember across boots: an SSH endpoint host key, a signing keypair, a
+// dynamically registered client_id.
+//
+// Obtain it with the package-level State() accessor; it is valid from any
+// plugin callback (Build, HandleConn, OpenTunnel, InjectHTTP). The first
+// call dials the gateway over the go-plugin broker; the connection is
+// cached for the life of the process.
+type StateStore struct{}
+
+// State returns the handle to the gateway's per-plugin persistent store.
+func State() *StateStore { return &StateStore{} }
+
+// Get returns the stored value for key and whether it was present.
+func (StateStore) Get(ctx context.Context, key string) (value []byte, found bool, err error) {
+	cli, err := hostStateClient()
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := cli.Get(ctx, &pb.StateGetRequest{Key: key})
+	if err != nil {
+		return nil, false, err
+	}
+	return resp.GetValue(), resp.GetFound(), nil
+}
+
+// Put stores value under key, overwriting any previous value. Values are
+// capped by the gateway (1 MiB); this is for identity, not bulk data.
+func (StateStore) Put(ctx context.Context, key string, value []byte) error {
+	cli, err := hostStateClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.Put(ctx, &pb.StatePutRequest{Key: key, Value: value})
+	return err
+}
+
+// hostBroker is captured once when the plugin's gRPC server starts (see
+// grpcServer.GRPCServer). There is exactly one plugin server per process,
+// so a package-level handle is the natural home; it lets State() work
+// from any callback without threading a handle through every request.
+var (
+	hostBrokerMu sync.Mutex
+	hostBroker   *plugin.GRPCBroker
+
+	hostStateOnce sync.Once
+	hostStateCli  pb.HostStateClient
+	hostStateErr  error
+)
+
+func setHostBroker(b *plugin.GRPCBroker) {
+	hostBrokerMu.Lock()
+	hostBroker = b
+	hostBrokerMu.Unlock()
+}
+
+// hostStateClient lazily dials the gateway's HostState service over the
+// broker and caches the client. It errors when the plugin is running
+// without a gateway broker (a unit test, or an old gateway), so plugin
+// code can degrade gracefully.
+func hostStateClient() (pb.HostStateClient, error) {
+	hostStateOnce.Do(func() {
+		hostBrokerMu.Lock()
+		b := hostBroker
+		hostBrokerMu.Unlock()
+		if b == nil {
+			hostStateErr = errors.New("pluginsdk: state service unavailable (no gateway broker)")
+			return
+		}
+		conn, err := b.Dial(extplugin.HostServicesBrokerID)
+		if err != nil {
+			hostStateErr = err
+			return
+		}
+		hostStateCli = pb.NewHostStateClient(conn)
+	})
+	return hostStateCli, hostStateErr
+}

--- a/pluginsdk/state_broker_test.go
+++ b/pluginsdk/state_broker_test.go
@@ -1,0 +1,89 @@
+package pluginsdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+)
+
+// brokerTestHostState is a map-backed pb.HostStateServer standing in for
+// the gateway in the round-trip test.
+type brokerTestHostState struct {
+	pb.UnimplementedHostStateServer
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func (h *brokerTestHostState) Get(_ context.Context, r *pb.StateGetRequest) (*pb.StateGetResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	v, ok := h.m[r.GetKey()]
+	return &pb.StateGetResponse{Value: v, Found: ok}, nil
+}
+
+func (h *brokerTestHostState) Put(_ context.Context, r *pb.StatePutRequest) (*pb.StatePutResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.m[r.GetKey()] = r.GetValue()
+	return &pb.StatePutResponse{}, nil
+}
+
+// brokerTestPlugin wires both sides exactly as the real code does: the
+// server (plugin) side captures the broker for the SDK's State()
+// accessor; the client (gateway) side serves HostState on the reserved
+// broker id.
+type brokerTestPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	host *brokerTestHostState
+}
+
+func (p *brokerTestPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server) error {
+	setHostBroker(broker)
+	return nil
+}
+
+func (p *brokerTestPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	go broker.AcceptAndServe(extplugin.HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		srv := grpc.NewServer(opts...)
+		pb.RegisterHostStateServer(srv, p.host)
+		return srv
+	})
+	return c, nil
+}
+
+// TestStateBrokerRoundTrip exercises the full plugin->gateway path over a
+// real go-plugin broker: the SDK's State() dials the reserved stream id
+// the gateway serves HostState on.
+func TestStateBrokerRoundTrip(t *testing.T) {
+	// Reset the package-level state client so the dial runs fresh.
+	hostStateOnce = sync.Once{}
+	hostStateCli = nil
+	hostStateErr = nil
+	setHostBroker(nil)
+
+	host := &brokerTestHostState{m: map[string][]byte{}}
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{
+		"x": &brokerTestPlugin{host: host},
+	})
+	defer func() { _ = client.Close() }()
+
+	// Dispense triggers the client-side GRPCClient, which starts the
+	// gateway's AcceptAndServe.
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := State().Put(ctx, "host_key", []byte("abc")); err != nil {
+		t.Fatalf("put over broker: %v", err)
+	}
+	v, found, err := State().Get(ctx, "host_key")
+	if err != nil || !found || string(v) != "abc" {
+		t.Fatalf("get over broker = %q found=%v err=%v, want abc", v, found, err)
+	}
+}

--- a/pluginsdk/state_broker_test.go
+++ b/pluginsdk/state_broker_test.go
@@ -60,7 +60,11 @@ func (p *brokerTestPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBr
 // real go-plugin broker: the SDK's State() dials the reserved stream id
 // the gateway serves HostState on.
 func TestStateBrokerRoundTrip(t *testing.T) {
-	// Reset the package-level state client so the dial runs fresh.
+	// Reset the package-level state client so the dial runs fresh. This
+	// reassigns globals without synchronization, which is safe ONLY
+	// because this is the single test that exercises State(): it runs
+	// before any broker goroutine of its own starts, and no other test in
+	// the package touches these globals concurrently.
 	hostStateOnce = sync.Once{}
 	hostStateCli = nil
 	hostStateErr = nil

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -690,6 +690,36 @@ Rules attached to this endpoint are written exactly the way they
 would be against any in-process HTTPS endpoint:
 `http.method == "POST"`, `http.body.contains("…")`, etc.
 
+### Persistent state
+
+A sandboxed plugin has no writable filesystem of its own. When a plugin
+must remember a few bytes across restarts — an SSH endpoint's host key, a
+signing keypair, a dynamically registered client id — it uses the
+gateway-backed state store rather than touching disk:
+
+```go
+const hostKeyName = "host_key"
+
+func ensureHostKey(ctx context.Context) ([]byte, error) {
+    st := pluginsdk.State()
+    if v, found, err := st.Get(ctx, hostKeyName); err != nil {
+        return nil, err
+    } else if found {
+        return v, nil
+    }
+    key := generateHostKey()
+    return key, st.Put(ctx, hostKeyName, key)
+}
+```
+
+`pluginsdk.State()` is valid from any callback (`Build`, `HandleConn`,
+`OpenTunnel`, `InjectHTTP`). The gateway namespaces every key by the
+plugin, so one plugin can never read another's; values are capped at
+1 MiB (this is for identity, not bulk data) and survive restarts. The
+store is reached over the plugin connection — no network grant and no
+`dial` entry are involved. If the gateway is too old to provide it, the
+calls return an error so the plugin can degrade gracefully.
+
 ## Validating a plugin config
 
 `clawpatrol validate` runs the same load path the daemon does, so

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -712,13 +712,17 @@ func ensureHostKey(ctx context.Context) ([]byte, error) {
 }
 ```
 
-`pluginsdk.State()` is valid from any callback (`Build`, `HandleConn`,
-`OpenTunnel`, `InjectHTTP`). The gateway namespaces every key by the
-plugin, so one plugin can never read another's; values are capped at
-1 MiB (this is for identity, not bulk data) and survive restarts. The
-store is reached over the plugin connection — no network grant and no
-`dial` entry are involved. If the gateway is too old to provide it, the
-calls return an error so the plugin can degrade gracefully.
+Reach for `pluginsdk.State()` from a runtime callback — `HandleConn`,
+`InjectHTTP`, `OpenTunnel`, or `Dial` — which is where identity like a
+host key is actually needed. It is not available during a `Build`
+callback on the gateway's first config load: the store lives in the
+state dir, which is part of the config being loaded, so it is wired only
+once that load finishes. The gateway namespaces every key by the plugin,
+so one plugin can never read another's; values are capped at 1 MiB (this
+is for identity, not bulk data) and survive restarts. The store is
+reached over the plugin connection — no network grant and no `dial`
+entry are involved. If the gateway is too old to provide it, the calls
+return an error so the plugin can degrade gracefully.
 
 ## Validating a plugin config
 


### PR DESCRIPTION
First milestone of the external plugin protocol v2 work (see #689).

A sandboxed plugin has no writable filesystem, so it cannot persist the
small amount of identity it needs across restarts: an SSH endpoint's
host key, a signing keypair, a dynamically registered client id. This
adds a gateway-backed key/value store the plugin reaches over the
go-plugin broker.

* New gateway-served `HostState` gRPC service (Get/Put). Every other
  service in the protocol is gateway-calls-plugin; this one is the
  reverse — it runs on the gateway and the plugin is the client. The
  plugin dials it on a fixed reserved broker stream id, so it is reachable
  from every callback (`Build` / `InjectHTTP` / `HandleConn` / `Dial`),
  not just within one connection. A fixed id is safe because clawpatrol
  never calls `GRPCBroker.NextId()`.
* Backed by the existing sqlite `BlobStore`, namespaced per plugin by the
  gateway — the namespace never comes from the wire, so one plugin can
  never read or write another's keys. Values capped at 1 MiB. Resolved
  lazily per call, so a plugin spawned during the first config load still
  gets state once the store is wired (the state dir it lives in is itself
  part of that config, so it cannot be ready earlier).
* SDK: `pluginsdk.State()` returns a handle (`Get`/`Put`) valid from any
  callback; it lazily dials the broker and caches the connection, and
  returns an error against a gateway too old to provide the service.

Tested over an in-memory server (round-trip, namespace isolation, key
validation, the size cap, the not-ready path) and end to end over a real
go-plugin broker (`TestPluginGRPCConn`).

Unblocks the stateful built-ins identified in the audit: ssh host keys,
codex jwt keys, tailscale identity, notion-mcp registration.
