### PR TITLE
extplugin: honor via/share/keepalive/credential on plugin tunnel blocks

### DIFF
--- a/cmd/clawpatrol/plugin_tunnel_via_test.go
+++ b/cmd/clawpatrol/plugin_tunnel_via_test.go
@@ -38,7 +38,9 @@ gateway {
   wireguard { subnet_cidr = "10.55.0.0/24" }
 }
 tunnel "example_socks" "corp" {
-  proxy = "10.0.0.9:1080"
+  proxy     = "10.0.0.9:1080"
+  share     = "per_conn"
+  keepalive = "5m"
 }
 tunnel "example_passthrough" "chained" {
   via = example_socks.corp
@@ -58,6 +60,13 @@ profile "default" { credentials = [] }
 	}
 	if chained.Via != corp {
 		t.Fatalf("via not wired on plugin tunnel: chained.Via = %v, want corp", chained.Via)
+	}
+	// share / keepalive on a plugin tunnel are peeled + compiled too.
+	if corp.Sharing != "per_conn" {
+		t.Errorf("share not wired: corp.Sharing = %q, want per_conn", corp.Sharing)
+	}
+	if corp.Keepalive != 5*time.Minute {
+		t.Errorf("keepalive not wired: corp.Keepalive = %v, want 5m", corp.Keepalive)
 	}
 }
 

