### PR TITLE
extplugin: host-served control plane (HostControl) for plugin Evaluate

### DIFF
--- a/doc/external-plugin-control-plane.md
+++ b/doc/external-plugin-control-plane.md
@@ -1,0 +1,233 @@
+# External plugin control plane
+
+How a sandboxed external plugin and the gateway call each other, and why
+the plugin→gateway callbacks are host-served gRPC methods (`HostControl`)
+rather than frames multiplexed inside the connection stream.
+
+## The problem
+
+External plugins run out-of-process and sandboxed on purpose — they are
+untrusted code that the gateway hands secrets to — so the gateway and a
+plugin talk over gRPC. Two directions of call exist:
+
+- The gateway calls the plugin: terminate this connection (`HandleConn`),
+  transform this request (`TransformHTTP`), …
+- The plugin calls the gateway back: rule on this action (`Evaluate`),
+  open this upstream (brokered `Dial`), persist these bytes (`State`), …
+
+The plugin→gateway callbacks started life as request/reply **frames
+multiplexed inside the `HandleConn` byte stream**, each correlated by a
+hand-rolled id: the plugin sends `EvaluateAction{call_id}` and later
+matches an `ActionVerdict{call_id}`; a brokered dial does the same with
+`dial_id`. Both sides keep an inflight map keyed by that id. Every new
+capability (an approver, a HITL prompt) would add another bespoke frame
+and another correlation map — bookkeeping gRPC does for free.
+
+## Design goals
+
+1. **Every cross-process call is an ordinary gRPC method.** gRPC
+   correlates each reply to its call, so the `call_id`/`dial_id` inflight
+   maps disappear and a new capability is a new *method*, not a new frame.
+2. **Two clean directions, each its own gRPC surface.** plugin→host is the
+   gateway's host-served control plane; host→plugin is the plugin's own
+   services. Don't conflate them onto one object.
+3. **Standard mechanisms over ad-hoc fields.** Cross-cutting concerns
+   (which connection a call belongs to) ride in gRPC metadata resolved by
+   an interceptor, not a token field repeated on every message.
+4. **Mirror the gateway's in-process contracts.** The plugin-facing
+   surface mirrors the interfaces the built-in plugins already use
+   (`BlobStore`, the verdict/approve types, …) so the external and
+   built-in paths converge instead of diverging.
+5. **Works for any plugin type.** An endpoint, a credential, or an
+   approver all reach the same host services for the capabilities they
+   need.
+6. **No weakening of the sandbox.** A plugin keeps `network = none`;
+   every new power is gateway-brokered (the gateway holds the socket, the
+   secret store, the rule list), so a compromised plugin can't reach past
+   what it was granted.
+
+## Two directions
+
+| Direction | What it is | Where it lives | Examples |
+|---|---|---|---|
+| **plugin → host** | the plugin calls the gateway | host-served services over the broker (`HostControl`, `HostState`) | `Evaluate`, brokered `Dial`, HITL `Decide`, `State` |
+| **host → plugin** | the gateway calls the plugin | the plugin's own gRPC services | `Endpoint.HandleConn`, `Credential.TransformHTTP`, `Approver.Approve`, `Approver.Notify` |
+
+The split matters because the two directions have different homes and
+both grow. A plugin→host capability is a method on `HostControl`; a
+host→plugin capability is a method on a plugin-served service. Neither is
+a new frame. And because the host-served side is shared, any plugin type
+reaches it.
+
+This is what makes the M4/M5 work fall out cleanly. The approver and HITL
+callbacks map onto existing gateway interfaces, and the *direction* of
+each decides its home:
+
+| Callback | mirrors | direction | home |
+|---|---|---|---|
+| rule on an action | the match + approve chain | plugin→host | `HostControl.Evaluate` |
+| resolve a pending HITL id | `HITLPool.Decide` | plugin→host | `HostControl.Decide` |
+| LLM judge | `ApproverRuntime.Approve` | host→plugin | plugin-served `Approver.Approve` |
+| post the prompt (Slack) | `HITLNotifier.NotifyHITL` | host→plugin | plugin-served `Approver.Notify` |
+| edit the posted prompt | `HITLMessageUpdater.UpdateHITLMessage` | host→plugin | plugin-served `Approver.Update` |
+
+So only `Decide` is a `HostControl` method; `Approve`/`Notify`/`Update`
+are a separate plugin-served `Approver` service. A sketch of both is at
+the end.
+
+## How it is put together
+
+### Host services over one broker stream
+
+The gateway serves two host-side services over the go-plugin broker on a
+single reserved stream id; the plugin dials it once and builds both stubs
+over that one connection:
+
+```proto
+service HostState   { rpc Get(...); rpc Put(...); }          // persistent bytes
+service HostControl {
+  rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
+  // grows plugin→host only: Dial(stream) for brokered dial, Decide(...) for HITL
+}
+```
+
+`HostState` is plugin-lifetime persistence; `HostControl` is
+connection-scoped control. Keep it to these two services and add
+*methods*, not services.
+
+### Session scoping in metadata, resolved by an interceptor
+
+A `HostControl` call must run against the right connection's evaluation
+context (its rules, approve chain, peer). The gateway mints an opaque
+`crypto/rand` token per connection, registers that context under it, and
+hands the token to the plugin in `ConnInit`. The plugin echoes it back as
+request **metadata** (`clawpatrol-session`), and a server interceptor
+resolves it once into the handler's context:
+
+- Messages stay payload-only; a new method is scoped for free.
+- The token is minted by the gateway, never taken from the wire, and the
+  registry is per-plugin — so it is unforgeable and never valid across
+  plugins. A forged, unknown, or removed token is rejected
+  (`Unauthenticated`) before the handler runs.
+- The token is registered when the connection starts and removed when it
+  ends, so no evaluation context dangles.
+
+### One evaluate core, two callers
+
+The legacy `EvaluateAction` frame handler and the `HostControl` session
+closure run the **same** `evaluateDecoded` core (decode → match → approve
+chain → emit the audit event). Verdicts are therefore identical by
+construction, whichever path a call took.
+
+### The SDK chooses the path
+
+`Conn.Evaluate` sends the action over `HostControl` (token threaded into
+metadata by the SDK; plugin authors never see it). The one case that
+keeps the legacy frame is an action carrying **stream-valued fields** —
+large bodies the gateway pulls lazily — since `HostControl.Evaluate`
+carries no stream handles.
+
+## Compatibility
+
+- **Older plugins keep working** with no change: a plugin that still sends
+  `EvaluateAction` frames is handled by the same frame handler (which also
+  serves the stream-valued path), and it simply ignores the new
+  `ConnInit.session_token`.
+- **The SDK targets the current gateway.** It does not carry a fallback
+  for a gateway without `HostControl`; the gateway always serves it and
+  issues a token.
+
+## Security invariants (unchanged)
+
+- The sandbox is mandatory and `network = none` is the default; a plugin
+  receives only the just-in-time secret bound to the entity it is
+  handling.
+- Decision authority stays in the gateway: a plugin *requests* a verdict
+  or a HITL decision; the gateway's rule engine and HITL pool own it.
+- High-risk powers (mounting a public webhook route for HITL, spawning a
+  host binary) remain operator-only grants, never plugin-declarable.
+
+## M4 / M5 sketch — both directions
+
+Concrete proto for the next milestones, so the direction split is visible
+end to end. **Sketch only** — not in `plugin.proto` yet. Wire-only fields
+are shown; the gateway-internal handles on the runtime structs (the pool,
+the secret store, the compiled endpoint/rule) do not cross the boundary —
+the plugin reaches that power through `HostControl` and its bound
+credential.
+
+### plugin → host: `HostControl` grows methods
+
+```proto
+service HostControl {
+  rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);    // implemented
+  // Brokered upstream dial as a method — removes the dial_id inflight map
+  // the way Evaluate removed call_id, and shrinks the data plane to bytes.
+  rpc Dial(stream DialChunk) returns (stream DialChunk);
+  // HITL: a notifier (a Slack button) resolves a pending decision. The
+  // gateway records it in the same pool the dashboard writes to.
+  rpc Decide(DecideRequest) returns (DecideAck);
+}
+message DecideRequest { string operation_id = 1; string decision = 2; string reason = 3; }
+message DecideAck     { bool resolved = 1; }
+```
+
+### host → plugin: a plugin-served `Approver` service
+
+Same shape as the existing plugin-served `Endpoint` / `Credential`
+services — the gateway is the client. Messages mirror the runtime
+approver / HITL types.
+
+```proto
+service Approver {
+  rpc Approve(ApproveRequest) returns (ApproveVerdict);   // LLM judge (sync)
+  rpc Notify(NotifyRequest)   returns (NotifyAck);        // post the prompt
+  rpc Update(UpdateRequest)   returns (UpdateAck);        // edit the prompt
+}
+
+message ApproveRequest {                 // wire subset of runtime.ApproveRequest
+  string stage = 1; string rule_name = 2; string approver_name = 3;
+  string profile = 4; string agent_ip = 5;
+  string method = 6; string host = 7; string path = 8;
+  string ua = 9; string body_sample = 10; string reason = 11;
+  string async_operation_id = 12;
+}
+message ApproveVerdict { string action = 1; string reason = 2; }
+
+message NotifyRequest {                  // wire subset of runtime.HITLTarget
+  string operation_id = 1; string channel = 2; bool interactive = 3;
+  string dashboard_url = 4; string thread_ts = 5;
+  string method = 6; string host = 7; string path = 8; string approval_message = 9;
+}
+message NotifyAck { string message_ref = 1; }   // opaque channel/ts, non-secret
+
+message UpdateRequest {                  // mirrors runtime.HITLMessageUpdate
+  string message_ref = 1; string operation_id = 2; string state = 3;
+  string method = 4; string host = 5; string path = 6;
+  bool upstream_called = 7; string last_error = 8;
+}
+message UpdateAck {}
+```
+
+### Flow: LLM judge (synchronous)
+
+1. A rule hits `approve = [llm.judge]`. The gateway calls
+   `Approver.Approve` (host→plugin) with the request shape.
+2. The plugin calls its model over `HostControl.Dial` (plugin→host,
+   brokered) using a bound credential — no network of its own, egress
+   audited — and returns `ApproveVerdict`.
+
+### Flow: human approver over Slack
+
+1. Rule hits `approve = [human.oncall]`. The gateway publishes a pending
+   entry and calls `Approver.Notify` (host→plugin); the plugin posts to
+   Slack and returns a `message_ref`.
+2. An operator clicks Approve; the provider delivers the interaction to
+   the plugin (a gateway-mounted ingress route — operator-granted).
+3. The plugin calls `HostControl.Decide` (plugin→host) with the
+   `operation_id`; the gateway records it in the shared pool.
+4. The gateway calls `Approver.Update` (host→plugin) and the plugin edits
+   the Slack message as the operation resolves.
+
+Every callback is a plain gRPC method on the correct side — no frame, no
+`call_id`, no inflight map, in either direction.

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -184,6 +184,23 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 	}
 	defer func() { _ = stream.CloseSend() }()
 
