### PR TITLE
Make external HTTPS plugin endpoints work end to end

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1490,17 +1490,20 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 		g.mitmHTTPSWithCertHost(c, authority, certHost, ep)
 		return
 	}
-	// External plugin conn-endpoints (e.g. an `aws_api` bound to
-	// `*.amazonaws.com`) terminate TLS themselves and pump the raw
-	// agent conn to the subprocess over gRPC, so they aren't an
-	// https-mitm facet. They're matched here purely by SNI: the agent
-	// resolves and dials the real upstream IP and the forwarder
-	// intercepts :443 promiscuously, so no VIP or conn-index entry is
-	// needed — which matters for a wildcard host, since it has
-	// neither (it can't be DNS-resolved to an IP for the conn-index,
-	// and an HTTPS plugin isn't RequiresVIP). Hand the peeked conn to
-	// the plugin instead of splicing past it.
-	if _, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime); ok {
+	// External plugin endpoints that terminate TLS themselves (e.g. an
+	// `aws_api` bound to `*.amazonaws.com`) pump the raw agent conn to
+	// the subprocess over gRPC, so they aren't an https-mitm facet.
+	// They're matched here purely by SNI: the agent resolves and dials
+	// the real upstream IP and the forwarder intercepts :443
+	// promiscuously, so no VIP or conn-index entry is needed — which
+	// matters for a wildcard host, since it has neither (it can't be
+	// DNS-resolved to an IP for the conn-index, and an HTTPS plugin
+	// isn't RequiresVIP). Gate on the plugin body's TLS-terminate
+	// marker, not just ConnEndpointRuntime: built-in wire-protocol
+	// runtimes (postgres / clickhouse / ssh) also satisfy that
+	// interface but can't read a raw ClientHello, and route via
+	// VIP/direct-IP rather than SNI-on-443.
+	if tt, ok := ep.Body.(interface{ TLSTerminates() bool }); ok && tt.TLSTerminates() {
 		log.Printf("sni-conn: %s → %s", host, ep.Name)
 		g.dispatchConnEndpoint(c, dstIP, dstPort, ep, host)
 		return
@@ -1843,7 +1846,12 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 			})
 		},
 	}
-	if err := connRT.HandleConn(context.Background(), ch); err != nil {
+	// Cancel on return so a pump goroutine still parked on the plugin
+	// stream (e.g. blocked in Send after the other direction finished)
+	// unblocks and the gRPC stream tears down instead of leaking.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := connRT.HandleConn(ctx, ch); err != nil {
 		if hostname != "" {
 			log.Printf("%s vip %s (%s): %v", mode, dstIP, hostname, err)
 		} else {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1490,6 +1490,21 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 		g.mitmHTTPSWithCertHost(c, authority, certHost, ep)
 		return
 	}
+	// External plugin conn-endpoints (e.g. an `aws_api` bound to
+	// `*.amazonaws.com`) terminate TLS themselves and pump the raw
+	// agent conn to the subprocess over gRPC, so they aren't an
+	// https-mitm facet. They're matched here purely by SNI: the agent
+	// resolves and dials the real upstream IP and the forwarder
+	// intercepts :443 promiscuously, so no VIP or conn-index entry is
+	// needed — which matters for a wildcard host, since it has
+	// neither (it can't be DNS-resolved to an IP for the conn-index,
+	// and an HTTPS plugin isn't RequiresVIP). Hand the peeked conn to
+	// the plugin instead of splicing past it.
+	if _, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime); ok {
+		log.Printf("sni-conn: %s → %s", host, ep.Name)
+		g.dispatchConnEndpoint(c, dstIP, dstPort, ep, host)
+		return
+	}
 	// Wire-protocol families (postgres / clickhouse_* / future
 	// native plugins) dispatch through their own port handlers,
 	// not through SNI peek on 443. Anything that lands here is

