### PR TITLE
relay: keep the seccomp notify file alive in the supervisor (fixes ENOTTY relay death)

### DIFF
--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -228,6 +228,16 @@ func runRelaySupervisor(_ []string) {
 		fail("relay-supervisor: expected fds 3,4,5 to be open")
 	}
 	notifyFD := int(notifyFile.Fd())
+	// notifyFile must outlive the notification loop below. We use the raw
+	// fd via ioctl (SECCOMP_IOCTL_NOTIF_RECV) rather than a RawConn, so
+	// nothing else holds a reference to the *os.File. Once it becomes
+	// unreachable its finalizer closes fd 3; the mirror/loopback goroutines
+	// then open sockets (net.Listen/net.Dial) that reuse the freed number,
+	// and the next NOTIF_RECV lands on a socket and fails with ENOTTY
+	// ("inappropriate ioctl for device"), killing the relay. Keep the file
+	// alive for the whole function — mirrors the RawConn protection the
+	// worker/lb socks get below.
+	defer runtime.KeepAlive(notifyFile)
 
 	// SIGPIPE on the worker socket shouldn't kill the supervisor — log
 	// from the accept goroutines instead.


### PR DESCRIPTION
## Problem

`runRelaySupervisor` grabs the seccomp user-notification fd as a raw int and then never references the backing `*os.File` again:

```go
notifyFile := os.NewFile(3, "seccomp-notify")
...
notifyFD := int(notifyFile.Fd())   // notifyFile is now unreachable
...
for {
    n, err := notifRecv(notifyFD)   // ioctl(SECCOMP_IOCTL_NOTIF_RECV) on the raw fd
    ...
}
```

Because nothing holds a reference to `notifyFile`, the GC finalizer can run and **close fd 3 while the notification loop is still using it**. The supervisor's mirror/loopback goroutines open sockets (`net.Listen` for each mirrored listener, `net.Dial` for each loopback job), which reuse the freed fd number. The next `SECCOMP_IOCTL_NOTIF_RECV` then runs an ioctl against a **socket** and fails with `ENOTTY` ("inappropriate ioctl for device"). The supervisor exits, the worker hits EOF and exits, and host-loopback forwarding is gone until the wrapped process is restarted.

The code already protects the *other* two fds from exactly this — the comment on `workerRC`/`lbRC` notes that the `RawConn` "carries an internal reference to the underlying `*os.File` (so GC can't pull the fd out from under the goroutines)". The notify fd just never got the same treatment.

Observed in production: a long-running `clawpatrol run` that pushes OTLP metrics to a host-loopback collector. After ~20 min the relay died with `notification channel failed (inappropriate ioctl for device)`; from then on the wrapped process kept serving traffic (its own in-netns listeners are reachable again thanks to #688's fail-open teardown) but could no longer reach the host collector, so metrics silently stopped. Restarting brought them back — until the next time.

## Fix

```go
notifyFD := int(notifyFile.Fd())
defer runtime.KeepAlive(notifyFile)
```

Keep `notifyFile` reachable for the lifetime of the supervisor so its finalizer cannot close the notify fd while the loop is running. This is the same liveness guarantee the worker/lb socks already get via their `RawConn`.

## Relationship to #688

#688 made a dying relay **fail open** (tear down the `REDIRECT` so loopback isn't black-holed) and log the death loudly instead of silently. That turned a hard outage ("everything refused") into a softer one ("self-connect works, host-loopback telemetry stops"), and the new loud log is what surfaced the exact `ENOTTY` error that pinpointed this. This PR removes the actual cause, so the relay no longer dies in the first place.

## Testing

- `go build` / `go vet` / `gofmt` clean; `go test ./cmd/clawpatrol` passes.
- The failure is a GC/fd-reuse race so it isn't cleanly unit-testable, but the mechanism is deterministic: `int(f.Fd())` + no further use of `f` makes `f` finalizer-eligible, and `runtime.KeepAlive` is the documented remedy.

## Scope

Client-side only (`relay-supervisor` is re-exec'd solely by `clawpatrol run`).
