### PR TITLE
fix(auth): preserve Basic authenticate challenges

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2561,7 +2561,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		// before stripping credential-bearing ones — the dashboard
 		// still wants to show what the upstream actually sent.
 		ev.RespHeaders = flatHeaders(resp.Header)
-		stripAuthResponseHeaders(resp.Header)
+		stripAuthResponseHeadersPreservingBasicChallenge(resp.Header)
 		stripAltSvc(resp.Header)
 		// Trailers fall outside resp.Header — Go's http.Transport
 		// surfaces them on resp.Trailer and http.Response.Write

--- a/cmd/clawpatrol/response_sanitize.go
+++ b/cmd/clawpatrol/response_sanitize.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"mime"
 	"net/http"
 	"strings"
 )
@@ -56,6 +57,93 @@ func stripAuthResponseHeaders(h http.Header) {
 	for _, name := range authResponseHeaders {
 		h.Del(name)
 	}
+}
+
+// stripAuthResponseHeadersPreservingBasicChallenge removes response-side
+// authentication artifacts but keeps Basic WWW-Authenticate challenges.
+// Basic challenges are protocol negotiation, not credentials; Git-over-HTTPS
+// needs them before it asks its credential helper and retries with auth.
+func stripAuthResponseHeadersPreservingBasicChallenge(h http.Header) {
+	challenges := h.Values("WWW-Authenticate")
+	stripAuthResponseHeaders(h)
+	for _, challenge := range challenges {
+		if isBasicAuthenticateChallenge(challenge) {
+			h.Add("WWW-Authenticate", challenge)
+		}
+	}
+}
+
+func isBasicAuthenticateChallenge(challenge string) bool {
+	scheme, params, ok := splitAuthChallenge(challenge)
+	if !ok || !strings.EqualFold(scheme, "Basic") || strings.TrimSpace(params) == "" {
+		return false
+	}
+
+	mediaValue, ok := authParamsAsMediaType(scheme, params)
+	if !ok {
+		return false
+	}
+	mediaType, parsedParams, err := mime.ParseMediaType(mediaValue)
+	if err != nil || !strings.EqualFold(mediaType, "Basic") {
+		return false
+	}
+	_, hasRealm := parsedParams["realm"]
+	return hasRealm
+}
+
+func splitAuthChallenge(challenge string) (scheme, params string, ok bool) {
+	challenge = strings.TrimSpace(challenge)
+	if challenge == "" {
+		return "", "", false
+	}
+	if i := strings.IndexAny(challenge, " \t"); i >= 0 {
+		scheme = challenge[:i]
+		params = strings.TrimSpace(challenge[i+1:])
+	} else {
+		scheme = challenge
+	}
+	if scheme == "" || strings.Contains(scheme, ",") {
+		return "", "", false
+	}
+	return scheme, params, true
+}
+
+func authParamsAsMediaType(scheme, params string) (string, bool) {
+	// WWW-Authenticate auth-params are comma-separated; mime.ParseMediaType
+	// validates the same param shape after we normalize the separators.
+	var b strings.Builder
+	b.WriteString(scheme)
+	for _, part := range commaPartsOutsideQuotes(params) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", false
+		}
+		b.WriteString("; ")
+		b.WriteString(part)
+	}
+	return b.String(), true
+}
+
+func commaPartsOutsideQuotes(s string) []string {
+	var parts []string
+	start := 0
+	inQuote := false
+	escaped := false
+	for i, r := range s {
+		switch {
+		case escaped:
+			escaped = false
+		case inQuote && r == '\\':
+			escaped = true
+		case r == '"':
+			inQuote = !inQuote
+		case r == ',' && !inQuote:
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
 }
 
 // stripAuthResponseHeadersRaw removes credential-bearing header

--- a/cmd/clawpatrol/response_sanitize_test.go
+++ b/cmd/clawpatrol/response_sanitize_test.go
@@ -3,10 +3,21 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
 func TestStripAuthResponseHeaders(t *testing.T) {
@@ -37,6 +48,325 @@ func TestStripAuthResponseHeaders(t *testing.T) {
 	}
 	if h.Get("X-Custom") != "keep" {
 		t.Errorf("X-Custom was clobbered: %q", h.Get("X-Custom"))
+	}
+}
+
+func TestStripAuthResponseHeadersPreservingBasicChallenge(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Add("Set-Cookie", "session=abc")
+	h.Set("Authentication-Info", `nextnonce="x"`)
+	h.Add("WWW-Authenticate", `Bearer realm="api"`)
+	h.Add("WWW-Authenticate", `Basic realm="GitLab"`)
+	h.Add("WWW-Authenticate", `basic realm="lower"`)
+	h.Add("WWW-Authenticate", `Basic realm="GitLab", charset="UTF-8"`)
+	h.Add("WWW-Authenticate", `Basic realm="GitLab", Bearer realm="api"`)
+	h.Set("Proxy-Authenticate", `Basic realm="proxy"`)
+	h.Set("X-Custom", "keep")
+
+	stripAuthResponseHeadersPreservingBasicChallenge(h)
+
+	if got := h.Values("WWW-Authenticate"); len(got) != 3 {
+		t.Fatalf("WWW-Authenticate values = %v, want only three Basic challenges", got)
+	} else {
+		for _, want := range []string{
+			`Basic realm="GitLab"`,
+			`basic realm="lower"`,
+			`Basic realm="GitLab", charset="UTF-8"`,
+		} {
+			found := false
+			for _, v := range got {
+				if v == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("WWW-Authenticate missing %q in %v", want, got)
+			}
+		}
+	}
+	for _, name := range []string{
+		"Set-Cookie", "Set-Cookie2", "Proxy-Authenticate",
+		"Authentication-Info", "Proxy-Authentication-Info",
+	} {
+		if v := h.Values(name); len(v) != 0 {
+			t.Errorf("header %q not stripped, got %v", name, v)
+		}
+	}
+	if h.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type was clobbered: %q", h.Get("Content-Type"))
+	}
+	if h.Get("X-Custom") != "keep" {
+		t.Errorf("X-Custom was clobbered: %q", h.Get("X-Custom"))
+	}
+}
+
+func TestIsBasicAuthenticateChallenge(t *testing.T) {
+	tests := []struct {
+		name      string
+		challenge string
+		want      bool
+	}{
+		{
+			name:      "basic realm",
+			challenge: `Basic realm="GitLab"`,
+			want:      true,
+		},
+		{
+			name:      "case insensitive scheme",
+			challenge: `basic realm="lower"`,
+			want:      true,
+		},
+		{
+			name:      "extra basic parameter",
+			challenge: `Basic realm="GitLab", charset="UTF-8"`,
+			want:      true,
+		},
+		{
+			name:      "quoted comma",
+			challenge: `Basic realm="GitLab, Inc."`,
+			want:      true,
+		},
+		{
+			name:      "escaped quote",
+			challenge: `Basic realm="GitLab \"private\""`,
+			want:      true,
+		},
+		{
+			name:      "leading and tab whitespace",
+			challenge: " Basic\trealm=\"GitLab\" ",
+			want:      true,
+		},
+		{
+			name:      "bearer",
+			challenge: `Bearer realm="api"`,
+			want:      false,
+		},
+		{
+			name:      "mixed challenge after basic",
+			challenge: `Basic realm="GitLab", Bearer realm="api"`,
+			want:      false,
+		},
+		{
+			name:      "mixed challenge before basic",
+			challenge: `Bearer realm="api", Basic realm="GitLab"`,
+			want:      false,
+		},
+		{
+			name:      "missing realm",
+			challenge: `Basic charset="UTF-8"`,
+			want:      false,
+		},
+		{
+			name:      "bare basic",
+			challenge: `Basic`,
+			want:      false,
+		},
+		{
+			name:      "token68",
+			challenge: `Basic abcdef`,
+			want:      false,
+		},
+		{
+			name:      "unclosed quote",
+			challenge: `Basic realm="GitLab`,
+			want:      false,
+		},
+		{
+			name:      "trailing comma",
+			challenge: `Basic realm="GitLab",`,
+			want:      false,
+		},
+		{
+			name:      "parameter without value",
+			challenge: `Basic realm`,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBasicAuthenticateChallenge(tt.challenge); got != tt.want {
+				t.Fatalf("isBasicAuthenticateChallenge(%q) = %v, want %v",
+					tt.challenge, got, tt.want)
+			}
+		})
+	}
+}
+
+type basicAuthChallengeSecretStore map[string]string
+
+func (s basicAuthChallengeSecretStore) Get(name string) (runtime.Secret, error) {
+	v, ok := s[name]
+	if !ok {
+		return runtime.Secret{}, fmt.Errorf("unexpected secret lookup %q", name)
+	}
+	return runtime.Secret{Bytes: []byte(v)}, nil
+}
+
+func TestMITMPreservesBasicChallengeThenRewritesPlaceholder(t *testing.T) {
+	const (
+		placeholder = "glpat-clawpatrol-git-placeholder-do-not-use"
+		realSecret  = "glpat-real-secret"
+		username    = "oauth2"
+	)
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+endpoint "https" "gitlab" {
+  hosts = ["gitlab.com"]
+}
+credential "header_token" "gitlab-api-token" {
+  endpoint    = https.gitlab
+  placeholder = "glpat-clawpatrol-api-placeholder-do-not-use"
+  header      = "PRIVATE-TOKEN"
+}
+credential "basic_auth" "gitlab-git-token" {
+  endpoint    = https.gitlab
+  placeholder = %q
+  username    = %q
+}
+profile "default" {
+  credentials = [
+    header_token.gitlab-api-token,
+    basic_auth.gitlab-git-token,
+  ]
+}
+rule "allow-gitlab" {
+  endpoint = https.gitlab
+  verdict  = "allow"
+}
+`, placeholder, username)), "basic-auth-challenge-test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load config: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile config: %v", err)
+	}
+	ep := policy.Endpoints["gitlab"]
+	if ep == nil {
+		t.Fatal("missing gitlab endpoint")
+	}
+
+	upstreamAuth := make(chan string, 1)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Add("WWW-Authenticate", `Bearer realm="api"`)
+			w.Header().Add("WWW-Authenticate", `Basic realm="GitLab"`)
+			w.Header().Add("Set-Cookie", "session=upstream")
+			w.Header().Set("Authentication-Info", `nextnonce="x"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		upstreamAuth <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamAddr := upstream.Listener.Addr().String()
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upstreamAddr)
+		},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: false,
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+
+	sink, err := NewSink(nil, 8)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+	t.Cleanup(func() { close(sink.ch) })
+	certs, _ := inMemoryCertCache(t)
+	g := &Gateway{
+		certs: certs,
+		sink:  sink,
+		secrets: basicAuthChallengeSecretStore{
+			"gitlab-git-token": realSecret,
+		},
+	}
+	g.cfg.Store(gw)
+	g.policy.Store(policy)
+	g.transports.Store(ep, transport)
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.mitmHTTPS(serverConn, "gitlab.com", ep)
+	}()
+
+	clientTLS := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true, ServerName: "gitlab.com"})
+	if err := clientTLS.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+
+	firstReq, err := http.NewRequest(http.MethodGet, "https://gitlab.com/example-group/private-repo.git/info/refs?service=git-upload-pack", nil)
+	if err != nil {
+		t.Fatalf("new first request: %v", err)
+	}
+	if err := firstReq.Write(clientTLS); err != nil {
+		t.Fatalf("write first request: %v", err)
+	}
+	firstResp, err := http.ReadResponse(bufio.NewReader(clientTLS), firstReq)
+	if err != nil {
+		t.Fatalf("read first response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, firstResp.Body)
+	_ = firstResp.Body.Close()
+	if firstResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("first status = %d, want %d", firstResp.StatusCode, http.StatusUnauthorized)
+	}
+	if got := firstResp.Header.Values("WWW-Authenticate"); len(got) != 1 || got[0] != `Basic realm="GitLab"` {
+		t.Fatalf("WWW-Authenticate = %v, want only Basic challenge", got)
+	}
+	if got := firstResp.Header.Values("Set-Cookie"); len(got) != 0 {
+		t.Fatalf("Set-Cookie leaked to client: %v", got)
+	}
+	if got := firstResp.Header.Get("Authentication-Info"); got != "" {
+		t.Fatalf("Authentication-Info leaked to client: %q", got)
+	}
+
+	secondReq, err := http.NewRequest(http.MethodGet, "https://gitlab.com/example-group/private-repo.git/info/refs?service=git-upload-pack", nil)
+	if err != nil {
+		t.Fatalf("new second request: %v", err)
+	}
+	secondReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+placeholder)))
+	if err := secondReq.Write(clientTLS); err != nil {
+		t.Fatalf("write second request: %v", err)
+	}
+	secondResp, err := http.ReadResponse(bufio.NewReader(clientTLS), secondReq)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, secondResp.Body)
+	_ = secondResp.Body.Close()
+	if secondResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("second status = %d, want %d", secondResp.StatusCode, http.StatusNoContent)
+	}
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+realSecret))
+	select {
+	case got := <-upstreamAuth:
+		if got != want {
+			t.Fatalf("upstream Authorization = %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream request")
+	}
+
+	_ = clientTLS.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gateway did not exit after client close")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix Git-over-HTTPS Basic Auth flows through the HTTPS MITM gateway.

When an upstream returns `401 Unauthorized`, Git waits for a `WWW-Authenticate: Basic ...` challenge before asking its credential helper for credentials and retrying the request. The gateway currently strips all `WWW-Authenticate` response headers on credentialled MITM responses. That is right for sensitive response-side auth material in general, but it also removes the Basic challenge Git needs to start the retry flow.

The result is that private GitLab clone/fetch requests can fail before the gateway has a chance to rewrite the client's Basic placeholder credential to the real secret.

## Fix

Preserve only clearly valid, single `WWW-Authenticate: Basic ...` challenges on the normal upstream MITM response path.

Everything else remains stripped:
- Bearer/Digest/Negotiate/etc. challenges
- mixed challenge values such as `Basic ..., Bearer ...`
- malformed or ambiguous challenge values
- `Proxy-Authenticate`, `Authentication-Info`, cookies, and trailers
- raw WebSocket/synthetic response paths

The Basic parser is intentionally fail-closed. It accepts only a Basic scheme with auth params including `realm`, normalizes auth params for stdlib `mime.ParseMediaType` validation, and strips anything ambiguous.

## Validation

Added tests covering:
- preserving valid Basic challenges
- stripping Bearer and mixed Basic/Bearer challenges
- malformed Basic challenge values
- quoted commas and escaped quotes in Basic params
- full MITM flow where:
  1. upstream returns 401 with both Bearer and Basic challenges
  2. gateway forwards only the Basic challenge
  3. client retries with Basic placeholder
  4. gateway rewrites the placeholder to the real Basic credential upstream

Local checks:
- `go test ./cmd/clawpatrol -run 'Test.*Basic|TestStripAuthResponse|TestMITMPreservesBasicChallenge' -count=1`
- `go test ./cmd/clawpatrol -count=1`
- `gofmt -l .`
- `git diff --check`

Also verified against a live GitLab private repo clone from an agent runner: the unauthenticated Git smart-HTTP request returned `401` with `WWW-Authenticate: Basic realm="GitLab"`, then Git retried with Basic auth and clone succeeded.