+	// Register this connection's evaluation context under a fresh,
+	// unforgeable session token and hand the token to the plugin in
+	// ConnInit. The plugin echoes it back as HostControl metadata to run an
+	// Evaluate over the broker (no EvaluateAction frame / call_id) — the
+	// session closure runs the same evaluateDecoded core the frame handler
+	// does. Removed when the connection ends so no context dangles.
+	var sessionToken string
+	if a.client != nil && a.client.sessions != nil {
+		tok, remove := a.client.sessions.register(&session{
+			evaluate: func(_ context.Context, _ string, actionJSON []byte, summary string) (Verdict, error) {
+				return evaluateInline(ch, summary, actionJSON), nil
+			},
+		})
+		sessionToken = tok
+		defer remove()
+	}
+
 	// Send ConnInit.
 	init := &pb.ConnInit{
 		EndpointTypeName:        body.adapter.typeName,
@@ -202,6 +219,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 		TunnelTypeName:          tunType,
 		TunnelInstance:          tunInst,
 		SupportsDialUpstream:    true,
+		SessionToken:            sessionToken,
 	}
 	if err := stream.Send(&pb.ConnMessage{Kind: &pb.ConnMessage_Init{Init: init}}); err != nil {
 		return fmt.Errorf("extplugin: send ConnInit: %w", err)
@@ -441,36 +459,20 @@ const streamCapBytesForLog = 1024
 // the action map as the facet payload — plugins don't need to
 // double-emit via Conn.Emit.
 func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.EvaluateAction, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk) {
-	verdict := &pb.ActionVerdict{CallId: ev.CallId}
-
-	// Decode the action payload into a map so it can both feed the
-	// CEL activation and ride along on the audit event.
-	var action map[string]any
-	if len(ev.ActionJson) > 0 {
-		if err := json.Unmarshal(ev.ActionJson, &action); err != nil {
-			verdict.Action = "error"
-			verdict.Reason = fmt.Sprintf("malformed action_json: %v", err)
-			emitEvaluation(ch, ev, verdict, action)
-			_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Verdict{Verdict: verdict}})
-			return
-		}
-	}
-	if action == nil {
-		action = map[string]any{}
+	action, derr := decodeAction(ev.ActionJson)
+	if derr != nil {
+		v := Verdict{Action: "error", Reason: fmt.Sprintf("malformed action_json: %v", derr)}
+		emitEvaluation(ch, ev.Summary, action, v)
+		_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Verdict{Verdict: actionVerdict(ev.CallId, v)}})
+		return
 	}
 
-	// Look up the synthetic facet, if any. nil means the endpoint
-	// binds to a built-in facet (http / sql / k8s) — the plugin sent
-	// an action shaped to that facet's variables and the adapter
-	// maps it onto the typed match.Request fields the built-in
-	// matcher reads, instead of stashing the action in Meta.
+	// Stream pulling (frame path only — the HostControl path carries the
+	// action inline): for each stream field present in ev.Streams, pull
+	// bytes until cap or EOF, cancel, and fold the bytes into the action
+	// map. For plugin facets the cap honours per-rule reference detection;
+	// for built-in facets we use the larger cap unconditionally.
 	pf := facetFor(ch.Endpoint.Family)
-
-	// Stream pulling: for each stream field present in ev.Streams,
-	// pull bytes until cap or EOF, then cancel. For plugin facets
-	// the cap honours per-rule reference detection; for built-in
-	// facets we use the larger cap unconditionally (rules attached
-	// to built-in matchers don't expose a SubFieldReferencer yet).
 	var truncated bool
 	streamBytes := map[string][]byte{}
 	if len(ev.Streams) > 0 {
@@ -490,19 +492,53 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 			if hit {
 				truncated = true
 			}
-			// Always cancel after we've taken what we need so the
-			// plugin can release its source. Safe even if the stream
-			// already eof-ed; the SDK ignores cancels for handles
-			// it has already dropped.
+			// Always cancel after we've taken what we need so the plugin can
+			// release its source. Safe even if the stream already eof-ed.
 			_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_StreamCancel{StreamCancel: &pb.StreamCancel{Handle: handle}}})
 			streamBytes[fieldName] = data
 			action[fieldName] = string(data)
 		}
 	}
 
