### PR TITLE
Prototype: plugin capability bundle (control-plane RPC over the broker)

### DIFF
--- a/doc/plugin-capability-bundle-prototype.md
+++ b/doc/plugin-capability-bundle-prototype.md
@@ -1,171 +1,335 @@
-# Plugin capability bundle — prototype + recommendation
+# Plugin capability bundle — design + prototype
 
 Status: **prototype / RFC.** A working spike lives behind this doc
-(`internal/config/extplugin/hostcontrol.go` + `_test.go`); it is not
-wired into the live request path.
+(`internal/config/extplugin/hostcontrol.go` + `_test.go`).
 
 ## Why
 
 A comparison with `unclaw`'s plugin model (in-process TS) surfaced a real
-smell in clawpatrol's gRPC plugin protocol: it is accreting a **new
-bespoke RPC + a new `*Init` message per capability**, and the
-plugin→gateway *callbacks* are hand-rolled as request/reply frames
-multiplexed inside the `HandleConn` stream with manual correlation.
+smell in clawpatrol's gRPC plugin protocol: it accretes a **new bespoke
+RPC + a new `*Init` message per capability**, and the plugin→gateway
+*callbacks* are hand-rolled request/reply frames multiplexed inside the
+`HandleConn` stream with manual correlation.
 
-Concretely, two kinds of redundancy:
+Two kinds of redundancy:
 
 1. **Three near-identical streaming RPCs** — `Endpoint.HandleConn`,
    `Credential.TransformHTTP`, `Tunnel.Dial` — each re-inventing an init
-   message, a body-chunk type, an eof/close convention, and (on the Go
-   side) its own dual-pump goroutines.
+   message, a body-chunk type, an eof/close convention, and its own
+   dual-pump goroutines.
 2. **Hand-rolled callback correlation.** A plugin asking the gateway to
    rule on an action sends an `EvaluateAction{call_id}` frame and later
    matches an `ActionVerdict{call_id}` reply; a brokered dial does the
-   same with `dial_id`. Both sides keep an inflight map keyed by that id.
-   ~30 lines of correlation bookkeeping that gRPC would do for free.
+   same with `dial_id`. Both sides keep an inflight map keyed by that id
+   — correlation bookkeeping gRPC would do for free.
 
-`unclaw` has neither: one `Endpoint` interface (layered `conn`/`tls`/
-`fetch` hooks over one `DuplexStream`) and one `EndpointFn` **capability
-bundle** object the host hands the plugin (`fetch`, `connectTcp`,
-`connectTls`, `session.approval`, `buffer`). A new capability is a method
-on that object, not a new message.
+`unclaw` has neither: one `Endpoint` interface and one `EndpointFn`
+**capability bundle** object the host hands the plugin (`fetch`,
+`connectTcp`, `connectTls`, `session.approval`). A new capability is a
+method on that object, not a new message.
 
 clawpatrol can't *be* unclaw — its plugins are out-of-process and
 sandboxed on purpose (untrusted code, secrets, provenance), so it needs a
-wire protocol. But it can port the two ideas that survive the process
-boundary: a **capability bundle** and a **shared session substrate**.
+wire protocol. But it can port the idea that survives the process
+boundary: a **host-served capability bundle** reached over the same
+go-plugin broker the state service (M1) already uses, where each
+plugin→gateway callback is an ordinary gRPC method.
+
+## Two directions — the framing that makes this work for every plugin type
+
+The single most important thing to get right: there are **two distinct
+call directions**, and they want different homes. Conflating them is the
+trap.
+
+| Direction | What it is | Home | Examples |
+|---|---|---|---|
+| **plugin → host** | the plugin calls the gateway | **host-served services** over the broker (the *capability bundle*) | `Evaluate`, brokered `Dial`, HITL `Decide`, `State` |
+| **host → plugin** | the gateway calls the plugin | the plugin's **own gRPC services** | `Endpoint.HandleConn`, `Credential.TransformHTTP`, `Approver.Approve`, `Approver.Notify` |
+
+`unclaw`'s `EndpointFn` is exactly the **plugin→host** direction. So the
+capability bundle is the home for plugin→host calls — and *only* those.
+The host→plugin calls are the plugin's own services; a new one there is
+"add a method to the plugin's service," which gRPC also correlates for
+free. The accretion this doc worries about exists in **both** directions
+today (everything is multiplexed inside `HandleConn`); the fix is
+**symmetric** — real gRPC methods each way — not "move everything onto
+one host service."
+
+This framing is what lets the bundle serve **multiple plugin types**: any
+plugin entrypoint — an endpoint's `HandleConn`, a credential's
+`TransformHTTP`, an approver's `Approve` — calls the *same* host-served
+`HostControl` / `HostState` for the capabilities it needs.
+
+### Consequence: the M4/M5 recommendation, corrected
+
+An earlier draft said "build M4/M5 (approver + HITL) as `HostControl`
+methods — `Approve(...)`, `NotifyHITL(...)`." That is **wrong by
+direction.** Mapping M4/M5 onto the runtime interfaces they mirror:
+
+| Callback | mirrors | direction | home |
+|---|---|---|---|
+| endpoint asks for a verdict | `match` + approve chain | plugin→host | **`HostControl.Evaluate`** |
+| HITL resolve a pending id | `HITLPool.Decide` | plugin→host | **`HostControl.Decide`** |
+| LLM judge | `ApproverRuntime.Approve` | **host→plugin** | plugin-served **`Approver.Approve`** |
+| post the prompt (Slack) | `HITLNotifier.NotifyHITL` | **host→plugin** | plugin-served **`Approver.Notify`** |
+| edit the posted prompt | `HITLMessageUpdater.UpdateHITLMessage` | **host→plugin** | plugin-served **`Approver.Update`** |
+
+So **only `Decide` is a `HostControl` method.** `Approve` / `Notify` /
+`Update` are a new **plugin-served `Approver` service**, exactly like
+`Endpoint`/`Credential`. See the M4 sketch at the end.
 
 ## The design
 
-Split the protocol into two planes:
-
-### Control plane — the capability bundle (`HostControl`)
+### Control plane — the host-served bundle (`HostControl`)
 
 A host-served gRPC service the plugin calls over the **same broker** the
-state service (M1) already uses. Each plugin→gateway callback becomes an
-ordinary method:
+state service (M1) serves on (`HostServicesBrokerID`). Each plugin→gateway
+callback is an ordinary method; gRPC correlates the response, so the
+`call_id`/`dial_id` inflight maps disappear.
 
 ```proto
 service HostControl {
   rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
-  // future: Dial(stream ...) returns (stream ...);  // brokered dial
-  //         Approve(ApproveRequest) returns (ApproveVerdict);  // M4/M5
+  // grows plugin→host only:
+  //   rpc Dial(stream DialChunk) returns (stream DialChunk);  // brokered dial
+  //   rpc Decide(DecideRequest)  returns (DecideAck);          // HITL resolve
 }
 ```
 
-gRPC correlates the response to the call — the `call_id`/`dial_id` maps
-disappear. A new capability (the M4/M5 approver, a HITL prompt) is a new
-method here, **not** a new frame in `HandleConn`.
+Two services on the one broker connection, split by responsibility — keep
+it to these two; add **methods**, not services:
 
-The one new thing a separate channel needs that a multiplexed stream got
-implicitly: a **session token** scoping a control call to one
-connection's evaluation context (its rules, approve chain, peer info).
-The gateway issues it in the session init; the plugin echoes it back; a
-`sessionRegistry` maps it to the connection's evaluator. A forged or
-expired token is rejected, so a plugin can't evaluate against a context
-it doesn't own.
+- **`HostState`** (M1) — plugin-lifetime persistent bytes.
+- **`HostControl`** — connection-scoped control calls.
 
-### Data plane — one session substrate (later)
+### Session scoping rides in gRPC **metadata**, not the message body
 
-The three streaming RPCs collapse to one:
+A separate channel needs the one thing a multiplexed stream got
+implicitly: which **connection's** evaluation context (its rules, approve
+chain, peer, secret scope) a call belongs to. The spike put a
+`session_token` field on the request message. That is the ad-hoc choice;
+the **standard** one is per-RPC **metadata + a server interceptor** —
+session scope is a cross-cutting concern, exactly what metadata/auth
+interceptors are for:
 
-```proto
-rpc Session(stream HostToPlugin) returns (stream PluginToHost);
-// HostToPlugin = oneof { SessionInit init; ByteChunk data }
-// SessionInit  = InstanceContext ctx + oneof role { Endpoint; Transform; Tunnel }
-```
+- The gateway issues an opaque, `crypto/rand` token in the connection's
+  init and the plugin echoes it back as request metadata
+  (`clawpatrol-session`).
+- A **server interceptor** resolves the token → the connection's
+  `session` object (its evaluator, and later its decide/dial context) and
+  puts it in the handler's `context.Context`. A forged/expired/removed
+  token is rejected (`Unauthenticated`).
+- Method **messages stay payload-only.** Every *future* control method is
+  scoped for free — no `session_token` to redeclare, no plugin-side field
+  to remember to set. The SDK threads the token via a client interceptor,
+  so the plugin author never sees it: `conn.Evaluate(...)` just works.
 
