### PR TITLE
Derive async grant TTL from approver and sync-wait timeouts

### DIFF
--- a/cmd/clawpatrol/hitl_async_e2e_test.go
+++ b/cmd/clawpatrol/hitl_async_e2e_test.go
@@ -156,7 +156,6 @@ approver "human_approver" "ops" {
   sync_wait_timeout = "1ms"
   async_grant {
     enabled            = true
-    approval_ttl       = "15m"
     approved_retry_ttl = "5m"
     fingerprint_body   = "raw"
     max_body_bytes     = 1048576

--- a/cmd/clawpatrol/hitl_async_runtime.go
+++ b/cmd/clawpatrol/hitl_async_runtime.go
@@ -29,7 +29,7 @@ const (
 type hitlAsyncGrantRuntime interface {
 	HITLAsyncGrantEnabled() bool
 	HITLSyncWaitTimeout() time.Duration
-	HITLAsyncApprovalTTL() time.Duration
+	HITLAsyncApprovalTTL(policy *config.CompiledPolicy) time.Duration
 	HITLAsyncApprovedRetryTTL() time.Duration
 	HITLAsyncMaxBodyBytes() int64
 	HITLAsyncFingerprintBody() string
@@ -155,7 +155,7 @@ func (g *Gateway) maybeStartAsyncHITLOperation(ctx context.Context, in hitlAsync
 		RequestFingerprint:  fp.RequestFingerprint,
 		CreatedAt:           now,
 		SyncWaitDeadline:    now.Add(syncWait),
-		ApprovalExpiresAt:   now.Add(in.Approver.HITLAsyncApprovalTTL()),
+		ApprovalExpiresAt:   now.Add(in.Approver.HITLAsyncApprovalTTL(policy)),
 		RetryExpiresAt:      now.Add(in.Approver.HITLAsyncApprovedRetryTTL()),
 	})
 	if err != nil {

--- a/internal/config/hitl_async.go
+++ b/internal/config/hitl_async.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	// HITLAsyncDefaultApprovalTTL is the default lifetime for an async
-	// operation after the original synchronous wait returns 202.
-	HITLAsyncDefaultApprovalTTL = 15 * time.Minute
 	// HITLAsyncDefaultApprovedRetryTTL is the default lifetime of the
 	// one-shot retry grant after a human approval.
 	HITLAsyncDefaultApprovedRetryTTL = 5 * time.Minute
@@ -33,8 +30,6 @@ type HITLAsyncGrantConfig struct {
 	// Enabled explicitly opts this approver into async retry-grant mode.
 	// The active profile must also set hitl_async_grants = true.
 	Enabled bool `hcl:"enabled,optional" json:"enabled,omitempty"`
-	// Human approval lifetime after the original sync wait falls back to a 202 response.
-	ApprovalTTL string `hcl:"approval_ttl,optional" json:"approval_ttl,omitempty"`
 	// Post-approval retry grant lifetime for the client to retry.
 	ApprovedRetryTTL string `hcl:"approved_retry_ttl,optional" json:"approved_retry_ttl,omitempty"`
 	// Request-body fingerprinting mode. V1 supports only "raw".
@@ -48,12 +43,6 @@ type HITLAsyncGrantConfig struct {
 // small avoids a config -> approvers package import cycle.
 type HITLAsyncGrantEnabler interface {
 	HITLAsyncGrantEnabled() bool
-}
-
-// ApprovalTTLDuration parses the configured approval TTL, falling back
-// to HITLAsyncDefaultApprovalTTL when unset.
-func (g *HITLAsyncGrantConfig) ApprovalTTLDuration() (time.Duration, error) {
-	return parseOptionalPositiveDuration(g, g.approvalTTLRaw(), HITLAsyncDefaultApprovalTTL)
 }
 
 // ApprovedRetryTTLDuration parses the approved-retry TTL, falling back
@@ -78,13 +67,6 @@ func (g *HITLAsyncGrantConfig) MaxBodyBytesValue() int64 {
 		return HITLAsyncDefaultMaxBodyBytes
 	}
 	return int64(*g.MaxBodyBytes)
-}
-
-func (g *HITLAsyncGrantConfig) approvalTTLRaw() string {
-	if g == nil {
-		return ""
-	}
-	return g.ApprovalTTL
 }
 
 func (g *HITLAsyncGrantConfig) approvedRetryTTLRaw() string {
@@ -187,13 +169,6 @@ func ValidateHITLAsyncGrant(name string, syncWaitTimeout string, grant *HITLAsyn
 		}
 	}
 
-	if grant.ApprovalTTL != "" {
-		if d, err := time.ParseDuration(grant.ApprovalTTL); err != nil {
-			diags = append(diags, hitlAsyncDiagnostic(name, "invalid async_grant.approval_ttl", err.Error()))
-		} else if d <= 0 {
-			diags = append(diags, hitlAsyncDiagnostic(name, "async_grant.approval_ttl must be positive", "approval_ttl must be greater than zero."))
-		}
-	}
 	if grant.ApprovedRetryTTL != "" {
 		if d, err := time.ParseDuration(grant.ApprovedRetryTTL); err != nil {
 			diags = append(diags, hitlAsyncDiagnostic(name, "invalid async_grant.approved_retry_ttl", err.Error()))

--- a/internal/config/hitl_async_config_test.go
+++ b/internal/config/hitl_async_config_test.go
@@ -38,7 +38,6 @@ approver "human_approver" "ops" {
   sync_wait_timeout = "90s"
   async_grant {
     enabled            = true
-    approval_ttl       = "15m"
     approved_retry_ttl = "5m"
     fingerprint_body   = "raw"
     max_body_bytes     = 1048576
@@ -70,7 +69,7 @@ rule "writes" {
 	reader, ok := gw.Policy.Approvers["ops"].Body.(interface {
 		HITLAsyncGrantEnabled() bool
 		HITLSyncWaitTimeout() time.Duration
-		HITLAsyncApprovalTTL() time.Duration
+		HITLAsyncApprovalTTL(*config.CompiledPolicy) time.Duration
 		HITLAsyncApprovedRetryTTL() time.Duration
 		HITLAsyncMaxBodyBytes() int64
 		HITLAsyncFingerprintBody() string
@@ -84,8 +83,10 @@ rule "writes" {
 	if got := reader.HITLSyncWaitTimeout(); got != 90*time.Second {
 		t.Fatalf("sync wait timeout = %v, want 90s", got)
 	}
-	if got := reader.HITLAsyncApprovalTTL(); got != 15*time.Minute {
-		t.Fatalf("approval ttl = %v, want 15m", got)
+	// No approver/policy timeout configured, so the approver timeout
+	// defaults to 10m; the async TTL is that minus the 90s sync wait.
+	if got := reader.HITLAsyncApprovalTTL(cp); got != 10*time.Minute-90*time.Second {
+		t.Fatalf("approval ttl = %v, want %v", got, 10*time.Minute-90*time.Second)
 	}
 	if got := reader.HITLAsyncApprovedRetryTTL(); got != 5*time.Minute {
 		t.Fatalf("approved retry ttl = %v, want 5m", got)
@@ -153,7 +154,7 @@ func TestHITLAsyncConfigReaderDefaultsWithoutAsyncGrant(t *testing.T) {
 	reader, ok := gw.Policy.Approvers["ops"].Body.(interface {
 		HITLAsyncGrantEnabled() bool
 		HITLSyncWaitTimeout() time.Duration
-		HITLAsyncApprovalTTL() time.Duration
+		HITLAsyncApprovalTTL(*config.CompiledPolicy) time.Duration
 		HITLAsyncApprovedRetryTTL() time.Duration
 		HITLAsyncMaxBodyBytes() int64
 		HITLAsyncFingerprintBody() string
@@ -167,8 +168,10 @@ func TestHITLAsyncConfigReaderDefaultsWithoutAsyncGrant(t *testing.T) {
 	if got := reader.HITLSyncWaitTimeout(); got != 0 {
 		t.Fatalf("sync wait timeout = %v, want 0", got)
 	}
-	if got := reader.HITLAsyncApprovalTTL(); got != config.HITLAsyncDefaultApprovalTTL {
-		t.Fatalf("approval ttl = %v, want default", got)
+	// No timeouts configured: the approver timeout defaults to 10m and
+	// the sync wait is zero, so the derived async TTL is the full 10m.
+	if got := reader.HITLAsyncApprovalTTL(nil); got != 10*time.Minute {
+		t.Fatalf("approval ttl = %v, want 10m", got)
 	}
 	if got := reader.HITLAsyncApprovedRetryTTL(); got != config.HITLAsyncDefaultApprovedRetryTTL {
 		t.Fatalf("approved retry ttl = %v, want default", got)
@@ -227,7 +230,6 @@ approver "human_approver" "ops" {
   sync_wait_timeout = "0s"
   async_grant {
     enabled            = true
-    approval_ttl       = "nope"
     approved_retry_ttl = "0s"
     fingerprint_body   = "json"
     max_body_bytes     = 0
@@ -244,7 +246,6 @@ rule "writes" {
 	}
 	for _, want := range []string{
 		"sync_wait_timeout must be positive",
-		"invalid async_grant.approval_ttl",
 		"async_grant.approved_retry_ttl must be positive",
 		"async_grant.fingerprint_body must be raw",
 		"async_grant.max_body_bytes must be positive",
@@ -252,6 +253,26 @@ rule "writes" {
 		if !diagnosticsContain(diags, want) {
 			t.Fatalf("diagnostics missing %q:\n%v", want, diags)
 		}
+	}
+}
+
+// approval_ttl was removed in favor of deriving the async TTL as
+// approver_timeout - sync_wait_timeout. Stale configs that still set it
+// must be rejected so the redundant knob can't silently drift.
+func TestHITLAsyncConfigRejectsRemovedApprovalTTL(t *testing.T) {
+	src := hitlAsyncConfigSource(
+		"https://clawpatrol.example.test",
+		true,
+		true,
+		"90s",
+		"enabled = true\n    approval_ttl = \"15m\"",
+	)
+	_, diags := config.LoadBytes([]byte(src), "stale_approval_ttl.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("load succeeded, want approval_ttl rejected")
+	}
+	if !diagnosticsContain(diags, "approval_ttl") {
+		t.Fatalf("diagnostics did not reject approval_ttl:\n%v", diags)
 	}
 }
 

--- a/internal/config/plugins/approvers/human.go
+++ b/internal/config/plugins/approvers/human.go
@@ -101,10 +101,19 @@ func (h *HumanApprover) HITLSyncWaitTimeout() time.Duration {
 	return d
 }
 
-// HITLAsyncApprovalTTL returns the async pending approval lifetime.
-func (h *HumanApprover) HITLAsyncApprovalTTL() time.Duration {
-	d, _ := h.AsyncGrant.ApprovalTTLDuration()
-	return d
+// HITLAsyncApprovalTTL returns the async pending approval lifetime,
+// derived as the approver's overall timeout minus the synchronous wait
+// window: once the sync wait elapses and the request falls back to a
+// 202, the grant should stay pending only for whatever is left of the
+// approval budget. When sync_wait_timeout >= the approver timeout the
+// difference is non-positive; we clamp to zero so the grant is born
+// already expired rather than carrying a negative lifetime.
+func (h *HumanApprover) HITLAsyncApprovalTTL(policy *config.CompiledPolicy) time.Duration {
+	ttl := h.approvalTimeout(policy) - h.HITLSyncWaitTimeout()
+	if ttl < 0 {
+		return 0
+	}
+	return ttl
 }
 
 // HITLAsyncApprovedRetryTTL returns the post-approval retry grant lifetime.
@@ -281,9 +290,6 @@ func init() {
 				ag := b.AppendNewBlock("async_grant", nil).Body()
 				if a.AsyncGrant.Enabled {
 					ag.SetAttributeValue("enabled", cty.True)
-				}
-				if a.AsyncGrant.ApprovalTTL != "" {
-					ag.SetAttributeValue("approval_ttl", cty.StringVal(a.AsyncGrant.ApprovalTTL))
 				}
 				if a.AsyncGrant.ApprovedRetryTTL != "" {
 					ag.SetAttributeValue("approved_retry_ttl", cty.StringVal(a.AsyncGrant.ApprovedRetryTTL))

--- a/internal/config/plugins/approvers/human_test.go
+++ b/internal/config/plugins/approvers/human_test.go
@@ -152,6 +152,29 @@ func TestHumanApproverPendingExpirationUsesDefaultTimeoutFallback(t *testing.T) 
 	assertPendingLifetime(t, pending, 10*time.Minute)
 }
 
+func TestHumanApproverAsyncApprovalTTLDerivedFromApproverTimeout(t *testing.T) {
+	h := &HumanApprover{Timeout: 600, SyncWaitTimeout: "90s"}
+	if got := h.HITLAsyncApprovalTTL(nil); got != 10*time.Minute-90*time.Second {
+		t.Fatalf("approval ttl = %v, want %v", got, 10*time.Minute-90*time.Second)
+	}
+}
+
+func TestHumanApproverAsyncApprovalTTLUsesPolicyTimeoutFallback(t *testing.T) {
+	h := &HumanApprover{SyncWaitTimeout: "30s"}
+	if got := h.HITLAsyncApprovalTTL(&config.CompiledPolicy{HumanTimeout: 600}); got != 10*time.Minute-30*time.Second {
+		t.Fatalf("approval ttl = %v, want %v", got, 10*time.Minute-30*time.Second)
+	}
+}
+
+func TestHumanApproverAsyncApprovalTTLClampsToZeroWhenSyncWaitExceedsTimeout(t *testing.T) {
+	// sync_wait_timeout >= approver timeout leaves no budget for the
+	// async grant: clamp to zero rather than a negative lifetime.
+	h := &HumanApprover{Timeout: 60, SyncWaitTimeout: "90s"}
+	if got := h.HITLAsyncApprovalTTL(nil); got != 0 {
+		t.Fatalf("approval ttl = %v, want 0", got)
+	}
+}
+
 func TestHumanApproverPendingIncludesSyncApprovalGuidance(t *testing.T) {
 	pending := captureHumanPending(t, &HumanApprover{Timeout: 17}, &config.CompiledPolicy{HumanTimeout: 600})
 	if pending.OperationState != runtime.HITLOperationStateSyncWaiting {


### PR DESCRIPTION
Remove the explicit `async_grant.approval_ttl` config option and derive the async approval TTL as `approver_timeout - sync_wait_timeout`.

## Why
`approval_ttl` was redundant, foot-gun config. The time an async grant should remain pending after the synchronous wait returns a 202 is just whatever is left of the overall approver timeout once the sync window elapses. Configuring it separately let it drift from or contradict the other two values.

## Changes
- Drop the `approval_ttl` field from the `async_grant` schema, its parse/validation code, and the default constant.
- Derive the TTL at the point of use from the approver's overall timeout (its `timeout`, falling back to `human_timeout`, then 10m) minus `sync_wait_timeout`.
- Clamp to zero when `sync_wait_timeout >= approver_timeout` so the grant is born already expired rather than carrying a negative lifetime.
- Stale configs that still set `approval_ttl` are rejected at load time.

## Tests
- Unit tests for the derivation, the policy-timeout fallback, and the clamp edge case.
- Config test asserting `approval_ttl` is rejected.
- Updated existing async config/e2e tests to drop the removed field.