### PR TITLE
extplugin: CLAWPATROL_PLUGIN_LOG to surface plugin subprocess logs

### DIFF
--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -89,18 +89,20 @@ func New(out *log.Logger) *Manager {
 	level := hclog.Info
 	var output io.Writer = hclogWriter{out}
 	// CLAWPATROL_PLUGIN_LOG raises the plugin-subprocess log level
-	// (trace/debug/info/warn/error). At trace/debug this surfaces the
-	// plugin's own stderr — invaluable when a sandboxed plugin dies
-	// before the go-plugin handshake. When no gateway log sink is wired
-	// (e.g. `validate`), send it to stderr so it isn't discarded.
+	// (trace/debug/info/warn/error/off). At trace/debug this surfaces the
+	// plugin's own stderr — invaluable when a sandboxed plugin dies before
+	// the go-plugin handshake. When no gateway log sink is wired (e.g.
+	// `validate`), send it to stderr so it isn't discarded. An unrecognized
+	// value is ignored (level stays Info) with a warning, rather than
+	// silently jumping to max verbosity on a typo.
 	if v := os.Getenv("CLAWPATROL_PLUGIN_LOG"); v != "" {
 		if lvl := hclog.LevelFromString(v); lvl != hclog.NoLevel {
 			level = lvl
+			if out == nil {
+				output = os.Stderr
+			}
 		} else {
-			level = hclog.Trace
-		}
-		if out == nil {
-			output = os.Stderr
+			fmt.Fprintf(os.Stderr, "clawpatrol: ignoring invalid CLAWPATROL_PLUGIN_LOG=%q (want trace|debug|info|warn|error|off)\n", v)
 		}
 	}
 	logger := hclog.New(&hclog.LoggerOptions{

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -86,9 +87,25 @@ type blockedRecord struct {
 // name; pass nil to use a default discarding logger.
 func New(out *log.Logger) *Manager {
 	level := hclog.Info
+	var output io.Writer = hclogWriter{out}
+	// CLAWPATROL_PLUGIN_LOG raises the plugin-subprocess log level
+	// (trace/debug/info/warn/error). At trace/debug this surfaces the
+	// plugin's own stderr — invaluable when a sandboxed plugin dies
+	// before the go-plugin handshake. When no gateway log sink is wired
+	// (e.g. `validate`), send it to stderr so it isn't discarded.
+	if v := os.Getenv("CLAWPATROL_PLUGIN_LOG"); v != "" {
+		if lvl := hclog.LevelFromString(v); lvl != hclog.NoLevel {
+			level = lvl
+		} else {
+			level = hclog.Trace
+		}
+		if out == nil {
+			output = os.Stderr
+		}
+	}
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   "plugin",
-		Output: hclogWriter{out},
+		Output: output,
 		Level:  level,
 	})
 	return &Manager{

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -246,6 +246,7 @@ device-side knobs:
 |---|---|
 | `CLAWPATROL_RUN_CONF` | Override the WG conf path `clawpatrol run` reads |
 | `CLAWPATROL_DEBUG` | Print the relay / auto-expose diagnostic lines, which are otherwise silent |
+| `CLAWPATROL_PLUGIN_LOG` | Raise the external-plugin subprocess log level (`trace`/`debug`/`info`/`warn`/`error`/`off`); at `trace`/`debug` surfaces a sandboxed plugin's own stderr, useful when a plugin dies before the handshake completes |
 | `CLAWPATROL_NO_ENV` | Skip the env pushdown (`SSL_CERT_FILE`, placeholders) when wrapping a command |
 | `CLAWPATROL_NO_SUDO` | Force the unprivileged user-namespace path even when passwordless `sudo` is available (see [Root and `sudo` inside `clawpatrol run`](#root-and-sudo-inside-clawpatrol-run-linux)); `sudo` won't work inside the wrapper |
 | `CLAWPATROL_TELEMETRY` | `0` to disable telemetry (same as `DO_NOT_TRACK=1`) |


### PR DESCRIPTION
Adds a `CLAWPATROL_PLUGIN_LOG` env var to raise the plugin-subprocess log
level (trace/debug/info/warn/error) above the default Info.

At trace/debug it surfaces the plugin's own stderr — otherwise invisible
when a sandboxed plugin exits before completing the go-plugin handshake,
where the only symptom is `Unrecognized remote plugin message` with no
cause. When no gateway log sink is wired (e.g. `clawpatrol validate`),
output goes to stderr rather than being discarded.

Default behavior is unchanged when the variable is unset.