-One init carries a shared `InstanceContext{type_name, instance,
-canonical_json}` + `CredentialBinding{secret, extras}` (killing the
-per-`Init` field redundancy), then raw bytes. One dual-pump
-implementation instead of three. The control frames that bloat
-`HandleConn` today (`EvaluateAction`, `DialUpstream`, `StreamRead`) move
-to the control plane, leaving the data plane as just bytes.
+Per-plugin server isolation already holds (each plugin gets its own
+`HostControl` instance + registry), so the token only disambiguates
+**connections within one plugin** — and a token is never accepted across
+plugins.
+
+**Token lifetime:** minted per connection at `HandleConn` start,
+registered in the per-plugin `sessionRegistry`, removed in its `defer` —
+no dangling evaluation context.
+
+### The registry holds a session object and returns a typed verdict
+
+The spike's registry value was `func(...) (action, reason, rule string,
+err error)` — a four-string return. Two fixes:
+
+- The registry maps a token to a **`session` object**, not a single func.
+  `Decide` and `Dial` will need the same connection context; don't
+  hardcode it to "evaluate."
+- `Evaluate` returns a **typed `Verdict{Action, Reason, Rule}`**
+  (mirroring `runtime`/`pluginsdk.Verdict`), not a tuple.
+
+### `action_json` stays JSON bytes
+
+The facet payload rides as JSON bytes — the same bytes `EvaluateAction`
+and M1/M2 already carry. Resist churning to `google.protobuf.Struct`
+(clunky in Go, loses numeric fidelity); consistency beats novelty, and we
+do not invent a new payload encoding per method.
+
+### Data plane — defer the unification, but `Dial` is the wedge
+
+The three streaming RPCs (`HandleConn` / `TransformHTTP` / `Tunnel.Dial`)
+collapsing into one `Session` substrate is real but **high-risk,
+mostly-internal** — it touches shipped, load-bearing code (#681) and every
+plugin. Defer it.
+
+But note: the *brokered upstream dial* a plugin makes is a **plugin→host**
+streaming capability, so it belongs on `HostControl` as a bidi-stream
+method — `rpc Dial(stream DialChunk) returns (stream DialChunk)`, scoped
+by the session metadata. Moving it there kills the `dial_id` correlation
+the same way `Evaluate` kills `call_id`, **and** it shrinks the data plane
+to *just raw bytes per connection* — making the eventual `Session`
+unification much smaller. So `HostControl.Dial` is the stepping stone, not
+a separate project.
 
 ## What the spike proves
 
 `hostcontrol.go` + `hostcontrol_test.go` implement `HostControl.Evaluate`
-end to end over a **real go-plugin broker** (the M1 test harness):
-
-- The plugin runs a rule evaluation with **one gRPC call** —
-  `ctrl.Evaluate(ctx, req)` — no frame, no `call_id`, no inflight map.
-- The gateway routes it to the connection's evaluator by session token.
-- A forged token and a removed (connection-ended) token are both
-  rejected.
+end to end over a **real go-plugin broker** (the M1 harness): the plugin
+runs a rule evaluation with **one gRPC call**, the gateway routes it to
+the connection's session via the metadata token, and a forged or removed
+token is rejected. No frame, no `call_id`, no inflight map.
 
 ### Before / after (the `Evaluate` callback)
 
-Today, on the SDK side (`pluginsdk/server.go`), `Conn.Evaluate`:
-
-```go
-callID := fmt.Sprintf("c%d", callSeq.Add(1))
-ch := make(chan *pb.ActionVerdict, 1)
-inflightMu.Lock(); inflight[callID] = ch; inflightMu.Unlock()
-defer func() { inflightMu.Lock(); delete(inflight, callID); inflightMu.Unlock() }()
-doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Evaluate{Evaluate: &pb.EvaluateAction{
-    CallId: callID, FacetName: facet, ActionJson: j, Summary: summary, ...}}})
-select {
-case v := <-ch: return Verdict{Action: v.Action, ...}, nil
-case <-ctx.Done(): ...
-case <-closed: ...
-}
-```
-
-plus a recv-loop branch on the gateway side that matches `Verdict.CallId`
-back to the channel, and a symmetric inflight map. With `HostControl`:
+Today (`pluginsdk/server.go`), `Conn.Evaluate` allocates a `call_id`, a
+reply channel, and an inflight-map entry, sends an `EvaluateAction` frame,
+and `select`s on the reply channel — plus a symmetric recv-loop branch on
+the gateway side matching `Verdict.CallId` back to the channel. With
+`HostControl`:
 
 ```go
 v, err := ctrl.Evaluate(ctx, &pb.EvaluateRequest{
-    SessionToken: tok, FacetName: facet, ActionJson: j, Summary: summary})
+    FacetName: facet, ActionJson: j, Summary: summary})   // token in metadata
 ```
 
-The correlation, the channels, and the recv-loop branch are gone.
-
-## Cost / blast radius
-
-- The **data-plane unification** touches `HandleConn` — shipped and load
-  bearing (#681) — and every plugin. High risk, mostly-internal payoff.
-  Not worth doing reactively.
-- The **control-plane capability bundle** is incremental: it rides the
-  broker M1 already established, and it does **not** require touching
-  `HandleConn` — a connection can keep its existing data stream and *also*
-  register a session token for control calls. The migration of the
-  existing `EvaluateAction`/`DialUpstream` frames can happen later,
-  opportunistically.
+The correlation, the channels, and both recv-loop branches are gone.
 
 ## Recommendation
 
-**Adopt the capability bundle (`HostControl`) as the home for new
-callbacks now; do not rewrite the shipped streaming RPCs yet.**
+**Adopt `HostControl` as the host-served (plugin→host) capability bundle
+now; build the M4/M5 *host→plugin* callbacks as a plugin-served `Approver`
+service; do not rewrite the shipped streaming RPCs yet.**
 
-The accretion this whole exercise is worried about happens *next*, in
-M4/M5 (approver + HITL): those are exactly plugin→gateway callbacks that,
-under the current pattern, would each add new frames and new correlation.
-Built on `HostControl` they are just methods — `Approve(...)`,
-`NotifyHITL(...)` — reusing the broker, the session-token scoping, and
-gRPC's correlation.
+1. **Now:** land `HostControl` (this spike, hardened) — interceptor-based
+   session scoping, typed verdict, session object, `crypto/rand` tokens —
+   served on the broker next to `HostState`. Wire session
+   registration into the endpoint path so `Evaluate` *can* move off the
+   `HandleConn` frame at our leisure; keep the frame working meanwhile.
+2. **M4/M5:** build `HostControl.Decide` (plugin→host) and the
+   plugin-served `Approver` service (`Approve`/`Notify`/`Update`,
+   host→plugin) — no new frames, no new correlation, in either direction.
+3. **Later / optional:** move `Evaluate`/`Dial` off `HandleConn` onto
+   `HostControl`, then collapse the three streaming RPCs into one
+   `Session`. Pure internal cleanup, done deliberately.
 
-So:
-
-1. **Now:** land `HostControl` as the control-plane channel (this spike,
-   hardened). Wire the session-token registration into the endpoint path
-   so `Evaluate` can move off the `HandleConn` frame at our leisure.
-2. **M4/M5:** build the approver and HITL callbacks as `HostControl`
-   methods from the start — no new frames.
-3. **Later / optional:** migrate `EvaluateAction` and `DialUpstream` off
-   `HandleConn` onto `HostControl`, then collapse the three streaming RPCs
-   into one `Session`. Pure internal cleanup, done deliberately.
-
-This banks the architectural lesson exactly where the next growth is,
-without destabilizing shipped, sandboxed code — which is the point of
-pausing to prototype before going further.
+This banks the architectural lesson where the next growth is, in both
+directions, without destabilizing shipped, sandboxed code.
 
 ## Open questions
 
-- Session-token issuance: random per connection, or derive from an
-  existing handle? Lifetime/cleanup tie-in with the connection.
-- Does `Dial` (a streaming, bidirectional capability) fit cleanly as a
-  `HostControl` streaming method, or does it argue for keeping some
-  callbacks on the data stream?
-- For `Evaluate`, the per-call context deadline and the existing
-  approve-chain blocking (HITL) behavior must carry over unchanged.
+- `HostControl.Dial` as a bidi stream vs. keeping a raw byte stream on the
+  data plane — both are gRPC streams; the bundle keeps the *correlation*
+  uniform either way.
+- `Evaluate`'s per-call deadline and the approve-chain (HITL) blocking
+  behavior must carry over unchanged when it moves off the frame.
+- Webhook ingress (M5) is host→plugin too (the gateway forwards an inbound
+  HTTP request to the plugin) — a plugin-served `Approver` stream — but
+  *mounting* the public route stays an operator-only grant.
+
+## M4 / M5 sketch — both directions, end to end
+
+Concrete proto for the next two milestones, so the corrected design is
+visible end to end. **Sketch only** — not in `plugin.proto` yet; M4
+implements the synchronous LLM `Approve`, M5 the human HITL
+`Notify`/`Decide`/`Update`. Wire-only fields are shown; the
+gateway-internal handles on the runtime structs (`Pool`, `Secrets`,
+`Endpoint`, `Rule`, `*match.Request`) do **not** cross the boundary — the
+plugin reaches that power through the bundle (`HostControl.Decide`) and
+its bound credential, never as raw objects.
+
+### plugin → host: `HostControl` grows methods (no new services)
+
+```proto
+service HostControl {
+  rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);    // landed
+  // Brokered upstream dial as a bundle method — kills the dial_id
+  // inflight map the way Evaluate kills call_id, and shrinks the data
+  // plane to raw bytes.
+  rpc Dial(stream DialChunk) returns (stream DialChunk);      // M-later
+  // HITL: a notifier (Slack button) resolves a pending decision. The
+  // gateway records it in the same HITLPool the dashboard writes to, so
+  // the plugin *requests* a decision, it never *owns* one.
+  rpc Decide(DecideRequest) returns (DecideAck);             // M5
+}
+message DecideRequest {                  // mirrors HITLPool.Decide(id, d)
+  string operation_id = 1;               // the pending entry id
+  string decision     = 2;               // "allow" | "deny"
+  string reason       = 3;
+  // session token in metadata, as for every HostControl call.
+}
+message DecideAck { bool resolved = 1; } // false = id unknown / already decided
+```
+
+### host → plugin: a new plugin-served `Approver` service
+
+Same shape as the existing plugin-served `Endpoint` / `Credential`
+services — the gateway is the client. The proto messages mirror
+`runtime.ApproveRequest` / `ApproveVerdict` / `HITLTarget` /
+`HITLMessageUpdate`, minus the non-serializable handles.
+
+```proto
+service Approver {
+  // M4: synchronous judge (LLM). The plugin reads the request shape,
+  // calls its model via a BOUND credential over a brokered dial (so it
+  // needs no network of its own), and returns a verdict.
+  rpc Approve(ApproveRequest) returns (ApproveVerdict);
+  // M5: post the prompt to a channel (Slack chat.postMessage). Returns a
+  // non-secret message ref for later edits. Mirrors HITLNotifier.NotifyHITL.
+  rpc Notify(NotifyRequest) returns (NotifyAck);
+  // M5: edit the posted prompt as the operation resolves. Mirrors
+  // HITLMessageUpdater.UpdateHITLMessage.
+  rpc Update(UpdateRequest) returns (UpdateAck);
+}
+
+message ApproveRequest {                 // wire subset of runtime.ApproveRequest
+  string stage = 1; string rule_name = 2; string approver_name = 3;
+  string profile = 4; string agent_ip = 5;
+  string method = 6; string host = 7; string path = 8;
+  string ua = 9; string body_sample = 10; string reason = 11;
+  string thread_ts = 12; string notify_channel = 13;
+  string async_operation_id = 14;
+  // Pool / Secrets / Endpoint / Rule / Request are NOT here — see above.
+}
+message ApproveVerdict { string action = 1; string reason = 2; }
+
+message NotifyRequest {                  // wire subset of runtime.HITLTarget
+  string operation_id = 1; string channel = 2; bool interactive = 3;
+  string dashboard_url = 4; string thread_ts = 5;
+  string method = 6; string host = 7; string path = 8; string approval_message = 9;
+}
+message NotifyAck { string message_ref = 1; }   // opaque channel/ts, non-secret
+
+message UpdateRequest {                  // mirrors runtime.HITLMessageUpdate
+  string message_ref = 1; string operation_id = 2; string state = 3;
+  string method = 4; string host = 5; string path = 6;
+  bool upstream_called = 7; string last_error = 8;
+}
+message UpdateAck {}
+```
+
+### Flow: LLM judge (M4, synchronous)
+
+1. An endpoint (or the gateway) hits a rule with `approve = [llm.judge]`.
+2. The gateway calls **`Approver.Approve`** (host→plugin) with the request
+   shape. The plugin needs no `Pool` — it decides synchronously.
+3. The plugin calls its model. It has no network; it dials the model API
+   over **`HostControl.Dial`** (plugin→host, brokered) using a **bound
+   credential** the gateway injected — so the key never sits in plugin
+   memory unredacted and the egress is audited.
+4. The plugin returns `ApproveVerdict{action,reason}`. Done — one
+   host→plugin call, one plugin→host call, both ordinary gRPC.
+
+### Flow: human approver over Slack (M5)
+
+1. Rule hits `approve = [human.oncall]`. The gateway publishes a pending
+   entry in its `HITLPool` and calls **`Approver.Notify`** (host→plugin);
+   the plugin posts to Slack and returns a `message_ref`.
+2. An operator clicks **Approve**. Slack delivers the interaction to the
+   plugin (via webhook ingress — host→plugin, operator-granted route).
+3. The plugin calls **`HostControl.Decide`** (plugin→host) with the
+   `operation_id`. The gateway records it in the **same pool** the
+   dashboard writes to — the decision authority never leaves the gateway.
+4. As the operation resolves, the gateway calls **`Approver.Update`**
+   (host→plugin) and the plugin edits the Slack message.
+
+Every callback is a plain gRPC method on the correct side. No
+`HandleConn` frame, no `call_id`, no inflight map — in either direction.
+That is the whole point of the bundle, and why the direction split
+matters: `Decide` belongs on `HostControl`, but `Approve`/`Notify`/
+`Update` are the plugin's own service.

--- a/doc/plugin-capability-bundle-prototype.md
+++ b/doc/plugin-capability-bundle-prototype.md
@@ -1,0 +1,171 @@
+# Plugin capability bundle — prototype + recommendation
+
+Status: **prototype / RFC.** A working spike lives behind this doc
+(`internal/config/extplugin/hostcontrol.go` + `_test.go`); it is not
+wired into the live request path.
+
+## Why
+
+A comparison with `unclaw`'s plugin model (in-process TS) surfaced a real
+smell in clawpatrol's gRPC plugin protocol: it is accreting a **new
+bespoke RPC + a new `*Init` message per capability**, and the
+plugin→gateway *callbacks* are hand-rolled as request/reply frames
+multiplexed inside the `HandleConn` stream with manual correlation.
+
+Concretely, two kinds of redundancy:
+
+1. **Three near-identical streaming RPCs** — `Endpoint.HandleConn`,
+   `Credential.TransformHTTP`, `Tunnel.Dial` — each re-inventing an init
+   message, a body-chunk type, an eof/close convention, and (on the Go
+   side) its own dual-pump goroutines.
+2. **Hand-rolled callback correlation.** A plugin asking the gateway to
+   rule on an action sends an `EvaluateAction{call_id}` frame and later
+   matches an `ActionVerdict{call_id}` reply; a brokered dial does the
+   same with `dial_id`. Both sides keep an inflight map keyed by that id.
+   ~30 lines of correlation bookkeeping that gRPC would do for free.
+
+`unclaw` has neither: one `Endpoint` interface (layered `conn`/`tls`/
+`fetch` hooks over one `DuplexStream`) and one `EndpointFn` **capability
+bundle** object the host hands the plugin (`fetch`, `connectTcp`,
+`connectTls`, `session.approval`, `buffer`). A new capability is a method
+on that object, not a new message.
+
+clawpatrol can't *be* unclaw — its plugins are out-of-process and
+sandboxed on purpose (untrusted code, secrets, provenance), so it needs a
+wire protocol. But it can port the two ideas that survive the process
+boundary: a **capability bundle** and a **shared session substrate**.
+
+## The design
+
+Split the protocol into two planes:
+
+### Control plane — the capability bundle (`HostControl`)
+
+A host-served gRPC service the plugin calls over the **same broker** the
+state service (M1) already uses. Each plugin→gateway callback becomes an
+ordinary method:
+
+```proto
+service HostControl {
+  rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
+  // future: Dial(stream ...) returns (stream ...);  // brokered dial
+  //         Approve(ApproveRequest) returns (ApproveVerdict);  // M4/M5
+}
+```
+
+gRPC correlates the response to the call — the `call_id`/`dial_id` maps
+disappear. A new capability (the M4/M5 approver, a HITL prompt) is a new
+method here, **not** a new frame in `HandleConn`.
+
+The one new thing a separate channel needs that a multiplexed stream got
+implicitly: a **session token** scoping a control call to one
+connection's evaluation context (its rules, approve chain, peer info).
+The gateway issues it in the session init; the plugin echoes it back; a
+`sessionRegistry` maps it to the connection's evaluator. A forged or
+expired token is rejected, so a plugin can't evaluate against a context
+it doesn't own.
+
+### Data plane — one session substrate (later)
+
+The three streaming RPCs collapse to one:
+
+```proto
+rpc Session(stream HostToPlugin) returns (stream PluginToHost);
+// HostToPlugin = oneof { SessionInit init; ByteChunk data }
+// SessionInit  = InstanceContext ctx + oneof role { Endpoint; Transform; Tunnel }
+```
+
+One init carries a shared `InstanceContext{type_name, instance,
+canonical_json}` + `CredentialBinding{secret, extras}` (killing the
+per-`Init` field redundancy), then raw bytes. One dual-pump
+implementation instead of three. The control frames that bloat
+`HandleConn` today (`EvaluateAction`, `DialUpstream`, `StreamRead`) move
+to the control plane, leaving the data plane as just bytes.
+
+## What the spike proves
+
+`hostcontrol.go` + `hostcontrol_test.go` implement `HostControl.Evaluate`
+end to end over a **real go-plugin broker** (the M1 test harness):
+
+- The plugin runs a rule evaluation with **one gRPC call** —
+  `ctrl.Evaluate(ctx, req)` — no frame, no `call_id`, no inflight map.
+- The gateway routes it to the connection's evaluator by session token.
+- A forged token and a removed (connection-ended) token are both
+  rejected.
+
+### Before / after (the `Evaluate` callback)
+
+Today, on the SDK side (`pluginsdk/server.go`), `Conn.Evaluate`:
+
+```go
+callID := fmt.Sprintf("c%d", callSeq.Add(1))
+ch := make(chan *pb.ActionVerdict, 1)
+inflightMu.Lock(); inflight[callID] = ch; inflightMu.Unlock()
+defer func() { inflightMu.Lock(); delete(inflight, callID); inflightMu.Unlock() }()
+doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Evaluate{Evaluate: &pb.EvaluateAction{
+    CallId: callID, FacetName: facet, ActionJson: j, Summary: summary, ...}}})
+select {
+case v := <-ch: return Verdict{Action: v.Action, ...}, nil
+case <-ctx.Done(): ...
+case <-closed: ...
+}
+```
+
+plus a recv-loop branch on the gateway side that matches `Verdict.CallId`
+back to the channel, and a symmetric inflight map. With `HostControl`:
+
+```go
+v, err := ctrl.Evaluate(ctx, &pb.EvaluateRequest{
+    SessionToken: tok, FacetName: facet, ActionJson: j, Summary: summary})
+```
+
+The correlation, the channels, and the recv-loop branch are gone.
+
+## Cost / blast radius
+
+- The **data-plane unification** touches `HandleConn` — shipped and load
+  bearing (#681) — and every plugin. High risk, mostly-internal payoff.
+  Not worth doing reactively.
+- The **control-plane capability bundle** is incremental: it rides the
+  broker M1 already established, and it does **not** require touching
+  `HandleConn` — a connection can keep its existing data stream and *also*
+  register a session token for control calls. The migration of the
+  existing `EvaluateAction`/`DialUpstream` frames can happen later,
+  opportunistically.
+
+## Recommendation
+
+**Adopt the capability bundle (`HostControl`) as the home for new
+callbacks now; do not rewrite the shipped streaming RPCs yet.**
+
+The accretion this whole exercise is worried about happens *next*, in
+M4/M5 (approver + HITL): those are exactly plugin→gateway callbacks that,
+under the current pattern, would each add new frames and new correlation.
+Built on `HostControl` they are just methods — `Approve(...)`,
+`NotifyHITL(...)` — reusing the broker, the session-token scoping, and
+gRPC's correlation.
+
+So:
+
+1. **Now:** land `HostControl` as the control-plane channel (this spike,
+   hardened). Wire the session-token registration into the endpoint path
+   so `Evaluate` can move off the `HandleConn` frame at our leisure.
+2. **M4/M5:** build the approver and HITL callbacks as `HostControl`
+   methods from the start — no new frames.
+3. **Later / optional:** migrate `EvaluateAction` and `DialUpstream` off
+   `HandleConn` onto `HostControl`, then collapse the three streaming RPCs
+   into one `Session`. Pure internal cleanup, done deliberately.
+
+This banks the architectural lesson exactly where the next growth is,
+without destabilizing shipped, sandboxed code — which is the point of
+pausing to prototype before going further.
+
+## Open questions
+
+- Session-token issuance: random per connection, or derive from an
+  existing handle? Lifetime/cleanup tie-in with the connection.
+- Does `Dial` (a streaming, bidirectional capability) fit cleanly as a
+  `HostControl` streaming method, or does it argue for keeping some
+  callbacks on the data stream?
+- For `Evaluate`, the per-call context deadline and the existing
+  approve-chain blocking (HITL) behavior must carry over unchanged.

--- a/internal/config/extplugin/hostcontrol.go
+++ b/internal/config/extplugin/hostcontrol.go
@@ -1,0 +1,93 @@
+package extplugin
+
+import (
+	"context"
+	"sync"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// PROTOTYPE — the capability bundle (host-served control plane).
+//
+// HostControl is the second host-served service (alongside HostState),
+// reached over the same go-plugin broker. It is the prototype home for the
+// plugin->gateway *control* callbacks that today live as hand-rolled
+// request/reply frames multiplexed inside the HandleConn stream — chiefly
+// EvaluateAction/ActionVerdict, which on each side carries an inflight map
+// keyed by a plugin-chosen call_id to match a reply to its request.
+//
+// As an ordinary gRPC method, Evaluate needs none of that: gRPC correlates
+// the response to the call. The only new bookkeeping is a session token
+// that scopes a control call to one connection's evaluation context — the
+// thing a multiplexed stream got for free by virtue of the frame arriving
+// on that connection's stream. sessionRegistry holds that mapping.
+//
+// This is a spike to evaluate the design (see
+// doc/plugin-capability-bundle-prototype.md); it is not wired into the
+// live HandleConn path.
+
+// EvaluateFunc runs one action through the gateway's rule + approve chain
+// for a given connection and returns the verdict. It is exactly the work
+// pumpConn's EvaluateAction branch does today, lifted behind a token so it
+// can be invoked from a separate channel.
+type EvaluateFunc func(ctx context.Context, facetName string, actionJSON []byte, summary string) (action, reason, rule string, err error)
+
+// sessionRegistry maps a session token to the connection's EvaluateFunc.
+// A HandleConn (or its successor) registers a token when it starts a
+// session and removes it when the connection ends.
+type sessionRegistry struct {
+	mu sync.Mutex
+	m  map[string]EvaluateFunc
+}
+
+func newSessionRegistry() *sessionRegistry {
+	return &sessionRegistry{m: map[string]EvaluateFunc{}}
+}
+
+func (r *sessionRegistry) register(token string, fn EvaluateFunc) {
+	r.mu.Lock()
+	r.m[token] = fn
+	r.mu.Unlock()
+}
+
+func (r *sessionRegistry) remove(token string) {
+	r.mu.Lock()
+	delete(r.m, token)
+	r.mu.Unlock()
+}
+
+func (r *sessionRegistry) lookup(token string) (EvaluateFunc, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fn, ok := r.m[token]
+	return fn, ok
+}
+
+// hostControl implements pb.HostControlServer for one plugin, backed by a
+// per-plugin session registry.
+type hostControl struct {
+	pb.UnimplementedHostControlServer
+	sessions *sessionRegistry
+}
+
+func newHostControl(sessions *sessionRegistry) *hostControl {
+	return &hostControl{sessions: sessions}
+}
+
+func (h *hostControl) Evaluate(ctx context.Context, req *pb.EvaluateRequest) (*pb.EvaluateVerdict, error) {
+	fn, ok := h.sessions.lookup(req.GetSessionToken())
+	if !ok {
+		// The session ended or the token was never issued — a malicious or
+		// confused plugin can't evaluate against a context it doesn't own.
+		return nil, status.Errorf(codes.NotFound, "unknown session token")
+	}
+	action, reason, rule, err := fn(ctx, req.GetFacetName(), req.GetActionJson(), req.GetSummary())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "evaluate: %v", err)
+	}
+	return &pb.EvaluateVerdict{Action: action, Reason: reason, Rule: rule}, nil
+}
+
+var _ pb.HostControlServer = (*hostControl)(nil)

--- a/internal/config/extplugin/hostcontrol.go
+++ b/internal/config/extplugin/hostcontrol.go
@@ -2,92 +2,145 @@ package extplugin
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"sync"
 
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
-// PROTOTYPE — the capability bundle (host-served control plane).
+// HostControl is the host-served (plugin->host) capability bundle. Unlike
+// the Credential / Endpoint / Tunnel services — which the gateway calls on
+// the plugin — this one runs on the gateway and a sandboxed plugin calls
+// it over the go-plugin broker, alongside HostState (M1).
 //
-// HostControl is the second host-served service (alongside HostState),
-// reached over the same go-plugin broker. It is the prototype home for the
-// plugin->gateway *control* callbacks that today live as hand-rolled
-// request/reply frames multiplexed inside the HandleConn stream — chiefly
-// EvaluateAction/ActionVerdict, which on each side carries an inflight map
-// keyed by a plugin-chosen call_id to match a reply to its request.
+// Each plugin->gateway callback is an ordinary gRPC method, so gRPC
+// correlates the reply and the hand-rolled call_id/dial_id inflight maps
+// that ride inside HandleConn today disappear. The bundle grows by adding
+// methods (Dial, Decide), not new frames or new services.
 //
-// As an ordinary gRPC method, Evaluate needs none of that: gRPC correlates
-// the response to the call. The only new bookkeeping is a session token
-// that scopes a control call to one connection's evaluation context — the
-// thing a multiplexed stream got for free by virtue of the frame arriving
-// on that connection's stream. sessionRegistry holds that mapping.
-//
-// This is a spike to evaluate the design (see
-// doc/plugin-capability-bundle-prototype.md); it is not wired into the
-// live HandleConn path.
+// Every call is scoped to one connection's evaluation context by an opaque
+// session token the gateway minted for that connection. The token rides in
+// gRPC metadata, not the message body: session scope is cross-cutting, so
+// sessionUnaryInterceptor resolves it once into the request context and
+// each method reads it from there — a new method is scoped for free. A
+// forged / expired / removed token is rejected before the handler runs.
 
-// EvaluateFunc runs one action through the gateway's rule + approve chain
-// for a given connection and returns the verdict. It is exactly the work
-// pumpConn's EvaluateAction branch does today, lifted behind a token so it
-// can be invoked from a separate channel.
-type EvaluateFunc func(ctx context.Context, facetName string, actionJSON []byte, summary string) (action, reason, rule string, err error)
+// sessionMetadataKey is the gRPC metadata key the per-connection session
+// token rides under on every HostControl call. Lower-case per gRPC's
+// metadata convention.
+const sessionMetadataKey = "clawpatrol-session"
 
-// sessionRegistry maps a session token to the connection's EvaluateFunc.
-// A HandleConn (or its successor) registers a token when it starts a
-// session and removes it when the connection ends.
+// Verdict is the gateway's decision on one Evaluate call. Mirrors
+// runtime / pluginsdk.Verdict so the host-served surface and the existing
+// frame path return the same shape.
+type Verdict struct {
+	Action string // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
+	Reason string
+	Rule   string
+}
+
+// session is one connection's control context — the work HostControl
+// methods run on its behalf. Today only Evaluate; Decide and Dial join it
+// as the bundle grows, reusing the same token scoping and registration.
+type session struct {
+	evaluate func(ctx context.Context, facetName string, actionJSON []byte, summary string) (Verdict, error)
+}
+
+// sessionRegistry maps an opaque session token to a *session, scoped to one
+// plugin (each plugin gets its own registry, so a token is never valid
+// across plugins). A connection registers a session when it starts and
+// removes it when it ends.
 type sessionRegistry struct {
 	mu sync.Mutex
-	m  map[string]EvaluateFunc
+	m  map[string]*session
 }
 
 func newSessionRegistry() *sessionRegistry {
-	return &sessionRegistry{m: map[string]EvaluateFunc{}}
+	return &sessionRegistry{m: map[string]*session{}}
 }
 
-func (r *sessionRegistry) register(token string, fn EvaluateFunc) {
+// register adds s under a fresh, unforgeable token and returns the token
+// plus a remove func the caller defers when the connection ends. Minting
+// the token here (crypto/rand) rather than taking it from the wire is what
+// makes it unforgeable — a plugin can only present tokens the gateway
+// issued to it.
+func (r *sessionRegistry) register(s *session) (token string, remove func()) {
+	token = newSessionToken()
 	r.mu.Lock()
-	r.m[token] = fn
+	r.m[token] = s
 	r.mu.Unlock()
+	return token, func() {
+		r.mu.Lock()
+		delete(r.m, token)
+		r.mu.Unlock()
+	}
 }
 
-func (r *sessionRegistry) remove(token string) {
-	r.mu.Lock()
-	delete(r.m, token)
-	r.mu.Unlock()
-}
-
-func (r *sessionRegistry) lookup(token string) (EvaluateFunc, bool) {
+func (r *sessionRegistry) lookup(token string) (*session, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	fn, ok := r.m[token]
-	return fn, ok
+	s, ok := r.m[token]
+	return s, ok
 }
 
-// hostControl implements pb.HostControlServer for one plugin, backed by a
-// per-plugin session registry.
+func newSessionToken() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// sessionCtxKey carries the resolved *session from the interceptor to the
+// method handler.
+type sessionCtxKey struct{}
+
+func sessionFromContext(ctx context.Context) (*session, bool) {
+	s, ok := ctx.Value(sessionCtxKey{}).(*session)
+	return s, ok
+}
+
+// sessionUnaryInterceptor resolves the session token carried in request
+// metadata to its *session and stashes it in the handler's context. A
+// present-but-unknown token is rejected here (a plugin cannot act on a
+// context it does not own); an absent token passes through unresolved, so
+// non-session-scoped host services (HostState) on the same server are
+// unaffected — the session-scoped methods (HostControl) require the
+// session themselves via sessionFromContext.
+func sessionUnaryInterceptor(reg *sessionRegistry) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		if vals := md.Get(sessionMetadataKey); len(vals) > 0 {
+			s, ok := reg.lookup(vals[0])
+			if !ok {
+				return nil, status.Error(codes.Unauthenticated, "unknown session token")
+			}
+			ctx = context.WithValue(ctx, sessionCtxKey{}, s)
+		}
+		return handler(ctx, req)
+	}
+}
+
+// hostControl implements pb.HostControlServer. It is stateless: the session
+// is resolved by sessionUnaryInterceptor and read from the context, so one
+// instance serves every connection of a plugin.
 type hostControl struct {
 	pb.UnimplementedHostControlServer
-	sessions *sessionRegistry
 }
 
-func newHostControl(sessions *sessionRegistry) *hostControl {
-	return &hostControl{sessions: sessions}
-}
-
-func (h *hostControl) Evaluate(ctx context.Context, req *pb.EvaluateRequest) (*pb.EvaluateVerdict, error) {
-	fn, ok := h.sessions.lookup(req.GetSessionToken())
+func (hostControl) Evaluate(ctx context.Context, req *pb.EvaluateRequest) (*pb.EvaluateVerdict, error) {
+	s, ok := sessionFromContext(ctx)
 	if !ok {
-		// The session ended or the token was never issued — a malicious or
-		// confused plugin can't evaluate against a context it doesn't own.
-		return nil, status.Errorf(codes.NotFound, "unknown session token")
+		return nil, status.Error(codes.Unauthenticated, "missing session token")
 	}
-	action, reason, rule, err := fn(ctx, req.GetFacetName(), req.GetActionJson(), req.GetSummary())
+	v, err := s.evaluate(ctx, req.GetFacetName(), req.GetActionJson(), req.GetSummary())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "evaluate: %v", err)
 	}
-	return &pb.EvaluateVerdict{Action: action, Reason: reason, Rule: rule}, nil
+	return &pb.EvaluateVerdict{Action: v.Action, Reason: v.Reason, Rule: v.Rule}, nil
 }
 
-var _ pb.HostControlServer = (*hostControl)(nil)
+var _ pb.HostControlServer = hostControl{}

--- a/internal/config/extplugin/hostcontrol_test.go
+++ b/internal/config/extplugin/hostcontrol_test.go
@@ -1,0 +1,103 @@
+package extplugin
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ctrlTestPlugin wires both sides over a real go-plugin broker, exactly as
+// the gateway/plugin do: the server (plugin) side captures the broker so
+// the plugin can dial the capability bundle; the client (gateway) side
+// serves HostControl on the reserved broker id, backed by a session
+// registry.
+type ctrlTestPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	broker   *goplugin.GRPCBroker
+	sessions *sessionRegistry
+}
+
+func (p *ctrlTestPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server) error {
+	p.broker = broker
+	return nil
+}
+
+func (p *ctrlTestPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		s := grpc.NewServer(opts...)
+		pb.RegisterHostControlServer(s, newHostControl(p.sessions))
+		return s
+	})
+	return c, nil
+}
+
+// TestHostControlEvaluateRoundTrip is the capability-bundle spike: a plugin
+// runs a rule evaluation by calling a plain gRPC method over the broker —
+// no EvaluateAction frame, no call_id, no inflight correlation map. The
+// gateway routes the call to the connection's evaluator via a session
+// token, and rejects a token it never issued.
+func TestHostControlEvaluateRoundTrip(t *testing.T) {
+	sessions := newSessionRegistry()
+	// What HandleConn would register when a connection starts: the same
+	// rule + approve work pumpConn's EvaluateAction branch does today.
+	var gotFacet string
+	var gotAction []byte
+	sessions.register("tok-1", func(_ context.Context, facet string, action []byte, _ string) (string, string, string, error) {
+		gotFacet = facet
+		gotAction = action
+		if facet == "http" {
+			return "allow", "matched", "rule-1", nil
+		}
+		return "deny", "no rule", "", nil
+	})
+
+	p := &ctrlTestPlugin{sessions: sessions}
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{"x": p})
+	defer func() { _ = client.Close() }()
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+
+	conn, err := p.broker.Dial(HostServicesBrokerID)
+	if err != nil {
+		t.Fatalf("dial broker: %v", err)
+	}
+	ctrl := pb.NewHostControlClient(conn)
+
+	// The whole client side: one call, gRPC correlates the reply.
+	v, err := ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{
+		SessionToken: "tok-1",
+		FacetName:    "http",
+		ActionJson:   []byte(`{"method":"GET"}`),
+		Summary:      "GET /",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if v.Action != "allow" || v.Rule != "rule-1" {
+		t.Fatalf("verdict = %+v, want allow/rule-1", v)
+	}
+	if gotFacet != "http" || string(gotAction) != `{"method":"GET"}` {
+		t.Fatalf("gateway saw facet=%q action=%q", gotFacet, gotAction)
+	}
+
+	// A token the gateway never issued is rejected — a plugin cannot
+	// evaluate against a connection context it does not own.
+	_, err = ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{SessionToken: "forged", FacetName: "http"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("forged token err = %v, want NotFound", err)
+	}
+
+	// Once the connection ends and its token is removed, further calls on
+	// it are rejected — no dangling evaluation context.
+	sessions.remove("tok-1")
+	_, err = ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{SessionToken: "tok-1", FacetName: "http"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("removed token err = %v, want NotFound", err)
+	}
+}

--- a/internal/config/extplugin/hostcontrol_test.go
+++ b/internal/config/extplugin/hostcontrol_test.go
@@ -8,14 +8,15 @@ import (
 	goplugin "github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
 // ctrlTestPlugin wires both sides over a real go-plugin broker, exactly as
 // the gateway/plugin do: the server (plugin) side captures the broker so
 // the plugin can dial the capability bundle; the client (gateway) side
-// serves HostControl on the reserved broker id, backed by a session
-// registry.
+// serves HostControl on the reserved broker id behind the session
+// interceptor, backed by a per-plugin session registry.
 type ctrlTestPlugin struct {
 	goplugin.NetRPCUnsupportedPlugin
 	broker   *goplugin.GRPCBroker
@@ -29,31 +30,48 @@ func (p *ctrlTestPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server)
 
 func (p *ctrlTestPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		opts = append(opts, grpc.ChainUnaryInterceptor(sessionUnaryInterceptor(p.sessions)))
 		s := grpc.NewServer(opts...)
-		pb.RegisterHostControlServer(s, newHostControl(p.sessions))
+		pb.RegisterHostControlServer(s, hostControl{})
 		return s
 	})
 	return c, nil
 }
 
+func dialHostControl(t *testing.T, p *ctrlTestPlugin) pb.HostControlClient {
+	t.Helper()
+	conn, err := p.broker.Dial(HostServicesBrokerID)
+	if err != nil {
+		t.Fatalf("dial broker: %v", err)
+	}
+	return pb.NewHostControlClient(conn)
+}
+
+// withSession returns a ctx carrying the session token as request metadata,
+// the way the SDK client interceptor will.
+func withSession(token string) context.Context {
+	return metadata.AppendToOutgoingContext(context.Background(), sessionMetadataKey, token)
+}
+
 // TestHostControlEvaluateRoundTrip is the capability-bundle spike: a plugin
 // runs a rule evaluation by calling a plain gRPC method over the broker —
 // no EvaluateAction frame, no call_id, no inflight correlation map. The
-// gateway routes the call to the connection's evaluator via a session
-// token, and rejects a token it never issued.
+// gateway routes the call to the connection's session via the metadata
+// token, resolved once in an interceptor.
 func TestHostControlEvaluateRoundTrip(t *testing.T) {
 	sessions := newSessionRegistry()
-	// What HandleConn would register when a connection starts: the same
-	// rule + approve work pumpConn's EvaluateAction branch does today.
 	var gotFacet string
 	var gotAction []byte
-	sessions.register("tok-1", func(_ context.Context, facet string, action []byte, _ string) (string, string, string, error) {
-		gotFacet = facet
-		gotAction = action
-		if facet == "http" {
-			return "allow", "matched", "rule-1", nil
-		}
-		return "deny", "no rule", "", nil
+	// What HandleConn will register when a connection starts: the same rule
+	// + approve work pumpConn's EvaluateAction branch does today.
+	token, remove := sessions.register(&session{
+		evaluate: func(_ context.Context, facet string, action []byte, _ string) (Verdict, error) {
+			gotFacet, gotAction = facet, action
+			if facet == "http" {
+				return Verdict{Action: "allow", Reason: "matched", Rule: "rule-1"}, nil
+			}
+			return Verdict{Action: "deny", Reason: "no rule"}, nil
+		},
 	})
 
 	p := &ctrlTestPlugin{sessions: sessions}
@@ -62,42 +80,61 @@ func TestHostControlEvaluateRoundTrip(t *testing.T) {
 	if _, err := client.Dispense("x"); err != nil {
 		t.Fatalf("dispense: %v", err)
 	}
+	ctrl := dialHostControl(t, p)
 
-	conn, err := p.broker.Dial(HostServicesBrokerID)
-	if err != nil {
-		t.Fatalf("dial broker: %v", err)
-	}
-	ctrl := pb.NewHostControlClient(conn)
-
-	// The whole client side: one call, gRPC correlates the reply.
-	v, err := ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{
-		SessionToken: "tok-1",
-		FacetName:    "http",
-		ActionJson:   []byte(`{"method":"GET"}`),
-		Summary:      "GET /",
+	// The whole client side: one call, gRPC correlates the reply; the token
+	// rides in metadata, not the message.
+	v, err := ctrl.Evaluate(withSession(token), &pb.EvaluateRequest{
+		FacetName:  "http",
+		ActionJson: []byte(`{"method":"GET"}`),
+		Summary:    "GET /",
 	})
 	if err != nil {
 		t.Fatalf("evaluate: %v", err)
 	}
-	if v.Action != "allow" || v.Rule != "rule-1" {
-		t.Fatalf("verdict = %+v, want allow/rule-1", v)
+	if v.Action != "allow" || v.Rule != "rule-1" || v.Reason != "matched" {
+		t.Fatalf("verdict = %+v, want allow/matched/rule-1", v)
 	}
 	if gotFacet != "http" || string(gotAction) != `{"method":"GET"}` {
 		t.Fatalf("gateway saw facet=%q action=%q", gotFacet, gotAction)
 	}
 
-	// A token the gateway never issued is rejected — a plugin cannot
-	// evaluate against a connection context it does not own.
-	_, err = ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{SessionToken: "forged", FacetName: "http"})
-	if status.Code(err) != codes.NotFound {
-		t.Fatalf("forged token err = %v, want NotFound", err)
+	// A token the gateway never issued is rejected by the interceptor — a
+	// plugin cannot evaluate against a context it does not own.
+	if _, err := ctrl.Evaluate(withSession("forged"), &pb.EvaluateRequest{FacetName: "http"}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("forged token err = %v, want Unauthenticated", err)
 	}
 
-	// Once the connection ends and its token is removed, further calls on
-	// it are rejected — no dangling evaluation context.
-	sessions.remove("tok-1")
-	_, err = ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{SessionToken: "tok-1", FacetName: "http"})
-	if status.Code(err) != codes.NotFound {
-		t.Fatalf("removed token err = %v, want NotFound", err)
+	// No token at all is rejected too (the method requires a session).
+	if _, err := ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{FacetName: "http"}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("missing token err = %v, want Unauthenticated", err)
+	}
+
+	// Once the connection ends and its token is removed, further calls on it
+	// are rejected — no dangling evaluation context.
+	remove()
+	if _, err := ctrl.Evaluate(withSession(token), &pb.EvaluateRequest{FacetName: "http"}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("removed token err = %v, want Unauthenticated", err)
+	}
+}
+
+// TestSessionRegistryTokensUnique guards the unforgeable-token property:
+// minted tokens are distinct, non-empty, and only resolve while registered.
+func TestSessionRegistryTokensUnique(t *testing.T) {
+	r := newSessionRegistry()
+	t1, rm1 := r.register(&session{})
+	t2, _ := r.register(&session{})
+	if t1 == t2 || t1 == "" {
+		t.Fatalf("tokens not unique/non-empty: %q %q", t1, t2)
+	}
+	if _, ok := r.lookup(t1); !ok {
+		t.Fatal("t1 should resolve while registered")
+	}
+	rm1()
+	if _, ok := r.lookup(t1); ok {
+		t.Fatal("t1 should not resolve after remove")
+	}
+	if _, ok := r.lookup(t2); !ok {
+		t.Fatal("t2 should still resolve")
 	}
 }

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3732,6 +3732,140 @@ func (*StatePutResponse) Descriptor() ([]byte, []int) {
 	return file_plugin_proto_rawDescGZIP(), []int{49}
 }
 
+type EvaluateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_token scopes the call to one connection's evaluation context
+	// (its rules, approve chain, peer info). Issued by the gateway in the
+	// session init; opaque to the plugin.
+	SessionToken string `protobuf:"bytes,1,opt,name=session_token,json=sessionToken,proto3" json:"session_token,omitempty"`
+	// facet_name is the namespaced facet the action conforms to.
+	FacetName string `protobuf:"bytes,2,opt,name=facet_name,json=facetName,proto3" json:"facet_name,omitempty"`
+	// action_json is the facet payload (the same bytes EvaluateAction
+	// carries today).
+	ActionJson    []byte `protobuf:"bytes,3,opt,name=action_json,json=actionJson,proto3" json:"action_json,omitempty"`
+	Summary       string `protobuf:"bytes,4,opt,name=summary,proto3" json:"summary,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateRequest) Reset() {
+	*x = EvaluateRequest{}
+	mi := &file_plugin_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateRequest) ProtoMessage() {}
+
+func (x *EvaluateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateRequest.ProtoReflect.Descriptor instead.
+func (*EvaluateRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *EvaluateRequest) GetSessionToken() string {
+	if x != nil {
+		return x.SessionToken
+	}
+	return ""
+}
+
+func (x *EvaluateRequest) GetFacetName() string {
+	if x != nil {
+		return x.FacetName
+	}
+	return ""
+}
+
+func (x *EvaluateRequest) GetActionJson() []byte {
+	if x != nil {
+		return x.ActionJson
+	}
+	return nil
+}
+
+func (x *EvaluateRequest) GetSummary() string {
+	if x != nil {
+		return x.Summary
+	}
+	return ""
+}
+
+type EvaluateVerdict struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Action        string                 `protobuf:"bytes,1,opt,name=action,proto3" json:"action,omitempty"` // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	Rule          string                 `protobuf:"bytes,3,opt,name=rule,proto3" json:"rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateVerdict) Reset() {
+	*x = EvaluateVerdict{}
+	mi := &file_plugin_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateVerdict) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateVerdict) ProtoMessage() {}
+
+func (x *EvaluateVerdict) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateVerdict.ProtoReflect.Descriptor instead.
+func (*EvaluateVerdict) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *EvaluateVerdict) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+func (x *EvaluateVerdict) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *EvaluateVerdict) GetRule() string {
+	if x != nil {
+		return x.Rule
+	}
+	return ""
+}
+
 var File_plugin_proto protoreflect.FileDescriptor
 
 const file_plugin_proto_rawDesc = "" +
