### PR TITLE
spike: plugin tunnel via-chaining + UDP (wireguard + socks)

### DIFF
--- a/cmd/clawpatrol/tunnelvia_e2e_test.go
+++ b/cmd/clawpatrol/tunnelvia_e2e_test.go
@@ -1,0 +1,187 @@
+//go:build linux
+
+package main
+
+// Live end-to-end driver for the plugin-tunnel via+UDP spike. Gated by
+// CLAWPATROL_VIA_E2E so it never runs in normal CI. It builds the real
+// socks + wireguard plugin binaries, loads a config with a wireguard
+// tunnel (optionally `via` a socks tunnel), acquires it through the
+// gateway's TunnelManager, dials a target over the WG netstack, and
+// checks the HTTP response.
+//
+// Run (against a live WireGuard server + SOCKS proxy + target):
+//
+//	CLAWPATROL_VIA_E2E=1 VIA=1 \
+//	WG_ENDPOINT=host:51820 WG_PRIV=... WG_PEERPUB=... WG_ADDR=10.9.0.2 \
+//	SOCKS_PROXY=host:1080 TARGET=10.9.0.1:8080 \
+//	go test ./cmd/clawpatrol -run TestTunnelViaE2E -count=1 -v
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func buildTunnelPlugin(t *testing.T, pkg, name string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), name)
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	cmd.Dir = root
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", pkg, err, b)
+	}
+	return out
+}
+
+func TestTunnelViaE2E(t *testing.T) {
+	if os.Getenv("CLAWPATROL_VIA_E2E") == "" {
+		t.Skip("set CLAWPATROL_VIA_E2E=1 (plus WG_*/SOCKS_PROXY/TARGET) to run the live spike")
+	}
+	wgEndpoint := os.Getenv("WG_ENDPOINT")
+	wgPriv := os.Getenv("WG_PRIV")
+	wgPeerPub := os.Getenv("WG_PEERPUB")
+	wgAddr := envOr("WG_ADDR", "10.9.0.2")
+	socksProxy := os.Getenv("SOCKS_PROXY")
+	target := envOr("TARGET", "10.9.0.1:8080")
+	useVia := os.Getenv("VIA") == "1"
+	if wgEndpoint == "" || wgPriv == "" || wgPeerPub == "" || (useVia && socksProxy == "") {
+		t.Fatal("need WG_ENDPOINT, WG_PRIV, WG_PEERPUB (and SOCKS_PROXY when VIA=1)")
+	}
+
+	socksBin := buildTunnelPlugin(t, "./pluginsdk/socks", "socks-tunnel")
+	wgBin := buildTunnelPlugin(t, "./pluginsdk/wireguard", "wireguard-tunnel")
+
+	stateDir := t.TempDir()
+	mgr := extplugin.New(log.New(os.Stderr, "", 0))
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	socksBlock := ""
+	if useVia {
+		socksBlock = fmt.Sprintf(`
+plugin "socks_tunnel" {
+  source  = %q
+  network = "outbound"
+  sandbox = "off"
+}
+tunnel "socks_proxy" "corp" {
+  proxy = %q
+}
+`, socksBin, socksProxy)
+	}
+
+	// NOTE: the HCL `via` attribute on a *plugin* tunnel block is a separate,
+	// unfinished config-layer gap (plugin tunnel bodies don't yet peel the
+	// common via/keepalive/share attrs the way built-in tunnels do via
+	// TunnelCommonRead). To exercise the runtime via path here we wire Via
+	// directly on the compiled tunnel below.
+	hcl := fmt.Sprintf(`
+plugin "wireguard_tunnel" {
+  source  = %q
+  network = "outbound"
+  sandbox = "off"
+}
+%s
+gateway {
+  state_dir  = %q
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "wireguard" "vpn" {
+  endpoint        = %q
+  private_key     = %q
+  peer_public_key = %q
+  address         = %q
+}
+endpoint "https" "via-target" {
+  hosts  = ["target.invalid"]
+  tunnel = wireguard.vpn
+}
+profile "default" { credentials = [] }
+`, wgBin, socksBlock, stateDir, wgEndpoint, wgPriv, wgPeerPub, wgAddr)
+
+	gw, diags := config.LoadBytes([]byte(hcl), "via-e2e.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ct := policy.Tunnels["vpn"]
+	if ct == nil {
+		t.Fatalf("no compiled tunnel 'vpn' (have %v)", keysOf(policy.Tunnels))
+	}
+	if useVia {
+		corp := policy.Tunnels["corp"]
+		if corp == nil {
+			t.Fatalf("no compiled tunnel 'corp' (have %v)", keysOf(policy.Tunnels))
+		}
+		ct.Via = corp // wire the via chain at runtime (HCL via is a separate gap)
+	}
+
+	tm := NewTunnelManager(runtime.EnvSecretStore{}, stateDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	t.Logf("acquiring wireguard tunnel (via=%v) -> %s", useVia, wgEndpoint)
+	tun, release, err := tm.Acquire(ctx, ct, "via-target")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer release()
+
+	// Dial the target over the WG netstack and do a plain HTTP GET.
+	t.Logf("dialing %s through the tunnel", target)
+	conn, err := tun.Dial(ctx, "tcp", target)
+	if err != nil {
+		t.Fatalf("dial through tunnel: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(20 * time.Second))
+
+	if _, err := fmt.Fprintf(conn, "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", target); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body := make([]byte, 256)
+	n, _ := resp.Body.Read(body)
+	t.Logf("RESPONSE %d: %q", resp.StatusCode, body[:n])
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+}
+
+func keysOf(m map[string]*config.CompiledTunnel) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -881,6 +881,16 @@ type dynamicTunnelBody struct {
 	canonicalJSON []byte
 }
 
+// dynamicTunnelBody is the CompiledTunnel.Body for a plugin tunnel; it
+// implements runtime.TunnelRuntime by delegating to its adapter so the
+// gateway's TunnelManager.Acquire can Open it (and thread a `via` parent)
+// exactly like a built-in tunnel.
+func (b *dynamicTunnelBody) Sharing() runtime.TunnelSharing { return b.adapter.Sharing() }
+
+func (b *dynamicTunnelBody) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
+	return b.adapter.Open(ctx, host, via)
+}
+
 // tunnelAdapter implements runtime.TunnelRuntime via OpenTunnel /
 // Dial / CloseTunnel RPCs.
 type tunnelAdapter struct {

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -890,10 +890,20 @@ type tunnelAdapter struct {
 
 func (a *tunnelAdapter) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
 
-func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ runtime.Tunnel) (runtime.Tunnel, error) {
+func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
 	body, ok := tunnelBodyOf(host)
 	if !ok {
 		return nil, fmt.Errorf("extplugin: tunnel %q has no dynamic body", host.Name)
+	}
+	// If this tunnel is chained through a parent (`via = <tunnel>`),
+	// register the already-acquired parent under an opaque token and hand
+	// the token to the plugin. The plugin routes its own transport
+	// connection through the parent by echoing the token to
+	// HostTunnel.DialVia. The gateway owns the composition; the plugin
+	// never holds the parent directly.
+	var viaToken string
+	if via != nil && a.client.viaReg != nil {
+		viaToken = a.client.viaReg.add(via)
 	}
 	var (
 		credSec   []byte
@@ -912,14 +922,19 @@ func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ run
 		CanonicalJson:    body.canonicalJSON,
 		CredentialSecret: credSec,
 		CredentialExtras: credExtra,
+		ViaTunnelHandle:  viaToken,
 	})
 	if err != nil {
+		if viaToken != "" {
+			a.client.viaReg.remove(viaToken)
+		}
 		return nil, fmt.Errorf("extplugin: OpenTunnel: %w", err)
 	}
 	return &remoteTunnel{
-		client: a.client,
-		handle: resp.Handle,
-		logger: host.Logger,
+		client:   a.client,
+		handle:   resp.Handle,
+		logger:   host.Logger,
+		viaToken: viaToken,
 	}, nil
 }
 
@@ -948,9 +963,10 @@ var tunnelBodies = struct {
 // remoteTunnel is the runtime.Tunnel handle returned from Open. Each
 // Dial call opens a fresh bidi stream against the subprocess.
 type remoteTunnel struct {
-	client *Client
-	handle string
-	logger *log.Logger
+	client   *Client
+	handle   string
+	logger   *log.Logger
+	viaToken string // non-empty when chained through a parent (`via`)
 }
 
 func (t *remoteTunnel) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -969,6 +985,9 @@ func (t *remoteTunnel) Dial(ctx context.Context, network, addr string) (net.Conn
 }
 
 func (t *remoteTunnel) Close() error {
+	if t.viaToken != "" && t.client.viaReg != nil {
+		t.client.viaReg.remove(t.viaToken)
+	}
 	_, err := t.client.tunnel.CloseTunnel(context.Background(), &pb.CloseTunnelRequest{Handle: t.handle})
 	return err
 }

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -310,10 +310,13 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 	// neither service (no idle broker goroutine).
 	gc := &grpcClient{}
 	var sessions *sessionRegistry
+	var viaReg *viaRegistry
 	if stateNS != "" {
 		gc.hostState = newHostState(m.blobStore, stateNS)
 		sessions = newSessionRegistry()
 		gc.sessions = sessions
+		viaReg = newViaRegistry()
+		gc.viaReg = viaReg
 	}
 	cli := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: HandshakeConfig,
@@ -337,6 +340,7 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 		socketDir:      spec.SocketDir,
 		gp:             cli,
 		sessions:       sessions,
+		viaReg:         viaReg,
 	}
 	rpcCli, err := cli.Client()
 	if err != nil {
@@ -1104,6 +1108,11 @@ type Client struct {
 	// resolves Evaluate calls against it. Shared with the grpcClient that
 	// serves the bundle.
 	sessions *sessionRegistry
+	// viaReg holds the parent tunnels this plugin's tunnels are chained
+	// through; the tunnelAdapter registers a parent at Open and the
+	// broker-served hostTunnel resolves it at DialVia. Shared with the
+	// grpcClient. nil on the probe path (no tunnels run).
+	viaReg *viaRegistry
 }
 
 // SandboxMode reports which sandbox backend the subprocess runs
@@ -1158,6 +1167,7 @@ type grpcClient struct {
 	plugin.NetRPCUnsupportedPlugin
 	hostState pb.HostStateServer // nil = state service disabled
 	sessions  *sessionRegistry   // nil = HostControl disabled (probe path)
+	viaReg    *viaRegistry       // nil = HostTunnel disabled (probe path)
 }
 
 func (g *grpcClient) GRPCServer(_ *plugin.GRPCBroker, _ *grpc.Server) error {
@@ -1170,14 +1180,16 @@ func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, co
 	// it in the background; the plugin only dials lazily on its first call.
 	// When the client tears down, the broker closes and AcceptAndServe
 	// returns.
-	if broker == nil || (g.hostState == nil && g.sessions == nil) {
+	if broker == nil || (g.hostState == nil && g.sessions == nil && g.viaReg == nil) {
 		return conn, nil
 	}
-	hs, sessions := g.hostState, g.sessions
+	hs, sessions, viaReg := g.hostState, g.sessions, g.viaReg
 	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
 		// HostControl calls are session-scoped via metadata; the interceptor
 		// resolves the token once. HostState carries no token and passes
-		// through (the interceptor only acts on a present token).
+		// through (the interceptor only acts on a present token). HostTunnel
+		// is streaming and capability-scoped by its via token, so it is not
+		// covered by the unary interceptor.
 		if sessions != nil {
 			opts = append(opts, grpc.ChainUnaryInterceptor(sessionUnaryInterceptor(sessions)))
 		}
@@ -1187,6 +1199,9 @@ func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, co
 		}
 		if sessions != nil {
 			pb.RegisterHostControlServer(s, hostControl{})
+		}
+		if viaReg != nil {
+			pb.RegisterHostTunnelServer(s, &hostTunnel{reg: viaReg})
 		}
 		return s
 	})

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3668,8 +3668,16 @@ type OpenTunnelRequest struct {
 	// Optional credential bound to the tunnel.
 	CredentialSecret []byte            `protobuf:"bytes,4,opt,name=credential_secret,json=credentialSecret,proto3" json:"credential_secret,omitempty"`
 	CredentialExtras map[string]string `protobuf:"bytes,5,rep,name=credential_extras,json=credentialExtras,proto3" json:"credential_extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// via_tunnel_handle is set (non-empty) when this tunnel is chained
+	// through a parent tunnel (`via = <tunnel>` in the gateway config).
+	// It is an opaque token the gateway assigns; the plugin echoes it back
+	// in a HostTunnel.DialVia init to route its transport connection
+	// through the parent. Empty means no parent — the plugin dials its
+	// transport directly (it has the outbound network capability). The
+	// gateway owns the composition; the plugin only names the parent.
+	ViaTunnelHandle string `protobuf:"bytes,6,opt,name=via_tunnel_handle,json=viaTunnelHandle,proto3" json:"via_tunnel_handle,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *OpenTunnelRequest) Reset() {
@@ -3735,6 +3743,13 @@ func (x *OpenTunnelRequest) GetCredentialExtras() map[string]string {
 		return x.CredentialExtras
 	}
 	return nil
+}
+
+func (x *OpenTunnelRequest) GetViaTunnelHandle() string {
+	if x != nil {
+		return x.ViaTunnelHandle
+	}
+	return ""
 }
 
 type OpenTunnelResponse struct {
@@ -4705,13 +4720,14 @@ const file_plugin_proto_rawDesc = "" +
 	"bytesCount\x12\x1f\n" +
 	"\vfacets_json\x18\x06 \x01(\fR\n" +
 	"facetsJson\x12\x12\n" +
-	"\x04rule\x18\a \x01(\tR\x04rule\"\xeb\x02\n" +
+	"\x04rule\x18\a \x01(\tR\x04rule\"\x97\x03\n" +
 	"\x11OpenTunnelRequest\x12(\n" +
 	"\x10tunnel_type_name\x18\x01 \x01(\tR\x0etunnelTypeName\x12'\n" +
 	"\x0ftunnel_instance\x18\x02 \x01(\tR\x0etunnelInstance\x12%\n" +
 	"\x0ecanonical_json\x18\x03 \x01(\fR\rcanonicalJson\x12+\n" +
 	"\x11credential_secret\x18\x04 \x01(\fR\x10credentialSecret\x12j\n" +
-	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntryR\x10credentialExtras\x1aC\n" +
+	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntryR\x10credentialExtras\x12*\n" +
+	"\x11via_tunnel_handle\x18\x06 \x01(\tR\x0fviaTunnelHandle\x1aC\n" +
 	"\x15CredentialExtrasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\",\n" +
@@ -4784,7 +4800,10 @@ const file_plugin_proto_rawDesc = "" +
 	"\x03Get\x12%.clawpatrol.plugin.v1.StateGetRequest\x1a&.clawpatrol.plugin.v1.StateGetResponse\x12T\n" +
 	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponse2g\n" +
 	"\vHostControl\x12X\n" +
-	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdictBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
+	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdict2a\n" +
+	"\n" +
+	"HostTunnel\x12S\n" +
+	"\aDialVia\x12!.clawpatrol.plugin.v1.DialMessage\x1a!.clawpatrol.plugin.v1.DialMessage(\x010\x01BCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -4944,19 +4963,21 @@ var file_plugin_proto_depIdxs = []int32{
 	57, // 66: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
 	59, // 67: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
 	61, // 68: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
-	6,  // 69: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 70: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 71: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	32, // 72: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
-	34, // 73: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	50, // 74: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	53, // 75: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	52, // 76: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	58, // 77: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	60, // 78: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	62, // 79: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
-	69, // [69:80] is the sub-list for method output_type
-	58, // [58:69] is the sub-list for method input_type
+	53, // 69: clawpatrol.plugin.v1.HostTunnel.DialVia:input_type -> clawpatrol.plugin.v1.DialMessage
+	6,  // 70: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 71: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 72: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 73: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 74: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	50, // 75: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	53, // 76: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	52, // 77: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	58, // 78: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	60, // 79: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	62, // 80: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
+	53, // 81: clawpatrol.plugin.v1.HostTunnel.DialVia:output_type -> clawpatrol.plugin.v1.DialMessage
+	70, // [70:82] is the sub-list for method output_type
+	58, // [58:70] is the sub-list for method input_type
 	58, // [58:58] is the sub-list for extension type_name
 	58, // [58:58] is the sub-list for extension extendee
 	0,  // [0:58] is the sub-list for field type_name
@@ -5004,7 +5025,7 @@ func file_plugin_proto_init() {
 			NumEnums:      5,
 			NumMessages:   67,
 			NumExtensions: 0,
-			NumServices:   6,
+			NumServices:   7,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -635,6 +635,14 @@ message OpenTunnelRequest {
   // Optional credential bound to the tunnel.
   bytes  credential_secret = 4;
   map<string,string> credential_extras = 5;
+  // via_tunnel_handle is set (non-empty) when this tunnel is chained
+  // through a parent tunnel (`via = <tunnel>` in the gateway config).
+  // It is an opaque token the gateway assigns; the plugin echoes it back
+  // in a HostTunnel.DialVia init to route its transport connection
+  // through the parent. Empty means no parent — the plugin dials its
+  // transport directly (it has the outbound network capability). The
+  // gateway owns the composition; the plugin only names the parent.
+  string via_tunnel_handle = 6;
 }
 
 message OpenTunnelResponse {
@@ -745,4 +753,25 @@ message EvaluateVerdict {
   string action = 1; // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
   string reason = 2;
   string rule = 3;
+}
+
+// HostTunnel lets a tunnel plugin route its own transport connection
+// through a PARENT tunnel (`via = <tunnel>`). Gateway-served, like
+// HostState/HostControl: the plugin is the client. The gateway resolves
+// the parent tunnel (built-in or another plugin) named by the opaque
+// via_tunnel_handle it handed the plugin at OpenTunnel, dials through it
+// (parent.Dial(network, addr)), and pumps bytes over this stream. This
+// is how WireGuard-over-SOCKS works: the WG plugin asks for a udp
+// conduit to its endpoint, the gateway routes it through the SOCKS
+// parent. The gateway owns the composition; the plugin only names the
+// parent (by echoing the handle).
+service HostTunnel {
+  // DialVia opens one connection THROUGH the calling tunnel's parent.
+  // The first DialMessage MUST be a DialInit whose tunnel_handle is the
+  // via_tunnel_handle from OpenTunnelRequest, and whose network/addr name
+  // the transport target ("udp"/"tcp", "host:port"). For network="udp"
+  // the byte stream carries length-prefixed datagrams (a 2-byte
+  // big-endian length per packet) so the parent can bridge to a real
+  // datagram transport (e.g. SOCKS5 UDP ASSOCIATE).
+  rpc DialVia(stream DialMessage) returns (stream DialMessage);
 }

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -950,3 +950,135 @@ var HostControl_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "plugin.proto",
 }
+
+const (
+	HostTunnel_DialVia_FullMethodName = "/clawpatrol.plugin.v1.HostTunnel/DialVia"
+)
+
+// HostTunnelClient is the client API for HostTunnel service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// HostTunnel lets a tunnel plugin route its own transport connection
+// through a PARENT tunnel (`via = <tunnel>`). Gateway-served, like
+// HostState/HostControl: the plugin is the client. The gateway resolves
+// the parent tunnel (built-in or another plugin) named by the opaque
+// via_tunnel_handle it handed the plugin at OpenTunnel, dials through it
+// (parent.Dial(network, addr)), and pumps bytes over this stream. This
+// is how WireGuard-over-SOCKS works: the WG plugin asks for a udp
+// conduit to its endpoint, the gateway routes it through the SOCKS
+// parent. The gateway owns the composition; the plugin only names the
+// parent (by echoing the handle).
+type HostTunnelClient interface {
+	// DialVia opens one connection THROUGH the calling tunnel's parent.
+	// The first DialMessage MUST be a DialInit whose tunnel_handle is the
+	// via_tunnel_handle from OpenTunnelRequest, and whose network/addr name
+	// the transport target ("udp"/"tcp", "host:port"). For network="udp"
+	// the byte stream carries length-prefixed datagrams (a 2-byte
+	// big-endian length per packet) so the parent can bridge to a real
+	// datagram transport (e.g. SOCKS5 UDP ASSOCIATE).
+	DialVia(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[DialMessage, DialMessage], error)
+}
+
+type hostTunnelClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewHostTunnelClient(cc grpc.ClientConnInterface) HostTunnelClient {
+	return &hostTunnelClient{cc}
+}
+
+func (c *hostTunnelClient) DialVia(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[DialMessage, DialMessage], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &HostTunnel_ServiceDesc.Streams[0], HostTunnel_DialVia_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[DialMessage, DialMessage]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type HostTunnel_DialViaClient = grpc.BidiStreamingClient[DialMessage, DialMessage]
+
+// HostTunnelServer is the server API for HostTunnel service.
+// All implementations must embed UnimplementedHostTunnelServer
+// for forward compatibility.
+//
+// HostTunnel lets a tunnel plugin route its own transport connection
+// through a PARENT tunnel (`via = <tunnel>`). Gateway-served, like
+// HostState/HostControl: the plugin is the client. The gateway resolves
+// the parent tunnel (built-in or another plugin) named by the opaque
+// via_tunnel_handle it handed the plugin at OpenTunnel, dials through it
+// (parent.Dial(network, addr)), and pumps bytes over this stream. This
+// is how WireGuard-over-SOCKS works: the WG plugin asks for a udp
+// conduit to its endpoint, the gateway routes it through the SOCKS
+// parent. The gateway owns the composition; the plugin only names the
+// parent (by echoing the handle).
+type HostTunnelServer interface {
+	// DialVia opens one connection THROUGH the calling tunnel's parent.
+	// The first DialMessage MUST be a DialInit whose tunnel_handle is the
+	// via_tunnel_handle from OpenTunnelRequest, and whose network/addr name
+	// the transport target ("udp"/"tcp", "host:port"). For network="udp"
+	// the byte stream carries length-prefixed datagrams (a 2-byte
+	// big-endian length per packet) so the parent can bridge to a real
+	// datagram transport (e.g. SOCKS5 UDP ASSOCIATE).
+	DialVia(grpc.BidiStreamingServer[DialMessage, DialMessage]) error
+	mustEmbedUnimplementedHostTunnelServer()
+}
+
+// UnimplementedHostTunnelServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedHostTunnelServer struct{}
+
+func (UnimplementedHostTunnelServer) DialVia(grpc.BidiStreamingServer[DialMessage, DialMessage]) error {
+	return status.Error(codes.Unimplemented, "method DialVia not implemented")
+}
+func (UnimplementedHostTunnelServer) mustEmbedUnimplementedHostTunnelServer() {}
+func (UnimplementedHostTunnelServer) testEmbeddedByValue()                    {}
+
+// UnsafeHostTunnelServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to HostTunnelServer will
+// result in compilation errors.
+type UnsafeHostTunnelServer interface {
+	mustEmbedUnimplementedHostTunnelServer()
+}
+
+func RegisterHostTunnelServer(s grpc.ServiceRegistrar, srv HostTunnelServer) {
+	// If the following call panics, it indicates UnimplementedHostTunnelServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&HostTunnel_ServiceDesc, srv)
+}
+
+func _HostTunnel_DialVia_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(HostTunnelServer).DialVia(&grpc.GenericServerStream[DialMessage, DialMessage]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type HostTunnel_DialViaServer = grpc.BidiStreamingServer[DialMessage, DialMessage]
+
+// HostTunnel_ServiceDesc is the grpc.ServiceDesc for HostTunnel service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var HostTunnel_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.HostTunnel",
+	HandlerType: (*HostTunnelServer)(nil),
+	Methods:     []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "DialVia",
+			Handler:       _HostTunnel_DialVia_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+	Metadata: "plugin.proto",
+}

--- a/internal/config/extplugin/tunnelvia.go
+++ b/internal/config/extplugin/tunnelvia.go
@@ -1,0 +1,140 @@
+package extplugin
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"net"
+	"sync"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// viaRegistry holds the PARENT tunnels a plugin's tunnels are chained
+// through (`via = <tunnel>`), keyed by an opaque, unguessable token the
+// gateway hands the plugin in OpenTunnelRequest.via_tunnel_handle. The
+// plugin echoes the token in a HostTunnel.DialVia call to route its own
+// transport connection through the parent; the gateway resolves the
+// parent here and dials through it. The token IS the capability — only a
+// plugin that was given a parent at OpenTunnel can reach it — so DialVia
+// needs no further session scoping.
+//
+// One registry per plugin subprocess (Client), shared between the
+// tunnelAdapter that registers parents at Open and the broker-served
+// hostTunnel that resolves them at DialVia.
+type viaRegistry struct {
+	mu sync.Mutex
+	m  map[string]runtime.Tunnel
+}
+
+func newViaRegistry() *viaRegistry {
+	return &viaRegistry{m: map[string]runtime.Tunnel{}}
+}
+
+func (r *viaRegistry) add(t runtime.Tunnel) string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	token := hex.EncodeToString(b[:])
+	r.mu.Lock()
+	r.m[token] = t
+	r.mu.Unlock()
+	return token
+}
+
+func (r *viaRegistry) get(token string) (runtime.Tunnel, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.m[token]
+	return t, ok
+}
+
+func (r *viaRegistry) remove(token string) {
+	if token == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.m, token)
+	r.mu.Unlock()
+}
+
+// hostTunnel is the gateway-served HostTunnel service: it lets a tunnel
+// plugin dial THROUGH its configured parent tunnel.
+type hostTunnel struct {
+	pb.UnimplementedHostTunnelServer
+	reg *viaRegistry
+}
+
+// DialVia resolves the parent tunnel named by the init's tunnel_handle
+// (a via token), dials through it, and pumps bytes between the plugin's
+// stream and the parent connection. For network="udp" the payloads are
+// length-prefixed datagrams end to end — the gateway is a transparent
+// byte pipe, so the parent tunnel (e.g. a SOCKS plugin) is the one that
+// reframes them onto a real datagram transport.
+func (h *hostTunnel) DialVia(stream pb.HostTunnel_DialViaServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	init := first.GetInit()
+	if init == nil {
+		return errors.New("extplugin: HostTunnel.DialVia: first message must be DialInit")
+	}
+	parent, ok := h.reg.get(init.GetTunnelHandle())
+	if !ok {
+		return errors.New("extplugin: HostTunnel.DialVia: unknown via handle (parent tunnel not open)")
+	}
+	conn, err := parent.Dial(stream.Context(), init.GetNetwork(), init.GetAddr())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	bridgeDialViaStream(stream, conn)
+	return nil
+}
+
+// bridgeDialViaStream pumps bytes both ways between a DialVia gRPC stream
+// and a parent net.Conn until either side closes.
+func bridgeDialViaStream(stream pb.HostTunnel_DialViaServer, conn net.Conn) {
+	done := make(chan struct{}, 2)
+	// conn -> stream
+	go func() {
+		buf := make([]byte, 32<<10)
+		for {
+			n, rerr := conn.Read(buf)
+			if n > 0 {
+				if serr := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+					Data: &pb.DialData{Payload: append([]byte(nil), buf[:n]...)},
+				}}); serr != nil {
+					break
+				}
+			}
+			if rerr != nil {
+				_ = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}})
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// stream -> conn
+	go func() {
+		for {
+			msg, rerr := stream.Recv()
+			if rerr != nil {
+				break
+			}
+			switch k := msg.GetKind().(type) {
+			case *pb.DialMessage_Data:
+				if _, werr := conn.Write(k.Data.GetPayload()); werr != nil {
+					break
+				}
+			case *pb.DialMessage_Close:
+				_ = conn.Close()
+			}
+		}
+		done <- struct{}{}
+	}()
+	<-done
+	_ = conn.Close()
+	<-done
+}

--- a/internal/config/extplugin/tunnelvia_test.go
+++ b/internal/config/extplugin/tunnelvia_test.go
@@ -1,0 +1,148 @@
+package extplugin
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+)
+
+// echoParent is a fake parent runtime.Tunnel: every Dial returns a conn
+// that echoes whatever is written to it. Stands in for a real parent
+// tunnel (a SOCKS plugin, ssh_port_forward, ...) in the via round-trip.
+type echoParent struct{ network, addr chan string }
+
+func (e echoParent) Dial(_ context.Context, network, addr string) (net.Conn, error) {
+	// Record what the gateway asked the parent to dial (so the test can
+	// assert the child's "udp"/endpoint request reached the parent).
+	select {
+	case e.network <- network:
+	default:
+	}
+	select {
+	case e.addr <- addr:
+	default:
+	}
+	c1, c2 := net.Pipe()
+	go func() { _, _ = io.Copy(c2, c2) }() // echo bytes written to c1
+	return c1, nil
+}
+
+func (echoParent) Close() error { return nil }
+
+// viaBrokerPlugin wires a go-plugin broker so the gateway serves
+// HostTunnel and the plugin side can call DialVia — the real path
+// req.Via.Dial takes, minus the SDK wrapper.
+type viaBrokerPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	reg      *viaRegistry
+	brokerCh chan *goplugin.GRPCBroker
+}
+
+func (p *viaBrokerPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server) error {
+	p.brokerCh <- broker // plugin side captures the broker to dial host services
+	return nil
+}
+
+func (p *viaBrokerPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		s := grpc.NewServer(opts...)
+		pb.RegisterHostTunnelServer(s, &hostTunnel{reg: p.reg})
+		return s
+	})
+	return c, nil
+}
+
+// TestDialViaRoundTrip exercises the full plugin-tunnel `via` path over a
+// real broker: the gateway registers a parent tunnel under a via token,
+// serves HostTunnel, and a chained plugin dials THROUGH the parent by
+// echoing the token to DialVia. Bytes must round-trip and the parent must
+// see the child's requested network/addr.
+func TestDialViaRoundTrip(t *testing.T) {
+	parent := echoParent{network: make(chan string, 1), addr: make(chan string, 1)}
+	reg := newViaRegistry()
+	token := reg.add(parent)
+
+	brokerCh := make(chan *goplugin.GRPCBroker, 1)
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{
+		"x": &viaBrokerPlugin{reg: reg, brokerCh: brokerCh},
+	})
+	defer func() { _ = client.Close() }()
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+
+	broker := <-brokerCh
+	conn, err := broker.Dial(HostServicesBrokerID)
+	if err != nil {
+		t.Fatalf("dial host services: %v", err)
+	}
+	cli := pb.NewHostTunnelClient(conn)
+	stream, err := cli.DialVia(context.Background())
+	if err != nil {
+		t.Fatalf("DialVia: %v", err)
+	}
+	// The child names its parent (the token) and the transport it wants —
+	// here a udp conduit to a WireGuard endpoint.
+	if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+		TunnelHandle: token, Network: "udp", Addr: "wg.example:51820",
+	}}}); err != nil {
+		t.Fatalf("send init: %v", err)
+	}
+	if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+		Data: &pb.DialData{Payload: []byte("handshake")},
+	}}); err != nil {
+		t.Fatalf("send data: %v", err)
+	}
+
+	got := recvData(t, stream)
+	if string(got) != "handshake" {
+		t.Fatalf("echoed payload = %q, want %q", got, "handshake")
+	}
+
+	// The gateway must have asked the PARENT to dial what the child named.
+	select {
+	case n := <-parent.network:
+		if n != "udp" {
+			t.Fatalf("parent dialed network %q, want udp", n)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("parent.Dial was never called")
+	}
+	if a := <-parent.addr; a != "wg.example:51820" {
+		t.Fatalf("parent dialed addr %q, want wg.example:51820", a)
+	}
+
+	// An unknown via token must be refused (capability check).
+	bad, _ := cli.DialVia(context.Background())
+	_ = bad.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+		TunnelHandle: "not-a-real-token", Network: "tcp", Addr: "x:1",
+	}}})
+	if _, err := bad.Recv(); err == nil {
+		t.Fatal("DialVia with unknown token should fail")
+	}
+}
+
+func recvData(t *testing.T, stream pb.HostTunnel_DialViaClient) []byte {
+	t.Helper()
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch k := msg.GetKind().(type) {
+		case *pb.DialMessage_Data:
+			return k.Data.GetPayload()
+		case *pb.DialMessage_Close:
+			t.Fatal("got Close before Data")
+		}
+	}
+}
+
+var _ runtime.Tunnel = echoParent{}

