### PR TITLE
status: free-form string + plugin-reported outcomes via ActionResult

### DIFF
--- a/cmd/clawpatrol/dev_seed.go
+++ b/cmd/clawpatrol/dev_seed.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strconv"
 	"sync"
 	"time"
 
@@ -463,7 +464,7 @@ func devSeedAction(r *rand.Rand, devices []devSeedDevice, ts time.Time) Event {
 		Host:     ep.host,
 		Method:   method,
 		Path:     path,
-		Status:   status,
+		Status:   strconv.Itoa(status),
 		In:       int64(50 + r.Intn(10000)),
 		Out:      int64(50 + r.Intn(50000)),
 		Ms:       devSeedLatency(r),

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2428,7 +2428,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				status, contentType, body := hitlRetryRelayFailure(err)
 				log.Printf("hitl retry rejected %s %s %s operation %q: %v", host, req.Method, req.URL.Path, retryOperationID, err)
 				_, _ = fmt.Fprintf(tc, "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", status, http.StatusText(status), contentType, len(body), body)
-				ev.Status = status
+				ev.Status = strconv.Itoa(status)
 				ev.Action = "hitl_retry_rejected"
 				ev.Reason = hitlRetryMismatchErrorValue
 				if status == http.StatusNotFound {
@@ -2492,7 +2492,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 						log.Printf("hitl async pending response write %s: %v", asyncOp.ID, err)
 					}
 					_ = tc.SetWriteDeadline(time.Time{})
-					ev.Status = http.StatusAccepted
+					ev.Status = "202"
 					ev.Action = "hitl_async_pending"
 					ev.Approver = v.ApproverName
 					ev.ApproverType = v.ApproverType
@@ -2514,7 +2514,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				log.Printf("denied %s %s %s: %s (by %s/%s/%s)",
 					host, req.Method, req.URL.Path, reason, v.ApproverType, v.ApproverName, v.By)
 				_, _ = fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
-				ev.Status = 403
+				ev.Status = "403"
 				ev.Action = "denied"
 				ev.Approver = v.ApproverName
 				ev.ApproverType = v.ApproverType
@@ -2552,7 +2552,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				}
 			}
 			_, _ = fmt.Fprintf(tc, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reason), reason)
-			ev.Status = 403
+			ev.Status = "403"
 			ev.Action = "deny"
 			ev.Reason = reason
 			ev.Ms = time.Since(start).Milliseconds()
@@ -2600,7 +2600,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				if r.Body != nil {
 					defer func() { _ = r.Body.Close() }()
 				}
-				ev.Status = r.StatusCode
+				ev.Status = strconv.Itoa(r.StatusCode)
 				ev.Action = "synth"
 				// Synthetic responses are clawpatrol-generated, so the
 				// stock plugins don't set auth-bearing headers — but
@@ -2686,7 +2686,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 							if rw, ok := injector.(runtime.HTTPRequestRewriter); ok && rw.RewritesHTTPRequest() {
 								log.Printf("transform %s: %v; failing closed", cc.Credential.Symbol.Name, err)
 								_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-								ev.Status = 502
+								ev.Status = "502"
 								ev.Action = "error"
 								ev.Reason = err.Error()
 								ev.Ms = time.Since(start).Milliseconds()
@@ -2747,7 +2747,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 					log.Printf("hitl retry transition %s to %s: %v", hitlRetryConsumedOperation.ID, HITLOperationStateUpstreamSucceeded, err)
 				}
 			}
-			ev.Status = 101
+			ev.Status = "101"
 			ev.Ms = time.Since(start).Milliseconds()
 			g.emitEnd(ev)
 			return
@@ -2792,7 +2792,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				}
 			}
 			_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-			ev.Status = 502
+			ev.Status = "502"
 			ev.Action = "error"
 			ev.Reason = err.Error()
 			ev.Ms = time.Since(start).Milliseconds()
@@ -2885,7 +2885,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 				log.Printf("hitl async operation upstream terminal %s: %v", asyncOp.ID, err)
 			}
 		}
-		ev.Status = resp.StatusCode
+		ev.Status = strconv.Itoa(resp.StatusCode)
 		ev.ReqHeaders = flatHeadersRedacted(req.Header, reqBodySecretRedactions)
 		ev.In = reqS.n
 		ev.Out = respS.n

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2032,6 +2032,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 			}
 			g.sink.Emit(Event{
 				Mode: mode, Family: ep.Family, Host: eventHost, AgentIP: agentPip,
+				ID: ev.ID, Phase: ev.Phase, Status: ev.Status,
 				Method: ev.Verb, Path: ev.Summary,
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,

--- a/cmd/clawpatrol/otel.go
+++ b/cmd/clawpatrol/otel.go
@@ -297,23 +297,12 @@ func otelRecordVerdict(verdict string) {
 	))
 }
 
