### PR TITLE
Add clawpatrol.device.{name,profile,owner} to GenAI spans

### DIFF
--- a/cmd/clawpatrol/genai.go
+++ b/cmd/clawpatrol/genai.go
@@ -114,6 +114,16 @@ type genAITurn struct {
 	ServerAddress string
 	ServerPort    int
 
+	// Device identity of the calling device (clawpatrol.device.*),
+	// resolved from the connection peer IP via the same device/profile
+	// path the discovery endpoint and dispatch use — never tokens or
+	// headers. Empty fields are omitted from the span: name and owner are
+	// empty for an unknown device; profile falls back to the default
+	// profile that governs unclaimed peers.
+	DeviceName    string // clawpatrol.device.name
+	DeviceProfile string // clawpatrol.device.profile
+	DeviceOwner   string // clawpatrol.device.owner
+
 	// Request sampling parameters (gen_ai.request.*). Pointers/zero-checks
 	// distinguish "not set in the request" from a real zero value
 	// (temperature 0 is valid and common).
@@ -174,6 +184,16 @@ func emitGenAISpan(tracer trace.Tracer, t genAITurn, includeContent bool) {
 	}
 	if t.ServerPort > 0 {
 		attrs = append(attrs, attribute.Int("server.port", t.ServerPort))
+	}
+	// clawpatrol.device.* — the device that made the intercepted request.
+	if t.DeviceName != "" {
+		attrs = append(attrs, attribute.String("clawpatrol.device.name", t.DeviceName))
+	}
+	if t.DeviceProfile != "" {
+		attrs = append(attrs, attribute.String("clawpatrol.device.profile", t.DeviceProfile))
+	}
+	if t.DeviceOwner != "" {
+		attrs = append(attrs, attribute.String("clawpatrol.device.owner", t.DeviceOwner))
 	}
 	if t.RequestModel != "" {
 		attrs = append(attrs, attribute.String("gen_ai.request.model", t.RequestModel))
@@ -295,10 +315,11 @@ func genAIContentAttrs(t genAITurn) []attribute.KeyValue {
 // gen_ai.provider.name value ("anthropic"/"openai"); convID is the
 // session correlation key emitted as gen_ai.conversation.id (empty when
 // the turn carries no session info); serverAddr is the upstream host the
-// turn went to (server.address, port 443). Content is parsed from the
-// bodies only when content capture is opted in, so the disabled and
-// no-content paths stay cheap.
-func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time) {
+// turn went to (server.address, port 443); agentIP is the calling
+// device's resolved peer IP, used to attach the clawpatrol.device.*
+// attributes. Content is parsed from the bodies only when content
+// capture is opted in, so the disabled and no-content paths stay cheap.
+func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respModel string, in, out int64, reqBody, respBody []byte, start time.Time, agentIP string) {
 	cfg := g.cfg.Load()
 	if genaiTracer == nil || !cfg.GenAITelemetryEnabled() {
 		return
@@ -327,6 +348,7 @@ func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respMo
 	if serverAddr != "" {
 		turn.ServerPort = 443
 	}
+	g.fillDeviceAttrs(&turn, agentIP)
 	includeContent := cfg.GenAITelemetryIncludeContent()
 	// Per-provider field mapping fills the shared genAITurn from each
 	// provider's own wire format. The representation and exporter
@@ -338,6 +360,24 @@ func (g *Gateway) recordGenAITurn(provider, convID, serverAddr, reqModel, respMo
 		mapOpenAITurn(&turn, reqBody, respBody, includeContent)
 	}
 	emitGenAISpan(genaiTracer, turn, includeContent)
+}
+
+// fillDeviceAttrs resolves the calling device's identity for the
+// clawpatrol.device.* span attributes from its peer IP, reusing the same
+// onboard registry / profileFor path the discovery endpoint and dispatch
+// use (never tokens or headers). Each field is best-effort: name and
+// owner stay empty for an unknown device, while profile falls back to
+// the default profile that governs unclaimed peers — matching how the
+// profile is resolved everywhere else. emitGenAISpan omits empty fields.
+func (g *Gateway) fillDeviceAttrs(turn *genAITurn, agentIP string) {
+	if agentIP == "" {
+		return
+	}
+	turn.DeviceProfile = g.profileFor(agentIP)
+	if g.onboard != nil {
+		turn.DeviceName = g.onboard.HostnameForIP(agentIP)
+		turn.DeviceOwner = g.onboard.OwnerForIP(agentIP)
+	}
 }
 
 // mapClaudeTurn fills the GenAI turn from an Anthropic /v1/messages

--- a/cmd/clawpatrol/genai_openai_test.go
+++ b/cmd/clawpatrol/genai_openai_test.go
@@ -291,7 +291,7 @@ func TestRecordGenAITurnOpenAINoContent(t *testing.T) {
 		"message":{"role":"assistant","content":"secret completion"},"finish_reason":"stop"}],
 		"usage":{"prompt_tokens":10,"completion_tokens":20}}`
 	g.recordGenAITurn("openai", "s_oai", "api.openai.com", "gpt-4o", "gpt-4o", 10, 20,
-		[]byte(req), []byte(resp), time.Time{})
+		[]byte(req), []byte(resp), time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {
@@ -349,7 +349,7 @@ func TestRecordGenAITurnOpenAIWithContent(t *testing.T) {
 		"message":{"role":"assistant","content":"general kenobi"},"finish_reason":"stop"}],
 		"usage":{"prompt_tokens":1,"completion_tokens":2}}`
 	g.recordGenAITurn("openai", "s_oai", "api.openai.com", "gpt-4o", "gpt-4o", 1, 2,
-		[]byte(req), []byte(resp), time.Time{})
+		[]byte(req), []byte(resp), time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {

--- a/cmd/clawpatrol/genai_test.go
+++ b/cmd/clawpatrol/genai_test.go
@@ -338,7 +338,7 @@ gateway {
 	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 1, 2,
 		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"yo"}]}`),
-		time.Time{})
+		time.Time{}, "")
 
 	if n := len(sr.Ended()); n != 0 {
 		t.Fatalf("got %d spans with telemetry disabled, want 0", n)
@@ -368,7 +368,7 @@ gateway {
 	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"messages":[{"role":"user","content":"hi there"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"secret"}]}`),