--- a/pluginsdk/datagram.go
+++ b/pluginsdk/datagram.go
@@ -1,0 +1,90 @@
+package pluginsdk
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Datagram framing for carrying UDP packets over a byte stream (a `via`
+// conduit through a parent tunnel). Each datagram is a 2-byte big-endian
+// length followed by that many payload bytes. Both ends of a chained
+// udp-via must use this framing: the child (e.g. WireGuard) writes/reads
+// packets, and the parent (e.g. a SOCKS plugin) reframes them onto a real
+// datagram transport. 16-bit length caps a datagram at 65535 bytes, which
+// covers any UDP payload.
+
+const maxDatagram = 0xffff
+
+// WriteDatagram writes one length-prefixed datagram to w.
+func WriteDatagram(w io.Writer, p []byte) error {
+	if len(p) > maxDatagram {
+		p = p[:maxDatagram]
+	}
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(p)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(p)
+	return err
+}
+
+// ReadDatagram reads one length-prefixed datagram from r.
+func ReadDatagram(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint16(hdr[:])
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// PacketConnOverStream presents a byte stream carrying length-prefixed
+// datagrams (see WriteDatagram/ReadDatagram) as a connected
+// net.PacketConn. The remote address is fixed (the stream already routes
+// to one endpoint), so the addr argument to WriteTo is ignored and
+// ReadFrom always reports remote. This is what a WireGuard plugin wraps
+// its `via` conduit in so wireguard-go's bind can speak datagrams over a
+// chained tunnel.
+func PacketConnOverStream(conn net.Conn, remote net.Addr) net.PacketConn {
+	return &packetConnOverStream{conn: conn, remote: remote}
+}
+
+type packetConnOverStream struct {
+	conn   net.Conn
+	remote net.Addr
+	rMu    sync.Mutex
+	wMu    sync.Mutex
+}
+
+func (p *packetConnOverStream) ReadFrom(b []byte) (int, net.Addr, error) {
+	p.rMu.Lock()
+	defer p.rMu.Unlock()
+	d, err := ReadDatagram(p.conn)
+	if err != nil {
+		return 0, nil, err
+	}
+	return copy(b, d), p.remote, nil
+}
+
+func (p *packetConnOverStream) WriteTo(b []byte, _ net.Addr) (int, error) {
+	p.wMu.Lock()
+	defer p.wMu.Unlock()
+	if err := WriteDatagram(p.conn, b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (p *packetConnOverStream) Close() error                       { return p.conn.Close() }
+func (p *packetConnOverStream) LocalAddr() net.Addr                { return p.conn.LocalAddr() }
+func (p *packetConnOverStream) SetDeadline(t time.Time) error      { return p.conn.SetDeadline(t) }
+func (p *packetConnOverStream) SetReadDeadline(t time.Time) error  { return p.conn.SetReadDeadline(t) }
+func (p *packetConnOverStream) SetWriteDeadline(t time.Time) error { return p.conn.SetWriteDeadline(t) }

--- a/pluginsdk/datagram_test.go
+++ b/pluginsdk/datagram_test.go
@@ -1,0 +1,58 @@
+package pluginsdk
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+// Datagram framing must round-trip exactly — both the WireGuard plugin
+// (writes/reads packets over its `via` conduit) and the SOCKS plugin
+// (reframes them onto a UDP relay) depend on this byte-for-byte.
+func TestDatagramRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	packets := [][]byte{
+		[]byte("first"),
+		{},                               // empty datagram
+		bytes.Repeat([]byte{0xab}, 1500), // jumbo-ish
+		[]byte("last"),
+	}
+	for _, p := range packets {
+		if err := WriteDatagram(&buf, p); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for i, want := range packets {
+		got, err := ReadDatagram(&buf)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("datagram %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// PacketConnOverStream presents the framed stream as a connected
+// net.PacketConn (what the WG plugin wraps its via conduit in).
+func TestPacketConnOverStream(t *testing.T) {
+	a, b := net.Pipe()
+	remote := &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 51820}
+	pcA := PacketConnOverStream(a, remote)
+	pcB := PacketConnOverStream(b, remote)
+
+	want := []byte("wireguard handshake bytes")
+	go func() { _, _ = pcA.WriteTo(want, remote) }()
+
+	buf := make([]byte, 1500)
+	n, addr, err := pcB.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("readfrom: %v", err)
+	}
+	if !bytes.Equal(buf[:n], want) {
+		t.Fatalf("got %q, want %q", buf[:n], want)
+	}
+	if addr.String() != remote.String() {
+		t.Fatalf("addr = %s, want %s", addr, remote)
+	}
+}

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -629,6 +629,14 @@ type TunnelOpenRequest struct {
 	CanonicalConfig  []byte
 	CredentialSecret []byte
 	CredentialExtras map[string]string
+	// Via is non-nil when this tunnel is chained through a PARENT tunnel
+	// (`via = <tunnel>` in the gateway config). Use it inside Open to route
+	// this tunnel's own transport connection through the parent instead of
+	// dialing it directly: a WireGuard tunnel asks Via for a "udp" conduit
+	// to its endpoint; an SSH tunnel asks for a "tcp" conn to its bastion.
+	// nil means no parent — dial the transport directly (the plugin holds
+	// the outbound network capability). The gateway owns the composition.
+	Via *TunnelVia
 }
 
 // TunnelDialRequest is what Dial callbacks receive when the gateway

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -1014,6 +1014,7 @@ func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb
 		CanonicalConfig:  req.CanonicalJson,
 		CredentialSecret: req.CredentialSecret,
 		CredentialExtras: req.CredentialExtras,
+		Via:              newTunnelVia(req.GetViaTunnelHandle()),
 	}
 	var (
 		handle any

--- a/pluginsdk/socks/main.go
+++ b/pluginsdk/socks/main.go
@@ -1,0 +1,356 @@
+// Standalone clawpatrol tunnel plugin: route upstream connections
+// through a SOCKS5 proxy. Spike — demonstrates the plugin tunnel `via`
+// surface as a PARENT tunnel, including carrying UDP (so a WireGuard
+// tunnel can chain `via = socks`).
+//
+// TCP upstreams use SOCKS5 CONNECT. "udp" dials (a chained child asking
+// for a datagram conduit) use SOCKS5 UDP ASSOCIATE; the child's bytes are
+// length-prefixed datagrams (pluginsdk.ReadDatagram/WriteDatagram) which
+// this plugin reframes onto the proxy's UDP relay.
+//
+// Build: go build -o socks-tunnel ./pluginsdk/socks
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name:    "socks_tunnel",
+		Version: "0.1",
+		// The plugin dials the SOCKS proxy itself (and, for udp, a relay
+		// socket), so it needs outbound network.
+		Capabilities: pluginsdk.Capabilities{Network: pluginsdk.NetworkOutbound},
+		Tunnels:      []pluginsdk.TunnelDef{socksDef()},
+	})
+}
+
+type socksConfig struct {
+	Proxy    string `json:"proxy"`    // host:port of the SOCKS5 server
+	Username string `json:"username"` // optional user/pass auth
+	Password string `json:"password"`
+}
+
+func socksDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "socks_proxy",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "proxy", TypeString: "string", Required: true},
+			{Name: "username", TypeString: "string"},
+			{Name: "password", TypeString: "string"},
+		}},
+		Open: func(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+			var cfg socksConfig
+			if len(req.CanonicalConfig) > 0 {
+				if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+					return nil, fmt.Errorf("socks_proxy config: %w", err)
+				}
+			}
+			if cfg.Proxy == "" {
+				return nil, errors.New("socks_proxy: proxy is required")
+			}
+			return &cfg, nil
+		},
+		Dial: func(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+			cfg, _ := req.Handle.(*socksConfig)
+			if cfg == nil {
+				return errors.New("socks_proxy: missing handle")
+			}
+			switch req.Network {
+			case "", "tcp":
+				return socksDialTCP(ctx, cfg, req.Addr, upstream)
+			case "udp":
+				return socksDialUDP(ctx, cfg, req.Addr, upstream)
+			default:
+				return fmt.Errorf("socks_proxy: unsupported network %q", req.Network)
+			}
+		},
+		Close: func(_ context.Context, _ any) error { return nil },
+	}
+}
+
+// ---- TCP: SOCKS5 CONNECT, then pump bytes ----
+
+func socksDialTCP(_ context.Context, cfg *socksConfig, addr string, upstream net.Conn) error {
+	c, err := net.Dial("tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+	if err := socksHandshake(c, cfg); err != nil {
+		return err
+	}
+	if _, err := socksRequest(c, cmdConnect, addr); err != nil {
+		return fmt.Errorf("socks CONNECT %s: %w", addr, err)
+	}
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+// ---- UDP: SOCKS5 UDP ASSOCIATE, datagram-framed over `upstream` ----
+
+func socksDialUDP(_ context.Context, cfg *socksConfig, target string, upstream net.Conn) error {
+	// The TCP control connection must stay open for the lifetime of the
+	// association — closing it tells the proxy to drop the UDP relay.
+	ctrl, err := net.Dial("tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = ctrl.Close() }()
+	if err := socksHandshake(ctrl, cfg); err != nil {
+		return err
+	}
+	relayStr, err := socksRequest(ctrl, cmdUDPAssociate, "0.0.0.0:0")
+	if err != nil {
+		return fmt.Errorf("socks UDP ASSOCIATE: %w", err)
+	}
+	relay, err := net.ResolveUDPAddr("udp", relayStr)
+	if err != nil {
+		return fmt.Errorf("resolve socks relay %q: %w", relayStr, err)
+	}
+	uc, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		return fmt.Errorf("listen udp: %w", err)
+	}
+	defer func() { _ = uc.Close() }()
+
+	hdr, err := socksUDPHeader(target)
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{}, 3)
+	// upstream datagrams -> SOCKS relay (prepend the UDP request header)
+	go func() {
+		for {
+			d, rerr := pluginsdk.ReadDatagram(upstream)
+			if rerr != nil {
+				break
+			}
+			pkt := append(append([]byte(nil), hdr...), d...)
+			if _, werr := uc.WriteToUDP(pkt, relay); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// SOCKS relay -> upstream datagrams (strip the UDP reply header)
+	go func() {
+		buf := make([]byte, 64<<10)
+		for {
+			n, _, rerr := uc.ReadFromUDP(buf)
+			if rerr != nil {
+				break
+			}
+			payload, ok := stripSocksUDPHeader(buf[:n])
+			if !ok {
+				continue
+			}
+			if werr := pluginsdk.WriteDatagram(upstream, payload); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// The control conn closing (proxy dropped the association) ends it.
+	go func() {
+		var b [1]byte
+		_, _ = ctrl.Read(b[:])
+		done <- struct{}{}
+	}()
+	<-done
+	return nil
+}
+
+// ---- SOCKS5 wire format (RFC 1928) ----
+
+const (
+	socksVer        = 0x05
+	cmdConnect      = 0x01
+	cmdUDPAssociate = 0x03
+	atypIPv4        = 0x01
+	atypDomain      = 0x03
+	atypIPv6        = 0x04
+)
+
+func socksHandshake(c net.Conn, cfg *socksConfig) error {
+	useAuth := cfg.Username != ""
+	methods := []byte{0x00}
+	if useAuth {
+		methods = []byte{0x02}
+	}
+	greeting := append([]byte{socksVer, byte(len(methods))}, methods...)
+	if _, err := c.Write(greeting); err != nil {
+		return err
+	}
+	var sel [2]byte
+	if _, err := io.ReadFull(c, sel[:]); err != nil {
+		return err
+	}
+	if sel[0] != socksVer {
+		return fmt.Errorf("socks: bad version %d", sel[0])
+	}
+	switch sel[1] {
+	case 0x00:
+		return nil
+	case 0x02:
+		return socksUserPassAuth(c, cfg)
+	default:
+		return fmt.Errorf("socks: no acceptable auth method (got %d)", sel[1])
+	}
+}
+
+func socksUserPassAuth(c net.Conn, cfg *socksConfig) error {
+	msg := []byte{0x01, byte(len(cfg.Username))}
+	msg = append(msg, cfg.Username...)
+	msg = append(msg, byte(len(cfg.Password)))
+	msg = append(msg, cfg.Password...)
+	if _, err := c.Write(msg); err != nil {
+		return err
+	}
+	var resp [2]byte
+	if _, err := io.ReadFull(c, resp[:]); err != nil {
+		return err
+	}
+	if resp[1] != 0x00 {
+		return errors.New("socks: user/pass auth failed")
+	}
+	return nil
+}
+
+// socksRequest sends a CONNECT or UDP ASSOCIATE request for addr and
+// returns the bound address from the reply ("host:port").
+func socksRequest(c net.Conn, cmd byte, addr string) (string, error) {
+	dst, err := encodeSocksAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	req := append([]byte{socksVer, cmd, 0x00}, dst...)
+	if _, err := c.Write(req); err != nil {
+		return "", err
+	}
+	// Reply: VER REP RSV ATYP BND.ADDR BND.PORT
+	var head [4]byte
+	if _, err := io.ReadFull(c, head[:]); err != nil {
+		return "", err
+	}
+	if head[1] != 0x00 {
+		return "", fmt.Errorf("socks reply code %d", head[1])
+	}
+	host, err := readSocksAddr(c, head[3])
+	if err != nil {
+		return "", err
+	}
+	var port [2]byte
+	if _, err := io.ReadFull(c, port[:]); err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(port[:])))), nil
+}
+
+// socksUDPHeader builds the per-datagram SOCKS UDP request header for a
+// fixed target: RSV(2)=0 FRAG=0 ATYP DST.ADDR DST.PORT.
+func socksUDPHeader(target string) ([]byte, error) {
+	dst, err := encodeSocksAddr(target)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{0x00, 0x00, 0x00}, dst...), nil
+}
+
+// stripSocksUDPHeader removes the SOCKS UDP reply header, returning the
+// inner payload.
+func stripSocksUDPHeader(b []byte) ([]byte, bool) {
+	if len(b) < 4 {
+		return nil, false
+	}
+	// b[0:2]=RSV, b[2]=FRAG, b[3]=ATYP
+	off := 4
+	switch b[3] {
+	case atypIPv4:
+		off += 4
+	case atypIPv6:
+		off += 16
+	case atypDomain:
+		if len(b) < 5 {
+			return nil, false
+		}
+		off += 1 + int(b[4])
+	default:
+		return nil, false
+	}
+	off += 2 // port
+	if off > len(b) {
+		return nil, false
+	}
+	return b[off:], true
+}
+
+func encodeSocksAddr(addr string) ([]byte, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	var out []byte
+	if ip := net.ParseIP(host); ip != nil {
+		if v4 := ip.To4(); v4 != nil {
+			out = append([]byte{atypIPv4}, v4...)
+		} else {
+			out = append([]byte{atypIPv6}, ip.To16()...)
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("socks: host too long")
+		}
+		out = append([]byte{atypDomain, byte(len(host))}, host...)
+	}
+	var port [2]byte
+	binary.BigEndian.PutUint16(port[:], uint16(p))
+	return append(out, port[:]...), nil
+}
+
+func readSocksAddr(c net.Conn, atyp byte) (string, error) {
+	switch atyp {
+	case atypIPv4:
+		var b [4]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case atypIPv6:
+		var b [16]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case atypDomain:
+		var l [1]byte
+		if _, err := io.ReadFull(c, l[:]); err != nil {
+			return "", err
+		}
+		b := make([]byte, l[0])
+		if _, err := io.ReadFull(c, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		return "", fmt.Errorf("socks: bad atyp %d", atyp)
+	}
+}

--- a/pluginsdk/socks/main.go
+++ b/pluginsdk/socks/main.go
@@ -117,9 +117,18 @@ func socksDialUDP(_ context.Context, cfg *socksConfig, target string, upstream n
 	if err != nil {
 		return fmt.Errorf("socks UDP ASSOCIATE: %w", err)
 	}
-	relay, err := net.ResolveUDPAddr("udp", relayStr)
+	// The reply's BND.ADDR is frequently unspecified (0.0.0.0) or an
+	// internal address when the proxy sits behind NAT (e.g. a cloud VM
+	// returning its private IP). The UDP relay lives on the proxy host, so
+	// fall back to the proxy's host with the returned port unless the reply
+	// names a concrete, routable address.
+	relayHost, relayPort, _ := net.SplitHostPort(relayStr)
+	if ip := net.ParseIP(relayHost); ip == nil || ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() {
+		relayHost, _, _ = net.SplitHostPort(cfg.Proxy)
+	}
+	relay, err := net.ResolveUDPAddr("udp", net.JoinHostPort(relayHost, relayPort))
 	if err != nil {
-		return fmt.Errorf("resolve socks relay %q: %w", relayStr, err)
+		return fmt.Errorf("resolve socks relay %q: %w", net.JoinHostPort(relayHost, relayPort), err)
 	}
 	uc, err := net.ListenUDP("udp", nil)
 	if err != nil {

--- a/pluginsdk/tunnelvia.go
+++ b/pluginsdk/tunnelvia.go
@@ -1,0 +1,147 @@
+package pluginsdk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+// TunnelVia routes a chained tunnel's own transport connection through
+// its parent tunnel (`via = <tunnel>`). The gateway hands the plugin an
+// opaque handle at OpenTunnel; Dial echoes it to the gateway's
+// HostTunnel.DialVia, which resolves the parent and dials through it.
+//
+// network is "tcp" for a stream transport (SSH bastion) or "udp" for a
+// datagram transport (WireGuard endpoint). For "udp" the returned conn
+// carries length-prefixed datagrams: write one whole packet per Write,
+// read one whole packet per Read (the SDK frames them on the wire; see
+// PacketConnOverStream for a net.PacketConn view).
+type TunnelVia struct {
+	handle string
+}
+
+func newTunnelVia(handle string) *TunnelVia {
+	if handle == "" {
+		return nil
+	}
+	return &TunnelVia{handle: handle}
+}
+
+// Dial opens one connection through the parent tunnel. The returned conn
+// is a byte stream; for network="udp" it carries length-prefixed
+// datagrams (use PacketConnOverStream to get a net.PacketConn).
+func (v *TunnelVia) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	cli, err := hostTunnelClient()
+	if err != nil {
+		return nil, err
+	}
+	stream, err := cli.DialVia(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+		TunnelHandle: v.handle,
+		Network:      network,
+		Addr:         addr,
+	}}}); err != nil {
+		return nil, err
+	}
+	return &viaConn{stream: stream, addr: addr}, nil
+}
+
+func hostTunnelClient() (pb.HostTunnelClient, error) {
+	c, err := hostServicesConn()
+	if err != nil {
+		return nil, err
+	}
+	return pb.NewHostTunnelClient(c), nil
+}
+
+// viaConn wraps a HostTunnel.DialVia bidi stream as a net.Conn (the
+// client-side mirror of the gateway's dialConn).
+type viaConn struct {
+	stream pb.HostTunnel_DialViaClient
+	addr   string
+
+	mu      sync.Mutex
+	readBuf []byte
+	closed  bool
+	wMu     sync.Mutex
+	once    sync.Once
+}
+
+func (c *viaConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	if len(c.readBuf) > 0 {
+		n := copy(p, c.readBuf)
+		c.readBuf = c.readBuf[n:]
+		c.mu.Unlock()
+		return n, nil
+	}
+	c.mu.Unlock()
+	for {
+		msg, err := c.stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+		switch k := msg.GetKind().(type) {
+		case *pb.DialMessage_Data:
+			n := copy(p, k.Data.Payload)
+			if n < len(k.Data.Payload) {
+				c.mu.Lock()
+				c.readBuf = append(c.readBuf, k.Data.Payload[n:]...)
+				c.mu.Unlock()
+			}
+			return n, nil
+		case *pb.DialMessage_Close:
+			return 0, io.EOF
+		}
+	}
+}
+
+func (c *viaConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	c.mu.Unlock()
+	c.wMu.Lock()
+	defer c.wMu.Unlock()
+	if err := c.stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+		Data: &pb.DialData{Payload: append([]byte(nil), p...)},
+	}}); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *viaConn) Close() error {
+	c.once.Do(func() {
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
+		_ = c.stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}})
+		_ = c.stream.CloseSend()
+	})
+	return nil
+}
+
+func (c *viaConn) LocalAddr() net.Addr                { return viaAddr("via") }
+func (c *viaConn) RemoteAddr() net.Addr               { return viaAddr(c.addr) }
+func (c *viaConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *viaConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *viaConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type viaAddr string
+
+func (a viaAddr) Network() string { return "plugin-tunnel-via" }
+func (a viaAddr) String() string  { return string(a) }

--- a/pluginsdk/wireguard/main.go
+++ b/pluginsdk/wireguard/main.go
@@ -1,0 +1,283 @@
+// Standalone clawpatrol tunnel plugin: route upstream connections
+// through a WireGuard tunnel. Spike — demonstrates a UDP-transport plugin
+// tunnel that also supports `via` chaining (e.g. `via = socks`, so the
+// WireGuard handshake's UDP rides over a SOCKS5 UDP relay).
+//
+// Mechanism: an in-process wireguard-go device over a gVisor netstack
+// (golang.zx2c4.com/wireguard/tun/netstack). Each Dial opens a TCP
+// connection over the WG netstack. The hard part is the transport — WG is
+// UDP. Direct: wireguard-go's default UDP bind dials the endpoint. Via:
+// point the device at a local relay socket and bridge that socket to the
+// parent tunnel's datagram conduit (req.Via.Dial(ctx, "udp", endpoint)),
+// so the WG UDP packets travel through the parent.
+//
+// Build: go build -o wireguard-tunnel ./pluginsdk/wireguard
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name:    "wireguard_tunnel",
+		Version: "0.1",
+		// Direct mode dials the WG endpoint over real UDP; via mode dials
+		// the parent. Either way the plugin needs outbound network.
+		Capabilities: pluginsdk.Capabilities{Network: pluginsdk.NetworkOutbound},
+		Tunnels:      []pluginsdk.TunnelDef{wireguardDef()},
+	})
+}
+
+type wgConfig struct {
+	Endpoint      string `json:"endpoint"`        // host:port of the WG server
+	PrivateKey    string `json:"private_key"`     // base64 (wg-quick form)
+	PeerPublicKey string `json:"peer_public_key"` // base64
+	Address       string `json:"address"`         // this peer's IP in the WG net
+	DNS           string `json:"dns"`             // optional in-tunnel resolver
+}
+
+type wgHandle struct {
+	dev   *device.Device
+	tnet  *netstack.Net
+	relay *net.UDPConn // non-nil in via mode (the local WG<->via bridge socket)
+	via   net.Conn     // non-nil in via mode (datagram conduit through parent)
+}
+
+func wireguardDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "wireguard",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "endpoint", TypeString: "string", Required: true},
+			{Name: "private_key", TypeString: "string", Required: true},
+			{Name: "peer_public_key", TypeString: "string", Required: true},
+			{Name: "address", TypeString: "string", Required: true},
+			{Name: "dns", TypeString: "string"},
+		}},
+		Open:  wireguardOpen,
+		Dial:  wireguardDial,
+		Close: wireguardClose,
+	}
+}
+
+func wireguardOpen(ctx context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+	var cfg wgConfig
+	if len(req.CanonicalConfig) > 0 {
+		if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+			return nil, fmt.Errorf("wireguard config: %w", err)
+		}
+	}
+	if cfg.Endpoint == "" || cfg.PrivateKey == "" || cfg.PeerPublicKey == "" || cfg.Address == "" {
+		return nil, errors.New("wireguard: endpoint, private_key, peer_public_key, address are required")
+	}
+	clientAddr, err := netip.ParseAddr(cfg.Address)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard address %q: %w", cfg.Address, err)
+	}
+	var dns []netip.Addr
+	if cfg.DNS != "" {
+		d, err := netip.ParseAddr(cfg.DNS)
+		if err != nil {
+			return nil, fmt.Errorf("wireguard dns %q: %w", cfg.DNS, err)
+		}
+		dns = append(dns, d)
+	}
+
+	tunDev, tnet, err := netstack.CreateNetTUN([]netip.Addr{clientAddr}, dns, 1420)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard netstack: %w", err)
+	}
+	h := &wgHandle{tnet: tnet}
+
+	// Determine the UDP endpoint the wireguard-go device dials. Direct: the
+	// resolved real endpoint. Via: a local relay socket we bridge to the
+	// parent tunnel's datagram conduit.
+	var deviceEndpoint string
+	if req.Via != nil {
+		via, err := req.Via.Dial(ctx, "udp", cfg.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("wireguard via dial: %w", err)
+		}
+		relay, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		if err != nil {
+			_ = via.Close()
+			return nil, fmt.Errorf("wireguard relay socket: %w", err)
+		}
+		h.via, h.relay = via, relay
+		deviceEndpoint = relay.LocalAddr().String()
+		go bridgeWGToVia(relay, via)
+	} else {
+		ep, err := net.ResolveUDPAddr("udp", cfg.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("wireguard resolve endpoint %q: %w", cfg.Endpoint, err)
+		}
+		deviceEndpoint = ep.String()
+	}
+
+	dev := device.NewDevice(tunDev, conn.NewDefaultBind(),
+		device.NewLogger(device.LogLevelError, "[wireguard-plugin] "))
+	uapi, err := buildWGIpc(cfg, deviceEndpoint)
+	if err != nil {
+		dev.Close()
+		return nil, err
+	}
+	if err := dev.IpcSet(uapi); err != nil {
+		dev.Close()
+		return nil, fmt.Errorf("wireguard IpcSet: %w", err)
+	}
+	if err := dev.Up(); err != nil {
+		dev.Close()
+		return nil, fmt.Errorf("wireguard up: %w", err)
+	}
+	h.dev = dev
+	return h, nil
+}
+
+func wireguardDial(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+	h, _ := req.Handle.(*wgHandle)
+	if h == nil {
+		return errors.New("wireguard: missing handle")
+	}
+	addrPort, err := resolveInTunnel(h.tnet, req.Addr)
+	if err != nil {
+		return err
+	}
+	c, err := h.tnet.DialContextTCPAddrPort(ctx, addrPort)
+	if err != nil {
+		return fmt.Errorf("wireguard dial %s: %w", req.Addr, err)
+	}
+	defer func() { _ = c.Close() }()
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+func wireguardClose(_ context.Context, handle any) error {
+	h, _ := handle.(*wgHandle)
+	if h == nil {
+		return nil
+	}
+	if h.dev != nil {
+		h.dev.Close()
+	}
+	if h.relay != nil {
+		_ = h.relay.Close()
+	}
+	if h.via != nil {
+		_ = h.via.Close()
+	}
+	return nil
+}
+
+// bridgeWGToVia couples the wireguard-go device's local UDP socket (which
+// sends to `relay`) with the parent tunnel's datagram conduit. WG packets
+// arriving at the relay are framed onto the via conduit; datagrams from
+// the conduit are delivered back to the device's source address.
+func bridgeWGToVia(relay *net.UDPConn, via net.Conn) {
+	var (
+		mu    sync.Mutex
+		wgSrc *net.UDPAddr
+	)
+	go func() {
+		buf := make([]byte, 64<<10)
+		for {
+			n, src, err := relay.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			wgSrc = src
+			mu.Unlock()
+			if err := pluginsdk.WriteDatagram(via, buf[:n]); err != nil {
+				return
+			}
+		}
+	}()
+	for {
+		d, err := pluginsdk.ReadDatagram(via)
+		if err != nil {
+			return
+		}
+		mu.Lock()
+		dst := wgSrc
+		mu.Unlock()
+		if dst != nil {
+			_, _ = relay.WriteToUDP(d, dst)
+		}
+	}
+}
+
+// buildWGIpc renders the wireguard-go IpcSet payload (keys are base64 in
+// config, hex on the wire). 0.0.0.0/0 allowed-ips + a forced keepalive so
+// the handshake runs eagerly.
+func buildWGIpc(cfg wgConfig, endpoint string) (string, error) {
+	privHex, err := base64ToHex(cfg.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("wireguard private_key: %w", err)
+	}
+	pubHex, err := base64ToHex(cfg.PeerPublicKey)
+	if err != nil {
+		return "", fmt.Errorf("wireguard peer_public_key: %w", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "private_key=%s\n", privHex)
+	fmt.Fprintf(&b, "replace_peers=true\n")
+	fmt.Fprintf(&b, "public_key=%s\n", pubHex)
+	fmt.Fprintf(&b, "endpoint=%s\n", endpoint)
+	fmt.Fprintf(&b, "persistent_keepalive_interval=25\n")
+	fmt.Fprintf(&b, "allowed_ip=0.0.0.0/0\n")
+	fmt.Fprintf(&b, "allowed_ip=::/0\n")
+	return b.String(), nil
+}
+
+func base64ToHex(b64 string) (string, error) {
+	dec, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(dec), nil
+}
+
+// resolveInTunnel turns "host:port" into a netip.AddrPort, resolving a
+// hostname through the WG netstack's resolver when needed (spike: the
+// common case is the gateway handing us an ip:port).
+func resolveInTunnel(tnet *netstack.Net, addr string) (netip.AddrPort, error) {
+	if ap, err := netip.ParseAddrPort(addr); err == nil {
+		return ap, nil
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("wireguard addr %q: %w", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("wireguard port %q: %w", portStr, err)
+	}
+	hosts, err := tnet.LookupHost(host)
+	if err != nil || len(hosts) == 0 {
+		return netip.AddrPort{}, fmt.Errorf("wireguard resolve %q: %w", host, err)
+	}
+	ip, err := netip.ParseAddr(hosts[0])
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	return netip.AddrPortFrom(ip, uint16(port)), nil
+}

--- a/pluginsdk/wireguard/main.go
+++ b/pluginsdk/wireguard/main.go
@@ -54,10 +54,11 @@ type wgConfig struct {
 }
 
 type wgHandle struct {
-	dev   *device.Device
-	tnet  *netstack.Net
-	relay *net.UDPConn // non-nil in via mode (the local WG<->via bridge socket)
-	via   net.Conn     // non-nil in via mode (datagram conduit through parent)
+	dev       *device.Device
+	tnet      *netstack.Net
+	relay     *net.UDPConn       // non-nil in via mode (local WG<->via bridge socket)
+	via       net.Conn           // non-nil in via mode (datagram conduit through parent)
+	viaCancel context.CancelFunc // cancels the via conduit's context on Close
 }
 
 func wireguardDef() pluginsdk.TunnelDef {
@@ -76,7 +77,7 @@ func wireguardDef() pluginsdk.TunnelDef {
 	}
 }
 
-func wireguardOpen(ctx context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+func wireguardOpen(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
 	var cfg wgConfig
 	if len(req.CanonicalConfig) > 0 {
 		if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
@@ -110,8 +111,16 @@ func wireguardOpen(ctx context.Context, req pluginsdk.TunnelOpenRequest) (any, e
 	// parent tunnel's datagram conduit.
 	var deviceEndpoint string
 	if req.Via != nil {
-		via, err := req.Via.Dial(ctx, "udp", cfg.Endpoint)
+		// The via conduit must outlive this Open call — it carries the WG
+		// transport for the tunnel's whole lifetime. The OpenTunnel request
+		// ctx is cancelled the moment Open returns, which would tear the
+		// DialVia stream down immediately; use a tunnel-lifetime context
+		// cancelled on Close instead.
+		dialCtx, cancel := context.WithCancel(context.Background())
+		h.viaCancel = cancel
+		via, err := req.Via.Dial(dialCtx, "udp", cfg.Endpoint)
 		if err != nil {
+			cancel()
 			return nil, fmt.Errorf("wireguard via dial: %w", err)
 		}
 		relay, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
@@ -180,6 +189,9 @@ func wireguardClose(_ context.Context, handle any) error {
 	}
 	if h.relay != nil {
 		_ = h.relay.Close()
+	}
+	if h.viaCancel != nil {
+		h.viaCancel()
 	}
 	if h.via != nil {
 		_ = h.via.Close()


### PR DESCRIPTION
**Spike / RFC — not for merge as-is.** Explores `via`-chaining for
external plugin tunnels (the deferred #705), with the wrinkle that
WireGuard is UDP and "via a SOCKS proxy" means carrying UDP over a
TCP-ish tunnel. Two example plugins are the real second consumer that
justifies building the interface.

## The interface

* `OpenTunnelRequest.via_tunnel_handle` + a gateway-served
  `HostTunnel.DialVia` stream (reuses `DialMessage`). When a plugin
  tunnel is chained, the gateway registers the already-acquired parent
  under an opaque token and hands it to the plugin; the plugin routes
  its transport through the parent by echoing the token to `DialVia`.
  The gateway resolves the parent (built-in or plugin) and dials
  through it — it owns the composition, the plugin just names the
  parent. This plugs into the existing `TunnelManager.Acquire`
  via-chain machinery; `tunnelAdapter.Open` previously dropped the
  `via` arg.
* SDK: `TunnelOpenRequest.Via` dialer (`req.Via.Dial(ctx, "udp",
  endpoint)`), nil when not chained.

## The UDP answer

No datagram proto. The tunnel `Dial` path already forwards a `network`
string, so `network="udp"` + a shared length-prefixed datagram framing
(`pluginsdk.WriteDatagram`/`ReadDatagram`, `PacketConnOverStream`) lets
the existing byte stream carry datagrams; the parent reframes them onto
a real datagram transport.

## The plugins

* **socks** — hand-rolled SOCKS5. `tcp` = CONNECT; `udp` = UDP
  ASSOCIATE, reframing the datagram-framed upstream onto the proxy's
  UDP relay. Works as a `via` parent.
* **wireguard** — wireguard-go + gVisor netstack
  (`netstack.CreateNetTUN`); `Dial` is TCP over the WG netstack. In
  `via` mode it points the WG device's normal UDP bind at a local relay
  socket bridged to `req.Via.Dial("udp", endpoint)`, so WG's handshake
  UDP rides the parent with no custom `conn.Bind`.

Enables:

```hcl
tunnel "socks_proxy" "corp" { proxy = "socks.corp:1080" }
tunnel "wireguard" "vpn" {
  endpoint = "wg.corp:51820"  address = "10.8.0.2"
  private_key = "…"  peer_public_key = "…"
  via = socks_proxy.corp
}
endpoint "https" "api" { hosts = ["api.internal"]  tunnel = wireguard.vpn }
```

## State

Builds (darwin + linux), gofmt + golangci-lint clean, no regressions.
Tested: datagram round-trip; full `DialVia` via round-trip over a real
go-plugin broker (parent receives the child's `udp`/endpoint request,
unknown token refused).

Not done: the live WG-over-SOCKS datapath against real peers; built-in
tunnels as udp `via` parents; MTU/fragmentation; the broker double-hop
for via-UDP is a spike simplification.