-	// Optional-field zero-fill so rule conditions can reference
-	// declared fields without `has()` guards. Plugin facets only —
-	// built-in facets have their own contract.
+	v := evaluateDecoded(ch, ev.Summary, action, streamBytes, truncated)
+	emitEvaluation(ch, ev.Summary, action, v)
+	_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Verdict{Verdict: actionVerdict(ev.CallId, v)}})
+}
+
+// decodeAction unmarshals an action payload into a map. An empty payload is
+// an empty map; malformed JSON is an error the caller reports as a verdict.
+func decodeAction(b []byte) (map[string]any, error) {
+	action := map[string]any{}
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &action); err != nil {
+			return map[string]any{}, err
+		}
+	}
+	return action, nil
+}
+
+func actionVerdict(callID string, v Verdict) *pb.ActionVerdict {
+	return &pb.ActionVerdict{CallId: callID, Action: v.Action, Reason: v.Reason, Rule: v.Rule}
+}
+
+// evaluateDecoded runs one decoded action through the connection's matcher
+// and approve chain and returns the verdict. It is the single source of
+// truth shared by the EvaluateAction frame handler and the HostControl
+// session closure, so both produce identical verdicts. streamBytes carries
+// any FACET_STREAM bytes the frame pulled (nil for the inline HostControl
+// path); truncated marks a capped stream so stream-typed facet fields fail
+// closed.
+func evaluateDecoded(ch *runtime.ConnHandle, summary string, action map[string]any, streamBytes map[string][]byte, truncated bool) Verdict {
+	// Look up the synthetic facet, if any. nil means the endpoint binds to
+	// a built-in facet (http / sql / k8s) — the action is shaped to that
+	// facet's variables and builtinRequestFor maps it onto the typed
+	// match.Request the built-in matcher reads instead of stashing it in
+	// Meta.
+	pf := facetFor(ch.Endpoint.Family)
+
+	// Optional-field zero-fill so rule conditions can reference declared
+	// fields without has() guards. Plugin facets only — built-in facets
+	// have their own contract.
 	if pf != nil {
 		for field := range pf.optionalFields {
 			if _, present := action[field]; present && action[field] != nil {
@@ -512,87 +548,93 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 		}
 	}
 
-	// Build a match.Request rich enough for the matcher AND for the
-	// HITL prompt fields a human approver might render. Truncated
-	// is set when at least one stream field hit its cap before
-	// EOF — the matcher then marks stream-typed fields CEL-unknown
-	// and any rule whose outcome depends on one is denied.
 	var req *match.Request
 	if pf != nil {
 		req = &match.Request{
 			Family:    ch.Endpoint.Family,
 			PeerIP:    ch.PeerIP,
 			Method:    stringField(action, "verb"),
-			URL:       &url.URL{Host: ch.UpstreamHost, Path: ev.Summary},
+			URL:       &url.URL{Host: ch.UpstreamHost, Path: summary},
 			Meta:      action,
 			Truncated: truncated,
 		}
 	} else {
-		req = builtinRequestFor(ch.Endpoint.Family, ch.PeerIP, ev.Summary, action, streamBytes)
+		req = builtinRequestFor(ch.Endpoint.Family, ch.PeerIP, summary, action, streamBytes)
 		req.Truncated = truncated
 	}
 
 	rule := runtime.MatchRequest(ch.Endpoint, req)
+	var v Verdict
 	switch {
 	case rule == nil:
-		// No rule matched — gateway's default-deny.
-		verdict.Action = "deny"
-		verdict.Reason = "no rule matched"
+		v.Action, v.Reason = "deny", "no rule matched"
 	case len(rule.Outcome.Approve) > 0:
 		if ch.Approve == nil {
-			verdict.Action = "deny"
-			verdict.Reason = "rule requires approval but host has no approver wired"
-			verdict.Rule = rule.Name
+			v.Action, v.Reason, v.Rule = "deny", "rule requires approval but host has no approver wired", rule.Name
 			break
 		}
-		v := ch.Approve(runtime.ApproveCallRequest{
+		av := ch.Approve(runtime.ApproveCallRequest{
 			Stages:  rule.Outcome.Approve,
 			Verb:    stringField(action, "verb"),
-			Summary: ev.Summary,
+			Summary: summary,
 			Rule:    rule,
 		})
-		verdict.Rule = rule.Name
-		verdict.Reason = v.Reason
-		switch v.Decision {
+		v.Rule, v.Reason = rule.Name, av.Reason
+		switch av.Decision {
 		case "allow":
-			verdict.Action = "hitl_allow"
+			v.Action = "hitl_allow"
 		case "deny":
-			verdict.Action = "hitl_deny"
+			v.Action = "hitl_deny"
 		default:
-			verdict.Action = "hitl_deny"
-			if v.Reason == "" {
-				verdict.Reason = "approver returned no decision"
+			v.Action = "hitl_deny"
+			if av.Reason == "" {
+				v.Reason = "approver returned no decision"
 			}
 		}
 	default:
-		verdict.Rule = rule.Name
+		v.Rule = rule.Name
 		if rule.Outcome.Verdict == "deny" {
-			verdict.Action = "deny"
+			v.Action = "deny"
 		} else {
-			verdict.Action = "allow"
+			v.Action = "allow"
 		}
-		verdict.Reason = rule.Outcome.Reason
+		v.Reason = rule.Outcome.Reason
 	}
+	return v
+}
 
-	emitEvaluation(ch, ev, verdict, action)
-	_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Verdict{Verdict: verdict}})
+// evaluateInline runs one inline action (no stream-valued fields, the
+// HostControl path) through the connection's matcher, emits the audit
+// event, and returns the verdict. The frame analogue is handleEvaluate; a
+// malformed payload becomes an "error" verdict here too, not a transport
+// error.
+func evaluateInline(ch *runtime.ConnHandle, summary string, actionJSON []byte) Verdict {
+	action, err := decodeAction(actionJSON)
+	if err != nil {
+		v := Verdict{Action: "error", Reason: fmt.Sprintf("malformed action_json: %v", err)}
+		emitEvaluation(ch, summary, action, v)
+		return v
+	}
+	v := evaluateDecoded(ch, summary, action, nil, false)
+	emitEvaluation(ch, summary, action, v)
+	return v
 }
 
 // emitEvaluation logs one EvaluateAction onto the gateway event
 // sink so the action shows up on the dashboard alongside built-in
 // facet events. Verb / Summary are pulled from the action so the
 // log line is human-readable; the action map rides as Facets.
-func emitEvaluation(ch *runtime.ConnHandle, ev *pb.EvaluateAction, verdict *pb.ActionVerdict, action map[string]any) {
+func emitEvaluation(ch *runtime.ConnHandle, summary string, action map[string]any, v Verdict) {
 	if ch.Emit == nil {
 		return
 	}
 	ch.Emit(runtime.ConnEvent{
-		Action:  verdict.Action,
-		Reason:  verdict.Reason,
+		Action:  v.Action,
+		Reason:  v.Reason,
 		Verb:    stringField(action, "verb"),
-		Summary: ev.Summary,
+		Summary: summary,
 		Facets:  action,
-		Rule:    verdict.Rule,
+		Rule:    v.Rule,
 	})
 }
 

--- a/internal/config/extplugin/hostcontrol.go
+++ b/internal/config/extplugin/hostcontrol.go
@@ -1,0 +1,146 @@
+package extplugin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// HostControl is the gateway's host-served control plane for plugin->host
+// calls. Unlike the Credential / Endpoint / Tunnel services — which the
+// gateway calls on the plugin — this one runs on the gateway and a
+// sandboxed plugin calls it over the go-plugin broker, alongside HostState.
+//
+// Each plugin->gateway callback is an ordinary gRPC method, so gRPC
+// correlates the reply and the hand-rolled call_id/dial_id inflight maps
+// that ride inside HandleConn today disappear. It grows by adding methods
+// (Dial, Decide), not new frames or new services.
+//
+// Every call is scoped to one connection's evaluation context by an opaque
+// session token the gateway minted for that connection. The token rides in
+// gRPC metadata, not the message body: session scope is cross-cutting, so
+// sessionUnaryInterceptor resolves it once into the request context and
+// each method reads it from there — a new method is scoped for free. A
+// forged / expired / removed token is rejected before the handler runs.
+
+// SessionMetadataKey is the gRPC metadata key the per-connection session
+// token rides under on every HostControl call. Lower-case per gRPC's
+// metadata convention.
+const SessionMetadataKey = "clawpatrol-session"
+
+// Verdict is the gateway's decision on one Evaluate call. Mirrors
+// runtime / pluginsdk.Verdict so the host-served surface and the existing
+// frame path return the same shape.
+type Verdict struct {
+	Action string // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
+	Reason string
+	Rule   string
+}
+
+// session is one connection's control context — the work HostControl
+// methods run on its behalf. Today only Evaluate; Decide and Dial join it
+// as the bundle grows, reusing the same token scoping and registration.
+type session struct {
+	evaluate func(ctx context.Context, facetName string, actionJSON []byte, summary string) (Verdict, error)
+}
+
+// sessionRegistry maps an opaque session token to a *session, scoped to one
+// plugin (each plugin gets its own registry, so a token is never valid
+// across plugins). A connection registers a session when it starts and
+// removes it when it ends.
+type sessionRegistry struct {
+	mu sync.Mutex
+	m  map[string]*session
+}
+
+func newSessionRegistry() *sessionRegistry {
+	return &sessionRegistry{m: map[string]*session{}}
+}
+
+// register adds s under a fresh, unforgeable token and returns the token
+// plus a remove func the caller defers when the connection ends. Minting
+// the token here (crypto/rand) rather than taking it from the wire is what
+// makes it unforgeable — a plugin can only present tokens the gateway
+// issued to it.
+func (r *sessionRegistry) register(s *session) (token string, remove func()) {
+	token = newSessionToken()
+	r.mu.Lock()
+	r.m[token] = s
+	r.mu.Unlock()
+	return token, func() {
+		r.mu.Lock()
+		delete(r.m, token)
+		r.mu.Unlock()
+	}
+}
+
+func (r *sessionRegistry) lookup(token string) (*session, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.m[token]
+	return s, ok
+}
+
+func newSessionToken() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// sessionCtxKey carries the resolved *session from the interceptor to the
+// method handler.
+type sessionCtxKey struct{}
+
+func sessionFromContext(ctx context.Context) (*session, bool) {
+	s, ok := ctx.Value(sessionCtxKey{}).(*session)
+	return s, ok
+}
+
+// sessionUnaryInterceptor resolves the session token carried in request
+// metadata to its *session and stashes it in the handler's context. A
+// present-but-unknown token is rejected here (a plugin cannot act on a
+// context it does not own); an absent token passes through unresolved, so
+// non-session-scoped host services (HostState) on the same server are
+// unaffected — the session-scoped methods (HostControl) require the
+// session themselves via sessionFromContext.
+func sessionUnaryInterceptor(reg *sessionRegistry) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		if vals := md.Get(SessionMetadataKey); len(vals) > 0 {
+			s, ok := reg.lookup(vals[0])
+			if !ok {
+				return nil, status.Error(codes.Unauthenticated, "unknown session token")
+			}
+			ctx = context.WithValue(ctx, sessionCtxKey{}, s)
+		}
+		return handler(ctx, req)
+	}
+}
+
+// hostControl implements pb.HostControlServer. It is stateless: the session
+// is resolved by sessionUnaryInterceptor and read from the context, so one
+// instance serves every connection of a plugin.
+type hostControl struct {
+	pb.UnimplementedHostControlServer
+}
+
+func (hostControl) Evaluate(ctx context.Context, req *pb.EvaluateRequest) (*pb.EvaluateVerdict, error) {
+	s, ok := sessionFromContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "missing session token")
+	}
+	v, err := s.evaluate(ctx, req.GetFacetName(), req.GetActionJson(), req.GetSummary())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "evaluate: %v", err)
+	}
+	return &pb.EvaluateVerdict{Action: v.Action, Reason: v.Reason, Rule: v.Rule}, nil
+}
+
+var _ pb.HostControlServer = hostControl{}

