### PR TITLE
Extend OTel GenAI telemetry to OpenAI providers

### DIFF
--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -328,35 +328,47 @@ func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respMo
 		turn.ServerPort = 443
 	}
 	includeContent := cfg.GenAITelemetryIncludeContent()
-	if provider == "anthropic" {
-		// Request sampling params and response metadata (id, cache-token
-		// breakdown, error/stop reason) ride the span regardless of
-		// content capture — they carry no prompt/completion text.
-		p := parseClaudeRequestParams(reqBody)
-		turn.Stream = p.Stream
-		turn.MaxTokens = p.MaxTokens
-		turn.Temperature = p.Temperature
-		turn.TopP = p.TopP
-		turn.TopK = p.TopK
-		turn.StopSequences = p.StopSequences
-		// Tool name+type ride the base span; the schema/description are
-		// gated behind the same content opt-in as message content.
-		turn.Tools = parseClaudeToolDefs(reqBody, includeContent)
-
-		meta := claudeResponseMeta(respBody)
-		turn.ResponseID = meta.ID
-		turn.CacheReadTokens = meta.CacheReadTokens
-		turn.CacheCreationTokens = meta.CacheCreationTokens
-		turn.ErrorType = meta.ErrorType
-
-		parts, finish := claudeResponseContent(respBody)
-		turn.FinishReason = finish
-		if includeContent {
-			turn.Messages = claudeContentMessages(reqBody)
-			turn.Output = parts
-		}
+	// Per-provider field mapping fills the shared genAITurn from each
+	// provider's own wire format. The representation and exporter
+	// (emitGenAISpan) are shared — only the extraction differs.
+	switch provider {
+	case "anthropic":
+		mapClaudeTurn(&turn, reqBody, respBody, includeContent)
+	case "openai":
+		mapOpenAITurn(&turn, reqBody, respBody, includeContent)
 	}
 	emitGenAISpan(genaiTracer, turn, includeContent)
+}
+
+// mapClaudeTurn fills the GenAI turn from an Anthropic /v1/messages
+// request/response pair. Request sampling params and response metadata
+// (id, cache-token breakdown, error/stop reason) ride the span
+// regardless of content capture — they carry no prompt/completion text;
+// message content and tool schemas are gated behind includeContent.
+func mapClaudeTurn(turn *genAITurn, reqBody, respBody []byte, includeContent bool) {
+	p := parseClaudeRequestParams(reqBody)
+	turn.Stream = p.Stream
+	turn.MaxTokens = p.MaxTokens
+	turn.Temperature = p.Temperature
+	turn.TopP = p.TopP
+	turn.TopK = p.TopK
+	turn.StopSequences = p.StopSequences
+	// Tool name+type ride the base span; the schema/description are
+	// gated behind the same content opt-in as message content.
+	turn.Tools = parseClaudeToolDefs(reqBody, includeContent)
+
+	meta := claudeResponseMeta(respBody)
+	turn.ResponseID = meta.ID
+	turn.CacheReadTokens = meta.CacheReadTokens
+	turn.CacheCreationTokens = meta.CacheCreationTokens
+	turn.ErrorType = meta.ErrorType
+
+	parts, finish := claudeResponseContent(respBody)
+	turn.FinishReason = finish
+	if includeContent {
+		turn.Messages = claudeContentMessages(reqBody)
+		turn.Output = parts
+	}
 }
 
 // claudeRequestParams holds the GenAI request sampling parameters parsed

