### PR TITLE
run: sanitize nsswitch hosts line in the sandbox

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -51,7 +51,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -384,7 +384,9 @@ func runRunChild() {
 	if os.Getenv("CLAWPATROL_RUN_KEEP_RESOLV") != "1" {
 		_ = bindResolv(childResolvConf())
 		if body, changed := childNsswitch(); changed {
-			_ = bindNsswitch(body)
+			if err := bindNsswitch(body); err != nil {
+				fmt.Fprintf(os.Stderr, "[clawpatrol] nsswitch sanitization failed: %v — getaddrinfo may bypass the gateway resolver (e.g. clawpatrol.internal may not resolve)\n", err)
+			}
 		}
 	}
 
@@ -937,24 +939,36 @@ func bindResolv(body string) error {
 // and `curl https://clawpatrol.internal` fails to resolve while `dig`
 // (which reads resolv.conf directly) succeeds.
 //
-// The fix rewrites only the `hosts:` line, keeping the sources that
-// don't bypass resolv.conf (`files`, `myhostname`) and dropping the
-// rest, then appending `dns`. Everything else in the file (passwd,
-// group, …) is preserved. When the host line already routes through
-// `dns` without an interfering module (e.g. Ubuntu's `files dns`), the
-// rewrite is a no-op and changed is false, so unaffected distros keep
-// their nsswitch untouched.
+// See rewriteHostsLine for what the sanitization removes. A missing
+// nsswitch.conf is normal (musl/Alpine has no NSS; getaddrinfo reads
+// resolv.conf directly), so it is not worth a warning; any other read
+// error is, since it likely leaves the resolved short-circuit in place
+// and would otherwise turn into a silent resolution failure.
 func childNsswitch() (body string, changed bool) {
-	return rewriteHostsLine(readFileSilent("/etc/nsswitch.conf"))
+	raw, err := os.ReadFile("/etc/nsswitch.conf")
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "[clawpatrol] cannot read /etc/nsswitch.conf: %v — getaddrinfo may bypass the gateway resolver (e.g. clawpatrol.internal may not resolve)\n", err)
+		}
+		return "", false
+	}
+	return rewriteHostsLine(string(raw))
 }
 
 // rewriteHostsLine sanitizes the `hosts:` line of an nsswitch.conf body,