--- a/cmd/clawpatrol/sni_dispatch_test.go
+++ b/cmd/clawpatrol/sni_dispatch_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// TestSNIDispatchMarkerExcludesBuiltinConnEndpoints guards the :443 SNI
+// dispatch branch in g.handle. That branch hands a connection to an
+// endpoint plugin that terminates TLS itself. Built-in wire-protocol conn
+// endpoints (postgres / clickhouse_native / ssh) also satisfy
+// runtime.ConnEndpointRuntime, but they can't read a raw TLS ClientHello —
+// they route via VIP / direct-IP, not SNI-on-443. So their compiled body
+// must NOT satisfy the TLSTerminates() marker the branch gates on;
+// otherwise a postgres endpoint declared with a bare/wildcard host and hit
+// on :443 would be misrouted to the plugin path and break.
+func TestSNIDispatchMarkerExcludesBuiltinConnEndpoints(t *testing.T) {
+	g := gatewayWithPolicy(t, `
+endpoint "postgres" "pg" { host = "pg.example.com:5432" }
+credential "postgres_credential" "pg-user" { endpoint = postgres.pg }
+profile "default" { credentials = [postgres_credential.pg-user] }
+`)
+	ep := g.Policy().Endpoints["pg"]
+	if ep == nil {
+		t.Fatal("missing pg endpoint")
+	}
+	// Premise: postgres is a conn runtime, so the broader
+	// ConnEndpointRuntime check alone would have misrouted it.
+	if _, ok := ep.Plugin.Runtime.(runtime.ConnEndpointRuntime); !ok {
+		t.Fatal("expected built-in postgres to be a ConnEndpointRuntime")
+	}
+	if tt, ok := ep.Body.(interface{ TLSTerminates() bool }); ok && tt.TLSTerminates() {
+		t.Fatal("built-in postgres endpoint satisfies TLSTerminates(); it would be misrouted to the plugin SNI dispatch path on :443")
+	}
+}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -91,6 +91,14 @@ func (b *dynamicEndpointBody) ConnRouteHosts() []string { return b.hosts }
 // plugin asked for it in its manifest.
 func (b *dynamicEndpointBody) RequiresVIP() bool { return b.wantsVIP }
 
+// TLSTerminates reports whether this plugin endpoint terminates the
+// agent's TLS itself (the plugin asked for TLSTerminate). The :443 SNI
+// dispatch uses this to route a matched HTTPS plugin endpoint to the
+// plugin — and only such endpoints, so built-in wire-protocol conn
+// runtimes (postgres / clickhouse / ssh) bound to a host aren't handed a
+// raw ClientHello they can't parse.
+func (b *dynamicEndpointBody) TLSTerminates() bool { return b.tlsTerminate }
+
 // HandleConn satisfies runtime.ConnEndpointRuntime. The host has
 // already routed the agent conn to this endpoint and bundled the
 // full per-conn context on ch.

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -236,7 +236,15 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 	dials := newDialRegistry()
 	defer dials.closeAll()
 
-	errCh := make(chan error, 2)
+	// agentDone fires when the agent->plugin copy stops (the agent closed
+	// or errored); pluginDone fires when the plugin->agent copy stops (the
+	// plugin's HandleConn returned — sending ConnClose — or the stream
+	// errored). Tracking them separately lets the teardown half-close the
+	// agent connection gracefully when the plugin finishes first, so a
+	// one-shot plugin's final response isn't truncated by an immediate hard
+	// close before the netstack has flushed it to the agent.
+	agentDone := make(chan error, 1)
+	pluginDone := make(chan error, 1)
 
 	// agent -> plugin
 	go func() {
@@ -247,16 +255,16 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 				if serr := doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Data{
 					Data: &pb.ConnData{Payload: append([]byte(nil), buf[:n]...)},
 				}}); serr != nil {
-					errCh <- serr
+					agentDone <- serr
 					return
 				}
 			}
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Close{Close: &pb.ConnClose{}}})
-					errCh <- nil
+					agentDone <- nil
 				} else {
-					errCh <- err
+					agentDone <- err
 				}
 				return
 			}