-func otelRecordRequest(d time.Duration, verdict string, status int) {
+func otelRecordRequest(d time.Duration, verdict, status string) {
 	if mReqDuration == nil {
 		return
 	}
-	klass := ""
-	switch {
-	case status >= 500:
-		klass = "5xx"
-	case status >= 400:
-		klass = "4xx"
-	case status >= 300:
-		klass = "3xx"
-	case status >= 200:
-		klass = "2xx"
-	}
 	mReqDuration.Record(context.Background(), d.Seconds(), metric.WithAttributes(
 		attribute.String("verdict", verdict),
-		attribute.String("status_class", klass),
+		attribute.String("status_class", statusClass(status)),
 	))
 }

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -2248,9 +2248,16 @@ func (w *webMux) apiAnalytics(
 	// the same range + agent as the events query above.
 	var totalCount int64
 	var errorCount sql.NullInt64
+	// Mirror statusClass: an error is a non-empty status that is either
+	// non-numeric (a named plugin error like "AccessDenied") or a numeric
+	// HTTP status >= 400. A bare `status >= 400` is wrong now that status is
+	// TEXT — SQLite sorts every text value above all numbers, so it would
+	// count "", "OK", and every named status as an error.
 	_ = w.g.db.QueryRow(
 		`SELECT COUNT(*),
-		        SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END)
+		        SUM(CASE WHEN status IS NOT NULL AND status <> ''
+		                  AND (NOT (status GLOB '[0-9]*') OR CAST(status AS INTEGER) >= 400)
+		                 THEN 1 ELSE 0 END)
 		 FROM actions WHERE `+where, whereArgs...,
 	).Scan(&totalCount, &errorCount)
 

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1759,7 +1759,7 @@ func (w *webMux) loadAction(actionID string) (*Event, error) {
 		agentIP      sql.NullString
 		method       sql.NullString
 		path         sql.NullString
-		status       sql.NullInt64
+		status       sql.NullString
 		in, ot       sql.NullInt64
 		ms           sql.NullInt64
 		action       sql.NullString
@@ -1805,7 +1805,7 @@ func (w *webMux) loadAction(actionID string) (*Event, error) {
 	e.AgentIP = agentIP.String
 	e.Method = method.String
 	e.Path = path.String
-	e.Status = int(status.Int64)
+	e.Status = status.String
 	e.In = in.Int64
 	e.Out = ot.Int64
 	e.Ms = ms.Int64
@@ -2205,7 +2205,7 @@ func (w *webMux) apiAnalytics(
 			agentIP  sql.NullString
 			method   sql.NullString
 			path     sql.NullString
-			status   sql.NullInt64
+			status   sql.NullString
 			in, ot   sql.NullInt64
 			ms       sql.NullInt64
 			action   sql.NullString
@@ -2227,7 +2227,7 @@ func (w *webMux) apiAnalytics(
 		e.AgentIP = agentIP.String
 		e.Method = method.String
 		e.Path = path.String
-		e.Status = int(status.Int64)
+		e.Status = status.String
 		e.In = in.Int64
 		e.Out = ot.Int64
 		e.Ms = ms.Int64
@@ -2370,6 +2370,33 @@ func writeJSON(rw http.ResponseWriter, v any) {
 // Event sink + sampling helpers (fed by g.handle/mitm/splice; consumed
 // by the dashboard SSE stream and the on-disk event log).
 
+// statusClass buckets a status string for metrics + dashboard coloring: a
+// numeric HTTP-style status by its leading digit (2xx..5xx), a non-empty
+// non-numeric status (e.g. a plugin's "AccessDenied") as "error" — a named
+// status is a failure; a successful plugin reports a 2xx — and an empty
+// status as "".
+func statusClass(status string) string {
+	if status == "" {
+		return ""
+	}
+	n, err := strconv.Atoi(status)
+	if err != nil {
+		return "error"
+	}
+	switch {
+	case n >= 500:
+		return "5xx"
+	case n >= 400:
+		return "4xx"
+	case n >= 300:
+		return "3xx"
+	case n >= 200:
+		return "2xx"
+	default:
+		return ""
+	}
+}
+
 type Event struct {
 	Ts      time.Time `json:"ts"`
 	ID      string    `json:"id,omitempty"`    // UUIDv7; correlates start/end/frame + DB key
@@ -2380,7 +2407,7 @@ type Event struct {
 	Host    string    `json:"host"`
 	Method  string    `json:"method,omitempty"`
 	Path    string    `json:"path,omitempty"`
-	Status  int       `json:"status,omitempty"`
+	Status  string    `json:"status,omitempty"`
 	In      int64     `json:"in,omitempty"`
 	Out     int64     `json:"out,omitempty"`
 	Ms      int64     `json:"ms"`
@@ -2509,7 +2536,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 			agentIP      sql.NullString
 			method       sql.NullString
 			path         sql.NullString
-			status       sql.NullInt64
+			status       sql.NullString
 			in, ot       sql.NullInt64
 			ms           sql.NullInt64
 			action       sql.NullString
@@ -2541,7 +2568,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		e.AgentIP = agentIP.String
 		e.Method = method.String
 		e.Path = path.String
-		e.Status = int(status.Int64)
+		e.Status = status.String
 		e.In = in.Int64
 		e.Out = ot.Int64
 		e.Ms = ms.Int64

--- a/dashboard/src/components/AnalyticsPage.tsx
+++ b/dashboard/src/components/AnalyticsPage.tsx
@@ -1,6 +1,7 @@
 import * as Plot from "@observablehq/plot";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getAnalytics, type Agent, type EventRecord } from "../lib/api";
+import { statusClass } from "../lib/format";
 import { Main } from "./Main";
 import { PageTitle, type Crumb } from "./PageTitle";
 import { Tag } from "./Tag";
@@ -144,7 +145,10 @@ export function AnalyticsPage({ ip, agents }: { ip?: string; agents: Agent[] }) 
     const p99 = lats.length ? lats[Math.min(Math.floor(lats.length * 0.99), lats.length - 1)] : 0;
     const devices = new Set(filtered.map((e) => e.agent_ip).filter(Boolean)).size;
     if (hasFilter) {
-      const errs = filtered.filter((e) => (e.status ?? 0) >= 400).length;
+      const errs = filtered.filter((e) => {
+        const c = statusClass(e.status);
+        return c === "4xx" || c === "5xx" || c === "error";
+      }).length;
       const errPct = sampleN > 0 ? (errs / sampleN) * 100 : 0;
       return { n: sampleN, avg, p99, errPct, devices };
     }
@@ -337,16 +341,8 @@ function LatencyChart({
         host: e.host,
         id: e.id,
         device: agentNames.get(e.agent_ip ?? "") ?? e.agent_ip ?? "?",
-        statusCode: e.status ?? 0,
-        status: e.status
-          ? e.status >= 500
-            ? "5xx"
-            : e.status >= 400
-              ? "4xx"
-              : e.status >= 300
-                ? "3xx"
-                : "2xx"
-          : "\u2014",
+        statusCode: e.status ?? "",
+        status: statusClass(e.status) || "\u2014",
       }));
 
     const colorField = colorBy === "status" ? "status" : colorBy === "device" ? "device" : "host";

--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { type EventRecord, type FacetSchema } from "../lib/api";
 import { formatFacetValue, useFacets } from "../lib/facets";
-import { fmtTime } from "../lib/format";
+import { fmtTime, statusColorClass } from "../lib/format";
 
 type RowState = EventRecord & {
   frames?: { direction: string; frame: string; ts: string }[];
@@ -224,18 +224,8 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
     : undefined;
   const time = fmtTime(ev.ts);
   const inFlight = ev.phase === "start";
-  const status = ev.status || 0;
-  const statusColor = inFlight
-    ? "text-text-subtle"
-    : status >= 500
-      ? "text-danger-500"
-      : status >= 400
-        ? "text-rust-500"
-        : status >= 300
-          ? "text-butter-600"
-          : status >= 200
-            ? "text-success-600"
-            : "text-text-muted";
+  const status = ev.status ?? "";
+  const statusColor = inFlight ? "text-text-subtle" : statusColorClass(status);
   const { verb, body } = rowDescriptors(ev, schema);
   const sep = body && !body.startsWith("/") ? " " : "";
   // "splice"/"relay" forward the bytes without inspecting them, so
@@ -262,7 +252,10 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
         <span className="font-mono text-2xs uppercase font-semibold text-text-muted shrink-0 w-11 flex items-center">
           {inspected ? verb : <LockGlyph />}
         </span>
-        <span className={"text-xs tabular-nums shrink-0 w-9 " + statusColor}>
+        <span
+          className={"text-xs shrink-0 w-14 truncate " + statusColor}
+          title={status || undefined}
+        >
           {inFlight ? <InFlightSpinner /> : status || "—"}
         </span>
         <span className="text-xs text-text truncate flex-1 min-w-0" title={ev.host + sep + body}>

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "../lib/api";
 import { copyText, headersToJSON } from "../lib/clipboard";
 import { formatFacetValue, useFacets } from "../lib/facets";
-import { fmtDateTime } from "../lib/format";
+import { fmtDateTime, statusColorClass } from "../lib/format";
 import { Button } from "./Button";
 import { CopyButton } from "./CopyButton";
 import { ApprovalStatusIcon, LockGlyph, rowDescriptors } from "./LiveRequests";
@@ -70,17 +70,8 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
   }
 
   const time = fmtDateTime(ev.ts);
-  const status = ev.status || 0;
-  const statusColor =
-    status >= 500
-      ? "text-danger-500"
-      : status >= 400
-        ? "text-rust-500"
-        : status >= 300
-          ? "text-butter-600"
-          : status >= 200
-            ? "text-success-600"
-            : "text-text-muted";
+  const status = ev.status ?? "";
+  const statusColor = statusColorClass(status);
   const schema = ev.family ? byFamily[ev.family] : undefined;
   // SQL-family records come from the postgres / clickhouse_native
   // conn-family plugins. They populate Facets with verb / tables /
@@ -126,9 +117,7 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
             )
           )}
           {!isSQL && (
-            <span className={"text-sm tabular-nums font-semibold " + statusColor}>
-              {status || "\u2014"}
-            </span>
+            <span className={"text-sm font-semibold " + statusColor}>{status || "\u2014"}</span>
           )}
           <span className="text-sm text-text break-all font-mono" title={fullUrl}>
             {fullUrl}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -529,7 +529,7 @@ export type EventRecord = {
   host: string;
   method?: string;
   path?: string;
-  status?: number;
+  status?: string;
   in?: number;
   out?: number;
   ms: number;

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -86,3 +86,37 @@ export function fmtExpiry(unix?: number): string {
   if (sec < 86400) return "in " + Math.floor(sec / 3600) + "h";
   return "in " + Math.floor(sec / 86400) + "d";
 }
+
+// statusClass buckets an action status string for coloring + analytics: a
+// numeric HTTP-style status by its leading digit, a non-empty non-numeric
+// status (e.g. a plugin's "AccessDenied") as "error" — a named status is a
+// failure; success reports a 2xx — and an empty status as "".
+export function statusClass(
+  status: string | undefined,
+): "" | "2xx" | "3xx" | "4xx" | "5xx" | "error" {
+  if (!status) return "";
+  const n = Number(status);
+  if (Number.isNaN(n)) return "error";
+  if (n >= 500) return "5xx";
+  if (n >= 400) return "4xx";
+  if (n >= 300) return "3xx";
+  if (n >= 200) return "2xx";
+  return "";
+}
+
+// statusColorClass maps a status string to a Tailwind text color.
+export function statusColorClass(status: string | undefined): string {
+  switch (statusClass(status)) {
+    case "5xx":
+      return "text-danger-500";
+    case "error":
+    case "4xx":
+      return "text-rust-500";
+    case "3xx":
+      return "text-butter-600";
+    case "2xx":
+      return "text-success-600";
+    default:
+      return "text-text-muted";
+  }
+}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/denoland/clawpatrol/internal/config/match"
 	"github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"github.com/google/uuid"
 	"golang.org/x/net/http/httpguts"
 )
 
@@ -190,11 +191,15 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 	// Evaluate over the broker (no EvaluateAction frame / call_id) — the
 	// session closure runs the same evaluateDecoded core the frame handler
 	// does. Removed when the connection ends so no context dangles.
+	// rs carries the start→end lifecycle for this conn's actions, shared by
+	// the inline (HostControl) and frame evaluate paths and the ActionResult
+	// handler in pumpConn.
+	rs := newResultState(ch)
 	var sessionToken string
 	if a.client != nil && a.client.sessions != nil {
 		tok, remove := a.client.sessions.register(&session{
 			evaluate: func(_ context.Context, _ string, actionJSON []byte, summary string) (Verdict, error) {
-				return evaluateInline(ch, summary, actionJSON), nil
+				return evaluateInline(ch, rs, summary, actionJSON), nil
 			},
 		})
 		sessionToken = tok
@@ -225,7 +230,7 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 		return fmt.Errorf("extplugin: send ConnInit: %w", err)
 	}
 
-	return pumpConn(ctx, conn, stream, ch)
+	return pumpConn(ctx, conn, stream, ch, rs)
 }
 
 // pumpConn runs two goroutines:
@@ -244,7 +249,11 @@ func (a *endpointAdapter) HandleConn(ctx context.Context, ch *runtime.ConnHandle
 // sendMu serializes everything that writes to the stream — the data
 // pump, async event forwarding, the close on shutdown, and verdict
 // replies fired from per-evaluate goroutines.
-func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnClient, ch *runtime.ConnHandle) error {
+func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnClient, ch *runtime.ConnHandle, rs *resultState) error {
+	// Guarantee an end event for every started action: a plugin that
+	// doesn't report (or a dropped conn) still persists its in-flight
+	// action with an empty status rather than leaving an orphaned start.
+	defer rs.flush()
 	var sendMu sync.Mutex
 	doSend := func(m *pb.ConnMessage) error {
 		sendMu.Lock()
@@ -351,7 +360,7 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 				// Run rule + approve chain off the recv loop so a
 				// HITL-blocking call doesn't stall data flow or
 				// other concurrent evaluations.
-				go handleEvaluate(ctx, ch, k.Evaluate, doSend, streamReply)
+				go handleEvaluate(ctx, ch, rs, k.Evaluate, doSend, streamReply)
 			case *pb.ConnMessage_StreamChunk:
 				replyCh := getStreamCh(k.StreamChunk.Handle)
 				select {
@@ -383,6 +392,12 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 					dials.remove(k.DialClose.DialId)
 					d.close()
 				}
+			case *pb.ConnMessage_Result:
+				// The plugin reports an action's outcome after the response;
+				// finalize the conn's in-flight action (emit its end event
+				// carrying the status). Synchronous so it completes before the
+				// trailing Close frame, leaving the flush-on-return a no-op.
+				rs.finish(k.Result.ResultJson)
 			case *pb.ConnMessage_Close:
 				pluginDone <- nil
 				return
@@ -458,11 +473,11 @@ const streamCapBytesForLog = 1024
 // ConnEvent so the action lands on the dashboard event sink with
 // the action map as the facet payload — plugins don't need to
 // double-emit via Conn.Emit.
-func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.EvaluateAction, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk) {
+func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, rs *resultState, ev *pb.EvaluateAction, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk) {
 	action, derr := decodeAction(ev.ActionJson)
 	if derr != nil {
 		v := Verdict{Action: "error", Reason: fmt.Sprintf("malformed action_json: %v", derr)}
-		emitEvaluation(ch, ev.Summary, action, v)
+		emitEvaluation(ch, rs, ev.Summary, action, v)
 		_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Verdict{Verdict: actionVerdict(ev.CallId, v)}})
 		return
 	}
@@ -501,7 +516,7 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, ev *pb.Evaluate
 	}
 
 	v := evaluateDecoded(ch, ev.Summary, action, streamBytes, truncated)
-	emitEvaluation(ch, ev.Summary, action, v)
+	emitEvaluation(ch, rs, ev.Summary, action, v)
 	_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Verdict{Verdict: actionVerdict(ev.CallId, v)}})
 }
 