--- a/internal/config/extplugin/hostcontrol_test.go
+++ b/internal/config/extplugin/hostcontrol_test.go
@@ -1,0 +1,194 @@
+package extplugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/facet"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// ctrlTestPlugin wires both sides over a real go-plugin broker, exactly as
+// the gateway/plugin do: the server (plugin) side captures the broker so
+// the plugin can dial the host services; the client (gateway) side
+// serves HostControl on the reserved broker id behind the session
+// interceptor, backed by a per-plugin session registry.
+type ctrlTestPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	broker   *goplugin.GRPCBroker
+	sessions *sessionRegistry
+}
+
+func (p *ctrlTestPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server) error {
+	p.broker = broker
+	return nil
+}
+
+func (p *ctrlTestPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		opts = append(opts, grpc.ChainUnaryInterceptor(sessionUnaryInterceptor(p.sessions)))
+		s := grpc.NewServer(opts...)
+		pb.RegisterHostControlServer(s, hostControl{})
+		return s
+	})
+	return c, nil
+}
+
+func dialHostControl(t *testing.T, p *ctrlTestPlugin) pb.HostControlClient {
+	t.Helper()
+	conn, err := p.broker.Dial(HostServicesBrokerID)
+	if err != nil {
+		t.Fatalf("dial broker: %v", err)
+	}
+	return pb.NewHostControlClient(conn)
+}
+
+// withSession returns a ctx carrying the session token as request metadata,
+// the way the SDK client interceptor will.
+func withSession(token string) context.Context {
+	return metadata.AppendToOutgoingContext(context.Background(), SessionMetadataKey, token)
+}
+
+// TestHostControlEvaluateRoundTrip: a plugin runs a rule evaluation by
+// calling a plain gRPC method over the broker — no EvaluateAction frame, no
+// call_id, no inflight correlation map. The gateway routes the call to the
+// connection's session via the metadata token, resolved once in an
+// interceptor.
+func TestHostControlEvaluateRoundTrip(t *testing.T) {
+	sessions := newSessionRegistry()
+	var gotFacet string
+	var gotAction []byte
+	// What HandleConn will register when a connection starts: the same rule
+	// + approve work pumpConn's EvaluateAction branch does today.
+	token, remove := sessions.register(&session{
+		evaluate: func(_ context.Context, facet string, action []byte, _ string) (Verdict, error) {
+			gotFacet, gotAction = facet, action
+			if facet == "http" {
+				return Verdict{Action: "allow", Reason: "matched", Rule: "rule-1"}, nil
+			}
+			return Verdict{Action: "deny", Reason: "no rule"}, nil
+		},
+	})
+
+	p := &ctrlTestPlugin{sessions: sessions}
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{"x": p})
+	defer func() { _ = client.Close() }()
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+	ctrl := dialHostControl(t, p)
+
+	// The whole client side: one call, gRPC correlates the reply; the token
+	// rides in metadata, not the message.
+	v, err := ctrl.Evaluate(withSession(token), &pb.EvaluateRequest{
+		FacetName:  "http",
+		ActionJson: []byte(`{"method":"GET"}`),
+		Summary:    "GET /",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if v.Action != "allow" || v.Rule != "rule-1" || v.Reason != "matched" {
+		t.Fatalf("verdict = %+v, want allow/matched/rule-1", v)
+	}
+	if gotFacet != "http" || string(gotAction) != `{"method":"GET"}` {
+		t.Fatalf("gateway saw facet=%q action=%q", gotFacet, gotAction)
+	}
+
+	// A token the gateway never issued is rejected by the interceptor — a
+	// plugin cannot evaluate against a context it does not own.
+	if _, err := ctrl.Evaluate(withSession("forged"), &pb.EvaluateRequest{FacetName: "http"}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("forged token err = %v, want Unauthenticated", err)
+	}
+
+	// No token at all is rejected too (the method requires a session).
+	if _, err := ctrl.Evaluate(context.Background(), &pb.EvaluateRequest{FacetName: "http"}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("missing token err = %v, want Unauthenticated", err)
+	}
+
+	// Once the connection ends and its token is removed, further calls on it
+	// are rejected — no dangling evaluation context.
+	remove()
+	if _, err := ctrl.Evaluate(withSession(token), &pb.EvaluateRequest{FacetName: "http"}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("removed token err = %v, want Unauthenticated", err)
+	}
+}
+
+// TestSessionRegistryTokensUnique guards the unforgeable-token property:
+// minted tokens are distinct, non-empty, and only resolve while registered.
+func TestSessionRegistryTokensUnique(t *testing.T) {
+	r := newSessionRegistry()
+	t1, rm1 := r.register(&session{})
+	t2, _ := r.register(&session{})
+	if t1 == t2 || t1 == "" {
+		t.Fatalf("tokens not unique/non-empty: %q %q", t1, t2)
+	}
+	if _, ok := r.lookup(t1); !ok {
+		t.Fatal("t1 should resolve while registered")
+	}
+	rm1()
+	if _, ok := r.lookup(t1); ok {
+		t.Fatal("t1 should not resolve after remove")
+	}
+	if _, ok := r.lookup(t2); !ok {
+		t.Fatal("t2 should still resolve")
+	}
+}
+
+// TestHostControlEvaluateThroughMatcher is the full wired path: a plugin
+// calls HostControl.Evaluate over a real broker; the gateway resolves the
+// session token, runs the connection's real rule matcher via the shared
+// evaluateDecoded core, and returns the verdict — the same core the
+// EvaluateAction frame handler runs.
+func TestHostControlEvaluateThroughMatcher(t *testing.T) {
+	m, err := facet.NewMatcher("http", "http.method == 'get'")
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	ep := &config.CompiledEndpoint{
+		Name:   "ext",
+		Family: "http",
+		Rules: []*config.CompiledRule{
+			{Name: "allow-get", Matcher: m, Outcome: config.Outcome{Verdict: "allow"}},
+		},
+	}
+	ch := &runtime.ConnHandle{Endpoint: ep, PeerIP: "1.2.3.4"}
+
+	sessions := newSessionRegistry()
+	token, _ := sessions.register(&session{
+		evaluate: func(_ context.Context, _ string, actionJSON []byte, summary string) (Verdict, error) {
+			return evaluateInline(ch, summary, actionJSON), nil
+		},
+	})
+
+	p := &ctrlTestPlugin{sessions: sessions}
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{"x": p})
+	defer func() { _ = client.Close() }()
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+	ctrl := dialHostControl(t, p)
+
+	// GET matches the rule → allow.
+	v, err := ctrl.Evaluate(withSession(token), &pb.EvaluateRequest{
+		FacetName: "http", ActionJson: []byte(`{"method":"GET"}`), Summary: "GET /",
+	})
+	if err != nil || v.Action != "allow" || v.Rule != "allow-get" {
+		t.Fatalf("GET verdict = %+v, %v; want allow/allow-get", v, err)
+	}
+
+	// POST matches no rule → default deny.
+	v, err = ctrl.Evaluate(withSession(token), &pb.EvaluateRequest{
+		FacetName: "http", ActionJson: []byte(`{"method":"POST"}`), Summary: "POST /",
+	})
+	if err != nil || v.Action != "deny" {
+		t.Fatalf("POST verdict = %+v, %v; want deny", v, err)
+	}
+}

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -272,9 +272,18 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 	// lazily per call, so it works even though the gateway's blob store is
 	// wired only after the first config load. The gateway serves it over
 	// the broker; the plugin dials it.