--- a/cmd/clawpatrol/genai_openai.go
+++ b/cmd/clawpatrol/genai_openai.go
@@ -1,0 +1,698 @@
+// OpenAI provider mapping for the OTel GenAI export. Fills the shared
+// genAITurn (see genai.go) from OpenAI's two wire formats — the Chat
+// Completions API (/v1/chat/completions, /v1/completions) and the
+// Responses API (/v1/responses and chatgpt.com's /backend-api/codex/
+// responses) — so OpenAI turns emit the same gen_ai.* telemetry as
+// Anthropic. The representation and span exporter are shared; only this
+// per-provider extraction differs.
+//
+// OpenAI has no top_k and no Anthropic-style prompt-cache token
+// breakdown, so those fields stay unset (the exporter omits them) rather
+// than carrying wrong/empty values. max-token caps are spread across
+// max_tokens / max_completion_tokens / max_output_tokens depending on
+// the API surface; all three are coalesced into gen_ai.request.max_tokens.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// mapOpenAITurn fills the GenAI turn from an OpenAI request/response
+// pair, transparently handling both the Chat Completions and Responses
+// API shapes. Request sampling params, tool name+type, the response id,
+// and the finish reason ride the span regardless of content capture;
+// message content and tool schemas are gated behind includeContent.
+func mapOpenAITurn(turn *genAITurn, reqBody, respBody []byte, includeContent bool) {
+	p := parseOpenAIRequestParams(reqBody)
+	turn.Stream = p.Stream
+	turn.MaxTokens = p.MaxTokens
+	turn.Temperature = p.Temperature
+	turn.TopP = p.TopP
+	turn.StopSequences = p.StopSequences
+	turn.Tools = parseOpenAIToolDefs(reqBody, includeContent)
+
+	id, errType := openAIResponseMeta(respBody)
+	turn.ResponseID = id
+	turn.ErrorType = errType
+
+	parts, finish := openAIResponseContent(respBody)
+	turn.FinishReason = finish
+	if includeContent {
+		turn.Messages = openAIContentMessages(reqBody)
+		turn.Output = parts
+	}
+}
+
+// openAIRequestParams holds the GenAI request sampling parameters parsed
+// from an OpenAI request body. Optional scalars are pointers so a real
+// zero (e.g. temperature 0) is distinguished from "absent". OpenAI has
+// no top_k, so the GenAI top_k attribute is never set for this provider.
+type openAIRequestParams struct {
+	Stream        *bool
+	MaxTokens     int64
+	Temperature   *float64
+	TopP          *float64
+	StopSequences []string
+}
+
+// parseOpenAIRequestParams pulls the sampling parameters from an OpenAI
+// request body. The max-token cap appears under different keys across
+// API surfaces (max_tokens on classic Chat Completions,
+// max_completion_tokens on newer Chat Completions, max_output_tokens on
+// the Responses API); the first non-zero one wins. `stop` may be a single
+// string or an array of strings. A malformed body yields the zero value.
+func parseOpenAIRequestParams(reqBody []byte) openAIRequestParams {
+	var req struct {
+		Stream              *bool           `json:"stream"`
+		MaxTokens           int64           `json:"max_tokens"`
+		MaxCompletionTokens int64           `json:"max_completion_tokens"`
+		MaxOutputTokens     int64           `json:"max_output_tokens"`
+		Temperature         *float64        `json:"temperature"`
+		TopP                *float64        `json:"top_p"`
+		Stop                json.RawMessage `json:"stop"`
+	}
+	if json.Unmarshal(reqBody, &req) != nil {
+		return openAIRequestParams{}
+	}
+	maxTokens := req.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = req.MaxCompletionTokens
+	}
+	if maxTokens == 0 {
+		maxTokens = req.MaxOutputTokens
+	}
+	return openAIRequestParams{
+		Stream:        req.Stream,
+		MaxTokens:     maxTokens,
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		StopSequences: parseStopSequences(req.Stop),
+	}
+}
+
+// parseStopSequences normalizes OpenAI's `stop` field — a single string
+// or an array of strings — into a slice. Returns nil when absent.
+func parseStopSequences(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var one string
+	if json.Unmarshal(raw, &one) == nil {
+		if one == "" {
+			return nil
+		}
+		return []string{one}
+	}
+	var many []string
+	if json.Unmarshal(raw, &many) == nil {
+		return many
+	}
+	return nil
+}
+
+// parseOpenAIToolDefs extracts the tool catalogue from an OpenAI request
+// body for gen_ai.tool.definitions, handling both shapes: Chat
+// Completions nests the spec under a `function` object
+// ({type:"function", function:{name, description, parameters}}), while
+// the Responses API carries it flat ({type:"function", name,
+// description, parameters}). Name and type ride the base span; the
+// description and JSON-schema parameters are captured only when
+// includeContent is set. Built-in Responses tools (e.g.
+// type:"web_search_preview") carry no name, so the type doubles as the
+// name to keep them recorded. A malformed body, or one offering no
+// tools, yields nil.
+func parseOpenAIToolDefs(reqBody []byte, includeContent bool) []genAIToolDef {
+	var req struct {
+		Tools []struct {
+			Type        string          `json:"type"`
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			Parameters  json.RawMessage `json:"parameters"`
+			Function    *struct {
+				Name        string          `json:"name"`
+				Description string          `json:"description"`
+				Parameters  json.RawMessage `json:"parameters"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if json.Unmarshal(reqBody, &req) != nil || len(req.Tools) == 0 {
+		return nil
+	}
+	defs := make([]genAIToolDef, 0, len(req.Tools))
+	for _, tl := range req.Tools {
+		name, desc, params := tl.Name, tl.Description, tl.Parameters
+		if tl.Function != nil {
+			name, desc, params = tl.Function.Name, tl.Function.Description, tl.Function.Parameters
+		}
+		typ := tl.Type
+		if typ == "" {
+			typ = "function"
+		}
+		// Built-in tools (web_search_preview, file_search, …) have no
+		// name; fall back to the type so they are still recorded.
+		if name == "" {
+			if typ == "function" {
+				continue
+			}
+			name = typ
+		}
+		d := genAIToolDef{Type: typ, Name: name}
+		if includeContent {
+			d.Description = desc
+			d.Parameters = rawOrNil(params)
+		}
+		defs = append(defs, d)
+	}
+	if len(defs) == 0 {
+		return nil
+	}
+	return defs
+}
+
+// openAIResponseMeta extracts the response id and any error type from an
+// OpenAI response, handling non-streaming JSON (both API shapes) and
+// streaming SSE. Chat Completions and Responses both carry a top-level
+// `id`; an error HTTP body is {"error":{"type":...,"code":...}}. In SSE,
+// Chat chunks repeat the id while a Responses stream's terminal event
+// carries response.id (and response.error on failure).
+func openAIResponseMeta(body []byte) (id, errorType string) {
+	var jr struct {
+		ID    string `json:"id"`
+		Error *struct {
+			Type string `json:"type"`
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &jr) == nil && (jr.ID != "" || jr.Error != nil) {
+		if jr.Error != nil {
+			return jr.ID, firstNonEmpty(jr.Error.Type, jr.Error.Code)
+		}
+		return jr.ID, ""
+	}
+	for _, payload := range sseDataPayloads(body) {
+		var ev struct {
+			ID    string `json:"id"`
+			Error *struct {
+				Type string `json:"type"`
+				Code string `json:"code"`
+			} `json:"error"`
+			Response struct {
+				ID    string `json:"id"`
+				Error *struct {
+					Type string `json:"type"`
+					Code string `json:"code"`
+				} `json:"error"`
+			} `json:"response"`
+		}
+		if json.Unmarshal(payload, &ev) != nil {
+			continue
+		}
+		if ev.Response.ID != "" {
+			id = ev.Response.ID
+		} else if ev.ID != "" {
+			id = ev.ID
+		}
+		if ev.Error != nil {
+			errorType = firstNonEmpty(ev.Error.Type, ev.Error.Code)
+		}
+		if ev.Response.Error != nil {
+			errorType = firstNonEmpty(ev.Response.Error.Type, ev.Response.Error.Code)
+		}
+	}
+	return id, errorType
+}
+
+// openAIResponseContent extracts the assistant response parts and finish
+// reason from an OpenAI response, handling non-streaming JSON for both
+// API shapes (Chat Completions `choices`, Responses `output`) and
+// streaming SSE. Every part (text, tool_call, reasoning, generic) maps to
+// a GenAI message part.
+func openAIResponseContent(body []byte) (parts []genAIPart, finish string) {
+	var jr struct {
+		Choices           json.RawMessage `json:"choices"`
+		Output            json.RawMessage `json:"output"`
+		Status            string          `json:"status"`
+		IncompleteDetails struct {
+			Reason string `json:"reason"`
+		} `json:"incomplete_details"`
+	}
+	if json.Unmarshal(body, &jr) == nil && (len(jr.Choices) > 0 || len(jr.Output) > 0) {
+		if len(jr.Choices) > 0 {
+			return openAIChatChoiceContent(jr.Choices)
+		}
+		return openAIResponsesOutput(jr.Output), responsesFinish(jr.Status, jr.IncompleteDetails.Reason)
+	}
+	return openAIResponseSSE(body)
+}
+
+// openAIChatChoiceContent maps the first choice of a non-streaming Chat
+// Completions response to GenAI parts (assistant text + tool_call parts)
+// and its finish_reason.
+func openAIChatChoiceContent(choices json.RawMessage) (parts []genAIPart, finish string) {
+	var cs []struct {
+		FinishReason string `json:"finish_reason"`
+		Message      struct {
+			Content   json.RawMessage  `json:"content"`
+			ToolCalls []openAIToolCall `json:"tool_calls"`
+		} `json:"message"`
+	}
+	if json.Unmarshal(choices, &cs) != nil || len(cs) == 0 {
+		return nil, ""
+	}
+	c := cs[0]
+	parts = append(parts, openAIContentParts(c.Message.Content)...)
+	parts = append(parts, openAIToolCallParts(c.Message.ToolCalls)...)
+	return parts, c.FinishReason
+}
+
+// openAIResponsesOutput maps a Responses API `output` array to GenAI
+// parts: message items become text/generic parts, function_call items
+// become tool_call parts, reasoning items become reasoning parts, and any
+// other item type becomes a generic part preserving its type.
+func openAIResponsesOutput(output json.RawMessage) []genAIPart {
+	var items []struct {
+		Type      string          `json:"type"`
+		Content   json.RawMessage `json:"content"`
+		CallID    string          `json:"call_id"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+		Summary   json.RawMessage `json:"summary"`
+	}
+	if json.Unmarshal(output, &items) != nil {
+		return nil
+	}
+	var parts []genAIPart
+	for _, it := range items {
+		switch it.Type {
+		case "message", "":
+			parts = append(parts, openAIContentParts(it.Content)...)
+		case "function_call":
+			parts = append(parts, genAIPart{
+				Type:      "tool_call",
+				ID:        it.CallID,
+				Name:      it.Name,
+				Arguments: rawArgsToRaw(it.Arguments),
+			})
+		case "reasoning":
+			if t := openAIReasoningText(it.Summary); t != "" {
+				parts = append(parts, genAIPart{Type: "reasoning", Content: t})
+			}
+		default:
+			parts = append(parts, genAIPart{Type: it.Type})
+		}
+	}
+	return parts
+}
+
+// openAIResponseSSE reconstructs the assistant response from a streaming
+// body. A Responses-API stream ends with a terminal event carrying the
+// full response object (response.completed / .incomplete / .failed) — when
+// present it is parsed exactly like a non-streaming Responses body.
+// Otherwise the body is a Chat Completions stream whose choice deltas are
+// accumulated: text content concatenates, and tool-call fragments
+// accumulate by index.
+func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
+	type toolAccum struct {
+		id   string
+		name string
+		args strings.Builder
+	}
+	var (
+		text     strings.Builder
+		tools    = map[int]*toolAccum{}
+		order    []int
+		haveChat bool
+	)
+	for _, payload := range sseDataPayloads(body) {
+		var ev struct {
+			Type     string          `json:"type"`
+			Response json.RawMessage `json:"response"`
+			Choices  []struct {
+				FinishReason string `json:"finish_reason"`
+				Delta        struct {
+					Content   string `json:"content"`
+					ToolCalls []struct {
+						Index    int    `json:"index"`
+						ID       string `json:"id"`
+						Function struct {
+							Name      string `json:"name"`
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if json.Unmarshal(payload, &ev) != nil {
+			continue
+		}
+		// Responses-API terminal event: the embedded response object
+		// carries the complete output, so parse it as a full body. Only
+		// the terminal events carry the final state — response.created /
+		// .in_progress snapshots also embed a (still-empty) response.
+		if isResponsesTerminalEvent(ev.Type) && len(ev.Response) > 0 {
+			var r struct {
+				Output            json.RawMessage `json:"output"`
+				Status            string          `json:"status"`
+				IncompleteDetails struct {
+					Reason string `json:"reason"`
+				} `json:"incomplete_details"`
+			}
+			if json.Unmarshal(ev.Response, &r) == nil {
+				return openAIResponsesOutput(r.Output), responsesFinish(r.Status, r.IncompleteDetails.Reason)
+			}
+			continue
+		}
+		if len(ev.Choices) == 0 {
+			continue
+		}
+		haveChat = true
+		ch := ev.Choices[0]
+		text.WriteString(ch.Delta.Content)
+		if ch.FinishReason != "" {
+			finish = ch.FinishReason
+		}
+		for _, tc := range ch.Delta.ToolCalls {
+			acc := tools[tc.Index]
+			if acc == nil {
+				acc = &toolAccum{}
+				tools[tc.Index] = acc
+				order = append(order, tc.Index)
+			}
+			if tc.ID != "" {
+				acc.id = tc.ID
+			}
+			if tc.Function.Name != "" {
+				acc.name = tc.Function.Name
+			}
+			acc.args.WriteString(tc.Function.Arguments)
+		}
+	}
+	if !haveChat {
+		return nil, finish
+	}
+	if text.Len() > 0 {
+		parts = append(parts, genAIPart{Type: "text", Content: text.String()})
+	}
+	for _, i := range order {
+		acc := tools[i]
+		parts = append(parts, genAIPart{
+			Type:      "tool_call",
+			ID:        acc.id,
+			Name:      acc.name,
+			Arguments: argStringToRaw(acc.args.String()),
+		})
+	}
+	return parts, finish
+}
+
+// openAIContentMessages extracts the ordered input messages from an
+// OpenAI request body for the GenAI content convention. Chat Completions
+// carries them under `messages`; the Responses API uses `input` (a string
+// or item array) plus a top-level `instructions` system prompt. A
+// malformed body, or one with neither field, yields nil.
+func openAIContentMessages(reqBody []byte) []genAIMessage {
+	var probe struct {
+		Messages     json.RawMessage `json:"messages"`
+		Input        json.RawMessage `json:"input"`
+		Instructions string          `json:"instructions"`
+	}
+	if json.Unmarshal(reqBody, &probe) != nil {
+		return nil
+	}
+	if len(probe.Messages) > 0 {
+		return openAIChatMessages(probe.Messages)
+	}
+	if len(probe.Input) > 0 {
+		return openAIResponsesInput(probe.Input, probe.Instructions)
+	}
+	return nil
+}
+
+// openAIChatMessages converts a Chat Completions `messages` array into
+// GenAI messages. A `tool` role message becomes a tool_call_response
+// part; an assistant message's tool_calls become tool_call parts
+// alongside any text content.
+func openAIChatMessages(raw json.RawMessage) []genAIMessage {
+	var msgs []struct {
+		Role       string           `json:"role"`
+		Content    json.RawMessage  `json:"content"`
+		ToolCalls  []openAIToolCall `json:"tool_calls"`
+		ToolCallID string           `json:"tool_call_id"`
+	}
+	if json.Unmarshal(raw, &msgs) != nil {
+		return nil
+	}
+	var out []genAIMessage
+	for _, m := range msgs {
+		var parts []genAIPart
+		if m.Role == "tool" && m.ToolCallID != "" {
+			parts = append(parts, genAIPart{
+				Type:     "tool_call_response",
+				ID:       m.ToolCallID,
+				Response: rawOrNil(m.Content),
+			})
+		} else {
+			parts = append(parts, openAIContentParts(m.Content)...)
+			parts = append(parts, openAIToolCallParts(m.ToolCalls)...)
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		out = append(out, genAIMessage{Role: m.Role, Parts: parts})
+	}
+	return out
+}
+
+// openAIResponsesInput converts a Responses API `input` (a plain string
+// or an item array) plus the top-level `instructions` into GenAI
+// messages. function_call items become assistant tool_call parts,
+// function_call_output items become tool tool_call_response parts, and
+// message items carry their text/generic content parts.
+func openAIResponsesInput(raw json.RawMessage, instructions string) []genAIMessage {
+	var out []genAIMessage
+	if instructions != "" {
+		out = append(out, genAIMessage{Role: "system", Parts: []genAIPart{{Type: "text", Content: instructions}}})
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if s != "" {
+			out = append(out, genAIMessage{Role: "user", Parts: []genAIPart{{Type: "text", Content: s}}})
+		}
+		return out
+	}
+	var items []struct {
+		Type      string          `json:"type"`
+		Role      string          `json:"role"`
+		Content   json.RawMessage `json:"content"`
+		CallID    string          `json:"call_id"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+		Output    json.RawMessage `json:"output"`
+	}
+	if json.Unmarshal(raw, &items) != nil {
+		return out
+	}
+	for _, it := range items {
+		switch it.Type {
+		case "function_call":
+			out = append(out, genAIMessage{Role: "assistant", Parts: []genAIPart{{
+				Type:      "tool_call",
+				ID:        it.CallID,
+				Name:      it.Name,
+				Arguments: rawArgsToRaw(it.Arguments),
+			}}})
+		case "function_call_output":
+			out = append(out, genAIMessage{Role: "tool", Parts: []genAIPart{{
+				Type:     "tool_call_response",
+				ID:       it.CallID,
+				Response: rawOrNil(it.Output),
+			}}})
+		case "message", "":
+			role := it.Role
+			if role == "" {
+				role = "user"
+			}
+			if parts := openAIContentParts(it.Content); len(parts) > 0 {
+				out = append(out, genAIMessage{Role: role, Parts: parts})
+			}
+		default:
+			out = append(out, genAIMessage{Role: it.Role, Parts: []genAIPart{{Type: it.Type}}})
+		}
+	}
+	return out
+}
+
+// openAIToolCall is a Chat Completions tool call ({id, type,
+// function:{name, arguments}}); arguments is a JSON-encoded string.
+type openAIToolCall struct {
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// openAIToolCallParts maps Chat Completions tool_calls to GenAI tool_call
+// parts, decoding each call's JSON-string arguments into structured JSON.
+func openAIToolCallParts(calls []openAIToolCall) []genAIPart {
+	var parts []genAIPart
+	for _, tc := range calls {
+		parts = append(parts, genAIPart{
+			Type:      "tool_call",
+			ID:        tc.ID,
+			Name:      tc.Function.Name,
+			Arguments: argStringToRaw(tc.Function.Arguments),
+		})
+	}
+	return parts
+}
+
+// openAIContentParts converts an OpenAI message `content` — a plain
+// string or an array of typed parts — into GenAI parts. Text parts
+// (text / input_text / output_text) carry their text; any other part
+// type (input_image, input_file, …) becomes a generic part preserving
+// the type rather than being dropped. Raw binary/url payloads are not
+// captured.
+func openAIContentParts(c json.RawMessage) []genAIPart {
+	if len(c) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(c, &s) == nil {
+		if s == "" {
+			return nil
+		}
+		return []genAIPart{{Type: "text", Content: s}}
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(c, &blocks) != nil {
+		return nil
+	}
+	var parts []genAIPart
+	for _, b := range blocks {
+		switch b.Type {
+		case "text", "input_text", "output_text":
+			if b.Text != "" {
+				parts = append(parts, genAIPart{Type: "text", Content: b.Text})
+			}
+		case "":
+			continue
+		default:
+			parts = append(parts, genAIPart{Type: b.Type})
+		}
+	}
+	return parts
+}
+
+// openAIReasoningText flattens a Responses API reasoning item's `summary`
+// (an array of {type:"summary_text", text} parts) into a single string.
+func openAIReasoningText(summary json.RawMessage) string {
+	if len(summary) == 0 {
+		return ""
+	}
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(summary, &parts) != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(p.Text)
+	}
+	return b.String()
+}
+
+// isResponsesTerminalEvent reports whether a Responses-API SSE event type
+// is the terminal one whose embedded response object holds the final
+// output — as opposed to the response.created / response.in_progress
+// snapshots that precede it.
+func isResponsesTerminalEvent(typ string) bool {
+	switch typ {
+	case "response.completed", "response.incomplete", "response.failed":
+		return true
+	}
+	return false
+}
+
+// responsesFinish maps a Responses API completion to a GenAI finish
+// reason: the incomplete reason when the response stopped short, else the
+// status ("completed", "failed", …).
+func responsesFinish(status, incompleteReason string) string {
+	if status == "incomplete" && incompleteReason != "" {
+		return incompleteReason
+	}
+	return status
+}
+
+// rawArgsToRaw normalizes a tool-call arguments value that may arrive
+// either as structured JSON or as a JSON-encoded string (OpenAI encodes
+// arguments as a string) into structured JSON for the part.
+func rawArgsToRaw(raw json.RawMessage) json.RawMessage {
+	raw = rawOrNil(raw)
+	if raw == nil {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return argStringToRaw(s)
+	}
+	return raw
+}
+
+// argStringToRaw turns a tool-call arguments string into a RawMessage: the
+// inner JSON when the string is valid JSON, otherwise the string itself
+// as a JSON string. Empty input yields nil.
+func argStringToRaw(s string) json.RawMessage {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if json.Valid([]byte(s)) {
+		return json.RawMessage(s)
+	}
+	if b, err := json.Marshal(s); err == nil {
+		return json.RawMessage(b)
+	}
+	return nil
+}
+
+// firstNonEmpty returns the first non-empty argument, or "".
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// sseDataPayloads returns the JSON object payloads of each `data:` line in
+// an SSE body, skipping non-JSON sentinels (e.g. "data: [DONE]").
+func sseDataPayloads(body []byte) [][]byte {
+	var out [][]byte
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 || payload[0] != '{' {
+			continue
+		}
+		out = append(out, payload)
+	}
+	return out
+}

--- a/cmd/clawpatrol/genai_openai_test.go
+++ b/cmd/clawpatrol/genai_openai_test.go
@@ -1,0 +1,392 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// newGenAIGateway builds a Gateway whose config enables GenAI telemetry,
+// optionally with message-content capture, for driving recordGenAITurn.
+func newGenAIGateway(t *testing.T, content bool) *Gateway {
+	t.Helper()
+	block := "genai_telemetry {}"
+	if content {
+		block = "genai_telemetry { include_message_content = true }"
+	}
+	src := `
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  ` + block + `
+}
+`
+	gw, diags := config.LoadBytes([]byte(src), "openai.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+	return g
+}
+
+func TestParseOpenAIRequestParams(t *testing.T) {
+	// Chat Completions: max_tokens, stop as array, no top_k.
+	p := parseOpenAIRequestParams([]byte(`{
+		"model":"gpt-4o","stream":true,"max_tokens":256,
+		"temperature":0.2,"top_p":0.9,"stop":["STOP","END"]
+	}`))
+	if p.Stream == nil || !*p.Stream {
+		t.Errorf("stream = %v, want true", p.Stream)
+	}
+	if p.MaxTokens != 256 {
+		t.Errorf("max_tokens = %d, want 256", p.MaxTokens)
+	}
+	if p.Temperature == nil || *p.Temperature != 0.2 {
+		t.Errorf("temperature = %v, want 0.2", p.Temperature)
+	}
+	if p.TopP == nil || *p.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9", p.TopP)
+	}
+	if !reflect.DeepEqual(p.StopSequences, []string{"STOP", "END"}) {
+		t.Errorf("stop = %v", p.StopSequences)
+	}
+
+	// Responses API: max_output_tokens, stop as single string.
+	r := parseOpenAIRequestParams([]byte(`{"model":"gpt-4o","max_output_tokens":99,"stop":"###"}`))
+	if r.MaxTokens != 99 {
+		t.Errorf("max_output_tokens → max_tokens = %d, want 99", r.MaxTokens)
+	}
+	if !reflect.DeepEqual(r.StopSequences, []string{"###"}) {
+		t.Errorf("stop = %v, want [###]", r.StopSequences)
+	}
+
+	// max_completion_tokens (newer Chat Completions).
+	c := parseOpenAIRequestParams([]byte(`{"max_completion_tokens":42}`))
+	if c.MaxTokens != 42 {
+		t.Errorf("max_completion_tokens → max_tokens = %d, want 42", c.MaxTokens)
+	}
+
+	// temperature 0 is a real value, not "unset".
+	z := parseOpenAIRequestParams([]byte(`{"temperature":0}`))
+	if z.Temperature == nil || *z.Temperature != 0 {
+		t.Errorf("temperature 0 not captured: %v", z.Temperature)
+	}
+}
+
+func TestParseOpenAIToolDefsChatAndResponses(t *testing.T) {
+	// Chat Completions: spec nested under "function".
+	chat := `{"tools":[
+		{"type":"function","function":{"name":"get_weather","description":"d","parameters":{"type":"object"}}}
+	]}`
+	base := parseOpenAIToolDefs([]byte(chat), false)
+	want := []genAIToolDef{{Type: "function", Name: "get_weather"}}
+	if !reflect.DeepEqual(base, want) {
+		t.Errorf("chat base = %#v, want %#v", base, want)
+	}
+	full := parseOpenAIToolDefs([]byte(chat), true)
+	if len(full) != 1 || full[0].Description != "d" || string(full[0].Parameters) != `{"type":"object"}` {
+		t.Errorf("chat full = %#v", full)
+	}
+
+	// Responses API: flat name/parameters + a built-in tool with no name.
+	resp := `{"tools":[
+		{"type":"function","name":"lookup","description":"x","parameters":{"a":1}},
+		{"type":"web_search_preview"}
+	]}`
+	defs := parseOpenAIToolDefs([]byte(resp), false)
+	want2 := []genAIToolDef{
+		{Type: "function", Name: "lookup"},
+		{Type: "web_search_preview", Name: "web_search_preview"},
+	}
+	if !reflect.DeepEqual(defs, want2) {
+		t.Errorf("responses defs = %#v, want %#v", defs, want2)
+	}
+
+	if got := parseOpenAIToolDefs([]byte(`{"model":"x"}`), true); got != nil {
+		t.Errorf("no tools should be nil, got %#v", got)
+	}
+}
+
+func TestOpenAIResponseContentChatJSON(t *testing.T) {
+	body := `{"id":"chatcmpl-1","model":"gpt-4o","choices":[
+		{"index":0,"message":{"role":"assistant","content":"hello world"},"finish_reason":"stop"}
+	],"usage":{"prompt_tokens":1,"completion_tokens":2}}`
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "stop" {
+		t.Errorf("finish = %q, want stop", finish)
+	}
+	want := []genAIPart{{Type: "text", Content: "hello world"}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+func TestOpenAIResponseContentChatToolCall(t *testing.T) {
+	body := `{"id":"chatcmpl-2","choices":[{"index":0,"message":{"role":"assistant","content":null,
+		"tool_calls":[{"id":"call_1","type":"function","function":{"name":"f","arguments":"{\"x\":1}"}}]},
+		"finish_reason":"tool_calls"}]}`
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "tool_calls" {
+		t.Errorf("finish = %q", finish)
+	}
+	want := []genAIPart{{Type: "tool_call", ID: "call_1", Name: "f", Arguments: json.RawMessage(`{"x":1}`)}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+func TestOpenAIResponseContentChatSSE(t *testing.T) {
+	body := "data: {\"id\":\"chatcmpl-3\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel\"}}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-3\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"}}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-3\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: [DONE]\n\n"
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "stop" {
+		t.Errorf("finish = %q, want stop", finish)
+	}
+	want := []genAIPart{{Type: "text", Content: "Hello"}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+func TestOpenAIResponseContentChatSSEToolCall(t *testing.T) {
+	body := "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_9\",\"function\":{\"name\":\"f\",\"arguments\":\"{\\\"a\\\":\"}}]}}]}\n\n" +
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"1}\"}}]}}]}\n\n" +
+		"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n"
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "tool_calls" {
+		t.Errorf("finish = %q", finish)
+	}
+	want := []genAIPart{{Type: "tool_call", ID: "call_9", Name: "f", Arguments: json.RawMessage(`{"a":1}`)}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+func TestOpenAIResponseContentResponsesJSON(t *testing.T) {
+	body := `{"id":"resp_1","object":"response","model":"gpt-4o","status":"completed","output":[
+		{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi there"}]},
+		{"type":"function_call","call_id":"fc_1","name":"f","arguments":"{\"q\":\"x\"}"}
+	],"usage":{"input_tokens":3,"output_tokens":4}}`
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "completed" {
+		t.Errorf("finish = %q, want completed", finish)
+	}
+	want := []genAIPart{
+		{Type: "text", Content: "hi there"},
+		{Type: "tool_call", ID: "fc_1", Name: "f", Arguments: json.RawMessage(`{"q":"x"}`)},
+	}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+func TestOpenAIResponseContentResponsesIncomplete(t *testing.T) {
+	body := `{"id":"resp_2","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},
+		"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial"}]}]}`
+	_, finish := openAIResponseContent([]byte(body))
+	if finish != "max_output_tokens" {
+		t.Errorf("finish = %q, want max_output_tokens", finish)
+	}
+}
+
+func TestOpenAIResponseContentResponsesSSE(t *testing.T) {
+	// Responses streams end with a terminal event carrying the full
+	// response object; the content parser reads it like a full body.
+	body := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_3\",\"status\":\"in_progress\",\"output\":[]}}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"par\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_3\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"done\"}]}]}}\n\n"
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "completed" {
+		t.Errorf("finish = %q, want completed", finish)
+	}
+	want := []genAIPart{{Type: "text", Content: "done"}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+func TestOpenAIResponseMeta(t *testing.T) {
+	if id, et := openAIResponseMeta([]byte(`{"id":"chatcmpl-x","choices":[]}`)); id != "chatcmpl-x" || et != "" {
+		t.Errorf("chat meta = %q/%q", id, et)
+	}
+	if id, et := openAIResponseMeta([]byte(`{"id":"resp_x","object":"response"}`)); id != "resp_x" || et != "" {
+		t.Errorf("responses meta = %q/%q", id, et)
+	}
+	// HTTP error body.
+	if _, et := openAIResponseMeta([]byte(`{"error":{"message":"bad","type":"invalid_request_error"}}`)); et != "invalid_request_error" {
+		t.Errorf("error type = %q", et)
+	}
+	// SSE: chat chunk id.
+	sse := "data: {\"id\":\"chatcmpl-s\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n"
+	if id, _ := openAIResponseMeta([]byte(sse)); id != "chatcmpl-s" {
+		t.Errorf("sse id = %q", id)
+	}
+}
+
+func TestOpenAIContentMessagesChat(t *testing.T) {
+	body := `{"messages":[
+		{"role":"system","content":"be terse"},
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{\"k\":1}"}}]},
+		{"role":"tool","tool_call_id":"c1","content":"42"}
+	]}`
+	msgs := openAIContentMessages([]byte(body))
+	want := []genAIMessage{
+		{Role: "system", Parts: []genAIPart{{Type: "text", Content: "be terse"}}},
+		{Role: "user", Parts: []genAIPart{{Type: "text", Content: "hi"}}},
+		{Role: "assistant", Parts: []genAIPart{{Type: "tool_call", ID: "c1", Name: "f", Arguments: json.RawMessage(`{"k":1}`)}}},
+		{Role: "tool", Parts: []genAIPart{{Type: "tool_call_response", ID: "c1", Response: json.RawMessage(`"42"`)}}},
+	}
+	if !reflect.DeepEqual(msgs, want) {
+		t.Errorf("msgs = %#v\nwant %#v", msgs, want)
+	}
+}
+
+func TestOpenAIContentMessagesResponses(t *testing.T) {
+	body := `{"instructions":"be terse","input":[
+		{"role":"user","content":[{"type":"input_text","text":"hi"}]},
+		{"type":"function_call","call_id":"fc1","name":"f","arguments":"{\"k\":1}"},
+		{"type":"function_call_output","call_id":"fc1","output":"ok"}
+	]}`
+	msgs := openAIContentMessages([]byte(body))
+	want := []genAIMessage{
+		{Role: "system", Parts: []genAIPart{{Type: "text", Content: "be terse"}}},
+		{Role: "user", Parts: []genAIPart{{Type: "text", Content: "hi"}}},
+		{Role: "assistant", Parts: []genAIPart{{Type: "tool_call", ID: "fc1", Name: "f", Arguments: json.RawMessage(`{"k":1}`)}}},
+		{Role: "tool", Parts: []genAIPart{{Type: "tool_call_response", ID: "fc1", Response: json.RawMessage(`"ok"`)}}},
+	}
+	if !reflect.DeepEqual(msgs, want) {
+		t.Errorf("msgs = %#v\nwant %#v", msgs, want)
+	}
+
+	// Responses `input` as a plain string → single user message.
+	one := openAIContentMessages([]byte(`{"input":"just text"}`))
+	wantOne := []genAIMessage{{Role: "user", Parts: []genAIPart{{Type: "text", Content: "just text"}}}}
+	if !reflect.DeepEqual(one, wantOne) {
+		t.Errorf("string input = %#v, want %#v", one, wantOne)
+	}
+}
+
+// TestRecordGenAITurnOpenAINoContent drives the full path for an OpenAI
+// Chat Completions turn: provider/model/usage/finish/tooldefs ride the
+// base span, no prompt/completion text without the content opt-in.
+func TestRecordGenAITurnOpenAINoContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	g := newGenAIGateway(t, false)
+	req := `{"model":"gpt-4o","temperature":0.5,"max_tokens":100,
+		"tools":[{"type":"function","function":{"name":"f","description":"secret","parameters":{"p":1}}}],
+		"messages":[{"role":"user","content":"secret prompt"}]}`
+	resp := `{"id":"chatcmpl-1","model":"gpt-4o","choices":[{"index":0,
+		"message":{"role":"assistant","content":"secret completion"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":10,"completion_tokens":20}}`
+	g.recordGenAITurn("openai", "s_oai", "api.openai.com", "gpt-4o", "gpt-4o", 10, 20,
+		[]byte(req), []byte(resp), time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	if m["gen_ai.provider.name"].AsString() != "openai" {
+		t.Errorf("provider = %q", m["gen_ai.provider.name"].AsString())
+	}
+	if m["gen_ai.request.model"].AsString() != "gpt-4o" {
+		t.Errorf("model = %q", m["gen_ai.request.model"].AsString())
+	}
+	if m["gen_ai.response.id"].AsString() != "chatcmpl-1" {
+		t.Errorf("response.id = %q", m["gen_ai.response.id"].AsString())
+	}
+	if got := m["gen_ai.usage.input_tokens"].AsInt64(); got != 10 {
+		t.Errorf("input_tokens = %d", got)
+	}
+	if got := m["gen_ai.request.max_tokens"].AsInt64(); got != 100 {
+		t.Errorf("max_tokens = %d", got)
+	}
+	if m["gen_ai.request.temperature"].AsFloat64() != 0.5 {
+		t.Errorf("temperature = %v", m["gen_ai.request.temperature"].AsFloat64())
+	}
+	if fr := m["gen_ai.response.finish_reasons"].AsStringSlice(); len(fr) != 1 || fr[0] != "stop" {
+		t.Errorf("finish_reasons = %v", fr)
+	}
+	// Tool name+type ride the base span; schema must NOT (content off).
+	var defs []genAIToolDef
+	if err := json.Unmarshal([]byte(m["gen_ai.tool.definitions"].AsString()), &defs); err != nil {
+		t.Fatalf("tool.definitions: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Name != "f" || defs[0].Description != "" || defs[0].Parameters != nil {
+		t.Errorf("tool defs leaked schema with content off: %#v", defs)
+	}
+	// No content attributes when content capture is off.
+	if _, ok := m["gen_ai.input.messages"]; ok {
+		t.Error("input.messages present with content off")
+	}
+}
+
+// TestRecordGenAITurnOpenAIWithContent verifies prompt/completion content
+// and tool schemas are attached under the content opt-in.
+func TestRecordGenAITurnOpenAIWithContent(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	g := newGenAIGateway(t, true)
+	req := `{"model":"gpt-4o",
+		"tools":[{"type":"function","function":{"name":"f","description":"the desc","parameters":{"p":1}}}],
+		"messages":[{"role":"system","content":"be terse"},{"role":"user","content":"hello there"}]}`
+	resp := `{"id":"chatcmpl-2","model":"gpt-4o","choices":[{"index":0,
+		"message":{"role":"assistant","content":"general kenobi"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":1,"completion_tokens":2}}`
+	g.recordGenAITurn("openai", "s_oai", "api.openai.com", "gpt-4o", "gpt-4o", 1, 2,
+		[]byte(req), []byte(resp), time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+
+	var sysParts []genAIPart
+	if err := json.Unmarshal([]byte(m["gen_ai.system_instructions"].AsString()), &sysParts); err != nil {
+		t.Fatalf("system_instructions: %v", err)
+	}
+	if !reflect.DeepEqual(sysParts, []genAIPart{{Type: "text", Content: "be terse"}}) {
+		t.Errorf("system_instructions = %#v", sysParts)
+	}
+
+	var input []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.input.messages"].AsString()), &input); err != nil {
+		t.Fatalf("input.messages: %v", err)
+	}
+	if len(input) != 1 || input[0].Role != "user" || len(input[0].Parts) != 1 || input[0].Parts[0].Content != "hello there" {
+		t.Errorf("input.messages = %#v", input)
+	}
+
+	var output []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.output.messages"].AsString()), &output); err != nil {
+		t.Fatalf("output.messages: %v", err)
+	}
+	if len(output) != 1 || output[0].Parts[0].Content != "general kenobi" || output[0].FinishReason != "stop" {
+		t.Errorf("output.messages = %#v", output)
+	}
+
+	// Tool schema present under content opt-in.
+	var defs []genAIToolDef
+	if err := json.Unmarshal([]byte(m["gen_ai.tool.definitions"].AsString()), &defs); err != nil {
+		t.Fatalf("tool.definitions: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Description != "the desc" || string(defs[0].Parameters) != `{"p":1}` {
+		t.Errorf("tool defs = %#v", defs)
+	}
+}


### PR DESCRIPTION
Extend the OTel GenAI semantic-convention export so OpenAI turns emit the
same `gen_ai.*` telemetry as Anthropic: request sampling params, the tool
catalogue (`gen_ai.tool.definitions`), response id, finish reason, and —
under the existing `include_message_content` opt-in — message content and
tool schemas.

Both OpenAI wire formats are covered:

- Chat Completions API (`/v1/chat/completions`, `/v1/completions`)
- Responses API (`/v1/responses` and the chatgpt.com codex backend)

each in non-streaming JSON and streaming SSE form. Per-provider field
mapping normalizes into the shared `genAITurn` representation and exporter
rather than forking a parallel path — `recordGenAITurn` now dispatches to
`mapClaudeTurn` / `mapOpenAITurn`.

Fields OpenAI lacks degrade gracefully: there is no `top_k` and no
prompt-cache token breakdown, so those attributes stay unset rather than
carrying empty values. The max-token cap is coalesced across
`max_tokens` / `max_completion_tokens` / `max_output_tokens`. The `stop`
field is normalized whether it arrives as a string or an array.

Anthropic behavior is unchanged, and an unrecognized provider falls
through to the base span (provider/model/usage only).

Covered by per-provider tests for request params, tool defs (both nested
and flat shapes), content messages, and end-to-end span emission with and
without the content opt-in.
