### PR TITLE
tailscale tunnel: wait for the node to join in Dial

### DIFF
--- a/internal/config/plugins/tunnels/tailscale.go
+++ b/internal/config/plugins/tunnels/tailscale.go
@@ -38,6 +38,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -292,28 +293,50 @@ func newTailscaleTunnelConn(name string, srv *tsnet.Server, logger *log.Logger) 
 	}
 }
 
-// Dial routes through the embedded tsnet node. For credential-driven
-// tunnels in the pending-auth window, returns a clear "node not
-// connected" error so the dashboard's pending integrations list reads
-// correctly; the literal-authkey path is always already joined.
+// dialJoinWait bounds how long Dial waits for a still-joining node before
+// giving up. The (re)join window is normally ~2s (state is cached in
+// sqlite); this cap only matters when a join is wedged, so a dependent
+// endpoint returns a clear error instead of blocking on a request whose
+// own deadline never fires.
+const dialJoinWait = 15 * time.Second
+
+// Dial routes through the embedded tsnet node. If the node is still
+// (re)joining, Dial waits for the join to finish rather than failing fast
+// — the pending window after Open or a restart is brief, and an endpoint
+// dialing through it should ride across it, not error. The wait is bounded
+// by the caller's ctx and dialJoinWait; runUp always closes `joined` (on
+// success and on permanent failure, where it also sets upErr), so the wait
+// can't hang. A genuinely unjoined node still returns the same
+// dashboard-friendly "node not connected" error.
 func (t *tailscaleTunnelConn) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
 	if t.srv == nil {
 		return nil, errors.New("tailscale tunnel closed")
 	}
 	select {
 	case <-t.joined:
-		if e := t.upErr.Load(); e != nil {
-			if err, ok := e.(error); ok && err != nil {
-				return nil, err
-			}
-		}
-		return t.srv.Dial(ctx, network, addr)
-	default:
-		if t.credential != "" {
-			return nil, fmt.Errorf("tailscale tunnel %q: node not connected — visit dashboard to complete %q sign-in", t.name, t.credential)
-		}
-		return nil, fmt.Errorf("tailscale tunnel %q: still joining", t.name)
+		// joined (success or permanent failure) — fall through.
+	case <-ctx.Done():
+		return nil, t.notConnectedErr(ctx.Err())
+	case <-time.After(dialJoinWait):
+		return nil, t.notConnectedErr(fmt.Errorf("still joining after %s", dialJoinWait))
 	}
+	if e := t.upErr.Load(); e != nil {
+		if err, ok := e.(error); ok && err != nil {
+			return nil, err
+		}
+	}
+	return t.srv.Dial(ctx, network, addr)
+}
+
+// notConnectedErr formats the pending-window error. Credential-driven
+// tunnels point the operator at the dashboard sign-in (the pending
+// integrations list keys off this); the literal-authkey path has no
+// sign-in to complete.
+func (t *tailscaleTunnelConn) notConnectedErr(cause error) error {
+	if t.credential != "" {
+		return fmt.Errorf("tailscale tunnel %q: node not connected — visit dashboard to complete %q sign-in (%w)", t.name, t.credential, cause)
+	}
+	return fmt.Errorf("tailscale tunnel %q: still joining (%w)", t.name, cause)
 }
 
 // CredentialName implements runtime.TunnelCredentialNamer so the

--- a/internal/config/plugins/tunnels/tailscale_test.go
+++ b/internal/config/plugins/tunnels/tailscale_test.go
@@ -1,8 +1,13 @@
 package tunnels
 
 import (
+	"context"
+	"errors"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"tailscale.com/tsnet"
@@ -108,4 +113,59 @@ func TestApplyOAuth(t *testing.T) {
 	if len(srv.AdvertiseTags) != 1 || srv.AdvertiseTags[0] != "tag:bot" {
 		t.Errorf("AdvertiseTags = %v", srv.AdvertiseTags)
 	}
+}
+
+// TestTailscaleDialWaitsForJoin covers the Dial join-window behavior: it
+// waits for the node to join (bounded by ctx / the cap) instead of failing
+// fast, surfaces a permanent join failure, and returns the right pending
+// message per auth path.
+func TestTailscaleDialWaitsForJoin(t *testing.T) {
+	mk := func(credential string) *tailscaleTunnelConn {
+		c := newTailscaleTunnelConn("ts-test", &tsnet.Server{}, log.New(io.Discard, "", 0))
+		c.credential = credential
+		return c
+	}
+
+	// Pending window + the caller's deadline fires: Dial does not fail fast
+	// (the join channel is still open) and returns the dashboard-friendly
+	// error rather than hanging.
+	t.Run("credential pending, ctx done", func(t *testing.T) {
+		c := mk("deno-tailnet")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := c.Dial(ctx, "tcp", "x:9440")
+		if err == nil || !strings.Contains(err.Error(), "node not connected") {
+			t.Fatalf("err = %v, want node-not-connected", err)
+		}
+	})
+
+	// Permanent join failure: joined is closed with upErr set, so Dial
+	// surfaces the real error instead of waiting.
+	t.Run("permanent failure surfaces upErr", func(t *testing.T) {
+		c := mk("deno-tailnet")
+		c.upErr.Store(errors.New("up: boom"))
+		close(c.joined)
+		_, err := c.Dial(context.Background(), "tcp", "x:9440")
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("err = %v, want upErr surfaced", err)
+		}
+	})
+
+	// Literal-authkey path (no credential) uses the "still joining" wording.
+	t.Run("literal authkey wording", func(t *testing.T) {
+		c := mk("")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := c.Dial(ctx, "tcp", "x:9440")
+		if err == nil || !strings.Contains(err.Error(), "still joining") {
+			t.Fatalf("err = %v, want still-joining", err)
+		}
+	})
+
+	t.Run("closed tunnel", func(t *testing.T) {
+		c := &tailscaleTunnelConn{}
+		if _, err := c.Dial(context.Background(), "tcp", "x:9440"); err == nil || !strings.Contains(err.Error(), "closed") {
+			t.Fatalf("err = %v, want closed", err)
+		}
+	})
 }


### PR DESCRIPTION
`Dial` failed fast with `node not connected` whenever the embedded tsnet
node was still (re)joining — the brief window after Open or a gateway
restart, or after an idle teardown re-opens it. A dependent endpoint
(e.g. an interactive ClickHouse query) dialing in that window got a hard
error instead of riding across the ~2s join.

* Wait for the join instead, bounded by the caller's ctx and a 15s cap
* `runUp` always closes the `joined` channel — on success and on
  permanent failure (where it also sets `upErr`) — so the wait can't
  hang; a genuinely unjoined node still returns the same
  dashboard-friendly error after the deadline

This is the actual fix for the join-window race; `keepalive = "always"`
(separate) only avoids the idle teardown that re-opens the window.