+	// For a real load (a state namespace is given; throwaway probes pass
+	// ""), wire the per-plugin HostState + HostControl services. The session
+	// registry is shared between the broker server that serves HostControl
+	// (gc) and the adapter that registers a session per connection (c);
+	// HandleConn populates it. Probes never handle connections, so they get
+	// neither service (no idle broker goroutine).
 	gc := &grpcClient{}
+	var sessions *sessionRegistry
 	if stateNS != "" {
 		gc.hostState = newHostState(m.blobStore, stateNS)
+		sessions = newSessionRegistry()
+		gc.sessions = sessions
 	}
 	cli := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: HandshakeConfig,
@@ -297,6 +306,7 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 		network:        spec.Network,
 		socketDir:      spec.SocketDir,
 		gp:             cli,
+		sessions:       sessions,
 	}
 	rpcCli, err := cli.Client()
 	if err != nil {
@@ -965,6 +975,12 @@ type Client struct {
 	credential pb.CredentialClient
 	endpoint   pb.EndpointClient
 	tunnel     pb.TunnelClient
+	// sessions maps a per-connection HostControl session token to the
+	// connection's evaluation context. HandleConn registers a session and
+	// removes it when the connection ends; the broker-served HostControl
+	// resolves Evaluate calls against it. Shared with the grpcClient that
+	// serves the bundle.
+	sessions *sessionRegistry
 }
 
 // SandboxMode reports which sandbox backend the subprocess runs
@@ -1018,6 +1034,7 @@ func (c *Client) TunnelRPC() pb.TunnelClient { return c.tunnel }
 type grpcClient struct {
 	plugin.NetRPCUnsupportedPlugin
 	hostState pb.HostStateServer // nil = state service disabled
+	sessions  *sessionRegistry   // nil = HostControl disabled (probe path)
 }
 
 func (g *grpcClient) GRPCServer(_ *plugin.GRPCBroker, _ *grpc.Server) error {
@@ -1025,18 +1042,31 @@ func (g *grpcClient) GRPCServer(_ *plugin.GRPCBroker, _ *grpc.Server) error {
 }
 
 func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, conn *grpc.ClientConn) (any, error) {
-	// Serve HostState on the reserved broker stream id. AcceptAndServe
-	// blocks until the plugin dials, so run it in the background; the
-	// plugin only dials lazily on its first State call. When the client
-	// tears down, the broker closes and AcceptAndServe returns.
-	if g.hostState != nil && broker != nil {
-		hs := g.hostState
-		go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
-			s := grpc.NewServer(opts...)
-			pb.RegisterHostStateServer(s, hs)
-			return s
-		})
+	// Serve the host-side services (HostState + HostControl) on the reserved
+	// broker stream id. AcceptAndServe blocks until the plugin dials, so run
+	// it in the background; the plugin only dials lazily on its first call.
+	// When the client tears down, the broker closes and AcceptAndServe
+	// returns.
+	if broker == nil || (g.hostState == nil && g.sessions == nil) {
+		return conn, nil
 	}
+	hs, sessions := g.hostState, g.sessions
+	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		// HostControl calls are session-scoped via metadata; the interceptor
+		// resolves the token once. HostState carries no token and passes
+		// through (the interceptor only acts on a present token).
+		if sessions != nil {
+			opts = append(opts, grpc.ChainUnaryInterceptor(sessionUnaryInterceptor(sessions)))
+		}
+		s := grpc.NewServer(opts...)
+		if hs != nil {
+			pb.RegisterHostStateServer(s, hs)
+		}
+		if sessions != nil {
+			pb.RegisterHostControlServer(s, hostControl{})
+		}
+		return s
+	})
 	return conn, nil
 }
 

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3218,8 +3218,14 @@ type ConnInit struct {
 	// false (they silently drop unknown frames); the SDK fails
 	// Conn.DialUpstream fast instead of hanging.
 	SupportsDialUpstream bool `protobuf:"varint,15,opt,name=supports_dial_upstream,json=supportsDialUpstream,proto3" json:"supports_dial_upstream,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// session_token scopes this connection's calls to the gateway's
+	// host-served HostControl service (Evaluate, and later Decide/Dial). The
+	// gateway mints it per connection, registers the connection's evaluation
+	// context under it, and the plugin echoes it back as HostControl request
+	// metadata.
+	SessionToken  string `protobuf:"bytes,17,opt,name=session_token,json=sessionToken,proto3" json:"session_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConnInit) Reset() {
@@ -3362,6 +3368,13 @@ func (x *ConnInit) GetSupportsDialUpstream() bool {
 		return x.SupportsDialUpstream
 	}
 	return false
+}
+
+func (x *ConnInit) GetSessionToken() string {
+	if x != nil {
+		return x.SessionToken
+	}
+	return ""
 }
 
 // BoundCredential is one credential bound to a plugin endpoint. The same
@@ -4261,6 +4274,129 @@ func (*StatePutResponse) Descriptor() ([]byte, []int) {
 	return file_plugin_proto_rawDescGZIP(), []int{55}
 }
 
