### PR TITLE
spike: example wireguard + socks tunnel plugins (brokered dial)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3093,6 +3093,12 @@ func runGateway(args []string) {
 		onboard:   newOnboardRegistry(),
 	}
 	g.cfg.Store(cfg)
+	// A tunnel plugin opens its transport through the gateway's brokered
+	// dial (HostTunnel.DialUpstream); when the tunnel has no `via` parent
+	// the gateway dials it directly with its own upstream dialer.
+	pluginMgr.SetTransportDialer(func(network, addr string) (net.Conn, error) {
+		return g.dialer.Dial(network, addr)
+	})
 	if cfg.DashboardConfigWrites() {
 		log.Printf("config: dashboard writes enabled (generated rules can be appended to gateway.hcl)")
 	} else {

--- a/cmd/clawpatrol/tunnelvia_e2e_test.go
+++ b/cmd/clawpatrol/tunnelvia_e2e_test.go
@@ -1,0 +1,218 @@
+//go:build linux
+
+package main
+
+// Live end-to-end driver for the plugin-tunnel via+UDP spike. Gated by
+// CLAWPATROL_VIA_E2E so it never runs in normal CI. It builds the real
+// socks + wireguard plugin binaries, loads a config with a wireguard
+// tunnel (optionally `via` a socks tunnel), acquires it through the
+// gateway's TunnelManager, dials a target over the WG netstack, and
+// checks the HTTP response.
+//
+// Run (against a live WireGuard server + SOCKS proxy + target):
+//
+//	CLAWPATROL_VIA_E2E=1 VIA=1 \
+//	WG_ENDPOINT=host:51820 WG_PRIV=... WG_PEERPUB=... WG_ADDR=10.9.0.2 \
+//	SOCKS_PROXY=host:1080 TARGET=10.9.0.1:8080 \
+//	go test ./cmd/clawpatrol -run TestTunnelViaE2E -count=1 -v
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func buildTunnelPlugin(t *testing.T, pkg, name string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), name)
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	cmd.Dir = root
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", pkg, err, b)
+	}
+	return out
+}
+
+func TestTunnelViaE2E(t *testing.T) {
+	if os.Getenv("CLAWPATROL_VIA_E2E") == "" {
+		t.Skip("set CLAWPATROL_VIA_E2E=1 (plus WG_*/SOCKS_PROXY/TARGET) to run the live spike")
+	}
+	wgEndpoint := os.Getenv("WG_ENDPOINT")
+	wgPriv := os.Getenv("WG_PRIV")
+	wgPeerPub := os.Getenv("WG_PEERPUB")
+	wgAddr := envOr("WG_ADDR", "10.9.0.2")
+	socksProxy := os.Getenv("SOCKS_PROXY")
+	target := envOr("TARGET", "10.9.0.1:8080")
+	useVia := os.Getenv("VIA") == "1"
+	// REVERSE flips the stack: acquire the SOCKS tunnel chained THROUGH the
+	// WireGuard tunnel (socks `via` wireguard), so the SOCKS proxy's TCP
+	// transport rides the WG tunnel and the WG plugin is the parent. The
+	// SOCKS proxy must live inside the WG network (proxy = 10.9.0.1:1080).
+	reverse := os.Getenv("REVERSE") == "1"
+	needSocks := useVia || reverse
+	if wgEndpoint == "" || wgPriv == "" || wgPeerPub == "" || (needSocks && socksProxy == "") {
+		t.Fatal("need WG_ENDPOINT, WG_PRIV, WG_PEERPUB (and SOCKS_PROXY when VIA/REVERSE=1)")
+	}
+
+	socksBin := buildTunnelPlugin(t, "./pluginsdk/socks", "socks-tunnel")
+	wgBin := buildTunnelPlugin(t, "./pluginsdk/wireguard", "wireguard-tunnel")
+
+	stateDir := t.TempDir()
+	mgr := extplugin.New(log.New(os.Stderr, "", 0))
+	// A tunnel plugin (network=none) opens its transport through the
+	// gateway's brokered dial; with no `via` the gateway dials directly.
+	// The real gateway wires this from g.dialer; the test uses a plain
+	// dialer.
+	mgr.SetTransportDialer(func(network, addr string) (net.Conn, error) {
+		return net.Dial(network, addr)
+	})
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	socksBlock := ""
+	if needSocks {
+		socksBlock = fmt.Sprintf(`
+plugin "socks_tunnel" {
+  source  = %q
+  network = "none"
+  sandbox = "off"
+}
+tunnel "socks_proxy" "corp" {
+  proxy = %q
+}
+`, socksBin, socksProxy)
+	}
+
+	// NOTE: the HCL `via` attribute on a *plugin* tunnel block is a separate,
+	// unfinished config-layer gap (plugin tunnel bodies don't yet peel the
+	// common via/keepalive/share attrs the way built-in tunnels do via
+	// TunnelCommonRead). To exercise the runtime via path here we wire Via
+	// directly on the compiled tunnel below.
+	hcl := fmt.Sprintf(`
+plugin "wireguard_tunnel" {
+  source  = %q
+  network = "none"
+  sandbox = "off"
+}
+%s
+gateway {
+  state_dir  = %q
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "wireguard" "vpn" {
+  endpoint        = %q
+  private_key     = %q
+  peer_public_key = %q
+  address         = %q
+}
+endpoint "https" "via-target" {
+  hosts  = ["target.invalid"]
+  tunnel = wireguard.vpn
+}
+profile "default" { credentials = [] }
+`, wgBin, socksBlock, stateDir, wgEndpoint, wgPriv, wgPeerPub, wgAddr)
+
+	gw, diags := config.LoadBytes([]byte(hcl), "via-e2e.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// Pick the tunnel to acquire and wire its via parent at runtime (the HCL
+	// `via` attribute on a plugin tunnel is a separate gap).
+	var ct *config.CompiledTunnel
+	if reverse {
+		// socks `via` wireguard: acquire the SOCKS tunnel, routed through WG.
+		ct = policy.Tunnels["corp"]
+		if ct == nil {
+			t.Fatalf("no compiled tunnel 'corp' (have %v)", keysOf(policy.Tunnels))
+		}
+		vpn := policy.Tunnels["vpn"]
+		if vpn == nil {
+			t.Fatalf("no compiled tunnel 'vpn' (have %v)", keysOf(policy.Tunnels))
+		}
+		ct.Via = vpn
+	} else {
+		// wireguard, optionally `via` socks.
+		ct = policy.Tunnels["vpn"]
+		if ct == nil {
+			t.Fatalf("no compiled tunnel 'vpn' (have %v)", keysOf(policy.Tunnels))
+		}
+		if useVia {
+			corp := policy.Tunnels["corp"]
+			if corp == nil {
+				t.Fatalf("no compiled tunnel 'corp' (have %v)", keysOf(policy.Tunnels))
+			}
+			ct.Via = corp
+		}
+	}
+
+	tm := NewTunnelManager(runtime.EnvSecretStore{}, stateDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	t.Logf("acquiring tunnel %q (via=%v reverse=%v)", ct.Name, useVia, reverse)
+	tun, release, err := tm.Acquire(ctx, ct, "via-target")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer release()
+
+	// Dial the target over the WG netstack and do a plain HTTP GET.
+	t.Logf("dialing %s through the tunnel", target)
+	conn, err := tun.Dial(ctx, "tcp", target)
+	if err != nil {
+		t.Fatalf("dial through tunnel: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(20 * time.Second))
+
+	if _, err := fmt.Fprintf(conn, "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", target); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body := make([]byte, 256)
+	n, _ := resp.Body.Read(body)
+	t.Logf("RESPONSE %d: %q", resp.StatusCode, body[:n])
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+}
+
+func keysOf(m map[string]*config.CompiledTunnel) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -881,6 +881,16 @@ type dynamicTunnelBody struct {
 	canonicalJSON []byte
 }
 
+// dynamicTunnelBody is the CompiledTunnel.Body for a plugin tunnel; it
+// implements runtime.TunnelRuntime by delegating to its adapter so the
+// gateway's TunnelManager.Acquire can Open it (and thread a `via` parent)
+// exactly like a built-in tunnel.
+func (b *dynamicTunnelBody) Sharing() runtime.TunnelSharing { return b.adapter.Sharing() }
+
+func (b *dynamicTunnelBody) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
+	return b.adapter.Open(ctx, host, via)
+}
+
 // tunnelAdapter implements runtime.TunnelRuntime via OpenTunnel /
 // Dial / CloseTunnel RPCs.
 type tunnelAdapter struct {
@@ -890,10 +900,21 @@ type tunnelAdapter struct {
 
 func (a *tunnelAdapter) Sharing() runtime.TunnelSharing { return runtime.TunnelShareSingleton }
 
-func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ runtime.Tunnel) (runtime.Tunnel, error) {
+func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, via runtime.Tunnel) (runtime.Tunnel, error) {
 	body, ok := tunnelBodyOf(host)
 	if !ok {
 		return nil, fmt.Errorf("extplugin: tunnel %q has no dynamic body", host.Name)
+	}
+	// Register this tunnel's transport-dial route and hand the plugin an
+	// opaque token. The plugin opens its transport by echoing the token to
+	// HostTunnel.DialUpstream; the gateway routes that dial through the
+	// parent tunnel when chained (`via = <tunnel>`, via != nil) or directly
+	// (via == nil) with its own dialer. The plugin never knows the route —
+	// it just dials, like an endpoint plugin's Conn.DialUpstream. The token
+	// is registered for every real tunnel, direct or chained.
+	var dialToken string
+	if a.client.routeReg != nil {
+		dialToken = a.client.routeReg.add(via) // via may be nil (direct route)
 	}
 	var (
 		credSec   []byte
@@ -907,19 +928,24 @@ func (a *tunnelAdapter) Open(ctx context.Context, host runtime.TunnelHost, _ run
 		}
 	}
 	resp, err := a.client.tunnel.OpenTunnel(ctx, &pb.OpenTunnelRequest{
-		TunnelTypeName:   a.typeName,
-		TunnelInstance:   body.instanceName,
-		CanonicalJson:    body.canonicalJSON,
-		CredentialSecret: credSec,
-		CredentialExtras: credExtra,
+		TunnelTypeName:      a.typeName,
+		TunnelInstance:      body.instanceName,
+		CanonicalJson:       body.canonicalJSON,
+		CredentialSecret:    credSec,
+		CredentialExtras:    credExtra,
+		TransportDialHandle: dialToken,
 	})
 	if err != nil {
+		if dialToken != "" {
+			a.client.routeReg.remove(dialToken)
+		}
 		return nil, fmt.Errorf("extplugin: OpenTunnel: %w", err)
 	}
 	return &remoteTunnel{
-		client: a.client,
-		handle: resp.Handle,
-		logger: host.Logger,
+		client:    a.client,
+		handle:    resp.Handle,
+		logger:    host.Logger,
+		dialToken: dialToken,
 	}, nil
 }
 
@@ -948,9 +974,10 @@ var tunnelBodies = struct {
 // remoteTunnel is the runtime.Tunnel handle returned from Open. Each
 // Dial call opens a fresh bidi stream against the subprocess.
 type remoteTunnel struct {
-	client *Client
-	handle string
-	logger *log.Logger
+	client    *Client
+	handle    string
+	logger    *log.Logger
+	dialToken string // non-empty when chained through a parent (`via`)
 }
 
 func (t *remoteTunnel) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -969,6 +996,9 @@ func (t *remoteTunnel) Dial(ctx context.Context, network, addr string) (net.Conn
 }
 
 func (t *remoteTunnel) Close() error {
+	if t.dialToken != "" && t.client.routeReg != nil {
+		t.client.routeReg.remove(t.dialToken)
+	}
 	_, err := t.client.tunnel.CloseTunnel(context.Background(), &pb.CloseTunnelRequest{Handle: t.handle})
 	return err
 }

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"slices"
 	"sort"
@@ -46,6 +47,13 @@ type Manager struct {
 	// opaque bytes across restarts. nil disables state (plugins that try to
 	// use it get an error); the gateway wires its BlobStore here.
 	blobs runtime.BlobStore
+
+	// transportDial is the gateway's direct upstream dialer, used to serve a
+	// tunnel plugin's HostTunnel.DialUpstream when the tunnel has no parent
+	// (no `via`). The gateway wires its own dialer here; nil means a tunnel
+	// plugin with no via can't open its transport (the CLI install/probe
+	// paths leave it nil — they never run a tunnel).
+	transportDial func(network, addr string) (net.Conn, error)
 
 	// ghBase overrides the GitHub API base URL (tests point it at an
 	// httptest server); empty means api.github.com. prov gates a
@@ -132,6 +140,22 @@ func (m *Manager) blobStore() runtime.BlobStore {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.blobs
+}
+
+// SetTransportDialer wires the gateway's direct upstream dialer, used to
+// serve a tunnel plugin's HostTunnel.DialUpstream when the tunnel has no
+// `via` parent. The gateway main provides its own dialer; CLI
+// install/probe paths leave it nil (they never run a tunnel).
+func (m *Manager) SetTransportDialer(d func(network, addr string) (net.Conn, error)) {
+	m.mu.Lock()
+	m.transportDial = d
+	m.mu.Unlock()
+}
+
+func (m *Manager) transportDialer() func(network, addr string) (net.Conn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.transportDial
 }
 
 // VerifyProvenance turns on GitHub build-provenance attestation checks
@@ -310,10 +334,14 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 	// neither service (no idle broker goroutine).
 	gc := &grpcClient{}
 	var sessions *sessionRegistry
+	var routeReg *transportRouteRegistry
 	if stateNS != "" {
 		gc.hostState = newHostState(m.blobStore, stateNS)
 		sessions = newSessionRegistry()
 		gc.sessions = sessions
+		routeReg = newTransportRouteRegistry()
+		gc.routeReg = routeReg
+		gc.transportDial = m.transportDialer()
 	}
 	cli := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: HandshakeConfig,
@@ -337,6 +365,7 @@ func (m *Manager) spawnClient(ctx context.Context, source string, spec sandbox.S
 		socketDir:      spec.SocketDir,
 		gp:             cli,
 		sessions:       sessions,
+		routeReg:       routeReg,
 	}
 	rpcCli, err := cli.Client()
 	if err != nil {
@@ -1104,6 +1133,11 @@ type Client struct {
 	// resolves Evaluate calls against it. Shared with the grpcClient that
 	// serves the bundle.
 	sessions *sessionRegistry
+	// routeReg holds the parent tunnels this plugin's tunnels are chained
+	// through; the tunnelAdapter registers a parent at Open and the
+	// broker-served hostTunnel resolves it at DialVia. Shared with the
+	// grpcClient. nil on the probe path (no tunnels run).
+	routeReg *transportRouteRegistry
 }
 
 // SandboxMode reports which sandbox backend the subprocess runs
@@ -1156,8 +1190,10 @@ func (c *Client) TunnelRPC() pb.TunnelClient { return c.tunnel }
 // the HostState service to the plugin over the broker.
 type grpcClient struct {
 	plugin.NetRPCUnsupportedPlugin
-	hostState pb.HostStateServer // nil = state service disabled
-	sessions  *sessionRegistry   // nil = HostControl disabled (probe path)
+	hostState     pb.HostStateServer      // nil = state service disabled
+	sessions      *sessionRegistry        // nil = HostControl disabled (probe path)
+	routeReg      *transportRouteRegistry // nil = HostTunnel disabled (probe path)
+	transportDial func(network, addr string) (net.Conn, error)
 }
 
 func (g *grpcClient) GRPCServer(_ *plugin.GRPCBroker, _ *grpc.Server) error {
@@ -1170,14 +1206,16 @@ func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, co
 	// it in the background; the plugin only dials lazily on its first call.
 	// When the client tears down, the broker closes and AcceptAndServe
 	// returns.
-	if broker == nil || (g.hostState == nil && g.sessions == nil) {
+	if broker == nil || (g.hostState == nil && g.sessions == nil && g.routeReg == nil) {
 		return conn, nil
 	}
-	hs, sessions := g.hostState, g.sessions
+	hs, sessions, routeReg, transportDial := g.hostState, g.sessions, g.routeReg, g.transportDial
 	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
 		// HostControl calls are session-scoped via metadata; the interceptor
 		// resolves the token once. HostState carries no token and passes
-		// through (the interceptor only acts on a present token).
+		// through (the interceptor only acts on a present token). HostTunnel
+		// is streaming and capability-scoped by its transport-dial token, so it is not
+		// covered by the unary interceptor.
 		if sessions != nil {
 			opts = append(opts, grpc.ChainUnaryInterceptor(sessionUnaryInterceptor(sessions)))
 		}
@@ -1187,6 +1225,9 @@ func (g *grpcClient) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, co
 		}
 		if sessions != nil {
 			pb.RegisterHostControlServer(s, hostControl{})
+		}
+		if routeReg != nil {
+			pb.RegisterHostTunnelServer(s, &hostTunnel{reg: routeReg, directDial: transportDial})
 		}
 		return s
 	})

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -3668,8 +3668,18 @@ type OpenTunnelRequest struct {
 	// Optional credential bound to the tunnel.
 	CredentialSecret []byte            `protobuf:"bytes,4,opt,name=credential_secret,json=credentialSecret,proto3" json:"credential_secret,omitempty"`
 	CredentialExtras map[string]string `protobuf:"bytes,5,rep,name=credential_extras,json=credentialExtras,proto3" json:"credential_extras,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// transport_dial_handle is the opaque token a tunnel plugin echoes to
+	// HostTunnel.DialUpstream to open its own transport connection (the
+	// socket the tunnel uses to reach its endpoint/bastion). The gateway
+	// routes that dial: directly, or — when the tunnel is chained
+	// (`via = <tunnel>` in the gateway config) — through the parent tunnel.
+	// The plugin never knows or names the route; it just dials, exactly
+	// like an endpoint plugin's Conn.DialUpstream. A tunnel plugin should
+	// therefore run with no network capability of its own and rely on this
+	// brokered dial. Always set for a real tunnel load.
+	TransportDialHandle string `protobuf:"bytes,6,opt,name=transport_dial_handle,json=transportDialHandle,proto3" json:"transport_dial_handle,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *OpenTunnelRequest) Reset() {
@@ -3735,6 +3745,13 @@ func (x *OpenTunnelRequest) GetCredentialExtras() map[string]string {
 		return x.CredentialExtras
 	}
 	return nil
+}
+
+func (x *OpenTunnelRequest) GetTransportDialHandle() string {
+	if x != nil {
+		return x.TransportDialHandle
+	}
+	return ""
 }
 
 type OpenTunnelResponse struct {
@@ -4705,13 +4722,14 @@ const file_plugin_proto_rawDesc = "" +
 	"bytesCount\x12\x1f\n" +
 	"\vfacets_json\x18\x06 \x01(\fR\n" +
 	"facetsJson\x12\x12\n" +
-	"\x04rule\x18\a \x01(\tR\x04rule\"\xeb\x02\n" +
+	"\x04rule\x18\a \x01(\tR\x04rule\"\x9f\x03\n" +
 	"\x11OpenTunnelRequest\x12(\n" +
 	"\x10tunnel_type_name\x18\x01 \x01(\tR\x0etunnelTypeName\x12'\n" +
 	"\x0ftunnel_instance\x18\x02 \x01(\tR\x0etunnelInstance\x12%\n" +
 	"\x0ecanonical_json\x18\x03 \x01(\fR\rcanonicalJson\x12+\n" +
 	"\x11credential_secret\x18\x04 \x01(\fR\x10credentialSecret\x12j\n" +
-	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntryR\x10credentialExtras\x1aC\n" +
+	"\x11credential_extras\x18\x05 \x03(\v2=.clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntryR\x10credentialExtras\x122\n" +
+	"\x15transport_dial_handle\x18\x06 \x01(\tR\x13transportDialHandle\x1aC\n" +
 	"\x15CredentialExtrasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\",\n" +
@@ -4784,7 +4802,10 @@ const file_plugin_proto_rawDesc = "" +
 	"\x03Get\x12%.clawpatrol.plugin.v1.StateGetRequest\x1a&.clawpatrol.plugin.v1.StateGetResponse\x12T\n" +
 	"\x03Put\x12%.clawpatrol.plugin.v1.StatePutRequest\x1a&.clawpatrol.plugin.v1.StatePutResponse2g\n" +
 	"\vHostControl\x12X\n" +
-	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdictBCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
+	"\bEvaluate\x12%.clawpatrol.plugin.v1.EvaluateRequest\x1a%.clawpatrol.plugin.v1.EvaluateVerdict2f\n" +
+	"\n" +
+	"HostTunnel\x12X\n" +
+	"\fDialUpstream\x12!.clawpatrol.plugin.v1.DialMessage\x1a!.clawpatrol.plugin.v1.DialMessage(\x010\x01BCZAgithub.com/denoland/clawpatrol/config/extplugin/proto;extpluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -4944,19 +4965,21 @@ var file_plugin_proto_depIdxs = []int32{
 	57, // 66: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
 	59, // 67: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
 	61, // 68: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
-	6,  // 69: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 70: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 71: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	32, // 72: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
-	34, // 73: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	50, // 74: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	53, // 75: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	52, // 76: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	58, // 77: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	60, // 78: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	62, // 79: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
-	69, // [69:80] is the sub-list for method output_type
-	58, // [58:69] is the sub-list for method input_type
+	53, // 69: clawpatrol.plugin.v1.HostTunnel.DialUpstream:input_type -> clawpatrol.plugin.v1.DialMessage
+	6,  // 70: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 71: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 72: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 73: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 74: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	50, // 75: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	53, // 76: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	52, // 77: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	58, // 78: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	60, // 79: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	62, // 80: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
+	53, // 81: clawpatrol.plugin.v1.HostTunnel.DialUpstream:output_type -> clawpatrol.plugin.v1.DialMessage
+	70, // [70:82] is the sub-list for method output_type
+	58, // [58:70] is the sub-list for method input_type
 	58, // [58:58] is the sub-list for extension type_name
 	58, // [58:58] is the sub-list for extension extendee
 	0,  // [0:58] is the sub-list for field type_name
@@ -5004,7 +5027,7 @@ func file_plugin_proto_init() {
 			NumEnums:      5,
 			NumMessages:   67,
 			NumExtensions: 0,
-			NumServices:   6,
+			NumServices:   7,
 		},
 		GoTypes:           file_plugin_proto_goTypes,
 		DependencyIndexes: file_plugin_proto_depIdxs,

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -635,6 +635,16 @@ message OpenTunnelRequest {
   // Optional credential bound to the tunnel.
   bytes  credential_secret = 4;
   map<string,string> credential_extras = 5;
+  // transport_dial_handle is the opaque token a tunnel plugin echoes to
+  // HostTunnel.DialUpstream to open its own transport connection (the
+  // socket the tunnel uses to reach its endpoint/bastion). The gateway
+  // routes that dial: directly, or — when the tunnel is chained
+  // (`via = <tunnel>` in the gateway config) — through the parent tunnel.
+  // The plugin never knows or names the route; it just dials, exactly
+  // like an endpoint plugin's Conn.DialUpstream. A tunnel plugin should
+  // therefore run with no network capability of its own and rely on this
+  // brokered dial. Always set for a real tunnel load.
+  string transport_dial_handle = 6;
 }
 
 message OpenTunnelResponse {
@@ -745,4 +755,26 @@ message EvaluateVerdict {
   string action = 1; // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
   string reason = 2;
   string rule = 3;
+}
+
+// HostTunnel is the brokered transport dial for tunnel plugins — the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream.
+// Gateway-served, like HostState/HostControl: the plugin is the client.
+// A tunnel plugin uses it to open the socket its transport rides on (the
+// TCP conn to an SSH bastion, the UDP conn to a WireGuard endpoint)
+// rather than opening a raw socket itself. The gateway routes the dial:
+// directly when the tunnel is top-level, or through the PARENT tunnel
+// when the tunnel is chained (`via = <tunnel>`). The plugin never knows
+// the route — that's how WireGuard-over-SOCKS works without the WG plugin
+// being SOCKS-aware. The gateway owns the composition.
+service HostTunnel {
+  // DialUpstream opens one transport connection for the calling tunnel.
+  // The first DialMessage MUST be a DialInit whose tunnel_handle is the
+  // transport_dial_handle from OpenTunnelRequest, and whose network/addr
+  // name the target ("tcp"/"udp", "host:port"). For network="udp" the
+  // byte stream carries length-prefixed datagrams (a 2-byte big-endian
+  // length per packet); the gateway frames a real UDP socket on the
+  // direct path, and a chained datagram tunnel (e.g. SOCKS5 UDP ASSOCIATE)
+  // on the via path.
+  rpc DialUpstream(stream DialMessage) returns (stream DialMessage);
 }

--- a/internal/config/extplugin/proto/plugin_grpc.pb.go
+++ b/internal/config/extplugin/proto/plugin_grpc.pb.go
@@ -950,3 +950,137 @@ var HostControl_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "plugin.proto",
 }
+
+const (
+	HostTunnel_DialUpstream_FullMethodName = "/clawpatrol.plugin.v1.HostTunnel/DialUpstream"
+)
+
+// HostTunnelClient is the client API for HostTunnel service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// HostTunnel is the brokered transport dial for tunnel plugins — the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream.
+// Gateway-served, like HostState/HostControl: the plugin is the client.
+// A tunnel plugin uses it to open the socket its transport rides on (the
+// TCP conn to an SSH bastion, the UDP conn to a WireGuard endpoint)
+// rather than opening a raw socket itself. The gateway routes the dial:
+// directly when the tunnel is top-level, or through the PARENT tunnel
+// when the tunnel is chained (`via = <tunnel>`). The plugin never knows
+// the route — that's how WireGuard-over-SOCKS works without the WG plugin
+// being SOCKS-aware. The gateway owns the composition.
+type HostTunnelClient interface {
+	// DialUpstream opens one transport connection for the calling tunnel.
+	// The first DialMessage MUST be a DialInit whose tunnel_handle is the
+	// transport_dial_handle from OpenTunnelRequest, and whose network/addr
+	// name the target ("tcp"/"udp", "host:port"). For network="udp" the
+	// byte stream carries length-prefixed datagrams (a 2-byte big-endian
+	// length per packet); the gateway frames a real UDP socket on the
+	// direct path, and a chained datagram tunnel (e.g. SOCKS5 UDP ASSOCIATE)
+	// on the via path.
+	DialUpstream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[DialMessage, DialMessage], error)
+}
+
+type hostTunnelClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewHostTunnelClient(cc grpc.ClientConnInterface) HostTunnelClient {
+	return &hostTunnelClient{cc}
+}
+
+func (c *hostTunnelClient) DialUpstream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[DialMessage, DialMessage], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &HostTunnel_ServiceDesc.Streams[0], HostTunnel_DialUpstream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[DialMessage, DialMessage]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type HostTunnel_DialUpstreamClient = grpc.BidiStreamingClient[DialMessage, DialMessage]
+
+// HostTunnelServer is the server API for HostTunnel service.
+// All implementations must embed UnimplementedHostTunnelServer
+// for forward compatibility.
+//
+// HostTunnel is the brokered transport dial for tunnel plugins — the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream.
+// Gateway-served, like HostState/HostControl: the plugin is the client.
+// A tunnel plugin uses it to open the socket its transport rides on (the
+// TCP conn to an SSH bastion, the UDP conn to a WireGuard endpoint)
+// rather than opening a raw socket itself. The gateway routes the dial:
+// directly when the tunnel is top-level, or through the PARENT tunnel
+// when the tunnel is chained (`via = <tunnel>`). The plugin never knows
+// the route — that's how WireGuard-over-SOCKS works without the WG plugin
+// being SOCKS-aware. The gateway owns the composition.
+type HostTunnelServer interface {
+	// DialUpstream opens one transport connection for the calling tunnel.
+	// The first DialMessage MUST be a DialInit whose tunnel_handle is the
+	// transport_dial_handle from OpenTunnelRequest, and whose network/addr
+	// name the target ("tcp"/"udp", "host:port"). For network="udp" the
+	// byte stream carries length-prefixed datagrams (a 2-byte big-endian
+	// length per packet); the gateway frames a real UDP socket on the
+	// direct path, and a chained datagram tunnel (e.g. SOCKS5 UDP ASSOCIATE)
+	// on the via path.
+	DialUpstream(grpc.BidiStreamingServer[DialMessage, DialMessage]) error
+	mustEmbedUnimplementedHostTunnelServer()
+}
+
+// UnimplementedHostTunnelServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedHostTunnelServer struct{}
+
+func (UnimplementedHostTunnelServer) DialUpstream(grpc.BidiStreamingServer[DialMessage, DialMessage]) error {
+	return status.Error(codes.Unimplemented, "method DialUpstream not implemented")
+}
+func (UnimplementedHostTunnelServer) mustEmbedUnimplementedHostTunnelServer() {}
+func (UnimplementedHostTunnelServer) testEmbeddedByValue()                    {}
+
+// UnsafeHostTunnelServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to HostTunnelServer will
+// result in compilation errors.
+type UnsafeHostTunnelServer interface {
+	mustEmbedUnimplementedHostTunnelServer()
+}
+
+func RegisterHostTunnelServer(s grpc.ServiceRegistrar, srv HostTunnelServer) {
+	// If the following call panics, it indicates UnimplementedHostTunnelServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&HostTunnel_ServiceDesc, srv)
+}
+
+func _HostTunnel_DialUpstream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(HostTunnelServer).DialUpstream(&grpc.GenericServerStream[DialMessage, DialMessage]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type HostTunnel_DialUpstreamServer = grpc.BidiStreamingServer[DialMessage, DialMessage]
+
+// HostTunnel_ServiceDesc is the grpc.ServiceDesc for HostTunnel service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var HostTunnel_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "clawpatrol.plugin.v1.HostTunnel",
+	HandlerType: (*HostTunnelServer)(nil),
+	Methods:     []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "DialUpstream",
+			Handler:       _HostTunnel_DialUpstream_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+	Metadata: "plugin.proto",
+}

--- a/internal/config/extplugin/tunneltransport.go
+++ b/internal/config/extplugin/tunneltransport.go
@@ -1,0 +1,221 @@
+package extplugin
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"net"
+	"sync"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// transportRouteRegistry records, per tunnel instance, how the gateway
+// routes that tunnel plugin's brokered transport dials (HostTunnel.
+// DialUpstream). Keyed by an opaque, unguessable token the gateway hands
+// the plugin at OpenTunnel (transport_dial_handle); the plugin echoes it
+// to dial. The route is the parent tunnel when the tunnel is chained
+// (`via = <tunnel>`), or nil for a direct dial. The token is the
+// capability — only a plugin whose gateway-side adapter registered it can
+// reach the route — so DialUpstream needs no further scoping.
+//
+// One registry per plugin subprocess (Client), shared between the
+// tunnelAdapter that registers routes at Open and the broker-served
+// hostTunnel that resolves them at DialUpstream.
+type transportRouteRegistry struct {
+	mu sync.Mutex
+	m  map[string]runtime.Tunnel // token -> parent tunnel (nil = dial direct)
+}
+
+func newTransportRouteRegistry() *transportRouteRegistry {
+	return &transportRouteRegistry{m: map[string]runtime.Tunnel{}}
+}
+
+// add registers a route (parent may be nil for a direct dial) and returns
+// its token.
+func (r *transportRouteRegistry) add(parent runtime.Tunnel) string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	token := hex.EncodeToString(b[:])
+	r.mu.Lock()
+	r.m[token] = parent // nil is a valid value: direct route
+	r.mu.Unlock()
+	return token
+}
+
+// get returns the route for a token: the parent tunnel (possibly nil for
+// direct) and whether the token is registered at all.
+func (r *transportRouteRegistry) get(token string) (parent runtime.Tunnel, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	parent, ok = r.m[token]
+	return parent, ok
+}
+
+func (r *transportRouteRegistry) remove(token string) {
+	if token == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.m, token)
+	r.mu.Unlock()
+}
+
+// hostTunnel is the gateway-served HostTunnel service: it dials a tunnel
+// plugin's transport on its behalf and routes it (direct or via parent).
+type hostTunnel struct {
+	pb.UnimplementedHostTunnelServer
+	reg *transportRouteRegistry
+	// directDial dials an upstream with no parent tunnel (the gateway's
+	// own dialer). Required so a tunnel plugin can run with no network of
+	// its own; nil only on paths that never serve real tunnels.
+	directDial func(network, addr string) (net.Conn, error)
+}
+
+// DialUpstream opens one transport connection for the calling tunnel,
+// routing it through the tunnel's parent (`via`) or directly, and pumps
+// bytes over the stream. For network="udp" the byte stream carries
+// length-prefixed datagrams end to end; the gateway frames a real UDP
+// socket on the direct path, while a chained datagram tunnel frames it on
+// the via path.
+func (h *hostTunnel) DialUpstream(stream pb.HostTunnel_DialUpstreamServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	init := first.GetInit()
+	if init == nil {
+		return errors.New("extplugin: HostTunnel.DialUpstream: first message must be DialInit")
+	}
+	parent, ok := h.reg.get(init.GetTunnelHandle())
+	if !ok {
+		return errors.New("extplugin: HostTunnel.DialUpstream: unknown transport handle")
+	}
+	network, addr := init.GetNetwork(), init.GetAddr()
+
+	var conn net.Conn
+	switch {
+	case parent != nil:
+		// Chained: route the transport through the parent tunnel. For udp
+		// the parent (e.g. a SOCKS plugin) already deals in length-prefixed
+		// datagrams, so the conn is a frame-carrying byte stream.
+		conn, err = parent.Dial(stream.Context(), network, addr)
+	case network == "udp":
+		// Direct udp: dial a real UDP socket and present it as a stream of
+		// length-prefixed datagrams so the pump is uniform with the via path.
+		var pc net.Conn
+		pc, err = h.dial(network, addr)
+		if err == nil {
+			conn = newFramedDatagramConn(pc)
+		}
+	default:
+		conn, err = h.dial(network, addr)
+	}
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	bridgeTransportStream(stream, conn)
+	return nil
+}
+
+func (h *hostTunnel) dial(network, addr string) (net.Conn, error) {
+	if h.directDial == nil {
+		return nil, errors.New("extplugin: no direct dialer wired for tunnel transport")
+	}
+	return h.directDial(network, addr)
+}
+
+// bridgeTransportStream pumps bytes both ways between a DialUpstream gRPC
+// stream and the dialed conn until either side closes. It returns as soon
+// as EITHER direction ends: closing conn unblocks the conn->stream reader,
+// and returning from the handler cancels the gRPC stream — the only way to
+// unblock a server-side stream.Recv. The buffered done channel lets the
+// surviving goroutine exit without blocking.
+func bridgeTransportStream(stream pb.HostTunnel_DialUpstreamServer, conn net.Conn) {
+	done := make(chan struct{}, 2)
+	go func() { // conn -> stream
+		buf := make([]byte, 32<<10)
+		for {
+			n, rerr := conn.Read(buf)
+			if n > 0 {
+				if serr := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+					Data: &pb.DialData{Payload: append([]byte(nil), buf[:n]...)},
+				}}); serr != nil {
+					break
+				}
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	go func() { // stream -> conn
+		for {
+			msg, rerr := stream.Recv()
+			if rerr != nil {
+				break
+			}
+			switch k := msg.GetKind().(type) {
+			case *pb.DialMessage_Data:
+				if _, werr := conn.Write(k.Data.GetPayload()); werr != nil {
+					return
+				}
+			case *pb.DialMessage_Close:
+				return
+			}
+		}
+		done <- struct{}{}
+	}()
+	<-done
+	_ = conn.Close()
+}
+
+// framedDatagramConn presents a connected packet conn (a UDP socket) as a
+// byte stream of length-prefixed datagrams, so it can be pumped over the
+// broker to a plugin that reads it with pluginsdk.PacketConnOverStream.
+// Read yields one framed datagram at a time; Write reassembles frames
+// across arbitrary chunk boundaries and sends each as one datagram.
+type framedDatagramConn struct {
+	net.Conn
+	rbuf []byte
+	wbuf []byte
+}
+
+func newFramedDatagramConn(pc net.Conn) *framedDatagramConn {
+	return &framedDatagramConn{Conn: pc}
+}
+
+func (f *framedDatagramConn) Read(p []byte) (int, error) {
+	if len(f.rbuf) == 0 {
+		buf := make([]byte, 64<<10)
+		n, err := f.Conn.Read(buf)
+		if err != nil {
+			return 0, err
+		}
+		var hdr [2]byte
+		binary.BigEndian.PutUint16(hdr[:], uint16(n))
+		f.rbuf = append(hdr[:], buf[:n]...)
+	}
+	m := copy(p, f.rbuf)
+	f.rbuf = f.rbuf[m:]
+	return m, nil
+}
+
+func (f *framedDatagramConn) Write(p []byte) (int, error) {
+	f.wbuf = append(f.wbuf, p...)
+	for len(f.wbuf) >= 2 {
+		n := int(binary.BigEndian.Uint16(f.wbuf[:2]))
+		if len(f.wbuf) < 2+n {
+			break
+		}
+		if _, err := f.Conn.Write(f.wbuf[2 : 2+n]); err != nil {
+			return 0, err
+		}
+		f.wbuf = f.wbuf[2+n:]
+	}
+	return len(p), nil
+}

--- a/internal/config/extplugin/tunneltransport_test.go
+++ b/internal/config/extplugin/tunneltransport_test.go
@@ -1,0 +1,198 @@
+package extplugin
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+)
+
+// echoParent is a fake parent runtime.Tunnel: every Dial returns a conn
+// that echoes whatever is written to it, and records what it was asked to
+// dial. Stands in for a real parent tunnel (a SOCKS plugin, ssh_port_forward)
+// on the via route.
+type echoParent struct{ network, addr chan string }
+
+func (e echoParent) Dial(_ context.Context, network, addr string) (net.Conn, error) {
+	select {
+	case e.network <- network:
+	default:
+	}
+	select {
+	case e.addr <- addr:
+	default:
+	}
+	return echoConn(), nil
+}
+
+func (echoParent) Close() error { return nil }
+
+func echoConn() net.Conn {
+	c1, c2 := net.Pipe()
+	go func() { _, _ = io.Copy(c2, c2) }() // echo bytes written to c1
+	return c1
+}
+
+// transportBrokerPlugin wires a go-plugin broker so the gateway serves
+// HostTunnel and the plugin side can call DialUpstream — the real path a
+// tunnel plugin's req.DialUpstream takes, minus the SDK wrapper.
+type transportBrokerPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	reg        *transportRouteRegistry
+	directDial func(network, addr string) (net.Conn, error)
+	brokerCh   chan *goplugin.GRPCBroker
+}
+
+func (p *transportBrokerPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Server) error {
+	p.brokerCh <- broker
+	return nil
+}
+
+func (p *transportBrokerPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	go broker.AcceptAndServe(HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+		s := grpc.NewServer(opts...)
+		pb.RegisterHostTunnelServer(s, &hostTunnel{reg: p.reg, directDial: p.directDial})
+		return s
+	})
+	return c, nil
+}
+
+func dialUpstream(t *testing.T, broker *goplugin.GRPCBroker, token, network, addr string) (pb.HostTunnel_DialUpstreamClient, error) {
+	t.Helper()
+	conn, err := broker.Dial(HostServicesBrokerID)
+	if err != nil {
+		t.Fatalf("dial host services: %v", err)
+	}
+	stream, err := pb.NewHostTunnelClient(conn).DialUpstream(context.Background())
+	if err != nil {
+		t.Fatalf("DialUpstream: %v", err)
+	}
+	err = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+		TunnelHandle: token, Network: network, Addr: addr,
+	}}})
+	return stream, err
+}
+
+// TestDialUpstreamRoutes exercises the brokered transport dial over a real
+// broker: a chained tunnel's dial is routed through its parent, a direct
+// tunnel's dial goes through the gateway's injected dialer, and an unknown
+// token is refused.
+func TestDialUpstreamRoutes(t *testing.T) {
+	parent := echoParent{network: make(chan string, 1), addr: make(chan string, 1)}
+	reg := newTransportRouteRegistry()
+	viaToken := reg.add(parent) // chained: route through the parent
+	directToken := reg.add(nil) // direct: route through the gateway dialer
+
+	// directDial stands in for the gateway's own dialer: an echo target.
+	var directNet, directAddr string
+	directDial := func(network, addr string) (net.Conn, error) {
+		directNet, directAddr = network, addr
+		return echoConn(), nil
+	}
+
+	brokerCh := make(chan *goplugin.GRPCBroker, 1)
+	client, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{
+		"x": &transportBrokerPlugin{reg: reg, directDial: directDial, brokerCh: brokerCh},
+	})
+	defer func() { _ = client.Close() }()
+	if _, err := client.Dispense("x"); err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+	broker := <-brokerCh
+
+	// Chained: dial routes through the parent (which echoes), and the parent
+	// sees the child's udp/endpoint request.
+	viaStream, err := dialUpstream(t, broker, viaToken, "udp", "wg.example:51820")
+	if err != nil {
+		t.Fatalf("via send init: %v", err)
+	}
+	if got := echoRoundTrip(t, viaStream, "handshake"); got != "handshake" {
+		t.Fatalf("via echo = %q", got)
+	}
+	if n := <-parent.network; n != "udp" {
+		t.Fatalf("parent dialed network %q, want udp", n)
+	}
+	if a := <-parent.addr; a != "wg.example:51820" {
+		t.Fatalf("parent dialed addr %q", a)
+	}
+
+	// Direct: dial goes through the gateway's injected dialer (echo target).
+	directStream, err := dialUpstream(t, broker, directToken, "tcp", "bastion:22")
+	if err != nil {
+		t.Fatalf("direct send init: %v", err)
+	}
+	if got := echoRoundTrip(t, directStream, "ping"); got != "ping" {
+		t.Fatalf("direct echo = %q", got)
+	}
+	if directNet != "tcp" || directAddr != "bastion:22" {
+		t.Fatalf("direct dialer got %q/%q, want tcp/bastion:22", directNet, directAddr)
+	}
+
+	// Unknown token must be refused.
+	bad, _ := dialUpstream(t, broker, "not-a-real-token", "tcp", "x:1")
+	if _, err := bad.Recv(); err == nil {
+		t.Fatal("DialUpstream with unknown token should fail")
+	}
+}
+
+func echoRoundTrip(t *testing.T, stream pb.HostTunnel_DialUpstreamClient, payload string) string {
+	t.Helper()
+	if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+		Data: &pb.DialData{Payload: []byte(payload)},
+	}}); err != nil {
+		t.Fatalf("send data: %v", err)
+	}
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		if d := msg.GetData(); d != nil {
+			return string(d.GetPayload())
+		}
+	}
+}
+
+// TestFramedDatagramConn round-trips length-prefixed datagrams across
+// arbitrary chunk boundaries — the gateway-side adapter for direct udp.
+func TestFramedDatagramConn(t *testing.T) {
+	a, b := net.Pipe()
+	go func() { _, _ = io.Copy(b, b) }() // echo the underlying "udp" conn
+	f := newFramedDatagramConn(a)
+	defer func() { _ = f.Close() }()
+	_ = f.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Two framed datagrams written in one Write must arrive as two packets,
+	// echoed back and re-framed for the reader.
+	want := []byte("alpha")
+	frame := append([]byte{0, byte(len(want))}, want...)
+	go func() { _, _ = f.Write(append(frame, frame...)) }()
+
+	for i := 0; i < 2; i++ {
+		got, err := readFrame(f)
+		if err != nil {
+			t.Fatalf("read frame %d: %v", i, err)
+		}
+		if string(got) != "alpha" {
+			t.Fatalf("frame %d = %q", i, got)
+		}
+	}
+}
+
+func readFrame(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, int(hdr[0])<<8|int(hdr[1]))
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}
+
+var _ runtime.Tunnel = echoParent{}