-		time.Time{})
+		time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {
@@ -417,7 +417,7 @@ gateway {
 	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"system":"be terse","messages":[{"role":"user","content":"hi there"}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"hello back"}]}`),
-		time.Time{})
+		time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {
@@ -569,7 +569,7 @@ gateway {
 	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"messages":[{"role":"user","content":"hi"}],"tools":[{"name":"get_weather","description":"secret","input_schema":{"type":"object"}}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}]}`),
-		time.Time{})
+		time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {
@@ -611,7 +611,7 @@ gateway {
 	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com", "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"messages":[{"role":"user","content":"hi"}],"tools":[{"name":"get_weather","description":"Look up the weather","input_schema":{"type":"object","properties":{"location":{"type":"string"}}}}]}`),
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}]}`),
-		time.Time{})
+		time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {
@@ -720,7 +720,7 @@ gateway {
 		"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
 		[]byte(`{"model":"claude-3-5-sonnet-20241022","max_tokens":2048,"stream":false,"temperature":0.7,"top_p":0.9,"top_k":50,"stop_sequences":["STOP"],"messages":[{"role":"user","content":"hi"}]}`),
 		[]byte(`{"id":"msg_01XYZ","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":256,"cache_creation_input_tokens":64},"content":[{"type":"text","text":"hello"}]}`),
-		time.Time{})
+		time.Time{}, "")
 
 	spans := sr.Ended()
 	if len(spans) != 1 {
@@ -763,5 +763,75 @@ gateway {
 	}
 	if got := m["gen_ai.usage.cache_creation.input_tokens"].AsInt64(); got != 64 {
 		t.Errorf("cache_creation.input_tokens = %d, want 64", got)
+	}
+}
+
+// TestRecordGenAITurnDeviceAttributes asserts the clawpatrol.device.*
+// attributes are resolved from the calling device's peer IP via the
+// onboard registry / profileFor path, and that an unknown device omits
+// the name/owner attributes rather than emitting a wrong value.
+func TestRecordGenAITurnDeviceAttributes(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	gw, diags := config.LoadBytes([]byte(`
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+  genai_telemetry {}
+}
+`), "device.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	g := &Gateway{onboard: newOnboardRegistry()}
+	g.cfg.Store(gw)
+
+	const ip = "10.55.0.7"
+	g.onboard.SetHostname(ip, "laptop-01")
+	g.onboard.SetOwner(ip, "alice@example.com")
+	g.onboard.AssignProfile(ip, "engineering")
+
+	req := []byte(`{"model":"claude-3-5-sonnet-20241022","messages":[{"role":"user","content":"hi"}]}`)
+	resp := []byte(`{"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","content":[{"type":"text","text":"yo"}]}`)
+
+	// Known device: all three attributes resolve.
+	g.recordGenAITurn("anthropic", "s_abc123", "api.anthropic.com",
+		"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		req, resp, time.Time{}, ip)
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	if got := m["clawpatrol.device.name"].AsString(); got != "laptop-01" {
+		t.Errorf("clawpatrol.device.name = %q, want laptop-01", got)
+	}
+	if got := m["clawpatrol.device.profile"].AsString(); got != "engineering" {
+		t.Errorf("clawpatrol.device.profile = %q, want engineering", got)
+	}
+	if got := m["clawpatrol.device.owner"].AsString(); got != "alice@example.com" {
+		t.Errorf("clawpatrol.device.owner = %q, want alice@example.com", got)
+	}
+
+	// Unknown device: name/owner omitted rather than emitting a wrong value.
+	g.recordGenAITurn("anthropic", "s_def456", "api.anthropic.com",
+		"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022", 10, 20,
+		req, resp, time.Time{}, "10.55.0.99")
+
+	spans = sr.Ended()
+	if len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2", len(spans))
+	}
+	m = attrMap(spans[1].Attributes())
+	if _, ok := m["clawpatrol.device.name"]; ok {
+		t.Errorf("clawpatrol.device.name set for unknown device: %q", m["clawpatrol.device.name"].AsString())
+	}
+	if _, ok := m["clawpatrol.device.owner"]; ok {
+		t.Errorf("clawpatrol.device.owner set for unknown device: %q", m["clawpatrol.device.owner"].AsString())
 	}
 }

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1083,7 +1083,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, host, path string, reqBody, re
 		if sid == "" && title != "" {
 			sid = shortHash(title)
 		}
-		g.recordGenAITurn("anthropic", sid, host, reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("anthropic", sid, host, reqInfo.Model, respModel, in, out, reqBody, respBody, reqStart, ip)
 		if sid == "" {
 			return // heartbeat/probe with no session info
 		}
@@ -1100,7 +1100,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, host, path string, reqBody, re
 		if model == "" && in == 0 && out == 0 && title == "" {
 			return
 		}
-		g.recordGenAITurn("openai", sid, host, model, model, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("openai", sid, host, model, model, in, out, reqBody, respBody, reqStart, ip)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	case "codex_ws_usage":
 		// chatgpt.com Codex backend. Two transports:
@@ -1130,7 +1130,7 @@ func (g *Gateway) trackLLMUsage(c net.Conn, kind, host, path string, reqBody, re
 		if sid == "" {
 			sid = shortHash(codexResponsesRequestFirstTitle(reqBody))
 		}
-		g.recordGenAITurn("openai", sid, host, model, model, in, out, reqBody, respBody, reqStart)
+		g.recordGenAITurn("openai", sid, host, model, model, in, out, reqBody, respBody, reqStart, ip)
 		g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 	}
 }


### PR DESCRIPTION
Attach the calling device's identity to every GenAI (`gen_ai.*`) span emitted for an intercepted LLM request:

- `clawpatrol.device.name` — the device name
- `clawpatrol.device.profile` — its bound profile
- `clawpatrol.device.owner` — the device/profile owner

Values resolve from the connection peer IP through the existing onboard registry / `profileFor` path that the discovery endpoint and dispatch already use, so identity comes from the tunnel, never from request tokens or headers.

Unknown devices degrade gracefully: `name` and `owner` are omitted rather than guessed, and `profile` falls back to the default profile that governs unclaimed peers. The standard `gen_ai.*` attributes are unchanged.