### PR TITLE
extplugin: plugin-declared "privileged" capability (run unsandboxed, explicit approval)

### DIFF
--- a/cmd/clawpatrol/plugins.go
+++ b/cmd/clawpatrol/plugins.go
@@ -25,8 +25,10 @@ commands:
   info      Show a GitHub-sourced plugin's metadata and required
             privileges from its signed static manifest, without
             downloading the binary.
-  approve   Re-approve a plugin after an intentional permission change,
-            clearing the escalation block so the gateway will load it.
+  approve   Approve a plugin's current permissions: clears an escalation
+            block after an intentional permission change, and grants a
+            plugin that declares the privileged capability (run with the
+            sandbox off) — held closed until you approve it here.
 
 With no name arguments a command applies to every plugin in the config.`
 
@@ -155,6 +157,9 @@ func runPluginsInfo(args []string) {
 			fmt.Printf("  version:   %s\n", pv.Version)
 		}
 		fmt.Printf("  requires:  network = %s\n", pv.Network)
+		if pv.Privileged {
+			fmt.Printf("  privileged: yes — needs the sandbox OFF (full host access)\n")
+		}
 		if len(pv.Egress) > 0 {
 			fmt.Printf("  egress:    %s\n", strings.Join(pv.Egress, ", "))
 		}
@@ -185,7 +190,11 @@ func runPluginsApprove(args []string) {
 		os.Exit(1)
 	}
 	for _, a := range approved {
-		fmt.Printf("approved plugin %q (network=%s)\n", a.Name, a.Network)
+		if a.Privileged {
+			fmt.Printf("approved plugin %q (network=%s, PRIVILEGED: runs with the sandbox off)\n", a.Name, a.Network)
+		} else {
+			fmt.Printf("approved plugin %q (network=%s)\n", a.Name, a.Network)
+		}
 	}
 	if len(approved) == 0 {
 		fmt.Println("no plugins to approve")

--- a/dashboard/src/components/PluginsPage.tsx
+++ b/dashboard/src/components/PluginsPage.tsx
@@ -32,8 +32,10 @@ export function PluginsPage() {
         External plugins run sandboxed. Each declares its own network need; the gateway records the
         approved permissions in <code className="font-mono text-xs">clawpatrol.lock.hcl</code> on
         first load and refuses to start a plugin whose update asks for more — shown below as a
-        blocked plugin until you re-approve it. Filesystem access and turning the sandbox off are
-        operator-only.
+        blocked plugin until you re-approve it. Network and egress are recorded on first load; a
+        plugin that declares it must run <span className="font-bold">privileged</span> (sandbox off,
+        full host access) is held back until you approve it explicitly. Granting extra filesystem
+        read paths stays operator-only.
       </p>
 
       {err && (
@@ -112,6 +114,7 @@ function BlockedCard({ p, onApproved }: { p: Plugin; onApproved: () => void }) {
                   <span className="font-mono text-2xs text-text-muted">{p.requested.version}</span>
                 )}
                 <NetworkBadge network={p.requested.network} />
+                {p.requested.privileged && <PrivilegedBadge />}
               </div>
               <RequestedTypes label="egress" items={p.requested.egress} />
               <RequestedTypes label="credentials" items={p.requested.credentials} />
@@ -242,6 +245,17 @@ function NetworkBadge({ network }: { network: string }) {
       }
     >
       net: {network || "none"}
+    </Badge>
+  );
+}
+
+function PrivilegedBadge() {
+  return (
+    <Badge
+      tone="danger"
+      title="Privileged — the plugin needs to run with the sandbox OFF (full host access). Approve only if you trust it."
+    >
+      privileged
     </Badge>
   );
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -218,6 +218,9 @@ export type RequestedPrivileges = {
   // it needs to reach via the gateway's brokered dial ("host:port" or
   // "*.suffix:port").
   egress?: string[];
+  // privileged means the plugin's manifest declares it must run unsandboxed
+  // (full host access). The operator must approve it explicitly.
+  privileged?: boolean;
   credentials?: string[];
   endpoints?: string[];
   tunnels?: string[];
@@ -236,6 +239,10 @@ export type Plugin = {
   // egress is the approved set of brokered-dial targets the plugin's
   // manifest declared, recorded in the lockfile.
   egress?: string[];
+  // privileged means the plugin runs unsandboxed (full host access) — the
+  // operator approved its declared privileged capability, or forced it with
+  // `sandbox = "off"`.
+  privileged?: boolean;
   sandboxMode?: string;
   sandboxWarning?: string;
   approvedHashes?: string[];

--- a/internal/config/extplugin/install.go
+++ b/internal/config/extplugin/install.go
@@ -109,6 +109,26 @@ func (m *Manager) Install(ctx context.Context, specs []config.PluginSource, name
 		if staticMf != nil {
 			m.lock.setEgress(sp.Name, egressFromManifest(staticMf))
 		}
+		// Record the privileged grant. install/update can only grant it from
+		// a signed static manifest — running install on a plugin whose
+		// manifest declares privileged is the operator explicitly accepting
+		// it. install does NOT spawn, so for a manifest-less release it cannot
+		// read the declaration; it must instead make sure no stale grant rides
+		// onto this binary. Unless this exact binary was already an
+		// approved-privileged hash (a re-download of the same approved
+		// binary), clear the grant — the plugin then fails closed at load
+		// until `clawpatrol plugins approve` (which probes the binary) grants
+		// it. This errs toward the sandboxed, more-restricted side and never
+		// grants privilege silently.
+		switch {
+		case staticMf != nil:
+			m.lock.setPrivileged(sp.Name, privilegedFromManifest(staticMf))
+		case have && entry.hasHash(res.binSHA) && entry.Privileged:
+			// Re-download of the same already-approved-privileged binary:
+			// preserve the existing approval.
+		default:
+			m.lock.setPrivileged(sp.Name, false)
+		}
 
 		out = append(out, InstalledPlugin{
 			Name:      sp.Name,

--- a/internal/config/extplugin/install.go
+++ b/internal/config/extplugin/install.go
@@ -200,6 +200,15 @@ func (m *Manager) LockPlatforms(ctx context.Context, specs []config.PluginSource
 				_ = os.RemoveAll(tmp)
 				return nil, fmt.Errorf("plugin %q (%s): %w", sp.Name, plat, err)
 			}
+			// addHash extends the entry's grants — including a recorded
+			// privileged grant, which is shared across the entry's hashes — to
+			// every sibling platform build of the SAME pinned release. That is
+			// intended: the operator pinned and approved this version, and lock
+			// is how one committed lockfile covers a mixed-OS team. A release
+			// that ships a signed static manifest still has each build's
+			// declaration checked against it at load (checkManifestConsistency);
+			// a manifest-less release is trusted per the pin, the same as its
+			// network/egress grants.
 			m.lock.addHash(sp.Name, res.binSHA, entry.Network)
 			if commit == "" {
 				commit = res.commit

--- a/internal/config/extplugin/install_test.go
+++ b/internal/config/extplugin/install_test.go
@@ -82,6 +82,68 @@ func TestInstallUpdateLock(t *testing.T) {
 	}
 }
 
+// TestInstallUpgradeClearsPrivileged is the regression test for the
+// silent-privilege-grant bypass: a manifest-less UPGRADE of a
+// previously-privileged-approved plugin must not let the new binary inherit
+// the old version's privileged grant. install can't read a manifest-less
+// release's declaration (it doesn't spawn), so it must clear the grant —
+// the new version then fails closed at load until `plugins approve` re-grants
+// it. Without the fix, the upgraded binary would silently run unsandboxed.
+func TestInstallUpgradeClearsPrivileged(t *testing.T) {
+	repo := "ssh_tools"
+	plats := []string{platformToken()}
+	srv := newReleaseServer(t, "o", repo, []relSpec{
+		mkRelease(t, repo, "1.2.0", plats),
+		mkRelease(t, repo, "1.3.0", plats),
+	})
+	m, _ := newFetchTestManager(t, srv.URL)
+	// Network override => install records without spawning the fake binary.
+	sp := config.PluginSource{Name: repo, Source: "github.com/o/ssh_tools", Version: "~> 1.2", Network: "outbound"}
+	specs := []config.PluginSource{sp}
+	ctx := context.Background()
+
+	// Seed a pin at v1.2.0 so the first install keeps it (rather than
+	// resolving ~> 1.2 to the newest in range).
+	m.lock.setSource(repo, "github.com/o/ssh_tools", "v1.2.0", "~> 1.2", "", false)
+	if err := m.lock.save(); err != nil {
+		t.Fatal(err)
+	}
+	// Install v1.2.0, then simulate the operator approving it as privileged
+	// (what `plugins approve` records for a manifest-less release after
+	// probing the binary).
+	if _, err := m.Install(ctx, specs, nil, false); err != nil {
+		t.Fatalf("install v1.2.0: %v", err)
+	}
+	m.lock.setPrivileged(repo, true)
+	if err := m.lock.save(); err != nil {
+		t.Fatal(err)
+	}
+	if e, _ := m.lock.get(repo); !e.Privileged || e.Version != "v1.2.0" {
+		t.Fatalf("precondition: entry = %+v, want privileged v1.2.0", e)
+	}
+
+	// Upgrade to the manifest-less v1.3.0. The stale grant must be dropped.
+	if _, err := m.Install(ctx, specs, nil, true); err != nil {
+		t.Fatalf("update v1.3.0: %v", err)
+	}
+	e, _ := m.lock.get(repo)
+	if e.Version != "v1.3.0" {
+		t.Fatalf("version = %q, want v1.3.0", e.Version)
+	}
+	if e.Privileged {
+		t.Fatalf("BYPASS: upgraded binary inherited privileged grant: %+v", e)
+	}
+
+	// Re-load the lockfile from disk to confirm it was persisted, not just
+	// the in-memory view.
+	if err := m.lock.load(); err != nil {
+		t.Fatal(err)
+	}
+	if e, _ := m.lock.get(repo); e.Privileged {
+		t.Fatalf("BYPASS persisted on disk: %+v", e)
+	}
+}
+
 func TestInstallFirstUsePicksNewest(t *testing.T) {
 	repo := "p"
 	plats := []string{platformToken()}

--- a/internal/config/extplugin/lockfile.go
+++ b/internal/config/extplugin/lockfile.go
@@ -64,6 +64,15 @@ type lockEntry struct {
 	// set — wants a destination none of these entries cover — fails closed
 	// until reapproved. Shared across the entry's Hashes, like Network.
 	Egress []string `hcl:"egress,optional"`
+	// Privileged records that the operator explicitly approved running this
+	// plugin unsandboxed (full host access), in response to the plugin's
+	// manifest-declared privileged capability. Unlike Network and Egress
+	// this is NEVER trust-on-first-use: it is written only by
+	// `clawpatrol plugins approve` (or the dashboard). The grant is gated on
+	// the binary's hash being in Hashes, so an upgrade — whose hash is not
+	// yet recorded — re-pends approval and the plugin fails closed until the
+	// operator re-approves the new binary.
+	Privileged bool `hcl:"privileged,optional"`
 }
 
 // hasHash reports whether hash is in the entry's approved set.
@@ -181,8 +190,14 @@ func (s *lockStore) setSource(name, source, version, constraints, commit string,
 	// A version change re-pins the plugin: the recorded hashes belonged
 	// to the old version's platform builds, so drop them — the new
 	// version's hashes are recorded fresh by the caller (addHash / lock).
+	// The privileged grant is per-version too (it is explicit-approval,
+	// never trust-on-first-use): drop it so the new version's binary cannot
+	// inherit the old version's approval and silently run unsandboxed. The
+	// caller re-records it from the new version's signed manifest, or it
+	// stays closed until `plugins approve`.
 	if e.Version != version {
 		e.Hashes = nil
+		e.Privileged = false
 	}
 	e.Name = name
 	e.Source = source
@@ -210,6 +225,22 @@ func (s *lockStore) setEgress(name string, egress []string) {
 	} else {
 		e.Egress = egress
 	}
+	s.entries[name] = e
+	s.dirty = true
+}
+
+// setPrivileged records (or clears) the operator's explicit approval to run
+// the plugin unsandboxed. Only `clawpatrol plugins approve` calls this — it
+// is never set trust-on-first-use. Marks dirty only on change.
+func (s *lockStore) setPrivileged(name string, privileged bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e := s.entries[name]
+	if e.Name == name && e.Privileged == privileged {
+		return
+	}
+	e.Name = name
+	e.Privileged = privileged
 	s.entries[name] = e
 	s.dirty = true
 }
@@ -267,6 +298,9 @@ func (s *lockStore) save() error {
 			blk.Body().SetAttributeValue("constraints", cty.StringVal(e.Constraints))
 		}
 		blk.Body().SetAttributeValue("network", cty.StringVal(e.Network))
+		if e.Privileged {
+			blk.Body().SetAttributeValue("privileged", cty.BoolVal(true))
+		}
 		if len(e.Egress) > 0 {
 			egVals := make([]cty.Value, len(e.Egress))
 			for i, eg := range e.Egress {

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -199,7 +199,37 @@ func (m *Manager) Start(ctx context.Context, sp config.PluginSource) (*Client, *
 	// fresh load look approved and silently drop the declared egress.
 	priorLock, priorLocked := m.lock.get(sp.Name)
 
-	network, warn, err := m.resolveNetwork(ctx, sp, bin, hash, staticMf)
+	// declaredMf is the manifest the capability resolvers read to learn what
+	// this binary requires. For a release with a signed static manifest it
+	// is that manifest (no plugin code runs). Otherwise, when the binary is
+	// not already approved in the lockfile (a first load or an upgrade), we
+	// probe once — a throwaway network-denied spawn — and share the result
+	// across resolveSandboxOff and resolveNetwork so neither probes again.
+	// An already-approved binary takes both resolvers' lockfile fast paths
+	// and needs no manifest, so declaredMf stays nil there.
+	declaredMf := staticMf
+	if declaredMf == nil && (!priorLocked || !priorLock.hasHash(hash)) {
+		declaredMf, err = m.probeManifest(ctx, sp, bin)
+		if err != nil {
+			return nil, nil, fmt.Errorf("plugin source %q: read manifest: %w", source, err)
+		}
+	}
+
+	// resolvePrivileged runs BEFORE resolveNetwork on purpose: an unapproved
+	// privileged declaration must fail closed here, before resolveNetwork
+	// records this binary's hash. Otherwise a same-or-reduced network
+	// upgrade would silently add the new hash to the approved set, and the
+	// next load would see it as approved-for-privileged without the operator
+	// ever running `plugins approve`.
+	privileged, privWarn, err := m.resolvePrivileged(sp, priorLock, priorLocked, hash, declaredMf)
+	if err != nil {
+		return nil, nil, err
+	}
+	if privWarn != "" {
+		m.logger.Warn("plugin permission", "plugin", sp.Name, "note", privWarn)
+	}
+
+	network, warn, err := m.resolveNetwork(ctx, sp, bin, hash, declaredMf)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -207,7 +237,7 @@ func (m *Manager) Start(ctx context.Context, sp config.PluginSource) (*Client, *
 		m.logger.Warn("plugin permission", "plugin", sp.Name, "note", warn)
 	}
 
-	spec, mode, sbWarn, err := buildSandboxSpec(sp, bin, network, m.stateDirLocked())
+	spec, mode, sbWarn, err := buildSandboxSpec(sp, bin, network, privileged, m.stateDirLocked())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -494,9 +524,11 @@ func (m *Manager) probeNetwork(ctx context.Context, sp config.PluginSource, binP
 // fetch needs no network, so this is safe even for a plugin that will
 // ultimately run with outbound access. Used to learn a local plugin's (or
 // a static-manifest-less release's) declared capabilities without granting
-// them.
+// them — privileged=false here so the probe stays sandboxed even when the
+// plugin declares the privileged capability (the operator's own
+// `sandbox = "off"` HCL still takes effect via buildSandboxSpec).
 func (m *Manager) probeManifest(ctx context.Context, sp config.PluginSource, binPath string) (*pb.ManifestResponse, error) {
-	spec, mode, _, err := buildSandboxSpec(sp, binPath, sandbox.NetworkNone, m.stateDirLocked())
+	spec, mode, _, err := buildSandboxSpec(sp, binPath, sandbox.NetworkNone, false, m.stateDirLocked())
 	if err != nil {
 		return nil, err
 	}
@@ -508,6 +540,66 @@ func (m *Manager) probeManifest(ctx context.Context, sp config.PluginSource, bin
 	}
 	defer c.kill()
 	return manifest, nil
+}
+
+// privilegedFromManifest reports whether the plugin's manifest declares the
+// privileged (run-unsandboxed) capability.
+func privilegedFromManifest(mf *pb.ManifestResponse) bool {
+	return mf.GetCapabilities().GetPrivileged()
+}
+
+// resolvePrivileged decides whether sp runs unsandboxed. Privileged is the
+// strongest grant a plugin can ask for — full host access — so unlike
+// network and egress it is NEVER trust-on-first-use: the operator must
+// approve it explicitly with `clawpatrol plugins approve` (or the
+// dashboard), which records it in the lockfile gated on the binary's hash.
+//
+// prior is the lockfile entry as it was at the start of this pass (the
+// snapshot Start captures before resolveNetwork records anything), so an
+// upgraded binary — whose hash is not yet in prior.Hashes — fails closed
+// here until re-approved. resolvePrivileged must run before resolveNetwork
+// so this fail-closed happens before the new hash is recorded.
+//
+// declaredMf is the plugin's manifest (signed static, or a probe), nil only
+// on the lockfile fast path where prior already records this exact binary.
+func (m *Manager) resolvePrivileged(sp config.PluginSource, prior lockEntry, priorRecorded bool, hash string, declaredMf *pb.ManifestResponse) (bool, string, error) {
+	// An operator `sandbox = "off"` HCL attribute is the operator already
+	// accepting full host access in a reviewable, committed file — it wins
+	// outright, no lockfile approval needed (buildSandboxSpec honours it
+	// too; returning true here keeps the two in step and short-circuits the
+	// declaration check).
+	if sp.Sandbox == "off" {
+		return true, "", nil
+	}
+
+	// Fast path: this exact binary is already recorded. Trust its recorded
+	// privileged flag without consulting the manifest.
+	if priorRecorded && prior.hasHash(hash) {
+		return prior.Privileged, "", nil
+	}
+
+	if !privilegedFromManifest(declaredMf) {
+		return false, "", nil // plugin runs sandboxed; nothing to approve.
+	}
+
+	// The plugin declares it needs full host access.
+	//
+	// No lockfile (tests, config.LoadBytes): there is no approval channel,
+	// so fall back to the declared capability directly — the same "trust the
+	// declaration, no enforcement" behaviour network and egress have without
+	// a lockfile. A real deployment always has a lockfile.
+	if !m.lock.active() {
+		return true, fmt.Sprintf("no lockfile: running plugin %q unsandboxed as it declares the privileged capability", sp.Name), nil
+	}
+
+	// Lockfile active but this binary is not approved-for-privileged: fail
+	// closed. resolvePrivileged never records the grant itself — only an
+	// explicit `plugins approve` does.
+	return false, "", fmt.Errorf(
+		"plugin %q declares the privileged capability: it needs to run with the sandbox OFF (full host access — "+
+			"it can read every file this user can, including clawpatrol's own secrets, and run any command). "+
+			"clawpatrol will not grant that silently. If you trust this plugin, approve it explicitly: "+
+			"clawpatrol plugins approve %s", sp.Name, sp.Name)
 }
 
 func networkFromManifest(mf *pb.ManifestResponse) sandbox.Network {
@@ -549,6 +641,11 @@ func checkManifestConsistency(name string, staticMf, runtimeMf *pb.ManifestRespo
 			"plugin %q binary requests network egress %v but its signed release manifest declares %v; "+
 				"the binary does not match its published manifest", name, g, s)
 	}
+	if s, g := privilegedFromManifest(staticMf), privilegedFromManifest(runtimeMf); s != g {
+		return fmt.Errorf(
+			"plugin %q binary requests privileged=%v but its signed release manifest declares privileged=%v; "+
+				"the binary does not match its published manifest", name, g, s)
+	}
 	return nil
 }
 
@@ -574,8 +671,9 @@ func manifestTypeKey(mf *pb.ManifestResponse) string {
 
 // ApprovedPlugin is one result row from Approve.
 type ApprovedPlugin struct {
-	Name    string
-	Network string
+	Name       string
+	Network    string
+	Privileged bool
 }
 
 // Approve (re)records the current permissions of the named plugins
@@ -614,6 +712,17 @@ func (m *Manager) Approve(ctx context.Context, specs []config.PluginSource, name
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q: %w", sp.Name, err)
 		}
+		// The declared manifest: the signed static one for a release, or a
+		// throwaway probe for a local / manifest-less plugin. Resolved once
+		// and reused for both network and privileged so a local plugin is
+		// probed at most once per approve.
+		declaredMf := staticMf
+		if declaredMf == nil {
+			declaredMf, err = m.probeManifest(ctx, sp, bin)
+			if err != nil {
+				return nil, fmt.Errorf("plugin %q: read manifest: %w", sp.Name, err)
+			}
+		}
 		declared := sandbox.Network("")
 		if sp.Network != "" {
 			declared, err = parseNetwork(sp.Network)
@@ -621,10 +730,7 @@ func (m *Manager) Approve(ctx context.Context, specs []config.PluginSource, name
 				return nil, fmt.Errorf("plugin %q: %w", sp.Name, err)
 			}
 		} else {
-			declared, err = m.pluginDeclaredNetwork(ctx, sp, bin, staticMf)
-			if err != nil {
-				return nil, fmt.Errorf("plugin %q: %w", sp.Name, err)
-			}
+			declared = networkFromManifest(declaredMf)
 		}
 		m.lock.addHash(sp.Name, hash, string(declared))
 		// Record the manifest-declared egress when the release ships a
@@ -633,7 +739,15 @@ func (m *Manager) Approve(ctx context.Context, specs []config.PluginSource, name
 		if staticMf != nil {
 			m.lock.setEgress(sp.Name, egressFromManifest(staticMf))
 		}
-		out = append(out, ApprovedPlugin{Name: sp.Name, Network: string(declared)})
+		// Record the privileged grant explicitly. This is the whole point of
+		// approving a privileged plugin: resolvePrivileged never records it
+		// on its own, so a plugin that declares the capability fails closed
+		// at load until this writes it. A plugin that does not declare it
+		// records privileged=false (clearing any stale grant from a prior
+		// version that did).
+		privileged := privilegedFromManifest(declaredMf)
+		m.lock.setPrivileged(sp.Name, privileged)
+		out = append(out, ApprovedPlugin{Name: sp.Name, Network: string(declared), Privileged: privileged})
 	}
 	for n := range want {
 		found := false
@@ -828,6 +942,7 @@ type PluginInfo struct {
 	Version        string   `json:"version,omitempty"`
 	Network        string   `json:"network,omitempty"`     // approved grant it runs with
 	Egress         []string `json:"egress,omitempty"`      // approved brokered-dial targets
+	Privileged     bool     `json:"privileged,omitempty"`  // approved to run unsandboxed
 	SandboxMode    string   `json:"sandboxMode,omitempty"` // namespaces | landlock | seatbelt | off
 	SandboxWarning string   `json:"sandboxWarning,omitempty"`
 	ApprovedHashes []string `json:"approvedHashes,omitempty"` // lockfile-approved binary hashes (one per platform build)
@@ -854,6 +969,7 @@ type RequestedPrivileges struct {
 	Version     string   `json:"version,omitempty"`
 	Network     string   `json:"network"`
 	Egress      []string `json:"egress,omitempty"`
+	Privileged  bool     `json:"privileged,omitempty"`
 	Credentials []string `json:"credentials,omitempty"`
 	Endpoints   []string `json:"endpoints,omitempty"`
 	Tunnels     []string `json:"tunnels,omitempty"`
@@ -899,6 +1015,12 @@ func (m *Manager) PluginInfos() []PluginInfo {
 		if e, ok := m.lock.get(c.Name()); ok {
 			info.ApprovedHashes = e.Hashes
 			info.Egress = e.Egress
+			info.Privileged = e.Privileged
+		}
+		// A plugin forced unsandboxed by the operator's `sandbox = "off"`
+		// HCL (rather than the approved capability) still runs privileged.
+		if c.SandboxMode() == string(sandbox.ModeOff) {
+			info.Privileged = true
 		}
 		if len(info.Egress) == 0 {
 			info.Egress = c.Egress()
@@ -920,6 +1042,7 @@ func (m *Manager) PluginInfos() []PluginInfo {
 				Version:     r.Version,
 				Network:     r.Network,
 				Egress:      r.Egress,
+				Privileged:  r.Privileged,
 				Credentials: r.Credentials,
 				Endpoints:   r.Endpoints,
 				Tunnels:     r.Tunnels,

--- a/internal/config/extplugin/manifest.go
+++ b/internal/config/extplugin/manifest.go
@@ -120,8 +120,9 @@ type ManifestPreview struct {
 	Source      string   `json:"source"`
 	Version     string   `json:"version"` // resolved release tag
 	Locked      string   `json:"locked,omitempty"`
-	Network     string   `json:"network"`          // required network grant
-	Egress      []string `json:"egress,omitempty"` // required brokered-dial targets
+	Network     string   `json:"network"`              // required network grant
+	Egress      []string `json:"egress,omitempty"`     // required brokered-dial targets
+	Privileged  bool     `json:"privileged,omitempty"` // requires running unsandboxed
 	Credentials []string `json:"credentials,omitempty"`
 	Endpoints   []string `json:"endpoints,omitempty"`
 	Tunnels     []string `json:"tunnels,omitempty"`
@@ -169,8 +170,9 @@ func (m *Manager) previewManifest(ctx context.Context, sp config.PluginSource) (
 func previewFromManifest(name, source, version, locked string, mf *pb.ManifestResponse) ManifestPreview {
 	pv := ManifestPreview{
 		Name: name, Source: source, Version: version, Locked: locked,
-		Network: string(networkFromManifest(mf)),
-		Egress:  egressFromManifest(mf),
+		Network:    string(networkFromManifest(mf)),
+		Egress:     egressFromManifest(mf),
+		Privileged: privilegedFromManifest(mf),
 	}
 	for _, c := range mf.GetCredentials() {
 		pv.Credentials = append(pv.Credentials, c.GetTypeName())

--- a/internal/config/extplugin/privileged_test.go
+++ b/internal/config/extplugin/privileged_test.go
@@ -1,0 +1,121 @@
+package extplugin
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+func mfPrivileged(privileged bool) *pb.ManifestResponse {
+	return &pb.ManifestResponse{
+		Name:         "p",
+		Capabilities: &pb.PluginCapabilities{Privileged: privileged},
+	}
+}
+
+func newPrivTestManager(t *testing.T) *Manager {
+	t.Helper()
+	m := New(nil)
+	m.lock.configure(filepath.Join(t.TempDir(), LockfileName), false)
+	if err := m.lock.load(); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+// A plugin that declares the privileged capability is held closed until the
+// operator approves it explicitly; resolvePrivileged never records the grant
+// on its own (unlike network/egress trust-on-first-use).
+func TestResolvePrivilegedFailsClosedUntilApproved(t *testing.T) {
+	m := newPrivTestManager(t)
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
+
+	call := func(hash string, declared bool) (bool, string, error) {
+		prior, priorRec := m.lock.get(sp.Name)
+		return m.resolvePrivileged(sp, prior, priorRec, hash, mfPrivileged(declared))
+	}
+
+	// First load of a privileged plugin: fail closed, nothing recorded.
+	if _, _, err := call("sha256:v1", true); err == nil ||
+		!strings.Contains(err.Error(), "privileged capability") {
+		t.Fatalf("first load err = %v, want fail-closed", err)
+	}
+	if e, ok := m.lock.get("p"); ok && e.Privileged {
+		t.Fatalf("resolvePrivileged must not record the grant itself: %+v", e)
+	}
+
+	// Operator approves: records the hash + privileged flag (as Approve does).
+	m.lock.addHash(sp.Name, "sha256:v1", "none")
+	m.lock.setPrivileged(sp.Name, true)
+
+	// Fast path: the approved binary now runs privileged, no error.
+	prior, priorRec := m.lock.get(sp.Name)
+	off, _, err := m.resolvePrivileged(sp, prior, priorRec, "sha256:v1", nil)
+	if err != nil || !off {
+		t.Fatalf("approved fast path = %v err=%v, want true", off, err)
+	}
+
+	// An upgrade (new hash) re-pends approval: the prior snapshot does not
+	// record sha256:v2, so it fails closed even though Privileged is set.
+	if _, _, err := call("sha256:v2", true); err == nil ||
+		!strings.Contains(err.Error(), "privileged capability") {
+		t.Fatalf("upgrade err = %v, want fail-closed", err)
+	}
+}
+
+// A plugin that does not declare the capability runs sandboxed with no
+// approval needed.
+func TestResolvePrivilegedNotDeclared(t *testing.T) {
+	m := newPrivTestManager(t)
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
+	prior, priorRec := m.lock.get(sp.Name)
+	off, warn, err := m.resolvePrivileged(sp, prior, priorRec, "sha256:v1", mfPrivileged(false))
+	if err != nil || off || warn != "" {
+		t.Fatalf("not declared = %v warn=%q err=%v, want false", off, warn, err)
+	}
+}
+
+// The operator's own `sandbox = "off"` HCL is an explicit, committed
+// acceptance that wins outright — no lockfile approval, no manifest check.
+func TestResolvePrivilegedOperatorOverride(t *testing.T) {
+	m := newPrivTestManager(t)
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p", Sandbox: "off"}
+	prior, priorRec := m.lock.get(sp.Name)
+	off, _, err := m.resolvePrivileged(sp, prior, priorRec, "sha256:v1", nil)
+	if err != nil || !off {
+		t.Fatalf("operator sandbox=off = %v err=%v, want true", off, err)
+	}
+}
+
+// Without a lockfile there is no approval channel, so a declared privileged
+// plugin runs unsandboxed directly (the same "trust the declaration, no
+// enforcement" behaviour network/egress have without a lockfile).
+func TestResolvePrivilegedNoLockfile(t *testing.T) {
+	m := New(nil) // no lockfile configured
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
+	prior, priorRec := m.lock.get(sp.Name)
+	off, warn, err := m.resolvePrivileged(sp, prior, priorRec, "sha256:v1", mfPrivileged(true))
+	if err != nil || !off || warn == "" {
+		t.Fatalf("no lockfile = %v warn=%q err=%v, want true with warn", off, warn, err)
+	}
+}
+
+// A binary approved without the privileged flag (e.g. it did not declare the
+// capability when approved) that now declares it must fail closed, even
+// though its hash is in the approved set.
+func TestResolvePrivilegedApprovedHashButFlagUnset(t *testing.T) {
+	m := newPrivTestManager(t)
+	sp := config.PluginSource{Name: "p", Source: "github.com/o/p"}
+	// Hash recorded, but Privileged never set.
+	m.lock.addHash(sp.Name, "sha256:v1", "none")
+
+	prior, priorRec := m.lock.get(sp.Name)
+	off, _, err := m.resolvePrivileged(sp, prior, priorRec, "sha256:v1", mfPrivileged(true))
+	// Fast path reads the recorded flag (false) — the binary runs sandboxed.
+	if err != nil || off {
+		t.Fatalf("flag-unset fast path = %v err=%v, want false (sandboxed)", off, err)
+	}
+}

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -431,7 +431,17 @@ type PluginCapabilities struct {
 	// the gateway's brokered dial, each "host:port" or "*.suffix.tld:port".
 	// Declared by the plugin; the gateway records the approved set in the
 	// lockfile (trust-on-first-use) and blocks an upgrade that broadens it.
-	Egress        []string `protobuf:"bytes,2,rep,name=egress,proto3" json:"egress,omitempty"`
+	Egress []string `protobuf:"bytes,2,rep,name=egress,proto3" json:"egress,omitempty"`
+	// privileged declares that this plugin cannot run sandboxed: it needs
+	// the gateway to run it with full host access (to exec arbitrary helper
+	// tools, read the user's tool configs, etc.). It is the same grant as
+	// the operator-written `sandbox = "off"` HCL attribute, but
+	// plugin-declared. Unlike network and egress it is NOT
+	// trust-on-first-use — handing a plugin full host access is too
+	// dangerous to grant silently — so the gateway holds the plugin closed
+	// until the operator explicitly approves it (clawpatrol plugins approve,
+	// or the dashboard). An upgrade re-pends approval.
+	Privileged    bool `protobuf:"varint,3,opt,name=privileged,proto3" json:"privileged,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -478,6 +488,13 @@ func (x *PluginCapabilities) GetEgress() []string {
 		return x.Egress
 	}
 	return nil