+type EvaluateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// facet_name is the namespaced facet the action conforms to.
+	FacetName string `protobuf:"bytes,1,opt,name=facet_name,json=facetName,proto3" json:"facet_name,omitempty"`
+	// action_json is the facet payload (the same bytes EvaluateAction
+	// carries today).
+	ActionJson    []byte `protobuf:"bytes,2,opt,name=action_json,json=actionJson,proto3" json:"action_json,omitempty"`
+	Summary       string `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"` // NB: the session token is carried in request metadata, not here.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateRequest) Reset() {
+	*x = EvaluateRequest{}
+	mi := &file_plugin_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateRequest) ProtoMessage() {}
+
+func (x *EvaluateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateRequest.ProtoReflect.Descriptor instead.
+func (*EvaluateRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *EvaluateRequest) GetFacetName() string {
+	if x != nil {
+		return x.FacetName
+	}
+	return ""
+}
+
+func (x *EvaluateRequest) GetActionJson() []byte {
+	if x != nil {
+		return x.ActionJson
+	}
+	return nil
+}
+
+func (x *EvaluateRequest) GetSummary() string {
+	if x != nil {
+		return x.Summary
+	}
+	return ""
+}
+
+type EvaluateVerdict struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Action        string                 `protobuf:"bytes,1,opt,name=action,proto3" json:"action,omitempty"` // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	Rule          string                 `protobuf:"bytes,3,opt,name=rule,proto3" json:"rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateVerdict) Reset() {
+	*x = EvaluateVerdict{}
+	mi := &file_plugin_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateVerdict) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateVerdict) ProtoMessage() {}
+
+func (x *EvaluateVerdict) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateVerdict.ProtoReflect.Descriptor instead.
+func (*EvaluateVerdict) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *EvaluateVerdict) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+func (x *EvaluateVerdict) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *EvaluateVerdict) GetRule() string {
+	if x != nil {
+		return x.Rule
+	}
+	return ""
+}
+
 var File_plugin_proto protoreflect.FileDescriptor
 
 const file_plugin_proto_rawDesc = "" +
@@ -4504,7 +4640,7 @@ const file_plugin_proto_rawDesc = "" +
 	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12\x16\n" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x12\n" +
-	"\x04rule\x18\x04 \x01(\tR\x04rule\"\xd6\x06\n" +
+	"\x04rule\x18\x04 \x01(\tR\x04rule\"\xfb\x06\n" +
 	"\bConnInit\x12,\n" +
 	"\x12endpoint_type_name\x18\x01 \x01(\tR\x10endpointTypeName\x12+\n" +
 	"\x11endpoint_instance\x18\x02 \x01(\tR\x10endpointInstance\x126\n" +
@@ -4522,7 +4658,8 @@ const file_plugin_proto_rawDesc = "" +
 	"\vcredentials\x18\x10 \x03(\v2%.clawpatrol.plugin.v1.BoundCredentialR\vcredentials\x12(\n" +
 	"\x10tunnel_type_name\x18\r \x01(\tR\x0etunnelTypeName\x12'\n" +
 	"\x0ftunnel_instance\x18\x0e \x01(\tR\x0etunnelInstance\x124\n" +
-	"\x16supports_dial_upstream\x18\x0f \x01(\bR\x14supportsDialUpstream\x1aC\n" +
+	"\x16supports_dial_upstream\x18\x0f \x01(\bR\x14supportsDialUpstream\x12#\n" +
+	"\rsession_token\x18\x11 \x01(\tR\fsessionToken\x1aC\n" +
 	"\x15CredentialExtrasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8f\x02\n" +
@@ -4584,7 +4721,17 @@ const file_plugin_proto_rawDesc = "" +
 	"\x0fStatePutRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value\"\x12\n" +
-	"\x10StatePutResponse*7\n" +
+	"\x10StatePutResponse\"k\n" +
+	"\x0fEvaluateRequest\x12\x1d\n" +
+	"\n" +
+	"facet_name\x18\x01 \x01(\tR\tfacetName\x12\x1f\n" +
+	"\vaction_json\x18\x02 \x01(\fR\n" +
+	"actionJson\x12\x18\n" +
+	"\asummary\x18\x03 \x01(\tR\asummary\"U\n" +
+	"\x0fEvaluateVerdict\x12\x16\n" +
+	"\x06action\x18\x01 \x01(\tR\x06action\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x12\n" +
+	"\x04rule\x18\x03 \x01(\tR\x04rule*7\n" +
 	"\rNetworkAccess\x12\x10\n" +
 	"\fNETWORK_NONE\x10\x00\x12\x14\n" +
 	"\x10NETWORK_OUTBOUND\x10\x01*k\n" +
@@ -4615,7 +4762,9 @@ const file_plugin_proto_rawDesc = "" +
 	"\vCloseTunnel\x12(.clawpatrol.plugin.v1.CloseTunnelRequest\x1a).clawpatrol.plugin.v1.CloseTunnelResponse2\xb7\x01\n" +
 	"\tHostState\x12T\n" +
 	"\x03Get\x12%.clawpatrol.plugin.v1.StateGetRequest\x1a&.clawpatrol.plugin.v1.StateGetResponse\x12T\n" +
