### PR TITLE
extplugin: brokered transport dial for tunnel plugins (via + UDP)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3093,6 +3093,12 @@ func runGateway(args []string) {
 		onboard:   newOnboardRegistry(),
 	}
 	g.cfg.Store(cfg)
+	// A tunnel plugin opens its transport through the gateway's brokered
+	// dial (HostTunnel.DialUpstream); when the tunnel has no `via` parent
+	// the gateway dials it directly with its own upstream dialer.
+	pluginMgr.SetTransportDialer(func(network, addr string) (net.Conn, error) {
+		return g.dialer.Dial(network, addr)
+	})
 	if cfg.DashboardConfigWrites() {
 		log.Printf("config: dashboard writes enabled (generated rules can be appended to gateway.hcl)")
 	} else {

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -881,6 +881,16 @@ type dynamicTunnelBody struct {
 	canonicalJSON []byte
 }
 
+// dynamicTunnelBody is the CompiledTunnel.Body for a plugin tunnel; it
+// implements runtime.TunnelRuntime by delegating to its adapter so the
+// gateway's TunnelManager.Acquire can Open it (and thread a `via` parent)
+// exactly like a built-in tunnel.
+func (b *dynamicTunnelBody) Sharing() runtime.TunnelSharing { return b.adapter.Sharing() }
+
+func (b *dynamicTunnelBody) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
+	return b.adapter.Open(ctx, host, via)
+}
+
 // tunnelAdapter implements runtime.TunnelRuntime via OpenTunnel /
 // Dial / CloseTunnel RPCs.
 type tunnelAdapter struct {
@@ -890,10 +900,21 @@ type tunnelAdapter struct {
 
 func (a *tunnelAdapter) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
 
-func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ runtime.Tunnel) (runtime.Tunnel, error) {
+func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
 	body, ok := tunnelBodyOf(host)
 	if !ok {
 		return nil, fmt.Errorf("extplugin: tunnel %q has no dynamic body", host.Name)
+	}
+	// Register this tunnel's transport-dial route and hand the plugin an
+	// opaque token. The plugin opens its transport by echoing the token to
+	// HostTunnel.DialUpstream; the gateway routes that dial through the
+	// parent tunnel when chained (`via = <tunnel>`, via != nil) or directly
+	// (via == nil) with its own dialer. The plugin never knows the route —
+	// it just dials, like an endpoint plugin's Conn.DialUpstream. The token
+	// is registered for every real tunnel, direct or chained.
+	var dialToken string
+	if a.client.routeReg != nil {
+		dialToken = a.client.routeReg.add(via) // via may be nil (direct route)
 	}
 	var (
 		credSec   []byte
@@ -907,19 +928,24 @@ func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ run
 		}
 	}
 	resp, err := a.client.tunnel.OpenTunnel(ctx, &pb.OpenTunnelRequest{
-		TunnelTypeName:   a.typeName,
-		TunnelInstance:   body.instanceName,
-		CanonicalJson:    body.canonicalJSON,
-		CredentialSecret: credSec,
-		CredentialExtras: credExtra,
+		TunnelTypeName:      a.typeName,
+		TunnelInstance:      body.instanceName,
+		CanonicalJson:       body.canonicalJSON,
+		CredentialSecret:    credSec,
+		CredentialExtras:    credExtra,
+		TransportDialHandle: dialToken,
 	})
 	if err != nil {
+		if dialToken != "" {
+			a.client.routeReg.remove(dialToken)
+		}
 		return nil, fmt.Errorf("extplugin: OpenTunnel: %w", err)
 	}
 	return &remoteTunnel{
-		client: a.client,
-		handle: resp.Handle,
-		logger: host.Logger,
+		client:    a.client,
+		handle:    resp.Handle,
+		logger:    host.Logger,
+		dialToken: dialToken,
 	}, nil
 }
 