@@ -608,34 +623,133 @@ func evaluateDecoded(ch *runtime.ConnHandle, summary string, action map[string]a
 // event, and returns the verdict. The frame analogue is handleEvaluate; a
 // malformed payload becomes an "error" verdict here too, not a transport
 // error.
-func evaluateInline(ch *runtime.ConnHandle, summary string, actionJSON []byte) Verdict {
+func evaluateInline(ch *runtime.ConnHandle, rs *resultState, summary string, actionJSON []byte) Verdict {
 	action, err := decodeAction(actionJSON)
 	if err != nil {
 		v := Verdict{Action: "error", Reason: fmt.Sprintf("malformed action_json: %v", err)}
-		emitEvaluation(ch, summary, action, v)
+		emitEvaluation(ch, rs, summary, action, v)
 		return v
 	}
 	v := evaluateDecoded(ch, summary, action, nil, false)
-	emitEvaluation(ch, summary, action, v)
+	emitEvaluation(ch, rs, summary, action, v)
 	return v
 }
 
-// emitEvaluation logs one EvaluateAction onto the gateway event
-// sink so the action shows up on the dashboard alongside built-in
-// facet events. Verb / Summary are pulled from the action so the
-// log line is human-readable; the action map rides as Facets.
-func emitEvaluation(ch *runtime.ConnHandle, summary string, action map[string]any, v Verdict) {
+// emitEvaluation logs one EvaluateAction onto the gateway event sink so the
+// action shows up on the dashboard alongside built-in facet events. Verb /
+// Summary are pulled from the action so the log line is human-readable; the
+// action map rides as Facets.
+//
+// When rs is non-nil and the verdict allows the request through, the action
+// is emitted as an in-flight "start" and the lifecycle is handed to rs,
+// which emits the "end" (carrying the plugin-reported Status) once an
+// ActionResult arrives or the connection closes. Terminal verdicts (deny /
+// error — no response is coming) emit a single complete event.
+func emitEvaluation(ch *runtime.ConnHandle, rs *resultState, summary string, action map[string]any, v Verdict) {
 	if ch.Emit == nil {
 		return
 	}
-	ch.Emit(runtime.ConnEvent{
+	ev := runtime.ConnEvent{
 		Action:  v.Action,
 		Reason:  v.Reason,
 		Verb:    stringField(action, "verb"),
 		Summary: summary,
 		Facets:  action,
 		Rule:    v.Rule,
-	})
+	}
+	if rs != nil && (v.Action == "allow" || v.Action == "hitl_allow") {
+		ev.ID = uuid.Must(uuid.NewV7()).String()
+		ev.Phase = "start"
+		rs.begin(ev)
+		return
+	}
+	ch.Emit(ev)
+}
+
+// resultState gives a plugin endpoint's action the same start→end lifecycle
+// the built-in HTTP path uses. emitEvaluation calls begin() with the
+// in-flight "start" event when a request is allowed through; the plugin
+// later reports the outcome via an ActionResult frame (finish), or the
+// connection closes (flush) — either way the action persists exactly once
+// as the "end" event, and the dashboard merges start→end by ID.
+//
+// Conn-scoped, not call_id-scoped: Conn.Evaluate's common no-stream path
+// runs inline over HostControl with no call_id, so the result finalizes the
+// connection's current action. Sequential request/response only — begin()
+// flushes any prior unfinished action so it can't be orphaned.
+type resultState struct {
+	mu      sync.Mutex
+	ch      *runtime.ConnHandle
+	title   string // result-schema title field name → Status
+	pending *runtime.ConnEvent
+	ended   bool
+}
+
+func newResultState(ch *runtime.ConnHandle) *resultState {
+	rs := &resultState{ch: ch}
+	if ch.Endpoint != nil {
+		if pf := facetFor(ch.Endpoint.Family); pf != nil {
+			rs.title = pf.resultTitle
+		}
+	}
+	return rs
+}
+
+func (rs *resultState) begin(ev runtime.ConnEvent) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.flushLocked() // end any prior unfinished action so it isn't orphaned
+	cp := ev
+	rs.pending = &cp
+	rs.ended = false
+	if rs.ch.Emit != nil {
+		rs.ch.Emit(ev)
+	}
+}
+
+// finish emits the end event carrying the plugin-reported status, lifted
+// from the result schema's title field in result_json.
+func (rs *resultState) finish(resultJSON []byte) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if rs.pending == nil || rs.ended {
+		return
+	}
+	end := *rs.pending
+	end.Phase = "end"
+	if rs.title != "" && len(resultJSON) > 0 {
+		var rj map[string]any
+		if json.Unmarshal(resultJSON, &rj) == nil {
+			if val, ok := rj[rs.title]; ok && val != nil {
+				end.Status = fmt.Sprint(val)
+			}
+		}
+	}
+	rs.ended = true
+	if rs.ch.Emit != nil {
+		rs.ch.Emit(end)
+	}
+}
+
+func (rs *resultState) flush() {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.flushLocked()
+}
+
+// flushLocked persists an unfinished action — no ActionResult arrived (a
+// plugin that doesn't report, or a closed conn) — as the end event with an
+// empty status, so the action is never lost. Caller holds rs.mu.
+func (rs *resultState) flushLocked() {
+	if rs.pending == nil || rs.ended {
+		return
+	}
+	end := *rs.pending
+	end.Phase = "end"
+	rs.ended = true
+	if rs.ch.Emit != nil {
+		rs.ch.Emit(end)
+	}
 }
 
 func stringField(m map[string]any, key string) string {

--- a/internal/config/extplugin/facet.go
+++ b/internal/config/extplugin/facet.go
@@ -44,6 +44,12 @@ type pluginFacet struct {
 	// fail-closed-on-truncation contract (req.Truncated marks the
 	// stream paths CEL-unknown) applies to plugin facets.
 	streamFields []string
+	// resultFields is the after-the-fact schema (FacetDecl.result_fields);
+	// resultTitle is the name of the result field marked Title — the
+	// field the adapter lifts into the action's Status. "" when the facet
+	// reports no result schema.
+	resultFields []facet.ReportFieldSpec
+	resultTitle  string
 }
 
 func (p *pluginFacet) Name() string                          { return p.name }
@@ -112,12 +118,22 @@ func registerFacet(pluginName string, decl *pb.FacetDecl) hcl.Diagnostics {
 			streams = append(streams, f.Name)
 		}
 	}
+	resultFields := protoFacetFieldsToSpec(decl.ResultFields)
+	resultTitle := ""
+	for _, rf := range resultFields {
+		if rf.Title {
+			resultTitle = rf.Name
+			break
+		}
+	}
 	pf := &pluginFacet{
 		name:           decl.Name,
 		reportFields:   protoFacetFieldsToSpec(decl.Fields),
 		kindByField:    kindByField,
 		optionalFields: optional,
 		streamFields:   streams,
+		resultFields:   resultFields,
+		resultTitle:    resultTitle,
 	}
 	facet.Register(pf)
 	return nil

--- a/internal/config/extplugin/hostcontrol_test.go
+++ b/internal/config/extplugin/hostcontrol_test.go
@@ -164,7 +164,7 @@ func TestHostControlEvaluateThroughMatcher(t *testing.T) {
 	sessions := newSessionRegistry()
 	token, _ := sessions.register(&session{
 		evaluate: func(_ context.Context, _ string, actionJSON []byte, summary string) (Verdict, error) {
-			return evaluateInline(ch, summary, actionJSON), nil
+			return evaluateInline(ch, nil, summary, actionJSON), nil
 		},
 	})
 

--- a/internal/config/extplugin/proto/plugin.pb.go
+++ b/internal/config/extplugin/proto/plugin.pb.go
@@ -503,9 +503,17 @@ func (x *PluginCapabilities) GetPrivileged() bool {
 // conditions against the declared fields. The facet's name is
 // auto-namespaced by the gateway as "<plugin>.<name>".
 type FacetDecl struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Fields        []*FacetFieldDecl      `protobuf:"bytes,2,rep,name=fields,proto3" json:"fields,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// fields is the request-time schema: what EvaluateAction.action_json
+	// conforms to, and what rules match on.
+	Fields []*FacetFieldDecl `protobuf:"bytes,2,rep,name=fields,proto3" json:"fields,omitempty"`
+	// result_fields is the after-the-fact schema, what ActionResult.result_json
+	// conforms to. It reuses FacetFieldDecl, so title/description/detail_only
+	// and FACET_STREAM apply: the field marked `title` is the action's status,
+	// and a FACET_STREAM result field is a response body the gateway streams
+	// and caps. Empty for facets that report nothing after the response.
+	ResultFields  []*FacetFieldDecl `protobuf:"bytes,3,rep,name=result_fields,json=resultFields,proto3" json:"result_fields,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -550,6 +558,13 @@ func (x *FacetDecl) GetName() string {
 func (x *FacetDecl) GetFields() []*FacetFieldDecl {
 	if x != nil {
 		return x.Fields
+	}
+	return nil
+}
+
+func (x *FacetDecl) GetResultFields() []*FacetFieldDecl {
+	if x != nil {
+		return x.ResultFields
 	}
 	return nil
 }
@@ -2404,6 +2419,7 @@ type ConnMessage struct {
 	//	*ConnMessage_DialReply
 	//	*ConnMessage_DialData
 	//	*ConnMessage_DialClose
+	//	*ConnMessage_Result
 	Kind          isConnMessage_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2563,6 +2579,15 @@ func (x *ConnMessage) GetDialClose() *DialUpstreamClose {
 	return nil
 }
 
+func (x *ConnMessage) GetResult() *ActionResult {
+	if x != nil {
+		if x, ok := x.Kind.(*ConnMessage_Result); ok {
+			return x.Result
+		}
+	}
+	return nil
+}
+
 type isConnMessage_Kind interface {
 	isConnMessage_Kind()
 }
@@ -2619,6 +2644,10 @@ type ConnMessage_DialClose struct {
 	DialClose *DialUpstreamClose `protobuf:"bytes,13,opt,name=dial_close,json=dialClose,proto3,oneof"` // both directions
 }
 
+type ConnMessage_Result struct {
+	Result *ActionResult `protobuf:"bytes,14,opt,name=result,proto3,oneof"` // plugin -> gateway (after-the-fact outcome)
+}
+
 func (*ConnMessage_Init) isConnMessage_Kind() {}
 
 func (*ConnMessage_Data) isConnMessage_Kind() {}
@@ -2644,6 +2673,8 @@ func (*ConnMessage_DialReply) isConnMessage_Kind() {}
 func (*ConnMessage_DialData) isConnMessage_Kind() {}
 
 func (*ConnMessage_DialClose) isConnMessage_Kind() {}
+
+func (*ConnMessage_Result) isConnMessage_Kind() {}
 
 // DialUpstreamRequest asks the gateway to open one upstream
 // connection on the plugin's behalf — the brokered-dial path that
@@ -3229,6 +3260,73 @@ func (x *ActionVerdict) GetRule() string {
 	return ""
 }
 
+// ActionResult is the after-the-fact counterpart of EvaluateAction: the
+// plugin reports an action's outcome once the response is known, keyed by
+// the same call_id. It mirrors EvaluateAction field-for-field —
+// result_json conforms to the facet's result_fields schema, and `streams`
+// carries FACET_STREAM result fields (e.g. a response body) the gateway
+// pulls up to its cap and cancels. The result field marked `title` becomes
+// the action's status.
+type ActionResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallId        string                 `protobuf:"bytes,1,opt,name=call_id,json=callId,proto3" json:"call_id,omitempty"`
+	ResultJson    []byte                 `protobuf:"bytes,2,opt,name=result_json,json=resultJson,proto3" json:"result_json,omitempty"`
+	Streams       map[string]string      `protobuf:"bytes,3,rep,name=streams,proto3" json:"streams,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActionResult) Reset() {
+	*x = ActionResult{}
+	mi := &file_plugin_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActionResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActionResult) ProtoMessage() {}
+
+func (x *ActionResult) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActionResult.ProtoReflect.Descriptor instead.
+func (*ActionResult) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *ActionResult) GetCallId() string {
+	if x != nil {
+		return x.CallId
+	}
+	return ""
+}
+
+func (x *ActionResult) GetResultJson() []byte {
+	if x != nil {
+		return x.ResultJson
+	}
+	return nil
+}
+
+func (x *ActionResult) GetStreams() map[string]string {
+	if x != nil {
+		return x.Streams
+	}
+	return nil
+}
+
 type ConnInit struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identifies which configured endpoint instance is being handled.
@@ -3281,7 +3379,7 @@ type ConnInit struct {
 
 func (x *ConnInit) Reset() {
 	*x = ConnInit{}
-	mi := &file_plugin_proto_msgTypes[39]
+	mi := &file_plugin_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3293,7 +3391,7 @@ func (x *ConnInit) String() string {
 func (*ConnInit) ProtoMessage() {}
 
 func (x *ConnInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[39]
+	mi := &file_plugin_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3306,7 +3404,7 @@ func (x *ConnInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnInit.ProtoReflect.Descriptor instead.
 func (*ConnInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{39}
+	return file_plugin_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ConnInit) GetEndpointTypeName() string {
@@ -3444,7 +3542,7 @@ type BoundCredential struct {
 
 func (x *BoundCredential) Reset() {
 	*x = BoundCredential{}
-	mi := &file_plugin_proto_msgTypes[40]
+	mi := &file_plugin_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3456,7 +3554,7 @@ func (x *BoundCredential) String() string {
 func (*BoundCredential) ProtoMessage() {}
 
 func (x *BoundCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[40]
+	mi := &file_plugin_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3469,7 +3567,7 @@ func (x *BoundCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoundCredential.ProtoReflect.Descriptor instead.
 func (*BoundCredential) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{40}
+	return file_plugin_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *BoundCredential) GetTypeName() string {
@@ -3516,7 +3614,7 @@ type ConnData struct {
 
 func (x *ConnData) Reset() {
 	*x = ConnData{}
-	mi := &file_plugin_proto_msgTypes[41]
+	mi := &file_plugin_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3528,7 +3626,7 @@ func (x *ConnData) String() string {
 func (*ConnData) ProtoMessage() {}
 
 func (x *ConnData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[41]
+	mi := &file_plugin_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3541,7 +3639,7 @@ func (x *ConnData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnData.ProtoReflect.Descriptor instead.
 func (*ConnData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{41}
+	return file_plugin_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ConnData) GetPayload() []byte {
@@ -3561,7 +3659,7 @@ type ConnClose struct {
 
 func (x *ConnClose) Reset() {
 	*x = ConnClose{}
-	mi := &file_plugin_proto_msgTypes[42]
+	mi := &file_plugin_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3573,7 +3671,7 @@ func (x *ConnClose) String() string {
 func (*ConnClose) ProtoMessage() {}
 
 func (x *ConnClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[42]
+	mi := &file_plugin_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3586,7 +3684,7 @@ func (x *ConnClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnClose.ProtoReflect.Descriptor instead.
 func (*ConnClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{42}
+	return file_plugin_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ConnClose) GetReason() string {
@@ -3617,7 +3715,7 @@ type ConnEvent struct {
 
 func (x *ConnEvent) Reset() {
 	*x = ConnEvent{}
-	mi := &file_plugin_proto_msgTypes[43]
+	mi := &file_plugin_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3629,7 +3727,7 @@ func (x *ConnEvent) String() string {
 func (*ConnEvent) ProtoMessage() {}
 
 func (x *ConnEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[43]
+	mi := &file_plugin_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3642,7 +3740,7 @@ func (x *ConnEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnEvent.ProtoReflect.Descriptor instead.
 func (*ConnEvent) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{43}
+	return file_plugin_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ConnEvent) GetAction() string {
@@ -3718,7 +3816,7 @@ type OpenTunnelRequest struct {
 
 func (x *OpenTunnelRequest) Reset() {
 	*x = OpenTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[44]
+	mi := &file_plugin_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3730,7 +3828,7 @@ func (x *OpenTunnelRequest) String() string {
 func (*OpenTunnelRequest) ProtoMessage() {}
 
 func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[44]
+	mi := &file_plugin_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3743,7 +3841,7 @@ func (x *OpenTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelRequest.ProtoReflect.Descriptor instead.
 func (*OpenTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{44}
+	return file_plugin_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *OpenTunnelRequest) GetTunnelTypeName() string {
@@ -3797,7 +3895,7 @@ type OpenTunnelResponse struct {
 
 func (x *OpenTunnelResponse) Reset() {
 	*x = OpenTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[45]
+	mi := &file_plugin_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3809,7 +3907,7 @@ func (x *OpenTunnelResponse) String() string {
 func (*OpenTunnelResponse) ProtoMessage() {}
 
 func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[45]
+	mi := &file_plugin_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3822,7 +3920,7 @@ func (x *OpenTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenTunnelResponse.ProtoReflect.Descriptor instead.
 func (*OpenTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{45}
+	return file_plugin_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *OpenTunnelResponse) GetHandle() string {
@@ -3841,7 +3939,7 @@ type CloseTunnelRequest struct {
 
 func (x *CloseTunnelRequest) Reset() {
 	*x = CloseTunnelRequest{}
-	mi := &file_plugin_proto_msgTypes[46]
+	mi := &file_plugin_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3853,7 +3951,7 @@ func (x *CloseTunnelRequest) String() string {
 func (*CloseTunnelRequest) ProtoMessage() {}
 
 func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[46]
+	mi := &file_plugin_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3866,7 +3964,7 @@ func (x *CloseTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelRequest.ProtoReflect.Descriptor instead.
 func (*CloseTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{46}
+	return file_plugin_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CloseTunnelRequest) GetHandle() string {
@@ -3884,7 +3982,7 @@ type CloseTunnelResponse struct {
 
 func (x *CloseTunnelResponse) Reset() {
 	*x = CloseTunnelResponse{}
-	mi := &file_plugin_proto_msgTypes[47]
+	mi := &file_plugin_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3896,7 +3994,7 @@ func (x *CloseTunnelResponse) String() string {
 func (*CloseTunnelResponse) ProtoMessage() {}
 
 func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[47]
+	mi := &file_plugin_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3909,7 +4007,7 @@ func (x *CloseTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseTunnelResponse.ProtoReflect.Descriptor instead.
 func (*CloseTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{47}
+	return file_plugin_proto_rawDescGZIP(), []int{48}
 }
 
 type DialMessage struct {
@@ -3926,7 +4024,7 @@ type DialMessage struct {
 
 func (x *DialMessage) Reset() {
 	*x = DialMessage{}
-	mi := &file_plugin_proto_msgTypes[48]
+	mi := &file_plugin_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3938,7 +4036,7 @@ func (x *DialMessage) String() string {
 func (*DialMessage) ProtoMessage() {}
 
 func (x *DialMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[48]
+	mi := &file_plugin_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3951,7 +4049,7 @@ func (x *DialMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialMessage.ProtoReflect.Descriptor instead.
 func (*DialMessage) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{48}
+	return file_plugin_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *DialMessage) GetKind() isDialMessage_Kind {
@@ -4021,7 +4119,7 @@ type DialInit struct {
 
 func (x *DialInit) Reset() {
 	*x = DialInit{}
-	mi := &file_plugin_proto_msgTypes[49]
+	mi := &file_plugin_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4033,7 +4131,7 @@ func (x *DialInit) String() string {
 func (*DialInit) ProtoMessage() {}
 
 func (x *DialInit) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[49]
+	mi := &file_plugin_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4046,7 +4144,7 @@ func (x *DialInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialInit.ProtoReflect.Descriptor instead.
 func (*DialInit) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{49}
+	return file_plugin_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *DialInit) GetTunnelHandle() string {
@@ -4079,7 +4177,7 @@ type DialData struct {
 
 func (x *DialData) Reset() {
 	*x = DialData{}
-	mi := &file_plugin_proto_msgTypes[50]
+	mi := &file_plugin_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4091,7 +4189,7 @@ func (x *DialData) String() string {
 func (*DialData) ProtoMessage() {}
 
 func (x *DialData) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[50]
+	mi := &file_plugin_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4104,7 +4202,7 @@ func (x *DialData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialData.ProtoReflect.Descriptor instead.
 func (*DialData) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{50}
+	return file_plugin_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *DialData) GetPayload() []byte {
@@ -4123,7 +4221,7 @@ type DialClose struct {
 
 func (x *DialClose) Reset() {
 	*x = DialClose{}
-	mi := &file_plugin_proto_msgTypes[51]
+	mi := &file_plugin_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4135,7 +4233,7 @@ func (x *DialClose) String() string {
 func (*DialClose) ProtoMessage() {}
 
 func (x *DialClose) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[51]
+	mi := &file_plugin_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4148,7 +4246,7 @@ func (x *DialClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialClose.ProtoReflect.Descriptor instead.
 func (*DialClose) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{51}
+	return file_plugin_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DialClose) GetReason() string {
@@ -4167,7 +4265,7 @@ type StateGetRequest struct {
 
 func (x *StateGetRequest) Reset() {
 	*x = StateGetRequest{}
-	mi := &file_plugin_proto_msgTypes[52]
+	mi := &file_plugin_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4179,7 +4277,7 @@ func (x *StateGetRequest) String() string {
 func (*StateGetRequest) ProtoMessage() {}
 
 func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[52]
+	mi := &file_plugin_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4192,7 +4290,7 @@ func (x *StateGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateGetRequest.ProtoReflect.Descriptor instead.
 func (*StateGetRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{52}
+	return file_plugin_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *StateGetRequest) GetKey() string {
@@ -4212,7 +4310,7 @@ type StateGetResponse struct {
 
 func (x *StateGetResponse) Reset() {
 	*x = StateGetResponse{}
-	mi := &file_plugin_proto_msgTypes[53]
+	mi := &file_plugin_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4224,7 +4322,7 @@ func (x *StateGetResponse) String() string {
 func (*StateGetResponse) ProtoMessage() {}
 
 func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[53]
+	mi := &file_plugin_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4237,7 +4335,7 @@ func (x *StateGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateGetResponse.ProtoReflect.Descriptor instead.
 func (*StateGetResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{53}
+	return file_plugin_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *StateGetResponse) GetValue() []byte {
@@ -4264,7 +4362,7 @@ type StatePutRequest struct {
 
 func (x *StatePutRequest) Reset() {
 	*x = StatePutRequest{}
-	mi := &file_plugin_proto_msgTypes[54]
+	mi := &file_plugin_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4276,7 +4374,7 @@ func (x *StatePutRequest) String() string {
 func (*StatePutRequest) ProtoMessage() {}
 
 func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[54]
+	mi := &file_plugin_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4289,7 +4387,7 @@ func (x *StatePutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatePutRequest.ProtoReflect.Descriptor instead.
 func (*StatePutRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{54}
+	return file_plugin_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *StatePutRequest) GetKey() string {
@@ -4314,7 +4412,7 @@ type StatePutResponse struct {
 
 func (x *StatePutResponse) Reset() {
 	*x = StatePutResponse{}
-	mi := &file_plugin_proto_msgTypes[55]
+	mi := &file_plugin_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4326,7 +4424,7 @@ func (x *StatePutResponse) String() string {
 func (*StatePutResponse) ProtoMessage() {}
 
 func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[55]
+	mi := &file_plugin_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4339,7 +4437,7 @@ func (x *StatePutResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatePutResponse.ProtoReflect.Descriptor instead.
 func (*StatePutResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{55}
+	return file_plugin_proto_rawDescGZIP(), []int{56}
 }
 
 type EvaluateRequest struct {
@@ -4356,7 +4454,7 @@ type EvaluateRequest struct {
 
 func (x *EvaluateRequest) Reset() {
 	*x = EvaluateRequest{}
-	mi := &file_plugin_proto_msgTypes[56]
+	mi := &file_plugin_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4368,7 +4466,7 @@ func (x *EvaluateRequest) String() string {
 func (*EvaluateRequest) ProtoMessage() {}
 
 func (x *EvaluateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[56]
+	mi := &file_plugin_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4381,7 +4479,7 @@ func (x *EvaluateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{56}
+	return file_plugin_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *EvaluateRequest) GetFacetName() string {
@@ -4416,7 +4514,7 @@ type EvaluateVerdict struct {
 
 func (x *EvaluateVerdict) Reset() {
 	*x = EvaluateVerdict{}
-	mi := &file_plugin_proto_msgTypes[57]
+	mi := &file_plugin_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4428,7 +4526,7 @@ func (x *EvaluateVerdict) String() string {
 func (*EvaluateVerdict) ProtoMessage() {}
 
 func (x *EvaluateVerdict) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[57]
+	mi := &file_plugin_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4441,7 +4539,7 @@ func (x *EvaluateVerdict) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateVerdict.ProtoReflect.Descriptor instead.
 func (*EvaluateVerdict) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{57}
+	return file_plugin_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *EvaluateVerdict) GetAction() string {
@@ -4484,10 +4582,11 @@ const file_plugin_proto_rawDesc = "" +
 	"\x06egress\x18\x02 \x03(\tR\x06egress\x12\x1e\n" +
 	"\n" +
 	"privileged\x18\x03 \x01(\bR\n" +
-	"privileged\"]\n" +
+	"privileged\"\xa8\x01\n" +
 	"\tFacetDecl\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
-	"\x06fields\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.FacetFieldDeclR\x06fields\"\xe4\x01\n" +
+	"\x06fields\x18\x02 \x03(\v2$.clawpatrol.plugin.v1.FacetFieldDeclR\x06fields\x12I\n" +
+	"\rresult_fields\x18\x03 \x03(\v2$.clawpatrol.plugin.v1.FacetFieldDeclR\fresultFields\"\xe4\x01\n" +
 	"\x0eFacetFieldDecl\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x123\n" +
 	"\x04kind\x18\x02 \x01(\x0e2\x1f.clawpatrol.plugin.v1.FacetKindR\x04kind\x12\x14\n" +
@@ -4655,7 +4754,7 @@ const file_plugin_proto_rawDesc = "" +
 	"redactions\x18\x04 \x03(\tR\n" +
 	"redactionsB\t\n" +
 	"\a_methodB\x06\n" +
-	"\x04_url\"\xfb\x06\n" +
+	"\x04_url\"\xb9\a\n" +
 	"\vConnMessage\x124\n" +
 	"\x04init\x18\x01 \x01(\v2\x1e.clawpatrol.plugin.v1.ConnInitH\x00R\x04init\x124\n" +
 	"\x04data\x18\x02 \x01(\v2\x1e.clawpatrol.plugin.v1.ConnDataH\x00R\x04data\x127\n" +
@@ -4673,7 +4772,8 @@ const file_plugin_proto_rawDesc = "" +
 	"dial_reply\x18\v \x01(\v2'.clawpatrol.plugin.v1.DialUpstreamReplyH\x00R\tdialReply\x12E\n" +
 	"\tdial_data\x18\f \x01(\v2&.clawpatrol.plugin.v1.DialUpstreamDataH\x00R\bdialData\x12H\n" +
 	"\n" +
-	"dial_close\x18\r \x01(\v2'.clawpatrol.plugin.v1.DialUpstreamCloseH\x00R\tdialCloseB\x06\n" +
+	"dial_close\x18\r \x01(\v2'.clawpatrol.plugin.v1.DialUpstreamCloseH\x00R\tdialClose\x12<\n" +
+	"\x06result\x18\x0e \x01(\v2\".clawpatrol.plugin.v1.ActionResultH\x00R\x06resultB\x06\n" +
 	"\x04kind\"\x96\x01\n" +
 	"\x13DialUpstreamRequest\x12\x17\n" +
 	"\adial_id\x18\x01 \x01(\tR\x06dialId\x12\x18\n" +
@@ -4715,7 +4815,15 @@ const file_plugin_proto_rawDesc = "" +
 	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12\x16\n" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x12\n" +
-	"\x04rule\x18\x04 \x01(\tR\x04rule\"\xfb\x06\n" +
+	"\x04rule\x18\x04 \x01(\tR\x04rule\"\xcf\x01\n" +
+	"\fActionResult\x12\x17\n" +
+	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x1f\n" +
+	"\vresult_json\x18\x02 \x01(\fR\n" +
+	"resultJson\x12I\n" +
+	"\astreams\x18\x03 \x03(\v2/.clawpatrol.plugin.v1.ActionResult.StreamsEntryR\astreams\x1a:\n" +
+	"\fStreamsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\x06\n" +
 	"\bConnInit\x12,\n" +
 	"\x12endpoint_type_name\x18\x01 \x01(\tR\x10endpointTypeName\x12+\n" +
 	"\x11endpoint_instance\x18\x02 \x01(\tR\x10endpointInstance\x126\n" +
@@ -4858,7 +4966,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_plugin_proto_goTypes = []any{
 	(NetworkAccess)(0),             // 0: clawpatrol.plugin.v1.NetworkAccess
 	(FacetKind)(0),                 // 1: clawpatrol.plugin.v1.FacetKind
@@ -4904,34 +5012,36 @@ var file_plugin_proto_goTypes = []any{
 	(*StreamCancel)(nil),           // 41: clawpatrol.plugin.v1.StreamCancel
 	(*EvaluateAction)(nil),         // 42: clawpatrol.plugin.v1.EvaluateAction
 	(*ActionVerdict)(nil),          // 43: clawpatrol.plugin.v1.ActionVerdict
-	(*ConnInit)(nil),               // 44: clawpatrol.plugin.v1.ConnInit
-	(*BoundCredential)(nil),        // 45: clawpatrol.plugin.v1.BoundCredential
-	(*ConnData)(nil),               // 46: clawpatrol.plugin.v1.ConnData
-	(*ConnClose)(nil),              // 47: clawpatrol.plugin.v1.ConnClose
-	(*ConnEvent)(nil),              // 48: clawpatrol.plugin.v1.ConnEvent
-	(*OpenTunnelRequest)(nil),      // 49: clawpatrol.plugin.v1.OpenTunnelRequest
-	(*OpenTunnelResponse)(nil),     // 50: clawpatrol.plugin.v1.OpenTunnelResponse
-	(*CloseTunnelRequest)(nil),     // 51: clawpatrol.plugin.v1.CloseTunnelRequest
-	(*CloseTunnelResponse)(nil),    // 52: clawpatrol.plugin.v1.CloseTunnelResponse
-	(*DialMessage)(nil),            // 53: clawpatrol.plugin.v1.DialMessage
-	(*DialInit)(nil),               // 54: clawpatrol.plugin.v1.DialInit
-	(*DialData)(nil),               // 55: clawpatrol.plugin.v1.DialData
-	(*DialClose)(nil),              // 56: clawpatrol.plugin.v1.DialClose
-	(*StateGetRequest)(nil),        // 57: clawpatrol.plugin.v1.StateGetRequest
-	(*StateGetResponse)(nil),       // 58: clawpatrol.plugin.v1.StateGetResponse
-	(*StatePutRequest)(nil),        // 59: clawpatrol.plugin.v1.StatePutRequest
-	(*StatePutResponse)(nil),       // 60: clawpatrol.plugin.v1.StatePutResponse
-	(*EvaluateRequest)(nil),        // 61: clawpatrol.plugin.v1.EvaluateRequest
-	(*EvaluateVerdict)(nil),        // 62: clawpatrol.plugin.v1.EvaluateVerdict
-	nil,                            // 63: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	nil,                            // 64: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	nil,                            // 65: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
-	nil,                            // 66: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
-	nil,                            // 67: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
-	nil,                            // 68: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	nil,                            // 69: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	nil,                            // 70: clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
-	nil,                            // 71: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	(*ActionResult)(nil),           // 44: clawpatrol.plugin.v1.ActionResult
+	(*ConnInit)(nil),               // 45: clawpatrol.plugin.v1.ConnInit
+	(*BoundCredential)(nil),        // 46: clawpatrol.plugin.v1.BoundCredential
+	(*ConnData)(nil),               // 47: clawpatrol.plugin.v1.ConnData
+	(*ConnClose)(nil),              // 48: clawpatrol.plugin.v1.ConnClose
+	(*ConnEvent)(nil),              // 49: clawpatrol.plugin.v1.ConnEvent
+	(*OpenTunnelRequest)(nil),      // 50: clawpatrol.plugin.v1.OpenTunnelRequest
+	(*OpenTunnelResponse)(nil),     // 51: clawpatrol.plugin.v1.OpenTunnelResponse
+	(*CloseTunnelRequest)(nil),     // 52: clawpatrol.plugin.v1.CloseTunnelRequest
+	(*CloseTunnelResponse)(nil),    // 53: clawpatrol.plugin.v1.CloseTunnelResponse
+	(*DialMessage)(nil),            // 54: clawpatrol.plugin.v1.DialMessage
+	(*DialInit)(nil),               // 55: clawpatrol.plugin.v1.DialInit
+	(*DialData)(nil),               // 56: clawpatrol.plugin.v1.DialData
+	(*DialClose)(nil),              // 57: clawpatrol.plugin.v1.DialClose
+	(*StateGetRequest)(nil),        // 58: clawpatrol.plugin.v1.StateGetRequest
+	(*StateGetResponse)(nil),       // 59: clawpatrol.plugin.v1.StateGetResponse
+	(*StatePutRequest)(nil),        // 60: clawpatrol.plugin.v1.StatePutRequest
+	(*StatePutResponse)(nil),       // 61: clawpatrol.plugin.v1.StatePutResponse
+	(*EvaluateRequest)(nil),        // 62: clawpatrol.plugin.v1.EvaluateRequest
+	(*EvaluateVerdict)(nil),        // 63: clawpatrol.plugin.v1.EvaluateVerdict
+	nil,                            // 64: clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	nil,                            // 65: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	nil,                            // 66: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	nil,                            // 67: clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	nil,                            // 68: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	nil,                            // 69: clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	nil,                            // 70: clawpatrol.plugin.v1.ActionResult.StreamsEntry
+	nil,                            // 71: clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	nil,                            // 72: clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
+	nil,                            // 73: clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
 }
 var file_plugin_proto_depIdxs = []int32{
 	19, // 0: clawpatrol.plugin.v1.ManifestResponse.credentials:type_name -> clawpatrol.plugin.v1.CredentialDecl
@@ -4941,86 +5051,89 @@ var file_plugin_proto_depIdxs = []int32{
 	7,  // 4: clawpatrol.plugin.v1.ManifestResponse.capabilities:type_name -> clawpatrol.plugin.v1.PluginCapabilities
 	0,  // 5: clawpatrol.plugin.v1.PluginCapabilities.network:type_name -> clawpatrol.plugin.v1.NetworkAccess
 	9,  // 6: clawpatrol.plugin.v1.FacetDecl.fields:type_name -> clawpatrol.plugin.v1.FacetFieldDecl
-	1,  // 7: clawpatrol.plugin.v1.FacetFieldDecl.kind:type_name -> clawpatrol.plugin.v1.FacetKind
-	11, // 8: clawpatrol.plugin.v1.Schema.fields:type_name -> clawpatrol.plugin.v1.SchemaField
-	14, // 9: clawpatrol.plugin.v1.OptionalScopeGroupDecl.scopes:type_name -> clawpatrol.plugin.v1.OptionalScopeDecl
-	16, // 10: clawpatrol.plugin.v1.OAuthIntegrationDecl.oauth:type_name -> clawpatrol.plugin.v1.OAuthConfigDecl
-	15, // 11: clawpatrol.plugin.v1.OAuthIntegrationDecl.optional_scopes:type_name -> clawpatrol.plugin.v1.OptionalScopeGroupDecl
-	12, // 12: clawpatrol.plugin.v1.CredentialMetadata.secret_slots:type_name -> clawpatrol.plugin.v1.SecretSlotDecl
-	13, // 13: clawpatrol.plugin.v1.CredentialMetadata.env_vars:type_name -> clawpatrol.plugin.v1.EnvVarDecl
-	17, // 14: clawpatrol.plugin.v1.CredentialMetadata.oauth:type_name -> clawpatrol.plugin.v1.OAuthIntegrationDecl
-	10, // 15: clawpatrol.plugin.v1.CredentialDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
-	10, // 16: clawpatrol.plugin.v1.TunnelDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
-	10, // 17: clawpatrol.plugin.v1.EndpointDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
-	2,  // 18: clawpatrol.plugin.v1.EndpointDecl.tls_mode:type_name -> clawpatrol.plugin.v1.TLSMode
-	24, // 19: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
-	18, // 20: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
-	3,  // 21: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
-	63, // 22: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
-	64, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
-	4,  // 24: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
-	27, // 25: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
-	65, // 26: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
-	31, // 27: clawpatrol.plugin.v1.TransformHTTPUp.init:type_name -> clawpatrol.plugin.v1.TransformHTTPInit
-	29, // 28: clawpatrol.plugin.v1.TransformHTTPUp.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
-	66, // 29: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
-	67, // 30: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
-	33, // 31: clawpatrol.plugin.v1.TransformHTTPDown.head:type_name -> clawpatrol.plugin.v1.TransformHTTPHead
-	29, // 32: clawpatrol.plugin.v1.TransformHTTPDown.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
-	27, // 33: clawpatrol.plugin.v1.TransformHTTPHead.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
-	44, // 34: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
-	46, // 35: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
-	47, // 36: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
-	48, // 37: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
-	42, // 38: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
-	43, // 39: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
-	39, // 40: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
-	40, // 41: clawpatrol.plugin.v1.ConnMessage.stream_chunk:type_name -> clawpatrol.plugin.v1.StreamChunk
-	41, // 42: clawpatrol.plugin.v1.ConnMessage.stream_cancel:type_name -> clawpatrol.plugin.v1.StreamCancel
-	35, // 43: clawpatrol.plugin.v1.ConnMessage.dial_request:type_name -> clawpatrol.plugin.v1.DialUpstreamRequest
-	36, // 44: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
-	37, // 45: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
-	38, // 46: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
-	68, // 47: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
-	69, // 48: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
-	45, // 49: clawpatrol.plugin.v1.ConnInit.credentials:type_name -> clawpatrol.plugin.v1.BoundCredential
-	70, // 50: clawpatrol.plugin.v1.BoundCredential.extras:type_name -> clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
-	71, // 51: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
-	54, // 52: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
-	55, // 53: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
-	56, // 54: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
-	25, // 55: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	25, // 56: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	25, // 57: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
-	5,  // 58: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
-	22, // 59: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
-	26, // 60: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
-	30, // 61: clawpatrol.plugin.v1.Credential.TransformHTTP:input_type -> clawpatrol.plugin.v1.TransformHTTPUp
-	34, // 62: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
-	49, // 63: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
-	53, // 64: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
-	51, // 65: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
-	57, // 66: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
-	59, // 67: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
-	61, // 68: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
-	53, // 69: clawpatrol.plugin.v1.HostTunnel.DialUpstream:input_type -> clawpatrol.plugin.v1.DialMessage
-	6,  // 70: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
-	23, // 71: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
-	28, // 72: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
-	32, // 73: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
-	34, // 74: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
-	50, // 75: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
-	53, // 76: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
-	52, // 77: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
-	58, // 78: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
-	60, // 79: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
-	62, // 80: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
-	53, // 81: clawpatrol.plugin.v1.HostTunnel.DialUpstream:output_type -> clawpatrol.plugin.v1.DialMessage
-	70, // [70:82] is the sub-list for method output_type
-	58, // [58:70] is the sub-list for method input_type
-	58, // [58:58] is the sub-list for extension type_name
-	58, // [58:58] is the sub-list for extension extendee
-	0,  // [0:58] is the sub-list for field type_name
+	9,  // 7: clawpatrol.plugin.v1.FacetDecl.result_fields:type_name -> clawpatrol.plugin.v1.FacetFieldDecl
+	1,  // 8: clawpatrol.plugin.v1.FacetFieldDecl.kind:type_name -> clawpatrol.plugin.v1.FacetKind
+	11, // 9: clawpatrol.plugin.v1.Schema.fields:type_name -> clawpatrol.plugin.v1.SchemaField
+	14, // 10: clawpatrol.plugin.v1.OptionalScopeGroupDecl.scopes:type_name -> clawpatrol.plugin.v1.OptionalScopeDecl
+	16, // 11: clawpatrol.plugin.v1.OAuthIntegrationDecl.oauth:type_name -> clawpatrol.plugin.v1.OAuthConfigDecl
+	15, // 12: clawpatrol.plugin.v1.OAuthIntegrationDecl.optional_scopes:type_name -> clawpatrol.plugin.v1.OptionalScopeGroupDecl
+	12, // 13: clawpatrol.plugin.v1.CredentialMetadata.secret_slots:type_name -> clawpatrol.plugin.v1.SecretSlotDecl
+	13, // 14: clawpatrol.plugin.v1.CredentialMetadata.env_vars:type_name -> clawpatrol.plugin.v1.EnvVarDecl
+	17, // 15: clawpatrol.plugin.v1.CredentialMetadata.oauth:type_name -> clawpatrol.plugin.v1.OAuthIntegrationDecl
+	10, // 16: clawpatrol.plugin.v1.CredentialDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
+	10, // 17: clawpatrol.plugin.v1.TunnelDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
+	10, // 18: clawpatrol.plugin.v1.EndpointDecl.schema:type_name -> clawpatrol.plugin.v1.Schema
+	2,  // 19: clawpatrol.plugin.v1.EndpointDecl.tls_mode:type_name -> clawpatrol.plugin.v1.TLSMode
+	24, // 20: clawpatrol.plugin.v1.BuildResponse.diagnostics:type_name -> clawpatrol.plugin.v1.Diagnostic
+	18, // 21: clawpatrol.plugin.v1.BuildResponse.credential_metadata:type_name -> clawpatrol.plugin.v1.CredentialMetadata
+	3,  // 22: clawpatrol.plugin.v1.Diagnostic.severity:type_name -> clawpatrol.plugin.v1.Diagnostic.Severity
+	64, // 23: clawpatrol.plugin.v1.InjectHTTPRequest.credential_extras:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.CredentialExtrasEntry
+	65, // 24: clawpatrol.plugin.v1.InjectHTTPRequest.headers:type_name -> clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry
+	4,  // 25: clawpatrol.plugin.v1.HeaderMutation.op:type_name -> clawpatrol.plugin.v1.HeaderMutation.Op
+	27, // 26: clawpatrol.plugin.v1.InjectHTTPResponse.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
+	66, // 27: clawpatrol.plugin.v1.HTTPBodyChunk.trailers:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry
+	31, // 28: clawpatrol.plugin.v1.TransformHTTPUp.init:type_name -> clawpatrol.plugin.v1.TransformHTTPInit
+	29, // 29: clawpatrol.plugin.v1.TransformHTTPUp.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
+	67, // 30: clawpatrol.plugin.v1.TransformHTTPInit.credential_extras:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.CredentialExtrasEntry
+	68, // 31: clawpatrol.plugin.v1.TransformHTTPInit.headers:type_name -> clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry
+	33, // 32: clawpatrol.plugin.v1.TransformHTTPDown.head:type_name -> clawpatrol.plugin.v1.TransformHTTPHead
+	29, // 33: clawpatrol.plugin.v1.TransformHTTPDown.body:type_name -> clawpatrol.plugin.v1.HTTPBodyChunk
+	27, // 34: clawpatrol.plugin.v1.TransformHTTPHead.headers:type_name -> clawpatrol.plugin.v1.HeaderMutation
+	45, // 35: clawpatrol.plugin.v1.ConnMessage.init:type_name -> clawpatrol.plugin.v1.ConnInit
+	47, // 36: clawpatrol.plugin.v1.ConnMessage.data:type_name -> clawpatrol.plugin.v1.ConnData
+	48, // 37: clawpatrol.plugin.v1.ConnMessage.close:type_name -> clawpatrol.plugin.v1.ConnClose
+	49, // 38: clawpatrol.plugin.v1.ConnMessage.event:type_name -> clawpatrol.plugin.v1.ConnEvent
+	42, // 39: clawpatrol.plugin.v1.ConnMessage.evaluate:type_name -> clawpatrol.plugin.v1.EvaluateAction
+	43, // 40: clawpatrol.plugin.v1.ConnMessage.verdict:type_name -> clawpatrol.plugin.v1.ActionVerdict
+	39, // 41: clawpatrol.plugin.v1.ConnMessage.stream_read:type_name -> clawpatrol.plugin.v1.StreamRead
+	40, // 42: clawpatrol.plugin.v1.ConnMessage.stream_chunk:type_name -> clawpatrol.plugin.v1.StreamChunk
+	41, // 43: clawpatrol.plugin.v1.ConnMessage.stream_cancel:type_name -> clawpatrol.plugin.v1.StreamCancel
+	35, // 44: clawpatrol.plugin.v1.ConnMessage.dial_request:type_name -> clawpatrol.plugin.v1.DialUpstreamRequest
+	36, // 45: clawpatrol.plugin.v1.ConnMessage.dial_reply:type_name -> clawpatrol.plugin.v1.DialUpstreamReply
+	37, // 46: clawpatrol.plugin.v1.ConnMessage.dial_data:type_name -> clawpatrol.plugin.v1.DialUpstreamData
+	38, // 47: clawpatrol.plugin.v1.ConnMessage.dial_close:type_name -> clawpatrol.plugin.v1.DialUpstreamClose
+	44, // 48: clawpatrol.plugin.v1.ConnMessage.result:type_name -> clawpatrol.plugin.v1.ActionResult
+	69, // 49: clawpatrol.plugin.v1.EvaluateAction.streams:type_name -> clawpatrol.plugin.v1.EvaluateAction.StreamsEntry
+	70, // 50: clawpatrol.plugin.v1.ActionResult.streams:type_name -> clawpatrol.plugin.v1.ActionResult.StreamsEntry
+	71, // 51: clawpatrol.plugin.v1.ConnInit.credential_extras:type_name -> clawpatrol.plugin.v1.ConnInit.CredentialExtrasEntry
+	46, // 52: clawpatrol.plugin.v1.ConnInit.credentials:type_name -> clawpatrol.plugin.v1.BoundCredential
+	72, // 53: clawpatrol.plugin.v1.BoundCredential.extras:type_name -> clawpatrol.plugin.v1.BoundCredential.ExtrasEntry
+	73, // 54: clawpatrol.plugin.v1.OpenTunnelRequest.credential_extras:type_name -> clawpatrol.plugin.v1.OpenTunnelRequest.CredentialExtrasEntry
+	55, // 55: clawpatrol.plugin.v1.DialMessage.init:type_name -> clawpatrol.plugin.v1.DialInit
+	56, // 56: clawpatrol.plugin.v1.DialMessage.data:type_name -> clawpatrol.plugin.v1.DialData
+	57, // 57: clawpatrol.plugin.v1.DialMessage.close:type_name -> clawpatrol.plugin.v1.DialClose
+	25, // 58: clawpatrol.plugin.v1.InjectHTTPRequest.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	25, // 59: clawpatrol.plugin.v1.HTTPBodyChunk.TrailersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	25, // 60: clawpatrol.plugin.v1.TransformHTTPInit.HeadersEntry.value:type_name -> clawpatrol.plugin.v1.HTTPHeaderValues
+	5,  // 61: clawpatrol.plugin.v1.Plugin.Manifest:input_type -> clawpatrol.plugin.v1.ManifestRequest
+	22, // 62: clawpatrol.plugin.v1.Plugin.Build:input_type -> clawpatrol.plugin.v1.BuildRequest
+	26, // 63: clawpatrol.plugin.v1.Credential.InjectHTTP:input_type -> clawpatrol.plugin.v1.InjectHTTPRequest
+	30, // 64: clawpatrol.plugin.v1.Credential.TransformHTTP:input_type -> clawpatrol.plugin.v1.TransformHTTPUp
+	34, // 65: clawpatrol.plugin.v1.Endpoint.HandleConn:input_type -> clawpatrol.plugin.v1.ConnMessage
+	50, // 66: clawpatrol.plugin.v1.Tunnel.OpenTunnel:input_type -> clawpatrol.plugin.v1.OpenTunnelRequest
+	54, // 67: clawpatrol.plugin.v1.Tunnel.Dial:input_type -> clawpatrol.plugin.v1.DialMessage
+	52, // 68: clawpatrol.plugin.v1.Tunnel.CloseTunnel:input_type -> clawpatrol.plugin.v1.CloseTunnelRequest
+	58, // 69: clawpatrol.plugin.v1.HostState.Get:input_type -> clawpatrol.plugin.v1.StateGetRequest
+	60, // 70: clawpatrol.plugin.v1.HostState.Put:input_type -> clawpatrol.plugin.v1.StatePutRequest
+	62, // 71: clawpatrol.plugin.v1.HostControl.Evaluate:input_type -> clawpatrol.plugin.v1.EvaluateRequest
+	54, // 72: clawpatrol.plugin.v1.HostTunnel.DialUpstream:input_type -> clawpatrol.plugin.v1.DialMessage
+	6,  // 73: clawpatrol.plugin.v1.Plugin.Manifest:output_type -> clawpatrol.plugin.v1.ManifestResponse
+	23, // 74: clawpatrol.plugin.v1.Plugin.Build:output_type -> clawpatrol.plugin.v1.BuildResponse
+	28, // 75: clawpatrol.plugin.v1.Credential.InjectHTTP:output_type -> clawpatrol.plugin.v1.InjectHTTPResponse
+	32, // 76: clawpatrol.plugin.v1.Credential.TransformHTTP:output_type -> clawpatrol.plugin.v1.TransformHTTPDown
+	34, // 77: clawpatrol.plugin.v1.Endpoint.HandleConn:output_type -> clawpatrol.plugin.v1.ConnMessage
+	51, // 78: clawpatrol.plugin.v1.Tunnel.OpenTunnel:output_type -> clawpatrol.plugin.v1.OpenTunnelResponse
+	54, // 79: clawpatrol.plugin.v1.Tunnel.Dial:output_type -> clawpatrol.plugin.v1.DialMessage
+	53, // 80: clawpatrol.plugin.v1.Tunnel.CloseTunnel:output_type -> clawpatrol.plugin.v1.CloseTunnelResponse
+	59, // 81: clawpatrol.plugin.v1.HostState.Get:output_type -> clawpatrol.plugin.v1.StateGetResponse
+	61, // 82: clawpatrol.plugin.v1.HostState.Put:output_type -> clawpatrol.plugin.v1.StatePutResponse
+	63, // 83: clawpatrol.plugin.v1.HostControl.Evaluate:output_type -> clawpatrol.plugin.v1.EvaluateVerdict
+	54, // 84: clawpatrol.plugin.v1.HostTunnel.DialUpstream:output_type -> clawpatrol.plugin.v1.DialMessage
+	73, // [73:85] is the sub-list for method output_type
+	61, // [61:73] is the sub-list for method input_type
+	61, // [61:61] is the sub-list for extension type_name
+	61, // [61:61] is the sub-list for extension extendee
+	0,  // [0:61] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -5051,8 +5164,9 @@ func file_plugin_proto_init() {
 		(*ConnMessage_DialReply)(nil),
 		(*ConnMessage_DialData)(nil),
 		(*ConnMessage_DialClose)(nil),
+		(*ConnMessage_Result)(nil),
 	}
-	file_plugin_proto_msgTypes[48].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[49].OneofWrappers = []any{
 		(*DialMessage_Init)(nil),
 		(*DialMessage_Data)(nil),
 		(*DialMessage_Close)(nil),
@@ -5063,7 +5177,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   67,
+			NumMessages:   69,
 			NumExtensions: 0,
 			NumServices:   7,
 		},

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -545,12 +545,17 @@ message ActionVerdict {
 }
 
 // ActionResult is the after-the-fact counterpart of EvaluateAction: the
-// plugin reports an action's outcome once the response is known, keyed by
-// the same call_id. It mirrors EvaluateAction field-for-field —
-// result_json conforms to the facet's result_fields schema, and `streams`
-// carries FACET_STREAM result fields (e.g. a response body) the gateway
-// pulls up to its cap and cancels. The result field marked `title` becomes
-// the action's status.
+// plugin reports an action's outcome once the response is known. It mirrors
+// EvaluateAction field-for-field — result_json conforms to the facet's
+// result_fields schema, and `streams` carries FACET_STREAM result fields
+// (e.g. a response body) the gateway pulls up to its cap and cancels. The
+// result field marked `title` becomes the action's status.
+//
+// v1 is conn-scoped: the result finalizes the connection's current action,
+// so call_id is unset (the common evaluate path runs inline over
+// HostControl with no call_id). call_id is reserved for a future per-call
+// correlation that would let a pipelined endpoint report several
+// concurrent actions' results out of order.
 message ActionResult {
   string call_id     = 1;
   bytes  result_json = 2;

--- a/internal/config/extplugin/proto/plugin.proto
+++ b/internal/config/extplugin/proto/plugin.proto
@@ -89,7 +89,15 @@ enum NetworkAccess {
 // auto-namespaced by the gateway as "<plugin>.<name>".
 message FacetDecl {
   string name = 1;
+  // fields is the request-time schema: what EvaluateAction.action_json
+  // conforms to, and what rules match on.
   repeated FacetFieldDecl fields = 2;
+  // result_fields is the after-the-fact schema, what ActionResult.result_json
+  // conforms to. It reuses FacetFieldDecl, so title/description/detail_only
+  // and FACET_STREAM apply: the field marked `title` is the action's status,
+  // and a FACET_STREAM result field is a response body the gateway streams
+  // and caps. Empty for facets that report nothing after the response.
+  repeated FacetFieldDecl result_fields = 3;
 }
 
 message FacetFieldDecl {
@@ -426,6 +434,8 @@ message ConnMessage {
     DialUpstreamReply   dial_reply   = 11;  // gateway -> plugin
     DialUpstreamData    dial_data    = 12;  // both directions
     DialUpstreamClose   dial_close   = 13;  // both directions
+
+    ActionResult result = 14;  // plugin -> gateway (after-the-fact outcome)
   }
 }
 
@@ -532,6 +542,19 @@ message ActionVerdict {
   string action  = 2;   // "allow" | "deny" | "hitl_allow" | "hitl_deny" | "error"
   string reason  = 3;
   string rule    = 4;   // matched rule name, or "" when no rule fired
+}
+
+// ActionResult is the after-the-fact counterpart of EvaluateAction: the
+// plugin reports an action's outcome once the response is known, keyed by
+// the same call_id. It mirrors EvaluateAction field-for-field —
+// result_json conforms to the facet's result_fields schema, and `streams`
+// carries FACET_STREAM result fields (e.g. a response body) the gateway
+// pulls up to its cap and cancels. The result field marked `title` becomes
+// the action's status.
+message ActionResult {
+  string call_id     = 1;
+  bytes  result_json = 2;
+  map<string, string> streams = 3;
 }
 
 message ConnInit {

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -311,6 +311,21 @@ type ConnEvent struct {
 	Approver     string
 	ApproverType string
 	ApproverBy   string
+
+	// ID / Phase give a plugin action the same start→end lifecycle the
+	// built-in HTTP path uses: the adapter emits Phase "start" (in-flight)
+	// when an action is evaluated and "end" (carrying Status + result
+	// facets) when the plugin reports its outcome via ActionResult, keyed
+	// by the same ID so the dashboard merges them. Empty Phase means a
+	// single terminal event (the legacy behavior, e.g. a denial).
+	ID    string
+	Phase string
+	// Status is the action's outcome — lifted from the result schema's
+	// title field (e.g. an AWS error code, "200"). Set on the end event.
+	Status string
+	// ResultFacets is the after-the-fact report payload (values keyed by
+	// the facet's result_fields). Set on the end event alongside Status.
+	ResultFacets map[string]any
 }
 
 // Secret is what credential plugins receive at injection time. The

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -108,6 +108,13 @@ const (
 type FacetDef struct {
 	Name   string
 	Fields []FacetField
+	// ResultFields is the after-the-fact schema a plugin reports via
+	// Conn.SetResult once an action's response is known. It mirrors Fields
+	// (same FacetField type, so Description/Title/DetailOnly and the
+	// FacetStream kind apply): the field marked Title becomes the action's
+	// status, a FacetStream field is a response body the gateway caps.
+	// Empty for facets that report nothing after the response.
+	ResultFields []FacetField
 }
 
 // FacetField declares one column in the facet's schema. Kind tells

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -534,6 +534,7 @@ type Conn struct {
 
 	emit         func(ConnEvent)
 	evaluate     func(ctx context.Context, facet string, action map[string]any, summary string) (Verdict, error)
+	setResult    func(ctx context.Context, result map[string]any) error
 	dialUpstream func(ctx context.Context, network, addr string, opts *DialUpstreamOptions) (net.Conn, error)
 }
 
@@ -615,6 +616,21 @@ func (c *Conn) Evaluate(ctx context.Context, facet string, action map[string]any
 		return Verdict{}, errors.New("pluginsdk: Conn.Evaluate not wired (running without a gateway?)")
 	}
 	return c.evaluate(ctx, facet, action, summary)
+}
+
+// SetResult reports an action's outcome once the response is known — the
+// after-the-fact counterpart of Evaluate. The result map's keys match the
+// facet's declared ResultFields; the field marked Title becomes the
+// action's status on the dashboard. Call it once, after the response is
+// read, for the action this connection just evaluated.
+//
+// (First cut: scalar result fields only. FacetStream result fields — a
+// response body the gateway streams and caps — are a follow-up.)
+func (c *Conn) SetResult(ctx context.Context, result map[string]any) error {
+	if c.setResult == nil {
+		return errors.New("pluginsdk: Conn.SetResult not wired (running without a gateway?)")
+	}
+	return c.setResult(ctx, result)
 }
 
 // Verdict is the gateway's decision on one EvaluateAction call.

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -174,21 +174,31 @@ func (s *server) Manifest(_ context.Context, _ *pb.ManifestRequest) (*pb.Manifes
 		})
 	}
 	for _, f := range s.plug.Facets {
-		fields := make([]*pb.FacetFieldDecl, 0, len(f.Fields))
-		for _, fld := range f.Fields {
-			fields = append(fields, &pb.FacetFieldDecl{
-				Name:        fld.Name,
-				Kind:        pb.FacetKind(fld.Kind),
-				Label:       fld.Label,
-				Optional:    fld.Optional,
-				Description: fld.Description,
-				Title:       fld.Title,
-				DetailOnly:  fld.DetailOnly,
-			})
-		}
-		resp.Facets = append(resp.Facets, &pb.FacetDecl{Name: f.Name, Fields: fields})
+		resp.Facets = append(resp.Facets, &pb.FacetDecl{
+			Name:         f.Name,
+			Fields:       facetFieldsToProto(f.Fields),
+			ResultFields: facetFieldsToProto(f.ResultFields),
+		})
 	}
 	return resp, nil
+}
+
+// facetFieldsToProto maps SDK facet fields (request or result schema) onto
+// their proto form.
+func facetFieldsToProto(in []FacetField) []*pb.FacetFieldDecl {
+	out := make([]*pb.FacetFieldDecl, 0, len(in))
+	for _, fld := range in {
+		out = append(out, &pb.FacetFieldDecl{
+			Name:        fld.Name,
+			Kind:        pb.FacetKind(fld.Kind),
+			Label:       fld.Label,
+			Optional:    fld.Optional,
+			Description: fld.Description,
+			Title:       fld.Title,
+			DetailOnly:  fld.DetailOnly,
+		})
+	}
+	return out
 }
 
 func networkAccessToProto(n NetworkAccess) pb.NetworkAccess {

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -518,6 +518,16 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		return stream.Send(m)
 	}
 
+	conn.setResult = func(_ context.Context, result map[string]any) error {
+		// First cut: scalar result fields only (the body-stream support that
+		// FacetStream result fields will need is a follow-up). The gateway
+		// correlates this to the conn's current action, so no call_id.
+		j, err := json.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("pluginsdk: marshal result: %w", err)
+		}
+		return doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Result{Result: &pb.ActionResult{ResultJson: j}}})
+	}
 	conn.emit = func(ev ConnEvent) {
 		facets, _ := json.Marshal(ev.Facets)
 		_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Event{Event: &pb.ConnEvent{


### PR DESCRIPTION
Lets a plugin endpoint report its action's outcome after the response —
the after-the-fact counterpart of `EvaluateAction` — so an AWS row shows a
real status (the HTTP code, or the AWS error code on failure) instead of
nothing. The response side mirrors the request side: a facet declares
`result_fields` (reusing the same `FacetField`, so `title`/`description`/
`detail_only` and the `FacetStream` kind apply), the plugin reports via
`Conn.SetResult`, and the result field marked `title` becomes the status.

* **status is a string** end to end (HTTP renders `"200"`/`"403"`; a plugin
  reports `"AccessDenied"`). `statusClass` buckets numeric by leading digit
  and a named status as an error; no DB migration.
* **proto** `ActionResult{call_id, result_json, streams}` mirrors
  `EvaluateAction`; `FacetDecl.result_fields`.
* **pluginsdk** `FacetDef.ResultFields` + `Conn.SetResult(ctx, map)`.
* **gateway** a plugin action takes the built-in HTTP start→end lifecycle:
  emitEvaluation emits an in-flight `start` on allow, the adapter emits the
  `end` (status lifted from the result-title field) on `ActionResult`, and
  a flush-on-close guarantees every started action persists exactly once.
  Correlation is conn-scoped (the common `HostControl` evaluate path has no
  call_id), so the result finalizes the connection's current action
  (sequential request/response).

The AWS plugin populates the new attributes + reports status in a
companion release. Follow-ups: a `FacetStream` result field (a response
body the gateway streams + caps), rendering non-status result facets in
the detail table, and a lifecycle integration test.