### PR TITLE
docs: plugin tunnel transport dial + plugin-docs audit corrections

### DIFF
--- a/doc/external-plugin-control-plane.md
+++ b/doc/external-plugin-control-plane.md
@@ -50,7 +50,7 @@ and another correlation map — bookkeeping gRPC does for free.
 
 | Direction | What it is | Where it lives | Examples |
 |---|---|---|---|
-| **plugin → host** | the plugin calls the gateway | host-served services over the broker (`HostControl`, `HostState`) | `Evaluate`, brokered `Dial`, HITL `Decide`, `State` |
+| **plugin → host** | the plugin calls the gateway | host-served services over the broker (`HostControl`, `HostState`, `HostTunnel`) | `Evaluate`, HITL `Decide`, `State`, tunnel transport `DialUpstream` |
 | **host → plugin** | the gateway calls the plugin | the plugin's own gRPC services | `Endpoint.HandleConn`, `Credential.TransformHTTP`, `Approver.Approve`, `Approver.Notify` |
 
 The split matters because the two directions have different homes and
@@ -79,21 +79,33 @@ the end.
 
 ### Host services over one broker stream
 
-The gateway serves two host-side services over the go-plugin broker on a
-single reserved stream id; the plugin dials it once and builds both stubs
-over that one connection:
+The gateway serves the host-side services over the go-plugin broker on a
+single reserved stream id; the plugin dials it once and builds all the
+stubs over that one connection. The broker is multiplexed over the
+plugin's main gRPC connection (`GRPCBrokerMultiplex`), not a separate
+socket — which is what lets a sandboxed plugin reach host services at all
+(a broker socket in the gateway's temp dir would be hidden by the
+namespaces sandbox's private `/tmp`).
 
 ```proto
 service HostState   { rpc Get(...); rpc Put(...); }          // persistent bytes
-service HostControl {
+service HostControl {                                        // connection-scoped control
   rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);
-  // grows plugin→host only: Dial(stream) for brokered dial, Decide(...) for HITL
+  // grows plugin→host only, e.g. Decide(...) for HITL
+}
+service HostTunnel  {                                        // tunnel transport dial
+  rpc DialUpstream(stream DialMessage) returns (stream DialMessage);
 }
 ```
 
 `HostState` is plugin-lifetime persistence; `HostControl` is
-connection-scoped control. Keep it to these two services and add
-*methods*, not services.
+connection-scoped control; `HostTunnel` is the brokered transport dial a
+tunnel plugin uses to open its own transport (the gateway routes it direct
+or through a `via` parent). `HostControl` is session-scoped via a metadata
+token (below); `HostTunnel` is instead capability-scoped by an unguessable
+per-tunnel transport-dial token, so it is not covered by the unary session
+interceptor. Prefer adding *methods* to an existing service over new
+services.
 
 ### Session scoping in metadata, resolved by an interceptor
 
@@ -161,9 +173,12 @@ credential.
 ```proto
 service HostControl {
   rpc Evaluate(EvaluateRequest) returns (EvaluateVerdict);    // implemented
-  // Brokered upstream dial as a method — removes the dial_id inflight map
-  // the way Evaluate removed call_id, and shrinks the data plane to bytes.
-  rpc Dial(stream DialChunk) returns (stream DialChunk);
+  // Original sketch: brokered upstream dial as a HostControl method. What
+  // actually shipped: the tunnel transport dial is the separate streaming
+  // service HostTunnel.DialUpstream (above), and the endpoint brokered dial
+  // rides the existing HandleConn stream as a frame — neither became a
+  // HostControl method, but the plugin→host direction is unchanged.
+  rpc Dial(stream DialChunk) returns (stream DialChunk);      // superseded by HostTunnel
   // HITL: a notifier (a Slack button) resolves a pending decision. The
   // gateway records it in the same pool the dashboard writes to.
   rpc Decide(DecideRequest) returns (DecideAck);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -618,11 +618,14 @@ type PluginSource struct {
 	Provenance string `hcl:"provenance,optional"`
 
 	// Network grants the plugin direct network access. "none" (the
-	// default) confines the plugin to its gateway socket — endpoint
-	// and credential plugins don't need more: upstream connections
-	// go through the gateway's brokered dial. "outbound" lets the
-	// plugin dial out itself; tunnel plugins (they are the upstream
-	// transport) need it.
+	// default) confines the plugin to its gateway socket — endpoint,
+	// credential, and tunnel plugins all reach the network through the
+	// gateway's brokered dial (endpoints via the upstream dial, tunnels
+	// via the transport dial), so they need no more. "outbound" lets the
+	// plugin dial out itself; it's only for the few plugins that can't use
+	// the broker — e.g. one that execs helper tools (ssh, kubectl) which
+	// open their own connections, or a credential plugin doing its own
+	// token exchange.
 	Network string `hcl:"network,optional"`
 
 	// Sandbox controls subprocess isolation. "enforce" (the default)

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -178,6 +178,30 @@ ok: gateway.hcl — 7 endpoints across 3 profile(s)
   plugin "example" v0.1: 2 facet(s), 1 credential type(s), 1 tunnel type(s), 3 endpoint type(s)
 ```
 
+### `clawpatrol plugins`
+
+Manage external plugins — download GitHub-sourced plugins, pin them in
+`clawpatrol.lock.hcl`, and approve permission grants. The running gateway
+only ever loads the locked version and never downloads on its own; these
+are the explicit, reviewable steps.
+
+```bash
+clawpatrol plugins install <config.hcl> [name...]   # download + pin the locked version
+clawpatrol plugins update  <config.hcl> [name...]   # re-pin to the newest matching release
+clawpatrol plugins lock    <config.hcl> [name...]   # record every platform's binary hash
+clawpatrol plugins info    <config.hcl> [name...]   # show required privileges (no download)
+clawpatrol plugins approve <config.hcl> [name...]   # approve a pending permission escalation
+```
+
+`info` reads each GitHub plugin's signed static manifest — without
+downloading the binary — and prints its types and the network / egress /
+privileged grants it requests. `approve` records a plugin's requested
+grants in the lockfile after a manifest escalation held it closed (a new
+version that wants more than the lockfile recorded). Local (`./path`)
+sources skip the download but still pin a binary hash. See
+[Plugins](/docs/plugins/) for the `source` / `version` syntax and the
+trust model.
+
 ### `clawpatrol status`
 
 Report device install state — whether `join`/`login` ran, whether

--- a/site/doc/plugins.md
+++ b/site/doc/plugins.md
@@ -15,8 +15,10 @@ They can declare:
 - **Credential types** (`credential "<type>" "<name>" { … }`) —
   describe a secret-bearing identity.
 - **Tunnel types** (`tunnel "<type>" "<name>" { … }`) — describe
-  how the gateway reaches the upstream when it isn’t directly
-  routable.
+  how the gateway reaches an upstream that isn’t directly routable
+  (a SOCKS proxy, a VPN, an SSH bastion). Like an endpoint, a tunnel
+  plugin opens its own transport through the gateway’s brokered dial,
+  so it too runs `network = "none"`.
 - **Facets** — protocol-family schemas with named fields. A facet
   exposes the variables a CEL rule condition can read
   (`example_smtp.verb`, `acme_webhook.signature`, …) and the
@@ -71,8 +73,8 @@ caches it, and pins the resolved version in the lockfile — the same
 model Terraform uses for providers:
 
 ```hcl
-plugin "customerio" {
-  source  = "github.com/denoland/clawpatrol-customerio-plugin"
+plugin "aws" {
+  source  = "github.com/denoland/clawpatrol-plugin-aws"
   version = "~> 1.2"   # newest 1.x ≥ 1.2 ; omit for the newest stable
 }
 ```
@@ -204,8 +206,8 @@ Three layers gate a downloaded binary, from least to most powerful:
    `provenance`:
 
    ```hcl
-   plugin "customerio" {
-     source     = "github.com/denoland/clawpatrol-customerio-plugin"
+   plugin "aws" {
+     source     = "github.com/denoland/clawpatrol-plugin-aws"
      version    = "~> 1.2"
      provenance = "require"   # "warn" (default) | "require" | "off"
    }
@@ -280,11 +282,17 @@ pluginsdk.Run(&pluginsdk.Plugin{
 ```
 
 `NetworkNone` (the default) cuts the plugin off from the network — its
-only channel is the gateway socket, and upstream connections go
-through the [brokered dial](#brokered-upstream-dial). `NetworkOutbound`
-lets the plugin dial out itself; **tunnel plugins** (they *are* the
-upstream transport, e.g. SSH or WireGuard) and credential plugins that
-do their own token exchange need it.
+only channel is the gateway socket, and upstream connections go through
+the gateway's brokered dial. This is enough for almost every plugin:
+endpoint plugins reach upstreams with the
+[brokered dial](#brokered-upstream-dial), and **tunnel plugins** open
+their own transport with the
+[tunnel transport dial](#tunnel-transport-dial), so both run
+`network = "none"` with no socket of their own. `NetworkOutbound` is for
+the few plugins that genuinely dial out themselves and can't use the
+broker — a plugin that execs helper tools (`ssh`, `kubectl`) which open
+their own connections, or a credential plugin doing its own token
+exchange.
 
 On first load the gateway records the plugin's declared network in
 **`clawpatrol.lock.hcl`** next to the config (commit it to VCS):
@@ -317,6 +325,13 @@ upgrade, re-approve it:
 ```
 clawpatrol plugins approve <config.hcl> ssh_tools
 ```
+
+Or approve it from the **dashboard**: any blocked plugin — an escalated
+network/egress grant, a lost provenance attestation, or a declared
+`privileged` request — shows on the **Plugins** page with the reason and an
+**Approve** button that records the grant and reloads, no CLI needed. This
+is the usual flow after installing or upgrading a GitHub plugin whose new
+release wants more than the lockfile recorded.
 
 An operator can still set `network` on the `plugin` block to override
 the plugin's request (force or veto); the override wins and is what
@@ -488,6 +503,41 @@ and then stops reading it can stall its own connection's other
 traffic (other dials, audit events, the agent response). This only
 affects the one connection the plugin is handling, but a misbehaving
 plugin can wedge itself — drain your dial conns.
+
+### Tunnel transport dial
+
+A tunnel plugin is the *transport* — it teaches the gateway how to reach
+an upstream that isn't directly routable (through a SOCKS proxy, a VPN, an
+SSH bastion). Like an endpoint plugin, it does **not** open that transport
+socket itself; from inside its `Dial` (or `Open`) it asks the gateway:
+
+```go
+c, err := req.DialUpstream(ctx, "tcp", cfg.Proxy)
+```
+
+The gateway opens the transport on the plugin's behalf, **routes** it
+(directly, or — when the tunnel is chained — through the parent tunnel),
+and hands back a `net.Conn`. The plugin opens no socket, so a tunnel plugin
+also runs with `network = "none"`.
+
+`req.DialUpstream` accepts **`"udp"`** as well as `"tcp"`. For UDP the
+returned conn carries length-prefixed datagrams; wrap it with
+`pluginsdk.PacketConnOverStream` for a `net.PacketConn`, or use
+`pluginsdk.WriteDatagram` / `ReadDatagram` directly. This is what lets a
+UDP-based tunnel (WireGuard) ride over a stream-based one (a SOCKS proxy):
+the datagrams are framed over the conduit end to end.
+
+The canonical example is `example_socks` (`pluginsdk/example/socks.go`): a
+SOCKS5 tunnel that opens both its TCP control connection (SOCKS CONNECT)
+and its UDP relay (SOCKS UDP ASSOCIATE) with `req.DialUpstream`, and runs
+`network = "none"`.
+
+**Chaining (`via`).** The gateway routes a tunnel's transport through the
+*parent* tunnel named by `via = <tunnel>` — this is how a chain composes
+without any plugin knowing about the others (a WireGuard tunnel's handshake
+routed through a SOCKS tunnel, say). `via` works on plugin tunnel blocks
+just like built-in ones, in either role (parent or child); see
+[Chaining tunnels](/docs/tunnels/#chaining-tunnels-with-via).
 
 ## Writing a plugin
 
@@ -890,11 +940,12 @@ ok: gateway.hcl — 7 endpoints across 3 profile(s)
 
 - [`pluginsdk/example/`](https://github.com/denoland/clawpatrol/tree/main/pluginsdk/example)
   — fully exercised plugin: `example_magic_token` credential,
-  `example_passthrough` tunnel (dials upstream itself),
-  `example_socks` tunnel (routes through a SOCKS5 proxy; opens
-  its transport via the gateway's brokered dial, so it needs no
-  network of its own and can be chained `via` another tunnel —
-  TCP via CONNECT, UDP via UDP ASSOCIATE), `example_https`
+  `example_passthrough` tunnel (a no-op tunnel — opens the upstream
+  through the gateway's brokered dial), `example_socks` tunnel
+  (routes through a SOCKS5 proxy; opens its transport via the
+  gateway's brokered dial, so it needs no network of its own —
+  TCP via CONNECT, UDP via UDP ASSOCIATE; usable as a `via` parent),
+  `example_https`
   endpoint (binds to the built-in `http` facet), `example_smtp`
   endpoint + matching `example_smtp` facet (optional + stream
   fields), `example_echo` endpoint + matching `example_echo`

--- a/site/doc/security-model.md
+++ b/site/doc/security-model.md
@@ -307,10 +307,13 @@ dial](plugins.md#brokered-upstream-dial), restricted to the targets the
 endpoint's `hosts`/`dial` HCL or the plugin's manifest-declared egress
 set sanctions and audited on every attempt. That egress set is recorded
 trust-on-first-use like the network grant, and an upgrade that broadens
-it fails closed until re-approved. Tunnel plugins
-are the upstream transport themselves and need outbound network; that
-grant is per-plugin, so it does not loosen the endpoint plugins beside
-it.
+it fails closed until re-approved. Tunnel plugins keep the same posture:
+they open their *own* transport (the socket to a SOCKS proxy, a bastion)
+through the gateway's brokered transport dial, so they also default to
+`network = "none"`. `outbound` is the exception, not the rule — only a
+plugin that genuinely dials out itself (one that execs helper tools, or a
+credential plugin doing its own token exchange) requests it, and that
+grant is per-plugin, so it does not loosen the plugins beside it.
 
 Network is **declared by the plugin** in its manifest and recorded,
 trust-on-first-use, in a committed lockfile (`clawpatrol.lock.hcl`).

--- a/site/doc/tunnels.md
+++ b/site/doc/tunnels.md
@@ -216,6 +216,24 @@ expires out from under you.
 
 See [config reference](/docs/config-reference/#tunnel-tailscale).
 
+## Plugin tunnel types
+
+External plugins can register their own tunnel types — a SOCKS proxy, a
+WireGuard or other VPN, anything that carries a connection. They are
+referenced exactly like the built-ins (`tunnel "<type>" "<name>" { … }`)
+and bound to endpoints the same way.
+
+A plugin tunnel does **not** open its transport socket itself. Like an
+endpoint plugin, it opens the connection it rides on (the TCP conn to a
+SOCKS proxy, the UDP conn to a WireGuard endpoint) through the gateway's
+brokered *transport dial*, so it runs with no network of its own
+(`network = "none"`); the gateway dials on its behalf. The brokered
+transport carries UDP as well as TCP, which is what lets a UDP tunnel
+(WireGuard) chain through a stream tunnel (a SOCKS proxy). See
+[plugins › tunnel transport dial](/docs/plugins/#tunnel-transport-dial). The
+example plugin ships `example_socks` (SOCKS5 CONNECT + UDP ASSOCIATE) and
+`example_passthrough`.
+
 ## share and keepalive
 
 Two knobs control how many runtime instances of a tunnel block
@@ -262,6 +280,13 @@ tunnel "ssh_port_forward" "rds-via-jump" {
 
 The manager opens, refcounts, and tears down the `via` chain
 automatically. Cycles in the `via` graph fail at compile time.
+
+`via` works the same on **plugin** tunnel blocks: a plugin tunnel can be
+either end of a chain — the `via` parent (the gateway routes a child's
+transport through it) or the child (`via = <other-tunnel>` on the plugin
+tunnel block itself). A plugin tunnel's transport is opened through the
+gateway's brokered dial, so the chaining composes without either plugin
+being aware of it.
 
 ## Credentials on tunnels
 


### PR DESCRIPTION
A docs audit of the recent plugin work (sandbox, GitHub distribution,
plugin interfaces) against the current code, plus the corrections and
additions it surfaced. The sandbox and distribution docs were already
accurate; the gaps were in the tunnel/interface area, where tunnel
plugins still being described as needing `network = "outbound"` was the
load-bearing stale claim.

## New coverage

* **plugins.md** — new "Tunnel transport dial" section: a tunnel plugin
  opens its own transport through the gateway's brokered `DialUpstream`
  (tcp + udp, with datagram framing), runs `network = "none"`, and the
  gateway routes it direct or through a `via` parent. Documents
  `example_socks`.
* **tunnels.md** — new "Plugin tunnel types" section.
* **cli.md** — the `clawpatrol plugins install|update|lock|info|approve`
  command group (was entirely absent from the CLI reference).
* **external-plugin-control-plane.md** (internal) — `HostTunnel` as the
  third host-served broker service; the broker-multiplex-over-main-
  connection note; reconciled the old `HostControl.Dial` sketch with the
  shipped `HostTunnel.DialUpstream`.

## Corrections (stale "tunnel plugins need outbound" claims)

* `plugins.md` `network` prose + the `example_passthrough`/"See also"
  descriptions (they said tunnels dial their own socket)
* `security-model.md`
* `config.go` `PluginSource.Network` comment

config-reference.md is unchanged — docgen doesn't render the
`PluginSource` sub-field comments, so no regen was needed.

## Note on `via`

This PR currently carries a caveat that `via` written on a **plugin**
tunnel block "isn't wired yet." #722 wires it. Once #722 lands, that
caveat is dropped here (in `tunnels.md` + the plugins.md "Chaining"
paragraph) so these docs describe shipped behavior with no asterisk.