@@ -948,9 +974,10 @@ var tunnelBodies = struct {
 // remoteTunnel is the runtime.Tunnel handle returned from Open. Each
 // Dial call opens a fresh bidi stream against the subprocess.
 type remoteTunnel struct {
-	client *Client
-	handle string
-	logger *log.Logger
+	client    *Client
+	handle    string
+	logger    *log.Logger
+	dialToken string // non-empty when chained through a parent (`via`)
 }
 
 func (t *remoteTunnel) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -969,6 +996,9 @@ func (t *remoteTunnel) Dial(ctx context.Context, network, addr string) (net.Conn
 }
 
 func (t *remoteTunnel) Close() error {
+	if t.dialToken != "" && t.client.routeReg != nil {
+		t.client.routeReg.remove(t.dialToken)
+	}
 	_, err := t.client.tunnel.CloseTunnel(context.Background(), &pb.CloseTunnelRequest{Handle: t.handle})
 	return err
 }

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"slices"
 	"sort"
@@ -46,6 +47,13 @@ type Manager struct {
 	// opaque bytes across restarts. nil disables state (plugins that try to
 	// use it get an error); the gateway wires its BlobStore here.
 	blobs runtime.BlobStore
+
+	// transportDial is the gateway's direct upstream dialer, used to serve a
+	// tunnel plugin's HostTunnel.DialUpstream when the tunnel has no parent
+	// (no `via`). The gateway wires its own dialer here; nil means a tunnel
+	// plugin with no via can't open its transport (the CLI install/probe
+	// paths leave it nil — they never run a tunnel).
+	transportDial func(network, addr string) (net.Conn, error)
 
 	// ghBase overrides the GitHub API base URL (tests point it at an
 	// httptest server); empty means api.github.com. prov gates a
@@ -132,6 +140,22 @@ func (m *Manager) blobStore() runtime.BlobStore {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.blobs
+}
+
+// SetTransportDialer wires the gateway's direct upstream dialer, used to
+// serve a tunnel plugin's HostTunnel.DialUpstream when the tunnel has no
+// `via` parent. The gateway main provides its own dialer; CLI
+// install/probe paths leave it nil (they never run a tunnel).
+func (m *Manager) SetTransportDialer(d func(network, addr string) (net.Conn, error)) {
+	m.mu.Lock()
+	m.transportDial = d
+	m.mu.Unlock()
+}
+
+func (m *Manager) transportDialer() func(network, addr string) (net.Conn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.transportDial
 }
 
 // VerifyProvenance turns on GitHub build-provenance attestation checks
@@ -310,10 +334,14 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 	// neither service (no idle broker goroutine).
 	gc := &grpcClient{}
 	var sessions *sessionRegistry
+	var routeReg *transportRouteRegistry
 	if stateNS != "" {
 		gc.hostState = newHostState(m.blobStore, stateNS)
 		sessions = newSessionRegistry()
 		gc.sessions = sessions
+		routeReg = newTransportRouteRegistry()
+		gc.routeReg = routeReg
+		gc.transportDial = m.transportDialer()
 	}
 	cli := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: HandshakeConfig,
@@ -328,6 +356,16 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 		SkipHostEnv:      true,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           m.logger,
+		// Multiplex the host-services broker (HostState/HostControl/
+		// HostTunnel) over the plugin's main gRPC connection instead of a
+		// separate unix socket. The broker's own socket would land in the
+		// gateway's temp dir, which the namespaces sandbox's private /tmp
+		// hides from the plugin — so a sandboxed plugin could never reach
+		// host services. Multiplexing reuses the main connection (already
+		// sandbox-visible), so it works under the sandbox. Both sides run
+		// the same go-plugin version, so the plugin negotiates support
+		// automatically.
+		GRPCBrokerMultiplex: true,
 	})
 	c := &Client{
 		source:         source,
@@ -337,6 +375,7 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 		socketDir:      spec.SocketDir,
 		gp:             cli,
 		sessions:       sessions,
+		routeReg:       routeReg,
 	}
 	rpcCli, err := cli.Client()
 	if err != nil {
@@ -1104,6 +1143,11 @@ type Client struct {
 	// resolves Evaluate calls against it. Shared with the grpcClient that
 	// serves the bundle.
 	sessions *sessionRegistry
+	// routeReg holds the parent tunnels this plugin's tunnels are chained
+	// through; the tunnelAdapter registers a parent at Open and the
+	// broker-served hostTunnel resolves it at DialVia. Shared with the
+	// grpcClient. nil on the probe path (no tunnels run).
+	routeReg *transportRouteRegistry
 }
 
 // SandboxMode reports which sandbox backend the subprocess runs
@@ -1156,8 +1200,10 @@ func (c *Client) TunnelRPC() pb.TunnelClient { return c.tunnel }
 // the HostState service to the plugin over the broker.
 type grpcClient struct {
 	plugin.NetRPCUnsupportedPlugin
-	hostState pb.HostStateServer // nil = state service disabled
-	sessions  *sessionRegistry   // nil = HostControl disabled (probe path)
+	hostState     pb.HostStateServer      // nil = state service disabled
+	sessions      *sessionRegistry        // nil = HostControl disabled (probe path)
+	routeReg      *transportRouteRegistry // nil = HostTunnel disabled (probe path)
+	transportDial func(network, addr string) (net.Conn, error)
 }
 
 func (g *grpcClient) GRPCServer(_ *plugin.GRPCBroker, _ *grpc.Server) error {
@@ -1170,14 +1216,16 @@ func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, co
 	// it in the background; the plugin only dials lazily on its first call.
 	// When the client tears down, the broker closes and AcceptAndServe
 	// returns.
-	if broker == nil || (g.hostState == nil && g.sessions == nil) {
+	if broker == nil || (g.hostState == nil && g.sessions == nil && g.routeReg == nil) {
 		return conn, nil
 	}
-	hs, sessions := g.hostState, g.sessions
+	hs, sessions, routeReg, transportDial := g.hostState, g.sessions, g.routeReg, g.transportDial
 	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
 		// HostControl calls are session-scoped via metadata; the interceptor
 		// resolves the token once. HostState carries no token and passes
-		// through (the interceptor only acts on a present token).
+		// through (the interceptor only acts on a present token). HostTunnel
+		// is streaming and capability-scoped by its transport-dial token, so it is not
+		// covered by the unary interceptor.
 		if sessions != nil {
 			opts = append(opts, grpc.ChainUnaryInterceptor(sessionUnaryInterceptor(sessions)))
 		}
@@ -1187,6 +1235,9 @@ func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, co
 		}
 		if sessions != nil {
 			pb.RegisterHostControlServer(s, hostControl{})
+		}
+		if routeReg != nil {
+			pb.RegisterHostTunnelServer(s, &hostTunnel{reg: routeReg, directDial: transportDial})
 		}
 		return s
 	})

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3668,8 +3668,18 @@ type OpenTunnelRequest struct {
 	// Optional credential bound to the tunnel.
 	CredentialSecret []byte            `protobuf:"bytes,4,opt,name=credential_secret,json=credentialSecret,proto3" json:"credential_secret,omitempty"`
 	CredentialExtras map[string]string `protobuf:"bytes,5,rep,name=credential_extras,json=credentialExtras,proto3" json:"credential_extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// transport_dial_handle is the opaque token a tunnel plugin echoes to
+	// HostTunnel.DialUpstream to open its own transport connection (the
+	// socket the tunnel uses to reach its endpoint/bastion). The gateway
+	// routes that dial: directly, or — when the tunnel is chained
+	// (`via = <tunnel>` in the gateway config) — through the parent tunnel.
+	// The plugin never knows or names the route; it just dials, exactly
+	// like an endpoint plugin's Conn.DialUpstream. A tunnel plugin should
+	// therefore run with no network capability of its own and rely on this
+	// brokered dial. Always set for a real tunnel load.
+	TransportDialHandle string `protobuf:"bytes,6,opt,name=transport_dial_handle,json=transportDialHandle,proto3" json:"transport_dial_handle,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *OpenTunnelRequest) Reset() {
@@ -3735,6 +3745,13 @@ func (x *OpenTunnelRequest) GetCredentialExtras() map[string]string {
 		return x.CredentialExtras
 	}
 	return nil
+}
+
+func (x *OpenTunnelRequest) GetTransportDialHandle() string {
+	if x != nil {
+		return x.TransportDialHandle
+	}
+	return ""
 }
 
 type OpenTunnelResponse struct {
@@ -4705,13 +4722,14 @@ const file_plugin_proto_rawDesc = "" +
 	"bytesCount\x12\x1f\n" +
 	"\vfacets_json\x18\x06 \x01(\fR\n" +
 	"facetsJson\x12\x12\n" +
-	"\x04rule\x18\a \x01(\tR\x04rule\"\xeb\x02\n" +
+	"\x04rule\x18\a \x01(\tR\x04rule\"\x9f\x03\n" +
 	"\x11OpenTunnelRequest\x12(\n" +
 	"\x10tunnel_type_name\x18\x01 \x01(\tR\x0etunnelTypeName\x12'\n" +
 	"\x0ftunnel_instance\x18\x02 \x01(\tR\x0etunnelInstance\x12%\n" +
 	"\x0ecanonical_json\x18\x03 \x01(\fR\rcanonicalJson\x12+\n" +
 	"\x11credential_secret\x18\x04 \x01(\fR\x10credentialSecret\x12j\n" +
-	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntryR\x10credentialExtras\x1aC\n" +
+	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntryR\x10credentialExtras\x122\n" +
+	"\x15transport_dial_handle\x18\x06 \x01(\tR\x13transportDialHandle\x1aC\n" +
 	"\x15CredentialExtrasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\",\n" +
@@ -4784,7 +4802,10 @@ const file_plugin_proto_rawDesc = "" +
 	"\x03Get\x12%.clawpatrol.plugin.v1.StateGetRequest\x1a&.clawpatrol.plugin.v1.StateGetResponse\x12T\n" +
 	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponse2g\n" +
 	"\vHostControl\x12X\n" +
-	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdictBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
+	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdict2f\n" +
+	"\n" +
+	"HostTunnel\x12X\n" +
+	"\fDialUpstream\x12!.clawpatrol.plugin.v1.DialMessage\x1a!.clawpatrol.plugin.v1.DialMessage(\x010\x01BCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -4944,19 +4965,21 @@ var file_plugin_proto_depIdxs = []int32{
 	57, // 66: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
 	59, // 67: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
 	61, // 68: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
-	6,  // 69: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 70: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 71: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	32, // 72: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
-	34, // 73: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	50, // 74: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	53, // 75: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	52, // 76: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	58, // 77: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	60, // 78: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	62, // 79: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
-	69, // [69:80] is the sub-list for method output_type
-	58, // [58:69] is the sub-list for method input_type
+	53, // 69: clawpatrol.plugin.v1.HostTunnel.DialUpstream:input_type -> clawpatrol.plugin.v1.DialMessage
+	6,  // 70: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 71: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 72: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 73: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 74: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	50, // 75: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	53, // 76: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	52, // 77: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	58, // 78: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	60, // 79: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	62, // 80: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
+	53, // 81: clawpatrol.plugin.v1.HostTunnel.DialUpstream:output_type -> clawpatrol.plugin.v1.DialMessage
+	70, // [70:82] is the sub-list for method output_type
+	58, // [58:70] is the sub-list for method input_type
 	58, // [58:58] is the sub-list for extension type_name
 	58, // [58:58] is the sub-list for extension extendee
 	0,  // [0:58] is the sub-list for field type_name
@@ -5004,7 +5027,7 @@ func file_plugin_proto_init() {
 			NumEnums:      5,
 			NumMessages:   67,
 			NumExtensions: 0,
-			NumServices:   6,
+			NumServices:   7,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -635,6 +635,16 @@ message OpenTunnelRequest {
   // Optional credential bound to the tunnel.
   bytes  credential_secret = 4;
   map<string,string> credential_extras = 5;
+  // transport_dial_handle is the opaque token a tunnel plugin echoes to
+  // HostTunnel.DialUpstream to open its own transport connection (the
+  // socket the tunnel uses to reach its endpoint/bastion). The gateway
+  // routes that dial: directly, or — when the tunnel is chained
+  // (`via = <tunnel>` in the gateway config) — through the parent tunnel.
+  // The plugin never knows or names the route; it just dials, exactly
+  // like an endpoint plugin's Conn.DialUpstream. A tunnel plugin should
+  // therefore run with no network capability of its own and rely on this
+  // brokered dial. Always set for a real tunnel load.
+  string transport_dial_handle = 6;
 }
 
 message OpenTunnelResponse {
@@ -745,4 +755,26 @@ message EvaluateVerdict {
   string action = 1; // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
   string reason = 2;
   string rule = 3;
+}
+
+// HostTunnel is the brokered transport dial for tunnel plugins — the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream.
+// Gateway-served, like HostState/HostControl: the plugin is the client.
+// A tunnel plugin uses it to open the socket its transport rides on (the
+// TCP conn to an SSH bastion, the UDP conn to a WireGuard endpoint)
+// rather than opening a raw socket itself. The gateway routes the dial:
+// directly when the tunnel is top-level, or through the PARENT tunnel
+// when the tunnel is chained (`via = <tunnel>`). The plugin never knows
+// the route — that's how WireGuard-over-SOCKS works without the WG plugin
+// being SOCKS-aware. The gateway owns the composition.
+service HostTunnel {
+  // DialUpstream opens one transport connection for the calling tunnel.
+  // The first DialMessage MUST be a DialInit whose tunnel_handle is the
+  // transport_dial_handle from OpenTunnelRequest, and whose network/addr
+  // name the target ("tcp"/"udp", "host:port"). For network="udp" the
+  // byte stream carries length-prefixed datagrams (a 2-byte big-endian
+  // length per packet); the gateway frames a real UDP socket on the
+  // direct path, and a chained datagram tunnel (e.g. SOCKS5 UDP ASSOCIATE)
+  // on the via path.
+  rpc DialUpstream(stream DialMessage) returns (stream DialMessage);
 }

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -950,3 +950,137 @@ var HostControl_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "plugin.proto",
 }
+
+const (
+	HostTunnel_DialUpstream_FullMethodName = "/clawpatrol.plugin.v1.HostTunnel/DialUpstream"
+)
+
+// HostTunnelClient is the client API for HostTunnel service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// HostTunnel is the brokered transport dial for tunnel plugins — the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream.
+// Gateway-served, like HostState/HostControl: the plugin is the client.
+// A tunnel plugin uses it to open the socket its transport rides on (the
+// TCP conn to an SSH bastion, the UDP conn to a WireGuard endpoint)
+// rather than opening a raw socket itself. The gateway routes the dial:
+// directly when the tunnel is top-level, or through the PARENT tunnel
+// when the tunnel is chained (`via = <tunnel>`). The plugin never knows
+// the route — that's how WireGuard-over-SOCKS works without the WG plugin
+// being SOCKS-aware. The gateway owns the composition.
+type HostTunnelClient interface {
+	// DialUpstream opens one transport connection for the calling tunnel.
+	// The first DialMessage MUST be a DialInit whose tunnel_handle is the
+	// transport_dial_handle from OpenTunnelRequest, and whose network/addr
+	// name the target ("tcp"/"udp", "host:port"). For network="udp" the
+	// byte stream carries length-prefixed datagrams (a 2-byte big-endian
+	// length per packet); the gateway frames a real UDP socket on the
+	// direct path, and a chained datagram tunnel (e.g. SOCKS5 UDP ASSOCIATE)
+	// on the via path.
+	DialUpstream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[DialMessage, DialMessage], error)
+}
+
+type hostTunnelClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewHostTunnelClient(cc grpc.ClientConnInterface) HostTunnelClient {
+	return &hostTunnelClient{cc}
+}
+
+func (c *hostTunnelClient) DialUpstream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[DialMessage, DialMessage], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &HostTunnel_ServiceDesc.Streams[0], HostTunnel_DialUpstream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[DialMessage, DialMessage]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type HostTunnel_DialUpstreamClient = grpc.BidiStreamingClient[DialMessage, DialMessage]
+
+// HostTunnelServer is the server API for HostTunnel service.
+// All implementations must embed UnimplementedHostTunnelServer
+// for forward compatibility.
+//
+// HostTunnel is the brokered transport dial for tunnel plugins — the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream.
+// Gateway-served, like HostState/HostControl: the plugin is the client.
+// A tunnel plugin uses it to open the socket its transport rides on (the
+// TCP conn to an SSH bastion, the UDP conn to a WireGuard endpoint)
+// rather than opening a raw socket itself. The gateway routes the dial:
+// directly when the tunnel is top-level, or through the PARENT tunnel
+// when the tunnel is chained (`via = <tunnel>`). The plugin never knows
+// the route — that's how WireGuard-over-SOCKS works without the WG plugin
+// being SOCKS-aware. The gateway owns the composition.
+type HostTunnelServer interface {
+	// DialUpstream opens one transport connection for the calling tunnel.
+	// The first DialMessage MUST be a DialInit whose tunnel_handle is the
+	// transport_dial_handle from OpenTunnelRequest, and whose network/addr
+	// name the target ("tcp"/"udp", "host:port"). For network="udp" the
+	// byte stream carries length-prefixed datagrams (a 2-byte big-endian
+	// length per packet); the gateway frames a real UDP socket on the
+	// direct path, and a chained datagram tunnel (e.g. SOCKS5 UDP ASSOCIATE)
+	// on the via path.
+	DialUpstream(grpc.BidiStreamingServer[DialMessage, DialMessage]) error
+	mustEmbedUnimplementedHostTunnelServer()
+}
+
+// UnimplementedHostTunnelServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedHostTunnelServer struct{}
+
+func (UnimplementedHostTunnelServer) DialUpstream(grpc.BidiStreamingServer[DialMessage, DialMessage]) error {
+	return status.Error(codes.Unimplemented, "method DialUpstream not implemented")
+}
+func (UnimplementedHostTunnelServer) mustEmbedUnimplementedHostTunnelServer() {}
+func (UnimplementedHostTunnelServer) testEmbeddedByValue()                    {}
+
+// UnsafeHostTunnelServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to HostTunnelServer will
+// result in compilation errors.
+type UnsafeHostTunnelServer interface {
+	mustEmbedUnimplementedHostTunnelServer()
+}
+
+func RegisterHostTunnelServer(s grpc.ServiceRegistrar, srv HostTunnelServer) {
+	// If the following call panics, it indicates UnimplementedHostTunnelServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&HostTunnel_ServiceDesc, srv)
+}
+
+func _HostTunnel_DialUpstream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(HostTunnelServer).DialUpstream(&grpc.GenericServerStream[DialMessage, DialMessage]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type HostTunnel_DialUpstreamServer = grpc.BidiStreamingServer[DialMessage, DialMessage]
+
+// HostTunnel_ServiceDesc is the grpc.ServiceDesc for HostTunnel service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var HostTunnel_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.HostTunnel",
+	HandlerType: (*HostTunnelServer)(nil),
+	Methods:     []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "DialUpstream",
+			Handler:       _HostTunnel_DialUpstream_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+	Metadata: "plugin.proto",
+}

--- a/internal/config/extplugin/tunneltransport.go
+++ b/internal/config/extplugin/tunneltransport.go
@@ -1,0 +1,224 @@
+package extplugin
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"net"
+	"sync"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// transportRouteRegistry records, per tunnel instance, how the gateway
+// routes that tunnel plugin's brokered transport dials (HostTunnel.
+// DialUpstream). Keyed by an opaque, unguessable token the gateway hands
+// the plugin at OpenTunnel (transport_dial_handle); the plugin echoes it
+// to dial. The route is the parent tunnel when the tunnel is chained
+// (`via = <tunnel>`), or nil for a direct dial. The token is the
+// capability — only a plugin whose gateway-side adapter registered it can
+// reach the route — so DialUpstream needs no further scoping.
+//
+// One registry per plugin subprocess (Client), shared between the
+// tunnelAdapter that registers routes at Open and the broker-served
+// hostTunnel that resolves them at DialUpstream.
+type transportRouteRegistry struct {
+	mu sync.Mutex
+	m  map[string]runtime.Tunnel // token -> parent tunnel (nil = dial direct)
+}
+
+func newTransportRouteRegistry() *transportRouteRegistry {
+	return &transportRouteRegistry{m: map[string]runtime.Tunnel{}}
+}
+
+// add registers a route (parent may be nil for a direct dial) and returns
+// its token.
+func (r *transportRouteRegistry) add(parent runtime.Tunnel) string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	token := hex.EncodeToString(b[:])
+	r.mu.Lock()
+	r.m[token] = parent // nil is a valid value: direct route
+	r.mu.Unlock()
+	return token
+}
+
+// get returns the route for a token: the parent tunnel (possibly nil for
+// direct) and whether the token is registered at all.
+func (r *transportRouteRegistry) get(token string) (parent runtime.Tunnel, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	parent, ok = r.m[token]
+	return parent, ok
+}
+
+func (r *transportRouteRegistry) remove(token string) {
+	if token == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.m, token)
+	r.mu.Unlock()
+}
+
+// hostTunnel is the gateway-served HostTunnel service: it dials a tunnel
+// plugin's transport on its behalf and routes it (direct or via parent).
+type hostTunnel struct {
+	pb.UnimplementedHostTunnelServer
+	reg *transportRouteRegistry
+	// directDial dials an upstream with no parent tunnel (the gateway's
+	// own dialer). Required so a tunnel plugin can run with no network of
+	// its own; nil only on paths that never serve real tunnels.
+	directDial func(network, addr string) (net.Conn, error)
+}
+
+// DialUpstream opens one transport connection for the calling tunnel,
+// routing it through the tunnel's parent (`via`) or directly, and pumps
+// bytes over the stream. For network="udp" the byte stream carries
+// length-prefixed datagrams end to end; the gateway frames a real UDP
+// socket on the direct path, while a chained datagram tunnel frames it on
+// the via path.
+func (h *hostTunnel) DialUpstream(stream pb.HostTunnel_DialUpstreamServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	init := first.GetInit()
+	if init == nil {
+		return errors.New("extplugin: HostTunnel.DialUpstream: first message must be DialInit")
+	}
+	parent, ok := h.reg.get(init.GetTunnelHandle())
+	if !ok {
+		return errors.New("extplugin: HostTunnel.DialUpstream: unknown transport handle")
+	}
+	network, addr := init.GetNetwork(), init.GetAddr()
+
+	var conn net.Conn
+	switch {
+	case parent != nil:
+		// Chained: route the transport through the parent tunnel. For udp
+		// the parent (e.g. a SOCKS plugin) already deals in length-prefixed
+		// datagrams, so the conn is a frame-carrying byte stream.
+		conn, err = parent.Dial(stream.Context(), network, addr)
+	case network == "udp":
+		// Direct udp: dial a real UDP socket and present it as a stream of
+		// length-prefixed datagrams so the pump is uniform with the via path.
+		var pc net.Conn
+		pc, err = h.dial(network, addr)
+		if err == nil {
+			conn = newFramedDatagramConn(pc)
+		}
+	default:
+		conn, err = h.dial(network, addr)
+	}
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	bridgeTransportStream(stream, conn)
+	return nil
+}
+
+func (h *hostTunnel) dial(network, addr string) (net.Conn, error) {
+	if h.directDial == nil {
+		return nil, errors.New("extplugin: no direct dialer wired for tunnel transport")
+	}
+	return h.directDial(network, addr)
+}
+
+// bridgeTransportStream pumps bytes both ways between a DialUpstream gRPC
+// stream and the dialed conn until either side closes. It returns as soon
+// as EITHER direction ends: closing conn unblocks the conn->stream reader,
+// and returning from the handler cancels the gRPC stream — the only way to
+// unblock a server-side stream.Recv. The buffered done channel lets the
+// surviving goroutine exit without blocking.
+func bridgeTransportStream(stream pb.HostTunnel_DialUpstreamServer, conn net.Conn) {
+	// Each goroutine signals exactly once on exit (deferred, so every return
+	// path counts). The channel is buffered to 2, so the surviving goroutine
+	// never blocks on its send after we've already returned on the first.
+	done := make(chan struct{}, 2)
+	go func() { // conn -> stream
+		defer func() { done <- struct{}{} }()
+		buf := make([]byte, 32<<10)
+		for {
+			n, rerr := conn.Read(buf)
+			if n > 0 {
+				if serr := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+					Data: &pb.DialData{Payload: append([]byte(nil), buf[:n]...)},
+				}}); serr != nil {
+					return
+				}
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	go func() { // stream -> conn
+		defer func() { done <- struct{}{} }()
+		for {
+			msg, rerr := stream.Recv()
+			if rerr != nil {
+				return
+			}
+			switch k := msg.GetKind().(type) {
+			case *pb.DialMessage_Data:
+				if _, werr := conn.Write(k.Data.GetPayload()); werr != nil {
+					return
+				}
+			case *pb.DialMessage_Close:
+				return
+			}
+		}
+	}()
+	<-done
+	_ = conn.Close()
+}
+
+// framedDatagramConn presents a connected packet conn (a UDP socket) as a
+// byte stream of length-prefixed datagrams, so it can be pumped over the
+// broker to a plugin that reads it with pluginsdk.PacketConnOverStream.
+// Read yields one framed datagram at a time; Write reassembles frames
+// across arbitrary chunk boundaries and sends each as one datagram.
+type framedDatagramConn struct {
+	net.Conn
+	rbuf []byte
+	wbuf []byte
+}
+
+func newFramedDatagramConn(pc net.Conn) *framedDatagramConn {
+	return &framedDatagramConn{Conn: pc}
+}
+
+func (f *framedDatagramConn) Read(p []byte) (int, error) {
+	if len(f.rbuf) == 0 {
+		buf := make([]byte, 64<<10)
+		n, err := f.Conn.Read(buf)
+		if err != nil {
+			return 0, err
+		}
+		var hdr [2]byte
+		binary.BigEndian.PutUint16(hdr[:], uint16(n))
+		f.rbuf = append(hdr[:], buf[:n]...)
+	}
+	m := copy(p, f.rbuf)
+	f.rbuf = f.rbuf[m:]
+	return m, nil
+}
+
+func (f *framedDatagramConn) Write(p []byte) (int, error) {
+	f.wbuf = append(f.wbuf, p...)
+	for len(f.wbuf) >= 2 {
+		n := int(binary.BigEndian.Uint16(f.wbuf[:2]))
+		if len(f.wbuf) < 2+n {
+			break
+		}
+		if _, err := f.Conn.Write(f.wbuf[2 : 2+n]); err != nil {
+			return 0, err
+		}
+		f.wbuf = f.wbuf[2+n:]
+	}
+	return len(p), nil
+}

