### PR TITLE
Record a plugin's deferred egress on first load

### DIFF
--- a/internal/config/extplugin/egress_test.go
+++ b/internal/config/extplugin/egress_test.go
@@ -157,6 +157,33 @@ func TestResolveEgressRecordsAfterAddHash(t *testing.T) {
 	}
 }
 
+// TestResolveEgressRecordsDeferredFromInstall covers `plugins install` from a
+// release without a signed static manifest: it records the binary hash but
+// defers egress to the first real load. resolveEgress must record the
+// manifest's declared egress on that load even though the hash is already
+// approved, otherwise the brokered-dial allow-list stays empty.
+func TestResolveEgressRecordsDeferredFromInstall(t *testing.T) {
+	m := newEgressTestManager(t)
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
+	const hash = "sha256:v1"
+
+	// Simulate the lockfile install wrote: hash + network, no egress.
+	m.lock.addHash(sp.Name, hash, "none")
+
+	// First real load: the snapshot already has the hash but no egress.
+	prior, priorRec := m.lock.get(sp.Name)
+	got, warn, err := m.resolveEgress(sp, prior, priorRec, hash, egressFromManifest(mfWithEgress("*.amazonaws.com:443")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, []string{"*.amazonaws.com:443"}) || warn == "" {
+		t.Fatalf("deferred egress = %v warn=%q, want recorded", got, warn)
+	}
+	if e, _ := m.lock.get("p"); !slices.Equal(e.Egress, []string{"*.amazonaws.com:443"}) {
+		t.Fatalf("deferred egress not persisted: %v", e.Egress)
+	}
+}
+
 func TestResolveEgressNoLockfile(t *testing.T) {
 	m := New(nil) // no lockfile configured
 	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -437,8 +437,16 @@ func (m *Manager) resolveEgress(sp config.PluginSource, prior lockEntry, priorRe
 	// already-approved binary, taking the fast path and dropping the
 	// declared egress.
 	if priorRecorded && prior.hasHash(hash) {
-		// Fast path: this exact binary was approved in a prior load — use
-		// its recorded set.
+		// This exact binary was approved in a prior load — trust its
+		// recorded egress. But `plugins install` from a release without a
+		// signed static manifest records the hash with egress deferred to
+		// the first real load (see install.go); record the declared set now
+		// when none is recorded yet. The binary is already approved, so this
+		// is trust-on-first-use, not an escalation.
+		if len(prior.Egress) == 0 && len(declared) > 0 {
+			m.lock.setEgress(sp.Name, declared)
+			return declared, fmt.Sprintf("first load: recorded deferred egress %v in %s", declared, LockfileName), nil
+		}
 		return prior.Egress, "", nil
 	}
 	if !priorRecorded {


### PR DESCRIPTION
\`plugins install\` from a GitHub release without a signed static
manifest records the binary hash and network but defers the
manifest-declared egress to the first real load (by design, see
install.go). The egress fast path keyed on that recorded hash and
returned the empty set, so the deferral never happened — the
brokered-dial allow-list stayed empty and the plugin couldn't reach
its declared upstream targets.

When the approved binary has no egress recorded yet, record the
declared set on load (trust-on-first-use; the binary is already
approved by hash, so this isn't an escalation). Regression test added.