### PR TITLE
extplugin: map the sql built-in family for external endpoints (v2 M3)

### DIFF
--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -18,6 +18,7 @@ import (
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 	"github.com/denoland/clawpatrol/internal/config/facet"
 	"github.com/denoland/clawpatrol/internal/config/match"
+	"github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 	"golang.org/x/net/http/httpguts"
 )
@@ -603,18 +604,58 @@ func stringField(m map[string]any, key string) string {
 	return v
 }
 
+// stringListField extracts a []string from action[key]. JSON decodes a
+// list into []any, so string elements are collected and anything else is
+// skipped; an already-[]string value passes through. Returns nil when the
+// key is absent or not a list.
+func stringListField(m map[string]any, key string) []string {
+	switch vv := m[key].(type) {
+	case []string:
+		return vv
+	case []any:
+		out := make([]string, 0, len(vv))
+		for _, item := range vv {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // builtinRequestFor maps an EvaluateAction's action map onto a
 // match.Request shaped the way a built-in facet's matcher expects.
 // Plugins that bind their endpoint's Family to a built-in facet
-// ("http", "sql", "k8s") send the action keyed by that facet's CEL
+// ("http", "sql") send the action keyed by that facet's CEL
 // variables; the gateway translates here so the same matcher the
-// gateway's own pipeline runs sees a familiar Request.
+// gateway's own pipeline runs sees a familiar Request — the endpoint
+// reuses the operator's existing http.* / sql.* rules verbatim.
 //
-// Only "http" is supported in v1. Other families fall back to a
-// permissive Meta-bag request — rules will likely not match, which
-// surfaces as the gateway's default-deny.
+// "http" and "sql" are mapped. Other families (k8s, ssh, anything
+// bespoke) fall back to a permissive Meta-bag request — a plugin that
+// wants those should declare its own facet instead; binding family to a
+// built-in we don't map here surfaces as the gateway's default-deny.
 func builtinRequestFor(family, peerIP, summary string, action map[string]any, streams map[string][]byte) *match.Request {
 	switch family {
+	case "sql":
+		// The plugin parsed the statement and sent the coarse sql.Meta
+		// fields (verb / tables / functions / statement / database); the
+		// built-in sql matcher type-asserts req.Meta to *sql.Meta, so build
+		// one. A large statement may arrive as a stream field instead of
+		// inline JSON.
+		meta := &sql.Meta{
+			Verb:      stringField(action, "verb"),
+			Tables:    stringListField(action, "tables"),
+			Functions: stringListField(action, "functions"),
+			Database:  stringField(action, "database"),
+		}
+		if b, ok := streams["statement"]; ok {
+			meta.Statement = string(b)
+		} else {
+			meta.Statement = stringField(action, "statement")
+		}
+		return &match.Request{Family: family, PeerIP: peerIP, Meta: meta}
 	case "http":
 		req := &match.Request{
 			Family: family,

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -605,13 +605,21 @@ func stringField(m map[string]any, key string) string {
 }
 
 // stringListField extracts a []string from action[key]. JSON decodes a
-// list into []any, so string elements are collected and anything else is
-// skipped; an already-[]string value passes through. Returns nil when the
-// key is absent or not a list.
-func stringListField(m map[string]any, key string) []string {
-	switch vv := m[key].(type) {
+// list into []any, so string elements are collected and non-string
+// elements are skipped; an already-[]string value passes through.
+// malformed is true when the key is present but not a list at all (e.g. a
+// string or number) — a contract violation the caller can treat as
+// unparseable (fail closed) instead of silently coercing to empty. An
+// absent key returns (nil, false): nothing was claimed, so nothing is
+// wrong.
+func stringListField(m map[string]any, key string) (vals []string, malformed bool) {
+	v, present := m[key]
+	if !present {
+		return nil, false
+	}
+	switch vv := v.(type) {
 	case []string:
-		return vv
+		return vv, false
 	case []any:
 		out := make([]string, 0, len(vv))
 		for _, item := range vv {
@@ -619,9 +627,9 @@ func stringListField(m map[string]any, key string) []string {
 				out = append(out, s)
 			}
 		}
-		return out
+		return out, false
 	}
-	return nil
+	return nil, true
 }
 
 // builtinRequestFor maps an EvaluateAction's action map onto a
@@ -644,10 +652,12 @@ func builtinRequestFor(family, peerIP, summary string, action map[string]any, st
 		// built-in sql matcher type-asserts req.Meta to *sql.Meta, so build
 		// one. A large statement may arrive as a stream field instead of
 		// inline JSON.
+		tables, badTables := stringListField(action, "tables")
+		functions, badFns := stringListField(action, "functions")
 		meta := &sql.Meta{
 			Verb:      stringField(action, "verb"),
-			Tables:    stringListField(action, "tables"),
-			Functions: stringListField(action, "functions"),
+			Tables:    tables,
+			Functions: functions,
 			Database:  stringField(action, "database"),
 		}
 		if b, ok := streams["statement"]; ok {
@@ -655,7 +665,16 @@ func builtinRequestFor(family, peerIP, summary string, action map[string]any, st
 		} else {
 			meta.Statement = stringField(action, "statement")
 		}
-		return &match.Request{Family: family, PeerIP: peerIP, Meta: meta}
+		req := &match.Request{Family: family, PeerIP: peerIP, Meta: meta}
+		// A present-but-wrong-typed list field (a plugin sending `tables`
+		// as a string/number instead of a list) is a contract violation.
+		// Mark the parse unreliable so sql.verb/tables/functions evaluate to
+		// a CEL unknown and any rule referencing them fails closed, rather
+		// than silently seeing an empty list and missing a guardrail.
+		if badTables || badFns {
+			req.Unparseable = true
+		}
+		return req
 	case "http":
 		req := &match.Request{
 			Family: family,

--- a/internal/config/extplugin/builtin_sql_test.go
+++ b/internal/config/extplugin/builtin_sql_test.go
@@ -1,0 +1,72 @@
+package extplugin
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/facet"
+	"github.com/denoland/clawpatrol/internal/config/match"
+	sqlfacet "github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
+)
+
+// TestBuiltinRequestForSQL covers M3: an external endpoint that binds
+// family="sql" sends the coarse sql action fields, and builtinRequestFor
+// maps them onto the typed *sql.Meta the built-in sql matcher reads — so
+// the endpoint reuses the operator's existing sql.* rules verbatim.
+func TestBuiltinRequestForSQL(t *testing.T) {
+	action := map[string]any{
+		"verb":      "delete",
+		"tables":    []any{"tokens", "sessions"},
+		"functions": []any{"now"},
+		"database":  "prod",
+		"statement": "DELETE FROM tokens WHERE id = 1",
+	}
+	req := builtinRequestFor("sql", "1.2.3.4", "summary", action, nil)
+
+	meta, ok := req.Meta.(*sqlfacet.Meta)
+	if !ok {
+		t.Fatalf("req.Meta is %T, want *sql.Meta", req.Meta)
+	}
+	if meta.Verb != "delete" || meta.Database != "prod" ||
+		len(meta.Tables) != 2 || meta.Tables[0] != "tokens" || meta.Tables[1] != "sessions" ||
+		len(meta.Functions) != 1 || meta.Functions[0] != "now" ||
+		meta.Statement != "DELETE FROM tokens WHERE id = 1" {
+		t.Fatalf("mapped meta = %+v", meta)
+	}
+
+	// End to end: real sql.* rules evaluate against the mapped request.
+	cases := []struct {
+		cond string
+		want match.Result
+	}{
+		{"sql.verb == 'delete'", match.Matched},
+		{"sql.verb == 'select'", match.NoMatch},
+		{"sets.intersects(sql.tables, ['tokens'])", match.Matched},
+		{"sets.intersects(sql.tables, ['unrelated'])", match.NoMatch},
+		{"sql.database == 'prod' && sql.verb == 'delete'", match.Matched},
+		{"sql.statement.contains('DELETE')", match.Matched},
+	}
+	for _, c := range cases {
+		m, err := facet.NewMatcher("sql", c.cond)
+		if err != nil {
+			t.Fatalf("NewMatcher(%q): %v", c.cond, err)
+		}
+		if got := m.Match(req).Result; got != c.want {
+			t.Errorf("%q: result = %v, want %v", c.cond, got, c.want)
+		}
+	}
+}
+
+// TestBuiltinRequestForSQLStatementStream confirms a large statement
+// delivered as a stream field (not inline JSON) reaches the matcher.
+func TestBuiltinRequestForSQLStatementStream(t *testing.T) {
+	req := builtinRequestFor("sql", "1.2.3.4", "summary",
+		map[string]any{"verb": "select"},
+		map[string][]byte{"statement": []byte("SELECT secret FROM vault")})
+	meta, ok := req.Meta.(*sqlfacet.Meta)
+	if !ok {
+		t.Fatalf("req.Meta is %T, want *sql.Meta", req.Meta)
+	}
+	if meta.Statement != "SELECT secret FROM vault" {
+		t.Errorf("statement = %q, want from stream", meta.Statement)
+	}
+}

--- a/internal/config/extplugin/builtin_sql_test.go
+++ b/internal/config/extplugin/builtin_sql_test.go
@@ -70,3 +70,42 @@ func TestBuiltinRequestForSQLStatementStream(t *testing.T) {
 		t.Errorf("statement = %q, want from stream", meta.Statement)
 	}
 }
+
+// TestBuiltinRequestForSQLMalformedListFailsClosed: a plugin that sends
+// `tables` as the wrong type marks the request unparseable, so a rule
+// referencing sql.tables fails closed (Unevaluable -> deny) instead of
+// silently seeing an empty list.
+func TestBuiltinRequestForSQLMalformedListFailsClosed(t *testing.T) {
+	// tables sent as a bare string instead of a list.
+	req := builtinRequestFor("sql", "1.2.3.4", "summary", map[string]any{
+		"verb":   "delete",
+		"tables": "tokens",
+	}, nil)
+	if !req.Unparseable {
+		t.Fatalf("wrong-typed tables should mark req.Unparseable")
+	}
+	m, err := facet.NewMatcher("sql", "sets.intersects(sql.tables, ['tokens'])")
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	if got := m.Match(req).Result; got != match.Unevaluable {
+		t.Errorf("tables rule on malformed action = %v, want Unevaluable (fail closed)", got)
+	}
+
+	// A well-formed action is not flagged, and absent list fields are not a
+	// violation (nothing was claimed).
+	ok := builtinRequestFor("sql", "1.2.3.4", "s", map[string]any{"verb": "select"}, nil)
+	if ok.Unparseable {
+		t.Errorf("absent tables/functions must not mark unparseable")
+	}
+}
+
+// TestBuiltinRequestForSQLInlineStatement: statement inline in the action
+// (no stream) reaches the matcher.
+func TestBuiltinRequestForSQLInlineStatement(t *testing.T) {
+	req := builtinRequestFor("sql", "1.2.3.4", "s",
+		map[string]any{"verb": "select", "statement": "SELECT 1"}, nil)
+	if got := req.Meta.(*sqlfacet.Meta).Statement; got != "SELECT 1" {
+		t.Errorf("inline statement = %q, want SELECT 1", got)
+	}
+}

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -733,6 +733,38 @@ Rules attached to this endpoint are written exactly the way they
 would be against any in-process HTTPS endpoint:
 `http.method == "POST"`, `http.body.contains("…")`, etc.
 
+The same applies to **SQL** endpoints. An endpoint that terminates a SQL
+wire protocol (postgres, mysql, clickhouse, …) sets `Family: "sql"`,
+parses each statement itself, and sends the coarse fields the built-in
+`sql` facet exposes — `verb`, `tables`, `functions`, `database`, and
+`statement` (which may be a `pluginsdk.Stream` for large queries):
+
+```go
+endpoint := pluginsdk.EndpointDef{
+    TypeName: "example_sql",
+    Family:   "sql", // bind to the built-in sql facet
+    TLSMode:  pluginsdk.TLSTerminate,
+    HandleConn: func(ctx context.Context, conn *pluginsdk.Conn) error {
+        // ... parse one statement from the wire ...
+        verdict, _ := conn.Evaluate(ctx, "sql", map[string]any{
+            "verb":      "delete",
+            "tables":    []string{"tokens"},
+            "functions": []string{},
+            "database":  db,
+            "statement": pluginsdk.Stream(strings.NewReader(stmt)),
+        }, stmt)
+        // ... act on verdict ...
+    },
+}
+```
+
+Operators then reuse their existing `sql.*` rules verbatim —
+`sql.verb == "delete"`, `sets.intersects(sql.tables, ["secrets"])`,
+`sql.statement.contains("DROP")` — across any SQL plugin. `sql` is the
+one shared built-in family exposed for opt-in (SQL has many engines that
+benefit from a portable coarse guardrail); `k8s`, `ssh`, and bespoke
+protocols use a plugin-declared facet instead.
+
 ### Persistent state
 
 A sandboxed plugin has no writable filesystem of its own. When a plugin


### PR DESCRIPTION
Implements section 4 of the protocol-v2 design (#689): the opt-in `sql`
built-in family for external endpoints.

An external endpoint could already bind `family = "sql"` (the compiler
accepts any registered facet name), so its rules compiled against the
built-in sql matcher. But `builtinRequestFor` only mapped `"http"` — the
sql action fell through to a permissive Meta bag, the sql matcher's
type-assert to `*sql.Meta` failed, and every request hit the
default-deny. So the family was accepted but unusable.

* Map `family = "sql"`: build a `*sql.Meta` from the coarse action
  fields (`verb` / `tables` / `functions` / `statement` / `database`).
  A large `statement` may arrive as a stream field instead of inline
  JSON; truncation flows through to the matcher's fail-closed path as it
  already does for the built-in SQL endpoints.
* An external SQL endpoint now reuses the operator's existing `sql.*`
  rules verbatim — no per-plugin vocabulary, no rule rewrites.
* `sql` is the *one* shared built-in family exposed for opt-in (many
  engines, a portable coarse guardrail); `k8s` / `ssh` / bespoke
  protocols continue to use a plugin-declared facet.

Tests map the action and then run real `sql.*` rules through
`facet.NewMatcher("sql", …)` against the result (verb / tables /
database / statement, plus the stream path). Docs: a "sql" example
added alongside the existing "http" one in `site/doc/plugins.md`.

No SDK change needed — a plugin sets `Family: "sql"` and calls
`conn.Evaluate(ctx, "sql", {…}, summary)`, exactly like the existing
`http` built-in-family pattern.