### PR TITLE
Emit GenAI spans for Codex responses over the WebSocket transport

### DIFF
--- a/cmd/clawpatrol/genai_openai_test.go
+++ b/cmd/clawpatrol/genai_openai_test.go
@@ -438,3 +438,115 @@ gateway {
 		t.Errorf("gen_ai.request.model = %q, want gpt-5-codex", got)
 	}
 }
+
+// TestCodexWSTurnAssembly covers the production Codex transport: the
+// /backend-api/codex/responses request is a WebSocket upgrade, so the turn
+// arrives as separate frames (client→server request envelope, then a
+// server→client response.completed frame) routed through handleWSUpgrade —
+// the HTTP-path trackLLMUsage never fires. The codexWSTurn assembler must
+// pair the frames and produce a completion that records a correct gen_ai
+// span with model, usage, and (under the content opt-in) prompt/output.
+func TestCodexWSTurnAssembly(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	g := newGenAIGateway(t, true)
+
+	// client→server: the full request envelope (prompt + model + tools).
+	reqEnvelope := []byte(`{"model":"gpt-5-codex","instructions":"be terse",` +
+		`"tools":[{"type":"function","name":"shell","description":"run a shell command","parameters":{"p":1}}],` +
+		`"input":[{"role":"user","content":[{"type":"input_text","text":"list files"}]}]}`)
+	// server→client: response.completed carries usage + output nested under
+	// `response` — no model and no token usage live at the frame top level,
+	// which is why a single-frame parse dropped the span before.
+	completed := []byte(`{"type":"response.completed","response":{` +
+		`"id":"resp_ws_1","model":"gpt-5-codex-2026","status":"completed",` +
+		`"usage":{"input_tokens":11,"output_tokens":7},` +
+		`"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}}`)
+
+	turn := &codexWSTurn{}
+	turn.observeRequest(reqEnvelope, time.Time{})
+	// A non-terminal server frame must not emit anything.
+	if c := turn.observeResponse([]byte(`{"type":"response.created","response":{"id":"resp_ws_1"}}`)); c != nil {
+		t.Fatalf("response.created should not produce a completion")
+	}
+	c := turn.observeResponse(completed)
+	if c == nil {
+		t.Fatal("response.completed produced no completion (WS turn dropped)")
+	}
+	g.recordGenAITurn("openai", "s_ws", "chatgpt.com", c.reqModel, c.respModel,
+		c.in, c.out, c.reqBody, c.respBody, c.start, "100.64.0.1")
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	if got := m["gen_ai.provider.name"].AsString(); got != "openai" {
+		t.Errorf("gen_ai.provider.name = %q, want openai", got)
+	}
+	if got := m["gen_ai.request.model"].AsString(); got != "gpt-5-codex" {
+		t.Errorf("gen_ai.request.model = %q, want gpt-5-codex", got)
+	}
+	if got := m["gen_ai.response.model"].AsString(); got != "gpt-5-codex-2026" {
+		t.Errorf("gen_ai.response.model = %q, want gpt-5-codex-2026", got)
+	}
+	if got := m["gen_ai.response.id"].AsString(); got != "resp_ws_1" {
+		t.Errorf("gen_ai.response.id = %q, want resp_ws_1", got)
+	}
+	if got := m["gen_ai.usage.input_tokens"].AsInt64(); got != 11 {
+		t.Errorf("input_tokens = %d, want 11", got)
+	}
+	if got := m["gen_ai.usage.output_tokens"].AsInt64(); got != 7 {
+		t.Errorf("output_tokens = %d, want 7", got)
+	}
+	if fr := m["gen_ai.response.finish_reasons"].AsStringSlice(); len(fr) != 1 || fr[0] != "completed" {
+		t.Errorf("finish_reasons = %v, want [completed]", fr)
+	}
+	// Content opt-in: the user prompt and assistant output ride the span.
+	var input []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.input.messages"].AsString()), &input); err != nil {
+		t.Fatalf("input.messages: %v", err)
+	}
+	if len(input) != 1 || input[0].Role != "user" || len(input[0].Parts) != 1 || input[0].Parts[0].Content != "list files" {
+		t.Errorf("input.messages = %#v", input)
+	}
+	var output []genAIChatMessage
+	if err := json.Unmarshal([]byte(m["gen_ai.output.messages"].AsString()), &output); err != nil {
+		t.Fatalf("output.messages: %v", err)
+	}
+	if len(output) != 1 || len(output[0].Parts) != 1 || output[0].Parts[0].Content != "ok" {
+		t.Errorf("output.messages = %#v", output)
+	}
+	// Tool definition (name+type) rides the span.
+	var defs []genAIToolDef
+	if err := json.Unmarshal([]byte(m["gen_ai.tool.definitions"].AsString()), &defs); err != nil {
+		t.Fatalf("tool.definitions: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Name != "shell" {
+		t.Errorf("tool defs = %#v", defs)
+	}
+}
+
+// TestCodexWSTurnFallsBackToResponseModel verifies a completion seen with no
+// preceding request frame (e.g. connection observed mid-turn) still records a
+// span, sourcing the model from the response.
+func TestCodexWSTurnFallsBackToResponseModel(t *testing.T) {
+	turn := &codexWSTurn{}
+	c := turn.observeResponse([]byte(`{"type":"response.completed","response":{` +
+		`"id":"r1","model":"gpt-5-codex","usage":{"input_tokens":3,"output_tokens":2}}}`))
+	if c == nil {
+		t.Fatal("completion dropped when no request frame was seen")
+	}
+	if c.reqBody != nil {
+		t.Errorf("reqBody = %q, want nil", c.reqBody)
+	}
+	if c.reqModel != "gpt-5-codex" {
+		t.Errorf("reqModel = %q, want gpt-5-codex (response fallback)", c.reqModel)
+	}
+	if c.in != 3 || c.out != 2 {
+		t.Errorf("usage in/out = %d/%d, want 3/2", c.in, c.out)
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -833,6 +833,101 @@ func (g *Gateway) trackCodexWSUsage(remoteAddr, wsSessionID string, payload []by
 	g.agents.recordLLMUsage(ip, "codex", sid, title, model, in, out)
 }
 
+// codexWSTurn assembles a GenAI turn from a Codex WebSocket frame
+// sequence. Codex's /backend-api/codex/responses runs over a WS upgrade
+// (see the WS-upgrade branch in mitmHTTPS) rather than the HTTP/SSE path
+// trackLLMUsage handles, so a turn's request and response arrive on
+// separate frames: the client→server request envelope carries the
+// prompt / model / tools, and the server→client response.completed frame
+// carries the output and usage. observeRequest stashes the envelope;
+// observeResponse returns a ready-to-record completion when the terminal
+// frame lands. The two WS pump goroutines (client→server and
+// server→client) call these concurrently, so the stashed state is mutex
+// guarded.
+type codexWSTurn struct {
+	mu          sync.Mutex
+	reqEnvelope []byte
+	start       time.Time
+}
+
+// observeRequest records a client→server request envelope — the frame
+// carrying the `input` array. Latest-wins: the most recent envelope seen
+// before a completion is the one paired with it.
+func (t *codexWSTurn) observeRequest(payload []byte, now time.Time) {
+	var probe struct {
+		Input json.RawMessage `json:"input"`
+	}
+	if json.Unmarshal(payload, &probe) != nil || len(probe.Input) == 0 {
+		return
+	}
+	t.mu.Lock()
+	t.reqEnvelope = append([]byte(nil), payload...)
+	t.start = now
+	t.mu.Unlock()
+}
+
+// codexWSCompletion is the assembled pieces of one Codex WS turn, ready to
+// hand to recordGenAITurn. respBody is the inner `response` object of the
+// terminal frame — a Responses-API response body that maps through
+// mapOpenAITurn exactly like the HTTP path's; reqBody is the paired request
+// envelope (nil if no request frame was seen on this connection).
+type codexWSCompletion struct {
+	reqBody   []byte
+	respBody  []byte
+	reqModel  string
+	respModel string
+	in, out   int64
+	start     time.Time
+}
+
+// observeResponse inspects a server→client frame. On a terminal
+// response.completed / .incomplete / .failed frame it returns the assembled
+// completion; every other frame returns nil. The request envelope is
+// consumed so a stray duplicate terminal frame can't re-emit a span.
+func (t *codexWSTurn) observeResponse(payload []byte) *codexWSCompletion {
+	var msg struct {
+		Type     string          `json:"type"`
+		Response json.RawMessage `json:"response"`
+	}
+	if json.Unmarshal(payload, &msg) != nil {
+		return nil
+	}
+	if !isResponsesTerminalEvent(msg.Type) || len(msg.Response) == 0 {
+		return nil
+	}
+	var resp struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	_ = json.Unmarshal(msg.Response, &resp)
+
+	t.mu.Lock()
+	reqBody := t.reqEnvelope
+	start := t.start
+	t.reqEnvelope = nil
+	t.mu.Unlock()
+
+	// Prefer the request's model (e.g. "gpt-5-codex"); the response may
+	// echo a dated variant. Fall back to the response model when the
+	// request frame wasn't captured.
+	reqModel := codexRequestModel(reqBody)
+	if reqModel == "" {
+		reqModel = resp.Model
+	}
+	return &codexWSCompletion{
+		reqBody:   reqBody,
+		respBody:  append([]byte(nil), msg.Response...),
+		reqModel:  reqModel,
+		respModel: resp.Model,
+		in:        resp.Usage.InputTokens,
+		out:       resp.Usage.OutputTokens,
+		start:     start,
+	}
+}
+
 // codexToolTitle formats a tool-call frame into "▸ name(arg)". Codex's
 // `arguments` field is a JSON string whose shape varies per tool —
 // shell.command[], apply_patch.input, file_search.query, etc. We pull

--- a/cmd/clawpatrol/ws.go
+++ b/cmd/clawpatrol/ws.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/denoland/clawpatrol/internal/config"
 )
@@ -193,10 +194,29 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 		wsSessionID = req.Header.Get("Sec-Websocket-Key") // unique per handshake
 	}
 