@@ -269,16 +277,16 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 			msg, err := stream.Recv()
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					errCh <- nil
+					pluginDone <- nil
 				} else {
-					errCh <- err
+					pluginDone <- err
 				}
 				return
 			}
 			switch k := msg.GetKind().(type) {
 			case *pb.ConnMessage_Data:
 				if _, werr := conn.Write(k.Data.Payload); werr != nil {
-					errCh <- werr
+					pluginDone <- werr
 					return
 				}
 			case *pb.ConnMessage_Event:
@@ -334,22 +342,58 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 					d.close()
 				}
 			case *pb.ConnMessage_Close:
-				errCh <- nil
+				pluginDone <- nil
 				return
 			}
 		}
 	}()
 
 	select {
-	case err := <-errCh:
+	case err := <-pluginDone:
+		// The plugin finished its side (a one-shot endpoint like aws_api
+		// returns after writing one response). Half-close the agent's write
+		// direction so the buffered response flushes and the agent sees
+		// end-of-stream, then wait — bounded — for the agent to read it and
+		// close. Hard-closing here instead would discard the response still
+		// queued in the netstack send buffer (the agent then hangs, having
+		// sent its request but received nothing).
+		halfCloseWrite(conn)
+		select {
+		case <-agentDone:
+		case <-time.After(connDrainTimeout):
+		}
 		_ = conn.Close()
-		<-errCh
+		return err
+	case err := <-agentDone:
+		// The agent closed/errored first — nothing in flight to protect, so
+		// tear down and let the plugin observe the ConnClose.
+		_ = conn.Close()
+		<-pluginDone
 		return err
 	case <-ctx.Done():
 		_ = conn.Close()
-		<-errCh
-		<-errCh
+		<-agentDone
+		<-pluginDone
 		return ctx.Err()
+	}
+}
+
+// connDrainTimeout bounds how long the gateway waits, after a plugin
+// finishes a connection, for the agent to read the final response and
+// close. The wait lets the netstack flush the buffered response before the
+// hard close; it ends as soon as the agent closes (the common case is a
+// few milliseconds), and the timeout is only a backstop for a peer that
+// holds the half-closed connection open.
+const connDrainTimeout = 30 * time.Second
+
+// halfCloseWrite shuts the write half of c so buffered bytes flush and the
+// peer sees end-of-stream, without tearing down the read half. For a TLS
+// server conn this sends close_notify; the underlying TCP FIN follows when
+// the peer closes its side. A no-op when c can't half-close — the caller
+// still performs a full Close afterwards.
+func halfCloseWrite(c net.Conn) {
+	if cw, ok := c.(interface{ CloseWrite() error }); ok {
+		_ = cw.CloseWrite()
 	}
 }
 

--- a/internal/config/extplugin/egress_test.go
+++ b/internal/config/extplugin/egress_test.go
@@ -84,8 +84,16 @@ func TestResolveEgressTOFUAndBroadening(t *testing.T) {
 	m := newEgressTestManager(t)
 	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
 
+	// resolveEgress reads the lockfile entry as it was at the start of the
+	// pass (the snapshot Manager.Start captures before resolveNetwork's
+	// addHash). Mirror that here.
+	call := func(hash string, egress ...string) ([]string, string, error) {
+		prior, priorRec := m.lock.get(sp.Name)
+		return m.resolveEgress(sp, prior, priorRec, hash, egressFromManifest(mfWithEgress(egress...)))
+	}
+
 	// First load records the declared set (trust on first use).
-	got, warn, err := m.resolveEgress(sp, "sha256:v1", egressFromManifest(mfWithEgress("*.foo.com:443")))
+	got, warn, err := call("sha256:v1", "*.foo.com:443")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,20 +105,20 @@ func TestResolveEgressTOFUAndBroadening(t *testing.T) {
 	}
 
 	// Same binary again: fast path returns the recorded set, no warn.
-	if got, warn, err := m.resolveEgress(sp, "sha256:v1", egressFromManifest(mfWithEgress("*.foo.com:443"))); err != nil ||
+	if got, warn, err := call("sha256:v1", "*.foo.com:443"); err != nil ||
 		warn != "" || !slices.Equal(got, []string{"*.foo.com:443"}) {
 		t.Fatalf("fast path = %v warn=%q err=%v", got, warn, err)
 	}
 
 	// A new binary that broadens egress fails closed.
-	_, _, err = m.resolveEgress(sp, "sha256:v2", egressFromManifest(mfWithEgress("*.foo.com:443", "evil.com:443")))
+	_, _, err = call("sha256:v2", "*.foo.com:443", "evil.com:443")
 	if err == nil || !strings.Contains(err.Error(), "broadens its network egress") {
 		t.Fatalf("broadening err = %v, want fail-closed", err)
 	}
 
 	// A new binary within the approved set is allowed and (narrowing)
 	// re-recorded.
-	got, _, err = m.resolveEgress(sp, "sha256:v3", egressFromManifest(mfWithEgress("a.foo.com:443")))
+	got, _, err = call("sha256:v3", "a.foo.com:443")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,10 +127,41 @@ func TestResolveEgressTOFUAndBroadening(t *testing.T) {
 	}
 }
 