--- a/pluginsdk/datagram.go
+++ b/pluginsdk/datagram.go
@@ -1,0 +1,90 @@
+package pluginsdk
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Datagram framing for carrying UDP packets over a byte stream (a `via`
+// conduit through a parent tunnel). Each datagram is a 2-byte big-endian
+// length followed by that many payload bytes. Both ends of a chained
+// udp-via must use this framing: the child (e.g. WireGuard) writes/reads
+// packets, and the parent (e.g. a SOCKS plugin) reframes them onto a real
+// datagram transport. 16-bit length caps a datagram at 65535 bytes, which
+// covers any UDP payload.
+
+const maxDatagram = 0xffff
+
+// WriteDatagram writes one length-prefixed datagram to w.
+func WriteDatagram(w io.Writer, p []byte) error {
+	if len(p) > maxDatagram {
+		p = p[:maxDatagram]
+	}
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(p)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(p)
+	return err
+}
+
+// ReadDatagram reads one length-prefixed datagram from r.
+func ReadDatagram(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint16(hdr[:])
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// PacketConnOverStream presents a byte stream carrying length-prefixed
+// datagrams (see WriteDatagram/ReadDatagram) as a connected
+// net.PacketConn. The remote address is fixed (the stream already routes
+// to one endpoint), so the addr argument to WriteTo is ignored and
+// ReadFrom always reports remote. This is what a WireGuard plugin wraps
+// its `via` conduit in so wireguard-go's bind can speak datagrams over a
+// chained tunnel.
+func PacketConnOverStream(conn net.Conn, remote net.Addr) net.PacketConn {
+	return &packetConnOverStream{conn: conn, remote: remote}
+}
+
+type packetConnOverStream struct {
+	conn   net.Conn
+	remote net.Addr
+	rMu    sync.Mutex
+	wMu    sync.Mutex
+}
+
+func (p *packetConnOverStream) ReadFrom(b []byte) (int, net.Addr, error) {
+	p.rMu.Lock()
+	defer p.rMu.Unlock()
+	d, err := ReadDatagram(p.conn)
+	if err != nil {
+		return 0, nil, err
+	}
+	return copy(b, d), p.remote, nil
+}
+
+func (p *packetConnOverStream) WriteTo(b []byte, _ net.Addr) (int, error) {
+	p.wMu.Lock()
+	defer p.wMu.Unlock()
+	if err := WriteDatagram(p.conn, b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (p *packetConnOverStream) Close() error                       { return p.conn.Close() }
+func (p *packetConnOverStream) LocalAddr() net.Addr                { return p.conn.LocalAddr() }
+func (p *packetConnOverStream) SetDeadline(t time.Time) error      { return p.conn.SetDeadline(t) }
+func (p *packetConnOverStream) SetReadDeadline(t time.Time) error  { return p.conn.SetReadDeadline(t) }
+func (p *packetConnOverStream) SetWriteDeadline(t time.Time) error { return p.conn.SetWriteDeadline(t) }

--- a/pluginsdk/datagram_test.go
+++ b/pluginsdk/datagram_test.go
@@ -1,0 +1,58 @@
+package pluginsdk
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+// Datagram framing must round-trip exactly — both the WireGuard plugin
+// (writes/reads packets over its `via` conduit) and the SOCKS plugin
+// (reframes them onto a UDP relay) depend on this byte-for-byte.
+func TestDatagramRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	packets := [][]byte{
+		[]byte("first"),
+		{},                               // empty datagram
+		bytes.Repeat([]byte{0xab}, 1500), // jumbo-ish
+		[]byte("last"),
+	}
+	for _, p := range packets {
+		if err := WriteDatagram(&buf, p); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for i, want := range packets {
+		got, err := ReadDatagram(&buf)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("datagram %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// PacketConnOverStream presents the framed stream as a connected
+// net.PacketConn (what the WG plugin wraps its via conduit in).
+func TestPacketConnOverStream(t *testing.T) {
+	a, b := net.Pipe()
+	remote := &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 51820}
+	pcA := PacketConnOverStream(a, remote)
+	pcB := PacketConnOverStream(b, remote)
+
+	want := []byte("wireguard handshake bytes")
+	go func() { _, _ = pcA.WriteTo(want, remote) }()
+
+	buf := make([]byte, 1500)
+	n, addr, err := pcB.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("readfrom: %v", err)
+	}
+	if !bytes.Equal(buf[:n], want) {
+		t.Fatalf("got %q, want %q", buf[:n], want)
+	}
+	if addr.String() != remote.String() {
+		t.Fatalf("addr = %s, want %s", addr, remote)
+	}
+}

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -629,6 +629,15 @@ type TunnelOpenRequest struct {
 	CanonicalConfig  []byte
 	CredentialSecret []byte
 	CredentialExtras map[string]string
+	// DialUpstream opens this tunnel's own transport connection — the
+	// socket the tunnel rides on to reach its endpoint (a "udp" conn to a
+	// WireGuard endpoint, a "tcp" conn to an SSH bastion). The gateway
+	// dials on the plugin's behalf and routes it directly, or through the
+	// parent tunnel when this tunnel is chained (`via = <tunnel>`). Use it
+	// instead of opening a raw socket, so the tunnel plugin can run with no
+	// network capability of its own and the gateway owns the composition.
+	// nil only against an old gateway with no HostTunnel support.
+	DialUpstream DialUpstreamFunc
 }
 
 // TunnelDialRequest is what Dial callbacks receive when the gateway
@@ -637,6 +646,11 @@ type TunnelDialRequest struct {
 	Handle  any
 	Network string
 	Addr    string
+	// DialUpstream opens an upstream transport connection for this tunnel,
+	// gateway-routed (direct or via the parent) — the same primitive as on
+	// TunnelOpenRequest, for tunnels that establish their transport
+	// per-Dial (e.g. a SOCKS tunnel dialing the proxy on each Dial).
+	DialUpstream DialUpstreamFunc
 }
 
 // ErrNoSuchType is returned by the SDK when the gateway invokes a

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -1001,6 +1001,9 @@ func serveStreamRead(req *pb.StreamRead, mu *sync.Mutex, streams map[string]*str
 type tunnelHandle struct {
 	def    TunnelDef
 	handle any
+	// dialUpstream opens this tunnel's transport, gateway-routed; reused by
+	// Dial for tunnels that establish their transport per-Dial.
+	dialUpstream DialUpstreamFunc
 }
 
 func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb.OpenTunnelResponse, error) {
@@ -1008,12 +1011,14 @@ func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb
 	if !ok {
 		return nil, fmt.Errorf("%w: tunnel %q", ErrNoSuchType, req.TunnelTypeName)
 	}
+	dialUpstream := transportDialer(req.GetTransportDialHandle())
 	openReq := TunnelOpenRequest{
 		TunnelTypeName:   req.TunnelTypeName,
 		TunnelInstance:   req.TunnelInstance,
 		CanonicalConfig:  req.CanonicalJson,
 		CredentialSecret: req.CredentialSecret,
 		CredentialExtras: req.CredentialExtras,
+		DialUpstream:     dialUpstream,
 	}
 	var (
 		handle any
@@ -1028,7 +1033,7 @@ func (s *server) OpenTunnel(ctx context.Context, req *pb.OpenTunnelRequest) (*pb
 		handle = req.TunnelInstance
 	}
 	id := fmt.Sprintf("t%d-%s", s.tunHandleID.Add(1), req.TunnelInstance)
-	s.tunHandles.Store(id, &tunnelHandle{def: def, handle: handle})
+	s.tunHandles.Store(id, &tunnelHandle{def: def, handle: handle, dialUpstream: dialUpstream})
 	return &pb.OpenTunnelResponse{Handle: id}, nil
 }
 
@@ -1120,9 +1125,10 @@ func (s *server) Dial(stream pb.Tunnel_DialServer) error {
 	}()
 
 	dialErr := invokeTunnelDial(ctx, th.def, TunnelDialRequest{
-		Handle:  th.handle,
-		Network: initMsg.Init.Network,
-		Addr:    initMsg.Init.Addr,
+		Handle:       th.handle,
+		Network:      initMsg.Init.Network,
+		Addr:         initMsg.Init.Addr,
+		DialUpstream: th.dialUpstream,
 	}, upstream)
 	_ = upstream.Close()
 	closer()

--- a/pluginsdk/socks/main.go
+++ b/pluginsdk/socks/main.go
@@ -1,0 +1,381 @@
+// Standalone clawpatrol tunnel plugin: route upstream connections
+// through a SOCKS5 proxy. Spike — demonstrates a PARENT tunnel that can
+// carry UDP (so a WireGuard tunnel can chain `via = socks`).
+//
+// TCP upstreams use SOCKS5 CONNECT. "udp" dials (a chained child asking
+// for a datagram conduit) use SOCKS5 UDP ASSOCIATE; the child's bytes are
+// length-prefixed datagrams (pluginsdk.ReadDatagram/WriteDatagram) which
+// this plugin reframes onto the proxy's UDP relay.
+//
+// The plugin opens NO raw sockets: it reaches the SOCKS proxy and the UDP
+// relay only through the gateway's brokered DialUpstream, so it runs with
+// no network capability of its own (network = "none"), just like an
+// endpoint plugin.
+//
+// Build: go build -o socks-tunnel ./pluginsdk/socks
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name:    "socks_tunnel",
+		Version: "0.1",
+		// No raw sockets: the plugin reaches the proxy and the UDP relay
+		// only through the gateway's brokered DialUpstream.
+		Capabilities: pluginsdk.Capabilities{Network: pluginsdk.NetworkNone},
+		Tunnels:      []pluginsdk.TunnelDef{socksDef()},
+	})
+}
+
+// strAddr is a synthetic net.Addr for the brokered relay conn (already
+// connected, so PacketConnOverStream only reports it back, never dials it).
+type strAddr string
+
+func (a strAddr) Network() string { return "udp" }
+func (a strAddr) String() string  { return string(a) }
+
+type socksConfig struct {
+	Proxy    string `json:"proxy"`    // host:port of the SOCKS5 server
+	Username string `json:"username"` // optional user/pass auth
+	Password string `json:"password"`
+}
+
+func socksDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "socks_proxy",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "proxy", TypeString: "string", Required: true},
+			{Name: "username", TypeString: "string"},
+			{Name: "password", TypeString: "string"},
+		}},
+		Open: func(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+			var cfg socksConfig
+			if len(req.CanonicalConfig) > 0 {
+				if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+					return nil, fmt.Errorf("socks_proxy config: %w", err)
+				}
+			}
+			if cfg.Proxy == "" {
+				return nil, errors.New("socks_proxy: proxy is required")
+			}
+			return &cfg, nil
+		},
+		Dial: func(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+			cfg, _ := req.Handle.(*socksConfig)
+			if cfg == nil {
+				return errors.New("socks_proxy: missing handle")
+			}
+			if req.DialUpstream == nil {
+				return errors.New("socks_proxy: gateway has no transport dial support")
+			}
+			switch req.Network {
+			case "", "tcp":
+				return socksDialTCP(ctx, req.DialUpstream, cfg, req.Addr, upstream)
+			case "udp":
+				return socksDialUDP(ctx, req.DialUpstream, cfg, req.Addr, upstream)
+			default:
+				return fmt.Errorf("socks_proxy: unsupported network %q", req.Network)
+			}
+		},
+		Close: func(_ context.Context, _ any) error { return nil },
+	}
+}
+
+// ---- TCP: SOCKS5 CONNECT, then pump bytes ----
+
+func socksDialTCP(ctx context.Context, dial pluginsdk.DialUpstreamFunc, cfg *socksConfig, addr string, upstream net.Conn) error {
+	c, err := dial(ctx, "tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+	if err := socksHandshake(c, cfg); err != nil {
+		return err
+	}
+	if _, err := socksRequest(c, cmdConnect, addr); err != nil {
+		return fmt.Errorf("socks CONNECT %s: %w", addr, err)
+	}
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+// ---- UDP: SOCKS5 UDP ASSOCIATE, datagram-framed over `upstream` ----
+
+func socksDialUDP(ctx context.Context, dial pluginsdk.DialUpstreamFunc, cfg *socksConfig, target string, upstream net.Conn) error {
+	// The TCP control connection must stay open for the lifetime of the
+	// association — closing it tells the proxy to drop the UDP relay.
+	ctrl, err := dial(ctx, "tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = ctrl.Close() }()
+	if err := socksHandshake(ctrl, cfg); err != nil {
+		return err
+	}
+	relayStr, err := socksRequest(ctrl, cmdUDPAssociate, "0.0.0.0:0")
+	if err != nil {
+		return fmt.Errorf("socks UDP ASSOCIATE: %w", err)
+	}
+	// The reply's BND.ADDR is frequently unspecified (0.0.0.0) or an
+	// internal address when the proxy sits behind NAT (e.g. a cloud VM
+	// returning its private IP). The UDP relay lives on the proxy host, so
+	// fall back to the proxy's host with the returned port unless the reply
+	// names a concrete, routable address.
+	relayHost, relayPort, _ := net.SplitHostPort(relayStr)
+	if ip := net.ParseIP(relayHost); ip == nil || ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() {
+		relayHost, _, _ = net.SplitHostPort(cfg.Proxy)
+	}
+	relayHostPort := net.JoinHostPort(relayHost, relayPort)
+
+	// Open the UDP relay through the gateway's brokered dial (no raw
+	// socket). The conn carries length-prefixed datagrams; treat it as a
+	// connected net.PacketConn.
+	relayConn, err := dial(ctx, "udp", relayHostPort)
+	if err != nil {
+		return fmt.Errorf("dial socks relay %q: %w", relayHostPort, err)
+	}
+	pc := pluginsdk.PacketConnOverStream(relayConn, strAddr(relayHostPort))
+	defer func() { _ = pc.Close() }()
+
+	hdr, err := socksUDPHeader(target)
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{}, 3)
+	// upstream datagrams -> SOCKS relay (prepend the UDP request header)
+	go func() {
+		for {
+			d, rerr := pluginsdk.ReadDatagram(upstream)
+			if rerr != nil {
+				break
+			}
+			pkt := append(append([]byte(nil), hdr...), d...)
+			if _, werr := pc.WriteTo(pkt, strAddr(relayHostPort)); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// SOCKS relay -> upstream datagrams (strip the UDP reply header)
+	go func() {
+		buf := make([]byte, 64<<10)
+		for {
+			n, _, rerr := pc.ReadFrom(buf)
+			if rerr != nil {
+				break
+			}
+			payload, ok := stripSocksUDPHeader(buf[:n])
+			if !ok {
+				continue
+			}
+			if werr := pluginsdk.WriteDatagram(upstream, payload); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// The control conn closing (proxy dropped the association) ends it.
+	go func() {
+		var b [1]byte
+		_, _ = ctrl.Read(b[:])
+		done <- struct{}{}
+	}()
+	<-done
+	return nil
+}
+
+// ---- SOCKS5 wire format (RFC 1928) ----
+
+const (
+	socksVer        = 0x05
+	cmdConnect      = 0x01
+	cmdUDPAssociate = 0x03
+	atypIPv4        = 0x01
+	atypDomain      = 0x03
+	atypIPv6        = 0x04
+)
+
+func socksHandshake(c net.Conn, cfg *socksConfig) error {
+	useAuth := cfg.Username != ""
+	methods := []byte{0x00}
+	if useAuth {
+		methods = []byte{0x02}
+	}
+	greeting := append([]byte{socksVer, byte(len(methods))}, methods...)
+	if _, err := c.Write(greeting); err != nil {
+		return err
+	}
+	var sel [2]byte
+	if _, err := io.ReadFull(c, sel[:]); err != nil {
+		return err
+	}
+	if sel[0] != socksVer {
+		return fmt.Errorf("socks: bad version %d", sel[0])
+	}
+	switch sel[1] {
+	case 0x00:
+		return nil
+	case 0x02:
+		return socksUserPassAuth(c, cfg)
+	default:
+		return fmt.Errorf("socks: no acceptable auth method (got %d)", sel[1])
+	}
+}
+
+func socksUserPassAuth(c net.Conn, cfg *socksConfig) error {
+	msg := []byte{0x01, byte(len(cfg.Username))}
+	msg = append(msg, cfg.Username...)
+	msg = append(msg, byte(len(cfg.Password)))
+	msg = append(msg, cfg.Password...)
+	if _, err := c.Write(msg); err != nil {
+		return err
+	}
+	var resp [2]byte
+	if _, err := io.ReadFull(c, resp[:]); err != nil {
+		return err
+	}
+	if resp[1] != 0x00 {
+		return errors.New("socks: user/pass auth failed")
+	}
+	return nil
+}
+
+// socksRequest sends a CONNECT or UDP ASSOCIATE request for addr and
+// returns the bound address from the reply ("host:port").
+func socksRequest(c net.Conn, cmd byte, addr string) (string, error) {
+	dst, err := encodeSocksAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	req := append([]byte{socksVer, cmd, 0x00}, dst...)
+	if _, err := c.Write(req); err != nil {
+		return "", err
+	}
+	// Reply: VER REP RSV ATYP BND.ADDR BND.PORT
+	var head [4]byte
+	if _, err := io.ReadFull(c, head[:]); err != nil {
+		return "", err
+	}
+	if head[1] != 0x00 {
+		return "", fmt.Errorf("socks reply code %d", head[1])
+	}
+	host, err := readSocksAddr(c, head[3])
+	if err != nil {
+		return "", err
+	}
+	var port [2]byte
+	if _, err := io.ReadFull(c, port[:]); err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(port[:])))), nil
+}
+
+// socksUDPHeader builds the per-datagram SOCKS UDP request header for a
+// fixed target: RSV(2)=0 FRAG=0 ATYP DST.ADDR DST.PORT.
+func socksUDPHeader(target string) ([]byte, error) {
+	dst, err := encodeSocksAddr(target)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{0x00, 0x00, 0x00}, dst...), nil
+}
+
+// stripSocksUDPHeader removes the SOCKS UDP reply header, returning the
+// inner payload.
+func stripSocksUDPHeader(b []byte) ([]byte, bool) {
+	if len(b) < 4 {
+		return nil, false
+	}
+	// b[0:2]=RSV, b[2]=FRAG, b[3]=ATYP
+	off := 4
+	switch b[3] {
+	case atypIPv4:
+		off += 4
+	case atypIPv6:
+		off += 16
+	case atypDomain:
+		if len(b) < 5 {
+			return nil, false
+		}
+		off += 1 + int(b[4])
+	default:
+		return nil, false
+	}
+	off += 2 // port
+	if off > len(b) {
+		return nil, false
+	}
+	return b[off:], true
+}
+
+func encodeSocksAddr(addr string) ([]byte, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	var out []byte
+	if ip := net.ParseIP(host); ip != nil {
+		if v4 := ip.To4(); v4 != nil {
+			out = append([]byte{atypIPv4}, v4...)
+		} else {
+			out = append([]byte{atypIPv6}, ip.To16()...)
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("socks: host too long")
+		}
+		out = append([]byte{atypDomain, byte(len(host))}, host...)
+	}
+	var port [2]byte
+	binary.BigEndian.PutUint16(port[:], uint16(p))
+	return append(out, port[:]...), nil
+}
+
+func readSocksAddr(c net.Conn, atyp byte) (string, error) {
+	switch atyp {
+	case atypIPv4:
+		var b [4]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case atypIPv6:
+		var b [16]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case atypDomain:
+		var l [1]byte
+		if _, err := io.ReadFull(c, l[:]); err != nil {
+			return "", err
+		}
+		b := make([]byte, l[0])
+		if _, err := io.ReadFull(c, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		return "", fmt.Errorf("socks: bad atyp %d", atyp)
+	}
+}

--- a/pluginsdk/tunneltransport.go
+++ b/pluginsdk/tunneltransport.go
@@ -1,0 +1,146 @@
+package pluginsdk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+// DialUpstreamFunc opens a tunnel plugin's transport connection — the
+// socket the tunnel rides on to reach its endpoint (the TCP conn to an
+// SSH bastion, the UDP conn to a WireGuard endpoint). It is the
+// tunnel-side equivalent of an endpoint plugin's Conn.DialUpstream: the
+// gateway dials on the plugin's behalf and routes it directly, or — when
+// the tunnel is chained (`via = <tunnel>`) — through the parent tunnel.
+// The plugin never knows the route, so a tunnel plugin should run with no
+// network capability of its own and dial only through this.
+//
+// network is "tcp" for a stream transport or "udp" for a datagram
+// transport. For "udp" the returned conn carries length-prefixed
+// datagrams (write one whole packet per Write, read one per Read); wrap
+// it with PacketConnOverStream for a net.PacketConn view.
+type DialUpstreamFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// transportDialer builds the DialUpstream closure bound to a tunnel's
+// transport_dial_handle. Returns nil when the handle is empty (an old
+// gateway, or a non-tunnel path).
+func transportDialer(handle string) DialUpstreamFunc {
+	if handle == "" {
+		return nil
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		cli, err := hostTunnelClient()
+		if err != nil {
+			return nil, err
+		}
+		stream, err := cli.DialUpstream(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+			TunnelHandle: handle,
+			Network:      network,
+			Addr:         addr,
+		}}}); err != nil {
+			return nil, err
+		}
+		return &transportConn{stream: stream, addr: addr}, nil
+	}
+}
+
+func hostTunnelClient() (pb.HostTunnelClient, error) {
+	c, err := hostServicesConn()
+	if err != nil {
+		return nil, err
+	}
+	return pb.NewHostTunnelClient(c), nil
+}
+
+// transportConn wraps a HostTunnel.DialUpstream bidi stream as a net.Conn
+// (the client-side mirror of the gateway's dialConn).
+type transportConn struct {
+	stream pb.HostTunnel_DialUpstreamClient
+	addr   string
+
+	mu      sync.Mutex
+	readBuf []byte
+	closed  bool
+	wMu     sync.Mutex
+	once    sync.Once
+}
+
+func (c *transportConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	if len(c.readBuf) > 0 {
+		n := copy(p, c.readBuf)
+		c.readBuf = c.readBuf[n:]
+		c.mu.Unlock()
+		return n, nil
+	}
+	c.mu.Unlock()
+	for {
+		msg, err := c.stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+		switch k := msg.GetKind().(type) {
+		case *pb.DialMessage_Data:
+			n := copy(p, k.Data.Payload)
+			if n < len(k.Data.Payload) {
+				c.mu.Lock()
+				c.readBuf = append(c.readBuf, k.Data.Payload[n:]...)
+				c.mu.Unlock()
+			}
+			return n, nil
+		case *pb.DialMessage_Close:
+			return 0, io.EOF
+		}
+	}
+}
+
+func (c *transportConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	c.mu.Unlock()
+	c.wMu.Lock()
+	defer c.wMu.Unlock()
+	if err := c.stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+		Data: &pb.DialData{Payload: append([]byte(nil), p...)},
+	}}); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *transportConn) Close() error {
+	c.once.Do(func() {
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
+		_ = c.stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}})
+		_ = c.stream.CloseSend()
+	})
+	return nil
+}
+
+func (c *transportConn) LocalAddr() net.Addr                { return transportAddr("transport") }
+func (c *transportConn) RemoteAddr() net.Addr               { return transportAddr(c.addr) }
+func (c *transportConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *transportConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *transportConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type transportAddr string
+
+func (a transportAddr) Network() string { return "plugin-tunnel-transport" }
+func (a transportAddr) String() string  { return string(a) }

--- a/pluginsdk/wireguard/main.go
+++ b/pluginsdk/wireguard/main.go
@@ -1,0 +1,316 @@
+// Standalone clawpatrol tunnel plugin: route upstream connections through
+// a WireGuard tunnel. Spike — a UDP-transport plugin tunnel that supports
+// `via` chaining (e.g. `via = socks`, so the WireGuard handshake's UDP
+// rides over a SOCKS5 UDP relay).
+//
+// The plugin runs with NO network of its own (network = "none"): it opens
+// its WireGuard transport through the gateway's brokered dial
+// (req.DialUpstream("udp", endpoint)), which the gateway routes directly
+// or through the parent tunnel. A small wireguard-go conn.Bind sends and
+// receives over that brokered datagram conduit instead of a real UDP
+// socket; an in-process gVisor netstack carries the tunnelled TCP.
+//
+// Build: go build -o wireguard-tunnel ./pluginsdk/wireguard
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name:    "wireguard_tunnel",
+		Version: "0.1",
+		// No raw sockets: the transport is opened through the gateway's
+		// brokered dial, which the gateway routes (direct or via parent).
+		Capabilities: pluginsdk.Capabilities{Network: pluginsdk.NetworkNone},
+		Tunnels:      []pluginsdk.TunnelDef{wireguardDef()},
+	})
+}
+
+type wgConfig struct {
+	Endpoint      string `json:"endpoint"`        // host:port of the WG server
+	PrivateKey    string `json:"private_key"`     // base64 (wg-quick form)
+	PeerPublicKey string `json:"peer_public_key"` // base64
+	Address       string `json:"address"`         // this peer's IP in the WG net
+	DNS           string `json:"dns"`             // optional in-tunnel resolver
+}
+
+type wgHandle struct {
+	dev    *device.Device
+	tnet   *netstack.Net
+	cancel context.CancelFunc // cancels the brokered transport's context on Close
+}
+
+func wireguardDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "wireguard",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "endpoint", TypeString: "string", Required: true},
+			{Name: "private_key", TypeString: "string", Required: true},
+			{Name: "peer_public_key", TypeString: "string", Required: true},
+			{Name: "address", TypeString: "string", Required: true},
+			{Name: "dns", TypeString: "string"},
+		}},
+		Open:  wireguardOpen,
+		Dial:  wireguardDial,
+		Close: wireguardClose,
+	}
+}
+
+func wireguardOpen(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+	var cfg wgConfig
+	if len(req.CanonicalConfig) > 0 {
+		if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+			return nil, fmt.Errorf("wireguard config: %w", err)
+		}
+	}
+	if cfg.Endpoint == "" || cfg.PrivateKey == "" || cfg.PeerPublicKey == "" || cfg.Address == "" {
+		return nil, errors.New("wireguard: endpoint, private_key, peer_public_key, address are required")
+	}
+	if req.DialUpstream == nil {
+		return nil, errors.New("wireguard: gateway provides no brokered dial (HostTunnel unavailable)")
+	}
+	clientAddr, err := netip.ParseAddr(cfg.Address)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard address %q: %w", cfg.Address, err)
+	}
+	var dns []netip.Addr
+	if cfg.DNS != "" {
+		d, err := netip.ParseAddr(cfg.DNS)
+		if err != nil {
+			return nil, fmt.Errorf("wireguard dns %q: %w", cfg.DNS, err)
+		}
+		dns = append(dns, d)
+	}
+
+	tunDev, tnet, err := netstack.CreateNetTUN([]netip.Addr{clientAddr}, dns, 1420)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard netstack: %w", err)
+	}
+
+	// The bind opens the WireGuard transport through the gateway's brokered
+	// dial. It dials inside Open (not here) because wireguard-go closes and
+	// re-opens the bind on every device Up (BindUpdate) — like StdNetBind
+	// re-creating its sockets — so the conduit must be (re)creatable, not a
+	// single conn opened once. The context is the tunnel's lifetime: the
+	// OpenTunnel ctx is cancelled when Open returns, so use a fresh one
+	// cancelled on Close.
+	dialCtx, cancel := context.WithCancel(context.Background())
+	bind := &brokeredBind{dial: req.DialUpstream, endpoint: cfg.Endpoint, ctx: dialCtx}
+
+	dev := device.NewDevice(tunDev, bind,
+		device.NewLogger(device.LogLevelError, "[wireguard-plugin] "))
+	uapi, err := buildWGIpc(cfg)
+	if err != nil {
+		dev.Close()
+		cancel()
+		return nil, err
+	}
+	if err := dev.IpcSet(uapi); err != nil {
+		dev.Close()
+		cancel()
+		return nil, fmt.Errorf("wireguard IpcSet: %w", err)
+	}
+	if err := dev.Up(); err != nil {
+		dev.Close()
+		cancel()
+		return nil, fmt.Errorf("wireguard up: %w", err)
+	}
+	return &wgHandle{dev: dev, tnet: tnet, cancel: cancel}, nil
+}
+
+func wireguardDial(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+	h, _ := req.Handle.(*wgHandle)
+	if h == nil {
+		return errors.New("wireguard: missing handle")
+	}
+	addrPort, err := resolveInTunnel(h.tnet, req.Addr)
+	if err != nil {
+		return err
+	}
+	c, err := h.tnet.DialContextTCPAddrPort(ctx, addrPort)
+	if err != nil {
+		return fmt.Errorf("wireguard dial %s: %w", req.Addr, err)
+	}
+	defer func() { _ = c.Close() }()
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+func wireguardClose(_ context.Context, handle any) error {
+	h, _ := handle.(*wgHandle)
+	if h == nil {
+		return nil
+	}
+	if h.dev != nil {
+		h.dev.Close()
+	}
+	if h.cancel != nil {
+		h.cancel()
+	}
+	return nil
+}
+
+// ---- wireguard-go conn.Bind over a single brokered datagram conduit ----
+
+// brokeredBind is a wireguard-go conn.Bind that sends and receives over the
+// gateway's brokered UDP conduit instead of a real UDP socket. There is
+// exactly one peer/endpoint — the tunnel's WG server — reached through the
+// connected conduit, so addresses are immaterial. Open dials a fresh
+// conduit (wireguard-go closes+reopens the bind on every device Up), Close
+// tears the current one down.
+type brokeredBind struct {
+	dial     pluginsdk.DialUpstreamFunc
+	endpoint string
+	ctx      context.Context
+	ep       brokeredEndpoint
+
+	mu sync.Mutex
+	pc net.PacketConn
+}
+
+func (b *brokeredBind) Open(port uint16) ([]conn.ReceiveFunc, uint16, error) {
+	transport, err := b.dial(b.ctx, "udp", b.endpoint)
+	if err != nil {
+		return nil, 0, err
+	}
+	pc := pluginsdk.PacketConnOverStream(transport, endpointAddr())
+	b.mu.Lock()
+	b.pc = pc
+	b.mu.Unlock()
+	recv := func(packets [][]byte, sizes []int, eps []conn.Endpoint) (int, error) {
+		n, _, err := pc.ReadFrom(packets[0])
+		if err != nil {
+			return 0, net.ErrClosed // the Bind contract: recv returns ErrClosed after Close
+		}
+		sizes[0] = n
+		eps[0] = b.ep
+		return 1, nil
+	}
+	return []conn.ReceiveFunc{recv}, port, nil
+}
+
+func (b *brokeredBind) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.pc != nil {
+		_ = b.pc.Close()
+		b.pc = nil
+	}
+	return nil
+}
+
+func (b *brokeredBind) SetMark(uint32) error { return nil }
+func (b *brokeredBind) BatchSize() int       { return 1 }
+
+func (b *brokeredBind) Send(bufs [][]byte, _ conn.Endpoint) error {
+	b.mu.Lock()
+	pc := b.pc
+	b.mu.Unlock()
+	if pc == nil {
+		return net.ErrClosed
+	}
+	for _, buf := range bufs {
+		if _, err := pc.WriteTo(buf, nil); err != nil { // PacketConnOverStream ignores addr
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *brokeredBind) ParseEndpoint(string) (conn.Endpoint, error) { return b.ep, nil }
+
+// brokeredEndpoint is the single, immaterial WG endpoint — the real route
+// is the connected conduit, so the address is cosmetic.
+type brokeredEndpoint struct{}
+
+func (brokeredEndpoint) ClearSrc()           {}
+func (brokeredEndpoint) SrcToString() string { return "" }
+func (brokeredEndpoint) DstToString() string { return "brokered" }
+func (brokeredEndpoint) DstToBytes() []byte  { return []byte{0} }
+func (brokeredEndpoint) DstIP() netip.Addr   { return netip.Addr{} }
+func (brokeredEndpoint) SrcIP() netip.Addr   { return netip.Addr{} }
+
+// endpointAddr returns a synthetic net.Addr for the conduit's remote (used
+// only as PacketConnOverStream's reported address).
+func endpointAddr() net.Addr { return &net.UDPAddr{IP: net.IPv4zero, Port: 0} }
+
+// ---- config ----
+
+// buildWGIpc renders the wireguard-go IpcSet payload (keys are base64 in
+// config, hex on the wire). The peer endpoint is a sentinel — the bind
+// ignores it and routes through the brokered conduit. 0.0.0.0/0 allowed-ips
+// + a forced keepalive so the handshake runs eagerly.
+func buildWGIpc(cfg wgConfig) (string, error) {
+	privHex, err := base64ToHex(cfg.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("wireguard private_key: %w", err)
+	}
+	pubHex, err := base64ToHex(cfg.PeerPublicKey)
+	if err != nil {
+		return "", fmt.Errorf("wireguard peer_public_key: %w", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "private_key=%s\n", privHex)
+	fmt.Fprintf(&b, "replace_peers=true\n")
+	fmt.Fprintf(&b, "public_key=%s\n", pubHex)
+	fmt.Fprintf(&b, "endpoint=0.0.0.0:0\n")
+	fmt.Fprintf(&b, "persistent_keepalive_interval=25\n")
+	fmt.Fprintf(&b, "allowed_ip=0.0.0.0/0\n")
+	fmt.Fprintf(&b, "allowed_ip=::/0\n")
+	return b.String(), nil
+}
+
+func base64ToHex(b64 string) (string, error) {
+	dec, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(dec), nil
+}
+
+// resolveInTunnel turns "host:port" into a netip.AddrPort, resolving a
+// hostname through the WG netstack's resolver when needed (spike: the
+// common case is the gateway handing us an ip:port).
+func resolveInTunnel(tnet *netstack.Net, addr string) (netip.AddrPort, error) {
+	if ap, err := netip.ParseAddrPort(addr); err == nil {
+		return ap, nil
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("wireguard addr %q: %w", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("wireguard port %q: %w", portStr, err)
+	}
+	hosts, err := tnet.LookupHost(host)
+	if err != nil || len(hosts) == 0 {
+		return netip.AddrPort{}, fmt.Errorf("wireguard resolve %q: %w", host, err)
+	}
+	ip, err := netip.ParseAddr(hosts[0])
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	return netip.AddrPortFrom(ip, uint16(port)), nil
+}


### PR DESCRIPTION
**Spike — not for merge.** Stacked on #714 (the brokered transport-dial
interface). Two external tunnel plugins that consume it, both running
with no network of their own (`network = "none"`).

* **socks** — hand-rolled SOCKS5; tcp = CONNECT, udp = UDP ASSOCIATE,
  reframing the brokered datagram conduit onto the proxy's UDP relay
  (BND.ADDR-behind-NAT fallback). Works as a `via` parent.
* **wireguard** — wireguard-go + gVisor netstack. A small `conn.Bind`
  sends/receives over the brokered UDP conduit
  (`req.DialUpstream("udp", endpoint)` wrapped as a `net.PacketConn`)
  instead of a raw socket, so WG's handshake UDP rides whatever route the
  gateway picks. The bind dials inside `Open` (wireguard-go closes and
  re-opens the bind on every device `Up`, like `StdNetBind` re-creating
  its sockets).
* env-gated linux `TestTunnelViaE2E` loading both plugins through the
  gateway and dialing a target over WG, with and without `via`.

Validated live (single-host loopback: userspace WireGuard server + SOCKS5
UDP-ASSOCIATE proxy): both **WG-direct** and **WG-over-SOCKS** return the
target's response, both plugins `network = "none"`.