-	var onPayload func([]byte)
+	// Codex WS frames feed two observers: trackCodexWSUsage keeps the
+	// dashboard session live (both directions), and codexWSTurn assembles
+	// a GenAI span from the client→server request envelope plus the
+	// server→client response.completed frame — the WS transport's
+	// equivalent of the HTTP/SSE path's trackLLMUsage span.
+	var onClientPayload, onServerPayload func([]byte)
 	if trackKindFor(upstream) == "codex_ws_usage" {
-		onPayload = func(text []byte) {
+		turn := &codexWSTurn{}
+		convID := "ws_" + shortHash(agentAddr)
+		if wsSessionID != "" {
+			convID = "s_" + shortHash(wsSessionID)
+		}
+		onClientPayload = func(text []byte) {
 			g.trackCodexWSUsage(agentAddr, wsSessionID, text)
+			turn.observeRequest(text, time.Now())
+		}
+		onServerPayload = func(text []byte) {
+			g.trackCodexWSUsage(agentAddr, wsSessionID, text)
+			if c := turn.observeResponse(text); c != nil {
+				g.recordGenAITurn("openai", convID, upstream,
+					c.reqModel, c.respModel, c.in, c.out,
+					c.reqBody, c.respBody, c.start, agentAddr)
+			}
 		}
 	}
 
@@ -215,8 +235,8 @@ func (g *Gateway) handleWSUpgrade(client *tls.Conn, br *bufio.Reader, req *http.
 			}
 		}
 	}