--- a/cmd/clawpatrol/plugin_tunnel_via_test.go
+++ b/cmd/clawpatrol/plugin_tunnel_via_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// TestPluginTunnelViaCompiles proves the `via` attribute on an EXTERNAL
+// (plugin) tunnel block is peeled and resolved: example_passthrough chains
+// through example_socks, and the compiled tunnel's Via pointer is wired —
+// the same as a built-in tunnel. (Plugin tunnel bodies decode the common
+// via/share/keepalive/credential attrs themselves, since tunnels skip the
+// loader's frameworkAttrsByKind extraction.)
+func TestPluginTunnelViaCompiles(t *testing.T) {
+	pluginPath := buildSharedExamplePlugin(t)
+	mgr := sharedExampleManager()
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+plugin "example" {
+  source  = %q
+  network = "none"
+}
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "example_socks" "corp" {
+  proxy = "10.0.0.9:1080"
+}
+tunnel "example_passthrough" "chained" {
+  via = example_socks.corp
+}
+profile "default" { credentials = [] }
+`, pluginPath)), "plugin-tunnel-via.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	chained, corp := policy.Tunnels["chained"], policy.Tunnels["corp"]
+	if chained == nil || corp == nil {
+		t.Fatalf("missing compiled tunnels (have %v)", keysOfTunnels(policy.Tunnels))
+	}
+	if chained.Via != corp {
+		t.Fatalf("via not wired on plugin tunnel: chained.Via = %v, want corp", chained.Via)
+	}
+}
+
+// TestPluginTunnelViaUnknownFails proves a `via` naming an undeclared
+// tunnel is caught (rather than silently dropped).
+func TestPluginTunnelViaUnknownFails(t *testing.T) {
+	pluginPath := buildSharedExamplePlugin(t)
+	mgr := sharedExampleManager()
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+plugin "example" { source = %q, network = "none" }
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "example_socks" "corp"    { proxy = "10.0.0.9:1080" }
+tunnel "example_passthrough" "x" { via   = example_socks.nope }
+profile "default" { credentials = [] }
+`, pluginPath)), "plugin-tunnel-via-bad.hcl")
+	// An undeclared `via` target is rejected — either at load (the
+	// bare-name ref doesn't resolve) or at compile (link pass).
+	if diags.HasErrors() {
+		return
+	}
+	if _, err := config.Compile(gw); err == nil {
+		t.Fatal("expected an error for via referencing an undeclared tunnel")
+	} else if !strings.Contains(err.Error(), "via") && !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestPluginTunnelViaE2E dials a target through a chain of two PLUGIN
+// tunnels wired entirely in HCL: example_passthrough `via` example_socks.
+// The gateway routes passthrough's transport through the socks parent,
+// which CONNECTs to the target via an in-test SOCKS5 proxy — proving the
+// HCL `via` on a plugin tunnel works end to end (sandbox on), not just at
+// compile time.
+func TestPluginTunnelViaE2E(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello-through-chained-plugin-tunnels")
+	}))
+	defer target.Close()
+	targetAddr := strings.TrimPrefix(target.URL, "http://")
+	socksAddr := startTestSocks5(t)
+
+	pluginPath := buildSharedExamplePlugin(t)
+	mgr := sharedExampleManager()
+	config.SetPluginLoader(mgr)
+	t.Cleanup(func() { config.SetPluginLoader(nil) })
+
+	gw, diags := config.LoadBytes([]byte(fmt.Sprintf(`
+plugin "example" {
+  source  = %q
+  network = "none"
+}
+gateway {
+  state_dir  = "/tmp/clawpatrol-test"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+tunnel "example_socks" "corp" {
+  proxy = %q
+}
+tunnel "example_passthrough" "chained" {
+  via = example_socks.corp
+}
+profile "default" { credentials = [] }
+`, pluginPath, socksAddr)), "plugin-tunnel-via-e2e.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	policy, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ct := policy.Tunnels["chained"]
+	if ct == nil || ct.Via == nil {
+		t.Fatalf("chained tunnel or its via not compiled: %+v", ct)
+	}
+
+	tm := NewTunnelManager(runtime.EnvSecretStore{}, t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	tun, release, err := tm.Acquire(ctx, ct, "demo")
+	if err != nil {
+		t.Fatalf("acquire chained tunnel: %v", err)
+	}
+	defer release()
+
+	conn, err := tun.Dial(ctx, "tcp", targetAddr)
+	if err != nil {
+		t.Fatalf("dial through chain: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := fmt.Fprintf(conn, "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", targetAddr); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 || !strings.Contains(string(body), "hello-through-chained-plugin-tunnels") {
+		t.Fatalf("got status %d body %q", resp.StatusCode, body)
+	}
+}
+
+func keysOfTunnels(m map[string]*config.CompiledTunnel) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -879,7 +879,18 @@ type dynamicTunnelBody struct {
 	adapter       *tunnelAdapter
 	instanceName  string
 	canonicalJSON []byte
+	// common holds the framework-level tunnel attrs (via / share /
+	// keepalive / credential) the loader peeled from the HCL block before
+	// the plugin's schema decode. Exposed via TunnelCommon so the compile
+	// pass picks them up exactly like a built-in tunnel.
+	common config.TunnelCommon
 }
+
+// TunnelCommon hands the framework-level attrs (via / share / keepalive /
+// credential) to the compile pass, which resolves `via` and `credential`
+// by name against the symbol table. This is what makes `via = <tunnel>`
+// (and the share/keepalive knobs) work on a plugin tunnel block.
+func (b *dynamicTunnelBody) TunnelCommon() config.TunnelCommon { return b.common }
 
 // dynamicTunnelBody is the CompiledTunnel.Body for a plugin tunnel; it
 // implements runtime.TunnelRuntime by delegating to its adapter so the

--- a/internal/config/extplugin/register.go
+++ b/internal/config/extplugin/register.go
@@ -334,6 +334,18 @@ func validateBuildDisambiguators(pluginName, typeName string, supported, got []s
 // =====================================================================
 
 func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.Diagnostics {
+	if decl.Schema != nil {
+		for _, f := range decl.Schema.Fields {
+			if tunnelCommonReserved[f.Name] {
+				// These are the framework-level tunnel attrs the loader peels
+				// (decodeTunnelCommon); a plugin field by the same name would be
+				// silently stolen. Reject at registration, like endpointSpec
+				// rejects `hosts`/`dial`.
+				return fail("plugin %q tunnel %q: declared reserved attribute %q (via / share / keepalive / credential are framework-level tunnel attrs)",
+					pluginName, decl.TypeName, f.Name)
+			}
+		}
+	}
 	spec, err := schemaToSpec(decl.Schema)
 	if err != nil {
 		return fail("plugin %q tunnel %q: %v", pluginName, decl.TypeName, err)
@@ -403,10 +415,16 @@ func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.
 // cycles), exactly as for a built-in tunnel. Tunnels skip the loader's
 // frameworkAttrsByKind extraction (it covers only endpoints/credentials),
 // so the plugin decode peels them here.
+// tunnelCommonReserved is the set of framework-level tunnel attr names
+// decodeTunnelCommon peels — the names a plugin tunnel manifest may not
+// reuse (enforced in registerTunnel).
+var tunnelCommonReserved = map[string]bool{"via": true, "share": true, "keepalive": true, "credential": true}
+
 func decodeTunnelCommon(body hcl.Body, ctx *hcl.EvalContext, tc *config.TunnelCommon) (hcl.Body, hcl.Diagnostics) {
-	schema := &hcl.BodySchema{Attributes: []hcl.AttributeSchema{
-		{Name: "via"}, {Name: "share"}, {Name: "keepalive"}, {Name: "credential"},
-	}}
+	schema := &hcl.BodySchema{}
+	for name := range tunnelCommonReserved {
+		schema.Attributes = append(schema.Attributes, hcl.AttributeSchema{Name: name})
+	}
 	content, remain, diags := body.PartialContent(schema)
 	for name, attr := range content.Attributes {
 		v, d := attr.Expr.Value(ctx)

--- a/internal/config/extplugin/register.go
+++ b/internal/config/extplugin/register.go
@@ -346,7 +346,16 @@ func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.
 		New:  func() any { return &dynamicTunnelBody{adapter: adapter} },
 		DecodeBody: func(body hcl.Body, ctx *hcl.EvalContext, target any) hcl.Diagnostics {
 			b := target.(*dynamicTunnelBody)
-			val, d := hcldec.Decode(body, spec, ctx)
+			// Peel the framework-level tunnel attrs (via / share / keepalive
+			// / credential) before the schema decode — the plugin's manifest
+			// schema doesn't know about them. TunnelCommon (on the body) hands
+			// them to compile, which resolves `via`/`credential` by name.
+			rest, d := decodeTunnelCommon(body, ctx, &b.common)
+			if d.HasErrors() {
+				return d
+			}
+			val, dd := hcldec.Decode(rest, spec, ctx)
+			d = append(d, dd...)
 			if d.HasErrors() {
 				return d
 			}
@@ -384,6 +393,49 @@ func registerTunnel(client *Client, pluginName string, decl *pb.TunnelDecl) hcl.
 		return d
 	}
 	return nil
+}
+
+// decodeTunnelCommon peels the framework-level tunnel attrs (via, share,
+// keepalive, credential) off a plugin tunnel block, fills tc, and returns
+// the remainder body for the plugin's schema decode. via and credential
+// are bare-name references that evaluate to the referenced block's name;
+// the compile pass resolves them against the symbol table (and detects via
+// cycles), exactly as for a built-in tunnel. Tunnels skip the loader's
+// frameworkAttrsByKind extraction (it covers only endpoints/credentials),
+// so the plugin decode peels them here.
+func decodeTunnelCommon(body hcl.Body, ctx *hcl.EvalContext, tc *config.TunnelCommon) (hcl.Body, hcl.Diagnostics) {
+	schema := &hcl.BodySchema{Attributes: []hcl.AttributeSchema{
+		{Name: "via"}, {Name: "share"}, {Name: "keepalive"}, {Name: "credential"},
+	}}
+	content, remain, diags := body.PartialContent(schema)
+	for name, attr := range content.Attributes {
+		v, d := attr.Expr.Value(ctx)
+		diags = append(diags, d...)
+		if d.HasErrors() || v.IsNull() {
+			continue
+		}
+		if v.Type() != cty.String {
+			rng := attr.Expr.Range()
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid %s attribute", name),
+				Detail:   fmt.Sprintf("Expected a string or bare-name reference; got %s.", v.Type().FriendlyName()),
+				Subject:  &rng,
+			})
+			continue
+		}
+		switch name {
+		case "via":
+			tc.Via = v.AsString()
+		case "share":
+			tc.Share = v.AsString()
+		case "keepalive":
+			tc.Keepalive = v.AsString()
+		case "credential":
+			tc.Credential = v.AsString()
+		}
+	}
+	return remain, diags
 }
 
 // =====================================================================

--- a/internal/config/extplugin/register_tunnel_test.go
+++ b/internal/config/extplugin/register_tunnel_test.go
@@ -1,0 +1,41 @@
+package extplugin
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+)
+
+// TestTunnelReservedAttrRejected verifies a plugin tunnel manifest that
+// declares a framework-reserved attr name (via / share / keepalive /
+// credential) is rejected at registration, rather than silently having
+// the operator's value stolen by the framework-attr peel (decodeTunnelCommon).
+func TestTunnelReservedAttrRejected(t *testing.T) {
+	for _, reserved := range []string{"via", "share", "keepalive", "credential"} {
+		t.Run(reserved, func(t *testing.T) {
+			// The client only needs to exist — the guard fires before any RPC.
+			client, cleanup := newCredentialPluginTestClient(t, &credentialPluginTestServer{
+				typeName: "unused", seen: make(chan *pb.InjectHTTPRequest, 1),
+			})
+			defer cleanup()
+
+			typeName := fmt.Sprintf("extplugin_test_tun_%d", time.Now().UnixNano())
+			diags := RegisterManifest(client, &pb.ManifestResponse{
+				Name: "exttuntest",
+				Tunnels: []*pb.TunnelDecl{{
+					TypeName: typeName,
+					Schema:   &pb.Schema{Fields: []*pb.SchemaField{{Name: reserved, TypeString: "string"}}},
+				}},
+			})
+			if !diags.HasErrors() {
+				t.Fatalf("expected error for tunnel declaring reserved attr %q", reserved)
+			}
+			if got := diags.Error(); !strings.Contains(got, "reserved attribute") || !strings.Contains(got, reserved) {
+				t.Fatalf("unexpected diagnostics: %v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Makes the `via` block (and the other common tunnel attrs) work on
**external** tunnel blocks. Previously `tunnel "wireguard" "vpn" { via =
socks }` was silently a no-op: `dynamicTunnelBody` didn't implement
`TunnelCommonRead`, and the loader's `frameworkAttrsByKind` extraction
covers only endpoints/credentials, not tunnels — so a plugin tunnel's
`via`/`share`/`keepalive`/`credential` were never parsed. The
via-chaining spike (#720) worked around this by setting
`CompiledTunnel.Via` in Go.

The plugin tunnel `DecodeBody` now peels these attrs (`decodeTunnelCommon`)
before the manifest-schema decode, and `dynamicTunnelBody` exposes them
through `TunnelCommon`, so the compile pass resolves `via`/`credential` by
name and detects cycles — the same path a built-in tunnel takes. Built-in
tunnels, compile, and HCL emit are untouched.

Tests:
* `via` on a plugin tunnel resolves the compiled `Via` pointer
* an undeclared `via` target is rejected
* an end-to-end dial through `example_passthrough via example_socks` —
  two plugin tunnels chained entirely in HCL, sandbox on — returns the
  target's response (the thing the spike could only do with a Go hook)

Follow-up: once this lands, the docs PR (#721) should drop its
"`via` on a plugin tunnel block isn't wired yet" caveat in `tunnels.md`
and `plugins.md`.