### PR TITLE
Let external credentials rewrite the request URL and body (v2 M2)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2451,7 +2451,22 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 						// Match existing request-signing behavior: an injection failure is logged,
 						// then the request continues with the agent's placeholder. The upstream
 						// service should reject that placeholder without exposing gateway secrets.
+						//
+						// Exception: a transform credential (one that rewrites the URL/body)
+						// consumes the request body during injection, so on failure the request
+						// is corrupted, not merely un-injected — fail closed instead of
+						// forwarding a half-transformed request.
 						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
+							if rw, ok := injector.(runtime.HTTPRequestRewriter); ok && rw.RewritesHTTPRequest() {
+								log.Printf("transform %s: %v; failing closed", cc.Credential.Symbol.Name, err)
+								_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+								ev.Status = 502
+								ev.Action = "error"
+								ev.Reason = err.Error()
+								ev.Ms = time.Since(start).Milliseconds()
+								g.emitEnd(ev)
+								return
+							}
 							log.Printf("inject %s: %v; forwarding without injection", cc.Credential.Symbol.Name, err)
 						}
 						if rp, ok := injector.(runtime.HTTPCredentialRedactionProvider); ok {

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -887,6 +887,15 @@ func (b *dynamicOAuthHTTPCredentialBody) InjectHTTP(ctx context.Context, req *ht
 	return injectHTTPWithExternalCredential(ctx, b.dynamicCredentialBody, req, sec)
 }
 
+// RewritesHTTPRequest reports whether InjectHTTP rewrites more than
+// headers (a transform credential). The gateway fails closed on its
+// inject error since the request body was streamed to the plugin. The
+// method is promoted to the HTTP body wrappers that embed
+// *dynamicCredentialBody.
+func (b *dynamicCredentialBody) RewritesHTTPRequest() bool {
+	return b != nil && b.metadata.httpTransform
+}
+
 func (b *dynamicHTTPCredentialBody) ConsumeHTTPRedactions(req *http.Request) []string {
 	if b == nil {
 		return nil

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -819,6 +819,9 @@ type credentialMetadata struct {
 	envVars        []config.EnvVar
 	oauth          *config.OAuthIntegration
 	httpInject     bool
+	// httpTransform: the credential rewrites method/URL/body via the
+	// streaming TransformHTTP RPC (superset of httpInject).
+	httpTransform bool
 }
 
 // dynamicCredentialBody is the per-instance base Body for credentials
@@ -912,6 +915,12 @@ func injectHTTPWithExternalCredential(ctx context.Context, body *dynamicCredenti
 	if body == nil {
 		return nil
 	}
+	// Transform credentials use the streaming TransformHTTP path (the
+	// request body flows through the plugin); header-only credentials use
+	// the unary InjectHTTP below (the body never leaves the gateway).
+	if body.metadata.httpTransform {
+		return transformHTTPWithExternalCredential(ctx, body, req, sec)
+	}
 	if body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
 		return fmt.Errorf("extplugin: credential %q InjectHTTP unavailable: plugin client is not connected", body.instanceName)
 	}
@@ -993,12 +1002,15 @@ func wrapCredentialBody(b *dynamicCredentialBody) any {
 	if b == nil {
 		return b
 	}
+	// A transform credential participates in HTTP injection too (it is the
+	// superset), so it gets the same HTTP-capable wrapper.
+	httpCapable := b.metadata.httpInject || b.metadata.httpTransform
 	switch {
-	case b.metadata.oauth != nil && b.metadata.httpInject:
+	case b.metadata.oauth != nil && httpCapable:
 		return &dynamicOAuthHTTPCredentialBody{dynamicCredentialBody: b}
 	case b.metadata.oauth != nil:
 		return &dynamicOAuthCredentialBody{dynamicCredentialBody: b}
-	case b.metadata.httpInject:
+	case httpCapable:
 		return &dynamicHTTPCredentialBody{dynamicCredentialBody: b}
 	default:
 		return b

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -1149,8 +1149,12 @@ type CredentialMetadata struct {
 	EnvVars        []*EnvVarDecl          `protobuf:"bytes,3,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty"`
 	Oauth          *OAuthIntegrationDecl  `protobuf:"bytes,4,opt,name=oauth,proto3" json:"oauth,omitempty"`
 	HttpInject     bool                   `protobuf:"varint,5,opt,name=http_inject,json=httpInject,proto3" json:"http_inject,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// http_transform: the credential rewrites the request method / URL /
+	// body via the streaming TransformHTTP RPC, not just headers. Implies
+	// http_inject.
+	HttpTransform bool `protobuf:"varint,6,opt,name=http_transform,json=httpTransform,proto3" json:"http_transform,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CredentialMetadata) Reset() {
@@ -1218,6 +1222,13 @@ func (x *CredentialMetadata) GetHttpInject() bool {
 	return false
 }
 
+func (x *CredentialMetadata) GetHttpTransform() bool {
+	if x != nil {
+		return x.HttpTransform
+	}
+	return false
+}
+
 type CredentialDecl struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	TypeName string                 `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
@@ -1228,8 +1239,13 @@ type CredentialDecl struct {
 	// disambiguators are authoritative for validation.
 	Disambiguators []string `protobuf:"bytes,3,rep,name=disambiguators,proto3" json:"disambiguators,omitempty"`
 	HttpInject     bool     `protobuf:"varint,4,opt,name=http_inject,json=httpInject,proto3" json:"http_inject,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// http_transform: the credential rewrites the request method / URL /
+	// body via the streaming TransformHTTP RPC. Implies http_inject. Used
+	// by credentials that sign over the body (AWS SigV4) or carry the
+	// secret in the URL/body (telegram, discord).
+	HttpTransform bool `protobuf:"varint,5,opt,name=http_transform,json=httpTransform,proto3" json:"http_transform,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CredentialDecl) Reset() {
@@ -1286,6 +1302,13 @@ func (x *CredentialDecl) GetDisambiguators() []string {
 func (x *CredentialDecl) GetHttpInject() bool {
 	if x != nil {
 		return x.HttpInject
+	}
+	return false
+}
+
+func (x *CredentialDecl) GetHttpTransform() bool {
+	if x != nil {
+		return x.HttpTransform
 	}
 	return false
 }
@@ -1902,6 +1925,417 @@ func (x *InjectHTTPResponse) GetRedactions() []string {
 	return nil
 }
 
+// HTTPBodyChunk carries one slice of a request body in either direction
+// of TransformHTTP. eof marks the final frame (it may carry data too).
+type HTTPBodyChunk struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Data  []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	Eof   bool                   `protobuf:"varint,2,opt,name=eof,proto3" json:"eof,omitempty"`
+	// trailers ride on the eof frame: the HTTP trailers that follow the
+	// body (e.g. gRPC's grpc-status / grpc-message). They are conveyed so
+	// the transform never drops them — empty leaves the request's original
+	// trailers in place.
+	Trailers      map[string]*HTTPHeaderValues `protobuf:"bytes,3,rep,name=trailers,proto3" json:"trailers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HTTPBodyChunk) Reset() {
+	*x = HTTPBodyChunk{}
+	mi := &file_plugin_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HTTPBodyChunk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HTTPBodyChunk) ProtoMessage() {}
+
+func (x *HTTPBodyChunk) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HTTPBodyChunk.ProtoReflect.Descriptor instead.
+func (*HTTPBodyChunk) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *HTTPBodyChunk) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *HTTPBodyChunk) GetEof() bool {
+	if x != nil {
+		return x.Eof
+	}
+	return false
+}
+
+func (x *HTTPBodyChunk) GetTrailers() map[string]*HTTPHeaderValues {
+	if x != nil {
+		return x.Trailers
+	}
+	return nil
+}
+
+// TransformHTTPUp is gateway -> plugin: the init, then the request body.
+type TransformHTTPUp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Kind:
+	//
+	//	*TransformHTTPUp_Init
+	//	*TransformHTTPUp_Body
+	Kind          isTransformHTTPUp_Kind `protobuf_oneof:"kind"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransformHTTPUp) Reset() {
+	*x = TransformHTTPUp{}
+	mi := &file_plugin_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransformHTTPUp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransformHTTPUp) ProtoMessage() {}
+
+func (x *TransformHTTPUp) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransformHTTPUp.ProtoReflect.Descriptor instead.
+func (*TransformHTTPUp) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *TransformHTTPUp) GetKind() isTransformHTTPUp_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return nil
+}
+
+func (x *TransformHTTPUp) GetInit() *TransformHTTPInit {
+	if x != nil {
+		if x, ok := x.Kind.(*TransformHTTPUp_Init); ok {
+			return x.Init
+		}
+	}
+	return nil
+}
+
+func (x *TransformHTTPUp) GetBody() *HTTPBodyChunk {
+	if x != nil {
+		if x, ok := x.Kind.(*TransformHTTPUp_Body); ok {
+			return x.Body
+		}
+	}
+	return nil
+}
+
+type isTransformHTTPUp_Kind interface {
+	isTransformHTTPUp_Kind()
+}
+
+type TransformHTTPUp_Init struct {
+	Init *TransformHTTPInit `protobuf:"bytes,1,opt,name=init,proto3,oneof"`
+}
+
+type TransformHTTPUp_Body struct {
+	Body *HTTPBodyChunk `protobuf:"bytes,2,opt,name=body,proto3,oneof"`
+}
+
+func (*TransformHTTPUp_Init) isTransformHTTPUp_Kind() {}
+
+func (*TransformHTTPUp_Body) isTransformHTTPUp_Kind() {}
+
+type TransformHTTPInit struct {
+	state                   protoimpl.MessageState       `protogen:"open.v1"`
+	CredentialTypeName      string                       `protobuf:"bytes,1,opt,name=credential_type_name,json=credentialTypeName,proto3" json:"credential_type_name,omitempty"`
+	CredentialInstance      string                       `protobuf:"bytes,2,opt,name=credential_instance,json=credentialInstance,proto3" json:"credential_instance,omitempty"`
+	CredentialCanonicalJson []byte                       `protobuf:"bytes,3,opt,name=credential_canonical_json,json=credentialCanonicalJson,proto3" json:"credential_canonical_json,omitempty"`
+	CredentialSecret        []byte                       `protobuf:"bytes,4,opt,name=credential_secret,json=credentialSecret,proto3" json:"credential_secret,omitempty"`
+	CredentialExtras        map[string]string            `protobuf:"bytes,5,rep,name=credential_extras,json=credentialExtras,proto3" json:"credential_extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Method                  string                       `protobuf:"bytes,6,opt,name=method,proto3" json:"method,omitempty"`
+	Url                     string                       `protobuf:"bytes,7,opt,name=url,proto3" json:"url,omitempty"`
+	Host                    string                       `protobuf:"bytes,8,opt,name=host,proto3" json:"host,omitempty"`
+	Headers                 map[string]*HTTPHeaderValues `protobuf:"bytes,9,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *TransformHTTPInit) Reset() {
+	*x = TransformHTTPInit{}
+	mi := &file_plugin_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransformHTTPInit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransformHTTPInit) ProtoMessage() {}
+
+func (x *TransformHTTPInit) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransformHTTPInit.ProtoReflect.Descriptor instead.
+func (*TransformHTTPInit) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *TransformHTTPInit) GetCredentialTypeName() string {
+	if x != nil {
+		return x.CredentialTypeName
+	}
+	return ""
+}
+
+func (x *TransformHTTPInit) GetCredentialInstance() string {
+	if x != nil {
+		return x.CredentialInstance
+	}
+	return ""
+}
+
+func (x *TransformHTTPInit) GetCredentialCanonicalJson() []byte {
+	if x != nil {
+		return x.CredentialCanonicalJson
+	}
+	return nil
+}
+
+func (x *TransformHTTPInit) GetCredentialSecret() []byte {
+	if x != nil {
+		return x.CredentialSecret
+	}
+	return nil
+}
+
+func (x *TransformHTTPInit) GetCredentialExtras() map[string]string {
+	if x != nil {
+		return x.CredentialExtras
+	}
+	return nil
+}
+
+func (x *TransformHTTPInit) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *TransformHTTPInit) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *TransformHTTPInit) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *TransformHTTPInit) GetHeaders() map[string]*HTTPHeaderValues {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+// TransformHTTPDown is plugin -> gateway: exactly one head, then the
+// transformed request body.
+type TransformHTTPDown struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Kind:
+	//
+	//	*TransformHTTPDown_Head
+	//	*TransformHTTPDown_Body
+	Kind          isTransformHTTPDown_Kind `protobuf_oneof:"kind"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransformHTTPDown) Reset() {
+	*x = TransformHTTPDown{}
+	mi := &file_plugin_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransformHTTPDown) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransformHTTPDown) ProtoMessage() {}
+
+func (x *TransformHTTPDown) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransformHTTPDown.ProtoReflect.Descriptor instead.
+func (*TransformHTTPDown) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *TransformHTTPDown) GetKind() isTransformHTTPDown_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return nil
+}
+
+func (x *TransformHTTPDown) GetHead() *TransformHTTPHead {
+	if x != nil {
+		if x, ok := x.Kind.(*TransformHTTPDown_Head); ok {
+			return x.Head
+		}
+	}
+	return nil
+}
+
+func (x *TransformHTTPDown) GetBody() *HTTPBodyChunk {
+	if x != nil {
+		if x, ok := x.Kind.(*TransformHTTPDown_Body); ok {
+			return x.Body
+		}
+	}
+	return nil
+}
+
+type isTransformHTTPDown_Kind interface {
+	isTransformHTTPDown_Kind()
+}
+
+type TransformHTTPDown_Head struct {
+	Head *TransformHTTPHead `protobuf:"bytes,1,opt,name=head,proto3,oneof"`
+}
+
+type TransformHTTPDown_Body struct {
+	Body *HTTPBodyChunk `protobuf:"bytes,2,opt,name=body,proto3,oneof"`
+}
+
+func (*TransformHTTPDown_Head) isTransformHTTPDown_Kind() {}
+
+func (*TransformHTTPDown_Body) isTransformHTTPDown_Kind() {}
+
+type TransformHTTPHead struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// headers / method / url rewrite the request before it is forwarded.
+	Headers []*HeaderMutation `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty"`
+	Method  *string           `protobuf:"bytes,2,opt,name=method,proto3,oneof" json:"method,omitempty"`
+	Url     *string           `protobuf:"bytes,3,opt,name=url,proto3,oneof" json:"url,omitempty"`
+	// redactions: exact derived secret strings to mask from audit samples.
+	Redactions    []string `protobuf:"bytes,4,rep,name=redactions,proto3" json:"redactions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransformHTTPHead) Reset() {
+	*x = TransformHTTPHead{}
+	mi := &file_plugin_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransformHTTPHead) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransformHTTPHead) ProtoMessage() {}
+
+func (x *TransformHTTPHead) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransformHTTPHead.ProtoReflect.Descriptor instead.
+func (*TransformHTTPHead) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *TransformHTTPHead) GetHeaders() []*HeaderMutation {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+func (x *TransformHTTPHead) GetMethod() string {
+	if x != nil && x.Method != nil {
+		return *x.Method
+	}
+	return ""
+}
+
+func (x *TransformHTTPHead) GetUrl() string {
+	if x != nil && x.Url != nil {
+		return *x.Url
+	}
+	return ""
+}
+
+func (x *TransformHTTPHead) GetRedactions() []string {
+	if x != nil {
+		return x.Redactions
+	}
+	return nil
+}
+
 type ConnMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -1926,7 +2360,7 @@ type ConnMessage struct {
 
 func (x *ConnMessage) Reset() {
 	*x = ConnMessage{}
-	mi := &file_plugin_proto_msgTypes[24]
+	mi := &file_plugin_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1938,7 +2372,7 @@ func (x *ConnMessage) String() string {
 func (*ConnMessage) ProtoMessage() {}
 
 func (x *ConnMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[24]
+	mi := &file_plugin_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1951,7 +2385,7 @@ func (x *ConnMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnMessage.ProtoReflect.Descriptor instead.
 func (*ConnMessage) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{24}
+	return file_plugin_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ConnMessage) GetKind() isConnMessage_Kind {
@@ -2194,7 +2628,7 @@ type DialUpstreamRequest struct {
 
 func (x *DialUpstreamRequest) Reset() {
 	*x = DialUpstreamRequest{}
-	mi := &file_plugin_proto_msgTypes[25]
+	mi := &file_plugin_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2206,7 +2640,7 @@ func (x *DialUpstreamRequest) String() string {
 func (*DialUpstreamRequest) ProtoMessage() {}
 
 func (x *DialUpstreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[25]
+	mi := &file_plugin_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2219,7 +2653,7 @@ func (x *DialUpstreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialUpstreamRequest.ProtoReflect.Descriptor instead.
 func (*DialUpstreamRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{25}
+	return file_plugin_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DialUpstreamRequest) GetDialId() string {
@@ -2269,7 +2703,7 @@ type DialUpstreamReply struct {
 
 func (x *DialUpstreamReply) Reset() {
 	*x = DialUpstreamReply{}
-	mi := &file_plugin_proto_msgTypes[26]
+	mi := &file_plugin_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2281,7 +2715,7 @@ func (x *DialUpstreamReply) String() string {
 func (*DialUpstreamReply) ProtoMessage() {}
 
 func (x *DialUpstreamReply) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[26]
+	mi := &file_plugin_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2294,7 +2728,7 @@ func (x *DialUpstreamReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialUpstreamReply.ProtoReflect.Descriptor instead.
 func (*DialUpstreamReply) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{26}
+	return file_plugin_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *DialUpstreamReply) GetDialId() string {
@@ -2321,7 +2755,7 @@ type DialUpstreamData struct {
 
 func (x *DialUpstreamData) Reset() {
 	*x = DialUpstreamData{}
-	mi := &file_plugin_proto_msgTypes[27]
+	mi := &file_plugin_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2333,7 +2767,7 @@ func (x *DialUpstreamData) String() string {
 func (*DialUpstreamData) ProtoMessage() {}
 
 func (x *DialUpstreamData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[27]
+	mi := &file_plugin_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2346,7 +2780,7 @@ func (x *DialUpstreamData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialUpstreamData.ProtoReflect.Descriptor instead.
 func (*DialUpstreamData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{27}
+	return file_plugin_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DialUpstreamData) GetDialId() string {
@@ -2373,7 +2807,7 @@ type DialUpstreamClose struct {
 
 func (x *DialUpstreamClose) Reset() {
 	*x = DialUpstreamClose{}
-	mi := &file_plugin_proto_msgTypes[28]
+	mi := &file_plugin_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2385,7 +2819,7 @@ func (x *DialUpstreamClose) String() string {
 func (*DialUpstreamClose) ProtoMessage() {}
 
 func (x *DialUpstreamClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[28]
+	mi := &file_plugin_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2398,7 +2832,7 @@ func (x *DialUpstreamClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialUpstreamClose.ProtoReflect.Descriptor instead.
 func (*DialUpstreamClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{28}
+	return file_plugin_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DialUpstreamClose) GetDialId() string {
@@ -2427,7 +2861,7 @@ type StreamRead struct {
 
 func (x *StreamRead) Reset() {
 	*x = StreamRead{}
-	mi := &file_plugin_proto_msgTypes[29]
+	mi := &file_plugin_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2439,7 +2873,7 @@ func (x *StreamRead) String() string {
 func (*StreamRead) ProtoMessage() {}
 
 func (x *StreamRead) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[29]
+	mi := &file_plugin_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2452,7 +2886,7 @@ func (x *StreamRead) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamRead.ProtoReflect.Descriptor instead.
 func (*StreamRead) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{29}
+	return file_plugin_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *StreamRead) GetHandle() string {
@@ -2483,7 +2917,7 @@ type StreamChunk struct {
 
 func (x *StreamChunk) Reset() {
 	*x = StreamChunk{}
-	mi := &file_plugin_proto_msgTypes[30]
+	mi := &file_plugin_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2495,7 +2929,7 @@ func (x *StreamChunk) String() string {
 func (*StreamChunk) ProtoMessage() {}
 
 func (x *StreamChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[30]
+	mi := &file_plugin_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2508,7 +2942,7 @@ func (x *StreamChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamChunk.ProtoReflect.Descriptor instead.
 func (*StreamChunk) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{30}
+	return file_plugin_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *StreamChunk) GetHandle() string {
@@ -2544,7 +2978,7 @@ type StreamCancel struct {
 
 func (x *StreamCancel) Reset() {
 	*x = StreamCancel{}
-	mi := &file_plugin_proto_msgTypes[31]
+	mi := &file_plugin_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2556,7 +2990,7 @@ func (x *StreamCancel) String() string {
 func (*StreamCancel) ProtoMessage() {}
 
 func (x *StreamCancel) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[31]
+	mi := &file_plugin_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2569,7 +3003,7 @@ func (x *StreamCancel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamCancel.ProtoReflect.Descriptor instead.
 func (*StreamCancel) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{31}
+	return file_plugin_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *StreamCancel) GetHandle() string {
@@ -2613,7 +3047,7 @@ type EvaluateAction struct {
 
 func (x *EvaluateAction) Reset() {
 	*x = EvaluateAction{}
-	mi := &file_plugin_proto_msgTypes[32]
+	mi := &file_plugin_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2625,7 +3059,7 @@ func (x *EvaluateAction) String() string {
 func (*EvaluateAction) ProtoMessage() {}
 
 func (x *EvaluateAction) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[32]
+	mi := &file_plugin_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2638,7 +3072,7 @@ func (x *EvaluateAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateAction.ProtoReflect.Descriptor instead.
 func (*EvaluateAction) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{32}
+	return file_plugin_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *EvaluateAction) GetCallId() string {
@@ -2688,7 +3122,7 @@ type ActionVerdict struct {
 
 func (x *ActionVerdict) Reset() {
 	*x = ActionVerdict{}
-	mi := &file_plugin_proto_msgTypes[33]
+	mi := &file_plugin_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2700,7 +3134,7 @@ func (x *ActionVerdict) String() string {
 func (*ActionVerdict) ProtoMessage() {}
 
 func (x *ActionVerdict) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[33]
+	mi := &file_plugin_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2713,7 +3147,7 @@ func (x *ActionVerdict) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActionVerdict.ProtoReflect.Descriptor instead.
 func (*ActionVerdict) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{33}
+	return file_plugin_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ActionVerdict) GetCallId() string {
@@ -2781,7 +3215,7 @@ type ConnInit struct {
 
 func (x *ConnInit) Reset() {
 	*x = ConnInit{}
-	mi := &file_plugin_proto_msgTypes[34]
+	mi := &file_plugin_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2793,7 +3227,7 @@ func (x *ConnInit) String() string {
 func (*ConnInit) ProtoMessage() {}
 
 func (x *ConnInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[34]
+	mi := &file_plugin_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2806,7 +3240,7 @@ func (x *ConnInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnInit.ProtoReflect.Descriptor instead.
 func (*ConnInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{34}
+	return file_plugin_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ConnInit) GetEndpointTypeName() string {
@@ -2923,7 +3357,7 @@ type ConnData struct {
 
 func (x *ConnData) Reset() {
 	*x = ConnData{}
-	mi := &file_plugin_proto_msgTypes[35]
+	mi := &file_plugin_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2935,7 +3369,7 @@ func (x *ConnData) String() string {
 func (*ConnData) ProtoMessage() {}
 
 func (x *ConnData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[35]
+	mi := &file_plugin_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2948,7 +3382,7 @@ func (x *ConnData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnData.ProtoReflect.Descriptor instead.
 func (*ConnData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{35}
+	return file_plugin_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ConnData) GetPayload() []byte {
@@ -2968,7 +3402,7 @@ type ConnClose struct {
 
 func (x *ConnClose) Reset() {
 	*x = ConnClose{}
-	mi := &file_plugin_proto_msgTypes[36]
+	mi := &file_plugin_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2980,7 +3414,7 @@ func (x *ConnClose) String() string {
 func (*ConnClose) ProtoMessage() {}
 
 func (x *ConnClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[36]
+	mi := &file_plugin_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2993,7 +3427,7 @@ func (x *ConnClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnClose.ProtoReflect.Descriptor instead.
 func (*ConnClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{36}
+	return file_plugin_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ConnClose) GetReason() string {
@@ -3024,7 +3458,7 @@ type ConnEvent struct {
 
 func (x *ConnEvent) Reset() {
 	*x = ConnEvent{}
-	mi := &file_plugin_proto_msgTypes[37]
+	mi := &file_plugin_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3036,7 +3470,7 @@ func (x *ConnEvent) String() string {
 func (*ConnEvent) ProtoMessage() {}
 
 func (x *ConnEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[37]
+	mi := &file_plugin_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3049,7 +3483,7 @@ func (x *ConnEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnEvent.ProtoReflect.Descriptor instead.
 func (*ConnEvent) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{37}
+	return file_plugin_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ConnEvent) GetAction() string {
@@ -3115,7 +3549,7 @@ type OpenTunnelRequest struct {
 
 func (x *OpenTunnelRequest) Reset() {
 	*x = OpenTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[38]
+	mi := &file_plugin_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3127,7 +3561,7 @@ func (x *OpenTunnelRequest) String() string {
 func (*OpenTunnelRequest) ProtoMessage() {}
 
 func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[38]
+	mi := &file_plugin_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3140,7 +3574,7 @@ func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelRequest.ProtoReflect.Descriptor instead.
 func (*OpenTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{38}
+	return file_plugin_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *OpenTunnelRequest) GetTunnelTypeName() string {
@@ -3187,7 +3621,7 @@ type OpenTunnelResponse struct {
 
 func (x *OpenTunnelResponse) Reset() {
 	*x = OpenTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[39]
+	mi := &file_plugin_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3199,7 +3633,7 @@ func (x *OpenTunnelResponse) String() string {
 func (*OpenTunnelResponse) ProtoMessage() {}
 
 func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[39]
+	mi := &file_plugin_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3212,7 +3646,7 @@ func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelResponse.ProtoReflect.Descriptor instead.
 func (*OpenTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{39}
+	return file_plugin_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *OpenTunnelResponse) GetHandle() string {
@@ -3231,7 +3665,7 @@ type CloseTunnelRequest struct {
 
 func (x *CloseTunnelRequest) Reset() {
 	*x = CloseTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[40]
+	mi := &file_plugin_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3243,7 +3677,7 @@ func (x *CloseTunnelRequest) String() string {
 func (*CloseTunnelRequest) ProtoMessage() {}
 
 func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[40]
+	mi := &file_plugin_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3256,7 +3690,7 @@ func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelRequest.ProtoReflect.Descriptor instead.
 func (*CloseTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{40}
+	return file_plugin_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *CloseTunnelRequest) GetHandle() string {
@@ -3274,7 +3708,7 @@ type CloseTunnelResponse struct {
 
 func (x *CloseTunnelResponse) Reset() {
 	*x = CloseTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[41]
+	mi := &file_plugin_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3286,7 +3720,7 @@ func (x *CloseTunnelResponse) String() string {
 func (*CloseTunnelResponse) ProtoMessage() {}
 
 func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[41]
+	mi := &file_plugin_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3299,7 +3733,7 @@ func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelResponse.ProtoReflect.Descriptor instead.
 func (*CloseTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{41}
+	return file_plugin_proto_rawDescGZIP(), []int{46}
 }
 
 type DialMessage struct {
@@ -3316,7 +3750,7 @@ type DialMessage struct {
 
 func (x *DialMessage) Reset() {
 	*x = DialMessage{}
-	mi := &file_plugin_proto_msgTypes[42]
+	mi := &file_plugin_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3328,7 +3762,7 @@ func (x *DialMessage) String() string {
 func (*DialMessage) ProtoMessage() {}
 
 func (x *DialMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[42]
+	mi := &file_plugin_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3341,7 +3775,7 @@ func (x *DialMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialMessage.ProtoReflect.Descriptor instead.
 func (*DialMessage) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{42}
+	return file_plugin_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *DialMessage) GetKind() isDialMessage_Kind {
@@ -3411,7 +3845,7 @@ type DialInit struct {
 
 func (x *DialInit) Reset() {
 	*x = DialInit{}
-	mi := &file_plugin_proto_msgTypes[43]
+	mi := &file_plugin_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3423,7 +3857,7 @@ func (x *DialInit) String() string {
 func (*DialInit) ProtoMessage() {}
 
 func (x *DialInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[43]
+	mi := &file_plugin_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3436,7 +3870,7 @@ func (x *DialInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialInit.ProtoReflect.Descriptor instead.
 func (*DialInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{43}
+	return file_plugin_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *DialInit) GetTunnelHandle() string {
@@ -3469,7 +3903,7 @@ type DialData struct {
 
 func (x *DialData) Reset() {
 	*x = DialData{}
-	mi := &file_plugin_proto_msgTypes[44]
+	mi := &file_plugin_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3481,7 +3915,7 @@ func (x *DialData) String() string {
 func (*DialData) ProtoMessage() {}
 
 func (x *DialData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[44]
+	mi := &file_plugin_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3494,7 +3928,7 @@ func (x *DialData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialData.ProtoReflect.Descriptor instead.
 func (*DialData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{44}
+	return file_plugin_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *DialData) GetPayload() []byte {
@@ -3513,7 +3947,7 @@ type DialClose struct {
 
 func (x *DialClose) Reset() {
 	*x = DialClose{}
-	mi := &file_plugin_proto_msgTypes[45]
+	mi := &file_plugin_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3525,7 +3959,7 @@ func (x *DialClose) String() string {
 func (*DialClose) ProtoMessage() {}
 
 func (x *DialClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[45]
+	mi := &file_plugin_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3538,7 +3972,7 @@ func (x *DialClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialClose.ProtoReflect.Descriptor instead.
 func (*DialClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{45}
+	return file_plugin_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *DialClose) GetReason() string {
@@ -3557,7 +3991,7 @@ type StateGetRequest struct {
 
 func (x *StateGetRequest) Reset() {
 	*x = StateGetRequest{}
-	mi := &file_plugin_proto_msgTypes[46]
+	mi := &file_plugin_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3569,7 +4003,7 @@ func (x *StateGetRequest) String() string {
 func (*StateGetRequest) ProtoMessage() {}
 
 func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[46]
+	mi := &file_plugin_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3582,7 +4016,7 @@ func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateGetRequest.ProtoReflect.Descriptor instead.
 func (*StateGetRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{46}
+	return file_plugin_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *StateGetRequest) GetKey() string {
@@ -3602,7 +4036,7 @@ type StateGetResponse struct {
 
 func (x *StateGetResponse) Reset() {
 	*x = StateGetResponse{}
-	mi := &file_plugin_proto_msgTypes[47]
+	mi := &file_plugin_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3614,7 +4048,7 @@ func (x *StateGetResponse) String() string {
 func (*StateGetResponse) ProtoMessage() {}
 
 func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[47]
+	mi := &file_plugin_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3627,7 +4061,7 @@ func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateGetResponse.ProtoReflect.Descriptor instead.
 func (*StateGetResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{47}
+	return file_plugin_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *StateGetResponse) GetValue() []byte {
@@ -3654,7 +4088,7 @@ type StatePutRequest struct {
 
 func (x *StatePutRequest) Reset() {
 	*x = StatePutRequest{}
-	mi := &file_plugin_proto_msgTypes[48]
+	mi := &file_plugin_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3666,7 +4100,7 @@ func (x *StatePutRequest) String() string {
 func (*StatePutRequest) ProtoMessage() {}
 
 func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[48]
+	mi := &file_plugin_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3679,7 +4113,7 @@ func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatePutRequest.ProtoReflect.Descriptor instead.
 func (*StatePutRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{48}
+	return file_plugin_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *StatePutRequest) GetKey() string {
@@ -3704,7 +4138,7 @@ type StatePutResponse struct {
 
 func (x *StatePutResponse) Reset() {
 	*x = StatePutResponse{}
-	mi := &file_plugin_proto_msgTypes[49]
+	mi := &file_plugin_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3716,7 +4150,7 @@ func (x *StatePutResponse) String() string {
 func (*StatePutResponse) ProtoMessage() {}
 
 func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[49]
+	mi := &file_plugin_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3729,7 +4163,7 @@ func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatePutResponse.ProtoReflect.Descriptor instead.
 func (*StatePutResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{49}
+	return file_plugin_proto_rawDescGZIP(), []int{54}
 }
 
 var File_plugin_proto protoreflect.FileDescriptor
@@ -3797,20 +4231,22 @@ const file_plugin_proto_rawDesc = "" +
 	"\x06prefix\x18\x03 \x01(\tR\x06prefix\x12\x12\n" +
 	"\x04flow\x18\x04 \x01(\tR\x04flow\x12;\n" +
 	"\x05oauth\x18\x05 \x01(\v2%.clawpatrol.plugin.v1.OAuthConfigDeclR\x05oauth\x12U\n" +
-	"\x0foptional_scopes\x18\x06 \x03(\v2,.clawpatrol.plugin.v1.OptionalScopeGroupDeclR\x0eoptionalScopes\"\xa5\x02\n" +
+	"\x0foptional_scopes\x18\x06 \x03(\v2,.clawpatrol.plugin.v1.OptionalScopeGroupDeclR\x0eoptionalScopes\"\xcc\x02\n" +
 	"\x12CredentialMetadata\x12&\n" +
 	"\x0edisambiguators\x18\x01 \x03(\tR\x0edisambiguators\x12G\n" +
 	"\fsecret_slots\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.SecretSlotDeclR\vsecretSlots\x12;\n" +
 	"\benv_vars\x18\x03 \x03(\v2 .clawpatrol.plugin.v1.EnvVarDeclR\aenvVars\x12@\n" +
 	"\x05oauth\x18\x04 \x01(\v2*.clawpatrol.plugin.v1.OAuthIntegrationDeclR\x05oauth\x12\x1f\n" +
 	"\vhttp_inject\x18\x05 \x01(\bR\n" +
-	"httpInject\"\xac\x01\n" +
+	"httpInject\x12%\n" +
+	"\x0ehttp_transform\x18\x06 \x01(\bR\rhttpTransform\"\xd3\x01\n" +
 	"\x0eCredentialDecl\x12\x1b\n" +
 	"\ttype_name\x18\x01 \x01(\tR\btypeName\x124\n" +
 	"\x06schema\x18\x02 \x01(\v2\x1c.clawpatrol.plugin.v1.SchemaR\x06schema\x12&\n" +
 	"\x0edisambiguators\x18\x03 \x03(\tR\x0edisambiguators\x12\x1f\n" +
 	"\vhttp_inject\x18\x04 \x01(\bR\n" +
-	"httpInject\"_\n" +
+	"httpInject\x12%\n" +
+	"\x0ehttp_transform\x18\x05 \x01(\bR\rhttpTransform\"_\n" +
 	"\n" +
 	"TunnelDecl\x12\x1b\n" +
 	"\ttype_name\x18\x01 \x01(\tR\btypeName\x124\n" +
@@ -3873,7 +4309,47 @@ const file_plugin_proto_rawDesc = "" +
 	"\aheaders\x18\x01 \x03(\v2$.clawpatrol.plugin.v1.HeaderMutationR\aheaders\x12\x1e\n" +
 	"\n" +
 	"redactions\x18\x02 \x03(\tR\n" +
-	"redactions\"\xfb\x06\n" +
+	"redactions\"\xe9\x01\n" +
+	"\rHTTPBodyChunk\x12\x12\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\x12\x10\n" +
+	"\x03eof\x18\x02 \x01(\bR\x03eof\x12M\n" +
+	"\btrailers\x18\x03 \x03(\v21.clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntryR\btrailers\x1ac\n" +
+	"\rTrailersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
+	"\x05value\x18\x02 \x01(\v2&.clawpatrol.plugin.v1.HTTPHeaderValuesR\x05value:\x028\x01\"\x93\x01\n" +
+	"\x0fTransformHTTPUp\x12=\n" +
+	"\x04init\x18\x01 \x01(\v2'.clawpatrol.plugin.v1.TransformHTTPInitH\x00R\x04init\x129\n" +
+	"\x04body\x18\x02 \x01(\v2#.clawpatrol.plugin.v1.HTTPBodyChunkH\x00R\x04bodyB\x06\n" +
+	"\x04kind\"\x82\x05\n" +
+	"\x11TransformHTTPInit\x120\n" +
+	"\x14credential_type_name\x18\x01 \x01(\tR\x12credentialTypeName\x12/\n" +
+	"\x13credential_instance\x18\x02 \x01(\tR\x12credentialInstance\x12:\n" +
+	"\x19credential_canonical_json\x18\x03 \x01(\fR\x17credentialCanonicalJson\x12+\n" +
+	"\x11credential_secret\x18\x04 \x01(\fR\x10credentialSecret\x12j\n" +
+	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntryR\x10credentialExtras\x12\x16\n" +
+	"\x06method\x18\x06 \x01(\tR\x06method\x12\x10\n" +
+	"\x03url\x18\a \x01(\tR\x03url\x12\x12\n" +
+	"\x04host\x18\b \x01(\tR\x04host\x12N\n" +
+	"\aheaders\x18\t \x03(\v24.clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntryR\aheaders\x1aC\n" +
+	"\x15CredentialExtrasEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1ab\n" +
+	"\fHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
+	"\x05value\x18\x02 \x01(\v2&.clawpatrol.plugin.v1.HTTPHeaderValuesR\x05value:\x028\x01\"\x95\x01\n" +
+	"\x11TransformHTTPDown\x12=\n" +
+	"\x04head\x18\x01 \x01(\v2'.clawpatrol.plugin.v1.TransformHTTPHeadH\x00R\x04head\x129\n" +
+	"\x04body\x18\x02 \x01(\v2#.clawpatrol.plugin.v1.HTTPBodyChunkH\x00R\x04bodyB\x06\n" +
+	"\x04kind\"\xba\x01\n" +
+	"\x11TransformHTTPHead\x12>\n" +
+	"\aheaders\x18\x01 \x03(\v2$.clawpatrol.plugin.v1.HeaderMutationR\aheaders\x12\x1b\n" +
+	"\x06method\x18\x02 \x01(\tH\x00R\x06method\x88\x01\x01\x12\x15\n" +
+	"\x03url\x18\x03 \x01(\tH\x01R\x03url\x88\x01\x01\x12\x1e\n" +
+	"\n" +
+	"redactions\x18\x04 \x03(\tR\n" +
+	"redactionsB\t\n" +
+	"\a_methodB\x06\n" +
+	"\x04_url\"\xfb\x06\n" +
 	"\vConnMessage\x124\n" +
 	"\x04init\x18\x01 \x01(\v2\x1e.clawpatrol.plugin.v1.ConnInitH\x00R\x04init\x124\n" +
 	"\x04data\x18\x02 \x01(\v2\x1e.clawpatrol.plugin.v1.ConnDataH\x00R\x04data\x127\n" +
@@ -4018,11 +4494,12 @@ const file_plugin_proto_rawDesc = "" +
 	"\rTLS_TERMINATE\x10\x012\xb5\x01\n" +
 	"\x06Plugin\x12Y\n" +
 	"\bManifest\x12%.clawpatrol.plugin.v1.ManifestRequest\x1a&.clawpatrol.plugin.v1.ManifestResponse\x12P\n" +
-	"\x05Build\x12\".clawpatrol.plugin.v1.BuildRequest\x1a#.clawpatrol.plugin.v1.BuildResponse2m\n" +
+	"\x05Build\x12\".clawpatrol.plugin.v1.BuildRequest\x1a#.clawpatrol.plugin.v1.BuildResponse2\xd2\x01\n" +
 	"\n" +
 	"Credential\x12_\n" +
 	"\n" +
-	"InjectHTTP\x12'.clawpatrol.plugin.v1.InjectHTTPRequest\x1a(.clawpatrol.plugin.v1.InjectHTTPResponse2b\n" +
+	"InjectHTTP\x12'.clawpatrol.plugin.v1.InjectHTTPRequest\x1a(.clawpatrol.plugin.v1.InjectHTTPResponse\x12c\n" +
+	"\rTransformHTTP\x12%.clawpatrol.plugin.v1.TransformHTTPUp\x1a'.clawpatrol.plugin.v1.TransformHTTPDown(\x010\x012b\n" +
 	"\bEndpoint\x12V\n" +
 	"\n" +
 	"HandleConn\x12!.clawpatrol.plugin.v1.ConnMessage\x1a!.clawpatrol.plugin.v1.ConnMessage(\x010\x012\x9f\x02\n" +
@@ -4048,7 +4525,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
 var file_plugin_proto_goTypes = []any{
 	(NetworkAccess)(0),             // 0: clawpatrol.plugin.v1.NetworkAccess
 	(FacetKind)(0),                 // 1: clawpatrol.plugin.v1.FacetKind
@@ -4079,37 +4556,45 @@ var file_plugin_proto_goTypes = []any{
 	(*InjectHTTPRequest)(nil),      // 26: clawpatrol.plugin.v1.InjectHTTPRequest
 	(*HeaderMutation)(nil),         // 27: clawpatrol.plugin.v1.HeaderMutation
 	(*InjectHTTPResponse)(nil),     // 28: clawpatrol.plugin.v1.InjectHTTPResponse
-	(*ConnMessage)(nil),            // 29: clawpatrol.plugin.v1.ConnMessage
-	(*DialUpstreamRequest)(nil),    // 30: clawpatrol.plugin.v1.DialUpstreamRequest
-	(*DialUpstreamReply)(nil),      // 31: clawpatrol.plugin.v1.DialUpstreamReply
-	(*DialUpstreamData)(nil),       // 32: clawpatrol.plugin.v1.DialUpstreamData
-	(*DialUpstreamClose)(nil),      // 33: clawpatrol.plugin.v1.DialUpstreamClose
-	(*StreamRead)(nil),             // 34: clawpatrol.plugin.v1.StreamRead
-	(*StreamChunk)(nil),            // 35: clawpatrol.plugin.v1.StreamChunk
-	(*StreamCancel)(nil),           // 36: clawpatrol.plugin.v1.StreamCancel
-	(*EvaluateAction)(nil),         // 37: clawpatrol.plugin.v1.EvaluateAction
-	(*ActionVerdict)(nil),          // 38: clawpatrol.plugin.v1.ActionVerdict
-	(*ConnInit)(nil),               // 39: clawpatrol.plugin.v1.ConnInit
-	(*ConnData)(nil),               // 40: clawpatrol.plugin.v1.ConnData
-	(*ConnClose)(nil),              // 41: clawpatrol.plugin.v1.ConnClose
-	(*ConnEvent)(nil),              // 42: clawpatrol.plugin.v1.ConnEvent
-	(*OpenTunnelRequest)(nil),      // 43: clawpatrol.plugin.v1.OpenTunnelRequest
-	(*OpenTunnelResponse)(nil),     // 44: clawpatrol.plugin.v1.OpenTunnelResponse
-	(*CloseTunnelRequest)(nil),     // 45: clawpatrol.plugin.v1.CloseTunnelRequest
-	(*CloseTunnelResponse)(nil),    // 46: clawpatrol.plugin.v1.CloseTunnelResponse
-	(*DialMessage)(nil),            // 47: clawpatrol.plugin.v1.DialMessage
-	(*DialInit)(nil),               // 48: clawpatrol.plugin.v1.DialInit
-	(*DialData)(nil),               // 49: clawpatrol.plugin.v1.DialData
-	(*DialClose)(nil),              // 50: clawpatrol.plugin.v1.DialClose
-	(*StateGetRequest)(nil),        // 51: clawpatrol.plugin.v1.StateGetRequest
-	(*StateGetResponse)(nil),       // 52: clawpatrol.plugin.v1.StateGetResponse
-	(*StatePutRequest)(nil),        // 53: clawpatrol.plugin.v1.StatePutRequest
-	(*StatePutResponse)(nil),       // 54: clawpatrol.plugin.v1.StatePutResponse
-	nil,                            // 55: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	nil,                            // 56: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	nil,                            // 57: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                            // 58: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                            // 59: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(*HTTPBodyChunk)(nil),          // 29: clawpatrol.plugin.v1.HTTPBodyChunk
+	(*TransformHTTPUp)(nil),        // 30: clawpatrol.plugin.v1.TransformHTTPUp
+	(*TransformHTTPInit)(nil),      // 31: clawpatrol.plugin.v1.TransformHTTPInit
+	(*TransformHTTPDown)(nil),      // 32: clawpatrol.plugin.v1.TransformHTTPDown
+	(*TransformHTTPHead)(nil),      // 33: clawpatrol.plugin.v1.TransformHTTPHead
+	(*ConnMessage)(nil),            // 34: clawpatrol.plugin.v1.ConnMessage
+	(*DialUpstreamRequest)(nil),    // 35: clawpatrol.plugin.v1.DialUpstreamRequest
+	(*DialUpstreamReply)(nil),      // 36: clawpatrol.plugin.v1.DialUpstreamReply
+	(*DialUpstreamData)(nil),       // 37: clawpatrol.plugin.v1.DialUpstreamData
+	(*DialUpstreamClose)(nil),      // 38: clawpatrol.plugin.v1.DialUpstreamClose
+	(*StreamRead)(nil),             // 39: clawpatrol.plugin.v1.StreamRead
+	(*StreamChunk)(nil),            // 40: clawpatrol.plugin.v1.StreamChunk
+	(*StreamCancel)(nil),           // 41: clawpatrol.plugin.v1.StreamCancel
+	(*EvaluateAction)(nil),         // 42: clawpatrol.plugin.v1.EvaluateAction
+	(*ActionVerdict)(nil),          // 43: clawpatrol.plugin.v1.ActionVerdict
+	(*ConnInit)(nil),               // 44: clawpatrol.plugin.v1.ConnInit
+	(*ConnData)(nil),               // 45: clawpatrol.plugin.v1.ConnData
+	(*ConnClose)(nil),              // 46: clawpatrol.plugin.v1.ConnClose
+	(*ConnEvent)(nil),              // 47: clawpatrol.plugin.v1.ConnEvent
+	(*OpenTunnelRequest)(nil),      // 48: clawpatrol.plugin.v1.OpenTunnelRequest
+	(*OpenTunnelResponse)(nil),     // 49: clawpatrol.plugin.v1.OpenTunnelResponse
+	(*CloseTunnelRequest)(nil),     // 50: clawpatrol.plugin.v1.CloseTunnelRequest
+	(*CloseTunnelResponse)(nil),    // 51: clawpatrol.plugin.v1.CloseTunnelResponse
+	(*DialMessage)(nil),            // 52: clawpatrol.plugin.v1.DialMessage
+	(*DialInit)(nil),               // 53: clawpatrol.plugin.v1.DialInit
+	(*DialData)(nil),               // 54: clawpatrol.plugin.v1.DialData
+	(*DialClose)(nil),              // 55: clawpatrol.plugin.v1.DialClose
+	(*StateGetRequest)(nil),        // 56: clawpatrol.plugin.v1.StateGetRequest
+	(*StateGetResponse)(nil),       // 57: clawpatrol.plugin.v1.StateGetResponse
+	(*StatePutRequest)(nil),        // 58: clawpatrol.plugin.v1.StatePutRequest
+	(*StatePutResponse)(nil),       // 59: clawpatrol.plugin.v1.StatePutResponse
+	nil,                            // 60: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 61: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 62: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	nil,                            // 63: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	nil,                            // 64: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	nil,                            // 65: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 66: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 67: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
 	19, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
@@ -4134,53 +4619,65 @@ var file_plugin_proto_depIdxs = []int32{
 	24, // 19: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
 	18, // 20: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
 	3,  // 21: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	55, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	56, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	60, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	61, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
 	4,  // 24: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
 	27, // 25: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
-	39, // 26: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
-	40, // 27: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
-	41, // 28: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
-	42, // 29: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
-	37, // 30: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
-	38, // 31: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
-	34, // 32: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
-	35, // 33: clawpatrol.plugin.v1.ConnMessage.stream_chunk:type_name -> clawpatrol.plugin.v1.StreamChunk
-	36, // 34: clawpatrol.plugin.v1.ConnMessage.stream_cancel:type_name -> clawpatrol.plugin.v1.StreamCancel
-	30, // 35: clawpatrol.plugin.v1.ConnMessage.dial_request:type_name -> clawpatrol.plugin.v1.DialUpstreamRequest
-	31, // 36: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
-	32, // 37: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
-	33, // 38: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
-	57, // 39: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	58, // 40: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	59, // 41: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
-	48, // 42: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
-	49, // 43: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
-	50, // 44: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
-	25, // 45: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	5,  // 46: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
-	22, // 47: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
-	26, // 48: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
-	29, // 49: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
-	43, // 50: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
-	47, // 51: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
-	45, // 52: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
-	51, // 53: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
-	53, // 54: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
-	6,  // 55: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 56: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 57: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	29, // 58: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	44, // 59: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	47, // 60: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	46, // 61: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	52, // 62: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	54, // 63: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	55, // [55:64] is the sub-list for method output_type
-	46, // [46:55] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	62, // 26: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	31, // 27: clawpatrol.plugin.v1.TransformHTTPUp.init:type_name -> clawpatrol.plugin.v1.TransformHTTPInit
+	29, // 28: clawpatrol.plugin.v1.TransformHTTPUp.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
+	63, // 29: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	64, // 30: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	33, // 31: clawpatrol.plugin.v1.TransformHTTPDown.head:type_name -> clawpatrol.plugin.v1.TransformHTTPHead
+	29, // 32: clawpatrol.plugin.v1.TransformHTTPDown.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
+	27, // 33: clawpatrol.plugin.v1.TransformHTTPHead.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
+	44, // 34: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
+	45, // 35: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
+	46, // 36: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
+	47, // 37: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
+	42, // 38: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
+	43, // 39: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
+	39, // 40: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
+	40, // 41: clawpatrol.plugin.v1.ConnMessage.stream_chunk:type_name -> clawpatrol.plugin.v1.StreamChunk
+	41, // 42: clawpatrol.plugin.v1.ConnMessage.stream_cancel:type_name -> clawpatrol.plugin.v1.StreamCancel
+	35, // 43: clawpatrol.plugin.v1.ConnMessage.dial_request:type_name -> clawpatrol.plugin.v1.DialUpstreamRequest
+	36, // 44: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
+	37, // 45: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
+	38, // 46: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
+	65, // 47: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	66, // 48: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	67, // 49: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	53, // 50: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
+	54, // 51: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
+	55, // 52: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
+	25, // 53: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	25, // 54: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	25, // 55: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	5,  // 56: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
+	22, // 57: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
+	26, // 58: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
+	30, // 59: clawpatrol.plugin.v1.Credential.TransformHTTP:input_type -> clawpatrol.plugin.v1.TransformHTTPUp
+	34, // 60: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
+	48, // 61: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
+	52, // 62: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
+	50, // 63: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
+	56, // 64: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
+	58, // 65: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
+	6,  // 66: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 67: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 68: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 69: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 70: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	49, // 71: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	52, // 72: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	51, // 73: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	57, // 74: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	59, // 75: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	66, // [66:76] is the sub-list for method output_type
+	56, // [56:66] is the sub-list for method input_type
+	56, // [56:56] is the sub-list for extension type_name
+	56, // [56:56] is the sub-list for extension extendee
+	0,  // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -4188,7 +4685,16 @@ func file_plugin_proto_init() {
 	if File_plugin_proto != nil {
 		return
 	}
-	file_plugin_proto_msgTypes[24].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[25].OneofWrappers = []any{
+		(*TransformHTTPUp_Init)(nil),
+		(*TransformHTTPUp_Body)(nil),
+	}
+	file_plugin_proto_msgTypes[27].OneofWrappers = []any{
+		(*TransformHTTPDown_Head)(nil),
+		(*TransformHTTPDown_Body)(nil),
+	}
+	file_plugin_proto_msgTypes[28].OneofWrappers = []any{}
+	file_plugin_proto_msgTypes[29].OneofWrappers = []any{
 		(*ConnMessage_Init)(nil),
 		(*ConnMessage_Data)(nil),
 		(*ConnMessage_Close)(nil),
@@ -4203,7 +4709,7 @@ func file_plugin_proto_init() {
 		(*ConnMessage_DialData)(nil),
 		(*ConnMessage_DialClose)(nil),
 	}
-	file_plugin_proto_msgTypes[42].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[47].OneofWrappers = []any{
 		(*DialMessage_Init)(nil),
 		(*DialMessage_Data)(nil),
 		(*DialMessage_Close)(nil),
@@ -4214,7 +4720,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   55,
+			NumMessages:   63,
 			NumExtensions: 0,
 			NumServices:   5,
 		},

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -172,6 +172,10 @@ message CredentialMetadata {
   repeated EnvVarDecl env_vars = 3;
   OAuthIntegrationDecl oauth = 4;
   bool http_inject = 5;
+  // http_transform: the credential rewrites the request method / URL /
+  // body via the streaming TransformHTTP RPC, not just headers. Implies
+  // http_inject.
+  bool http_transform = 6;
 }
 
 message CredentialDecl {
@@ -184,6 +188,11 @@ message CredentialDecl {
   // disambiguators are authoritative for validation.
   repeated string disambiguators = 3;
   bool http_inject = 4;
+  // http_transform: the credential rewrites the request method / URL /
+  // body via the streaming TransformHTTP RPC. Implies http_inject. Used
+  // by credentials that sign over the body (AWS SigV4) or carry the
+  // secret in the URL/body (telegram, discord).
+  bool http_transform = 5;
 }
 
 message TunnelDecl {
@@ -250,7 +259,24 @@ message Diagnostic {
 service Credential {
   // InjectHTTP lets an external credential type participate in the
   // built-in HTTPS endpoint's request-time credential injection path.
+  // Header-only: the request body never flows through the plugin.
   rpc InjectHTTP(InjectHTTPRequest) returns (InjectHTTPResponse);
+
+  // TransformHTTP is the streaming superset for credentials that declared
+  // http_transform: ones that rewrite the request method / URL / body,
+  // not just headers (AWS SigV4 over the body, telegram/discord secrets
+  // carried in the URL or body).
+  //
+  // The gateway sends a TransformHTTPInit, then streams the request body
+  // as HTTPBodyChunk frames (ending eof=true). The plugin reads as much
+  // as it needs — buffering is the plugin's choice — then sends exactly
+  // one TransformHTTPHead (header / method / URL mutations) followed by
+  // the transformed body as HTTPBodyChunk frames. The gateway applies the
+  // head before forwarding upstream (a body-derived header like a SigV4
+  // signature is finalized first), then pipes the plugin's body chunks on
+  // to the upstream. A plugin that doesn't touch the body just copies the
+  // input chunks straight to its output (no buffering).
+  rpc TransformHTTP(stream TransformHTTPUp) returns (stream TransformHTTPDown);
 }
 
 message HTTPHeaderValues {
@@ -294,6 +320,56 @@ message InjectHTTPResponse {
   // short-lived bearer token, that should be redacted from logs if
   // encountered.
   repeated string redactions = 2;
+}
+
+// HTTPBodyChunk carries one slice of a request body in either direction
+// of TransformHTTP. eof marks the final frame (it may carry data too).
+message HTTPBodyChunk {
+  bytes data = 1;
+  bool eof = 2;
+  // trailers ride on the eof frame: the HTTP trailers that follow the
+  // body (e.g. gRPC's grpc-status / grpc-message). They are conveyed so
+  // the transform never drops them — empty leaves the request's original
+  // trailers in place.
+  map<string, HTTPHeaderValues> trailers = 3;
+}
+
+// TransformHTTPUp is gateway -> plugin: the init, then the request body.
+message TransformHTTPUp {
+  oneof kind {
+    TransformHTTPInit init = 1;
+    HTTPBodyChunk body = 2;
+  }
+}
+
+message TransformHTTPInit {
+  string credential_type_name = 1;
+  string credential_instance = 2;
+  bytes credential_canonical_json = 3;
+  bytes credential_secret = 4;
+  map<string, string> credential_extras = 5;
+  string method = 6;
+  string url = 7;
+  string host = 8;
+  map<string, HTTPHeaderValues> headers = 9;
+}
+
+// TransformHTTPDown is plugin -> gateway: exactly one head, then the
+// transformed request body.
+message TransformHTTPDown {
+  oneof kind {
+    TransformHTTPHead head = 1;
+    HTTPBodyChunk body = 2;
+  }
+}
+
+message TransformHTTPHead {
+  // headers / method / url rewrite the request before it is forwarded.
+  repeated HeaderMutation headers = 1;
+  optional string method = 2;
+  optional string url = 3;
+  // redactions: exact derived secret strings to mask from audit samples.
+  repeated string redactions = 4;
 }
 
 // =====================================================================

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -190,7 +190,8 @@ var Plugin_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	Credential_InjectHTTP_FullMethodName = "/clawpatrol.plugin.v1.Credential/InjectHTTP"
+	Credential_InjectHTTP_FullMethodName    = "/clawpatrol.plugin.v1.Credential/InjectHTTP"
+	Credential_TransformHTTP_FullMethodName = "/clawpatrol.plugin.v1.Credential/TransformHTTP"
 )
 
 // CredentialClient is the client API for Credential service.
@@ -199,7 +200,23 @@ const (
 type CredentialClient interface {
 	// InjectHTTP lets an external credential type participate in the
 	// built-in HTTPS endpoint's request-time credential injection path.
+	// Header-only: the request body never flows through the plugin.
 	InjectHTTP(ctx context.Context, in *InjectHTTPRequest, opts ...grpc.CallOption) (*InjectHTTPResponse, error)
+	// TransformHTTP is the streaming superset for credentials that declared
+	// http_transform: ones that rewrite the request method / URL / body,
+	// not just headers (AWS SigV4 over the body, telegram/discord secrets
+	// carried in the URL or body).
+	//
+	// The gateway sends a TransformHTTPInit, then streams the request body
+	// as HTTPBodyChunk frames (ending eof=true). The plugin reads as much
+	// as it needs — buffering is the plugin's choice — then sends exactly
+	// one TransformHTTPHead (header / method / URL mutations) followed by
+	// the transformed body as HTTPBodyChunk frames. The gateway applies the
+	// head before forwarding upstream (a body-derived header like a SigV4
+	// signature is finalized first), then pipes the plugin's body chunks on
+	// to the upstream. A plugin that doesn't touch the body just copies the
+	// input chunks straight to its output (no buffering).
+	TransformHTTP(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TransformHTTPUp, TransformHTTPDown], error)
 }
 
 type credentialClient struct {
@@ -220,13 +237,42 @@ func (c *credentialClient) InjectHTTP(ctx context.Context, in *InjectHTTPRequest
 	return out, nil
 }
 
+func (c *credentialClient) TransformHTTP(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TransformHTTPUp, TransformHTTPDown], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Credential_ServiceDesc.Streams[0], Credential_TransformHTTP_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[TransformHTTPUp, TransformHTTPDown]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Credential_TransformHTTPClient = grpc.BidiStreamingClient[TransformHTTPUp, TransformHTTPDown]
+
 // CredentialServer is the server API for Credential service.
 // All implementations must embed UnimplementedCredentialServer
 // for forward compatibility.
 type CredentialServer interface {
 	// InjectHTTP lets an external credential type participate in the
 	// built-in HTTPS endpoint's request-time credential injection path.
+	// Header-only: the request body never flows through the plugin.
 	InjectHTTP(context.Context, *InjectHTTPRequest) (*InjectHTTPResponse, error)
+	// TransformHTTP is the streaming superset for credentials that declared
+	// http_transform: ones that rewrite the request method / URL / body,
+	// not just headers (AWS SigV4 over the body, telegram/discord secrets
+	// carried in the URL or body).
+	//
+	// The gateway sends a TransformHTTPInit, then streams the request body
+	// as HTTPBodyChunk frames (ending eof=true). The plugin reads as much
+	// as it needs — buffering is the plugin's choice — then sends exactly
+	// one TransformHTTPHead (header / method / URL mutations) followed by
+	// the transformed body as HTTPBodyChunk frames. The gateway applies the
+	// head before forwarding upstream (a body-derived header like a SigV4
+	// signature is finalized first), then pipes the plugin's body chunks on
+	// to the upstream. A plugin that doesn't touch the body just copies the
+	// input chunks straight to its output (no buffering).
+	TransformHTTP(grpc.BidiStreamingServer[TransformHTTPUp, TransformHTTPDown]) error
 	mustEmbedUnimplementedCredentialServer()
 }
 
@@ -239,6 +285,9 @@ type UnimplementedCredentialServer struct{}
 
 func (UnimplementedCredentialServer) InjectHTTP(context.Context, *InjectHTTPRequest) (*InjectHTTPResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InjectHTTP not implemented")
+}
+func (UnimplementedCredentialServer) TransformHTTP(grpc.BidiStreamingServer[TransformHTTPUp, TransformHTTPDown]) error {
+	return status.Error(codes.Unimplemented, "method TransformHTTP not implemented")
 }
 func (UnimplementedCredentialServer) mustEmbedUnimplementedCredentialServer() {}
 func (UnimplementedCredentialServer) testEmbeddedByValue()                    {}
@@ -279,6 +328,13 @@ func _Credential_InjectHTTP_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Credential_TransformHTTP_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(CredentialServer).TransformHTTP(&grpc.GenericServerStream[TransformHTTPUp, TransformHTTPDown]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Credential_TransformHTTPServer = grpc.BidiStreamingServer[TransformHTTPUp, TransformHTTPDown]
+
 // Credential_ServiceDesc is the grpc.ServiceDesc for Credential service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -291,7 +347,14 @@ var Credential_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Credential_InjectHTTP_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "TransformHTTP",
+			Handler:       _Credential_TransformHTTP_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "plugin.proto",
 }
 

--- a/internal/config/extplugin/register.go
+++ b/internal/config/extplugin/register.go
@@ -151,8 +151,11 @@ func registerCredential(client *Client, pluginName string, decl *pb.CredentialDe
 				if d := validateBuildDisambiguators(pluginName, decl.TypeName, decl.Disambiguators, resp.CredentialMetadata.Disambiguators); d.HasErrors() {
 					return nil, d
 				}
-				if resp.CredentialMetadata.HttpInject && !decl.HttpInject {
+				if resp.CredentialMetadata.HttpInject && !decl.HttpInject && !decl.HttpTransform {
 					return nil, fail("plugin %q credential %q: build metadata declared HTTP injection but manifest did not", pluginName, decl.TypeName)
+				}
+				if resp.CredentialMetadata.HttpTransform && !decl.HttpTransform {
+					return nil, fail("plugin %q credential %q: build metadata declared HTTP transform but manifest did not", pluginName, decl.TypeName)
 				}
 				instanceMeta := credentialMetadataFromProto(resp.CredentialMetadata)
 				if d := validateCredentialMetadataShape(pluginName, decl.TypeName, instanceMeta); d.HasErrors() {
@@ -177,7 +180,8 @@ func credentialMetadataFromDecl(decl *pb.CredentialDecl) credentialMetadata {
 	}
 	return credentialMetadata{
 		disambiguators: append([]string(nil), decl.Disambiguators...),
-		httpInject:     decl.HttpInject,
+		httpInject:     decl.HttpInject || decl.HttpTransform,
+		httpTransform:  decl.HttpTransform,
 	}
 }
 
@@ -187,7 +191,8 @@ func credentialMetadataFromProto(in *pb.CredentialMetadata) credentialMetadata {
 	}
 	out := credentialMetadata{
 		disambiguators: append([]string(nil), in.Disambiguators...),
-		httpInject:     in.HttpInject,
+		httpInject:     in.HttpInject || in.HttpTransform,
+		httpTransform:  in.HttpTransform,
 	}
 	for _, s := range in.SecretSlots {
 		if s == nil {
@@ -268,10 +273,11 @@ func mergeCredentialMetadata(base, instance credentialMetadata) credentialMetada
 	// OAuth is intentionally instance-scoped Build metadata: region, scopes,
 	// URLs, and flow can differ across two HCL blocks of the same type.
 	out.oauth = instance.oauth
-	// HTTP injection is a registration-time capability. Build metadata
-	// can restate it but cannot enable it for a type whose manifest did
-	// not declare it.
+	// HTTP injection / transform are registration-time capabilities. Build
+	// metadata can restate them but cannot enable them for a type whose
+	// manifest did not declare them.
 	out.httpInject = base.httpInject
+	out.httpTransform = base.httpTransform
 	return out
 }
 

--- a/internal/config/extplugin/transform.go
+++ b/internal/config/extplugin/transform.go
@@ -1,0 +1,147 @@
+package extplugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// transformHTTPWithExternalCredential runs the streaming credential
+// transform for an http_transform credential. It streams the request body
+// to the plugin, applies the returned head (header / method / URL
+// mutations) before the request is forwarded, and replaces the request
+// body with the plugin's transformed stream.
+//
+// Trailers: the request's trailers (e.g. gRPC's) are conveyed to the
+// plugin for inspection and pass through to the upstream unchanged
+// (req.Trailer is left in place). Plugin-rewritten request trailers are a
+// follow-up — rewriting them safely across the body swap is non-trivial
+// (Go populates req.Trailer from the original body read).
+func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) error {
+	if body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
+		return fmt.Errorf("extplugin: credential %q TransformHTTP unavailable: plugin client is not connected", body.instanceName)
+	}
+	stream, err := body.adapter.client.credential.TransformHTTP(ctx)
+	if err != nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP: %w", body.adapter.typeName, body.instanceName, err)
+	}
+
+	if err := stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Init{Init: &pb.TransformHTTPInit{
+		CredentialTypeName:      body.adapter.typeName,
+		CredentialInstance:      body.instanceName,
+		CredentialCanonicalJson: body.canonicalJSON,
+		CredentialSecret:        sec.Bytes,
+		CredentialExtras:        sec.Extras,
+		Method:                  req.Method,
+		Url:                     req.URL.String(),
+		Host:                    req.Host,
+		Headers:                 headersToProto(req.Header),
+	}}}); err != nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP send init: %w", body.adapter.typeName, body.instanceName, err)
+	}
+
+	// Up-pump: stream the request body to the plugin, then an eof frame
+	// carrying the request trailers (populated once the body is fully
+	// read). req.Trailer is read here, by this goroutine, right after the
+	// body EOFs — and otherwise only by the forwarder after the swapped
+	// body EOFs (which is strictly later), so no concurrent access.
+	origBody := req.Body
+	go func() {
+		if origBody != nil {
+			buf := make([]byte, brokeredDialChunk)
+			for {
+				n, rerr := origBody.Read(buf)
+				if n > 0 {
+					if serr := stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Body{
+						Body: &pb.HTTPBodyChunk{Data: append([]byte(nil), buf[:n]...)},
+					}}); serr != nil {
+						return
+					}
+				}
+				if rerr != nil {
+					break
+				}
+			}
+			_ = origBody.Close()
+		}
+		eof := &pb.HTTPBodyChunk{Eof: true}
+		if len(req.Trailer) > 0 {
+			eof.Trailers = headersToProto(req.Trailer)
+		}
+		_ = stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Body{Body: eof}})
+	}()
+
+	// Receive the head — it must arrive before we forward, since a
+	// body-derived header (a SigV4 signature) is finalized here.
+	first, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP recv head: %w", body.adapter.typeName, body.instanceName, err)
+	}
+	headMsg, ok := first.GetKind().(*pb.TransformHTTPDown_Head)
+	if !ok || headMsg.Head == nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP: first reply must be the head", body.adapter.typeName, body.instanceName)
+	}
+	head := headMsg.Head
+	applyHeaderMutations(req.Header, head.Headers)
+	if m := head.GetMethod(); m != "" {
+		req.Method = m
+	}
+	if u := head.GetUrl(); u != "" {
+		parsed, perr := url.Parse(u)
+		if perr != nil {
+			return fmt.Errorf("extplugin: credential %s.%s returned invalid url %q: %w", body.adapter.typeName, body.instanceName, u, perr)
+		}
+		req.URL = parsed
+	}
+	body.recordHTTPRedactions(req, head.Redactions)
+	syncTransformContentLength(req)
+
+	// Down-pump: feed the plugin's transformed body chunks into a pipe
+	// that becomes the new req.Body. Trailers on the plugin's eof frame
+	// are accepted but not applied to req in v1 (see the doc comment).
+	pr, pw := io.Pipe()
+	req.Body = pr
+	go func() {
+		for {
+			msg, rerr := stream.Recv()
+			if rerr != nil {
+				_ = pw.CloseWithError(rerr)
+				return
+			}
+			b, ok := msg.GetKind().(*pb.TransformHTTPDown_Body)
+			if !ok || b.Body == nil {
+				continue
+			}
+			if len(b.Body.Data) > 0 {
+				if _, werr := pw.Write(b.Body.Data); werr != nil {
+					return
+				}
+			}
+			if b.Body.Eof {
+				_ = pw.Close()
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// syncTransformContentLength sets req.ContentLength from a Content-Length
+// header the transform credential supplied (it knows the new body length),
+// or marks the length unknown so the forwarder uses chunked transfer.
+func syncTransformContentLength(req *http.Request) {
+	if cl := req.Header.Get("Content-Length"); cl != "" {
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil && n >= 0 {
+			req.ContentLength = n
+			return
+		}
+	}
+	req.ContentLength = -1
+	req.Header.Del("Content-Length")
+}

--- a/internal/config/extplugin/transform.go
+++ b/internal/config/extplugin/transform.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
@@ -18,21 +19,37 @@ import (
 // mutations) before the request is forwarded, and replaces the request
 // body with the plugin's transformed stream.
 //
+// On any error it returns without leaving a usable request: the body has
+// been streamed to the plugin (consumed), so the caller must fail closed
+// rather than forward a half-transformed request — see
+// dynamicCredentialBody.RewritesHTTPRequest and the gateway call site.
+//
 // Trailers: the request's trailers (e.g. gRPC's) are conveyed to the
 // plugin for inspection and pass through to the upstream unchanged
-// (req.Trailer is left in place). Plugin-rewritten request trailers are a
-// follow-up — rewriting them safely across the body swap is non-trivial
-// (Go populates req.Trailer from the original body read).
-func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) error {
+// (req.Trailer is left in place).
+func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCredentialBody, req *http.Request, sec runtime.Secret) (err error) {
 	if body.adapter == nil || body.adapter.client == nil || body.adapter.client.credential == nil {
 		return fmt.Errorf("extplugin: credential %q TransformHTTP unavailable: plugin client is not connected", body.instanceName)
 	}
-	stream, err := body.adapter.client.credential.TransformHTTP(ctx)
-	if err != nil {
-		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP: %w", body.adapter.typeName, body.instanceName, err)
-	}
 
-	if err := stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Init{Init: &pb.TransformHTTPInit{
+	// The stream runs under a cancelable context. On any error return we
+	// cancel — tearing down the gRPC stream and the up-pump goroutine. On
+	// success the down-pump goroutine owns the context and cancels once the
+	// transformed body is fully delivered (or the stream errors), which
+	// also stops the up-pump. Without this a stuck plugin would leak both
+	// goroutines and the stream (the request context is never canceled).
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
+	stream, serr := body.adapter.client.credential.TransformHTTP(streamCtx)
+	if serr != nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP: %w", body.adapter.typeName, body.instanceName, serr)
+	}
+	if serr := stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Init{Init: &pb.TransformHTTPInit{
 		CredentialTypeName:      body.adapter.typeName,
 		CredentialInstance:      body.instanceName,
 		CredentialCanonicalJson: body.canonicalJSON,
@@ -42,17 +59,22 @@ func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCrede
 		Url:                     req.URL.String(),
 		Host:                    req.Host,
 		Headers:                 headersToProto(req.Header),
-	}}}); err != nil {
-		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP send init: %w", body.adapter.typeName, body.instanceName, err)
+	}}}); serr != nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP send init: %w", body.adapter.typeName, body.instanceName, serr)
 	}
 
 	// Up-pump: stream the request body to the plugin, then an eof frame
 	// carrying the request trailers (populated once the body is fully
-	// read). req.Trailer is read here, by this goroutine, right after the
-	// body EOFs — and otherwise only by the forwarder after the swapped
-	// body EOFs (which is strictly later), so no concurrent access.
+	// read). Closes the original body and half-closes the send direction
+	// when done; exits if the stream is canceled mid-send.
 	origBody := req.Body
 	go func() {
+		defer func() {
+			if origBody != nil {
+				_ = origBody.Close()
+			}
+			_ = stream.CloseSend()
+		}()
 		if origBody != nil {
 			buf := make([]byte, brokeredDialChunk)
 			for {
@@ -68,7 +90,6 @@ func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCrede
 					break
 				}
 			}
-			_ = origBody.Close()
 		}
 		eof := &pb.HTTPBodyChunk{Eof: true}
 		if len(req.Trailer) > 0 {
@@ -77,11 +98,15 @@ func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCrede
 		_ = stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Body{Body: eof}})
 	}()
 
-	// Receive the head — it must arrive before we forward, since a
-	// body-derived header (a SigV4 signature) is finalized here.
-	first, err := stream.Recv()
-	if err != nil {
-		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP recv head: %w", body.adapter.typeName, body.instanceName, err)
+	// The head must arrive before we forward — a body-derived header (a
+	// SigV4 signature) is finalized here. Bound the wait: a buggy plugin
+	// that never sends the head must not hang the request. The timer fires
+	// cancel(), which unblocks the Recv with a context error.
+	headTimer := time.AfterFunc(injectHTTPTimeout, cancel)
+	first, rerr := stream.Recv()
+	headTimer.Stop()
+	if rerr != nil {
+		return fmt.Errorf("extplugin: credential %s.%s TransformHTTP recv head: %w", body.adapter.typeName, body.instanceName, rerr)
 	}
 	headMsg, ok := first.GetKind().(*pb.TransformHTTPDown_Head)
 	if !ok || headMsg.Head == nil {
@@ -102,16 +127,20 @@ func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCrede
 	body.recordHTTPRedactions(req, head.Redactions)
 	syncTransformContentLength(req)
 
-	// Down-pump: feed the plugin's transformed body chunks into a pipe
-	// that becomes the new req.Body. Trailers on the plugin's eof frame
-	// are accepted but not applied to req in v1 (see the doc comment).
+	// Down-pump owns the stream now: feed the plugin's transformed body
+	// chunks into the pipe that becomes the new req.Body, and cancel() when
+	// done (eof, stream error, or the forwarder closing pr) so the up-pump
+	// and stream are torn down. Trailers on the plugin's eof frame are
+	// accepted but not applied to req in v1 (request trailers pass through
+	// unchanged); see the doc comment.
 	pr, pw := io.Pipe()
 	req.Body = pr
 	go func() {
+		defer cancel()
 		for {
-			msg, rerr := stream.Recv()
-			if rerr != nil {
-				_ = pw.CloseWithError(rerr)
+			msg, mrerr := stream.Recv()
+			if mrerr != nil {
+				_ = pw.CloseWithError(mrerr)
 				return
 			}
 			b, ok := msg.GetKind().(*pb.TransformHTTPDown_Body)
@@ -134,7 +163,9 @@ func transformHTTPWithExternalCredential(ctx context.Context, body *dynamicCrede
 
 // syncTransformContentLength sets req.ContentLength from a Content-Length
 // header the transform credential supplied (it knows the new body length),
-// or marks the length unknown so the forwarder uses chunked transfer.
+// or marks the length unknown so the forwarder uses chunked transfer. A
+// credential that changes the body length but leaves a stale Content-Length
+// would corrupt the upstream write — it must update or drop the header.
 func syncTransformContentLength(req *http.Request) {
 	if cl := req.Header.Get("Content-Length"); cl != "" {
 		if n, err := strconv.ParseInt(cl, 10, 64); err == nil && n >= 0 {

--- a/internal/config/extplugin/transform_test.go
+++ b/internal/config/extplugin/transform_test.go
@@ -3,6 +3,7 @@ package extplugin
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -149,6 +150,51 @@ func TestTransformHTTPPassThrough(t *testing.T) {
 	got, _ := io.ReadAll(req.Body)
 	if string(got) != "the body streams through" {
 		t.Fatalf("body = %q, want unchanged", got)
+	}
+}
+
+// errBeforeHeadServer reads the init then closes the stream with an error
+// without ever sending a head — modeling a buggy plugin.
+type errBeforeHeadServer struct {
+	pb.UnimplementedCredentialServer
+}
+
+func (errBeforeHeadServer) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
+	_, _ = stream.Recv()
+	return fmt.Errorf("plugin boom")
+}
+
+// TestTransformHTTPErrorFailsClosed confirms a plugin error surfaces as an
+// error from the transform call (so the gateway fails closed) rather than
+// hanging or silently forwarding.
+func TestTransformHTTPErrorFailsClosed(t *testing.T) {
+	cli := transformTestClient(t, errBeforeHeadServer{})
+	body := &dynamicCredentialBody{
+		adapter:      &credentialAdapter{client: &Client{credential: cli}, typeName: "x"},
+		instanceName: "i",
+		metadata:     credentialMetadata{httpTransform: true},
+	}
+	u, _ := url.Parse("https://api.example.com/x")
+	req := &http.Request{
+		Method: "POST", URL: u, Host: "api.example.com", Header: http.Header{},
+		Body: io.NopCloser(strings.NewReader("data")),
+	}
+	err := transformHTTPWithExternalCredential(context.Background(), body, req, runtime.Secret{})
+	if err == nil {
+		t.Fatal("expected an error so the caller fails closed")
+	}
+}
+
+// TestRewritesHTTPRequestMarker confirms only transform credentials report
+// as request rewriters (the gateway uses this to fail closed on error).
+func TestRewritesHTTPRequestMarker(t *testing.T) {
+	transform := &dynamicCredentialBody{metadata: credentialMetadata{httpTransform: true}}
+	headerOnly := &dynamicCredentialBody{metadata: credentialMetadata{httpInject: true}}
+	if !transform.RewritesHTTPRequest() {
+		t.Fatal("transform credential should report RewritesHTTPRequest")
+	}
+	if headerOnly.RewritesHTTPRequest() {
+		t.Fatal("header-only credential must not report RewritesHTTPRequest")
 	}
 }
 

--- a/internal/config/extplugin/transform_test.go
+++ b/internal/config/extplugin/transform_test.go
@@ -1,0 +1,190 @@
+package extplugin
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// testTransformServer is a minimal streaming credential server: it reads
+// the whole request body (like a body-signing credential), adds a header,
+// and returns the body uppercased — exercising both header mutation and a
+// full body rewrite over the real TransformHTTP stream.
+type testTransformServer struct {
+	pb.UnimplementedCredentialServer
+	gotSecret []byte
+	gotMethod string
+}
+
+func (s *testTransformServer) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	init := first.GetInit()
+	s.gotSecret = init.GetCredentialSecret()
+	s.gotMethod = init.GetMethod()
+
+	var body bytes.Buffer
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		b := msg.GetBody()
+		if b == nil {
+			continue
+		}
+		body.Write(b.GetData())
+		if b.GetEof() {
+			break
+		}
+	}
+
+	if err := stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Head{Head: &pb.TransformHTTPHead{
+		Headers:    []*pb.HeaderMutation{{Op: pb.HeaderMutation_SET, Name: "X-Signed", Values: []string{"yes"}}},
+		Redactions: []string{"sig-abc"},
+	}}}); err != nil {
+		return err
+	}
+	out := bytes.ToUpper(body.Bytes())
+	return stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Body{
+		Body: &pb.HTTPBodyChunk{Data: out, Eof: true},
+	}})
+}
+
+func transformTestClient(t *testing.T, srv pb.CredentialServer) pb.CredentialClient {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	pb.RegisterCredentialServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return pb.NewCredentialClient(conn)
+}
+
+func TestTransformHTTPRoundTrip(t *testing.T) {
+	srv := &testTransformServer{}
+	cli := transformTestClient(t, srv)
+
+	body := &dynamicCredentialBody{
+		adapter:      &credentialAdapter{client: &Client{credential: cli}, typeName: "signer"},
+		instanceName: "inst",
+		metadata:     credentialMetadata{httpTransform: true},
+	}
+	u, _ := url.Parse("https://api.example.com/things")
+	req := &http.Request{
+		Method: "POST",
+		URL:    u,
+		Host:   "api.example.com",
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("hello world")),
+	}
+
+	if err := transformHTTPWithExternalCredential(context.Background(), body, req, runtime.Secret{Bytes: []byte("topsecret")}); err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+
+	// Header mutation applied before forwarding.
+	if got := req.Header.Get("X-Signed"); got != "yes" {
+		t.Fatalf("X-Signed = %q, want yes", got)
+	}
+	// The plugin saw the init (secret + method).
+	if string(srv.gotSecret) != "topsecret" || srv.gotMethod != "POST" {
+		t.Fatalf("server saw secret=%q method=%q", srv.gotSecret, srv.gotMethod)
+	}
+	// The forwarded body is the plugin's transformed stream.
+	got, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read transformed body: %v", err)
+	}
+	if string(got) != "HELLO WORLD" {
+		t.Fatalf("transformed body = %q, want HELLO WORLD", got)
+	}
+	// Redaction recorded for audit masking.
+	if r := consumeHTTPRedactions(body, req); len(r) != 1 || r[0] != "sig-abc" {
+		t.Fatalf("redactions = %v, want [sig-abc]", r)
+	}
+}
+
+// TestTransformHTTPPassThrough checks a credential that only rewrites the
+// URL and streams the body through unchanged (no buffering of the body on
+// the plugin side beyond a copy).
+func TestTransformHTTPPassThrough(t *testing.T) {
+	cli := transformTestClient(t, &passthroughURLServer{})
+	body := &dynamicCredentialBody{
+		adapter:      &credentialAdapter{client: &Client{credential: cli}, typeName: "urlcred"},
+		instanceName: "inst",
+		metadata:     credentialMetadata{httpTransform: true},
+	}
+	u, _ := url.Parse("https://api.example.com/bot-PLACEHOLDER/send")
+	req := &http.Request{
+		Method: "POST", URL: u, Host: "api.example.com", Header: http.Header{},
+		Body: io.NopCloser(strings.NewReader("the body streams through")),
+	}
+	if err := transformHTTPWithExternalCredential(context.Background(), body, req, runtime.Secret{Bytes: []byte("tok")}); err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	if req.URL.Path != "/bot-tok/send" {
+		t.Fatalf("url path = %q, want /bot-tok/send", req.URL.Path)
+	}
+	got, _ := io.ReadAll(req.Body)
+	if string(got) != "the body streams through" {
+		t.Fatalf("body = %q, want unchanged", got)
+	}
+}
+
+// passthroughURLServer rewrites the URL (swapping a placeholder for the
+// secret) and echoes body chunks straight back as it receives them.
+type passthroughURLServer struct {
+	pb.UnimplementedCredentialServer
+}
+
+func (passthroughURLServer) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	init := first.GetInit()
+	newURL := strings.ReplaceAll(init.GetUrl(), "PLACEHOLDER", string(init.GetCredentialSecret()))
+	if err := stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Head{Head: &pb.TransformHTTPHead{
+		Url: &newURL,
+	}}}); err != nil {
+		return err
+	}
+	// Echo body chunks straight through.
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		b := msg.GetBody()
+		if b == nil {
+			continue
+		}
+		if err := stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Body{Body: b}}); err != nil {
+			return err
+		}
+		if b.GetEof() {
+			return nil
+		}
+	}
+}

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -46,6 +46,18 @@ type HTTPCredentialRedactionProvider interface {
 	ConsumeHTTPRedactions(req *http.Request) []string
 }
 
+// HTTPRequestRewriter is an optional marker on an HTTPCredentialRuntime
+// whose InjectHTTP may rewrite the request beyond headers — its URL or
+// body — and, in doing so, consume the request body. When such an
+// injector's InjectHTTP returns an error the request is left unusable
+// (the body was streamed away), so the gateway MUST fail closed rather
+// than forward it. Header-only injectors do not implement this; their
+// failed injection leaves the request untouched and forwarding the
+// agent's placeholder is safe.
+type HTTPRequestRewriter interface {
+	RewritesHTTPRequest() bool
+}
+
 // HTTPRequestSigner is the credential-plugin contract for HTTP auth
 // shapes whose signature spans the *whole request* (method, URL,
 // headers, body) and need parameters that live on the endpoint, not

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -339,12 +339,6 @@ type HTTPTransformRequest struct {
 	// (the gateway streams the whole body); reading a prefix and returning
 	// a Body that copies the rest through is also fine.
 	Body io.Reader
-
-	// Trailers are the HTTP trailers that follow the body (e.g. gRPC
-	// request trailers). HTTP semantics: they are only fully populated
-	// once Body has been read to EOF. Most credentials can ignore them;
-	// they are preserved across the transform by default.
-	Trailers http.Header
 }
 
 // HTTPTransformResponse is what a TransformHTTP callback returns.
@@ -363,12 +357,11 @@ type HTTPTransformResponse struct {
 	// Body is the outgoing request body the gateway forwards upstream. To
 	// pass the input through unchanged, set Body = req.Body. To replace it,
 	// return any io.Reader (e.g. bytes.NewReader). nil sends an empty body.
+	//
+	// HTTP trailers that follow the request body (e.g. gRPC's) are
+	// preserved by the gateway across the transform; the plugin does not
+	// handle them.
 	Body io.Reader
-
-	// Trailers are HTTP trailers to send after the body. Leave nil to pass
-	// the request's original trailers (req.Trailers) through unchanged —
-	// the common case, and what preserves gRPC trailers.
-	Trailers http.Header
 }
 
 // TunnelDef declares one tunnel type. Open returns an opaque handle

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -213,6 +213,9 @@ type CredentialMetadata struct {
 	EnvVars        []EnvVar
 	OAuth          *OAuthIntegration
 	HTTPInject     bool
+	// HTTPTransform mirrors CredentialDef.HTTPTransform (the credential
+	// rewrites method/URL/body via TransformHTTP). Registration-time only.
+	HTTPTransform bool
 }
 
 // CredentialBuildResult lets a Build callback return both canonical
@@ -299,8 +302,73 @@ type CredentialDef struct {
 	Build func(req BuildRequest) (any, error)
 
 	// InjectHTTP is called for credentials bound to a built-in HTTPS
-	// endpoint when HTTPInject is true.
+	// endpoint when HTTPInject is true. Header-only: the request body does
+	// not flow through the plugin.
 	InjectHTTP func(ctx context.Context, req HTTPInjectRequest) (*HTTPInjectResponse, error)
+
+	// HTTPTransform declares that this credential rewrites more than
+	// headers — the request method / URL / body — via TransformHTTP.
+	// Implies HTTPInject. Use for credentials that sign over the body (AWS
+	// SigV4) or carry the secret in the URL/body (telegram, discord).
+	HTTPTransform bool
+
+	// TransformHTTP is called for HTTPTransform credentials. It receives
+	// the request body as a stream (req.Body) and returns the mutations
+	// plus the transformed body. Buffering is the plugin's choice: read
+	// only what you need and stream the rest, or read it all to sign. See
+	// HTTPTransformRequest / HTTPTransformResponse.
+	TransformHTTP func(ctx context.Context, req HTTPTransformRequest) (*HTTPTransformResponse, error)
+}
+
+// HTTPTransformRequest is delivered to a credential's TransformHTTP
+// callback before the built-in HTTPS endpoint forwards a request upstream.
+type HTTPTransformRequest struct {
+	CredentialTypeName        string
+	CredentialInstance        string
+	CredentialCanonicalConfig []byte
+	CredentialSecret          []byte
+	CredentialExtras          map[string]string
+
+	Method  string
+	URL     string
+	Host    string
+	Headers http.Header
+
+	// Body is the request body, streamed from the gateway. Read as much
+	// as you need — the plugin controls buffering. Reading to EOF is fine
+	// (the gateway streams the whole body); reading a prefix and returning
+	// a Body that copies the rest through is also fine.
+	Body io.Reader
+
+	// Trailers are the HTTP trailers that follow the body (e.g. gRPC
+	// request trailers). HTTP semantics: they are only fully populated
+	// once Body has been read to EOF. Most credentials can ignore them;
+	// they are preserved across the transform by default.
+	Trailers http.Header
+}
+
+// HTTPTransformResponse is what a TransformHTTP callback returns.
+type HTTPTransformResponse struct {
+	// Headers / Method / URL rewrite the request line and headers; applied
+	// by the gateway before the request is forwarded. A credential that
+	// signs over the body sets the signature header here (and a
+	// Content-Length header if it changed the body length).
+	Headers []HeaderMutation
+	Method  string
+	URL     string
+	// Redactions are exact derived secret strings to mask from audit
+	// samples (a computed signature, an exchanged token).
+	Redactions []string
+
+	// Body is the outgoing request body the gateway forwards upstream. To
+	// pass the input through unchanged, set Body = req.Body. To replace it,
+	// return any io.Reader (e.g. bytes.NewReader). nil sends an empty body.
+	Body io.Reader
+
+	// Trailers are HTTP trailers to send after the body. Leave nil to pass
+	// the request's original trailers (req.Trailers) through unchanged —
+	// the common case, and what preserves gRPC trailers.
+	Trailers http.Header
 }
 
 // TunnelDef declares one tunnel type. Open returns an opaque handle

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -152,7 +152,8 @@ func (s *server) Manifest(_ context.Context, _ *pb.ManifestRequest) (*pb.Manifes
 			TypeName:       c.TypeName,
 			Schema:         schemaToProto(c.Schema),
 			Disambiguators: append([]string(nil), c.Disambiguators...),
-			HttpInject:     c.HTTPInject,
+			HttpInject:     c.HTTPInject || c.HTTPTransform,
+			HttpTransform:  c.HTTPTransform,
 		})
 	}
 	for _, t := range s.plug.Tunnels {
@@ -304,7 +305,8 @@ func invokeBuild(kind, typeName, instanceName string, fn func(BuildRequest) (any
 func credentialMetadataToProto(m CredentialMetadata) *pb.CredentialMetadata {
 	out := &pb.CredentialMetadata{
 		Disambiguators: append([]string(nil), m.Disambiguators...),
-		HttpInject:     m.HTTPInject,
+		HttpInject:     m.HTTPInject || m.HTTPTransform,
+		HttpTransform:  m.HTTPTransform,
 	}
 	for _, s := range m.SecretSlots {
 		out.SecretSlots = append(out.SecretSlots, &pb.SecretSlotDecl{

--- a/pluginsdk/transform.go
+++ b/pluginsdk/transform.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 )
@@ -38,12 +37,9 @@ func (s *server) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
 	}
 
 	// A goroutine receives the request body chunks into a pipe the plugin
-	// reads as req.Body. Request trailers arrive on the eof frame; they
-	// are filled into reqTrailers before the pipe is closed, so a plugin
-	// that reads them after Body hits EOF sees them (the pipe's close /
-	// read ordering provides the happens-before).
+	// reads as req.Body. Trailers on the eof frame (e.g. gRPC's) are
+	// preserved by the gateway, not surfaced to the plugin.
 	pr, pw := io.Pipe()
-	reqTrailers := http.Header{}
 	go func() {
 		for {
 			msg, rerr := stream.Recv()
@@ -61,7 +57,6 @@ func (s *server) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
 				}
 			}
 			if b.Body.Eof {
-				copyHeader(reqTrailers, headersFromProto(b.Body.Trailers))
 				_ = pw.Close()
 				return
 			}
@@ -79,7 +74,6 @@ func (s *server) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
 		Host:                      in.Host,
 		Headers:                   headersFromProto(in.Headers),
 		Body:                      pr,
-		Trailers:                  reqTrailers,
 	}
 
 	resp, err := invokeTransformHTTP(ctx, in.CredentialTypeName, in.CredentialInstance, def.TransformHTTP, req)
@@ -127,20 +121,7 @@ func (s *server) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
 			return fmt.Errorf("pluginsdk TransformHTTP: read transformed body: %w", rerr)
 		}
 	}
-
-	// Outgoing trailers: the plugin's explicit set, else the request's
-	// trailers passed through. reqTrailers is safe to read here — the body
-	// loop above drained the input pipe to EOF, which is ordered after the
-	// recv goroutine filled the trailers and closed the pipe.
-	outT := resp.Trailers
-	if outT == nil {
-		outT = reqTrailers
-	}
-	eof := &pb.HTTPBodyChunk{Eof: true}
-	if len(outT) > 0 {
-		eof.Trailers = headersToProtoMap(outT)
-	}
-	return stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Body{Body: eof}})
+	return stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Body{Body: &pb.HTTPBodyChunk{Eof: true}}})
 }
 
 func invokeTransformHTTP(ctx context.Context, typeName, instanceName string, fn func(context.Context, HTTPTransformRequest) (*HTTPTransformResponse, error), req HTTPTransformRequest) (out *HTTPTransformResponse, err error) {
@@ -150,24 +131,6 @@ func invokeTransformHTTP(ctx context.Context, typeName, instanceName string, fn 
 		}
 	}()
 	return fn(ctx, req)
-}
-
-// copyHeader merges src into dst in place.
-func copyHeader(dst, src http.Header) {
-	for k, vs := range src {
-		dst[k] = append([]string(nil), vs...)
-	}
-}
-
-func headersToProtoMap(in http.Header) map[string]*pb.HTTPHeaderValues {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string]*pb.HTTPHeaderValues, len(in))
-	for k, vs := range in {
-		out[k] = &pb.HTTPHeaderValues{Values: append([]string(nil), vs...)}
-	}
-	return out
 }
 
 func headerMutationsToProto(in []HeaderMutation) []*pb.HeaderMutation {

--- a/pluginsdk/transform.go
+++ b/pluginsdk/transform.go
@@ -1,0 +1,193 @@
+package pluginsdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+// TransformHTTP serves the streaming credential-transform RPC for
+// HTTPTransform credentials. The gateway sends an init then streams the
+// request body; the plugin's callback receives the body as an io.Reader,
+// returns the head mutations plus the outgoing body, and the SDK streams
+// that back. See the proto for the framing and CredentialDef.TransformHTTP
+// for the plugin contract.
+func (s *server) TransformHTTP(stream pb.Credential_TransformHTTPServer) error {
+	ctx := stream.Context()
+
+	first, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("pluginsdk TransformHTTP: recv init: %w", err)
+	}
+	initMsg, ok := first.GetKind().(*pb.TransformHTTPUp_Init)
+	if !ok || initMsg.Init == nil {
+		return errors.New("pluginsdk TransformHTTP: first message must be init")
+	}
+	in := initMsg.Init
+	def, ok := s.credentials[in.CredentialTypeName]
+	if !ok {
+		return fmt.Errorf("%w: credential %q", ErrNoSuchType, in.CredentialTypeName)
+	}
+	if def.TransformHTTP == nil {
+		return fmt.Errorf("pluginsdk: credential %q has no TransformHTTP callback", in.CredentialTypeName)
+	}
+
+	// A goroutine receives the request body chunks into a pipe the plugin
+	// reads as req.Body. Request trailers arrive on the eof frame; they
+	// are filled into reqTrailers before the pipe is closed, so a plugin
+	// that reads them after Body hits EOF sees them (the pipe's close /
+	// read ordering provides the happens-before).
+	pr, pw := io.Pipe()
+	reqTrailers := http.Header{}
+	go func() {
+		for {
+			msg, rerr := stream.Recv()
+			if rerr != nil {
+				_ = pw.CloseWithError(rerr)
+				return
+			}
+			b, ok := msg.GetKind().(*pb.TransformHTTPUp_Body)
+			if !ok || b.Body == nil {
+				continue
+			}
+			if len(b.Body.Data) > 0 {
+				if _, werr := pw.Write(b.Body.Data); werr != nil {
+					return
+				}
+			}
+			if b.Body.Eof {
+				copyHeader(reqTrailers, headersFromProto(b.Body.Trailers))
+				_ = pw.Close()
+				return
+			}
+		}
+	}()
+
+	req := HTTPTransformRequest{
+		CredentialTypeName:        in.CredentialTypeName,
+		CredentialInstance:        in.CredentialInstance,
+		CredentialCanonicalConfig: in.CredentialCanonicalJson,
+		CredentialSecret:          in.CredentialSecret,
+		CredentialExtras:          in.CredentialExtras,
+		Method:                    in.Method,
+		URL:                       in.Url,
+		Host:                      in.Host,
+		Headers:                   headersFromProto(in.Headers),
+		Body:                      pr,
+		Trailers:                  reqTrailers,
+	}
+
+	resp, err := invokeTransformHTTP(ctx, in.CredentialTypeName, in.CredentialInstance, def.TransformHTTP, req)
+	if err != nil {
+		_ = pr.CloseWithError(err) // unblock the recv goroutine's pipe writes
+		return err
+	}
+	if resp == nil {
+		resp = &HTTPTransformResponse{}
+	}
+
+	head := &pb.TransformHTTPHead{
+		Headers:    headerMutationsToProto(resp.Headers),
+		Redactions: append([]string(nil), resp.Redactions...),
+	}
+	if resp.Method != "" {
+		head.Method = &resp.Method
+	}
+	if resp.URL != "" {
+		head.Url = &resp.URL
+	}
+	if err := stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Head{Head: head}}); err != nil {
+		return err
+	}
+
+	// Stream the outgoing body.
+	out := resp.Body
+	if out == nil {
+		out = bytes.NewReader(nil)
+	}
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := out.Read(buf)
+		if n > 0 {
+			if serr := stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Body{
+				Body: &pb.HTTPBodyChunk{Data: append([]byte(nil), buf[:n]...)},
+			}}); serr != nil {
+				return serr
+			}
+		}
+		if errors.Is(rerr, io.EOF) {
+			break
+		}
+		if rerr != nil {
+			return fmt.Errorf("pluginsdk TransformHTTP: read transformed body: %w", rerr)
+		}
+	}
+
+	// Outgoing trailers: the plugin's explicit set, else the request's
+	// trailers passed through. reqTrailers is safe to read here — the body
+	// loop above drained the input pipe to EOF, which is ordered after the
+	// recv goroutine filled the trailers and closed the pipe.
+	outT := resp.Trailers
+	if outT == nil {
+		outT = reqTrailers
+	}
+	eof := &pb.HTTPBodyChunk{Eof: true}
+	if len(outT) > 0 {
+		eof.Trailers = headersToProtoMap(outT)
+	}
+	return stream.Send(&pb.TransformHTTPDown{Kind: &pb.TransformHTTPDown_Body{Body: eof}})
+}
+
+func invokeTransformHTTP(ctx context.Context, typeName, instanceName string, fn func(context.Context, HTTPTransformRequest) (*HTTPTransformResponse, error), req HTTPTransformRequest) (out *HTTPTransformResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = callbackPanicError(fmt.Sprintf("credential.%s %q TransformHTTP", typeName, instanceName), r)
+		}
+	}()
+	return fn(ctx, req)
+}
+
+// copyHeader merges src into dst in place.
+func copyHeader(dst, src http.Header) {
+	for k, vs := range src {
+		dst[k] = append([]string(nil), vs...)
+	}
+}
+
+func headersToProtoMap(in http.Header) map[string]*pb.HTTPHeaderValues {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]*pb.HTTPHeaderValues, len(in))
+	for k, vs := range in {
+		out[k] = &pb.HTTPHeaderValues{Values: append([]string(nil), vs...)}
+	}
+	return out
+}
+
+func headerMutationsToProto(in []HeaderMutation) []*pb.HeaderMutation {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*pb.HeaderMutation, 0, len(in))
+	for _, h := range in {
+		op := pb.HeaderMutation_SET
+		switch h.Op {
+		case HeaderAdd:
+			op = pb.HeaderMutation_ADD
+		case HeaderDel:
+			op = pb.HeaderMutation_DEL
+		}
+		out = append(out, &pb.HeaderMutation{
+			Op:     op,
+			Name:   h.Name,
+			Values: append([]string(nil), h.Values...),
+		})
+	}
+	return out
+}

--- a/pluginsdk/transform_test.go
+++ b/pluginsdk/transform_test.go
@@ -1,0 +1,103 @@
+package pluginsdk
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// TestSDKTransformHTTP drives the real SDK TransformHTTP handler (the
+// plugin-author io.Reader contract) with a hand-written gRPC client,
+// exercising the streaming round trip from the plugin side.
+func TestSDKTransformHTTP(t *testing.T) {
+	var gotBody []byte
+	var gotSecret []byte
+	p := &Plugin{
+		Name: "p",
+		Credentials: []CredentialDef{{
+			TypeName:      "signer",
+			HTTPTransform: true,
+			TransformHTTP: func(_ context.Context, req HTTPTransformRequest) (*HTTPTransformResponse, error) {
+				b, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				gotBody = b
+				gotSecret = req.CredentialSecret
+				return &HTTPTransformResponse{
+					Headers: []HeaderMutation{{Op: HeaderSet, Name: "X-Signed", Values: []string{"yes"}}},
+					Body:    bytes.NewReader(bytes.ToUpper(b)),
+				}, nil
+			},
+		}},
+	}
+	srv := newServer(p)
+
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	pb.RegisterCredentialServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	stream, err := pb.NewCredentialClient(conn).TransformHTTP(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Init{Init: &pb.TransformHTTPInit{
+		CredentialTypeName: "signer", CredentialInstance: "i", Method: "POST", CredentialSecret: []byte("sec"),
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&pb.TransformHTTPUp{Kind: &pb.TransformHTTPUp_Body{
+		Body: &pb.HTTPBodyChunk{Data: []byte("hello"), Eof: true},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// First reply: the head.
+	first, err := stream.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := first.GetHead()
+	if head == nil || len(head.Headers) != 1 || head.Headers[0].Name != "X-Signed" {
+		t.Fatalf("head = %+v, want one X-Signed mutation", head)
+	}
+
+	// Then the transformed body until eof.
+	var out bytes.Buffer
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		b := msg.GetBody()
+		if b == nil {
+			continue
+		}
+		out.Write(b.GetData())
+		if b.GetEof() {
+			break
+		}
+	}
+	if out.String() != "HELLO" {
+		t.Fatalf("transformed body = %q, want HELLO", out.String())
+	}
+	if string(gotBody) != "hello" || string(gotSecret) != "sec" {
+		t.Fatalf("plugin saw body=%q secret=%q", gotBody, gotSecret)
+	}
+}

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -556,9 +556,12 @@ Set `Response.Body = req.Body` to pass the input straight through (no
 buffering — right for a URL-only rewrite). The gateway applies the
 returned mutations **before** forwarding, so a body-derived signature
 header is finalized first, then pipes the plugin's body upstream. If you
-change the body length, set a `Content-Length` header mutation. HTTP
-trailers (e.g. gRPC's) are conveyed to the plugin and pass through to
-the upstream unchanged.
+change the body length, set a `Content-Length` header mutation (or leave
+it unset to forward with chunked transfer). HTTP trailers (e.g. gRPC's)
+are preserved by the gateway across the transform — the plugin does not
+handle them. If the plugin fails, the gateway fails the request closed
+(the body was already streamed away), rather than forwarding a
+half-transformed request.
 
 At runtime the built-in HTTPS endpoint keeps the privilege split:
 

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -514,11 +514,51 @@ pluginsdk.CredentialDef{
 for multi-credential dispatch. For HTTP credentials the conventional
 field is `placeholder`: the agent sends a placeholder-looking token,
 and the built-in HTTPS endpoint selects the matching credential
-before calling `InjectHTTP`. `InjectHTTP` is intentionally
-header-only; external credentials cannot rewrite the destination URL
-or request body through this hook. Use `HeaderSet` for auth headers
-such as `Authorization`; `HeaderAdd` appends and may leave the
-agent's placeholder value in place.
+before calling `InjectHTTP`. `InjectHTTP` is header-only by design —
+the request body never flows through the plugin — so it stays cheap
+for the common case. Use `HeaderSet` for auth headers such as
+`Authorization`; `HeaderAdd` appends and may leave the agent's
+placeholder value in place. A credential that must rewrite the URL or
+body uses `TransformHTTP` instead (below).
+
+#### Rewriting the URL or body: `TransformHTTP`
+
+A credential that signs over the request body (AWS SigV4) or carries
+its secret in the URL or body (telegram, discord) sets
+`HTTPTransform: true` and implements `TransformHTTP`. The request body
+is streamed to the plugin as an `io.Reader`, and the plugin returns the
+header/method/URL mutations plus the outgoing body — so **buffering is
+the plugin's choice**: read a prefix and stream the rest, or read it
+all to sign.
+
+```go
+pluginsdk.CredentialDef{
+    TypeName:      "example_sigv4",
+    HTTPTransform: true,
+    TransformHTTP: func(ctx context.Context, req pluginsdk.HTTPTransformRequest) (*pluginsdk.HTTPTransformResponse, error) {
+        body, err := io.ReadAll(req.Body) // SigV4 needs the whole body to hash
+        if err != nil {
+            return nil, err
+        }
+        sig := sign(req.Method, req.URL, req.Headers, body, req.CredentialSecret)
+        return &pluginsdk.HTTPTransformResponse{
+            Headers: []pluginsdk.HeaderMutation{
+                {Op: pluginsdk.HeaderSet, Name: "Authorization", Values: []string{sig}},
+            },
+            Redactions: []string{sig},
+            Body:       bytes.NewReader(body), // forward the body unchanged
+        }, nil
+    },
+}
+```
+
+Set `Response.Body = req.Body` to pass the input straight through (no
+buffering — right for a URL-only rewrite). The gateway applies the
+returned mutations **before** forwarding, so a body-derived signature
+header is finalized first, then pipes the plugin's body upstream. If you
+change the body length, set a `Content-Length` header mutation. HTTP
+trailers (e.g. gRPC's) are conveyed to the plugin and pass through to
+the upstream unchanged.
 
 At runtime the built-in HTTPS endpoint keeps the privilege split:
 


### PR DESCRIPTION
Second milestone of the external plugin protocol v2 work (see #689),
on top of M1 (#690).

Today an external credential's `InjectHTTP` is header-only — it cannot
rewrite the destination URL or the request body. That blocks
credentials that sign over the body (AWS SigV4) or carry their secret
in the URL/body (telegram, discord). This adds a streaming transform
path for them, while keeping the common header-only case cheap.

* New `http_transform` capability and a bidirectional `TransformHTTP`
  RPC. The gateway streams the request body to the plugin as
  `HTTPBodyChunk` frames; the plugin returns a head (header / method /
  URL mutations) followed by the outgoing body. **Buffering is the
  plugin's choice** — read a prefix and stream the rest, or read it all
  to sign. Header-only `InjectHTTP` is unchanged: the request body never
  flows through the plugin.
* The gateway applies the head **before** forwarding (so a body-derived
  header like a SigV4 signature is finalized first), then pipes the
  plugin's transformed body upstream. Content-Length comes from a header
  mutation the plugin supplies (it knows the new length); otherwise the
  body is forwarded with chunked transfer.
* HTTP **trailers** (e.g. gRPC's `grpc-status`) are carried on the
  body-stream framing, conveyed to the plugin, and pass through to the
  upstream unchanged. Plugin-*rewritten* request trailers are a
  follow-up (rewriting them across the body swap races Go's trailer
  population — called out in the code).
* SDK: `CredentialDef.HTTPTransform` + a `TransformHTTP` callback in
  plain `io.Reader` terms; the streaming is hidden behind it. Set
  `Response.Body = req.Body` to pass the input through with no buffering.

Verified with round-trip tests under the race detector: the gateway
dual-pump (header + full-body rewrite, and URL rewrite + body
pass-through) and the SDK handler (the io.Reader contract).

Unblocks the AWS plugin (SigV4 as a standalone credential) and the
telegram / discord / mtls cases from the audit.