--- a/internal/config/extplugin/tunneltransport_test.go
+++ b/internal/config/extplugin/tunneltransport_test.go
@@ -1,0 +1,216 @@
+package extplugin
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+)
+
+// echoParent is a fake parent runtime.Tunnel: every Dial returns a conn
+// that echoes whatever is written to it, and records what it was asked to
+// dial. Stands in for a real parent tunnel (a SOCKS plugin, ssh_port_forward)
+// on the via route.
+type echoParent struct{ network, addr chan string }
+
+func (e echoParent) Dial(_ context.Context, network, addr string) (net.Conn, error) {
+	select {
+	case e.network <- network:
+	default:
+	}
+	select {
+	case e.addr <- addr:
+	default:
+	}
+	return echoConn(), nil
+}
+
+func (echoParent) Close() error { return nil }
+
+func echoConn() net.Conn {
+	c1, c2 := net.Pipe()
+	go func() { _, _ = io.Copy(c2, c2) }() // echo bytes written to c1
+	return c1
+}
+
+// transportBrokerPlugin wires a go-plugin broker so the gateway serves
+// HostTunnel and the plugin side can call DialUpstream — the real path a
+// tunnel plugin's req.DialUpstream takes, minus the SDK wrapper.
+type transportBrokerPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	reg        *transportRouteRegistry
+	directDial func(network, addr string) (net.Conn, error)
+	brokerCh   chan *goplugin.GRPCBroker
+}
+
+func (p *transportBrokerPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server) error {
+	p.brokerCh <- broker
+	return nil
+}
+
+func (p *transportBrokerPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		s := grpc.NewServer(opts...)
+		pb.RegisterHostTunnelServer(s, &hostTunnel{reg: p.reg, directDial: p.directDial})
+		return s
+	})
+	return c, nil
+}
+
+func dialUpstream(t *testing.T, broker *goplugin.GRPCBroker, token, network, addr string) (pb.HostTunnel_DialUpstreamClient, error) {
+	t.Helper()
+	conn, err := broker.Dial(HostServicesBrokerID)
+	if err != nil {
+		t.Fatalf("dial host services: %v", err)
+	}
+	stream, err := pb.NewHostTunnelClient(conn).DialUpstream(context.Background())
+	if err != nil {
+		t.Fatalf("DialUpstream: %v", err)
+	}
+	err = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+		TunnelHandle: token, Network: network, Addr: addr,
+	}}})
+	return stream, err
+}
+
+// TestDialUpstreamRoutes exercises the brokered transport dial over a real
+// broker: a chained tunnel's dial is routed through its parent, a direct
+// tunnel's dial goes through the gateway's injected dialer, and an unknown
+// token is refused.
+func TestDialUpstreamRoutes(t *testing.T) {
+	parent := echoParent{network: make(chan string, 1), addr: make(chan string, 1)}
+	reg := newTransportRouteRegistry()
+	viaToken := reg.add(parent) // chained: route through the parent
+	directToken := reg.add(nil) // direct: route through the gateway dialer
+
+	// directDial stands in for the gateway's own dialer: an echo target.
+	var directNet, directAddr string
+	directDial := func(network, addr string) (net.Conn, error) {
+		directNet, directAddr = network, addr
+		return echoConn(), nil
+	}
+
+	brokerCh := make(chan *goplugin.GRPCBroker, 1)
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{
+		"x": &transportBrokerPlugin{reg: reg, directDial: directDial, brokerCh: brokerCh},
+	})
+	defer func() { _ = client.Close() }()
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+	broker := <-brokerCh
+
+	// Chained: dial routes through the parent (which echoes), and the parent
+	// sees the child's udp/endpoint request.
+	viaStream, err := dialUpstream(t, broker, viaToken, "udp", "wg.example:51820")
+	if err != nil {
+		t.Fatalf("via send init: %v", err)
+	}
+	if got := echoRoundTrip(t, viaStream, "handshake"); got != "handshake" {
+		t.Fatalf("via echo = %q", got)
+	}
+	if n := <-parent.network; n != "udp" {
+		t.Fatalf("parent dialed network %q, want udp", n)
+	}
+	if a := <-parent.addr; a != "wg.example:51820" {
+		t.Fatalf("parent dialed addr %q", a)
+	}
+
+	// Direct: dial goes through the gateway's injected dialer (echo target).
+	directStream, err := dialUpstream(t, broker, directToken, "tcp", "bastion:22")
+	if err != nil {
+		t.Fatalf("direct send init: %v", err)
+	}
+	if got := echoRoundTrip(t, directStream, "ping"); got != "ping" {
+		t.Fatalf("direct echo = %q", got)
+	}
+	if directNet != "tcp" || directAddr != "bastion:22" {
+		t.Fatalf("direct dialer got %q/%q, want tcp/bastion:22", directNet, directAddr)
+	}
+
+	// Half-close: when the plugin sends a DialClose, the bridge must tear
+	// down and return — not leak a goroutine parked in conn.Read on the
+	// still-open echo target.
+	hc, err := dialUpstream(t, broker, directToken, "tcp", "bastion:22")
+	if err != nil {
+		t.Fatalf("half-close send init: %v", err)
+	}
+	if err := hc.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}}); err != nil {
+		t.Fatalf("send close: %v", err)
+	}
+	recvErr := make(chan error, 1)
+	go func() { _, e := hc.Recv(); recvErr <- e }()
+	select {
+	case <-recvErr: // handler returned, stream closed — the bridge tore down
+	case <-time.After(3 * time.Second):
+		t.Fatal("DialUpstream did not return after DialClose (bridge leak)")
+	}
+
+	// Unknown token must be refused.
+	bad, _ := dialUpstream(t, broker, "not-a-real-token", "tcp", "x:1")
+	if _, err := bad.Recv(); err == nil {
+		t.Fatal("DialUpstream with unknown token should fail")
+	}
+}
+
+func echoRoundTrip(t *testing.T, stream pb.HostTunnel_DialUpstreamClient, payload string) string {
+	t.Helper()
+	if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+		Data: &pb.DialData{Payload: []byte(payload)},
+	}}); err != nil {
+		t.Fatalf("send data: %v", err)
+	}
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		if d := msg.GetData(); d != nil {
+			return string(d.GetPayload())
+		}
+	}
+}
+
+// TestFramedDatagramConn round-trips length-prefixed datagrams across
+// arbitrary chunk boundaries — the gateway-side adapter for direct udp.
+func TestFramedDatagramConn(t *testing.T) {
+	a, b := net.Pipe()
+	go func() { _, _ = io.Copy(b, b) }() // echo the underlying "udp" conn
+	f := newFramedDatagramConn(a)
+	defer func() { _ = f.Close() }()
+	_ = f.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Two framed datagrams written in one Write must arrive as two packets,
+	// echoed back and re-framed for the reader.
+	want := []byte("alpha")
+	frame := append([]byte{0, byte(len(want))}, want...)
+	go func() { _, _ = f.Write(append(frame, frame...)) }()
+
+	for i := 0; i < 2; i++ {
+		got, err := readFrame(f)
+		if err != nil {
+			t.Fatalf("read frame %d: %v", i, err)
+		}
+		if string(got) != "alpha" {
+			t.Fatalf("frame %d = %q", i, got)
+		}
+	}
+}
+
+func readFrame(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, int(hdr[0])<<8|int(hdr[1]))
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}
+
+var _ runtime.Tunnel = echoParent{}

