### PR TITLE
spike: wireguard + socks tunnel plugins (live via-chaining PoC)

### DIFF
--- a/cmd/clawpatrol/tunnelvia_e2e_test.go
+++ b/cmd/clawpatrol/tunnelvia_e2e_test.go
@@ -1,0 +1,218 @@
+//go:build linux
+
+package main
+
+// Live end-to-end driver for the plugin-tunnel via+UDP spike. Gated by
+// CLAWPATROL_VIA_E2E so it never runs in normal CI. It builds the real
+// socks + wireguard plugin binaries, loads a config with a wireguard
+// tunnel (optionally `via` a socks tunnel), acquires it through the
+// gateway's TunnelManager, dials a target over the WG netstack, and
+// checks the HTTP response.
+//
+// Run (against a live WireGuard server + SOCKS proxy + target):
+//
+//	CLAWPATROL_VIA_E2E=1 VIA=1 \
+//	WG_ENDPOINT=host:51820 WG_PRIV=... WG_PEERPUB=... WG_ADDR=10.9.0.2 \
+//	SOCKS_PROXY=host:1080 TARGET=10.9.0.1:8080 \
+//	go test ./cmd/clawpatrol -run TestTunnelViaE2E -count=1 -v
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/extplugin"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func buildTunnelPlugin(t *testing.T, pkg, name string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), name)
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	cmd.Dir = root
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", pkg, err, b)
+	}
+	return out
+}
+
+func TestTunnelViaE2E(t *testing.T) {
+	if os.Getenv("CLAWPATROL_VIA_E2E") == "" {
+		t.Skip("set CLAWPATROL_VIA_E2E=1 (plus WG_*/SOCKS_PROXY/TARGET) to run the live spike")
+	}
+	wgEndpoint := os.Getenv("WG_ENDPOINT")
+	wgPriv := os.Getenv("WG_PRIV")
+	wgPeerPub := os.Getenv("WG_PEERPUB")
+	wgAddr := envOr("WG_ADDR", "10.9.0.2")
+	socksProxy := os.Getenv("SOCKS_PROXY")
+	target := envOr("TARGET", "10.9.0.1:8080")
+	useVia := os.Getenv("VIA") == "1"
+	// REVERSE flips the stack: acquire the SOCKS tunnel chained THROUGH the
+	// WireGuard tunnel (socks `via` wireguard), so the SOCKS proxy's TCP
+	// transport rides the WG tunnel and the WG plugin is the parent. The
+	// SOCKS proxy must live inside the WG network (proxy = 10.9.0.1:1080).
+	reverse := os.Getenv("REVERSE") == "1"
+	needSocks := useVia || reverse
+	if wgEndpoint == "" || wgPriv == "" || wgPeerPub == "" || (needSocks && socksProxy == "") {
+		t.Fatal("need WG_ENDPOINT, WG_PRIV, WG_PEERPUB (and SOCKS_PROXY when VIA/REVERSE=1)")
+	}
+
+	socksBin := buildTunnelPlugin(t, "./pluginsdk/socks", "socks-tunnel")
+	wgBin := buildTunnelPlugin(t, "./pluginsdk/wireguard", "wireguard-tunnel")
+
+	stateDir := t.TempDir()
+	mgr := extplugin.New(log.New(os.Stderr, "", 0))
+	// A tunnel plugin (network=none) opens its transport through the
+	// gateway's brokered dial; with no `via` the gateway dials directly.
+	// The real gateway wires this from g.dialer; the test uses a plain
+	// dialer.
+	mgr.SetTransportDialer(func(network, addr string) (net.Conn, error) {
+		return net.Dial(network, addr)
+	})
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	socksBlock := ""
+	if needSocks {
+		socksBlock = fmt.Sprintf(`
+plugin "socks_tunnel" {
+  source  = %q
+  network = "none"
+  sandbox = "off"
+}
+tunnel "socks_proxy" "corp" {
+  proxy = %q
+}
+`, socksBin, socksProxy)
+	}
+
+	// NOTE: the HCL `via` attribute on a *plugin* tunnel block is a separate,
+	// unfinished config-layer gap (plugin tunnel bodies don't yet peel the
+	// common via/keepalive/share attrs the way built-in tunnels do via
+	// TunnelCommonRead). To exercise the runtime via path here we wire Via
+	// directly on the compiled tunnel below.
+	hcl := fmt.Sprintf(`
+plugin "wireguard_tunnel" {
+  source  = %q
+  network = "none"
+  sandbox = "off"
+}
+%s
+gateway {
+  state_dir  = %q
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "wireguard" "vpn" {
+  endpoint        = %q
+  private_key     = %q
+  peer_public_key = %q
+  address         = %q
+}
+endpoint "https" "via-target" {
+  hosts  = ["target.invalid"]
+  tunnel = wireguard.vpn
+}
+profile "default" { credentials = [] }
+`, wgBin, socksBlock, stateDir, wgEndpoint, wgPriv, wgPeerPub, wgAddr)
+
+	gw, diags := config.LoadBytes([]byte(hcl), "via-e2e.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// Pick the tunnel to acquire and wire its via parent at runtime (the HCL
+	// `via` attribute on a plugin tunnel is a separate gap).
+	var ct *config.CompiledTunnel
+	if reverse {
+		// socks `via` wireguard: acquire the SOCKS tunnel, routed through WG.
+		ct = policy.Tunnels["corp"]
+		if ct == nil {
+			t.Fatalf("no compiled tunnel 'corp' (have %v)", keysOf(policy.Tunnels))
+		}
+		vpn := policy.Tunnels["vpn"]
+		if vpn == nil {
+			t.Fatalf("no compiled tunnel 'vpn' (have %v)", keysOf(policy.Tunnels))
+		}
+		ct.Via = vpn
+	} else {
+		// wireguard, optionally `via` socks.
+		ct = policy.Tunnels["vpn"]
+		if ct == nil {
+			t.Fatalf("no compiled tunnel 'vpn' (have %v)", keysOf(policy.Tunnels))
+		}
+		if useVia {
+			corp := policy.Tunnels["corp"]
+			if corp == nil {
+				t.Fatalf("no compiled tunnel 'corp' (have %v)", keysOf(policy.Tunnels))
+			}
+			ct.Via = corp
+		}
+	}
+
+	tm := NewTunnelManager(runtime.EnvSecretStore{}, stateDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	t.Logf("acquiring tunnel %q (via=%v reverse=%v)", ct.Name, useVia, reverse)
+	tun, release, err := tm.Acquire(ctx, ct, "via-target")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer release()
+
+	// Dial the target over the WG netstack and do a plain HTTP GET.
+	t.Logf("dialing %s through the tunnel", target)
+	conn, err := tun.Dial(ctx, "tcp", target)
+	if err != nil {
+		t.Fatalf("dial through tunnel: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(20 * time.Second))
+
+	if _, err := fmt.Fprintf(conn, "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", target); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body := make([]byte, 256)
+	n, _ := resp.Body.Read(body)
+	t.Logf("RESPONSE %d: %q", resp.StatusCode, body[:n])
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+}
+
+func keysOf(m map[string]*config.CompiledTunnel) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pluginsdk/socks/main.go
+++ b/pluginsdk/socks/main.go
@@ -1,0 +1,381 @@
+// Standalone clawpatrol tunnel plugin: route upstream connections
+// through a SOCKS5 proxy. Spike — demonstrates a PARENT tunnel that can
+// carry UDP (so a WireGuard tunnel can chain `via = socks`).
+//
+// TCP upstreams use SOCKS5 CONNECT. "udp" dials (a chained child asking
+// for a datagram conduit) use SOCKS5 UDP ASSOCIATE; the child's bytes are
+// length-prefixed datagrams (pluginsdk.ReadDatagram/WriteDatagram) which
+// this plugin reframes onto the proxy's UDP relay.
+//
+// The plugin opens NO raw sockets: it reaches the SOCKS proxy and the UDP
+// relay only through the gateway's brokered DialUpstream, so it runs with
+// no network capability of its own (network = "none"), just like an
+// endpoint plugin.
+//
+// Build: go build -o socks-tunnel ./pluginsdk/socks
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name:    "socks_tunnel",
+		Version: "0.1",
+		// No raw sockets: the plugin reaches the proxy and the UDP relay
+		// only through the gateway's brokered DialUpstream.
+		Capabilities: pluginsdk.Capabilities{Network: pluginsdk.NetworkNone},
+		Tunnels:      []pluginsdk.TunnelDef{socksDef()},
+	})
+}
+
+// strAddr is a synthetic net.Addr for the brokered relay conn (already
+// connected, so PacketConnOverStream only reports it back, never dials it).
+type strAddr string
+
+func (a strAddr) Network() string { return "udp" }
+func (a strAddr) String() string  { return string(a) }
+
+type socksConfig struct {
+	Proxy    string `json:"proxy"`    // host:port of the SOCKS5 server
+	Username string `json:"username"` // optional user/pass auth
+	Password string `json:"password"`
+}
+
+func socksDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "socks_proxy",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "proxy", TypeString: "string", Required: true},
+			{Name: "username", TypeString: "string"},
+			{Name: "password", TypeString: "string"},
+		}},
+		Open: func(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+			var cfg socksConfig
+			if len(req.CanonicalConfig) > 0 {
+				if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+					return nil, fmt.Errorf("socks_proxy config: %w", err)
+				}
+			}
+			if cfg.Proxy == "" {
+				return nil, errors.New("socks_proxy: proxy is required")
+			}
+			return &cfg, nil
+		},
+		Dial: func(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+			cfg, _ := req.Handle.(*socksConfig)
+			if cfg == nil {
+				return errors.New("socks_proxy: missing handle")
+			}
+			if req.DialUpstream == nil {
+				return errors.New("socks_proxy: gateway has no transport dial support")
+			}
+			switch req.Network {
+			case "", "tcp":
+				return socksDialTCP(ctx, req.DialUpstream, cfg, req.Addr, upstream)
+			case "udp":
+				return socksDialUDP(ctx, req.DialUpstream, cfg, req.Addr, upstream)
+			default:
+				return fmt.Errorf("socks_proxy: unsupported network %q", req.Network)
+			}
+		},
+		Close: func(_ context.Context, _ any) error { return nil },
+	}
+}
+
+// ---- TCP: SOCKS5 CONNECT, then pump bytes ----
+
+func socksDialTCP(ctx context.Context, dial pluginsdk.DialUpstreamFunc, cfg *socksConfig, addr string, upstream net.Conn) error {
+	c, err := dial(ctx, "tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+	if err := socksHandshake(c, cfg); err != nil {
+		return err
+	}
+	if _, err := socksRequest(c, cmdConnect, addr); err != nil {
+		return fmt.Errorf("socks CONNECT %s: %w", addr, err)
+	}
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+// ---- UDP: SOCKS5 UDP ASSOCIATE, datagram-framed over `upstream` ----
+
+func socksDialUDP(ctx context.Context, dial pluginsdk.DialUpstreamFunc, cfg *socksConfig, target string, upstream net.Conn) error {
+	// The TCP control connection must stay open for the lifetime of the
+	// association — closing it tells the proxy to drop the UDP relay.
+	ctrl, err := dial(ctx, "tcp", cfg.Proxy)
+	if err != nil {
+		return fmt.Errorf("dial socks proxy: %w", err)
+	}
+	defer func() { _ = ctrl.Close() }()
+	if err := socksHandshake(ctrl, cfg); err != nil {
+		return err
+	}
+	relayStr, err := socksRequest(ctrl, cmdUDPAssociate, "0.0.0.0:0")
+	if err != nil {
+		return fmt.Errorf("socks UDP ASSOCIATE: %w", err)
+	}
+	// The reply's BND.ADDR is frequently unspecified (0.0.0.0) or an
+	// internal address when the proxy sits behind NAT (e.g. a cloud VM
+	// returning its private IP). The UDP relay lives on the proxy host, so
+	// fall back to the proxy's host with the returned port unless the reply
+	// names a concrete, routable address.
+	relayHost, relayPort, _ := net.SplitHostPort(relayStr)
+	if ip := net.ParseIP(relayHost); ip == nil || ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() {
+		relayHost, _, _ = net.SplitHostPort(cfg.Proxy)
+	}
+	relayHostPort := net.JoinHostPort(relayHost, relayPort)
+
+	// Open the UDP relay through the gateway's brokered dial (no raw
+	// socket). The conn carries length-prefixed datagrams; treat it as a
+	// connected net.PacketConn.
+	relayConn, err := dial(ctx, "udp", relayHostPort)
+	if err != nil {
+		return fmt.Errorf("dial socks relay %q: %w", relayHostPort, err)
+	}
+	pc := pluginsdk.PacketConnOverStream(relayConn, strAddr(relayHostPort))
+	defer func() { _ = pc.Close() }()
+
+	hdr, err := socksUDPHeader(target)
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{}, 3)
+	// upstream datagrams -> SOCKS relay (prepend the UDP request header)
+	go func() {
+		for {
+			d, rerr := pluginsdk.ReadDatagram(upstream)
+			if rerr != nil {
+				break
+			}
+			pkt := append(append([]byte(nil), hdr...), d...)
+			if _, werr := pc.WriteTo(pkt, strAddr(relayHostPort)); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// SOCKS relay -> upstream datagrams (strip the UDP reply header)
+	go func() {
+		buf := make([]byte, 64<<10)
+		for {
+			n, _, rerr := pc.ReadFrom(buf)
+			if rerr != nil {
+				break
+			}
+			payload, ok := stripSocksUDPHeader(buf[:n])
+			if !ok {
+				continue
+			}
+			if werr := pluginsdk.WriteDatagram(upstream, payload); werr != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}()
+	// The control conn closing (proxy dropped the association) ends it.
+	go func() {
+		var b [1]byte
+		_, _ = ctrl.Read(b[:])
+		done <- struct{}{}
+	}()
+	<-done
+	return nil
+}
+
+// ---- SOCKS5 wire format (RFC 1928) ----
+
+const (
+	socksVer        = 0x05
+	cmdConnect      = 0x01
+	cmdUDPAssociate = 0x03
+	atypIPv4        = 0x01
+	atypDomain      = 0x03
+	atypIPv6        = 0x04
+)
+
+func socksHandshake(c net.Conn, cfg *socksConfig) error {
+	useAuth := cfg.Username != ""
+	methods := []byte{0x00}
+	if useAuth {
+		methods = []byte{0x02}
+	}
+	greeting := append([]byte{socksVer, byte(len(methods))}, methods...)
+	if _, err := c.Write(greeting); err != nil {
+		return err
+	}
+	var sel [2]byte
+	if _, err := io.ReadFull(c, sel[:]); err != nil {
+		return err
+	}
+	if sel[0] != socksVer {
+		return fmt.Errorf("socks: bad version %d", sel[0])
+	}
+	switch sel[1] {
+	case 0x00:
+		return nil
+	case 0x02:
+		return socksUserPassAuth(c, cfg)
+	default:
+		return fmt.Errorf("socks: no acceptable auth method (got %d)", sel[1])
+	}
+}
+
+func socksUserPassAuth(c net.Conn, cfg *socksConfig) error {
+	msg := []byte{0x01, byte(len(cfg.Username))}
+	msg = append(msg, cfg.Username...)
+	msg = append(msg, byte(len(cfg.Password)))
+	msg = append(msg, cfg.Password...)
+	if _, err := c.Write(msg); err != nil {
+		return err
+	}
+	var resp [2]byte
+	if _, err := io.ReadFull(c, resp[:]); err != nil {
+		return err
+	}
+	if resp[1] != 0x00 {
+		return errors.New("socks: user/pass auth failed")
+	}
+	return nil
+}
+
+// socksRequest sends a CONNECT or UDP ASSOCIATE request for addr and
+// returns the bound address from the reply ("host:port").
+func socksRequest(c net.Conn, cmd byte, addr string) (string, error) {
+	dst, err := encodeSocksAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	req := append([]byte{socksVer, cmd, 0x00}, dst...)
+	if _, err := c.Write(req); err != nil {
+		return "", err
+	}
+	// Reply: VER REP RSV ATYP BND.ADDR BND.PORT
+	var head [4]byte
+	if _, err := io.ReadFull(c, head[:]); err != nil {
+		return "", err
+	}
+	if head[1] != 0x00 {
+		return "", fmt.Errorf("socks reply code %d", head[1])
+	}
+	host, err := readSocksAddr(c, head[3])
+	if err != nil {
+		return "", err
+	}
+	var port [2]byte
+	if _, err := io.ReadFull(c, port[:]); err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(port[:])))), nil
+}
+
+// socksUDPHeader builds the per-datagram SOCKS UDP request header for a
+// fixed target: RSV(2)=0 FRAG=0 ATYP DST.ADDR DST.PORT.
+func socksUDPHeader(target string) ([]byte, error) {
+	dst, err := encodeSocksAddr(target)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{0x00, 0x00, 0x00}, dst...), nil
+}
+
+// stripSocksUDPHeader removes the SOCKS UDP reply header, returning the
+// inner payload.
+func stripSocksUDPHeader(b []byte) ([]byte, bool) {
+	if len(b) < 4 {
+		return nil, false
+	}
+	// b[0:2]=RSV, b[2]=FRAG, b[3]=ATYP
+	off := 4
+	switch b[3] {
+	case atypIPv4:
+		off += 4
+	case atypIPv6:
+		off += 16
+	case atypDomain:
+		if len(b) < 5 {
+			return nil, false
+		}
+		off += 1 + int(b[4])
+	default:
+		return nil, false
+	}
+	off += 2 // port
+	if off > len(b) {
+		return nil, false
+	}
+	return b[off:], true
+}
+
+func encodeSocksAddr(addr string) ([]byte, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	var out []byte
+	if ip := net.ParseIP(host); ip != nil {
+		if v4 := ip.To4(); v4 != nil {
+			out = append([]byte{atypIPv4}, v4...)
+		} else {
+			out = append([]byte{atypIPv6}, ip.To16()...)
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("socks: host too long")
+		}
+		out = append([]byte{atypDomain, byte(len(host))}, host...)
+	}
+	var port [2]byte
+	binary.BigEndian.PutUint16(port[:], uint16(p))
+	return append(out, port[:]...), nil
+}
+
+func readSocksAddr(c net.Conn, atyp byte) (string, error) {
+	switch atyp {
+	case atypIPv4:
+		var b [4]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case atypIPv6:
+		var b [16]byte
+		if _, err := io.ReadFull(c, b[:]); err != nil {
+			return "", err
+		}
+		return net.IP(b[:]).String(), nil
+	case atypDomain:
+		var l [1]byte
+		if _, err := io.ReadFull(c, l[:]); err != nil {
+			return "", err
+		}
+		b := make([]byte, l[0])
+		if _, err := io.ReadFull(c, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		return "", fmt.Errorf("socks: bad atyp %d", atyp)
+	}
+}

--- a/pluginsdk/wireguard/main.go
+++ b/pluginsdk/wireguard/main.go
@@ -1,0 +1,316 @@
+// Standalone clawpatrol tunnel plugin: route upstream connections through
+// a WireGuard tunnel. Spike — a UDP-transport plugin tunnel that supports
+// `via` chaining (e.g. `via = socks`, so the WireGuard handshake's UDP
+// rides over a SOCKS5 UDP relay).
+//
+// The plugin runs with NO network of its own (network = "none"): it opens
+// its WireGuard transport through the gateway's brokered dial
+// (req.DialUpstream("udp", endpoint)), which the gateway routes directly
+// or through the parent tunnel. A small wireguard-go conn.Bind sends and
+// receives over that brokered datagram conduit instead of a real UDP
+// socket; an in-process gVisor netstack carries the tunnelled TCP.
+//
+// Build: go build -o wireguard-tunnel ./pluginsdk/wireguard
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/denoland/clawpatrol/pluginsdk"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+func main() {
+	pluginsdk.Run(&pluginsdk.Plugin{
+		Name:    "wireguard_tunnel",
+		Version: "0.1",
+		// No raw sockets: the transport is opened through the gateway's
+		// brokered dial, which the gateway routes (direct or via parent).
+		Capabilities: pluginsdk.Capabilities{Network: pluginsdk.NetworkNone},
+		Tunnels:      []pluginsdk.TunnelDef{wireguardDef()},
+	})
+}
+
+type wgConfig struct {
+	Endpoint      string `json:"endpoint"`        // host:port of the WG server
+	PrivateKey    string `json:"private_key"`     // base64 (wg-quick form)
+	PeerPublicKey string `json:"peer_public_key"` // base64
+	Address       string `json:"address"`         // this peer's IP in the WG net
+	DNS           string `json:"dns"`             // optional in-tunnel resolver
+}
+
+type wgHandle struct {
+	dev    *device.Device
+	tnet   *netstack.Net
+	cancel context.CancelFunc // cancels the brokered transport's context on Close
+}
+
+func wireguardDef() pluginsdk.TunnelDef {
+	return pluginsdk.TunnelDef{
+		TypeName: "wireguard",
+		Schema: pluginsdk.Schema{Fields: []pluginsdk.SchemaField{
+			{Name: "endpoint", TypeString: "string", Required: true},
+			{Name: "private_key", TypeString: "string", Required: true},
+			{Name: "peer_public_key", TypeString: "string", Required: true},
+			{Name: "address", TypeString: "string", Required: true},
+			{Name: "dns", TypeString: "string"},
+		}},
+		Open:  wireguardOpen,
+		Dial:  wireguardDial,
+		Close: wireguardClose,
+	}
+}
+
+func wireguardOpen(_ context.Context, req pluginsdk.TunnelOpenRequest) (any, error) {
+	var cfg wgConfig
+	if len(req.CanonicalConfig) > 0 {
+		if err := json.Unmarshal(req.CanonicalConfig, &cfg); err != nil {
+			return nil, fmt.Errorf("wireguard config: %w", err)
+		}
+	}
+	if cfg.Endpoint == "" || cfg.PrivateKey == "" || cfg.PeerPublicKey == "" || cfg.Address == "" {
+		return nil, errors.New("wireguard: endpoint, private_key, peer_public_key, address are required")
+	}
+	if req.DialUpstream == nil {
+		return nil, errors.New("wireguard: gateway provides no brokered dial (HostTunnel unavailable)")
+	}
+	clientAddr, err := netip.ParseAddr(cfg.Address)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard address %q: %w", cfg.Address, err)
+	}
+	var dns []netip.Addr
+	if cfg.DNS != "" {
+		d, err := netip.ParseAddr(cfg.DNS)
+		if err != nil {
+			return nil, fmt.Errorf("wireguard dns %q: %w", cfg.DNS, err)
+		}
+		dns = append(dns, d)
+	}
+
+	tunDev, tnet, err := netstack.CreateNetTUN([]netip.Addr{clientAddr}, dns, 1420)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard netstack: %w", err)
+	}
+
+	// The bind opens the WireGuard transport through the gateway's brokered
+	// dial. It dials inside Open (not here) because wireguard-go closes and
+	// re-opens the bind on every device Up (BindUpdate) — like StdNetBind
+	// re-creating its sockets — so the conduit must be (re)creatable, not a
+	// single conn opened once. The context is the tunnel's lifetime: the
+	// OpenTunnel ctx is cancelled when Open returns, so use a fresh one
+	// cancelled on Close.
+	dialCtx, cancel := context.WithCancel(context.Background())
+	bind := &brokeredBind{dial: req.DialUpstream, endpoint: cfg.Endpoint, ctx: dialCtx}
+
+	dev := device.NewDevice(tunDev, bind,
+		device.NewLogger(device.LogLevelError, "[wireguard-plugin] "))
+	uapi, err := buildWGIpc(cfg)
+	if err != nil {
+		dev.Close()
+		cancel()
+		return nil, err
+	}
+	if err := dev.IpcSet(uapi); err != nil {
+		dev.Close()
+		cancel()
+		return nil, fmt.Errorf("wireguard IpcSet: %w", err)
+	}
+	if err := dev.Up(); err != nil {
+		dev.Close()
+		cancel()
+		return nil, fmt.Errorf("wireguard up: %w", err)
+	}
+	return &wgHandle{dev: dev, tnet: tnet, cancel: cancel}, nil
+}
+
+func wireguardDial(ctx context.Context, req pluginsdk.TunnelDialRequest, upstream net.Conn) error {
+	h, _ := req.Handle.(*wgHandle)
+	if h == nil {
+		return errors.New("wireguard: missing handle")
+	}
+	addrPort, err := resolveInTunnel(h.tnet, req.Addr)
+	if err != nil {
+		return err
+	}
+	c, err := h.tnet.DialContextTCPAddrPort(ctx, addrPort)
+	if err != nil {
+		return fmt.Errorf("wireguard dial %s: %w", req.Addr, err)
+	}
+	defer func() { _ = c.Close() }()
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, c); done <- struct{}{} }()
+	<-done
+	return nil
+}
+
+func wireguardClose(_ context.Context, handle any) error {
+	h, _ := handle.(*wgHandle)
+	if h == nil {
+		return nil
+	}
+	if h.dev != nil {
+		h.dev.Close()
+	}
+	if h.cancel != nil {
+		h.cancel()
+	}
+	return nil
+}
+
+// ---- wireguard-go conn.Bind over a single brokered datagram conduit ----
+
+// brokeredBind is a wireguard-go conn.Bind that sends and receives over the
+// gateway's brokered UDP conduit instead of a real UDP socket. There is
+// exactly one peer/endpoint — the tunnel's WG server — reached through the
+// connected conduit, so addresses are immaterial. Open dials a fresh
+// conduit (wireguard-go closes+reopens the bind on every device Up), Close
+// tears the current one down.
+type brokeredBind struct {
+	dial     pluginsdk.DialUpstreamFunc
+	endpoint string
+	ctx      context.Context
+	ep       brokeredEndpoint
+
+	mu sync.Mutex
+	pc net.PacketConn
+}
+
+func (b *brokeredBind) Open(port uint16) ([]conn.ReceiveFunc, uint16, error) {
+	transport, err := b.dial(b.ctx, "udp", b.endpoint)
+	if err != nil {
+		return nil, 0, err
+	}
+	pc := pluginsdk.PacketConnOverStream(transport, endpointAddr())
+	b.mu.Lock()
+	b.pc = pc
+	b.mu.Unlock()
+	recv := func(packets [][]byte, sizes []int, eps []conn.Endpoint) (int, error) {
+		n, _, err := pc.ReadFrom(packets[0])
+		if err != nil {
+			return 0, net.ErrClosed // the Bind contract: recv returns ErrClosed after Close
+		}
+		sizes[0] = n
+		eps[0] = b.ep
+		return 1, nil
+	}
+	return []conn.ReceiveFunc{recv}, port, nil
+}
+
+func (b *brokeredBind) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.pc != nil {
+		_ = b.pc.Close()
+		b.pc = nil
+	}
+	return nil
+}
+
+func (b *brokeredBind) SetMark(uint32) error { return nil }
+func (b *brokeredBind) BatchSize() int       { return 1 }
+
+func (b *brokeredBind) Send(bufs [][]byte, _ conn.Endpoint) error {
+	b.mu.Lock()
+	pc := b.pc
+	b.mu.Unlock()
+	if pc == nil {
+		return net.ErrClosed
+	}
+	for _, buf := range bufs {
+		if _, err := pc.WriteTo(buf, nil); err != nil { // PacketConnOverStream ignores addr
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *brokeredBind) ParseEndpoint(string) (conn.Endpoint, error) { return b.ep, nil }
+
+// brokeredEndpoint is the single, immaterial WG endpoint — the real route
+// is the connected conduit, so the address is cosmetic.
+type brokeredEndpoint struct{}
+
+func (brokeredEndpoint) ClearSrc()           {}
+func (brokeredEndpoint) SrcToString() string { return "" }
+func (brokeredEndpoint) DstToString() string { return "brokered" }
+func (brokeredEndpoint) DstToBytes() []byte  { return []byte{0} }
+func (brokeredEndpoint) DstIP() netip.Addr   { return netip.Addr{} }
+func (brokeredEndpoint) SrcIP() netip.Addr   { return netip.Addr{} }
+
+// endpointAddr returns a synthetic net.Addr for the conduit's remote (used
+// only as PacketConnOverStream's reported address).
+func endpointAddr() net.Addr { return &net.UDPAddr{IP: net.IPv4zero, Port: 0} }
+
+// ---- config ----
+
+// buildWGIpc renders the wireguard-go IpcSet payload (keys are base64 in
+// config, hex on the wire). The peer endpoint is a sentinel — the bind
+// ignores it and routes through the brokered conduit. 0.0.0.0/0 allowed-ips
+// + a forced keepalive so the handshake runs eagerly.
+func buildWGIpc(cfg wgConfig) (string, error) {
+	privHex, err := base64ToHex(cfg.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("wireguard private_key: %w", err)
+	}
+	pubHex, err := base64ToHex(cfg.PeerPublicKey)
+	if err != nil {
+		return "", fmt.Errorf("wireguard peer_public_key: %w", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "private_key=%s\n", privHex)
+	fmt.Fprintf(&b, "replace_peers=true\n")
+	fmt.Fprintf(&b, "public_key=%s\n", pubHex)
+	fmt.Fprintf(&b, "endpoint=0.0.0.0:0\n")
+	fmt.Fprintf(&b, "persistent_keepalive_interval=25\n")
+	fmt.Fprintf(&b, "allowed_ip=0.0.0.0/0\n")
+	fmt.Fprintf(&b, "allowed_ip=::/0\n")
+	return b.String(), nil
+}
+
+func base64ToHex(b64 string) (string, error) {
+	dec, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(dec), nil
+}
+
+// resolveInTunnel turns "host:port" into a netip.AddrPort, resolving a
+// hostname through the WG netstack's resolver when needed (spike: the
+// common case is the gateway handing us an ip:port).
+func resolveInTunnel(tnet *netstack.Net, addr string) (netip.AddrPort, error) {
+	if ap, err := netip.ParseAddrPort(addr); err == nil {
+		return ap, nil
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("wireguard addr %q: %w", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("wireguard port %q: %w", portStr, err)
+	}
+	hosts, err := tnet.LookupHost(host)
+	if err != nil || len(hosts) == 0 {
+		return netip.AddrPort{}, fmt.Errorf("wireguard resolve %q: %w", host, err)
+	}
+	ip, err := netip.ParseAddr(hosts[0])
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	return netip.AddrPortFrom(ip, uint16(port)), nil
+}


### PR DESCRIPTION
**Spike — not for merge.** Kept for reference: the proof-of-concept that
drove the brokered transport-dial interface (#714) and the SOCKS example
(#719), now rebased onto main.

Two standalone external tunnel plugins, both `network = "none"`, and an
env-gated live e2e that exercised them end to end:

* `pluginsdk/wireguard/main.go` — wireguard-go + gVisor netstack; a small
  `conn.Bind` carries WG's UDP over the gateway's brokered `DialUpstream`
  instead of a raw socket.
* `pluginsdk/socks/main.go` — SOCKS5 (CONNECT + UDP ASSOCIATE), usable as
  a `via` parent. (The landable version of this is `example_socks` in
  #719; this standalone copy is what the e2e builds.)
* `cmd/clawpatrol/tunnelvia_e2e_test.go` — `TestTunnelViaE2E`, gated by
  `CLAWPATROL_VIA_E2E`. `VIA`/`REVERSE` flags select the stacking.

Validated live (userspace WireGuard server + SOCKS5 UDP proxy): all three
stackings returned the target's response —
* wireguard direct,
* wireguard `via` socks (WG handshake UDP over the SOCKS5 UDP relay),
* socks `via` wireguard (SOCKS TCP transport over the WG tunnel).

Known gap: the HCL `via` attribute on a plugin tunnel block isn't peeled
yet, so the e2e wires `Via` on the compiled tunnel directly.