### PR TITLE
extplugin: move shared wire constants to a leaf package (slim the plugin SDK)

### DIFF
--- a/internal/config/extplugin/handshake.go
+++ b/internal/config/extplugin/handshake.go
@@ -8,22 +8,15 @@
 package extplugin
 
 import (
-	"github.com/hashicorp/go-plugin"
+	"github.com/denoland/clawpatrol/internal/config/extplugin/wire"
 )
 
-// HandshakeConfig is the magic-cookie pair every clawpatrol plugin
-// subprocess must echo back. A mismatch means the gateway is
-// invoking the wrong binary, or the binary is from an incompatible
-// build of the SDK; go-plugin refuses to start in either case.
-//
-// ProtocolVersion bumps when the wire protocol breaks compatibility.
-var HandshakeConfig = plugin.HandshakeConfig{
-	ProtocolVersion:  1,
-	MagicCookieKey:   "CLAWPATROL_PLUGIN",
-	MagicCookieValue: "clawpatrol-plugin-v1",
-}
+// HandshakeConfig and PluginName are the go-plugin handshake shared by the
+// gateway and every plugin. The canonical definitions live in the wire
+// leaf package — kept dependency-light so the SDK (and thus a plugin's
+// binary) doesn't pull the manager's graph just to name them. These
+// aliases keep extplugin's many in-package references unchanged.
+var HandshakeConfig = wire.HandshakeConfig
 
 // PluginName is the registered plugin name in go-plugin's plugin map.
-// Every clawpatrol plugin exports a single entry under this key whose
-// gRPC service set covers Manifest / Build / HandleConn / Tunnel.
-const PluginName = "clawpatrol"
+const PluginName = wire.PluginName

--- a/internal/config/extplugin/hostcontrol.go
+++ b/internal/config/extplugin/hostcontrol.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/extplugin/wire"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -32,8 +33,8 @@ import (
 
 // SessionMetadataKey is the gRPC metadata key the per-connection session
 // token rides under on every HostControl call. Lower-case per gRPC's
-// metadata convention.
-const SessionMetadataKey = "clawpatrol-session"
+// metadata convention. Canonical definition in wire.
+const SessionMetadataKey = wire.SessionMetadataKey
 
 // Verdict is the gateway's decision on one Evaluate call. Mirrors
 // runtime / pluginsdk.Verdict so the host-served surface and the existing

--- a/internal/config/extplugin/hoststate.go
+++ b/internal/config/extplugin/hoststate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/extplugin/wire"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,8 +27,8 @@ import (
 // gateway serves host services on and the plugin dials. A constant is
 // safe because clawpatrol never calls GRPCBroker.NextId() — the brokered
 // upstream dial multiplexes over the HandleConn stream, not the broker —
-// so nothing else competes for stream ids.
-const HostServicesBrokerID uint32 = 1
+// so nothing else competes for stream ids. Canonical definition in wire.
+const HostServicesBrokerID = wire.HostServicesBrokerID
 
 // maxStateValueBytes caps a single stored value. The known consumers
 // (host keys, key material, a client_id) are well under a kilobyte; the