@@ -4003,7 +4137,18 @@ const file_plugin_proto_rawDesc = "" +
 	"\x0fStatePutRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value\"\x12\n" +
-	"\x10StatePutResponse*7\n" +
+	"\x10StatePutResponse\"\x90\x01\n" +
+	"\x0fEvaluateRequest\x12#\n" +
+	"\rsession_token\x18\x01 \x01(\tR\fsessionToken\x12\x1d\n" +
+	"\n" +
+	"facet_name\x18\x02 \x01(\tR\tfacetName\x12\x1f\n" +
+	"\vaction_json\x18\x03 \x01(\fR\n" +
+	"actionJson\x12\x18\n" +
+	"\asummary\x18\x04 \x01(\tR\asummary\"U\n" +
+	"\x0fEvaluateVerdict\x12\x16\n" +
+	"\x06action\x18\x01 \x01(\tR\x06action\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x12\n" +
+	"\x04rule\x18\x03 \x01(\tR\x04rule*7\n" +
 	"\rNetworkAccess\x12\x10\n" +
 	"\fNETWORK_NONE\x10\x00\x12\x14\n" +
 	"\x10NETWORK_OUTBOUND\x10\x01*k\n" +
@@ -4033,7 +4178,9 @@ const file_plugin_proto_rawDesc = "" +
 	"\vCloseTunnel\x12(.clawpatrol.plugin.v1.CloseTunnelRequest\x1a).clawpatrol.plugin.v1.CloseTunnelResponse2\xb7\x01\n" +
 	"\tHostState\x12T\n" +
 	"\x03Get\x12%.clawpatrol.plugin.v1.StateGetRequest\x1a&.clawpatrol.plugin.v1.StateGetResponse\x12T\n" +