+}
+
+func (x *PluginCapabilities) GetPrivileged() bool {
+	if x != nil {
+		return x.Privileged
+	}
+	return false
 }
 
 // FacetDecl describes one protocol-family schema the plugin exports.
@@ -4410,10 +4427,13 @@ const file_plugin_proto_rawDesc = "" +
 	"\atunnels\x18\x04 \x03(\v2 .clawpatrol.plugin.v1.TunnelDeclR\atunnels\x12@\n" +
 	"\tendpoints\x18\x05 \x03(\v2\".clawpatrol.plugin.v1.EndpointDeclR\tendpoints\x127\n" +
 	"\x06facets\x18\x06 \x03(\v2\x1f.clawpatrol.plugin.v1.FacetDeclR\x06facets\x12L\n" +
-	"\fcapabilities\x18\a \x01(\v2(.clawpatrol.plugin.v1.PluginCapabilitiesR\fcapabilities\"k\n" +
+	"\fcapabilities\x18\a \x01(\v2(.clawpatrol.plugin.v1.PluginCapabilitiesR\fcapabilities\"\x8b\x01\n" +
 	"\x12PluginCapabilities\x12=\n" +
 	"\anetwork\x18\x01 \x01(\x0e2#.clawpatrol.plugin.v1.NetworkAccessR\anetwork\x12\x16\n" +
