### PR TITLE
facet: title/description/detail_only fields + AWS-friendly activity log

### DIFF
--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -2287,9 +2287,12 @@ func (w *webMux) apiAnalytics(
 func (w *webMux) apiFacets(rw http.ResponseWriter, r *http.Request) {
 	_ = r
 	type reportFieldJSON struct {
-		Name  string `json:"name"`
-		Kind  string `json:"kind"`
-		Label string `json:"label,omitempty"`
+		Name        string `json:"name"`
+		Kind        string `json:"kind"`
+		Label       string `json:"label,omitempty"`
+		Description string `json:"description,omitempty"`
+		Title       bool   `json:"title,omitempty"`
+		DetailOnly  bool   `json:"detail_only,omitempty"`
 	}
 	type facetJSON struct {
 		Name             string            `json:"name"`
@@ -2314,6 +2317,7 @@ func (w *webMux) apiFacets(rw http.ResponseWriter, r *http.Request) {
 		for i, fk := range fks {
 			entry.ReportFields[i] = reportFieldJSON{
 				Name: fk.Name, Kind: reportKindName(fk.Kind), Label: fk.Label,
+				Description: fk.Description, Title: fk.Title, DetailOnly: fk.DetailOnly,
 			}
 		}
 		out = append(out, entry)

--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -181,7 +181,7 @@ function mergeEvent(prev: RowState[], ev: EventRecord, max: number): RowState[] 
 // protocol plugins drop in without dashboard edits; falls back to
 // the legacy method/path stuffing when facets aren't populated
 // (pre-migration rows / unknown families).
-function rowDescriptors(
+export function rowDescriptors(
   ev: EventRecord,
   schema: FacetSchema | undefined,
 ): { verb: string; body: string } {

--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -7,6 +7,18 @@ type RowState = EventRecord & {
   frames?: { direction: string; frame: string; ts: string }[];
 };
 
+function isDeniedAction(ev: EventRecord): boolean {
+  return ev.action === "deny" || ev.action === "denied" || ev.action === "hitl_deny";
+}
+
+// A "quiet" dial is an allowed brokered-dial action — the gateway→upstream
+// dial a plugin endpoint makes (e.g. an AWS call's dial to *.amazonaws.com).
+// It carries no metadata, so it's hidden unless the operator opts in. A
+// denied dial is a blocked egress and is never hidden.
+function isQuietDial(ev: EventRecord): boolean {
+  return ev.method === "dial" && !isDeniedAction(ev);
+}
+
 export function LiveRequests({
   agentIP,
   max = 200,
@@ -17,6 +29,11 @@ export function LiveRequests({
   height?: string;
 }) {
   const [events, setEvents] = useState<RowState[]>([]);
+  // Allowed brokered "dial" actions are the plumbing behind a plugin
+  // endpoint (an AWS API call's gateway→AWS dial); they carry no metadata
+  // and just clutter the log, so hide them by default. Denied dials are a
+  // real egress block and always show (isQuietDial excludes them).
+  const [showDials, setShowDials] = useState(false);
   const { byFamily } = useFacets();
 
   useEffect(() => {
@@ -72,6 +89,9 @@ export function LiveRequests({
     };
   }, [agentIP, max]);
 
+  const hiddenDials = events.reduce((n, e) => n + (isQuietDial(e) ? 1 : 0), 0);
+  const shown = showDials ? events : events.filter((e) => !isQuietDial(e));
+
   return (
     <div
       className="flex flex-col bg-canvas border-1.5 border-navy overflow-hidden"
@@ -81,18 +101,28 @@ export function LiveRequests({
         <span>Live requests</span>
         <span className="ml-2 text-success-500 tabular-nums flex items-center gap-1">
           <span className="w-1.5 h-1.5 rounded-full bg-success-500 animate-pulse" />
-          {events.length}
+          {shown.length}
         </span>
+        {hiddenDials > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowDials((v) => !v)}
+            className="ml-auto normal-case tracking-normal font-normal text-2xs text-text-subtle hover:text-text-muted"
+            title="Brokered upstream dials carry no metadata; hidden by default"
+          >
+            {showDials ? "hide" : "show"} {hiddenDials} dial{hiddenDials === 1 ? "" : "s"}
+          </button>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto">
-        {events.length === 0 ? (
+        {shown.length === 0 ? (
           <div className="px-5 py-8 text-center text-xs text-text-subtle flex items-center justify-center gap-2">
             <span className="w-1.5 h-1.5 rounded-full bg-success-500 animate-pulse" />
             Waiting for requests
             <AnimatedDots />
           </div>
         ) : (
-          events.map((e, i) => (
+          shown.map((e, i) => (
             <Row key={i} ev={e} schema={e.family ? byFamily[e.family] : undefined} />
           ))
         )}
@@ -157,19 +187,21 @@ function rowDescriptors(
 ): { verb: string; body: string } {
   const facets = ev.facets ?? {};
   if (schema && Object.keys(facets).length > 0) {
-    // Convention shared by the built-in facets: the leading column
-    // is either "method" (HTTPS) or "verb" (SQL / k8s); the rest of
-    // the report fields render into the trailing body. The schema
-    // controls how each value formats.
-    const leadName =
-      schema.report_fields.find((f) => f.name === "method")?.name ??
-      schema.report_fields.find((f) => f.name === "verb")?.name ??
-      "";
-    const verbField = leadName ? schema.report_fields.find((f) => f.name === leadName) : undefined;
-    const verb = verbField ? formatFacetValue(verbField.kind, facets[leadName]) : "";
+    // The leading column (the "verb") is the field the facet marks as
+    // `title` — e.g. an AWS plugin marks iam_action so the row reads
+    // "s3:ListBucket" rather than "POST". Facets that declare no title
+    // (the built-ins) fall back to the method/verb-named field. The rest
+    // of the report fields render into the trailing body, except those
+    // marked `detail_only` (kept for the per-action detail view).
+    const lead =
+      schema.report_fields.find((f) => f.title) ??
+      schema.report_fields.find((f) => f.name === "method") ??
+      schema.report_fields.find((f) => f.name === "verb");
+    const verb = lead ? formatFacetValue(lead.kind, facets[lead.name]) : "";
     const bodyParts: string[] = [];
     for (const f of schema.report_fields) {
-      if (f.name === leadName) continue;
+      if (lead && f.name === lead.name) continue;
+      if (f.detail_only) continue;
       // Status is rendered in its own coloured slot below — don't
       // duplicate it in the body.
       if (f.name === "status") continue;

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -584,43 +584,62 @@ function headerFromFacets(
 // report-field the schema declares for which the event carries a
 // non-empty value; unknown families fall back to the raw facets
 // object so the operator still sees what was captured.
-function facetDetailRows(
-  ev: EventRecord,
-  schema: FacetSchema | undefined,
-): Array<{ name: string; label: string; value: string }> {
+type FacetRow = { key: string; facet: string; description: string; value: string };
+
+function facetDetailRows(ev: EventRecord, schema: FacetSchema | undefined): FacetRow[] {
   const facets = ev.facets;
   if (!facets || Object.keys(facets).length === 0) return [];
   if (!schema) {
     return Object.entries(facets).map(([k, v]) => ({
-      name: k,
-      label: k,
+      key: k,
+      facet: k,
+      description: "",
       value: typeof v === "string" ? v : JSON.stringify(v),
     }));
   }
-  const out: Array<{ name: string; label: string; value: string }> = [];
+  const out: FacetRow[] = [];
   for (const f of schema.report_fields) {
     const v = formatFacetValue(f.kind, facets[f.name]);
-    if (v) out.push({ name: f.name, label: f.label || f.name, value: v });
+    if (!v) continue;
+    out.push({
+      // The fully-qualified CEL name (e.g. "aws.action") is what an
+      // operator writes in a matching rule — show it verbatim.
+      key: f.name,
+      facet: `${schema.name}.${f.name}`,
+      description: f.description || f.label || "",
+      value: v,
+    });
   }
   return out;
 }
 
-// Facets renders the per-family report payload using the same
-// monospace key:value layout as the Request/Response headers list,
-// so the detail page reads consistently regardless of which facet
-// owns the row. No masking: the facets payload is policy metadata,
+// Facets renders the per-family report payload as a three-column table —
+// the fully-qualified facet name (what you write in a rule), a human
+// description, and the captured value — so an operator can see exactly
+// what's matchable. No masking: the facets payload is policy metadata,
 // not secret material (credentials live in headers).
-function Facets({ rows }: { rows: Array<{ name: string; label: string; value: string }> }) {
+function Facets({ rows }: { rows: FacetRow[] }) {
   return (
-    <pre className="overflow-auto whitespace-pre-wrap break-all px-4 py-3 font-mono text-xs leading-relaxed">
-      {rows.map((r) => (
-        <div key={r.name}>
-          <span className="font-semibold text-text">{r.label}</span>
-          <span className="text-text-subtle">: </span>
-          <span className="text-text-muted">{r.value}</span>
-        </div>
-      ))}
-    </pre>
+    <div className="overflow-auto px-4 py-3">
+      <table className="w-full font-mono text-xs">
+        <thead>
+          <tr className="text-2xs uppercase tracking-wider text-text-subtle">
+            <th className="text-left font-semibold pb-1.5 pr-4">Facet</th>
+            <th className="text-left font-semibold pb-1.5 pr-4">Description</th>
+            <th className="text-left font-semibold pb-1.5">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.key} className="align-top border-t border-canvas-muted">
+              <td className="py-1.5 pr-4 font-semibold text-text whitespace-nowrap">{r.facet}</td>
+              <td className="py-1.5 pr-4 text-text-subtle">{r.description}</td>
+              <td className="py-1.5 text-text-muted break-all">{r.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -14,7 +14,7 @@ import { formatFacetValue, useFacets } from "../lib/facets";
 import { fmtDateTime } from "../lib/format";
 import { Button } from "./Button";
 import { CopyButton } from "./CopyButton";
-import { ApprovalStatusIcon, LockGlyph } from "./LiveRequests";
+import { ApprovalStatusIcon, LockGlyph, rowDescriptors } from "./LiveRequests";
 import { Main } from "./Main";
 import { Modal } from "./Modal";
 import { PageTitle, type Crumb } from "./PageTitle";
@@ -95,7 +95,7 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
         verb: ((ev.facets?.verb as string | undefined) ?? ev.method ?? "").toUpperCase(),
         body: "",
       }
-    : headerFromFacets(ev, schema);
+    : rowDescriptors(ev, schema);
   const { verb, body } = header;
   const fullUrl = ev.host + (body && !body.startsWith("/") ? " " : "") + body;
   const facetFields = facetDetailRows(ev, schema);
@@ -549,34 +549,6 @@ function Shell({
       {children}
     </Main>
   );
-}
-
-// headerFromFacets picks the verb + body strings for the event
-// header. With a known facet schema, the leading column is
-// method/verb and the trailing body collapses every other report
-// field (status excepted, since it has its own coloured slot). New
-// protocol facets render correctly without touching this file.
-function headerFromFacets(
-  ev: EventRecord,
-  schema: FacetSchema | undefined,
-): { verb: string; body: string } {
-  const facets = ev.facets ?? {};
-  if (schema && Object.keys(facets).length > 0) {
-    const leadName =
-      schema.report_fields.find((f) => f.name === "method")?.name ??
-      schema.report_fields.find((f) => f.name === "verb")?.name ??
-      "";
-    const verbField = leadName ? schema.report_fields.find((f) => f.name === leadName) : undefined;
-    const verb = verbField ? formatFacetValue(verbField.kind, facets[leadName]) : "";
-    const bodyParts: string[] = [];
-    for (const f of schema.report_fields) {
-      if (f.name === leadName || f.name === "status") continue;
-      const v = formatFacetValue(f.kind, facets[f.name]);
-      if (v) bodyParts.push(v);
-    }
-    return { verb, body: bodyParts.join(" · ") };
-  }
-  return { verb: ev.method ?? "", body: ev.path ?? "" };
 }
 
 // facetDetailRows returns the per-family fields shown in the

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -613,13 +613,25 @@ export async function applyGeneratedRule(
 // dashboard fetches it once at boot and uses it to render
 // per-family columns from the facets payload without hardcoding the
 // list of protocol families.
+export type FacetField = {
+  name: string;
+  kind: string;
+  label?: string;
+  // description: longer explanation for the per-action facet table.
+  description?: string;
+  // title: this field's value is the row's primary identifier (the "verb").
+  title?: boolean;
+  // detail_only: omit from the compact activity-log row (still in detail).
+  detail_only?: boolean;
+};
+
 export type FacetSchema = {
   name: string;
   endpoint_families: string[];
   transport?: string;
   hitl_query_label?: string;
   host_is_resource: boolean;
-  report_fields: Array<{ name: string; kind: string; label?: string }>;
+  report_fields: Array<FacetField>;
 };
 
 export async function getFacets(): Promise<FacetSchema[]> {

--- a/internal/config/extplugin/facet.go
+++ b/internal/config/extplugin/facet.go
@@ -127,9 +127,12 @@ func protoFacetFieldsToSpec(in []*pb.FacetFieldDecl) []facet.ReportFieldSpec {
 	out := make([]facet.ReportFieldSpec, 0, len(in))
 	for _, f := range in {
 		out = append(out, facet.ReportFieldSpec{
-			Name:  f.Name,
-			Kind:  pluginFacetKind(f.Kind),
-			Label: f.Label,
+			Name:        f.Name,
+			Kind:        pluginFacetKind(f.Kind),
+			Label:       f.Label,
+			Description: f.Description,
+			Title:       f.Title,
+			DetailOnly:  f.DetailOnly,
 		})
 	}
 	return out

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -563,7 +563,20 @@ type FacetFieldDecl struct {
 	// The gateway substitutes a kind-zero value (empty string, empty
 	// list, empty map, 0) before CEL evaluation so rule conditions
 	// can reference them without `has()` guards.
-	Optional      bool `protobuf:"varint,4,opt,name=optional,proto3" json:"optional,omitempty"`
+	Optional bool `protobuf:"varint,4,opt,name=optional,proto3" json:"optional,omitempty"`
+	// description is a human explanation of the field shown in the
+	// dashboard's per-action facet table (e.g. "API action (CloudTrail)").
+	// Falls back to label when empty.
+	Description string `protobuf:"bytes,5,opt,name=description,proto3" json:"description,omitempty"`
+	// title marks the single field whose value is the action's primary
+	// identifier — shown as the activity log's "verb" instead of the HTTP
+	// method (e.g. an AWS plugin marks iam_action). At most one per facet.
+	Title bool `protobuf:"varint,6,opt,name=title,proto3" json:"title,omitempty"`
+	// detail_only keeps the field out of the compact activity-log row
+	// (it still appears in the per-action detail). Use for fields made
+	// redundant by the title field (e.g. AWS action/service once
+	// iam_action is the title).
+	DetailOnly    bool `protobuf:"varint,7,opt,name=detail_only,json=detailOnly,proto3" json:"detail_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -622,6 +635,27 @@ func (x *FacetFieldDecl) GetLabel() string {
 func (x *FacetFieldDecl) GetOptional() bool {
 	if x != nil {
 		return x.Optional
+	}
+	return false
+}
+
+func (x *FacetFieldDecl) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *FacetFieldDecl) GetTitle() bool {
+	if x != nil {
+		return x.Title
+	}
+	return false
+}
+
+func (x *FacetFieldDecl) GetDetailOnly() bool {
+	if x != nil {
+		return x.DetailOnly
 	}
 	return false
 }
@@ -4453,12 +4487,16 @@ const file_plugin_proto_rawDesc = "" +
 	"privileged\"]\n" +
 	"\tFacetDecl\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
-	"\x06fields\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.FacetFieldDeclR\x06fields\"\x8b\x01\n" +
+	"\x06fields\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.FacetFieldDeclR\x06fields\"\xe4\x01\n" +
 	"\x0eFacetFieldDecl\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x123\n" +
 	"\x04kind\x18\x02 \x01(\x0e2\x1f.clawpatrol.plugin.v1.FacetKindR\x04kind\x12\x14\n" +
 	"\x05label\x18\x03 \x01(\tR\x05label\x12\x1a\n" +
-	"\boptional\x18\x04 \x01(\bR\boptional\"C\n" +
+	"\boptional\x18\x04 \x01(\bR\boptional\x12 \n" +
+	"\vdescription\x18\x05 \x01(\tR\vdescription\x12\x14\n" +
+	"\x05title\x18\x06 \x01(\bR\x05title\x12\x1f\n" +
+	"\vdetail_only\x18\a \x01(\bR\n" +
+	"detailOnly\"C\n" +
 	"\x06Schema\x129\n" +
 	"\x06fields\x18\x01 \x03(\v2!.clawpatrol.plugin.v1.SchemaFieldR\x06fields\"^\n" +
 	"\vSchemaField\x12\x12\n" +

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -101,6 +101,19 @@ message FacetFieldDecl {
   // list, empty map, 0) before CEL evaluation so rule conditions
   // can reference them without `has()` guards.
   bool optional = 4;
+  // description is a human explanation of the field shown in the
+  // dashboard's per-action facet table (e.g. "API action (CloudTrail)").
+  // Falls back to label when empty.
+  string description = 5;
+  // title marks the single field whose value is the action's primary
+  // identifier — shown as the activity log's "verb" instead of the HTTP
+  // method (e.g. an AWS plugin marks iam_action). At most one per facet.
+  bool title = 6;
+  // detail_only keeps the field out of the compact activity-log row
+  // (it still appears in the per-action detail). Use for fields made
+  // redundant by the title field (e.g. AWS action/service once
+  // iam_action is the title).
+  bool detail_only = 7;
 }
 
 enum FacetKind {

--- a/internal/config/facet/facet.go
+++ b/internal/config/facet/facet.go
@@ -112,6 +112,16 @@ type ReportFieldSpec struct {
 	Name  string
 	Kind  ReportValueKind
 	Label string
+	// Description is a longer explanation shown in the dashboard's
+	// per-action facet table; falls back to Label when empty.
+	Description string
+	// Title marks the field whose value is the action's primary
+	// identifier — the activity log renders it as the "verb" instead of
+	// the HTTP method. At most one field per facet sets it.
+	Title bool
+	// DetailOnly keeps the field out of the compact activity-log row; it
+	// still appears in the per-action detail table.
+	DetailOnly bool
 }
 
 // registry holds every facet registered at init time. The blank-

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -125,6 +125,18 @@ type FacetField struct {
 	Kind     FacetKind
 	Label    string
 	Optional bool
+	// Description is a human explanation of the field, shown in the
+	// dashboard's per-action facet table (e.g. "API action (CloudTrail)").
+	// Falls back to Label when empty.
+	Description string
+	// Title marks this as the action's primary identifier — shown as the
+	// activity log's "verb" instead of the HTTP method. At most one field
+	// per facet should set it (e.g. an AWS plugin marks iam_action).
+	Title bool
+	// DetailOnly keeps the field out of the compact activity-log row (it
+	// still appears in the per-action detail). Use for fields the Title
+	// makes redundant (e.g. AWS action/service once iam_action is Title).
+	DetailOnly bool
 }
 
 // FacetKind mirrors pb.FacetKind.

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -177,10 +177,13 @@ func (s *server) Manifest(_ context.Context, _ *pb.ManifestRequest) (*pb.Manifes
 		fields := make([]*pb.FacetFieldDecl, 0, len(f.Fields))
 		for _, fld := range f.Fields {
 			fields = append(fields, &pb.FacetFieldDecl{
-				Name:     fld.Name,
-				Kind:     pb.FacetKind(fld.Kind),
-				Label:    fld.Label,
-				Optional: fld.Optional,
+				Name:        fld.Name,
+				Kind:        pb.FacetKind(fld.Kind),
+				Label:       fld.Label,
+				Optional:    fld.Optional,
+				Description: fld.Description,
+				Title:       fld.Title,
+				DetailOnly:  fld.DetailOnly,
 			})
 		}
 		resp.Facets = append(resp.Facets, &pb.FacetDecl{Name: f.Name, Fields: fields})


### PR DESCRIPTION
Makes the activity log read sensibly for plugin endpoints like AWS, where
the useful identifier is the IAM/API action, not the HTTP method.

A facet field gains three optional attributes, plumbed proto → SDK → facet
registry → `/api/facets` → dashboard:

* **`title`** — the field whose value is the action's primary identifier.
  The activity-log verb becomes this instead of the HTTP method, so an AWS
  plugin marking `iam_action` makes a row read `s3:ListBucket`, not `POST`.
* **`description`** — a human explanation shown in the per-action facet
  table (e.g. "API action (CloudTrail)").
* **`detail_only`** — keep a field out of the compact row (still in detail).

Dashboard:

* verb = the title field (falling back to today's method/verb heuristic),
  and the inline body drops `detail_only` fields.
* the per-action facet block is now a **three-column table** —
  fully-qualified facet name (`aws.action`, what you write in a rule),
  description, value — so it's obvious what's matchable.
* allowed brokered `dial` rows (a plugin endpoint's gateway→upstream dial,
  no metadata) are hidden by default behind a "show N dials" toggle;
  **denied** dials (a blocked egress) always show.

Defaults preserve today's behavior for every existing facet; the AWS
plugin populates the new attributes in a companion release.