### PR TITLE
Capture Codex output messages in GenAI traces

### DIFF
--- a/cmd/clawpatrol/genai_openai.go
+++ b/cmd/clawpatrol/genai_openai.go
@@ -310,10 +310,15 @@ func openAIResponsesOutput(output json.RawMessage) []genAIPart {
 // openAIResponseSSE reconstructs the assistant response from a streaming
 // body. A Responses-API stream ends with a terminal event carrying the
 // full response object (response.completed / .incomplete / .failed) — when
-// present it is parsed exactly like a non-streaming Responses body.
-// Otherwise the body is a Chat Completions stream whose choice deltas are
-// accumulated: text content concatenates, and tool-call fragments
-// accumulate by index.
+// its output is populated it is parsed exactly like a non-streaming
+// Responses body. Codex's /backend-api/codex/responses stream is the
+// exception: its terminal frame's output is always empty ([]), and the
+// finished output items ride the per-item response.output_item.done events
+// instead — so those are accumulated (by output_index, latest-wins) and
+// used to reconstruct the output when the terminal output is empty or no
+// terminal event arrives. Otherwise the body is a Chat Completions stream
+// whose choice deltas are accumulated: text content concatenates, and
+// tool-call fragments accumulate by index.
 func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
 	type toolAccum struct {
 		id   string
@@ -321,16 +326,20 @@ func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
 		args strings.Builder
 	}
 	var (
-		text     strings.Builder
-		tools    = map[int]*toolAccum{}
-		order    []int
-		haveChat bool
+		text      strings.Builder
+		tools     = map[int]*toolAccum{}
+		order     []int
+		haveChat  bool
+		respItems = map[int]json.RawMessage{}
+		respOrder []int
 	)
 	for _, payload := range sseDataPayloads(body) {
 		var ev struct {
-			Type     string          `json:"type"`
-			Response json.RawMessage `json:"response"`
-			Choices  []struct {
+			Type        string          `json:"type"`
+			Response    json.RawMessage `json:"response"`
+			Item        json.RawMessage `json:"item"`
+			OutputIndex int             `json:"output_index"`
+			Choices     []struct {
 				FinishReason string `json:"finish_reason"`
 				Delta        struct {
 					Content   string `json:"content"`
@@ -348,10 +357,22 @@ func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
 		if json.Unmarshal(payload, &ev) != nil {
 			continue
 		}
+		// Responses-API per-item completion: a fully-formed output item
+		// (message / reasoning / function_call). Codex delivers the real
+		// output here, not on the terminal frame. Latest-wins per index.
+		if ev.Type == "response.output_item.done" && len(ev.Item) > 0 {
+			if _, seen := respItems[ev.OutputIndex]; !seen {
+				respOrder = append(respOrder, ev.OutputIndex)
+			}
+			respItems[ev.OutputIndex] = ev.Item
+			continue
+		}
 		// Responses-API terminal event: the embedded response object
-		// carries the complete output, so parse it as a full body. Only
-		// the terminal events carry the final state — response.created /
-		// .in_progress snapshots also embed a (still-empty) response.
+		// carries the final state. Its output is the source of truth when
+		// populated; when empty (Codex) fall back to the items accumulated
+		// from response.output_item.done events. Only the terminal events
+		// carry the final state — response.created / .in_progress snapshots
+		// also embed a (still-empty) response.
 		if isResponsesTerminalEvent(ev.Type) && len(ev.Response) > 0 {
 			var r struct {
 				Output            json.RawMessage `json:"output"`
@@ -361,7 +382,11 @@ func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
 				} `json:"incomplete_details"`
 			}
 			if json.Unmarshal(ev.Response, &r) == nil {
-				return openAIResponsesOutput(r.Output), responsesFinish(r.Status, r.IncompleteDetails.Reason)
+				finish = responsesFinish(r.Status, r.IncompleteDetails.Reason)
+				if out := openAIResponsesOutput(r.Output); len(out) > 0 {
+					return out, finish
+				}
+				return assembleResponsesOutput(respItems, respOrder), finish
 			}
 			continue
 		}
@@ -391,7 +416,9 @@ func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
 		}
 	}
 	if !haveChat {
-		return nil, finish
+		// No chat deltas and no terminal frame (e.g. a truncated Codex
+		// stream): reconstruct from the per-item events seen so far.
+		return assembleResponsesOutput(respItems, respOrder), finish
 	}
 	if text.Len() > 0 {
 		parts = append(parts, genAIPart{Type: "text", Content: text.String()})
@@ -406,6 +433,26 @@ func openAIResponseSSE(body []byte) (parts []genAIPart, finish string) {
 		})
 	}
 	return parts, finish
+}
+
+// assembleResponsesOutput maps the output items accumulated from
+// response.output_item.done events into GenAI parts, reusing the
+// non-streaming Responses output mapper. items is keyed by output_index;
+// order preserves first-seen index order. Returns nil when no items were
+// collected.
+func assembleResponsesOutput(items map[int]json.RawMessage, order []int) []genAIPart {
+	if len(items) == 0 {
+		return nil
+	}
+	arr := make([]json.RawMessage, 0, len(order))
+	for _, i := range order {
+		arr = append(arr, items[i])
+	}
+	js, err := json.Marshal(arr)
+	if err != nil {
+		return nil
+	}
+	return openAIResponsesOutput(js)
 }
 
 // openAIContentMessages extracts the ordered input messages from an

--- a/cmd/clawpatrol/genai_openai_test.go
+++ b/cmd/clawpatrol/genai_openai_test.go
@@ -550,3 +550,114 @@ func TestCodexWSTurnFallsBackToResponseModel(t *testing.T) {
 		t.Errorf("usage in/out = %d/%d, want 3/2", c.in, c.out)
 	}
 }
