### PR TITLE
extplugin: deliver all bound credentials to conn endpoints

### DIFF
--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -132,26 +132,40 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Resolve credential secret.
+	// Resolve credential secrets. Every credential bound to the endpoint is
+	// delivered in `allCreds` (declaration order) for plugins that select
+	// among several — e.g. the aws plugin picks a base key by target
+	// account. The singular cred* fields below mirror the first so plugins
+	// that read only one keep working unchanged.
 	var (
 		credName  string
 		credType  string
 		credSec   []byte
 		credCanon []byte
 		credExtra map[string]string
+		allCreds  []*pb.BoundCredential
 	)
-	if len(ch.Endpoint.Credentials) > 0 {
-		c := ch.Endpoint.Credentials[0]
-		credName = c.Symbol.Name
-		credType = c.Symbol.Type
-		secret, err := ch.Secrets.Get(credName)
-		if err == nil {
-			credSec = secret.Bytes
-			credExtra = secret.Extras
+	for _, c := range ch.Endpoint.Credentials {
+		bc := &pb.BoundCredential{
+			TypeName: c.Symbol.Type,
+			Instance: c.Symbol.Name,
+		}
+		if secret, err := ch.Secrets.Get(c.Symbol.Name); err == nil {
+			bc.Secret = secret.Bytes
+			bc.Extras = secret.Extras
 		}
 		if cb, ok := credentialBaseOf(c.Body); ok {
-			credCanon = cb.canonicalJSON
+			bc.CanonicalJson = cb.canonicalJSON
 		}
+		allCreds = append(allCreds, bc)
+	}
+	if len(allCreds) > 0 {
+		first := allCreds[0]
+		credType = first.TypeName
+		credName = first.Instance
+		credSec = first.Secret
+		credExtra = first.Extras
+		credCanon = first.CanonicalJson
 	}
 
 	// Tunnel binding (informational only — gateway dialing happens
@@ -183,6 +197,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 		CredentialCanonicalJson: credCanon,
 		CredentialSecret:        credSec,
 		CredentialExtras:        credExtra,
+		Credentials:             allCreds,
 		TunnelTypeName:          tunType,
 		TunnelInstance:          tunInst,
 		SupportsDialUpstream:    true,

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3193,12 +3193,21 @@ type ConnInit struct {
 	DstPort      uint32 `protobuf:"varint,7,opt,name=dst_port,json=dstPort,proto3" json:"dst_port,omitempty"`
 	// Bound credential. credential_secret is the secret material
 	// fetched by the gateway just-in-time from its secret store.
-	// Empty when the endpoint has no credential.
+	// Empty when the endpoint has no credential. When more than one
+	// credential is bound to the endpoint these fields carry the first
+	// (declaration order); the full set is in `credentials` below.
 	CredentialTypeName      string            `protobuf:"bytes,8,opt,name=credential_type_name,json=credentialTypeName,proto3" json:"credential_type_name,omitempty"`
 	CredentialInstance      string            `protobuf:"bytes,9,opt,name=credential_instance,json=credentialInstance,proto3" json:"credential_instance,omitempty"`
 	CredentialCanonicalJson []byte            `protobuf:"bytes,10,opt,name=credential_canonical_json,json=credentialCanonicalJson,proto3" json:"credential_canonical_json,omitempty"`
 	CredentialSecret        []byte            `protobuf:"bytes,11,opt,name=credential_secret,json=credentialSecret,proto3" json:"credential_secret,omitempty"`
 	CredentialExtras        map[string]string `protobuf:"bytes,12,rep,name=credential_extras,json=credentialExtras,proto3" json:"credential_extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// All credentials bound to this endpoint, in declaration order, when
+	// the endpoint binds more than one. A plugin that supports
+	// multi-credential endpoints selects among these per connection (e.g.
+	// the aws plugin picks a base key by the target account). Fields 8-12
+	// stay populated with credentials[0] for plugins that read only the
+	// single bound credential. Empty when the endpoint has no credential.
+	Credentials []*BoundCredential `protobuf:"bytes,16,rep,name=credentials,proto3" json:"credentials,omitempty"`
 	// Bound tunnel (optional, informational). Brokered dials
 	// (DialUpstreamRequest) are routed through this tunnel by the
 	// gateway automatically.
@@ -3327,6 +3336,13 @@ func (x *ConnInit) GetCredentialExtras() map[string]string {
 	return nil
 }
 
+func (x *ConnInit) GetCredentials() []*BoundCredential {
+	if x != nil {
+		return x.Credentials
+	}
+	return nil
+}
+
 func (x *ConnInit) GetTunnelTypeName() string {
 	if x != nil {
 		return x.TunnelTypeName
@@ -3348,6 +3364,85 @@ func (x *ConnInit) GetSupportsDialUpstream() bool {
 	return false
 }
 
+// BoundCredential is one credential bound to a plugin endpoint. The same
+// shape the singular ConnInit.credential_* fields carry, repeated so an
+// endpoint can offer several (the plugin chooses which to use).
+type BoundCredential struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TypeName      string                 `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Instance      string                 `protobuf:"bytes,2,opt,name=instance,proto3" json:"instance,omitempty"`
+	CanonicalJson []byte                 `protobuf:"bytes,3,opt,name=canonical_json,json=canonicalJson,proto3" json:"canonical_json,omitempty"`
+	Secret        []byte                 `protobuf:"bytes,4,opt,name=secret,proto3" json:"secret,omitempty"`
+	Extras        map[string]string      `protobuf:"bytes,5,rep,name=extras,proto3" json:"extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BoundCredential) Reset() {
+	*x = BoundCredential{}
+	mi := &file_plugin_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BoundCredential) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoundCredential) ProtoMessage() {}
+
+func (x *BoundCredential) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoundCredential.ProtoReflect.Descriptor instead.
+func (*BoundCredential) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *BoundCredential) GetTypeName() string {
+	if x != nil {
+		return x.TypeName
+	}
+	return ""
+}
+
+func (x *BoundCredential) GetInstance() string {
+	if x != nil {
+		return x.Instance
+	}
+	return ""
+}
+
+func (x *BoundCredential) GetCanonicalJson() []byte {
+	if x != nil {
+		return x.CanonicalJson
+	}
+	return nil
+}
+
+func (x *BoundCredential) GetSecret() []byte {
+	if x != nil {
+		return x.Secret
+	}
+	return nil
+}
+
+func (x *BoundCredential) GetExtras() map[string]string {
+	if x != nil {
+		return x.Extras
+	}
+	return nil
+}
+
 type ConnData struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Payload       []byte                 `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
@@ -3357,7 +3452,7 @@ type ConnData struct {
 
 func (x *ConnData) Reset() {
 	*x = ConnData{}
-	mi := &file_plugin_proto_msgTypes[40]
+	mi := &file_plugin_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3369,7 +3464,7 @@ func (x *ConnData) String() string {
 func (*ConnData) ProtoMessage() {}
 
 func (x *ConnData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[40]
+	mi := &file_plugin_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3382,7 +3477,7 @@ func (x *ConnData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnData.ProtoReflect.Descriptor instead.
 func (*ConnData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{40}
+	return file_plugin_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ConnData) GetPayload() []byte {
@@ -3402,7 +3497,7 @@ type ConnClose struct {
 
 func (x *ConnClose) Reset() {
 	*x = ConnClose{}
-	mi := &file_plugin_proto_msgTypes[41]
+	mi := &file_plugin_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3414,7 +3509,7 @@ func (x *ConnClose) String() string {
 func (*ConnClose) ProtoMessage() {}
 
 func (x *ConnClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[41]
+	mi := &file_plugin_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3427,7 +3522,7 @@ func (x *ConnClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnClose.ProtoReflect.Descriptor instead.
 func (*ConnClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{41}
+	return file_plugin_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ConnClose) GetReason() string {
@@ -3458,7 +3553,7 @@ type ConnEvent struct {
 
 func (x *ConnEvent) Reset() {
 	*x = ConnEvent{}
-	mi := &file_plugin_proto_msgTypes[42]
+	mi := &file_plugin_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3470,7 +3565,7 @@ func (x *ConnEvent) String() string {
 func (*ConnEvent) ProtoMessage() {}
 
 func (x *ConnEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[42]
+	mi := &file_plugin_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3483,7 +3578,7 @@ func (x *ConnEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnEvent.ProtoReflect.Descriptor instead.
 func (*ConnEvent) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{42}
+	return file_plugin_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ConnEvent) GetAction() string {
@@ -3549,7 +3644,7 @@ type OpenTunnelRequest struct {
 
 func (x *OpenTunnelRequest) Reset() {
 	*x = OpenTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[43]
+	mi := &file_plugin_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3561,7 +3656,7 @@ func (x *OpenTunnelRequest) String() string {
 func (*OpenTunnelRequest) ProtoMessage() {}
 
 func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[43]
+	mi := &file_plugin_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3574,7 +3669,7 @@ func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelRequest.ProtoReflect.Descriptor instead.
 func (*OpenTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{43}
+	return file_plugin_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *OpenTunnelRequest) GetTunnelTypeName() string {
@@ -3621,7 +3716,7 @@ type OpenTunnelResponse struct {
 
 func (x *OpenTunnelResponse) Reset() {
 	*x = OpenTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[44]
+	mi := &file_plugin_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3633,7 +3728,7 @@ func (x *OpenTunnelResponse) String() string {
 func (*OpenTunnelResponse) ProtoMessage() {}
 
 func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[44]
+	mi := &file_plugin_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3646,7 +3741,7 @@ func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelResponse.ProtoReflect.Descriptor instead.
 func (*OpenTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{44}
+	return file_plugin_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *OpenTunnelResponse) GetHandle() string {
@@ -3665,7 +3760,7 @@ type CloseTunnelRequest struct {
 
 func (x *CloseTunnelRequest) Reset() {
 	*x = CloseTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[45]
+	mi := &file_plugin_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3677,7 +3772,7 @@ func (x *CloseTunnelRequest) String() string {
 func (*CloseTunnelRequest) ProtoMessage() {}
 
 func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[45]
+	mi := &file_plugin_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3690,7 +3785,7 @@ func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelRequest.ProtoReflect.Descriptor instead.
 func (*CloseTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{45}
+	return file_plugin_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *CloseTunnelRequest) GetHandle() string {
@@ -3708,7 +3803,7 @@ type CloseTunnelResponse struct {
 
 func (x *CloseTunnelResponse) Reset() {
 	*x = CloseTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[46]
+	mi := &file_plugin_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3720,7 +3815,7 @@ func (x *CloseTunnelResponse) String() string {
 func (*CloseTunnelResponse) ProtoMessage() {}
 
 func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[46]
+	mi := &file_plugin_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3733,7 +3828,7 @@ func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelResponse.ProtoReflect.Descriptor instead.
 func (*CloseTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{46}
+	return file_plugin_proto_rawDescGZIP(), []int{47}
 }
 
 type DialMessage struct {
@@ -3750,7 +3845,7 @@ type DialMessage struct {
 
 func (x *DialMessage) Reset() {
 	*x = DialMessage{}
-	mi := &file_plugin_proto_msgTypes[47]
+	mi := &file_plugin_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3762,7 +3857,7 @@ func (x *DialMessage) String() string {
 func (*DialMessage) ProtoMessage() {}
 
 func (x *DialMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[47]
+	mi := &file_plugin_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3775,7 +3870,7 @@ func (x *DialMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialMessage.ProtoReflect.Descriptor instead.
 func (*DialMessage) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{47}
+	return file_plugin_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *DialMessage) GetKind() isDialMessage_Kind {
@@ -3845,7 +3940,7 @@ type DialInit struct {
 
 func (x *DialInit) Reset() {
 	*x = DialInit{}
-	mi := &file_plugin_proto_msgTypes[48]
+	mi := &file_plugin_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3857,7 +3952,7 @@ func (x *DialInit) String() string {
 func (*DialInit) ProtoMessage() {}
 
 func (x *DialInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[48]
+	mi := &file_plugin_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3870,7 +3965,7 @@ func (x *DialInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialInit.ProtoReflect.Descriptor instead.
 func (*DialInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{48}
+	return file_plugin_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *DialInit) GetTunnelHandle() string {
@@ -3903,7 +3998,7 @@ type DialData struct {
 
 func (x *DialData) Reset() {
 	*x = DialData{}
-	mi := &file_plugin_proto_msgTypes[49]
+	mi := &file_plugin_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3915,7 +4010,7 @@ func (x *DialData) String() string {
 func (*DialData) ProtoMessage() {}
 
 func (x *DialData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[49]
+	mi := &file_plugin_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3928,7 +4023,7 @@ func (x *DialData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialData.ProtoReflect.Descriptor instead.
 func (*DialData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{49}
+	return file_plugin_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *DialData) GetPayload() []byte {
@@ -3947,7 +4042,7 @@ type DialClose struct {
 
 func (x *DialClose) Reset() {
 	*x = DialClose{}
-	mi := &file_plugin_proto_msgTypes[50]
+	mi := &file_plugin_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3959,7 +4054,7 @@ func (x *DialClose) String() string {
 func (*DialClose) ProtoMessage() {}
 
 func (x *DialClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[50]
+	mi := &file_plugin_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3972,7 +4067,7 @@ func (x *DialClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialClose.ProtoReflect.Descriptor instead.
 func (*DialClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{50}
+	return file_plugin_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *DialClose) GetReason() string {
@@ -3991,7 +4086,7 @@ type StateGetRequest struct {
 
 func (x *StateGetRequest) Reset() {
 	*x = StateGetRequest{}
-	mi := &file_plugin_proto_msgTypes[51]
+	mi := &file_plugin_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4003,7 +4098,7 @@ func (x *StateGetRequest) String() string {
 func (*StateGetRequest) ProtoMessage() {}
 
 func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[51]
+	mi := &file_plugin_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4016,7 +4111,7 @@ func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateGetRequest.ProtoReflect.Descriptor instead.
 func (*StateGetRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{51}
+	return file_plugin_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *StateGetRequest) GetKey() string {
@@ -4036,7 +4131,7 @@ type StateGetResponse struct {
 
 func (x *StateGetResponse) Reset() {
 	*x = StateGetResponse{}
-	mi := &file_plugin_proto_msgTypes[52]
+	mi := &file_plugin_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4048,7 +4143,7 @@ func (x *StateGetResponse) String() string {
 func (*StateGetResponse) ProtoMessage() {}
 
 func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[52]
+	mi := &file_plugin_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4061,7 +4156,7 @@ func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateGetResponse.ProtoReflect.Descriptor instead.
 func (*StateGetResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{52}
+	return file_plugin_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *StateGetResponse) GetValue() []byte {
@@ -4088,7 +4183,7 @@ type StatePutRequest struct {
 
 func (x *StatePutRequest) Reset() {
 	*x = StatePutRequest{}
-	mi := &file_plugin_proto_msgTypes[53]
+	mi := &file_plugin_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4100,7 +4195,7 @@ func (x *StatePutRequest) String() string {
 func (*StatePutRequest) ProtoMessage() {}
 
 func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[53]
+	mi := &file_plugin_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4113,7 +4208,7 @@ func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatePutRequest.ProtoReflect.Descriptor instead.
 func (*StatePutRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{53}
+	return file_plugin_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *StatePutRequest) GetKey() string {
@@ -4138,7 +4233,7 @@ type StatePutResponse struct {
 
 func (x *StatePutResponse) Reset() {
 	*x = StatePutResponse{}
-	mi := &file_plugin_proto_msgTypes[54]
+	mi := &file_plugin_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4150,7 +4245,7 @@ func (x *StatePutResponse) String() string {
 func (*StatePutResponse) ProtoMessage() {}
 
 func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[54]
+	mi := &file_plugin_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4163,7 +4258,7 @@ func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatePutResponse.ProtoReflect.Descriptor instead.
 func (*StatePutResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{54}
+	return file_plugin_proto_rawDescGZIP(), []int{55}
 }
 
 var File_plugin_proto protoreflect.FileDescriptor
@@ -4409,7 +4504,7 @@ const file_plugin_proto_rawDesc = "" +
 	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12\x16\n" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x12\n" +
-	"\x04rule\x18\x04 \x01(\tR\x04rule\"\x8d\x06\n" +
+	"\x04rule\x18\x04 \x01(\tR\x04rule\"\xd6\x06\n" +
 	"\bConnInit\x12,\n" +
 	"\x12endpoint_type_name\x18\x01 \x01(\tR\x10endpointTypeName\x12+\n" +
 	"\x11endpoint_instance\x18\x02 \x01(\tR\x10endpointInstance\x126\n" +
@@ -4423,11 +4518,21 @@ const file_plugin_proto_rawDesc = "" +
 	"\x19credential_canonical_json\x18\n" +
 	" \x01(\fR\x17credentialCanonicalJson\x12+\n" +
 	"\x11credential_secret\x18\v \x01(\fR\x10credentialSecret\x12a\n" +
-	"\x11credential_extras\x18\f \x03(\v24.clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntryR\x10credentialExtras\x12(\n" +
+	"\x11credential_extras\x18\f \x03(\v24.clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntryR\x10credentialExtras\x12G\n" +
+	"\vcredentials\x18\x10 \x03(\v2%.clawpatrol.plugin.v1.BoundCredentialR\vcredentials\x12(\n" +
 	"\x10tunnel_type_name\x18\r \x01(\tR\x0etunnelTypeName\x12'\n" +
 	"\x0ftunnel_instance\x18\x0e \x01(\tR\x0etunnelInstance\x124\n" +
 	"\x16supports_dial_upstream\x18\x0f \x01(\bR\x14supportsDialUpstream\x1aC\n" +
 	"\x15CredentialExtrasEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8f\x02\n" +
+	"\x0fBoundCredential\x12\x1b\n" +
+	"\ttype_name\x18\x01 \x01(\tR\btypeName\x12\x1a\n" +
+	"\binstance\x18\x02 \x01(\tR\binstance\x12%\n" +
+	"\x0ecanonical_json\x18\x03 \x01(\fR\rcanonicalJson\x12\x16\n" +
+	"\x06secret\x18\x04 \x01(\fR\x06secret\x12I\n" +
+	"\x06extras\x18\x05 \x03(\v21.clawpatrol.plugin.v1.BoundCredential.ExtrasEntryR\x06extras\x1a9\n" +
+	"\vExtrasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"$\n" +
 	"\bConnData\x12\x18\n" +
@@ -4525,7 +4630,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
 var file_plugin_proto_goTypes = []any{
 	(NetworkAccess)(0),             // 0: clawpatrol.plugin.v1.NetworkAccess
 	(FacetKind)(0),                 // 1: clawpatrol.plugin.v1.FacetKind
@@ -4572,29 +4677,31 @@ var file_plugin_proto_goTypes = []any{
 	(*EvaluateAction)(nil),         // 42: clawpatrol.plugin.v1.EvaluateAction
 	(*ActionVerdict)(nil),          // 43: clawpatrol.plugin.v1.ActionVerdict
 	(*ConnInit)(nil),               // 44: clawpatrol.plugin.v1.ConnInit
-	(*ConnData)(nil),               // 45: clawpatrol.plugin.v1.ConnData
-	(*ConnClose)(nil),              // 46: clawpatrol.plugin.v1.ConnClose
-	(*ConnEvent)(nil),              // 47: clawpatrol.plugin.v1.ConnEvent
-	(*OpenTunnelRequest)(nil),      // 48: clawpatrol.plugin.v1.OpenTunnelRequest
-	(*OpenTunnelResponse)(nil),     // 49: clawpatrol.plugin.v1.OpenTunnelResponse
-	(*CloseTunnelRequest)(nil),     // 50: clawpatrol.plugin.v1.CloseTunnelRequest
-	(*CloseTunnelResponse)(nil),    // 51: clawpatrol.plugin.v1.CloseTunnelResponse
-	(*DialMessage)(nil),            // 52: clawpatrol.plugin.v1.DialMessage
-	(*DialInit)(nil),               // 53: clawpatrol.plugin.v1.DialInit
-	(*DialData)(nil),               // 54: clawpatrol.plugin.v1.DialData
-	(*DialClose)(nil),              // 55: clawpatrol.plugin.v1.DialClose
-	(*StateGetRequest)(nil),        // 56: clawpatrol.plugin.v1.StateGetRequest
-	(*StateGetResponse)(nil),       // 57: clawpatrol.plugin.v1.StateGetResponse
-	(*StatePutRequest)(nil),        // 58: clawpatrol.plugin.v1.StatePutRequest
-	(*StatePutResponse)(nil),       // 59: clawpatrol.plugin.v1.StatePutResponse
-	nil,                            // 60: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	nil,                            // 61: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	nil,                            // 62: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
-	nil,                            // 63: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
-	nil,                            // 64: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
-	nil,                            // 65: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                            // 66: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                            // 67: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(*BoundCredential)(nil),        // 45: clawpatrol.plugin.v1.BoundCredential
+	(*ConnData)(nil),               // 46: clawpatrol.plugin.v1.ConnData
+	(*ConnClose)(nil),              // 47: clawpatrol.plugin.v1.ConnClose
+	(*ConnEvent)(nil),              // 48: clawpatrol.plugin.v1.ConnEvent
+	(*OpenTunnelRequest)(nil),      // 49: clawpatrol.plugin.v1.OpenTunnelRequest
+	(*OpenTunnelResponse)(nil),     // 50: clawpatrol.plugin.v1.OpenTunnelResponse
+	(*CloseTunnelRequest)(nil),     // 51: clawpatrol.plugin.v1.CloseTunnelRequest
+	(*CloseTunnelResponse)(nil),    // 52: clawpatrol.plugin.v1.CloseTunnelResponse
+	(*DialMessage)(nil),            // 53: clawpatrol.plugin.v1.DialMessage
+	(*DialInit)(nil),               // 54: clawpatrol.plugin.v1.DialInit
+	(*DialData)(nil),               // 55: clawpatrol.plugin.v1.DialData
+	(*DialClose)(nil),              // 56: clawpatrol.plugin.v1.DialClose
+	(*StateGetRequest)(nil),        // 57: clawpatrol.plugin.v1.StateGetRequest
+	(*StateGetResponse)(nil),       // 58: clawpatrol.plugin.v1.StateGetResponse
+	(*StatePutRequest)(nil),        // 59: clawpatrol.plugin.v1.StatePutRequest
+	(*StatePutResponse)(nil),       // 60: clawpatrol.plugin.v1.StatePutResponse
+	nil,                            // 61: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 62: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 63: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	nil,                            // 64: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	nil,                            // 65: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	nil,                            // 66: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 67: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 68: clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
+	nil,                            // 69: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
 	19, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
@@ -4619,22 +4726,22 @@ var file_plugin_proto_depIdxs = []int32{
 	24, // 19: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
 	18, // 20: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
 	3,  // 21: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	60, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	61, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	61, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	62, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
 	4,  // 24: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
 	27, // 25: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
-	62, // 26: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	63, // 26: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
 	31, // 27: clawpatrol.plugin.v1.TransformHTTPUp.init:type_name -> clawpatrol.plugin.v1.TransformHTTPInit
 	29, // 28: clawpatrol.plugin.v1.TransformHTTPUp.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
-	63, // 29: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
-	64, // 30: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	64, // 29: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	65, // 30: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
 	33, // 31: clawpatrol.plugin.v1.TransformHTTPDown.head:type_name -> clawpatrol.plugin.v1.TransformHTTPHead
 	29, // 32: clawpatrol.plugin.v1.TransformHTTPDown.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
 	27, // 33: clawpatrol.plugin.v1.TransformHTTPHead.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
 	44, // 34: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
-	45, // 35: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
-	46, // 36: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
-	47, // 37: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
+	46, // 35: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
+	47, // 36: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
+	48, // 37: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
 	42, // 38: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
 	43, // 39: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
 	39, // 40: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
@@ -4644,40 +4751,42 @@ var file_plugin_proto_depIdxs = []int32{
 	36, // 44: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
 	37, // 45: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
 	38, // 46: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
-	65, // 47: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	66, // 48: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	67, // 49: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
-	53, // 50: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
-	54, // 51: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
-	55, // 52: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
-	25, // 53: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	25, // 54: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	25, // 55: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	5,  // 56: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
-	22, // 57: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
-	26, // 58: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
-	30, // 59: clawpatrol.plugin.v1.Credential.TransformHTTP:input_type -> clawpatrol.plugin.v1.TransformHTTPUp
-	34, // 60: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
-	48, // 61: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
-	52, // 62: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
-	50, // 63: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
-	56, // 64: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
-	58, // 65: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
-	6,  // 66: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 67: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 68: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	32, // 69: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
-	34, // 70: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	49, // 71: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	52, // 72: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	51, // 73: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	57, // 74: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	59, // 75: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	66, // [66:76] is the sub-list for method output_type
-	56, // [56:66] is the sub-list for method input_type
-	56, // [56:56] is the sub-list for extension type_name
-	56, // [56:56] is the sub-list for extension extendee
-	0,  // [0:56] is the sub-list for field type_name
+	66, // 47: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	67, // 48: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	45, // 49: clawpatrol.plugin.v1.ConnInit.credentials:type_name -> clawpatrol.plugin.v1.BoundCredential
+	68, // 50: clawpatrol.plugin.v1.BoundCredential.extras:type_name -> clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
+	69, // 51: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	54, // 52: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
+	55, // 53: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
+	56, // 54: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
+	25, // 55: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	25, // 56: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	25, // 57: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	5,  // 58: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
+	22, // 59: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
+	26, // 60: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
+	30, // 61: clawpatrol.plugin.v1.Credential.TransformHTTP:input_type -> clawpatrol.plugin.v1.TransformHTTPUp
+	34, // 62: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
+	49, // 63: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
+	53, // 64: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
+	51, // 65: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
+	57, // 66: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
+	59, // 67: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
+	6,  // 68: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 69: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 70: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 71: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 72: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	50, // 73: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	53, // 74: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	52, // 75: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	58, // 76: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	60, // 77: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	68, // [68:78] is the sub-list for method output_type
+	58, // [58:68] is the sub-list for method input_type
+	58, // [58:58] is the sub-list for extension type_name
+	58, // [58:58] is the sub-list for extension extendee
+	0,  // [0:58] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -4709,7 +4818,7 @@ func file_plugin_proto_init() {
 		(*ConnMessage_DialData)(nil),
 		(*ConnMessage_DialClose)(nil),
 	}
-	file_plugin_proto_msgTypes[47].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[48].OneofWrappers = []any{
 		(*DialMessage_Init)(nil),
 		(*DialMessage_Data)(nil),
 		(*DialMessage_Close)(nil),
@@ -4720,7 +4829,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   63,
+			NumMessages:   65,
 			NumExtensions: 0,
 			NumServices:   5,
 		},

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -527,12 +527,22 @@ message ConnInit {
 
   // Bound credential. credential_secret is the secret material
   // fetched by the gateway just-in-time from its secret store.
-  // Empty when the endpoint has no credential.
+  // Empty when the endpoint has no credential. When more than one
+  // credential is bound to the endpoint these fields carry the first
+  // (declaration order); the full set is in `credentials` below.
   string credential_type_name = 8;
   string credential_instance  = 9;
   bytes  credential_canonical_json = 10;
   bytes  credential_secret    = 11;
   map<string,string> credential_extras = 12;
+
+  // All credentials bound to this endpoint, in declaration order, when
+  // the endpoint binds more than one. A plugin that supports
+  // multi-credential endpoints selects among these per connection (e.g.
+  // the aws plugin picks a base key by the target account). Fields 8-12
+  // stay populated with credentials[0] for plugins that read only the
+  // single bound credential. Empty when the endpoint has no credential.
+  repeated BoundCredential credentials = 16;
 
   // Bound tunnel (optional, informational). Brokered dials
   // (DialUpstreamRequest) are routed through this tunnel by the
@@ -545,6 +555,17 @@ message ConnInit {
   // false (they silently drop unknown frames); the SDK fails
   // Conn.DialUpstream fast instead of hanging.
   bool supports_dial_upstream = 15;
+}
+
+// BoundCredential is one credential bound to a plugin endpoint. The same
+// shape the singular ConnInit.credential_* fields carry, repeated so an
+// endpoint can offer several (the plugin chooses which to use).
+message BoundCredential {
+  string type_name = 1;
+  string instance  = 2;
+  bytes  canonical_json = 3;
+  bytes  secret    = 4;
+  map<string,string> extras = 5;
 }
 
 message ConnData {

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -448,10 +448,6 @@ func (r BuildRequest) Decode(v any) error {
 	return json.Unmarshal(r.ConfigJSON, v)
 }
 
-// Conn is the per-inbound-conn handle a plugin's HandleConn receives.
-// Reading / writing the underlying agent connection is done through
-// the embedded net.Conn (which is a TLS-terminated *tls.Conn for
-// TLSMode=TLSTerminate, or a raw stream-backed conn otherwise).
 // ConnCredential is one credential bound to a plugin endpoint, as
 // delivered on Conn.Credentials. Mirrors the singular Conn.Credential*
 // fields; carried as a list so an endpoint can offer several and the
@@ -464,6 +460,10 @@ type ConnCredential struct {
 	CanonicalConfig []byte
 }
 
+// Conn is the per-inbound-conn handle a plugin's HandleConn receives.
+// Reading / writing the underlying agent connection is done through
+// the embedded net.Conn (which is a TLS-terminated *tls.Conn for
+// TLSMode=TLSTerminate, or a raw stream-backed conn otherwise).
 type Conn struct {
 	net.Conn
 

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -452,6 +452,18 @@ func (r BuildRequest) Decode(v any) error {
 // Reading / writing the underlying agent connection is done through
 // the embedded net.Conn (which is a TLS-terminated *tls.Conn for
 // TLSMode=TLSTerminate, or a raw stream-backed conn otherwise).
+// ConnCredential is one credential bound to a plugin endpoint, as
+// delivered on Conn.Credentials. Mirrors the singular Conn.Credential*
+// fields; carried as a list so an endpoint can offer several and the
+// plugin picks which to use per connection.
+type ConnCredential struct {
+	TypeName        string
+	Instance        string
+	Secret          []byte
+	Extras          map[string]string
+	CanonicalConfig []byte
+}
+
 type Conn struct {
 	net.Conn
 
@@ -469,6 +481,14 @@ type Conn struct {
 	CredentialSecret          []byte
 	CredentialExtras          map[string]string
 	CredentialCanonicalConfig []byte
+
+	// Credentials is every credential bound to this endpoint, in
+	// declaration order, for plugins that support multi-credential
+	// endpoints (e.g. a base key per account). The singular Credential*
+	// fields above mirror Credentials[0]. On single-credential endpoints
+	// it holds that one credential; on older gateways that don't send the
+	// set it is nil (read the singular fields instead).
+	Credentials []ConnCredential
 
 	TunnelTypeName string
 	TunnelInstance string

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -489,6 +489,7 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		CredentialSecret:          in.CredentialSecret,
 		CredentialExtras:          in.CredentialExtras,
 		CredentialCanonicalConfig: in.CredentialCanonicalJson,
+		Credentials:               connCredentialsFromProto(in.Credentials),
 		TunnelTypeName:            in.TunnelTypeName,
 		TunnelInstance:            in.TunnelInstance,
 	}
@@ -1111,4 +1112,28 @@ func (s *server) Dial(stream pb.Tunnel_DialServer) error {
 		_ = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}})
 	}
 	return dialErr
+}
+
+// connCredentialsFromProto maps the repeated BoundCredential set carried on
+// ConnInit to the SDK's ConnCredential slice. Returns nil when the gateway
+// sent none (older gateways, or an endpoint with no credential) — callers
+// then fall back to the singular Conn.Credential* fields.
+func connCredentialsFromProto(in []*pb.BoundCredential) []ConnCredential {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ConnCredential, 0, len(in))
+	for _, c := range in {
+		if c == nil {
+			continue
+		}
+		out = append(out, ConnCredential{
+			TypeName:        c.TypeName,
+			Instance:        c.Instance,
+			Secret:          c.Secret,
+			Extras:          c.Extras,
+			CanonicalConfig: c.CanonicalJson,
+		})
+	}
+	return out
 }

--- a/pluginsdk/server_test.go
+++ b/pluginsdk/server_test.go
@@ -158,3 +158,26 @@ func TestServerCredentialBuildPlainCanonicalRemainsBackwardCompatible(t *testing
 		t.Fatalf("canonical = %#v", canonical)
 	}
 }
+
+func TestConnCredentialsFromProto(t *testing.T) {
+	if got := connCredentialsFromProto(nil); got != nil {
+		t.Errorf("nil input = %v, want nil", got)
+	}
+	in := []*pb.BoundCredential{
+		nil, // skipped
+		{TypeName: "aws_account", Instance: "prod", Secret: []byte("s"), Extras: map[string]string{"access_key_id": "AKIA"}, CanonicalJson: []byte(`{"accounts":["111"]}`)},
+		{TypeName: "aws_account", Instance: "fallback"},
+	}
+	got := connCredentialsFromProto(in)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (nil skipped)", len(got))
+	}
+	if got[0].TypeName != "aws_account" || got[0].Instance != "prod" ||
+		string(got[0].Secret) != "s" || got[0].Extras["access_key_id"] != "AKIA" ||
+		string(got[0].CanonicalConfig) != `{"accounts":["111"]}` {
+		t.Errorf("first credential mapped wrong: %+v", got[0])
+	}
+	if got[1].Instance != "fallback" {
+		t.Errorf("second credential = %+v, want instance fallback", got[1])
+	}
+}


### PR DESCRIPTION
A plugin endpoint could bind several credentials, but the
conn-endpoint adapter only ever delivered the first
(`Credentials[0]`), so a plugin could not select among them per
connection. The aws plugin needs this to use a distinct base key per
target account.

* Add a repeated `BoundCredential` field to `ConnInit`
  (type/instance/canonical/secret/extras) carrying every credential
  bound to the endpoint, in declaration order
* The singular `credential_*` fields stay populated with the first
  credential, so plugins that read only one are unaffected and older
  plugins ignore the new field
* SDK exposes the set as `Conn.Credentials` (`[]ConnCredential`); the
  gateway adapter fills it from every bound credential

Backward compatible in both directions: old plugins on a new gateway
read the singular fields; new plugins on an old gateway get a nil
`Credentials` and fall back to the singular fields.