### PR TITLE
gateway: clear error when state_dir isn't writable

### DIFF
--- a/cmd/clawpatrol/db_test.go
+++ b/cmd/clawpatrol/db_test.go
@@ -61,12 +61,12 @@ func TestOpenDB_TightensExisting0644(t *testing.T) {
 	}
 }
 
-// TestPreflightStateDirWritable_OK: a writable state_dir passes and the
-// probe file is cleaned up (it must not be mistaken for real state).
-func TestPreflightStateDirWritable_OK(t *testing.T) {
+// TestCheckDirWritable_OK: a writable dir passes and the probe file is
+// cleaned up (it must not be mistaken for real state).
+func TestCheckDirWritable_OK(t *testing.T) {
 	dir := t.TempDir()
-	if err := preflightStateDirWritable(dir); err != nil {
-		t.Fatalf("preflightStateDirWritable: %v", err)
+	if err := checkDirWritable(dir); err != nil {
+		t.Fatalf("checkDirWritable: %v", err)
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -77,12 +77,12 @@ func TestPreflightStateDirWritable_OK(t *testing.T) {
 	}
 }
 
-// TestPreflightStateDirWritable_ReadOnly is the regression for the
-// root-owned /opt/clawpatrol case: MkdirAll no-ops on the existing
-// dir, but the unprivileged gateway can't create clawpatrol.db inside
-// it. The preflight must catch that with a clear error instead of
-// letting sqlite fail later with SQLITE_CANTOPEN(14).
-func TestPreflightStateDirWritable_ReadOnly(t *testing.T) {
+// TestCheckDirWritable_ReadOnly is the regression for the root-owned
+// /opt/clawpatrol case: MkdirAll no-ops on the existing dir, but the
+// unprivileged gateway can't create clawpatrol.db inside it. The
+// preflight must catch that with a clear error instead of letting
+// sqlite fail later with SQLITE_CANTOPEN(14).
+func TestCheckDirWritable_ReadOnly(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses directory write permissions")
 	}
@@ -93,7 +93,7 @@ func TestPreflightStateDirWritable_ReadOnly(t *testing.T) {
 	// Restore write so t.TempDir's cleanup can remove the dir.
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
 
-	if err := preflightStateDirWritable(dir); err == nil {
+	if err := checkDirWritable(dir); err == nil {
 		t.Fatal("expected error for read-only state_dir, got nil")
 	}
 }

--- a/cmd/clawpatrol/db_test.go
+++ b/cmd/clawpatrol/db_test.go
@@ -60,3 +60,40 @@ func TestOpenDB_TightensExisting0644(t *testing.T) {
 		t.Errorf("%s mode = %#o, want 0600 after OpenDB tightens it", dbPath, mode)
 	}
 }
+
+// TestPreflightStateDirWritable_OK: a writable state_dir passes and the
+// probe file is cleaned up (it must not be mistaken for real state).
+func TestPreflightStateDirWritable_OK(t *testing.T) {
+	dir := t.TempDir()
+	if err := preflightStateDirWritable(dir); err != nil {
+		t.Fatalf("preflightStateDirWritable: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("probe left files behind: %v", entries)
+	}
+}
+
+// TestPreflightStateDirWritable_ReadOnly is the regression for the
+// root-owned /opt/clawpatrol case: MkdirAll no-ops on the existing
+// dir, but the unprivileged gateway can't create clawpatrol.db inside
+// it. The preflight must catch that with a clear error instead of
+// letting sqlite fail later with SQLITE_CANTOPEN(14).
+func TestPreflightStateDirWritable_ReadOnly(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory write permissions")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	// Restore write so t.TempDir's cleanup can remove the dir.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := preflightStateDirWritable(dir); err == nil {
+		t.Fatal("expected error for read-only state_dir, got nil")
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -59,23 +59,20 @@ func resolveStateDir(cfg *config.Gateway) string {
 	return ""
 }
 
-// preflightStateDirWritable verifies the current process can create
-// files inside stateDir before the sqlite driver tries to. os.MkdirAll
-// is a no-op when the directory already exists, so a root-owned
-// state_dir — e.g. the example config's /opt/clawpatrol created under
-// sudo — sails past the mkdir step and only fails later when sqlite
-// can't create clawpatrol.db, surfacing as the opaque "unable to open
-// database file (14)" (SQLITE_CANTOPEN). Probing here turns that into
-// an actionable error naming the directory and the uid that can't
-// write to it.
-func preflightStateDirWritable(stateDir string) error {
-	f, err := os.CreateTemp(stateDir, ".write-probe-*")
-	if err != nil {
-		return fmt.Errorf("cannot create files in state_dir %s as uid %d: %w", stateDir, os.Getuid(), err)
+// checkDirWritable verifies the current process can create files in
+// dir. os.MkdirAll is a no-op when the directory already exists, so a
+// root-owned directory — the example config's /opt/clawpatrol created
+// under sudo, or a Docker `-v` mount owned by root — passes MkdirAll
+// but fails every later write. Probing with a temp file surfaces that
+// as a clear error instead of an opaque downstream failure (sqlite's
+// "unable to open database file (14)" / SQLITE_CANTOPEN when the
+// gateway opens clawpatrol.db, a silently-dropped write on join).
+func checkDirWritable(dir string) error {
+	probe := filepath.Join(dir, ".write-probe")
+	if err := os.WriteFile(probe, nil, 0o600); err != nil {
+		return err
 	}
-	name := f.Name()
-	_ = f.Close()
-	_ = os.Remove(name)
+	_ = os.Remove(probe)
 	return nil
 }
 
@@ -3059,8 +3056,8 @@ func runGateway(args []string) {
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		log.Fatalf("state dir: %v", err)
 	}
-	if err := preflightStateDirWritable(stateDir); err != nil {
-		log.Fatalf("state dir: %v\n      Fix: run the gateway as the user that owns %[2]s, `chown` it to that user, or set a writable state_dir in the gateway block of %[3]s.", err, stateDir, cfgPath)
+	if err := checkDirWritable(stateDir); err != nil {
+		log.Fatalf("state dir: cannot create files in state_dir %s as uid %d: %v\n      Fix: run the gateway as the user that owns it, `chown` it to that user, or set a writable state_dir in the gateway block of %s.", stateDir, os.Getuid(), err, cfgPath)
 	}
 	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
 	if err != nil {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -59,6 +59,26 @@ func resolveStateDir(cfg *config.Gateway) string {
 	return ""
 }
 
+// preflightStateDirWritable verifies the current process can create
+// files inside stateDir before the sqlite driver tries to. os.MkdirAll
+// is a no-op when the directory already exists, so a root-owned
+// state_dir — e.g. the example config's /opt/clawpatrol created under
+// sudo — sails past the mkdir step and only fails later when sqlite
+// can't create clawpatrol.db, surfacing as the opaque "unable to open
+// database file (14)" (SQLITE_CANTOPEN). Probing here turns that into
+// an actionable error naming the directory and the uid that can't
+// write to it.
+func preflightStateDirWritable(stateDir string) error {
+	f, err := os.CreateTemp(stateDir, ".write-probe-*")
+	if err != nil {
+		return fmt.Errorf("cannot create files in state_dir %s as uid %d: %w", stateDir, os.Getuid(), err)
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return nil
+}
+
 const hitlOperationTerminalRetention = 7 * 24 * time.Hour
 
 func runHITLOperationStartupMaintenance(ctx context.Context, db *sql.DB) (HITLOperationMaintenanceResult, error) {
@@ -3038,6 +3058,9 @@ func runGateway(args []string) {
 	stateDir := resolveStateDir(cfg)
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		log.Fatalf("state dir: %v", err)
+	}
+	if err := preflightStateDirWritable(stateDir); err != nil {
+		log.Fatalf("state dir: %v\n      Fix: run the gateway as the user that owns %[2]s, `chown` it to that user, or set a writable state_dir in the gateway block of %[3]s.", err, stateDir, cfgPath)
 	}
 	db, err := OpenDB(filepath.Join(stateDir, "clawpatrol.db"))
 	if err != nil {

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -331,11 +331,9 @@ func preJoinFetchCA(gateway, caDir string, cli *http.Client) (joinSetup, error) 
 	// user. A root-owned dir from a previous `docker run -v` will pass
 	// MkdirAll (dir already exists) but fail every subsequent WriteFile,
 	// causing join to report success while writing nothing.
-	probe := filepath.Join(caDir, ".write-probe")
-	if err := os.WriteFile(probe, nil, 0o600); err != nil {
+	if err := checkDirWritable(caDir); err != nil {
 		return s, fmt.Errorf("config dir %s is not writable (owner mismatch?): %w", caDir, err)
 	}
-	_ = os.Remove(probe)
 	// Persist the dashboard URL before the CA fetch so subsequent
 	// `clawpatrol env` / `clawpatrol run` invocations work even when
 	// the CA fetch is deferred (Tailscale mode, 404 on /ca.crt).


### PR DESCRIPTION
Surfaces a clear, actionable error when the gateway can't write to
its `state_dir`, instead of the opaque sqlite failure reported in #702.

* When `state_dir` already exists but is not writable by the user
  running the gateway (e.g. the example config's root-owned
  `/opt/clawpatrol`, created under `sudo` and then started as a
  normal user), `os.MkdirAll` no-ops on the existing directory and
  startup only fails later when sqlite can't create
  `clawpatrol.db` — surfacing as `db: sqlite ping: unable to open
  database file (14)` (`SQLITE_CANTOPEN`).
* Probe writability right after `MkdirAll` with a temp file and fail
  fast with a message naming the directory, the uid that can't
  write to it, and the fix (run as the owning user, `chown`, or set
  a writable `state_dir`).

Closes #702.