+
+// TestOpenAIResponseContentCodexSSEEmptyTerminal mirrors the real Codex
+// /backend-api/codex/responses stream: the terminal response.completed
+// frame carries output:[] (empty), while the finished output items —
+// reasoning + assistant message — ride per-item response.output_item.done
+// events. The reconstruction must fall back to those items so the output is
+// not lost. Payload shapes are taken verbatim from a captured Codex turn.
+func TestOpenAIResponseContentCodexSSEEmptyTerminal(t *testing.T) {
+	body := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_x\",\"status\":\"in_progress\",\"output\":[]}}\n\n" +
+		"data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"thinking\"}]}}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ban\",\"output_index\":1}\n\n" +
+		"data: {\"type\":\"response.output_text.done\",\"content_index\":0,\"output_index\":1,\"text\":\"banana\"}\n\n" +
+		"data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"banana\"}]}}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_x\",\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":5}}}\n\n"
+	parts, finish := openAIResponseContent([]byte(body))
+	if finish != "completed" {
+		t.Errorf("finish = %q, want completed", finish)
+	}
+	want := []genAIPart{
+		{Type: "reasoning", Content: "thinking"},
+		{Type: "text", Content: "banana"},
+	}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+// TestOpenAIResponseSSECodexTruncated covers a Codex stream cut off before
+// the terminal frame: the output items seen so far must still reconstruct
+// the output rather than yielding nothing.
+func TestOpenAIResponseSSECodexTruncated(t *testing.T) {
+	body := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_y\",\"status\":\"in_progress\",\"output\":[]}}\n\n" +
+		"data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi\"}]}}\n\n"
+	parts, _ := openAIResponseContent([]byte(body))
+	want := []genAIPart{{Type: "text", Content: "hi"}}
+	if !reflect.DeepEqual(parts, want) {
+		t.Errorf("parts = %#v, want %#v", parts, want)
+	}
+}
+
+// TestCodexWSTurnOutputFromItemDoneFrames covers the production Codex WS
+// transport with realistic frames: the assistant output rides a
+// response.output_item.done frame and the terminal response.completed frame
+// carries output:[] (empty) plus usage. The assembler must splice the
+// per-item output into the response so the recorded span carries
+// gen_ai.output.messages.
+func TestCodexWSTurnOutputFromItemDoneFrames(t *testing.T) {
+	sr, tp := newRecordingTracer(t)
+	prev := genaiTracer
+	genaiTracer = tp.Tracer("test")
+	defer func() { genaiTracer = prev }()
+
+	g := newGenAIGateway(t, true)
+
+	reqEnvelope := []byte(`{"model":"gpt-5-codex",` +
+		`"input":[{"role":"user","content":[{"type":"input_text","text":"say banana"}]}]}`)
+	// Real Codex frame ordering: a finished output item, then a terminal
+	// response.completed whose output is empty.
+	itemDone := []byte(`{"type":"response.output_item.done","output_index":0,"item":{` +
+		`"id":"msg_1","type":"message","status":"completed","role":"assistant",` +
+		`"content":[{"type":"output_text","text":"banana"}]}}`)
+	completed := []byte(`{"type":"response.completed","response":{` +
+		`"id":"resp_ws_2","model":"gpt-5-codex","status":"completed",` +
+		`"usage":{"input_tokens":24950,"output_tokens":5},"output":[]}}`)
+
+	turn := &codexWSTurn{}
+	turn.observeRequest(reqEnvelope, time.Time{})
+	if c := turn.observeResponse(itemDone); c != nil {
+		t.Fatalf("response.output_item.done should not produce a completion")
+	}
+	c := turn.observeResponse(completed)
+	if c == nil {
+		t.Fatal("response.completed produced no completion (WS turn dropped)")
+	}
+	g.recordGenAITurn("openai", "s_ws", "chatgpt.com", c.reqModel, c.respModel,
+		c.in, c.out, c.reqBody, c.respBody, c.start, "100.64.0.1")
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	m := attrMap(spans[0].Attributes())
+	if got := m["gen_ai.usage.output_tokens"].AsInt64(); got != 5 {
+		t.Errorf("output_tokens = %d, want 5", got)
+	}
+	var output []genAIChatMessage
+	raw := m["gen_ai.output.messages"].AsString()
+	if raw == "" {
+		t.Fatal("gen_ai.output.messages missing — output not spliced from item.done frame")
+	}
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("output.messages: %v (raw %q)", err, raw)
+	}
+	if len(output) != 1 || output[0].Role != "assistant" ||
+		len(output[0].Parts) != 1 || output[0].Parts[0].Content != "banana" {
+		t.Errorf("output.messages = %#v", output)
+	}
+}
+
+// TestCodexSpliceOutputPrefersExisting verifies the splice is a no-op when
+// the terminal response already carries a populated output (e.g. the
+// standard OpenAI Responses API, or a future Codex change) — the verbatim
+// response is returned and the accumulated items are ignored.
+func TestCodexSpliceOutputPrefersExisting(t *testing.T) {
+	response := json.RawMessage(`{"id":"r","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"real"}]}]}`)
+	items := map[int]json.RawMessage{0: json.RawMessage(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"stale"}]}`)}
+	got := codexSpliceOutput(response, items, []int{0})
+	if !reflect.DeepEqual([]byte(response), got) {
+		t.Errorf("splice mutated a populated response: %s", got)
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -848,11 +848,21 @@ type codexWSTurn struct {
 	mu          sync.Mutex
 	reqEnvelope []byte
 	start       time.Time
+	// outputItems holds the finished output items (message / reasoning /
+	// function_call) accumulated from response.output_item.done frames,
+	// keyed by output_index (latest-wins); outputOrder preserves first-seen
+	// order. Codex's terminal response.completed frame carries an empty
+	// output array — the real output rides these per-item frames — so they
+	// are spliced into the response body when the terminal frame lands.
+	outputItems map[int]json.RawMessage
+	outputOrder []int
 }
 
 // observeRequest records a client→server request envelope — the frame
 // carrying the `input` array. Latest-wins: the most recent envelope seen
-// before a completion is the one paired with it.
+// before a completion is the one paired with it. A new request envelope
+// starts a new turn, so any output items accumulated for a prior,
+// terminal-less turn are dropped.
 func (t *codexWSTurn) observeRequest(payload []byte, now time.Time) {
 	var probe struct {
 		Input json.RawMessage `json:"input"`
@@ -863,6 +873,8 @@ func (t *codexWSTurn) observeRequest(payload []byte, now time.Time) {
 	t.mu.Lock()
 	t.reqEnvelope = append([]byte(nil), payload...)
 	t.start = now
+	t.outputItems = nil
+	t.outputOrder = nil
 	t.mu.Unlock()
 }
 
@@ -886,10 +898,28 @@ type codexWSCompletion struct {
 // consumed so a stray duplicate terminal frame can't re-emit a span.
 func (t *codexWSTurn) observeResponse(payload []byte) *codexWSCompletion {
 	var msg struct {
-		Type     string          `json:"type"`
-		Response json.RawMessage `json:"response"`
+		Type        string          `json:"type"`
+		Response    json.RawMessage `json:"response"`
+		Item        json.RawMessage `json:"item"`
+		OutputIndex int             `json:"output_index"`
 	}
 	if json.Unmarshal(payload, &msg) != nil {
+		return nil
+	}
+	// A finished output item (message / reasoning / function_call). Codex
+	// streams the real output on these frames; the terminal frame's output
+	// is always empty. Stash by output_index (latest-wins) to splice in
+	// when the terminal frame lands.
+	if msg.Type == "response.output_item.done" && len(msg.Item) > 0 {
+		t.mu.Lock()
+		if t.outputItems == nil {
+			t.outputItems = map[int]json.RawMessage{}
+		}
+		if _, seen := t.outputItems[msg.OutputIndex]; !seen {
+			t.outputOrder = append(t.outputOrder, msg.OutputIndex)
+		}
+		t.outputItems[msg.OutputIndex] = append([]byte(nil), msg.Item...)
+		t.mu.Unlock()
 		return nil
 	}
 	if !isResponsesTerminalEvent(msg.Type) || len(msg.Response) == 0 {
@@ -907,8 +937,16 @@ func (t *codexWSTurn) observeResponse(payload []byte) *codexWSCompletion {
 	t.mu.Lock()
 	reqBody := t.reqEnvelope
 	start := t.start
+	items := t.outputItems
+	order := t.outputOrder
 	t.reqEnvelope = nil
+	t.outputItems = nil
+	t.outputOrder = nil
 	t.mu.Unlock()
+
+	// Codex's terminal response carries output:[]; splice the accumulated
+	// per-item output in so mapOpenAITurn extracts gen_ai.output.messages.
+	respBody := codexSpliceOutput(msg.Response, items, order)
 
 	// Prefer the request's model (e.g. "gpt-5-codex"); the response may
 	// echo a dated variant. Fall back to the response model when the
@@ -919,13 +957,49 @@ func (t *codexWSTurn) observeResponse(payload []byte) *codexWSCompletion {
 	}
 	return &codexWSCompletion{
 		reqBody:   reqBody,
-		respBody:  append([]byte(nil), msg.Response...),
+		respBody:  respBody,
 		reqModel:  reqModel,
 		respModel: resp.Model,
 		in:        resp.Usage.InputTokens,
 		out:       resp.Usage.OutputTokens,
 		start:     start,
 	}
+}
+
+// codexSpliceOutput returns the terminal response object with its `output`
+// array replaced by the items accumulated from response.output_item.done
+// frames, keyed by output_index in first-seen order. Codex's terminal frame
+// always carries output:[], so without this the assistant output is lost.
+// When the response already carries a non-empty output (e.g. a future Codex
+// change, or the standard OpenAI Responses API), or no items were collected,
+// the response is returned unchanged.
+func codexSpliceOutput(response json.RawMessage, items map[int]json.RawMessage, order []int) []byte {
+	verbatim := append([]byte(nil), response...)
+	if len(items) == 0 {
+		return verbatim
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(response, &obj) != nil {
+		return verbatim
+	}
+	var existing []json.RawMessage
+	if json.Unmarshal(obj["output"], &existing) == nil && len(existing) > 0 {
+		return verbatim
+	}
+	arr := make([]json.RawMessage, 0, len(order))
+	for _, i := range order {
+		arr = append(arr, items[i])
+	}
+	outJS, err := json.Marshal(arr)
+	if err != nil {
+		return verbatim
+	}
+	obj["output"] = outJS
+	spliced, err := json.Marshal(obj)
+	if err != nil {
+		return verbatim
+	}
+	return spliced
 }
 
 // codexToolTitle formats a tool-call frame into "▸ name(arg)". Codex's


### PR DESCRIPTION
Codex (`/backend-api/codex/responses`) runs over a WebSocket, and its terminal `response.completed` frame always carries an **empty** `output` array — confirmed by capturing a live Codex turn (the frame has `output: []` even with `usage.output_tokens > 0`). The finished output items (reasoning, assistant message, function calls) arrive on the per-item `response.output_item.done` frames instead.

The WS turn assembler read only `response.completed`'s `output`, so the emitted GenAI span never carried `gen_ai.output.messages`.

## Fix

- Accumulate `response.output_item.done` items (keyed by `output_index`, latest-wins) and splice them into the response when its `output` is empty.
- Applied in both the WebSocket turn assembler (`codexWSTurn`) and the SSE reconstruction (`openAIResponseSSE`), and on truncated streams with no terminal frame.
- When the terminal `output` is already populated (standard OpenAI Responses API), behaviour is unchanged — the terminal output is preferred.

## Tests

- `TestCodexWSTurnOutputFromItemDoneFrames` — production WS shape: item rides `response.output_item.done`, terminal frame has `output: []`; span now carries `gen_ai.output.messages`.
- `TestOpenAIResponseContentCodexSSEEmptyTerminal` — SSE stream with empty terminal output, reasoning + message reconstructed from per-item frames.
- `TestOpenAIResponseSSECodexTruncated` — output reconstructed when the stream is cut off before the terminal frame.
- `TestCodexSpliceOutputPrefersExisting` — splice is a no-op when the response already has output.

No regression to input messages or other providers' output messages.