-	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponseBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
+	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponse2g\n" +
+	"\vHostControl\x12X\n" +
+	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdictBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -4048,7 +4195,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_plugin_proto_goTypes = []any{
 	(NetworkAccess)(0),             // 0: clawpatrol.plugin.v1.NetworkAccess
 	(FacetKind)(0),                 // 1: clawpatrol.plugin.v1.FacetKind
@@ -4105,11 +4252,13 @@ var file_plugin_proto_goTypes = []any{
 	(*StateGetResponse)(nil),       // 52: clawpatrol.plugin.v1.StateGetResponse
 	(*StatePutRequest)(nil),        // 53: clawpatrol.plugin.v1.StatePutRequest
 	(*StatePutResponse)(nil),       // 54: clawpatrol.plugin.v1.StatePutResponse
-	nil,                            // 55: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	nil,                            // 56: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	nil,                            // 57: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                            // 58: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                            // 59: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(*EvaluateRequest)(nil),        // 55: clawpatrol.plugin.v1.EvaluateRequest
+	(*EvaluateVerdict)(nil),        // 56: clawpatrol.plugin.v1.EvaluateVerdict
+	nil,                            // 57: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 58: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 59: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 60: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 61: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
 	19, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
@@ -4134,8 +4283,8 @@ var file_plugin_proto_depIdxs = []int32{
 	24, // 19: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
 	18, // 20: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
 	3,  // 21: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	55, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	56, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	57, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	58, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
 	4,  // 24: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
 	27, // 25: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
 	39, // 26: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
@@ -4151,9 +4300,9 @@ var file_plugin_proto_depIdxs = []int32{
 	31, // 36: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
 	32, // 37: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
 	33, // 38: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
-	57, // 39: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	58, // 40: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	59, // 41: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	59, // 39: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	60, // 40: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	61, // 41: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 	48, // 42: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
 	49, // 43: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
 	50, // 44: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
@@ -4167,17 +4316,19 @@ var file_plugin_proto_depIdxs = []int32{
 	45, // 52: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
 	51, // 53: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
 	53, // 54: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
-	6,  // 55: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 56: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 57: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	29, // 58: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	44, // 59: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	47, // 60: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	46, // 61: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	52, // 62: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	54, // 63: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	55, // [55:64] is the sub-list for method output_type
-	46, // [46:55] is the sub-list for method input_type
+	55, // 55: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
+	6,  // 56: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 57: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 58: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	29, // 59: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	44, // 60: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	47, // 61: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	46, // 62: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	52, // 63: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	54, // 64: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	56, // 65: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
+	56, // [56:66] is the sub-list for method output_type
+	46, // [46:56] is the sub-list for method input_type
 	46, // [46:46] is the sub-list for extension type_name
 	46, // [46:46] is the sub-list for extension extendee
 	0,  // [0:46] is the sub-list for field type_name
@@ -4214,9 +4365,9 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   55,
+			NumMessages:   57,
 			NumExtensions: 0,
-			NumServices:   5,
+			NumServices:   6,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3734,16 +3734,12 @@ func (*StatePutResponse) Descriptor() ([]byte, []int) {
 
 type EvaluateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// session_token scopes the call to one connection's evaluation context
-	// (its rules, approve chain, peer info). Issued by the gateway in the
-	// session init; opaque to the plugin.
-	SessionToken string `protobuf:"bytes,1,opt,name=session_token,json=sessionToken,proto3" json:"session_token,omitempty"`
 	// facet_name is the namespaced facet the action conforms to.
-	FacetName string `protobuf:"bytes,2,opt,name=facet_name,json=facetName,proto3" json:"facet_name,omitempty"`
+	FacetName string `protobuf:"bytes,1,opt,name=facet_name,json=facetName,proto3" json:"facet_name,omitempty"`
 	// action_json is the facet payload (the same bytes EvaluateAction
 	// carries today).
-	ActionJson    []byte `protobuf:"bytes,3,opt,name=action_json,json=actionJson,proto3" json:"action_json,omitempty"`
-	Summary       string `protobuf:"bytes,4,opt,name=summary,proto3" json:"summary,omitempty"`
+	ActionJson    []byte `protobuf:"bytes,2,opt,name=action_json,json=actionJson,proto3" json:"action_json,omitempty"`
+	Summary       string `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"` // NB: the session token is carried in request metadata, not here.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3776,13 +3772,6 @@ func (x *EvaluateRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use EvaluateRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateRequest) Descriptor() ([]byte, []int) {
 	return file_plugin_proto_rawDescGZIP(), []int{50}
-}
-
-func (x *EvaluateRequest) GetSessionToken() string {
-	if x != nil {
-		return x.SessionToken
-	}
-	return ""
 }
 
 func (x *EvaluateRequest) GetFacetName() string {
@@ -4137,14 +4126,13 @@ const file_plugin_proto_rawDesc = "" +
 	"\x0fStatePutRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value\"\x12\n" +
-	"\x10StatePutResponse\"\x90\x01\n" +
-	"\x0fEvaluateRequest\x12#\n" +
-	"\rsession_token\x18\x01 \x01(\tR\fsessionToken\x12\x1d\n" +
+	"\x10StatePutResponse\"k\n" +
+	"\x0fEvaluateRequest\x12\x1d\n" +
 	"\n" +
-	"facet_name\x18\x02 \x01(\tR\tfacetName\x12\x1f\n" +
-	"\vaction_json\x18\x03 \x01(\fR\n" +
+	"facet_name\x18\x01 \x01(\tR\tfacetName\x12\x1f\n" +
+	"\vaction_json\x18\x02 \x01(\fR\n" +
 	"actionJson\x12\x18\n" +
-	"\asummary\x18\x04 \x01(\tR\asummary\"U\n" +
+	"\asummary\x18\x03 \x01(\tR\asummary\"U\n" +
 	"\x0fEvaluateVerdict\x12\x16\n" +
 	"\x06action\x18\x01 \x01(\tR\x06action\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x12\n" +

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -594,3 +594,47 @@ message StatePutRequest {
 }
 
 message StatePutResponse {}
+
+// =====================================================================
+// PROTOTYPE: HostControl — the capability bundle (host-served control
+// plane). See doc/plugin-capability-bundle-prototype.md.
+// =====================================================================
+//
+// Like HostState, HostControl is implemented by the GATEWAY and called by
+// the plugin over the broker — but it carries the *control* callbacks a
+// plugin makes (rule evaluation, brokered dial, ...), which today are
+// hand-rolled as request/reply frames inside the HandleConn stream with
+// manual call_id / dial_id correlation. As ordinary gRPC methods the
+// correlation is free and a new capability (an approver, a HITL prompt)
+// is a new method here, not a new frame.
+//
+// Calls are scoped to a connection by a session token the gateway issues
+// in the session init and the plugin echoes back — the one piece of
+// bookkeeping a separate control channel needs that a multiplexed stream
+// gets implicitly.
+service HostControl {
+  // Evaluate runs the gateway's rule + approve chain for one action and
+  // returns the verdict. Prototype replacement for the
+  // EvaluateAction / ActionVerdict frames (and the inflight call_id map
+  // on both sides of HandleConn).
+  rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
+}
+
+message EvaluateRequest {
+  // session_token scopes the call to one connection's evaluation context
+  // (its rules, approve chain, peer info). Issued by the gateway in the
+  // session init; opaque to the plugin.
+  string session_token = 1;
+  // facet_name is the namespaced facet the action conforms to.
+  string facet_name = 2;
+  // action_json is the facet payload (the same bytes EvaluateAction
+  // carries today).
+  bytes action_json = 3;
+  string summary = 4;
+}
+
+message EvaluateVerdict {
+  string action = 1; // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
+  string reason = 2;
+  string rule = 3;
+}

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -612,25 +612,34 @@ message StatePutResponse {}
 // in the session init and the plugin echoes back — the one piece of
 // bookkeeping a separate control channel needs that a multiplexed stream
 // gets implicitly.
+// HostControl is the host-served (plugin->host) capability bundle: the
+// gateway serves it over the go-plugin broker (next to HostState) and a
+// plugin calls it. Each plugin->gateway callback is an ordinary gRPC
+// method, so gRPC correlates the reply and the hand-rolled call_id/dial_id
+// inflight maps disappear. It grows by adding methods (Dial, Decide), not
+// new frames.
+//
+// Every call is scoped to one connection's evaluation context by an opaque
+// session token the gateway issued for that connection. The token rides in
+// gRPC METADATA (key "clawpatrol-session"), not in the message — session
+// scope is a cross-cutting concern, so a server interceptor resolves it
+// once and every method is scoped without repeating the field. A forged,
+// expired, or removed token is rejected before the handler runs.
 service HostControl {
   // Evaluate runs the gateway's rule + approve chain for one action and
-  // returns the verdict. Prototype replacement for the
-  // EvaluateAction / ActionVerdict frames (and the inflight call_id map
-  // on both sides of HandleConn).
+  // returns the verdict. Replaces the EvaluateAction / ActionVerdict
+  // frames (and the inflight call_id map on both sides of HandleConn).
   rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
 }
 
 message EvaluateRequest {
-  // session_token scopes the call to one connection's evaluation context
-  // (its rules, approve chain, peer info). Issued by the gateway in the
-  // session init; opaque to the plugin.
-  string session_token = 1;
   // facet_name is the namespaced facet the action conforms to.
-  string facet_name = 2;
+  string facet_name = 1;
   // action_json is the facet payload (the same bytes EvaluateAction
   // carries today).
-  bytes action_json = 3;
-  string summary = 4;
+  bytes action_json = 2;
+  string summary = 3;
+  // NB: the session token is carried in request metadata, not here.
 }
 
 message EvaluateVerdict {

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -747,3 +747,149 @@ var HostState_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "plugin.proto",
 }
+
+const (
+	HostControl_Evaluate_FullMethodName = "/clawpatrol.plugin.v1.HostControl/Evaluate"
+)
+
+// HostControlClient is the client API for HostControl service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// =====================================================================
+// PROTOTYPE: HostControl — the capability bundle (host-served control
+// plane). See doc/plugin-capability-bundle-prototype.md.
+// =====================================================================
+//
+// Like HostState, HostControl is implemented by the GATEWAY and called by
+// the plugin over the broker — but it carries the *control* callbacks a
+// plugin makes (rule evaluation, brokered dial, ...), which today are
+// hand-rolled as request/reply frames inside the HandleConn stream with
+// manual call_id / dial_id correlation. As ordinary gRPC methods the
+// correlation is free and a new capability (an approver, a HITL prompt)
+// is a new method here, not a new frame.
+//
+// Calls are scoped to a connection by a session token the gateway issues
+// in the session init and the plugin echoes back — the one piece of
+// bookkeeping a separate control channel needs that a multiplexed stream
+// gets implicitly.
+type HostControlClient interface {
+	// Evaluate runs the gateway's rule + approve chain for one action and
+	// returns the verdict. Prototype replacement for the
+	// EvaluateAction / ActionVerdict frames (and the inflight call_id map
+	// on both sides of HandleConn).
+	Evaluate(ctx context.Context, in *EvaluateRequest, opts ...grpc.CallOption) (*EvaluateVerdict, error)
+}
+
+type hostControlClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewHostControlClient(cc grpc.ClientConnInterface) HostControlClient {
+	return &hostControlClient{cc}
+}
+
+func (c *hostControlClient) Evaluate(ctx context.Context, in *EvaluateRequest, opts ...grpc.CallOption) (*EvaluateVerdict, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EvaluateVerdict)
+	err := c.cc.Invoke(ctx, HostControl_Evaluate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// HostControlServer is the server API for HostControl service.
+// All implementations must embed UnimplementedHostControlServer
+// for forward compatibility.
+//
+// =====================================================================
+// PROTOTYPE: HostControl — the capability bundle (host-served control
+// plane). See doc/plugin-capability-bundle-prototype.md.
+// =====================================================================
+//
+// Like HostState, HostControl is implemented by the GATEWAY and called by
+// the plugin over the broker — but it carries the *control* callbacks a
+// plugin makes (rule evaluation, brokered dial, ...), which today are
+// hand-rolled as request/reply frames inside the HandleConn stream with
+// manual call_id / dial_id correlation. As ordinary gRPC methods the
+// correlation is free and a new capability (an approver, a HITL prompt)
+// is a new method here, not a new frame.
+//
+// Calls are scoped to a connection by a session token the gateway issues
+// in the session init and the plugin echoes back — the one piece of
+// bookkeeping a separate control channel needs that a multiplexed stream
+// gets implicitly.
+type HostControlServer interface {
+	// Evaluate runs the gateway's rule + approve chain for one action and
+	// returns the verdict. Prototype replacement for the
+	// EvaluateAction / ActionVerdict frames (and the inflight call_id map
+	// on both sides of HandleConn).
+	Evaluate(context.Context, *EvaluateRequest) (*EvaluateVerdict, error)
+	mustEmbedUnimplementedHostControlServer()
+}
+
+// UnimplementedHostControlServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedHostControlServer struct{}
+
+func (UnimplementedHostControlServer) Evaluate(context.Context, *EvaluateRequest) (*EvaluateVerdict, error) {
+	return nil, status.Error(codes.Unimplemented, "method Evaluate not implemented")
+}
+func (UnimplementedHostControlServer) mustEmbedUnimplementedHostControlServer() {}
+func (UnimplementedHostControlServer) testEmbeddedByValue()                     {}
+
+// UnsafeHostControlServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to HostControlServer will
+// result in compilation errors.
+type UnsafeHostControlServer interface {
+	mustEmbedUnimplementedHostControlServer()
+}
+
+func RegisterHostControlServer(s grpc.ServiceRegistrar, srv HostControlServer) {
+	// If the following call panics, it indicates UnimplementedHostControlServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&HostControl_ServiceDesc, srv)
+}
+
+func _HostControl_Evaluate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EvaluateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostControlServer).Evaluate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostControl_Evaluate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostControlServer).Evaluate(ctx, req.(*EvaluateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// HostControl_ServiceDesc is the grpc.ServiceDesc for HostControl service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var HostControl_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.HostControl",
+	HandlerType: (*HostControlServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Evaluate",
+			Handler:    _HostControl_Evaluate_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "plugin.proto",
+}

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -773,11 +773,23 @@ const (
 // in the session init and the plugin echoes back — the one piece of
 // bookkeeping a separate control channel needs that a multiplexed stream
 // gets implicitly.
+// HostControl is the host-served (plugin->host) capability bundle: the
+// gateway serves it over the go-plugin broker (next to HostState) and a
+// plugin calls it. Each plugin->gateway callback is an ordinary gRPC
+// method, so gRPC correlates the reply and the hand-rolled call_id/dial_id
+// inflight maps disappear. It grows by adding methods (Dial, Decide), not
+// new frames.
+//
+// Every call is scoped to one connection's evaluation context by an opaque
+// session token the gateway issued for that connection. The token rides in
+// gRPC METADATA (key "clawpatrol-session"), not in the message — session
+// scope is a cross-cutting concern, so a server interceptor resolves it
+// once and every method is scoped without repeating the field. A forged,
+// expired, or removed token is rejected before the handler runs.
 type HostControlClient interface {
 	// Evaluate runs the gateway's rule + approve chain for one action and
-	// returns the verdict. Prototype replacement for the
-	// EvaluateAction / ActionVerdict frames (and the inflight call_id map
-	// on both sides of HandleConn).
+	// returns the verdict. Replaces the EvaluateAction / ActionVerdict
+	// frames (and the inflight call_id map on both sides of HandleConn).
 	Evaluate(ctx context.Context, in *EvaluateRequest, opts ...grpc.CallOption) (*EvaluateVerdict, error)
 }
 
@@ -820,11 +832,23 @@ func (c *hostControlClient) Evaluate(ctx context.Context, in *EvaluateRequest, o
 // in the session init and the plugin echoes back — the one piece of
 // bookkeeping a separate control channel needs that a multiplexed stream
 // gets implicitly.
+// HostControl is the host-served (plugin->host) capability bundle: the
+// gateway serves it over the go-plugin broker (next to HostState) and a
+// plugin calls it. Each plugin->gateway callback is an ordinary gRPC
+// method, so gRPC correlates the reply and the hand-rolled call_id/dial_id
+// inflight maps disappear. It grows by adding methods (Dial, Decide), not
+// new frames.
+//
+// Every call is scoped to one connection's evaluation context by an opaque
+// session token the gateway issued for that connection. The token rides in
+// gRPC METADATA (key "clawpatrol-session"), not in the message — session
+// scope is a cross-cutting concern, so a server interceptor resolves it
+// once and every method is scoped without repeating the field. A forged,
+// expired, or removed token is rejected before the handler runs.
 type HostControlServer interface {
 	// Evaluate runs the gateway's rule + approve chain for one action and
-	// returns the verdict. Prototype replacement for the
-	// EvaluateAction / ActionVerdict frames (and the inflight call_id map
-	// on both sides of HandleConn).
+	// returns the verdict. Replaces the EvaluateAction / ActionVerdict
+	// frames (and the inflight call_id map on both sides of HandleConn).
 	Evaluate(context.Context, *EvaluateRequest) (*EvaluateVerdict, error)
 	mustEmbedUnimplementedHostControlServer()
 }


### PR DESCRIPTION
Draft / RFC, now hardened along the reviewed design.

A host-served control plane (`HostControl`) over the same go-plugin
broker the M1 state service uses: each plugin→gateway callback is an
ordinary gRPC method, so gRPC's correlation replaces the hand-rolled
`call_id`/`dial_id` inflight maps multiplexed inside `HandleConn`.

What changed in this revision (vs. the original spike):

* **Direction is the load-bearing decision.** `HostControl` is the
  **plugin→host** capability bundle (`Evaluate` now; brokered `Dial` and
  HITL `Decide` later). The **host→plugin** callbacks — the LLM
  `Approve`, the HITL `Notify`/`Update` — are a plugin-served `Approver`
  service, **not** `HostControl` methods. Only `Decide` is plugin→host.
  The earlier "build M4/M5 as `HostControl` methods" was wrong by
  direction; the doc now has the corrected mapping and an end-to-end M4/M5
  sketch (both directions).
* **Session scoping moved to gRPC metadata + a server interceptor**
  (standard over ad-hoc): the `session_token` message field is gone, so
  request messages stay payload-only and every future method is scoped
  for free. Tokens are minted `crypto/rand` at registration (unforgeable);
  forged / absent / removed are rejected `Unauthenticated`.
* **Typed `Verdict` + session object** mirroring `runtime`/`pluginsdk`
  types, instead of the four-string tuple.

Proven end to end over a real go-plugin broker (the state-service
harness), under `-race`. Still a prototype — served and tested, not yet
wired into the live `HandleConn` path (the deferred migration in the
recommendation).

`doc/plugin-capability-bundle-prototype.md` has the full two-direction
design, the M4/M5 proto sketch, and the phased recommendation.

The decision this asks for: adopt `HostControl` as the plugin→host bundle
and build M4/M5's host→plugin callbacks as a plugin-served `Approver`
service — confirmed?