### PR TITLE
Fix missing GenAI traces for Codex /codex/responses turns

### DIFF
--- a/cmd/clawpatrol/genai_openai_test.go
+++ b/cmd/clawpatrol/genai_openai_test.go
@@ -390,3 +390,51 @@ func TestRecordGenAITurnOpenAIWithContent(t *testing.T) {
 		t.Errorf("tool defs = %#v", defs)
 	}
 }
+
+// TestTrackLLMUsageCodexModelFromRequest covers the Codex
+// /backend-api/codex/responses path: its SSE response body carries
+// neither the model (it rides the OpenAI-Model response header) nor
+// token usage, so sourcing the model only from the response left
+// recordGenAITurn's guard unsatisfied and the GenAI span was dropped.
+// The model must fall back to the request body so the turn is recorded.
+func TestTrackLLMUsageCodexModelFromRequest(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry {}
+}
+`), "base.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{}
+	g.cfg.Store(gw)
+	g.agents = NewAgentRegistry()
+
+	// Request carries the model; the SSE response has no model and no
+	// parseable usage — exactly the shape that produced no span before.
+	reqBody := []byte(`{"model":"gpt-5-codex","input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}]}`)
+	respBody := []byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n")
+
+	g.trackLLMUsage(nil, "codex_ws_usage", "chatgpt.com",
+		"/backend-api/codex/responses", reqBody, respBody, "sess-1", time.Time{})
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1 (codex turn dropped — model not sourced from request)", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	if got := m["gen_ai.provider.name"].AsString(); got != "openai" {
+		t.Errorf("gen_ai.provider.name = %q, want openai", got)
+	}
+	if got := m["gen_ai.request.model"].AsString(); got != "gpt-5-codex" {
+		t.Errorf("gen_ai.request.model = %q, want gpt-5-codex", got)
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1097,6 +1097,15 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, host, path string, reqBody, re
 		}
 		title := codexResponsesRequestTitle(reqBody)
 		model, in, out := parseOpenAIResponse(respBody)
+		// Codex's SSE response body carries neither the model (it rides the
+		// OpenAI-Model response header) nor, on many turns, token usage —
+		// so the response alone leaves recordGenAITurn's model/usage guard
+		// unsatisfied and the GenAI span is silently dropped. Source the
+		// model from the request body, the same place the dashboard usage
+		// path reads it, so the turn is recorded.
+		if model == "" {
+			model = codexRequestModel(reqBody)
+		}
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}


### PR DESCRIPTION
## Summary

Codex traffic (`chatgpt.com/backend-api/codex/responses`) produced **no GenAI/OTel spans at all**, even with `genai_telemetry {}` enabled and the OpenAI mapping from #711 in place.

Root cause is in `trackLLMUsage`'s `codex_ws_usage` case, not in the GenAI code itself. The Codex backend:

- **doesn't put the model in its SSE response body** — it ships in the `OpenAI-Model` response header (already documented on `codexRequestModel`), and
- on many turns carries **no token usage** in the parseable body either.

That case sourced the model only from `parseOpenAIResponse(respBody)`, so it called `recordGenAITurn` with an empty model and zero usage. `recordGenAITurn`'s guard (`model == "" && in == 0 && out == 0`) then dropped the turn — before the provider switch, so the `mapOpenAITurn` content mapping never ran.

The dashboard usage path was unaffected because it reads the model from the **request** body (`codexRequestModel`), which is why Codex usage showed in the dashboard but never in OTel.

## Fix

Fall back to `codexRequestModel(reqBody)` when the response yields no model — the same source the dashboard path already uses — so the turn clears the guard and the span (with its content mapping) is emitted.

```go
model, in, out := parseOpenAIResponse(respBody)
if model == "" {
    model = codexRequestModel(reqBody) // Codex model is in the request / OpenAI-Model header, not the SSE body
}
```

Scoped to the Codex path; standard `api.openai.com` `/v1/chat/completions` and `/v1/responses` include the model in the response body and are unaffected.

## Test

Adds `TestTrackLLMUsageCodexModelFromRequest`, which drives `trackLLMUsage` with a model-less Codex SSE response. It produces **0 spans before the fix** (reproducing the symptom) and **1 span with `gen_ai.request.model=gpt-5-codex` after**.

Verified: `go build ./...`, `go test ./cmd/clawpatrol/ ./internal/config/`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)