-	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponseBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
+	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponse2g\n" +
+	"\vHostControl\x12X\n" +
+	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdictBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -4630,7 +4779,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_plugin_proto_goTypes = []any{
 	(NetworkAccess)(0),             // 0: clawpatrol.plugin.v1.NetworkAccess
 	(FacetKind)(0),                 // 1: clawpatrol.plugin.v1.FacetKind
@@ -4693,15 +4842,17 @@ var file_plugin_proto_goTypes = []any{
 	(*StateGetResponse)(nil),       // 58: clawpatrol.plugin.v1.StateGetResponse
 	(*StatePutRequest)(nil),        // 59: clawpatrol.plugin.v1.StatePutRequest
 	(*StatePutResponse)(nil),       // 60: clawpatrol.plugin.v1.StatePutResponse
-	nil,                            // 61: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	nil,                            // 62: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	nil,                            // 63: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
-	nil,                            // 64: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
-	nil,                            // 65: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
-	nil,                            // 66: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                            // 67: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                            // 68: clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
-	nil,                            // 69: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(*EvaluateRequest)(nil),        // 61: clawpatrol.plugin.v1.EvaluateRequest
+	(*EvaluateVerdict)(nil),        // 62: clawpatrol.plugin.v1.EvaluateVerdict
+	nil,                            // 63: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 64: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 65: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	nil,                            // 66: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	nil,                            // 67: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	nil,                            // 68: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 69: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 70: clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
+	nil,                            // 71: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
 	19, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
@@ -4726,15 +4877,15 @@ var file_plugin_proto_depIdxs = []int32{
 	24, // 19: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
 	18, // 20: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
 	3,  // 21: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	61, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	62, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	63, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	64, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
 	4,  // 24: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
 	27, // 25: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
-	63, // 26: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	65, // 26: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
 	31, // 27: clawpatrol.plugin.v1.TransformHTTPUp.init:type_name -> clawpatrol.plugin.v1.TransformHTTPInit
 	29, // 28: clawpatrol.plugin.v1.TransformHTTPUp.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
-	64, // 29: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
-	65, // 30: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	66, // 29: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	67, // 30: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
 	33, // 31: clawpatrol.plugin.v1.TransformHTTPDown.head:type_name -> clawpatrol.plugin.v1.TransformHTTPHead
 	29, // 32: clawpatrol.plugin.v1.TransformHTTPDown.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
 	27, // 33: clawpatrol.plugin.v1.TransformHTTPHead.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
@@ -4751,11 +4902,11 @@ var file_plugin_proto_depIdxs = []int32{
 	36, // 44: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
 	37, // 45: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
 	38, // 46: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
-	66, // 47: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	67, // 48: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	68, // 47: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	69, // 48: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
 	45, // 49: clawpatrol.plugin.v1.ConnInit.credentials:type_name -> clawpatrol.plugin.v1.BoundCredential
-	68, // 50: clawpatrol.plugin.v1.BoundCredential.extras:type_name -> clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
-	69, // 51: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	70, // 50: clawpatrol.plugin.v1.BoundCredential.extras:type_name -> clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
+	71, // 51: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 	54, // 52: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
 	55, // 53: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
 	56, // 54: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
@@ -4772,18 +4923,20 @@ var file_plugin_proto_depIdxs = []int32{
 	51, // 65: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
 	57, // 66: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
 	59, // 67: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
-	6,  // 68: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 69: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 70: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	32, // 71: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
-	34, // 72: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	50, // 73: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	53, // 74: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	52, // 75: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	58, // 76: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	60, // 77: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	68, // [68:78] is the sub-list for method output_type
-	58, // [58:68] is the sub-list for method input_type
+	61, // 68: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
+	6,  // 69: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 70: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 71: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 72: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 73: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	50, // 74: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	53, // 75: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	52, // 76: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	58, // 77: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	60, // 78: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	62, // 79: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
+	69, // [69:80] is the sub-list for method output_type
+	58, // [58:69] is the sub-list for method input_type
 	58, // [58:58] is the sub-list for extension type_name
 	58, // [58:58] is the sub-list for extension extendee
 	0,  // [0:58] is the sub-list for field type_name
@@ -4829,9 +4982,9 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   65,
+			NumMessages:   67,
 			NumExtensions: 0,
-			NumServices:   5,
+			NumServices:   6,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -555,6 +555,13 @@ message ConnInit {
   // false (they silently drop unknown frames); the SDK fails
   // Conn.DialUpstream fast instead of hanging.
   bool supports_dial_upstream = 15;
+
+  // session_token scopes this connection's calls to the gateway's
+  // host-served HostControl service (Evaluate, and later Decide/Dial). The
+  // gateway mints it per connection, registers the connection's evaluation
+  // context under it, and the plugin echoes it back as HostControl request
+  // metadata.
+  string session_token = 17;
 }
 
 // BoundCredential is one credential bound to a plugin endpoint. The same
@@ -691,3 +698,41 @@ message StatePutRequest {
 }
 
 message StatePutResponse {}
+
+// HostControl is the gateway's host-served control plane for plugin->host
+// calls: the gateway serves it over the go-plugin broker (next to
+// HostState) and a plugin calls it. Each plugin->gateway callback is an
+// ordinary gRPC method, so gRPC correlates the reply and the hand-rolled
+// call_id/dial_id inflight maps that ride inside HandleConn disappear. It
+// grows by adding methods (Dial, HITL Decide), not new frames.
+//
+// Every call is scoped to one connection's evaluation context by the
+// opaque session_token the gateway issued in that connection's ConnInit.
+// The token rides in gRPC METADATA (key "clawpatrol-session"), not in the
+// message — session scope is cross-cutting, so a server interceptor
+// resolves it once and every method is scoped without repeating the field.
+// A forged / expired / removed token is rejected before the handler runs.
+service HostControl {
+  // Evaluate runs the gateway's rule + approve chain for one action and
+  // returns the verdict. The host-served replacement for the
+  // EvaluateAction / ActionVerdict frames (and the inflight call_id map on
+  // both sides of HandleConn). Stream-valued facet fields still use the
+  // frame; inline actions use this.
+  rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
+}
+
+message EvaluateRequest {
+  // facet_name is the namespaced facet the action conforms to.
+  string facet_name = 1;
+  // action_json is the facet payload (the same bytes EvaluateAction
+  // carries today).
+  bytes action_json = 2;
+  string summary = 3;
+  // NB: the session token is carried in request metadata, not here.
+}
+
+message EvaluateVerdict {
+  string action = 1; // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
+  string reason = 2;
+  string rule = 3;
+}

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -810,3 +810,143 @@ var HostState_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "plugin.proto",
 }
+
+const (
+	HostControl_Evaluate_FullMethodName = "/clawpatrol.plugin.v1.HostControl/Evaluate"
+)
+
+// HostControlClient is the client API for HostControl service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// HostControl is the gateway's host-served control plane for plugin->host
+// calls: the gateway serves it over the go-plugin broker (next to
+// HostState) and a plugin calls it. Each plugin->gateway callback is an
+// ordinary gRPC method, so gRPC correlates the reply and the hand-rolled
+// call_id/dial_id inflight maps that ride inside HandleConn disappear. It
+// grows by adding methods (Dial, HITL Decide), not new frames.
+//
+// Every call is scoped to one connection's evaluation context by the
+// opaque session_token the gateway issued in that connection's ConnInit.
+// The token rides in gRPC METADATA (key "clawpatrol-session"), not in the
+// message — session scope is cross-cutting, so a server interceptor
+// resolves it once and every method is scoped without repeating the field.
+// A forged / expired / removed token is rejected before the handler runs.
+type HostControlClient interface {
+	// Evaluate runs the gateway's rule + approve chain for one action and
+	// returns the verdict. The host-served replacement for the
+	// EvaluateAction / ActionVerdict frames (and the inflight call_id map on
+	// both sides of HandleConn). Stream-valued facet fields still use the
+	// frame; inline actions use this.
+	Evaluate(ctx context.Context, in *EvaluateRequest, opts ...grpc.CallOption) (*EvaluateVerdict, error)
+}
+
+type hostControlClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewHostControlClient(cc grpc.ClientConnInterface) HostControlClient {
+	return &hostControlClient{cc}
+}
+
+func (c *hostControlClient) Evaluate(ctx context.Context, in *EvaluateRequest, opts ...grpc.CallOption) (*EvaluateVerdict, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EvaluateVerdict)
+	err := c.cc.Invoke(ctx, HostControl_Evaluate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// HostControlServer is the server API for HostControl service.
+// All implementations must embed UnimplementedHostControlServer
+// for forward compatibility.
+//
+// HostControl is the gateway's host-served control plane for plugin->host
+// calls: the gateway serves it over the go-plugin broker (next to
+// HostState) and a plugin calls it. Each plugin->gateway callback is an
+// ordinary gRPC method, so gRPC correlates the reply and the hand-rolled
+// call_id/dial_id inflight maps that ride inside HandleConn disappear. It
+// grows by adding methods (Dial, HITL Decide), not new frames.
+//
+// Every call is scoped to one connection's evaluation context by the
+// opaque session_token the gateway issued in that connection's ConnInit.
+// The token rides in gRPC METADATA (key "clawpatrol-session"), not in the
+// message — session scope is cross-cutting, so a server interceptor
+// resolves it once and every method is scoped without repeating the field.
+// A forged / expired / removed token is rejected before the handler runs.
+type HostControlServer interface {
+	// Evaluate runs the gateway's rule + approve chain for one action and
+	// returns the verdict. The host-served replacement for the
+	// EvaluateAction / ActionVerdict frames (and the inflight call_id map on
+	// both sides of HandleConn). Stream-valued facet fields still use the
+	// frame; inline actions use this.
+	Evaluate(context.Context, *EvaluateRequest) (*EvaluateVerdict, error)
+	mustEmbedUnimplementedHostControlServer()
+}
+
+// UnimplementedHostControlServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedHostControlServer struct{}
+
+func (UnimplementedHostControlServer) Evaluate(context.Context, *EvaluateRequest) (*EvaluateVerdict, error) {
+	return nil, status.Error(codes.Unimplemented, "method Evaluate not implemented")
+}
+func (UnimplementedHostControlServer) mustEmbedUnimplementedHostControlServer() {}
+func (UnimplementedHostControlServer) testEmbeddedByValue()                     {}
+
+// UnsafeHostControlServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to HostControlServer will
+// result in compilation errors.
+type UnsafeHostControlServer interface {
+	mustEmbedUnimplementedHostControlServer()
+}
+
+func RegisterHostControlServer(s grpc.ServiceRegistrar, srv HostControlServer) {
+	// If the following call panics, it indicates UnimplementedHostControlServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&HostControl_ServiceDesc, srv)
+}
+
+func _HostControl_Evaluate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EvaluateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostControlServer).Evaluate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostControl_Evaluate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostControlServer).Evaluate(ctx, req.(*EvaluateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// HostControl_ServiceDesc is the grpc.ServiceDesc for HostControl service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var HostControl_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.HostControl",
+	HandlerType: (*HostControlServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Evaluate",
+			Handler:    _HostControl_Evaluate_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "plugin.proto",
+}

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -490,6 +490,12 @@ type Conn struct {
 	// set it is nil (read the singular fields instead).
 	Credentials []ConnCredential
 
+	// SessionToken scopes this connection's calls to the gateway's
+	// host-served HostControl service. The SDK threads it into
+	// Conn.Evaluate automatically (as request metadata); plugin authors
+	// don't use it directly.
+	SessionToken string
+
 	TunnelTypeName string
 	TunnelInstance string
 

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -490,6 +491,7 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		CredentialExtras:          in.CredentialExtras,
 		CredentialCanonicalConfig: in.CredentialCanonicalJson,
 		Credentials:               connCredentialsFromProto(in.Credentials),
+		SessionToken:              in.SessionToken,
 		TunnelTypeName:            in.TunnelTypeName,
 		TunnelInstance:            in.TunnelInstance,
 	}
@@ -575,6 +577,26 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		if err != nil {
 			return Verdict{}, fmt.Errorf("pluginsdk: marshal action: %w", err)
 		}
+
+		// Inline actions go over the host control plane: one gRPC call, gRPC
+		// correlates the reply, no call_id and no inflight map. Only
+		// stream-valued fields keep the legacy frame (HostControl.Evaluate
+		// carries no stream handles). The gateway always serves HostControl
+		// and issues a session token, so there is no fallback for its
+		// absence.
+		if streamHandles == nil {
+			cli, err := hostControlClient()
+			if err != nil {
+				return Verdict{}, fmt.Errorf("pluginsdk: host control plane: %w", err)
+			}
+			mctx := metadata.AppendToOutgoingContext(ctx, extplugin.SessionMetadataKey, conn.SessionToken)
+			v, err := cli.Evaluate(mctx, &pb.EvaluateRequest{FacetName: facet, ActionJson: j, Summary: summary})
+			if err != nil {
+				return Verdict{}, fmt.Errorf("pluginsdk: HostControl.Evaluate: %w", err)
+			}
+			return Verdict{Action: v.Action, Reason: v.Reason, Rule: v.Rule}, nil
+		}
+
 		callID := fmt.Sprintf("c%d", callSeq.Add(1))
 		ch := make(chan *pb.ActionVerdict, 1)
 		inflightMu.Lock()

--- a/pluginsdk/state.go
+++ b/pluginsdk/state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/denoland/clawpatrol/internal/config/extplugin"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
 	"github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
 )
 
 // StateStore is the handle to the gateway's per-plugin persistent byte
@@ -66,9 +67,13 @@ var (
 	hostBrokerMu sync.Mutex
 	hostBroker   *plugin.GRPCBroker
 
-	hostStateOnce sync.Once
-	hostStateCli  pb.HostStateClient
-	hostStateErr  error
+	// The gateway serves HostState and HostControl on one broker stream
+	// (HostServicesBrokerID), so the plugin dials it once and builds both
+	// stubs over the single connection — AcceptAndServe accepts that id
+	// only once.
+	hostConnOnce sync.Once
+	hostConn     *grpc.ClientConn
+	hostConnErr  error
 )
 
 func setHostBroker(b *plugin.GRPCBroker) {
@@ -77,25 +82,36 @@ func setHostBroker(b *plugin.GRPCBroker) {
 	hostBrokerMu.Unlock()
 }
 
-// hostStateClient lazily dials the gateway's HostState service over the
-// broker and caches the client. It errors when the plugin is running
-// without a gateway broker (a unit test, or an old gateway), so plugin
-// code can degrade gracefully.
-func hostStateClient() (pb.HostStateClient, error) {
-	hostStateOnce.Do(func() {
+// hostServicesConn lazily dials the gateway's host-services broker stream
+// and caches the connection. It errors when the plugin is running without a
+// gateway broker (a unit test, or an old gateway), so plugin code can
+// degrade gracefully.
+func hostServicesConn() (*grpc.ClientConn, error) {
+	hostConnOnce.Do(func() {
 		hostBrokerMu.Lock()
 		b := hostBroker
 		hostBrokerMu.Unlock()
 		if b == nil {
-			hostStateErr = errors.New("pluginsdk: state service unavailable (no gateway broker)")
+			hostConnErr = errors.New("pluginsdk: host services unavailable (no gateway broker)")
 			return
 		}
-		conn, err := b.Dial(extplugin.HostServicesBrokerID)
-		if err != nil {
-			hostStateErr = err
-			return
-		}
-		hostStateCli = pb.NewHostStateClient(conn)
+		hostConn, hostConnErr = b.Dial(extplugin.HostServicesBrokerID)
 	})
-	return hostStateCli, hostStateErr
+	return hostConn, hostConnErr
+}
+
+func hostStateClient() (pb.HostStateClient, error) {
+	c, err := hostServicesConn()
+	if err != nil {
+		return nil, err
+	}
+	return pb.NewHostStateClient(c), nil
+}
+
+func hostControlClient() (pb.HostControlClient, error) {
+	c, err := hostServicesConn()
+	if err != nil {
+		return nil, err
+	}
+	return pb.NewHostControlClient(c), nil
 }

--- a/pluginsdk/state_broker_test.go
+++ b/pluginsdk/state_broker_test.go
@@ -65,9 +65,9 @@ func TestStateBrokerRoundTrip(t *testing.T) {
 	// because this is the single test that exercises State(): it runs
 	// before any broker goroutine of its own starts, and no other test in
 	// the package touches these globals concurrently.
-	hostStateOnce = sync.Once{}
-	hostStateCli = nil
-	hostStateErr = nil
+	hostConnOnce = sync.Once{}
+	hostConn = nil
+	hostConnErr = nil
 	setHostBroker(nil)
 
 	host := &brokerTestHostState{m: map[string][]byte{}}


### PR DESCRIPTION
Adds the gateway's host-served **control plane** for plugin→host calls
and routes the `Evaluate` callback through it: a plugin→gateway call is
now an ordinary gRPC method over the go-plugin broker, so gRPC's
correlation replaces the hand-rolled `call_id` inflight map that rode
inside `HandleConn`. Design: `doc/external-plugin-control-plane.md`.

## What it does

* **Proto** — `HostControl{Evaluate}` served over the broker next to
  `HostState`; `ConnInit.session_token` carries the per-connection token.
* **Gateway** — a per-plugin `sessionRegistry` shared between the broker
  server (serves `HostControl` behind a metadata session interceptor) and
  the adapter. `HandleConn` mints a `crypto/rand` token, registers the
  connection's evaluation context under it, hands it to the plugin in
  `ConnInit`, and removes it on close. `handleEvaluate` (frame) and the
  `HostControl` session closure share **one `evaluateDecoded` core**, so
  verdicts are identical by construction.
* **SDK** — `Conn.Evaluate` goes over `HostControl` (token threaded into
  metadata; plugin authors never see it). The only case that keeps the
  legacy frame is an action with **stream-valued fields** (the gateway
  pulls those lazily; `HostControl.Evaluate` carries no stream handles).

## Scoping / security

Tokens are `crypto/rand`, minted at registration (never from the wire),
and the registry is per-plugin, so a token can't cross plugins or be
forged. The interceptor resolves a present token (rejects unknown →
`Unauthenticated`) and passes an absent one through (HostState is
unscoped); the method itself requires a session. `defer remove()` runs on
every `HandleConn` return, so no context dangles.

## Compatibility

* **Older plugins keep working** — the `EvaluateAction` frame handler
  stays (it also serves the stream-valued path), and an old plugin just
  ignores the new `ConnInit` field.
* **The SDK targets the current gateway** — no fallback for a gateway
  without `HostControl`.

## Direction

`HostControl` is the **plugin→host** surface (`Evaluate` now; HITL
`Decide` and brokered `Dial` next). The host→plugin approver/HITL
callbacks (`Approve`/`Notify`/`Update`) are a plugin-served `Approver`
service, not `HostControl` methods — see the doc's sketch.

Supersedes the design discussion in #692. Tested over a real go-plugin
broker, including the full path through a real rule matcher and
forged/removed/missing-token rejection; the real-subprocess e2e suite
passes.