-	"\x06egress\x18\x02 \x03(\tR\x06egress\"]\n" +
+	"\x06egress\x18\x02 \x03(\tR\x06egress\x12\x1e\n" +
+	"\n" +
+	"privileged\x18\x03 \x01(\bR\n" +
+	"privileged\"]\n" +
 	"\tFacetDecl\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
 	"\x06fields\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.FacetFieldDeclR\x06fields\"\x8b\x01\n" +

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -61,6 +61,16 @@ message PluginCapabilities {
   // Declared by the plugin; the gateway records the approved set in the
   // lockfile (trust-on-first-use) and blocks an upgrade that broadens it.
   repeated string egress = 2;
+  // privileged declares that this plugin cannot run sandboxed: it needs
+  // the gateway to run it with full host access (to exec arbitrary helper
+  // tools, read the user's tool configs, etc.). It is the same grant as
+  // the operator-written `sandbox = "off"` HCL attribute, but
+  // plugin-declared. Unlike network and egress it is NOT
+  // trust-on-first-use — handing a plugin full host access is too
+  // dangerous to grant silently — so the gateway holds the plugin closed
+  // until the operator explicitly approves it (clawpatrol plugins approve,
+  // or the dashboard). An upgrade re-pends approval.
+  bool privileged = 3;
 }
 
 enum NetworkAccess {

--- a/internal/config/extplugin/sandboxspec.go
+++ b/internal/config/extplugin/sandboxspec.go
@@ -21,11 +21,15 @@ import (
 // the cause and the cost of sandbox = "off".
 //
 // network is the already-resolved network grant (from the manifest +
-// lockfile, or an operator override); see resolveNetwork.
+// lockfile, or an operator override); see resolveNetwork. privileged is
+// the already-resolved privileged grant (the operator-approved answer to
+// the plugin's declared privileged capability); see resolvePrivileged.
+// Either it or the operator's `sandbox = "off"` HCL attribute turns the
+// sandbox off.
 //
 // The caller owns spec.SocketDir and must remove it when the plugin
 // dies.
-func buildSandboxSpec(sp config.PluginSource, binSource string, network sandbox.Network, stateDir string) (sandbox.Spec, sandbox.Mode, string, error) {
+func buildSandboxSpec(sp config.PluginSource, binSource string, network sandbox.Network, privileged bool, stateDir string) (sandbox.Spec, sandbox.Mode, string, error) {
 	var zero sandbox.Spec
 
 	switch sp.Sandbox {
@@ -59,7 +63,7 @@ func buildSandboxSpec(sp config.PluginSource, binSource string, network sandbox.
 
 	mode := sandbox.Mode("")
 	warning := ""
-	if sp.Sandbox == "off" {
+	if sp.Sandbox == "off" || privileged {
 		mode = sandbox.ModeOff
 	} else {
 		av, err := sandbox.Probe()

--- a/internal/config/extplugin/sandboxspec_test.go
+++ b/internal/config/extplugin/sandboxspec_test.go
@@ -85,7 +85,7 @@ func TestBuildSandboxSpecValidation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, _, err := buildSandboxSpec(tc.sp, tc.sp.Source, sandbox.NetworkNone, "")
+			_, _, _, err := buildSandboxSpec(tc.sp, tc.sp.Source, sandbox.NetworkNone, false, "")
 			if err == nil {
 				t.Fatalf("buildSandboxSpec accepted %+v", tc.sp)
 			}
@@ -109,7 +109,7 @@ func TestBuildSandboxSpecOff(t *testing.T) {
 	bin := testPluginBinary(t)
 	spec, mode, warning, err := buildSandboxSpec(config.PluginSource{
 		Name: "x", Source: bin, Sandbox: "off",
-	}, bin, sandbox.NetworkNone, "")
+	}, bin, sandbox.NetworkNone, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -75,6 +75,20 @@ type Capabilities struct {
 	// lockfile (trust-on-first-use) and blocks an upgrade that broadens
 	// it, the same model as Network; the operator never hand-writes it.
 	Egress []string
+
+	// Privileged declares that this plugin cannot run sandboxed and needs
+	// full host access — to exec arbitrary helper tools (ssh, kubectl,
+	// aws, ...), read the user's tool configs (~/.ssh, ~/.aws, ~/.kube),
+	// and so on. It is the same grant as the operator-written
+	// `sandbox = "off"` HCL attribute, just plugin-declared. Unlike
+	// Network and Egress it is NOT trust-on-first-use: handing a plugin
+	// full host access is too dangerous to grant silently, so the gateway
+	// holds the plugin closed until the operator explicitly approves it
+	// (clawpatrol plugins approve, or the dashboard). An upgrade re-pends
+	// approval. Prefer a narrower capability (Egress, a built-in tunnel)
+	// whenever one fits; reach for this only when the plugin genuinely
+	// must shell out.
+	Privileged bool
 }
 
 // NetworkAccess is a plugin's declared network requirement.

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -144,8 +144,9 @@ func (s *server) Manifest(_ context.Context, _ *pb.ManifestRequest) (*pb.Manifes
 		Name:    s.plug.Name,
 		Version: s.plug.Version,
 		Capabilities: &pb.PluginCapabilities{
-			Network: networkAccessToProto(s.plug.Capabilities.Network),
-			Egress:  append([]string(nil), s.plug.Capabilities.Egress...),
+			Network:    networkAccessToProto(s.plug.Capabilities.Network),
+			Egress:     append([]string(nil), s.plug.Capabilities.Egress...),
+			Privileged: s.plug.Capabilities.Privileged,
 		},
 	}
 	for _, c := range s.plug.Credentials {

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -244,14 +244,17 @@ a scrubbed environment — it inherits **none** of the gateway's
 environment, only `PATH`, `HOME`, `TMPDIR` (pointing at a private
 scratch dir) and the plugin socket path.
 
-Permissions come from two places, by risk:
+Permissions come from three places, by risk:
 
-- **Network is declared by the plugin** in its manifest (a *leak path*
-  the sandbox keeps bounded — see below). The operator doesn't write
-  it.
-- **Host filesystem access and the sandbox opt-out are operator-only**,
-  declared on the `plugin` block, because they can expose every
-  credential.
+- **Network and egress are declared by the plugin** in its manifest
+  (*leak paths* the sandbox keeps bounded — see below) and recorded
+  trust-on-first-use. The operator doesn't write them.
+- **Privileged (sandbox off) is declared by the plugin but never
+  trust-on-first-use** — handing a plugin full host access is too
+  dangerous to grant silently, so it is held closed until the operator
+  approves it explicitly (see below).
+- **Extra host filesystem read paths and the operator-forced sandbox
+  opt-out are operator-only**, declared on the `plugin` block.
 
 ```hcl
 plugin "ssh_tools" {
@@ -319,6 +322,54 @@ An operator can still set `network` on the `plugin` block to override
 the plugin's request (force or veto); the override wins and is what
 gets recorded.
 
+### Privileged: declared by the plugin, approved explicitly
+
+Some plugins genuinely cannot run sandboxed — they need to exec
+arbitrary helper tools (`ssh`, `kubectl`, `aws`, …) and read the user's
+tool configs (`~/.ssh`, `~/.aws`, `~/.kube`). Enumerating which binaries
+and paths such a plugin touches is hopeless (a plugin that can run a
+shell can run anything), so there is no fine-grained "exec" grant: a
+plugin that needs this declares a single coarse **privileged**
+capability, which runs it with the **sandbox off** — the same full host
+access as the operator's `sandbox = "off"`.
+
+```go
+pluginsdk.Run(&pluginsdk.Plugin{
+    Name:         "ssh_tools",
+    Capabilities: pluginsdk.Capabilities{Privileged: true},
+    // …
+})
+```
+
+Because privileged hands the plugin full host access — it can read every
+file the gateway user can, including clawpatrol's own secret store, and
+run any command — it is **not** trust-on-first-use like network and
+egress. The gateway holds a privileged plugin **closed** until the
+operator approves it explicitly:
+
+```
+clawpatrol plugins approve <config.hcl> ssh_tools
+```
+
+Approval records `privileged = true` in `clawpatrol.lock.hcl`, gated on
+the binary hash like every other grant, so a later version re-pends
+approval. The dashboard's Plugins page shows the request on the blocked
+card (a red **privileged** badge) and offers the same one-click approve.
+
+```hcl
+plugin "ssh_tools" {
+  network    = "outbound"
+  privileged = true
+  hashes     = ["sha256:…"]
+}
+```
+
+`privileged` is the plugin asking for what `sandbox = "off"` grants;
+the operator's `sandbox = "off"` on the block is the operator forcing
+the same thing directly (and wins outright, no approval needed). Prefer
+a narrower capability — `Egress`, a built-in tunnel — whenever one fits;
+reach for `privileged` only when the plugin must shell out.
+
 ### Filesystem and full-trust grants (operator-only)
 
 - **`read_paths`** — extra host paths the plugin may read recursively,
@@ -337,7 +388,10 @@ gets recorded.
   sandbox entirely (full host read, write, and exec — the plugin can
   read every credential in the state DB), so only set it for a plugin
   you fully trust on a host that can't sandbox. The environment is
-  scrubbed either way.
+  scrubbed either way. A plugin can also *request* the same full host
+  access by declaring the [`privileged`](#privileged-declared-by-the-plugin-approved-explicitly)
+  capability, which the operator then approves explicitly rather than
+  hand-writing `sandbox = "off"`.
 
 Backends, by platform:
 

--- a/site/doc/security-model.md
+++ b/site/doc/security-model.md
@@ -291,7 +291,12 @@ Two mechanisms contain a malicious or compromised plugin:
   sandbox hides the filesystem (the plugin sees only its own binary,
   system libraries, and explicitly granted paths) and, by default,
   the network. If no sandbox can be established the plugin **fails to
-  load** unless the operator explicitly sets `sandbox = "off"`.
+  load** unless the operator explicitly sets `sandbox = "off"`. A plugin
+  that genuinely cannot run sandboxed (it must exec helper tools and read
+  the user's tool configs) can declare the **privileged** capability,
+  which runs it unsandboxed — but, because that is full host access, the
+  gateway holds it closed until the operator approves it explicitly (it
+  is never trust-on-first-use), and an upgrade re-pends that approval.
 
 Because the default `network = "none"` cuts a plugin off from the
 network entirely, an endpoint plugin that receives credential secrets


### PR DESCRIPTION
A plugin can declare it must run **unsandboxed** (full host access — to
exec helper tools like `ssh`/`kubectl`/`aws` and read the user's tool
configs). Enumerating which binaries/paths such a plugin touches is
hopeless (a plugin that can run a shell can run anything), so there is
no fine-grained exec grant: a plugin declares one coarse `privileged`
capability, which reuses the existing unsandboxed run mode. No
sandbox-backend changes.

Unlike `network`/`egress` (trust-on-first-use), `privileged` is never
granted silently: the gateway holds the plugin closed (fails config
load) until the operator approves it explicitly via `clawpatrol plugins
approve` or the dashboard. Recorded in `clawpatrol.lock.hcl`, gated on
the binary hash, so an upgrade re-pends approval.

* declared via `Capabilities{Privileged: true}`; a bool in the manifest
  proto and lockfile
* `resolvePrivileged` runs before the network resolver, so an unapproved
  privileged plugin fails closed before any hash is recorded — a
  same-or-reduced network upgrade can't back-door the grant onto a new
  binary
* a version change clears the grant, and a manifest-less install/update
  clears it unless the exact binary was already approved-privileged, so
  an upgraded binary can never inherit the old version's grant
* manifest consistency check compares the signed vs runtime privileged
  bit; the operator's own `sandbox = "off"` still wins outright
* surfaced in `plugins info`/`approve` output and on the dashboard
  Plugins page (a red privileged badge on the blocked card); docs in
  `plugins.md` and `security-model.md`