+// TestResolveEgressRecordsAfterAddHash reproduces the load-time ordering in
+// Manager.Start: resolveNetwork's addHash records the binary's hash before
+// resolveEgress runs. On a first load resolveEgress must still record the
+// declared egress — it keys off the pre-pass snapshot, not the live entry
+// whose hash addHash just added. Regression: a fast path keyed on the live
+// hash saw addHash's entry and silently dropped egress on every fresh
+// lockfile, leaving the brokered-dial allow-list empty.
+func TestResolveEgressRecordsAfterAddHash(t *testing.T) {
+	m := newEgressTestManager(t)
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
+	const hash = "sha256:v1"
+
+	// Snapshot up front, exactly as Start does before resolveNetwork.
+	prior, priorRec := m.lock.get(sp.Name)
+
+	// resolveNetwork records the hash first.
+	m.lock.addHash(sp.Name, hash, "none")
+
+	got, warn, err := m.resolveEgress(sp, prior, priorRec, hash, egressFromManifest(mfWithEgress("*.amazonaws.com:443")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, []string{"*.amazonaws.com:443"}) || warn == "" {
+		t.Fatalf("first load after addHash = %v warn=%q, want egress recorded", got, warn)
+	}
+	if e, _ := m.lock.get("p"); !slices.Equal(e.Egress, []string{"*.amazonaws.com:443"}) {
+		t.Fatalf("egress not persisted after addHash: %v", e.Egress)
+	}
+}
+
 func TestResolveEgressNoLockfile(t *testing.T) {
 	m := New(nil) // no lockfile configured
 	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
-	got, _, err := m.resolveEgress(sp, "sha256:x", egressFromManifest(mfWithEgress("*.foo.com:443")))
+	prior, priorRec := m.lock.get(sp.Name)
+	got, _, err := m.resolveEgress(sp, prior, priorRec, "sha256:x", egressFromManifest(mfWithEgress("*.foo.com:443")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -191,6 +191,14 @@ func (m *Manager) Start(ctx context.Context, sp config.PluginSource) (*Client, *
 		return nil, nil, fmt.Errorf("plugin source %q: %w", source, err)
 	}
 
+	// Snapshot the lockfile entry as loaded from disk, before
+	// resolveNetwork's addHash records this binary's hash. resolveEgress
+	// needs the pre-pass view to tell a first load (record the declared
+	// egress) from an already-approved binary (trust the recorded set):
+	// once addHash adds the hash below, a live re-read would make every
+	// fresh load look approved and silently drop the declared egress.
+	priorLock, priorLocked := m.lock.get(sp.Name)
+
 	network, warn, err := m.resolveNetwork(ctx, sp, bin, hash, staticMf)
 	if err != nil {
 		return nil, nil, err
@@ -226,7 +234,7 @@ func (m *Manager) Start(ctx context.Context, sp config.PluginSource) (*Client, *
 	// trust-on-first-use model as the network grant. Egress doesn't gate
 	// the sandbox — the plugin already runs network=none — so this happens
 	// after the spawn, off the real manifest.
-	egress, eWarn, err := m.resolveEgress(sp, hash, egressFromManifest(manifest))
+	egress, eWarn, err := m.resolveEgress(sp, priorLock, priorLocked, hash, egressFromManifest(manifest))
 	if err != nil {
 		c.kill()
 		return nil, nil, err
@@ -413,7 +421,7 @@ func (m *Manager) resolveNetwork(ctx context.Context, sp config.PluginSource, bi
 // approved (a destination none of the approved entries cover). A same or
 // narrower set is recorded and allowed. Egress does not gate the sandbox;
 // it bounds which upstream targets the gateway's brokered dial will open.
-func (m *Manager) resolveEgress(sp config.PluginSource, hash string, declared []string) ([]string, string, error) {
+func (m *Manager) resolveEgress(sp config.PluginSource, prior lockEntry, priorRecorded bool, hash string, declared []string) ([]string, string, error) {
 	declared = normalizeEgress(declared)
 
 	// No lockfile (tests, config.LoadBytes): use the declared set directly,
@@ -422,12 +430,18 @@ func (m *Manager) resolveEgress(sp config.PluginSource, hash string, declared []
 		return declared, "", nil
 	}
 
-	entry, recorded := m.lock.get(sp.Name)
-	if recorded && entry.hasHash(hash) {
-		// Fast path: this exact binary is approved — use its recorded set.
-		return entry.Egress, "", nil
+	// Every decision below reads `prior` — the lockfile entry as it was on
+	// disk at the start of this pass, captured before resolveNetwork's
+	// addHash recorded this binary's hash. Reading the live entry here
+	// would see that freshly-added hash and mistake a first load for an
+	// already-approved binary, taking the fast path and dropping the
+	// declared egress.
+	if priorRecorded && prior.hasHash(hash) {
+		// Fast path: this exact binary was approved in a prior load — use
+		// its recorded set.
+		return prior.Egress, "", nil
 	}
-	if !recorded {
+	if !priorRecorded {
 		// Trust on first use: record and proceed.
 		m.lock.setEgress(sp.Name, declared)
 		if len(declared) > 0 {
@@ -435,12 +449,12 @@ func (m *Manager) resolveEgress(sp config.PluginSource, hash string, declared []
 		}
 		return declared, "", nil
 	}
-	if broadened := egressBroadened(entry.Egress, declared); len(broadened) > 0 {
+	if broadened := egressBroadened(prior.Egress, declared); len(broadened) > 0 {
 		return nil, "", fmt.Errorf(
 			"plugin %q upgrade broadens its network egress: it now wants to reach %v but was approved only for %v. "+
 				"A compromised plugin update adding an exfiltration destination looks exactly like this. "+
 				"If you trust this update, re-approve it: clawpatrol plugins approve %s",
-			sp.Name, broadened, entry.Egress, sp.Name)
+			sp.Name, broadened, prior.Egress, sp.Name)
 	}
 	// Same or narrowed: record the (possibly tightened) declared set.
 	m.lock.setEgress(sp.Name, declared)


### PR DESCRIPTION
Three fixes that an external endpoint plugin which terminates TLS and
serves HTTPS (matched by SNI, including wildcard hosts) needs to work
end to end. Found while bringing up such a plugin.

* **Dispatch SNI-matched plugin conn-endpoints.** `g.handle` peeked
  the SNI and resolved the owning endpoint but only served built-in
  https-mitm facets, splicing everything else through. A plugin
  conn-endpoint bound to a wildcard host was matched yet never handed
  the connection. It now routes a matched `ConnEndpointRuntime`
  through `dispatchConnEndpoint`. No VIP/conn-index entry is needed —
  a wildcard host has neither, which is the whole point.
* **Record plugin egress on first load.** `resolveNetwork`'s `addHash`
  ran before `resolveEgress`, whose fast path then saw the hash and
  returned the empty recorded egress, dropping the manifest-declared
  targets on every fresh lockfile. `resolveEgress` now reads a
  pre-pass snapshot of the lockfile entry. Regression test added.
* **Flush the response before closing.** A one-shot plugin's agent
  connection was hard-closed the moment `HandleConn` returned,
  discarding the response still in the netstack send buffer (client
  hangs with no response). The teardown now half-closes the write side
  and waits, bounded, for the agent to drain before the full close.