--- a/pluginsdk/datagram.go
+++ b/pluginsdk/datagram.go
@@ -1,0 +1,90 @@
+package pluginsdk
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Datagram framing for carrying UDP packets over a byte stream (a `via`
+// conduit through a parent tunnel). Each datagram is a 2-byte big-endian
+// length followed by that many payload bytes. Both ends of a chained
+// udp-via must use this framing: the child (e.g. WireGuard) writes/reads
+// packets, and the parent (e.g. a SOCKS plugin) reframes them onto a real
+// datagram transport. 16-bit length caps a datagram at 65535 bytes, which
+// covers any UDP payload.
+
+const maxDatagram = 0xffff
+
+// WriteDatagram writes one length-prefixed datagram to w.
+func WriteDatagram(w io.Writer, p []byte) error {
+	if len(p) > maxDatagram {
+		p = p[:maxDatagram]
+	}
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(p)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(p)
+	return err
+}
+
+// ReadDatagram reads one length-prefixed datagram from r.
+func ReadDatagram(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint16(hdr[:])
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// PacketConnOverStream presents a byte stream carrying length-prefixed
+// datagrams (see WriteDatagram/ReadDatagram) as a connected
+// net.PacketConn. The remote address is fixed (the stream already routes
+// to one endpoint), so the addr argument to WriteTo is ignored and
+// ReadFrom always reports remote. This is what a WireGuard plugin wraps
+// its `via` conduit in so wireguard-go's bind can speak datagrams over a
+// chained tunnel.
+func PacketConnOverStream(conn net.Conn, remote net.Addr) net.PacketConn {
+	return &packetConnOverStream{conn: conn, remote: remote}
+}
+
+type packetConnOverStream struct {
+	conn   net.Conn
+	remote net.Addr
+	rMu    sync.Mutex
+	wMu    sync.Mutex
+}
+
+func (p *packetConnOverStream) ReadFrom(b []byte) (int, net.Addr, error) {
+	p.rMu.Lock()
+	defer p.rMu.Unlock()
+	d, err := ReadDatagram(p.conn)
+	if err != nil {
+		return 0, nil, err
+	}
+	return copy(b, d), p.remote, nil
+}
+
+func (p *packetConnOverStream) WriteTo(b []byte, _ net.Addr) (int, error) {
+	p.wMu.Lock()
+	defer p.wMu.Unlock()
+	if err := WriteDatagram(p.conn, b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (p *packetConnOverStream) Close() error                       { return p.conn.Close() }
+func (p *packetConnOverStream) LocalAddr() net.Addr                { return p.conn.LocalAddr() }
+func (p *packetConnOverStream) SetDeadline(t time.Time) error      { return p.conn.SetDeadline(t) }
+func (p *packetConnOverStream) SetReadDeadline(t time.Time) error  { return p.conn.SetReadDeadline(t) }
+func (p *packetConnOverStream) SetWriteDeadline(t time.Time) error { return p.conn.SetWriteDeadline(t) }

--- a/pluginsdk/datagram_test.go
+++ b/pluginsdk/datagram_test.go
@@ -1,0 +1,58 @@
+package pluginsdk
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+// Datagram framing must round-trip exactly — both the WireGuard plugin
+// (writes/reads packets over its `via` conduit) and the SOCKS plugin
+// (reframes them onto a UDP relay) depend on this byte-for-byte.
+func TestDatagramRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	packets := [][]byte{
+		[]byte("first"),
+		{},                               // empty datagram
+		bytes.Repeat([]byte{0xab}, 1500), // jumbo-ish
+		[]byte("last"),
+	}
+	for _, p := range packets {
+		if err := WriteDatagram(&buf, p); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for i, want := range packets {
+		got, err := ReadDatagram(&buf)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("datagram %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// PacketConnOverStream presents the framed stream as a connected
+// net.PacketConn (what the WG plugin wraps its via conduit in).
+func TestPacketConnOverStream(t *testing.T) {
+	a, b := net.Pipe()
+	remote := &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 51820}
+	pcA := PacketConnOverStream(a, remote)
+	pcB := PacketConnOverStream(b, remote)
+
+	want := []byte("wireguard handshake bytes")
+	go func() { _, _ = pcA.WriteTo(want, remote) }()
+
+	buf := make([]byte, 1500)
+	n, addr, err := pcB.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("readfrom: %v", err)
+	}
+	if !bytes.Equal(buf[:n], want) {
+		t.Fatalf("got %q, want %q", buf[:n], want)
+	}
+	if addr.String() != remote.String() {
+		t.Fatalf("addr = %s, want %s", addr, remote)
+	}
+}

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -629,6 +629,15 @@ type TunnelOpenRequest struct {
 	CanonicalConfig  []byte
 	CredentialSecret []byte
 	CredentialExtras map[string]string
+	// DialUpstream opens this tunnel's own transport connection — the
+	// socket the tunnel rides on to reach its endpoint (a "udp" conn to a
+	// WireGuard endpoint, a "tcp" conn to an SSH bastion). The gateway
+	// dials on the plugin's behalf and routes it directly, or through the
+	// parent tunnel when this tunnel is chained (`via = <tunnel>`). Use it
+	// instead of opening a raw socket, so the tunnel plugin can run with no
+	// network capability of its own and the gateway owns the composition.
+	// nil only against an old gateway with no HostTunnel support.
+	DialUpstream DialUpstreamFunc
 }
 
 // TunnelDialRequest is what Dial callbacks receive when the gateway
@@ -637,6 +646,11 @@ type TunnelDialRequest struct {
 	Handle  any
 	Network string
 	Addr    string
+	// DialUpstream opens an upstream transport connection for this tunnel,
+	// gateway-routed (direct or via the parent) — the same primitive as on
+	// TunnelOpenRequest, for tunnels that establish their transport
+	// per-Dial (e.g. a SOCKS tunnel dialing the proxy on each Dial).
+	DialUpstream DialUpstreamFunc
 }
 
 // ErrNoSuchType is returned by the SDK when the gateway invokes a

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -1001,6 +1001,9 @@ func serveStreamRead(req *pb.StreamRead, mu *sync.Mutex, streams map[string]*str
 type tunnelHandle struct {
 	def    TunnelDef
 	handle any
+	// dialUpstream opens this tunnel's transport, gateway-routed; reused by
+	// Dial for tunnels that establish their transport per-Dial.
+	dialUpstream DialUpstreamFunc
 }
 
 func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb.OpenTunnelResponse, error) {
@@ -1008,12 +1011,14 @@ func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb
 	if !ok {
 		return nil, fmt.Errorf("%w: tunnel %q", ErrNoSuchType, req.TunnelTypeName)
 	}
+	dialUpstream := transportDialer(req.GetTransportDialHandle())
 	openReq := TunnelOpenRequest{
 		TunnelTypeName:   req.TunnelTypeName,
 		TunnelInstance:   req.TunnelInstance,
 		CanonicalConfig:  req.CanonicalJson,
 		CredentialSecret: req.CredentialSecret,
 		CredentialExtras: req.CredentialExtras,
+		DialUpstream:     dialUpstream,
 	}
 	var (
 		handle any
@@ -1028,7 +1033,7 @@ func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb
 		handle = req.TunnelInstance
 	}
 	id := fmt.Sprintf("t%d-%s", s.tunHandleID.Add(1), req.TunnelInstance)
-	s.tunHandles.Store(id, &tunnelHandle{def: def, handle: handle})
+	s.tunHandles.Store(id, &tunnelHandle{def: def, handle: handle, dialUpstream: dialUpstream})
 	return &pb.OpenTunnelResponse{Handle: id}, nil
 }
 
@@ -1120,9 +1125,10 @@ func (s *server) Dial(stream pb.Tunnel_DialServer) error {
 	}()
 
 	dialErr := invokeTunnelDial(ctx, th.def, TunnelDialRequest{
-		Handle:  th.handle,
-		Network: initMsg.Init.Network,
-		Addr:    initMsg.Init.Addr,
+		Handle:       th.handle,
+		Network:      initMsg.Init.Network,
+		Addr:         initMsg.Init.Addr,
+		DialUpstream: th.dialUpstream,
 	}, upstream)
 	_ = upstream.Close()
 	closer()

--- a/pluginsdk/tunneltransport.go
+++ b/pluginsdk/tunneltransport.go
@@ -1,0 +1,146 @@
+package pluginsdk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+// DialUpstreamFunc opens a tunnel plugin's transport connection — the
+// socket the tunnel rides on to reach its endpoint (the TCP conn to an
+// SSH bastion, the UDP conn to a WireGuard endpoint). It is the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream: the
+// gateway dials on the plugin's behalf and routes it directly, or — when
+// the tunnel is chained (`via = <tunnel>`) — through the parent tunnel.
+// The plugin never knows the route, so a tunnel plugin should run with no
+// network capability of its own and dial only through this.
+//
+// network is "tcp" for a stream transport or "udp" for a datagram
+// transport. For "udp" the returned conn carries length-prefixed
+// datagrams (write one whole packet per Write, read one per Read); wrap
+// it with PacketConnOverStream for a net.PacketConn view.
+type DialUpstreamFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// transportDialer builds the DialUpstream closure bound to a tunnel's
+// transport_dial_handle. Returns nil when the handle is empty (an old
+// gateway, or a non-tunnel path).
+func transportDialer(handle string) DialUpstreamFunc {
+	if handle == "" {
+		return nil
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		cli, err := hostTunnelClient()
+		if err != nil {
+			return nil, err
+		}
+		stream, err := cli.DialUpstream(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+			TunnelHandle: handle,
+			Network:      network,
+			Addr:         addr,
+		}}}); err != nil {
+			return nil, err
+		}
+		return &transportConn{stream: stream, addr: addr}, nil
+	}
+}
+
+func hostTunnelClient() (pb.HostTunnelClient, error) {
+	c, err := hostServicesConn()
+	if err != nil {
+		return nil, err
+	}
+	return pb.NewHostTunnelClient(c), nil
+}
+
+// transportConn wraps a HostTunnel.DialUpstream bidi stream as a net.Conn
+// (the client-side mirror of the gateway's dialConn).
+type transportConn struct {
+	stream pb.HostTunnel_DialUpstreamClient
+	addr   string
+
+	mu      sync.Mutex
+	readBuf []byte
+	closed  bool
+	wMu     sync.Mutex
+	once    sync.Once
+}
+
+func (c *transportConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	if len(c.readBuf) > 0 {
+		n := copy(p, c.readBuf)
+		c.readBuf = c.readBuf[n:]
+		c.mu.Unlock()
+		return n, nil
+	}
+	c.mu.Unlock()
+	for {
+		msg, err := c.stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+		switch k := msg.GetKind().(type) {
+		case *pb.DialMessage_Data:
+			n := copy(p, k.Data.Payload)
+			if n < len(k.Data.Payload) {
+				c.mu.Lock()
+				c.readBuf = append(c.readBuf, k.Data.Payload[n:]...)
+				c.mu.Unlock()
+			}
+			return n, nil
+		case *pb.DialMessage_Close:
+			return 0, io.EOF
+		}
+	}
+}
+
+func (c *transportConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	c.mu.Unlock()
+	c.wMu.Lock()
+	defer c.wMu.Unlock()
+	if err := c.stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+		Data: &pb.DialData{Payload: append([]byte(nil), p...)},
+	}}); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *transportConn) Close() error {
+	c.once.Do(func() {
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
+		_ = c.stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}})
+		_ = c.stream.CloseSend()
+	})
+	return nil
+}
+
+func (c *transportConn) LocalAddr() net.Addr                { return transportAddr("transport") }
+func (c *transportConn) RemoteAddr() net.Addr               { return transportAddr(c.addr) }
+func (c *transportConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *transportConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *transportConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type transportAddr string
+
+func (a transportAddr) Network() string { return "plugin-tunnel-transport" }
+func (a transportAddr) String() string  { return string(a) }


### PR DESCRIPTION
A tunnel plugin opens its transport — the socket it rides on to reach
its endpoint — through the gateway's brokered dial, exactly like an
endpoint plugin's `Conn.DialUpstream`, instead of opening a raw socket.
The gateway routes that dial: directly, or through a PARENT tunnel when
the tunnel is chained (`via = <tunnel>`). The plugin never knows the
route, so it can run with `network = "none"`, and WireGuard-over-SOCKS
works without the WG plugin being SOCKS-aware. Adds UDP to the brokered
path. **This is the landable half**; the example plugins are stacked
separately.

(Redesigned from the earlier explicit-`via` shape after review: the
gateway owns the composition; the plugin just dials. The reviewer's
APPROVE was for the old shape and is superseded by this one.)

## Interface

* proto: `OpenTunnelRequest.transport_dial_handle` + a gateway-served
  `HostTunnel.DialUpstream` stream (reuses `DialMessage`).
* gateway: a per-plugin `transportRouteRegistry` maps an opaque,
  capability-scoped token to the tunnel's route (parent tunnel, or nil =
  direct). `hostTunnel.DialUpstream` resolves the token and dials —
  `parent.Dial` when chained, the gateway's injected dialer
  (`SetTransportDialer`) when direct — then pumps bytes. For udp the
  byte stream carries length-prefixed datagrams; `framedDatagramConn`
  presents a real UDP socket as that stream on the direct path.
* pluginsdk: `TunnelOpenRequest`/`TunnelDialRequest` gain a
  `DialUpstream` func; `WriteDatagram`/`ReadDatagram` +
  `PacketConnOverStream` carry UDP over the stream.

## Bugfix

`dynamicTunnelBody` now implements `runtime.TunnelRuntime` (delegating to
its adapter) so the `TunnelManager` can `Open` a plugin tunnel at all —
latent because no external tunnel plugin existed to hit it.

## Tested

`TestDialUpstreamRoutes` exercises both routes over a real broker
(parent-routed + gateway-direct, unknown token refused);
`TestFramedDatagramConn` round-trips the direct-udp framing. End to end
(WireGuard-over-SOCKS, both plugins `network=none`) by the stacked PR.

## Known gap (follow-up)

The HCL `via` attribute on a *plugin* tunnel block isn't peeled yet; the
runtime route is complete, only the declarative wiring remains.