-	clientToServer := wrapPayload("c→s", onPayload)
-	serverToClient := wrapPayload("s→c", onPayload)
+	clientToServer := wrapPayload("c→s", onClientPayload)
+	serverToClient := wrapPayload("s→c", onServerPayload)
 
 	// Per-frame byte tracker fed to AgentRegistry.track. Calling once
 	// at session close was insufficient — the dashboard sparkline


### PR DESCRIPTION
Codex's `/backend-api/codex/responses` requests run as a WebSocket upgrade, so their frames are handled by the WS bridge rather than the HTTP/SSE request path. The WS frame parser updated the dashboard session but never recorded a GenAI turn, so these requests emitted no `gen_ai` span. The earlier fix only covered the HTTP/SSE branch, which this endpoint never takes.

A turn is now assembled from the WS frame sequence: the client→server request envelope carries the prompt, model, and tool definitions, and the server→client `response.completed` frame carries the output and token usage. The inner `response` object is a Responses-API response body, so it maps through the existing OpenAI turn machinery for parity with the other providers. The assembler is mutex-guarded because the two WS pump goroutines feed it concurrently.

## Test
- A Codex WebSocket turn (request envelope + `response.completed` frame) now emits a `gen_ai` span with the correct model, token usage, response id, finish reason, and — under the content opt-in — prompt and output messages and tool definitions.
- A completion seen with no preceding request frame still records a span, sourcing the model from the response.
