### PR TITLE
extplugin: don't block plugins update to a newer attested version

### DIFF
--- a/internal/config/extplugin/fetch.go
+++ b/internal/config/extplugin/fetch.go
@@ -530,7 +530,7 @@ func (m *Manager) resolvePluginBinary(ctx context.Context, sp config.PluginSourc
 			return "", nil, fmt.Errorf(
 				"downloaded binary hash %s is not in the lockfile (expected one of %v); refusing", res.binSHA, entry.Hashes)
 		}
-		if err := checkProvenanceNotDowngraded(sp.Name, mode, entry, res); err != nil {
+		if err := checkProvenanceNotDowngraded(sp.Name, mode, entry, res, r.TagName); err != nil {
 			_ = os.Remove(res.path)
 			return "", nil, err
 		}
@@ -586,10 +586,16 @@ func (f *fetcher) staticManifest(ctx context.Context, p parsedSource, r ghReleas
 
 // checkProvenanceNotDowngraded fails closed when a freshly-fetched binary
 // has weaker provenance than the lockfile recorded: it lost the
-// attestation entirely, or its attestation now names a different source
-// commit (a re-pointed tag). Skipped when the operator set provenance =
-// "off". The fix is `clawpatrol plugins approve`.
-func checkProvenanceNotDowngraded(name string, mode provenanceMode, entry lockEntry, res fetchResult) error {
+// attestation entirely, or — for the *same* version — its attestation now
+// names a different source commit (the tag was re-pointed). An explicit
+// upgrade to a *new* version legitimately carries a new commit and is
+// re-pinned by the caller, not blocked. Skipped when the operator set
+// provenance = "off". The fix is `clawpatrol plugins approve`.
+//
+// fetchedVersion is the tag actually fetched: it equals entry.Version on
+// the load / keep-pinned path, and is the newest satisfying tag on an
+// explicit `plugins update` (upgrade), where it may differ.
+func checkProvenanceNotDowngraded(name string, mode provenanceMode, entry lockEntry, res fetchResult, fetchedVersion string) error {
 	if mode == provOff {
 		return nil
 	}
@@ -599,10 +605,14 @@ func checkProvenanceNotDowngraded(name string, mode provenanceMode, entry lockEn
 				"a benign plugin's build dropping provenance looks exactly like this. "+
 				"If you trust it, re-approve: clawpatrol plugins approve %s", name, name)
 	}
-	if entry.Commit != "" && res.commit != "" && res.commit != entry.Commit {
+	// A changed attested commit is only a re-pointed-tag signal when the
+	// version is unchanged: the same tag now vouches a different commit. A
+	// new version naturally has a new commit, so an upgrade is accepted.
+	if entry.Commit != "" && res.commit != "" && res.commit != entry.Commit && fetchedVersion == entry.Version {
 		return fmt.Errorf(
-			"plugin %q: attested source commit %s does not match the locked commit %s (a re-pointed tag); "+
-				"run `clawpatrol plugins update %s` or re-approve it", name, res.commit, entry.Commit, name)
+			"plugin %q: attested source commit %s does not match the locked commit %s (the %s tag was re-pointed); "+
+				"if you trust the new build, re-approve: clawpatrol plugins approve %s",
+			name, res.commit, entry.Commit, entry.Version, name)
 	}
 	return nil
 }

--- a/internal/config/extplugin/install.go
+++ b/internal/config/extplugin/install.go
@@ -83,8 +83,10 @@ func (m *Manager) Install(ctx context.Context, specs []config.PluginSource, name
 			return nil, fmt.Errorf("plugin %q: %w", sp.Name, err)
 		}
 		// A version (or re-download) that loses provenance is blocked until
-		// the operator accepts it with `clawpatrol plugins approve`.
-		if err := checkProvenanceNotDowngraded(sp.Name, mode, entry, res); err != nil {
+		// the operator accepts it with `clawpatrol plugins approve`. A new
+		// version's changed commit is not a re-point (r.TagName != the locked
+		// version), so an explicit upgrade is re-pinned, not blocked.
+		if err := checkProvenanceNotDowngraded(sp.Name, mode, entry, res, r.TagName); err != nil {
 			return nil, err
 		}
 		m.lock.setSource(sp.Name, p.slug(), r.TagName, strings.TrimSpace(sp.Version), res.commit, res.attested)

--- a/internal/config/extplugin/install_test.go
+++ b/internal/config/extplugin/install_test.go
@@ -82,6 +82,47 @@ func TestInstallUpdateLock(t *testing.T) {
 	}
 }
 
+// TestInstallUpgradeAcceptsNewVersionCommit drives the re-pointed-tag fix
+// end-to-end: an attested plugin pinned at v1.2.0/commit-aaa is upgraded to
+// v1.3.0, whose attestation vouches a different commit (commit-bbb). The new
+// commit belongs to a new version, so it is NOT a re-pointed tag — the
+// upgrade must re-pin it rather than fail closed (which it did before the
+// fix, the changed commit wrongly tripping the guard).
+func TestInstallUpgradeAcceptsNewVersionCommit(t *testing.T) {
+	owner, repo := "acme", "myplugin"
+	plats := []string{"linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"}
+	if !slices.Contains(plats, platformToken()) {
+		plats = append(plats, platformToken())
+	}
+	srv := newReleaseServer(t, owner, repo, []relSpec{
+		mkRelease(t, repo, "1.2.0", plats),
+		mkRelease(t, repo, "1.3.0", plats),
+	})
+
+	m, _ := newFetchTestManager(t, srv.URL)
+	m.prov = stubProv{commit: "commit-bbb"} // the fetched (newest) release's attestation
+	sp := config.PluginSource{Name: repo, Source: "github.com/acme/myplugin", Version: "~> 1.2", Network: "outbound"}
+	specs := []config.PluginSource{sp}
+	ctx := context.Background()
+
+	// Pinned to v1.2.0 with an attested commit-aaa.
+	m.lock.setSource(repo, "github.com/acme/myplugin", "v1.2.0", "~> 1.2", "commit-aaa", true)
+	if err := m.lock.save(); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := m.Install(ctx, specs, nil, true)
+	if err != nil {
+		t.Fatalf("upgrade to a newer attested version must not be blocked, got: %v", err)
+	}
+	if len(res) != 1 || res[0].Version != "v1.3.0" || !res[0].Updated {
+		t.Fatalf("update = %+v, want v1.2.0 -> v1.3.0 updated", res)
+	}
+	if e, _ := m.lock.get(repo); e.Version != "v1.3.0" || e.Commit != "commit-bbb" {
+		t.Fatalf("after upgrade entry = version %q commit %q, want v1.3.0 / commit-bbb", e.Version, e.Commit)
+	}
+}
+
 // TestInstallUpgradeClearsPrivileged is the regression test for the
 // silent-privilege-grant bypass: a manifest-less UPGRADE of a
 // previously-privileged-approved plugin must not let the new binary inherit

--- a/internal/config/extplugin/provenance_test.go
+++ b/internal/config/extplugin/provenance_test.go
@@ -184,6 +184,35 @@ func TestProvenanceRecordsAndPinsCommit(t *testing.T) {
 	}
 }
 
+// TestProvenanceCommitCheckIsVersionAware covers that the re-pointed-tag
+// guard fires only for a re-download of the *same* version, not for an
+// explicit upgrade to a *new* version (whose commit legitimately differs).
+// Without this distinction `clawpatrol plugins update` to a newer attested
+// release is wrongly blocked.
+func TestProvenanceCommitCheckIsVersionAware(t *testing.T) {
+	entry := lockEntry{Version: "v1.0.0", Commit: "commit-aaa", Attested: true}
+	res := fetchResult{commit: "commit-bbb", attested: true}
+
+	// Same tag, different commit: the tag was re-pointed -> blocked.
+	if err := checkProvenanceNotDowngraded("p", provWarn, entry, res, "v1.0.0"); err == nil ||
+		!strings.Contains(err.Error(), "re-pointed") {
+		t.Fatalf("same-version commit change should be blocked, got: %v", err)
+	}
+	// Newer version, different commit: a legitimate upgrade -> accepted.
+	if err := checkProvenanceNotDowngraded("p", provWarn, entry, res, "v1.1.0"); err != nil {
+		t.Fatalf("upgrade to a new version must not be blocked, got: %v", err)
+	}
+	// A lost attestation still blocks, regardless of the version change.
+	if err := checkProvenanceNotDowngraded("p", provWarn, entry, fetchResult{}, "v1.1.0"); err == nil ||
+		!strings.Contains(err.Error(), "lost its build-provenance") {
+		t.Fatalf("lost attestation should block, got: %v", err)
+	}
+	// provenance = "off" disables every check.
+	if err := checkProvenanceNotDowngraded("p", provOff, entry, fetchResult{}, "v1.0.0"); err != nil {
+		t.Fatalf("provOff should skip checks, got: %v", err)
+	}
+}
+
 // TestProvenanceDowngradeBlockedUntilApproved covers the TOFU model: a
 // plugin recorded as attested that loses provenance is blocked on load
 // until Approve (accept=true) re-records the lower level.


### PR DESCRIPTION
`clawpatrol plugins update` to a newer **attested** plugin release was
wrongly blocked. `checkProvenanceNotDowngraded` (fetch.go) flagged any
change in the attested source commit as a re-pointed tag and failed
closed — but across a version bump the commit always changes. The error
even told the operator to "run `clawpatrol plugins update`", which is
exactly what was failing (circular); the real remedy is `clawpatrol
plugins approve`.

A re-pointed tag means the **same** tag now vouches a **different**
commit. So the guard now treats a commit change as a re-point only when
the fetched version equals the locked version. An explicit upgrade fetches
a newer tag, whose new commit is legitimate and is re-pinned by the caller
(the attestation itself is still verified at fetch time, independently).
The load and keep-pinned paths fetch the locked version, so they are
unchanged and still catch a genuine re-point. The error message now points
at `plugins approve`.

Hit live while upgrading the production gateway's aws plugin v0.3.2 →
v0.3.3; `plugins approve` (which re-resolves + accepts) was the working
path.

* test: same-version commit change still blocks; a newer version with a
  different commit is accepted; a lost attestation still blocks regardless
  of version; provenance = "off" skips the checks.