--- a/internal/config/extplugin/wire/wire.go
+++ b/internal/config/extplugin/wire/wire.go
@@ -1,0 +1,40 @@
+// Package wire holds the small set of protocol constants shared between
+// the gateway-side plugin manager (extplugin) and the plugin SDK
+// (pluginsdk): the go-plugin handshake, the dispensed plugin name, the
+// host-services broker stream id, and the per-call session metadata key.
+//
+// It is deliberately a leaf with a single dependency (go-plugin). The SDK
+// references these constants, but a plugin author's binary must not pull
+// the manager's transitive graph — CEL, Sigstore, OpenAPI — into itself
+// just to name them. Keeping them here is what lets a plugin's dependency
+// closure (and its compiled size) stay small.
+package wire
+
+import "github.com/hashicorp/go-plugin"
+
+// HandshakeConfig is the magic-cookie pair every clawpatrol plugin
+// subprocess must echo back. A mismatch means the gateway is invoking the
+// wrong binary, or the binary is from an incompatible build of the SDK;
+// go-plugin refuses to start in either case.
+//
+// ProtocolVersion bumps when the wire protocol breaks compatibility.
+var HandshakeConfig = plugin.HandshakeConfig{
+	ProtocolVersion:  1,
+	MagicCookieKey:   "CLAWPATROL_PLUGIN",
+	MagicCookieValue: "clawpatrol-plugin-v1",
+}
+
+// PluginName is the registered plugin name in go-plugin's plugin map.
+// Every clawpatrol plugin exports a single entry under this key whose
+// gRPC service set covers Manifest / Build / HandleConn / Tunnel.
+const PluginName = "clawpatrol"
+
+// HostServicesBrokerID is the go-plugin broker stream id the gateway
+// serves host services (HostState / HostControl / HostTunnel) on and the
+// plugin dials back through.
+const HostServicesBrokerID uint32 = 1
+
+// SessionMetadataKey is the gRPC metadata key the per-connection session
+// token rides under on every HostControl call. Lower-case per gRPC's
+// metadata convention.
+const SessionMetadataKey = "clawpatrol-session"

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/denoland/clawpatrol/internal/config/extplugin"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/extplugin/wire"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -47,9 +47,9 @@ func Run(p *Plugin) {
 		os.Exit(0)
 	}
 	plugin.Serve(&plugin.ServeConfig{
-		HandshakeConfig: extplugin.HandshakeConfig,
+		HandshakeConfig: wire.HandshakeConfig,
 		Plugins: map[string]plugin.Plugin{
-			extplugin.PluginName: &grpcServer{srv: srv},
+			wire.PluginName: &grpcServer{srv: srv},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})
@@ -590,7 +590,7 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 			if err != nil {
 				return Verdict{}, fmt.Errorf("pluginsdk: host control plane: %w", err)
 			}
-			mctx := metadata.AppendToOutgoingContext(ctx, extplugin.SessionMetadataKey, conn.SessionToken)
+			mctx := metadata.AppendToOutgoingContext(ctx, wire.SessionMetadataKey, conn.SessionToken)
 			v, err := cli.Evaluate(mctx, &pb.EvaluateRequest{FacetName: facet, ActionJson: j, Summary: summary})
 			if err != nil {
 				return Verdict{}, fmt.Errorf("pluginsdk: HostControl.Evaluate: %w", err)

--- a/pluginsdk/state.go
+++ b/pluginsdk/state.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/denoland/clawpatrol/internal/config/extplugin"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/extplugin/wire"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 )
@@ -95,7 +95,7 @@ func hostServicesConn() (*grpc.ClientConn, error) {
 			hostConnErr = errors.New("pluginsdk: host services unavailable (no gateway broker)")
 			return
 		}
-		hostConn, hostConnErr = b.Dial(extplugin.HostServicesBrokerID)
+		hostConn, hostConnErr = b.Dial(wire.HostServicesBrokerID)
 	})
 	return hostConn, hostConnErr
 }

--- a/pluginsdk/state_broker_test.go
+++ b/pluginsdk/state_broker_test.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/denoland/clawpatrol/internal/config/extplugin"
 	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"github.com/denoland/clawpatrol/internal/config/extplugin/wire"
 	goplugin "github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 )
@@ -48,7 +48,7 @@ func (p *brokerTestPlugin) GRPCServer(broker *goplugin.GRPCBroker, _ *grpc.Serve
 }
 
 func (p *brokerTestPlugin) GRPCClient(_ context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
-	go broker.AcceptAndServe(extplugin.HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
+	go broker.AcceptAndServe(wire.HostServicesBrokerID, func(opts []grpc.ServerOption) *grpc.Server {
 		srv := grpc.NewServer(opts...)
 		pb.RegisterHostStateServer(srv, p.host)
 		return srv


### PR DESCRIPTION
`pluginsdk` imported `internal/config/extplugin` (the gateway-side plugin
manager) for four protocol constants — `HandshakeConfig`, `PluginName`,
`HostServicesBrokerID`, `SessionMetadataKey`. Go links at the package
level, so naming those four constants pulled the manager's whole
transitive graph into every plugin binary: `cel-go`/`antlr`,
`sigstore-go` + `certificate-transparency-go` (the provenance verifier),
`go-openapi`, etc.

This moves the four constants into a new leaf package
`internal/config/extplugin/wire` (only dependency: `go-plugin`).
`extplugin` re-exports them, so its ~19 in-package references are
untouched; `pluginsdk` imports `wire` instead of the manager.

Result, measured with `go list -deps ./pluginsdk`:

* distinct external modules in the SDK closure: **69 → 15**
* `cel-go`, `antlr`, `sigstore-go`, `certificate-transparency-go`,
  `go-openapi`, `go-containerregistry` all leave the closure
* the manager (`extplugin`) is no longer in a plugin's build graph

Plugins shrink their `go.sum` (~500 lines today) and binary size on their
next clawpatrol bump, with no code change of their own. No behavior
change: the constants are identical, just relocated.