### PR TITLE
example: SOCKS5 tunnel + brokered passthrough (example is network=none)

### DIFF
--- a/cmd/clawpatrol/example_socks_test.go
+++ b/cmd/clawpatrol/example_socks_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// TestExampleSocksTunnel dials an HTTP target through the example plugin's
+// example_socks tunnel: gateway -> example_socks.Dial -> brokered
+// DialUpstream(tcp, proxy) -> in-test SOCKS5 server -> CONNECT -> target.
+// Self-contained (no external proxy/server), so it runs in CI and proves
+// the example tunnel actually works through the brokered transport dial.
+func TestExampleSocksTunnel(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello-through-example-socks")
+	}))
+	defer target.Close()
+	targetAddr := strings.TrimPrefix(target.URL, "http://")
+
+	socksAddr := startTestSocks5(t)
+
+	pluginPath := buildSharedExamplePlugin(t)
+	mgr := sharedExampleManager() // carries a transport dialer for the tunnel
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+plugin "example" {
+  source  = %q
+  network = "none"
+}
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "example_socks" "proxy1" {
+  proxy = %q
+}
+endpoint "example_https" "demo" {
+  hosts    = ["demo.invalid"]
+  upstream = "http://127.0.0.1:8000"
+}
+profile "default" { credentials = [] }
+`, pluginPath, socksAddr)), "example-socks.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ct := policy.Tunnels["proxy1"]
+	if ct == nil {
+		t.Fatal("no compiled tunnel 'proxy1'")
+	}
+
+	tm := NewTunnelManager(runtime.EnvSecretStore{}, t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	tun, release, err := tm.Acquire(ctx, ct, "demo")
+	if err != nil {
+		t.Fatalf("acquire example_socks: %v", err)
+	}
+	defer release()
+
+	conn, err := tun.Dial(ctx, "tcp", targetAddr)
+	if err != nil {
+		t.Fatalf("dial through tunnel: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := fmt.Fprintf(conn, "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", targetAddr); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 || !strings.Contains(string(body), "hello-through-example-socks") {
+		t.Fatalf("got status %d body %q", resp.StatusCode, body)
+	}
+}
+
+// startTestSocks5 starts a minimal SOCKS5 CONNECT proxy on 127.0.0.1 and
+// returns its address.
+func startTestSocks5(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go testSocksConnect(c)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func testSocksConnect(c net.Conn) {
+	defer func() { _ = c.Close() }()
+	hdr := make([]byte, 2)
+	if _, err := io.ReadFull(c, hdr); err != nil {
+		return
+	}
+	if _, err := io.ReadFull(c, make([]byte, int(hdr[1]))); err != nil {
+		return
+	}
+	_, _ = c.Write([]byte{0x05, 0x00})
+	req := make([]byte, 4)
+	if _, err := io.ReadFull(c, req); err != nil {
+		return
+	}
+	var host string
+	switch req[3] {
+	case 1:
+		b := make([]byte, 4)
+		_, _ = io.ReadFull(c, b)
+		host = net.IP(b).String()
+	case 3:
+		l := make([]byte, 1)
+		_, _ = io.ReadFull(c, l)
+		b := make([]byte, int(l[0]))
+		_, _ = io.ReadFull(c, b)
+		host = string(b)
+	case 4:
+		b := make([]byte, 16)
+		_, _ = io.ReadFull(c, b)
+		host = net.IP(b).String()
+	}
+	pb := make([]byte, 2)
+	if _, err := io.ReadFull(c, pb); err != nil {
+		return
+	}
+	up, err := net.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(pb)))))
+	if err != nil {
+		_, _ = c.Write([]byte{5, 1, 0, 1, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	defer func() { _ = up.Close() }()
+	_, _ = c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+	go func() { _, _ = io.Copy(up, c) }()
+	_, _ = io.Copy(c, up)
+}

--- a/cmd/clawpatrol/extplugin_dial_e2e_test.go
+++ b/cmd/clawpatrol/extplugin_dial_e2e_test.go
@@ -63,7 +63,15 @@ var buildSharedExamplePlugin = func() func(t *testing.T) string {
 // collide. The manager dedups by plugin name, so reusing it across
 // loads re-registers nothing.
 var sharedExampleManager = sync.OnceValue(func() *extplugin.Manager {
-	return extplugin.New(nil)
+	m := extplugin.New(nil)
+	// A tunnel plugin (e.g. example_socks) opens its transport through the
+	// gateway's brokered dial; with no `via` the gateway dials directly.
+	// Wire it here, before any test spawns the plugin, so the dialer is
+	// captured at spawn regardless of test order. Inert for endpoint tests.
+	m.SetTransportDialer(func(network, addr string) (net.Conn, error) {
+		return net.Dial(network, addr)
+	})
+	return m
 })
 
 // loadDemoPluginPolicy loads a config wired to the real example plugin
@@ -78,9 +86,9 @@ func loadDemoPluginPolicy(t *testing.T, dialList string) *config.CompiledPolicy 
 	t.Cleanup(func() { config.SetPluginLoader(nil) })
 
 	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
-// Force network = "none" (operator override) so this exercises the
-// brokered dial with no plugin-side network, even though the example
-// plugin's manifest declares outbound for its passthrough tunnel.
+// network = "none": the example plugin reaches the network only through
+// the gateway's brokered dial, so this exercises that path with no
+// plugin-side network.
 plugin "example" {
   source  = %q
   network = "none"

--- a/pluginsdk/example/main.go
+++ b/pluginsdk/example/main.go
@@ -3,8 +3,8 @@
 // Build:   go build -o example ./pluginsdk/example
 // Run:     the gateway spawns the binary; not invoked directly.
 //
-// Provides one credential (magic_token), one tunnel (passthrough),
-// and three endpoints (demo_https, demo_smtp, demo_echo) covering
+// Provides one credential (magic_token), two tunnels (passthrough and
+// socks), and three endpoints (demo_https, demo_smtp, demo_echo) covering
 // HTTPS, TLS-but-not-HTTPS, and plain TCP respectively.
 package main
 
@@ -14,18 +14,19 @@ func main() {
 	pluginsdk.Run(&pluginsdk.Plugin{
 		Name:    "example",
 		Version: "0.1",
-		// The passthrough tunnel dials upstream itself, so the plugin
-		// declares it needs outbound network. The operator no longer
-		// writes network = "outbound" in the HCL; the gateway records
-		// this on first load.
+		// Every type here reaches the network only through the gateway's
+		// brokered dial (endpoints via Conn.DialUpstream, tunnels via the
+		// transport DialUpstream), so the plugin needs no network of its
+		// own.
 		Capabilities: pluginsdk.Capabilities{
-			Network: pluginsdk.NetworkOutbound,
+			Network: pluginsdk.NetworkNone,
 		},
 		Credentials: []pluginsdk.CredentialDef{
 			magicTokenDef(),
 		},
 		Tunnels: []pluginsdk.TunnelDef{
 			passthroughDef(),
+			socksDef(),
 		},
 		Endpoints: []pluginsdk.EndpointDef{
 			demoHTTPSDef(),

--- a/pluginsdk/example/passthrough.go
+++ b/pluginsdk/example/passthrough.go
@@ -2,17 +2,22 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 
 	"github.com/denoland/clawpatrol/pluginsdk"
 )
 
-// passthrough is a no-op tunnel: Dial does net.Dial and pumps bytes
-// in both directions. Exists to demonstrate the tunnel API surface;
-// real tunnel plugins would establish the underlying transport
-// (Wireguard, Tailscale, SSH, ...) inside Open and reuse it across
-// many Dials.
+// passthrough is a no-op tunnel: Dial opens the upstream and pumps bytes
+// in both directions. Exists to demonstrate the tunnel API surface; real
+// tunnel plugins would establish the underlying transport (Wireguard,
+// Tailscale, SSH, ...) inside Open and reuse it across many Dials.
+//
+// It dials through the gateway's brokered DialUpstream rather than a raw
+// net.Dial, so it needs no network of its own (network = "none"). For a
+// top-level tunnel the gateway dials directly, so this is a true no-op;
+// see the socks tunnel for one that does real work with the same dial.
 func passthroughDef() pluginsdk.TunnelDef {
 	return pluginsdk.TunnelDef{
 		TypeName: "example_passthrough",
@@ -21,8 +26,11 @@ func passthroughDef() pluginsdk.TunnelDef {
 			// No state to keep; the tunnel name itself is enough.
 			return req.TunnelInstance, nil
 		},
-		Dial: func(_ context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
-			c, err := net.Dial(req.Network, req.Addr)
+		Dial: func(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+			if req.DialUpstream == nil {
+				return errors.New("example_passthrough: gateway has no transport dial support")
+			}
+			c, err := req.DialUpstream(ctx, req.Network, req.Addr)
 			if err != nil {
 				return err
 			}

--- a/pluginsdk/example/socks.go
+++ b/pluginsdk/example/socks.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+)
+
+// socks is an example tunnel plugin that routes upstream connections
+// through a SOCKS5 proxy (RFC 1928). Unlike passthrough, which dials the
+// upstream itself, this tunnel opens its OWN transport — the connection to
+// the proxy — through the gateway's brokered DialUpstream rather than a raw
+// socket. So it needs no network of its own: deploy it with
+// network = "none" and the gateway dials the proxy on its behalf, either
+// directly or through a parent tunnel when chained (`via = <tunnel>`).
+//
+// It also shows a tunnel carrying UDP: a "tcp" Dial uses SOCKS5 CONNECT,
+// while a "udp" Dial (a chained child asking for a datagram conduit — e.g.
+// a WireGuard tunnel set to `via` this one) uses SOCKS5 UDP ASSOCIATE. The
+// child's packets arrive length-prefixed (pluginsdk.ReadDatagram/
+// WriteDatagram) and are reframed onto the proxy's UDP relay.
+func socksDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "example_socks",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "proxy", TypeString: "string", Required: true},
+			{Name: "username", TypeString: "string"},
+			{Name: "password", TypeString: "string"},
+		}},
+		Open: func(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+			var cfg socksConfig
+			if len(req.CanonicalConfig) > 0 {
+				if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+					return nil, fmt.Errorf("example_socks config: %w", err)
+				}
+			}
+			if cfg.Proxy == "" {
+				return nil, errors.New("example_socks: proxy is required")
+			}
+			return &cfg, nil
+		},
+		Dial: func(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+			cfg, _ := req.Handle.(*socksConfig)
+			if cfg == nil {
+				return errors.New("example_socks: missing handle")
+			}
+			if req.DialUpstream == nil {
+				return errors.New("example_socks: gateway has no transport dial support")
+			}
+			switch req.Network {
+			case "", "tcp":
+				return socksDialTCP(ctx, req.DialUpstream, cfg, req.Addr, upstream)
+			case "udp":
+				return socksDialUDP(ctx, req.DialUpstream, cfg, req.Addr, upstream)
+			default:
+				return fmt.Errorf("example_socks: unsupported network %q", req.Network)
+			}
+		},
+		Close: func(_ context.Context, _ any) error { return nil },
+	}
+}
+
+type socksConfig struct {
+	Proxy    string `json:"proxy"`    // host:port of the SOCKS5 server
+	Username string `json:"username"` // optional user/pass auth
+	Password string `json:"password"`
+}
+
+// socksRelayAddr is a synthetic net.Addr for the brokered relay conn
+// (already connected, so PacketConnOverStream only reports it back).
+type socksRelayAddr string
+
+func (a socksRelayAddr) Network() string { return "udp" }
+func (a socksRelayAddr) String() string  { return string(a) }
+
+// ---- TCP: SOCKS5 CONNECT, then pump bytes ----
+
+func socksDialTCP(ctx context.Context, dial pluginsdk.DialUpstreamFunc, cfg *socksConfig, addr string, upstream net.Conn) error {
+	c, err := dial(ctx, "tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+	if err := socksHandshake(c, cfg); err != nil {
+		return err
+	}
+	if _, err := socksRequest(c, socksCmdConnect, addr); err != nil {
+		return fmt.Errorf("socks CONNECT %s: %w", addr, err)
+	}
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+// ---- UDP: SOCKS5 UDP ASSOCIATE, datagram-framed over `upstream` ----
+
+func socksDialUDP(ctx context.Context, dial pluginsdk.DialUpstreamFunc, cfg *socksConfig, target string, upstream net.Conn) error {
+	// The TCP control connection must stay open for the lifetime of the
+	// association — closing it tells the proxy to drop the UDP relay.
+	ctrl, err := dial(ctx, "tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = ctrl.Close() }()
+	if err := socksHandshake(ctrl, cfg); err != nil {
+		return err
+	}
+	relayStr, err := socksRequest(ctrl, socksCmdUDPAssociate, "0.0.0.0:0")
+	if err != nil {
+		return fmt.Errorf("socks UDP ASSOCIATE: %w", err)
+	}
+	// The reply's BND.ADDR is frequently unspecified (0.0.0.0) or an
+	// internal address when the proxy sits behind NAT (e.g. a cloud VM
+	// returning its private IP). The UDP relay lives on the proxy host, so
+	// fall back to the proxy's host with the returned port unless the reply
+	// names a concrete, routable address.
+	relayHost, relayPort, _ := net.SplitHostPort(relayStr)
+	if ip := net.ParseIP(relayHost); ip == nil || ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() {
+		relayHost, _, _ = net.SplitHostPort(cfg.Proxy)
+	}
+	relayHostPort := net.JoinHostPort(relayHost, relayPort)
+
+	// Open the UDP relay through the gateway's brokered dial (no raw
+	// socket). The conn carries length-prefixed datagrams; treat it as a
+	// connected net.PacketConn.
+	relayConn, err := dial(ctx, "udp", relayHostPort)
+	if err != nil {
+		return fmt.Errorf("dial socks relay %q: %w", relayHostPort, err)
+	}
+	pc := pluginsdk.PacketConnOverStream(relayConn, socksRelayAddr(relayHostPort))
+	defer func() { _ = pc.Close() }()
+
+	hdr, err := socksUDPHeader(target)
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{}, 3)
+	// upstream datagrams -> SOCKS relay (prepend the UDP request header)
+	go func() {
+		for {
+			d, rerr := pluginsdk.ReadDatagram(upstream)
+			if rerr != nil {
+				break
+			}
+			pkt := append(append([]byte(nil), hdr...), d...)
+			if _, werr := pc.WriteTo(pkt, socksRelayAddr(relayHostPort)); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// SOCKS relay -> upstream datagrams (strip the UDP reply header)
+	go func() {
+		buf := make([]byte, 64<<10)
+		for {
+			n, _, rerr := pc.ReadFrom(buf)
+			if rerr != nil {
+				break
+			}
+			payload, ok := stripSocksUDPHeader(buf[:n])
+			if !ok {
+				continue
+			}
+			if werr := pluginsdk.WriteDatagram(upstream, payload); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// The control conn closing (proxy dropped the association) ends it.
+	go func() {
+		var b [1]byte
+		_, _ = ctrl.Read(b[:])
+		done <- struct{}{}
+	}()
+	<-done
+	return nil
+}
+
+// ---- SOCKS5 wire format (RFC 1928) ----
+
+const (
+	socksVer             = 0x05
+	socksCmdConnect      = 0x01
+	socksCmdUDPAssociate = 0x03
+	socksAtypIPv4        = 0x01
+	socksAtypDomain      = 0x03
+	socksAtypIPv6        = 0x04
+)
+
+func socksHandshake(c net.Conn, cfg *socksConfig) error {
+	// Offer no-auth, or — when credentials are configured — user/pass only,
+	// so a tunnel that was handed credentials won't silently fall back to an
+	// unauthenticated proxy. (A more lenient client would offer both methods
+	// and let the proxy choose.)
+	methods := []byte{0x00}
+	if cfg.Username != "" {
+		methods = []byte{0x02}
+	}
+	greeting := append([]byte{socksVer, byte(len(methods))}, methods...)
+	if _, err := c.Write(greeting); err != nil {
+		return err
+	}
+	var sel [2]byte
+	if _, err := io.ReadFull(c, sel[:]); err != nil {
+		return err
+	}
+	if sel[0] != socksVer {
+		return fmt.Errorf("socks: bad version %d", sel[0])
+	}
+	switch sel[1] {
+	case 0x00:
+		return nil
+	case 0x02:
+		return socksUserPassAuth(c, cfg)
+	default:
+		return fmt.Errorf("socks: no acceptable auth method (got %d)", sel[1])
+	}
+}
+
+func socksUserPassAuth(c net.Conn, cfg *socksConfig) error {
+	msg := []byte{0x01, byte(len(cfg.Username))}
+	msg = append(msg, cfg.Username...)
+	msg = append(msg, byte(len(cfg.Password)))
+	msg = append(msg, cfg.Password...)
+	if _, err := c.Write(msg); err != nil {
+		return err
+	}
+	var resp [2]byte
+	if _, err := io.ReadFull(c, resp[:]); err != nil {
+		return err
+	}
+	if resp[1] != 0x00 {
+		return errors.New("socks: user/pass auth failed")
+	}
+	return nil
+}
+
+// socksRequest sends a CONNECT or UDP ASSOCIATE request for addr and
+// returns the bound address from the reply ("host:port").
+func socksRequest(c net.Conn, cmd byte, addr string) (string, error) {
+	dst, err := encodeSocksAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	req := append([]byte{socksVer, cmd, 0x00}, dst...)
+	if _, err := c.Write(req); err != nil {
+		return "", err
+	}
+	// Reply: VER REP RSV ATYP BND.ADDR BND.PORT
+	var head [4]byte
+	if _, err := io.ReadFull(c, head[:]); err != nil {
+		return "", err
+	}
+	if head[1] != 0x00 {
+		return "", fmt.Errorf("socks reply code %d", head[1])
+	}
+	host, err := readSocksAddr(c, head[3])
+	if err != nil {
+		return "", err
+	}
+	var port [2]byte
+	if _, err := io.ReadFull(c, port[:]); err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(port[:])))), nil
+}
+
+// socksUDPHeader builds the per-datagram SOCKS UDP request header for a
+// fixed target: RSV(2)=0 FRAG=0 ATYP DST.ADDR DST.PORT.
+func socksUDPHeader(target string) ([]byte, error) {
+	dst, err := encodeSocksAddr(target)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{0x00, 0x00, 0x00}, dst...), nil
+}
+
+// stripSocksUDPHeader removes the SOCKS UDP reply header, returning the
+// inner payload.
+func stripSocksUDPHeader(b []byte) ([]byte, bool) {
+	if len(b) < 4 {
+		return nil, false
+	}
+	off := 4 // RSV(2) FRAG(1) ATYP(1)
+	switch b[3] {
+	case socksAtypIPv4:
+		off += 4
+	case socksAtypIPv6:
+		off += 16
+	case socksAtypDomain:
+		if len(b) < 5 {
+			return nil, false
+		}
+		off += 1 + int(b[4])
+	default:
+		return nil, false
+	}
+	off += 2 // port
+	if off > len(b) {
+		return nil, false
+	}
+	return b[off:], true
+}
+
+func encodeSocksAddr(addr string) ([]byte, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	var out []byte
+	if ip := net.ParseIP(host); ip != nil {
+		if v4 := ip.To4(); v4 != nil {
+			out = append([]byte{socksAtypIPv4}, v4...)
+		} else {
+			out = append([]byte{socksAtypIPv6}, ip.To16()...)
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("socks: host too long")
+		}
+		out = append([]byte{socksAtypDomain, byte(len(host))}, host...)
+	}
+	var port [2]byte
+	binary.BigEndian.PutUint16(port[:], uint16(p))
+	return append(out, port[:]...), nil
+}
+
+func readSocksAddr(c net.Conn, atyp byte) (string, error) {
+	switch atyp {
+	case socksAtypIPv4:
+		var b [4]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case socksAtypIPv6:
+		var b [16]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case socksAtypDomain:
+		var l [1]byte
+		if _, err := io.ReadFull(c, l[:]); err != nil {
+			return "", err
+		}
+		b := make([]byte, l[0])
+		if _, err := io.ReadFull(c, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		return "", fmt.Errorf("socks: bad atyp %d", atyp)
+	}
+}

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -890,8 +890,12 @@ ok: gateway.hcl — 7 endpoints across 3 profile(s)
 
 - [`pluginsdk/example/`](https://github.com/denoland/clawpatrol/tree/main/pluginsdk/example)
   — fully exercised plugin: `example_magic_token` credential,
-  `example_passthrough` tunnel, `example_https` endpoint
-  (binds to the built-in `http` facet), `example_smtp`
+  `example_passthrough` tunnel (dials upstream itself),
+  `example_socks` tunnel (routes through a SOCKS5 proxy; opens
+  its transport via the gateway's brokered dial, so it needs no
+  network of its own and can be chained `via` another tunnel —
+  TCP via CONNECT, UDP via UDP ASSOCIATE), `example_https`
+  endpoint (binds to the built-in `http` facet), `example_smtp`
   endpoint + matching `example_smtp` facet (optional + stream
   fields), `example_echo` endpoint + matching `example_echo`
   facet (plain TCP).


### PR DESCRIPTION
Adds `example_socks` to the example plugin — a tunnel that routes through
a SOCKS5 proxy — and migrates the existing `example_passthrough` tunnel to
the brokered dial too, so the **whole example binary is now
`network = "none"`**. Builds on the brokered transport-dial interface
(landed in #714).

Answers "why does passthrough need NetworkOutbound": it didn't have to —
it predated the brokered transport-dial interface and used a raw
`net.Dial`. Both tunnels now open their transport through the gateway's
`DialUpstream` (gateway dials directly, or routes through a parent when
chained `via = <tunnel>`), so neither needs network of its own.

`example_socks` also shows a tunnel carrying UDP: `tcp` Dials use SOCKS5
CONNECT, `udp` Dials (a chained child asking for a datagram conduit, e.g.
WireGuard set to `via` this) use SOCKS5 UDP ASSOCIATE.

* `pluginsdk/example/socks.go` — the tunnel + SOCKS5 wire format.
* `pluginsdk/example/passthrough.go` — dials via `req.DialUpstream`.
* `pluginsdk/example/main.go` — capability drops to `NetworkNone`.
* `TestExampleSocksTunnel` — dials an HTTP target through the tunnel via
  an in-test SOCKS5 server (self-contained, CI-runnable, **sandbox on**).
  The shared example manager gains a transport dialer so the brokered
  tunnel dial resolves regardless of test order.
* doc: listed under `plugins.md` "See also".

The tunnel transport dial under the namespaces sandbox relies on the
host-services broker multiplexing fix from #714. Validated live on a
Linux VM with `backend=namespaces` active.