-// keeping only the sources that don't bypass the bind-mounted
-// resolv.conf (`files`, `myhostname`) and appending `dns`. It returns
-// the full rewritten body and whether anything changed; changed is
-// false when raw has no hosts: line or the line already matches the
-// sanitized form (so we don't bind-mount a no-op over unaffected
-// distros).
+// removing only the NSS modules that bypass the bind-mounted resolv.conf
+// — systemd-resolved (`resolve`) and Avahi mDNS (`mdns*`) — along with
+// the bracketed action items that trail them, and ensuring `dns` is
+// present so getaddrinfo consults resolv.conf. Every other source
+// (`files`, `myhostname`, `sss`, `ldap`, `nis`, …) is preserved in its
+// original position, so a host that resolves internal names through
+// sssd/LDAP keeps doing so inside the sandbox.
+//
+// It returns the full rewritten body and whether anything changed;
+// changed is false when raw has no hosts: line or the line already
+// routes through dns without an interfering module (e.g. Ubuntu's
+// `files dns`), so unaffected distros keep their nsswitch untouched
+// rather than rebinding an identical copy.
 func rewriteHostsLine(raw string) (body string, changed bool) {
 	if raw == "" {
 		return "", false
@@ -971,18 +985,31 @@ func rewriteHostsLine(raw string) (body string, changed bool) {
 		}
 		orig := strings.Fields(rest)
 		var kept []string
+		dropAction := false // drop bracketed actions trailing a removed module
 		for _, tok := range orig {
-			// Drop bracketed action modifiers ([!UNAVAIL=return] etc.)
-			// and any module that resolves ahead of resolv.conf.
-			if tok == "files" || tok == "myhostname" {
-				kept = append(kept, tok)
+			if strings.HasPrefix(tok, "[") {
+				// Action modifier ([!UNAVAIL=return] etc.) applies to the
+				// preceding source; keep it only if that source survived.
+				if !dropAction {
+					kept = append(kept, tok)
+				}
+				continue
 			}
+			// resolve (systemd-resolved) and mdns* (Avahi) answer ahead
+			// of dns and can't reach the gateway through the tunnel.
+			if tok == "resolve" || strings.HasPrefix(tok, "mdns") {
+				dropAction = true
+				continue
+			}
+			dropAction = false
+			kept = append(kept, tok)
 		}
-		kept = append(kept, "dns")
-		// No-op when the source list is already exactly our sanitized
-		// form (token-wise, ignoring whitespace) — leaves unaffected
-		// distros' nsswitch untouched rather than rebinding a copy.
-		if reflect.DeepEqual(orig, kept) {
+		if !slices.Contains(kept, "dns") {
+			kept = append(kept, "dns")
+		}
+		// No-op when no bypassing module was present (token sequence
+		// unchanged), so unaffected distros' nsswitch is left untouched.
+		if slices.Equal(orig, kept) {
 			return "", false
 		}
 		lines[i] = "hosts:      " + strings.Join(kept, " ")

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -384,6 +384,12 @@ func runRunChild() {
 	if os.Getenv("CLAWPATROL_RUN_KEEP_RESOLV") != "1" {
 		_ = bindResolv(childResolvConf())
 		if body, changed := childNsswitch(); changed {
+			// Warn rather than abort: we can't know whether this command
+			// actually needs DNS. It may only talk to raw IPs, or not
+			// resolve anything at all, in which case a failed nsswitch
+			// rewrite breaks nothing. Failing hard here would block runs
+			// that would have worked fine; the warning is enough for the
+			// case where a lookup later fails for no obvious reason.
 			if err := bindNsswitch(body); err != nil {
 				fmt.Fprintf(os.Stderr, "[clawpatrol] nsswitch sanitization failed: %v — DNS lookups may fail\n", err)
 			}

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -385,7 +385,7 @@ func runRunChild() {
 		_ = bindResolv(childResolvConf())
 		if body, changed := childNsswitch(); changed {
 			if err := bindNsswitch(body); err != nil {
-				fmt.Fprintf(os.Stderr, "[clawpatrol] nsswitch sanitization failed: %v — getaddrinfo may bypass the gateway resolver (e.g. clawpatrol.internal may not resolve)\n", err)
+				fmt.Fprintf(os.Stderr, "[clawpatrol] nsswitch sanitization failed: %v — DNS lookups may fail\n", err)
 			}
 		}
 	}
@@ -948,7 +948,7 @@ func childNsswitch() (body string, changed bool) {
 	raw, err := os.ReadFile("/etc/nsswitch.conf")
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "[clawpatrol] cannot read /etc/nsswitch.conf: %v — getaddrinfo may bypass the gateway resolver (e.g. clawpatrol.internal may not resolve)\n", err)
+			fmt.Fprintf(os.Stderr, "[clawpatrol] cannot read /etc/nsswitch.conf: %v — DNS lookups may fail\n", err)
 		}
 		return "", false
 	}

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -51,6 +51,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -382,6 +383,9 @@ func runRunChild() {
 
 	if os.Getenv("CLAWPATROL_RUN_KEEP_RESOLV") != "1" {
 		_ = bindResolv(childResolvConf())
+		if body, changed := childNsswitch(); changed {
+			_ = bindNsswitch(body)
+		}
 	}
 
 	// The agent runs as the same uid as the parent and can therefore
@@ -890,6 +894,13 @@ func recvFDs(s *os.File, n int) ([]int, error) {
 // any public-looking nameserver works; fall back to 1.1.1.1 / 8.8.8.8
 // for that and for joins old enough that they predate the gateway-IP
 // file.
+//
+// Note: the bind-mounted resolv.conf only governs the glibc `dns` NSS
+// module (and tools like dig that read resolv.conf directly). On hosts
+// whose nsswitch.conf puts `resolve` (systemd-resolved) ahead of `dns`
+// — Fedora's default — getaddrinfo answers from the host resolver
+// before ever consulting resolv.conf, so this alone is not enough.
+// childNsswitch handles that case.
 func childResolvConf() string {
 	caDir := defaultClawpatrolDir()
 	if gwIP := strings.TrimSpace(readFileSilent(filepath.Join(caDir, "tailnet-gateway-ip"))); gwIP != "" {
@@ -899,43 +910,124 @@ func childResolvConf() string {
 }
 
 // bindResolv writes body to a temp file and bind-mounts it over
-// /etc/resolv.conf in the calling mount namespace. The temp file is
-// unlinked on every path — including success: once the bind-mount is
-// in place it holds a reference to the inode, so removing the source
-// directory entry leaves /etc/resolv.conf intact (it points at the
-// inode, not the path) while ensuring we don't strand one
-// /tmp/clawpatrol-resolv-* file per `clawpatrol run`. The kernel
-// reclaims the inode when the mount goes away on namespace exit.
+// /etc/resolv.conf in the calling mount namespace.
+//
+// The temp file is made world-readable (0644) before the mount. In the
+// sudo path bindResolv runs as root (before the drop to the invoking
+// user), so a 0600 file ends up root-owned and the unprivileged command
+// can't read the resolv.conf bind-mounted over /etc/resolv.conf — every
+// name lookup then fails with "could not resolve host" while raw-IP
+// traffic still works. A resolv.conf holds only nameserver lines,
+// nothing sensitive.
 func bindResolv(body string) error {
-	tmp, err := os.CreateTemp("", "clawpatrol-resolv-*")
+	return bindOverEtc("/etc/resolv.conf", "clawpatrol-resolv-*", body)
+}
+
+// childNsswitch returns a sanitized /etc/nsswitch.conf body and whether
+// it differs from the host's. The sandbox bind-mounts a private
+// /etc/resolv.conf pointing at the gateway, but resolv.conf only governs
+// the glibc `dns` NSS module. Distros that list a host-resolver module
+// ahead of `dns` in the `hosts:` line — Fedora ships
+// `files myhostname mdns4_minimal [NOTFOUND=return] resolve
+// [!UNAVAIL=return] dns` — answer getaddrinfo from systemd-resolved (or
+// mDNS) first. That resolver runs on the host, is oblivious to the
+// sandbox's resolv.conf, and returns NXDOMAIN for gateway-only names
+// like clawpatrol.internal; the `[!UNAVAIL=return]` action then stops
+// the lookup before `dns` is ever tried, so the override is bypassed
+// and `curl https://clawpatrol.internal` fails to resolve while `dig`
+// (which reads resolv.conf directly) succeeds.
+//
+// The fix rewrites only the `hosts:` line, keeping the sources that
+// don't bypass resolv.conf (`files`, `myhostname`) and dropping the
+// rest, then appending `dns`. Everything else in the file (passwd,
+// group, …) is preserved. When the host line already routes through
+// `dns` without an interfering module (e.g. Ubuntu's `files dns`), the
+// rewrite is a no-op and changed is false, so unaffected distros keep
+// their nsswitch untouched.
+func childNsswitch() (body string, changed bool) {
+	return rewriteHostsLine(readFileSilent("/etc/nsswitch.conf"))
+}
+
+// rewriteHostsLine sanitizes the `hosts:` line of an nsswitch.conf body,
+// keeping only the sources that don't bypass the bind-mounted
+// resolv.conf (`files`, `myhostname`) and appending `dns`. It returns
+// the full rewritten body and whether anything changed; changed is
+// false when raw has no hosts: line or the line already matches the
+// sanitized form (so we don't bind-mount a no-op over unaffected
+// distros).
+func rewriteHostsLine(raw string) (body string, changed bool) {
+	if raw == "" {
+		return "", false
+	}
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		rest, ok := strings.CutPrefix(strings.TrimLeft(line, " \t"), "hosts:")
+		if !ok {
+			continue
+		}
+		// Strip trailing comments before tokenizing the source list.
+		if c := strings.IndexByte(rest, '#'); c >= 0 {
+			rest = rest[:c]
+		}
+		orig := strings.Fields(rest)
+		var kept []string
+		for _, tok := range orig {
+			// Drop bracketed action modifiers ([!UNAVAIL=return] etc.)
+			// and any module that resolves ahead of resolv.conf.
+			if tok == "files" || tok == "myhostname" {
+				kept = append(kept, tok)
+			}
+		}
+		kept = append(kept, "dns")
+		// No-op when the source list is already exactly our sanitized
+		// form (token-wise, ignoring whitespace) — leaves unaffected
+		// distros' nsswitch untouched rather than rebinding a copy.
+		if reflect.DeepEqual(orig, kept) {
+			return "", false
+		}
+		lines[i] = "hosts:      " + strings.Join(kept, " ")
+		return strings.Join(lines, "\n"), true
+	}
+	return "", false
+}
+
+// bindNsswitch bind-mounts body over /etc/nsswitch.conf in the calling
+// mount namespace. Same 0644/teardown semantics as bindResolv.
+func bindNsswitch(body string) error {
+	return bindOverEtc("/etc/nsswitch.conf", "clawpatrol-nsswitch-*", body)
+}
+
+// bindOverEtc writes body to a temp file (named via pattern) and
+// bind-mounts it over target in the calling mount namespace. The temp
+// file is unlinked on every path — including success: once the
+// bind-mount is in place it holds a reference to the inode, so removing
+// the source directory entry leaves target intact (the mount points at
+// the inode, not the path) while ensuring we don't strand a temp file
+// per `clawpatrol run`. The kernel reclaims the inode when the mount
+// goes away on namespace exit. The file is made world-readable (0644)
+// so an unprivileged wrapped command can read it on the sudo path.
+func bindOverEtc(target, pattern, body string) error {
+	tmp, err := os.CreateTemp("", pattern)
 	if err != nil {
-		return fmt.Errorf("create resolv temp file: %w", err)
+		return fmt.Errorf("create temp file for %s: %w", target, err)
 	}
 	if _, err := tmp.WriteString(body); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("write resolv temp file: %w", err)
+		return fmt.Errorf("write temp file for %s: %w", target, err)
 	}
-	// os.CreateTemp makes the file 0600. In the sudo path bindResolv
-	// runs as root (before the drop to the invoking user), so a 0600
-	// file ends up root-owned and the unprivileged command can't read
-	// the resolv.conf bind-mounted over /etc/resolv.conf — every name
-	// lookup then fails with "could not resolve host" while raw-IP
-	// traffic still works. Make it world-readable like a normal
-	// /etc/resolv.conf; it holds only a nameserver line, nothing
-	// sensitive.
 	if err := tmp.Chmod(0o644); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("chmod resolv temp file: %w", err)
+		return fmt.Errorf("chmod temp file for %s: %w", target, err)
 	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("close resolv temp file: %w", err)
+		return fmt.Errorf("close temp file for %s: %w", target, err)
 	}
-	if err := unix.Mount(tmp.Name(), "/etc/resolv.conf", "", unix.MS_BIND, ""); err != nil {
+	if err := unix.Mount(tmp.Name(), target, "", unix.MS_BIND, ""); err != nil {
 		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("bind-mount resolv: %w", err)
+		return fmt.Errorf("bind-mount %s: %w", target, err)
 	}
 	// Mount holds the inode; drop the now-redundant /tmp path so it
 	// doesn't accumulate across runs.

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -961,6 +961,42 @@ func childNsswitch() (body string, changed bool) {
 	return rewriteHostsLine(string(raw))
 }
 
+// splitHostsTokens splits an nsswitch source list into tokens, treating
+// a bracketed action item as a single token even when it contains
+// whitespace. glibc accepts spaces inside the brackets and the
+// multi-status form `[SUCCESS=return NOTFOUND=continue]` is common, so
+// strings.Fields would shatter one action into several bogus tokens.
+// A `[` always starts an action token that runs to the next `]`
+// (inclusive); everything else is whitespace-separated.
+func splitHostsTokens(s string) []string {
+	var toks []string
+	for i := 0; i < len(s); {
+		if s[i] == ' ' || s[i] == '\t' {
+			i++
+			continue
+		}
+		if s[i] == '[' {
+			j := i + 1
+			for j < len(s) && s[j] != ']' {
+				j++
+			}
+			if j < len(s) {
+				j++ // include the closing ']'
+			}
+			toks = append(toks, s[i:j])
+			i = j
+			continue
+		}
+		j := i
+		for j < len(s) && s[j] != ' ' && s[j] != '\t' && s[j] != '[' {
+			j++
+		}
+		toks = append(toks, s[i:j])
+		i = j
+	}
+	return toks
+}
+
 // rewriteHostsLine sanitizes the `hosts:` line of an nsswitch.conf body,
 // removing only the NSS modules that bypass the bind-mounted resolv.conf
 // — systemd-resolved (`resolve`) and Avahi mDNS (`mdns*`) — along with
@@ -989,7 +1025,7 @@ func rewriteHostsLine(raw string) (body string, changed bool) {
 		if c := strings.IndexByte(rest, '#'); c >= 0 {
 			rest = rest[:c]
 		}
-		orig := strings.Fields(rest)
+		orig := splitHostsTokens(rest)
 		var kept []string
 		dropAction := false // drop bracketed actions trailing a removed module
 		for _, tok := range orig {

--- a/cmd/clawpatrol/run_linux_test.go
+++ b/cmd/clawpatrol/run_linux_test.go
@@ -4,8 +4,87 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestRewriteHostsLine(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantChanged bool
+		wantHosts   string // expected hosts: line when changed
+	}{
+		{
+			name:        "fedora resolve short-circuit",
+			in:          "passwd: files\nhosts:      files myhostname mdns4_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] dns\ngroup: files\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files myhostname dns",
+		},
+		{
+			name:        "already files dns - no change",
+			in:          "hosts: files dns\n",
+			wantChanged: false,
+		},
+		{
+			name:        "already sanitized form - no change",
+			in:          "hosts:      files myhostname dns\n",
+			wantChanged: false,
+		},
+		{
+			name:        "no hosts line",
+			in:          "passwd: files\ngroup: files\n",
+			wantChanged: false,
+		},
+		{
+			name:        "empty",
+			in:          "",
+			wantChanged: false,
+		},
+		{
+			name:        "trailing comment stripped",
+			in:          "hosts: files resolve [!UNAVAIL=return] dns # managed\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files dns",
+		},
+		{
+			name:        "only dns appended when no keepable sources",
+			in:          "hosts: resolve [!UNAVAIL=return]\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      dns",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, changed := rewriteHostsLine(tc.in)
+			if changed != tc.wantChanged {
+				t.Fatalf("changed = %v, want %v (body=%q)", changed, tc.wantChanged, body)
+			}
+			if !changed {
+				return
+			}
+			var got string
+			for _, l := range strings.Split(body, "\n") {
+				if strings.HasPrefix(strings.TrimLeft(l, " \t"), "hosts:") {
+					got = l
+					break
+				}
+			}
+			if got != tc.wantHosts {
+				t.Fatalf("hosts line = %q, want %q", got, tc.wantHosts)
+			}
+			// Non-hosts lines must be preserved verbatim.
+			for _, l := range strings.Split(tc.in, "\n") {
+				if l == "" || strings.HasPrefix(strings.TrimLeft(l, " \t"), "hosts:") {
+					continue
+				}
+				if !strings.Contains(body, l) {
+					t.Fatalf("line %q dropped from rewritten body", l)
+				}
+			}
+		})
+	}
+}
 
 func TestSplitWGAddresses(t *testing.T) {
 	cases := []struct {

--- a/cmd/clawpatrol/run_linux_test.go
+++ b/cmd/clawpatrol/run_linux_test.go
@@ -53,6 +53,44 @@ func TestRewriteHostsLine(t *testing.T) {
 			wantChanged: true,
 			wantHosts:   "hosts:      dns",
 		},
+		{
+			// Regression: a resolv.conf-respecting module like sssd must
+			// not be dropped — only resolve/mdns short-circuiters are.
+			name:        "preserves sssd module - no change",
+			in:          "hosts: files sss dns\n",
+			wantChanged: false,
+		},
+		{
+			name:        "preserves ldap module - no change",
+			in:          "hosts: files myhostname ldap dns\n",
+			wantChanged: false,
+		},
+		{
+			// dns-first is unusual but intentional; must not be reordered.
+			name:        "dns before files not reordered - no change",
+			in:          "hosts: dns files\n",
+			wantChanged: false,
+		},
+		{
+			name:        "removes resolve but keeps sss in place",
+			in:          "hosts: files sss resolve [!UNAVAIL=return] dns\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files sss dns",
+		},
+		{
+			name:        "removes mdns keeps myhostname and dns",
+			in:          "hosts: files mdns4_minimal [NOTFOUND=return] myhostname dns\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files myhostname dns",
+		},
+		{
+			// No dns and no bypassing module: dns is appended so the
+			// gateway resolv.conf is still consulted.
+			name:        "appends dns when absent",
+			in:          "hosts: files myhostname\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files myhostname dns",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/clawpatrol/run_linux_test.go
+++ b/cmd/clawpatrol/run_linux_test.go
@@ -91,6 +91,29 @@ func TestRewriteHostsLine(t *testing.T) {
 			wantChanged: true,
 			wantHosts:   "hosts:      files myhostname dns",
 		},
+		{
+			// Multi-status action bracket contains a space; it must be
+			// treated as one token, not shattered by the tokenizer.
+			name:        "multi-status bracket on removed module",
+			in:          "hosts: files resolve [NOTFOUND=return UNAVAIL=return] dns\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files dns",
+		},
+		{
+			// Spaces inside the brackets, no bypassing module → no-op,
+			// preserved verbatim (also exercises the kept-bracket path).
+			name:        "spaced bracket on kept source - no change",
+			in:          "hosts: files [SUCCESS=return  NOTFOUND=continue] dns\n",
+			wantChanged: false,
+		},
+		{
+			// A bracket trailing a surviving source must be kept in place
+			// while the resolve module ahead of it is removed.
+			name:        "keeps bracket after surviving source, drops resolve",
+			in:          "hosts: files [SUCCESS=return] resolve [!UNAVAIL=return] dns\n",
+			wantChanged: true,
+			wantHosts:   "hosts:      files [SUCCESS=return] dns",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -111,14 +134,20 @@ func TestRewriteHostsLine(t *testing.T) {
 			if got != tc.wantHosts {
 				t.Fatalf("hosts line = %q, want %q", got, tc.wantHosts)
 			}
-			// Non-hosts lines must be preserved verbatim.
-			for _, l := range strings.Split(tc.in, "\n") {
-				if l == "" || strings.HasPrefix(strings.TrimLeft(l, " \t"), "hosts:") {
-					continue
+			// Non-hosts lines must be preserved verbatim and in order —
+			// compare the full sequence, not mere substring membership,
+			// so a reordering/duplication regression can't slip through.
+			nonHosts := func(s string) []string {
+				var out []string
+				for _, l := range strings.Split(s, "\n") {
+					if !strings.HasPrefix(strings.TrimLeft(l, " \t"), "hosts:") {
+						out = append(out, l)
+					}
 				}
-				if !strings.Contains(body, l) {
-					t.Fatalf("line %q dropped from rewritten body", l)
-				}
+				return out
+			}
+			if before, after := nonHosts(tc.in), nonHosts(body); !reflect.DeepEqual(before, after) {
+				t.Fatalf("non-hosts lines changed: %q -> %q", before, after)
 			}
 		})
 	}


### PR DESCRIPTION
`clawpatrol run` bind-mounts a private `/etc/resolv.conf` pointing at
the gateway, but resolv.conf only governs the glibc `dns` NSS module.
On hosts whose nsswitch.conf lists a resolver module ahead of `dns`
in the `hosts:` line — Fedora's default `files myhostname
mdns4_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] dns` —
getaddrinfo answers from systemd-resolved first. That resolver runs
on the host, ignores the sandbox's resolv.conf, and returns NXDOMAIN
for gateway-only names; the `[!UNAVAIL=return]` action then stops the
lookup before `dns` is tried.

Result: inside `clawpatrol run`, `curl https://clawpatrol.internal`
fails with "Could not resolve host" while `dig` (which reads
resolv.conf directly) succeeds.

* alongside the resolv.conf bind-mount, also bind-mount a sanitized
  `/etc/nsswitch.conf` whose `hosts:` line keeps only `files` /
  `myhostname` and routes the rest through `dns`, so getaddrinfo
  honors the bind-mounted resolv.conf
* no-op on distros whose hosts line already routes through `dns`
  without an interfering module (e.g. `files dns`); their nsswitch
  is left untouched
* factor the resolv.conf temp-file + bind-mount logic into a shared
  `bindOverEtc` helper used by both `bindResolv` and `bindNsswitch`