### PR TITLE
dashboard: widen activity-log verb column and add result section

### DIFF
--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -2308,6 +2308,7 @@ func (w *webMux) apiFacets(rw http.ResponseWriter, r *http.Request) {
 		HITLQueryLabel   string            `json:"hitl_query_label,omitempty"`
 		HostIsResource   bool              `json:"host_is_resource"`
 		ReportFields     []reportFieldJSON `json:"report_fields"`
+		ResultFields     []reportFieldJSON `json:"result_fields,omitempty"`
 	}
 	all := facet.All()
 	out := make([]facetJSON, 0, len(all))
@@ -2325,6 +2326,21 @@ func (w *webMux) apiFacets(rw http.ResponseWriter, r *http.Request) {
 			entry.ReportFields[i] = reportFieldJSON{
 				Name: fk.Name, Kind: reportKindName(fk.Kind), Label: fk.Label,
 				Description: fk.Description, Title: fk.Title, DetailOnly: fk.DetailOnly,
+			}
+		}
+		// result_fields is the after-the-fact result schema, exposed
+		// only by facets that implement the optional accessor (plugin
+		// facets). Don't widen the core facet.Runtime interface for it.
+		if rf, ok := f.(interface {
+			ResultFields() []facet.ReportFieldSpec
+		}); ok {
+			rfs := rf.ResultFields()
+			entry.ResultFields = make([]reportFieldJSON, len(rfs))
+			for i, fk := range rfs {
+				entry.ResultFields[i] = reportFieldJSON{
+					Name: fk.Name, Kind: reportKindName(fk.Kind), Label: fk.Label,
+					Description: fk.Description, Title: fk.Title, DetailOnly: fk.DetailOnly,
+				}
 			}
 		}
 		out = append(out, entry)

--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -249,7 +249,10 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
       >
         <span className="text-2xs tabular-nums text-text-subtle shrink-0">{time}</span>
         <ApprovalStatusIcon ev={ev} inFlight={inFlight} />
-        <span className="font-mono text-2xs uppercase font-semibold text-text-muted shrink-0 w-11 flex items-center">
+        <span
+          className="font-mono text-2xs font-semibold text-text-muted shrink-0 w-44 truncate flex items-center"
+          title={inspected ? verb : undefined}
+        >
           {inspected ? verb : <LockGlyph />}
         </span>
         <span

--- a/dashboard/src/components/RequestDetailPage.tsx
+++ b/dashboard/src/components/RequestDetailPage.tsx
@@ -90,12 +90,14 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
   const { verb, body } = header;
   const fullUrl = ev.host + (body && !body.startsWith("/") ? " " : "") + body;
   const facetFields = facetDetailRows(ev, schema);
+  const resultFields = resultDetailRows(ev, schema);
   const hasReq = !!ev.req_body;
   const hasResp = !!ev.resp_body;
   const hasReqH = ev.req_headers && Object.keys(ev.req_headers).length > 0;
   const hasRespH = ev.resp_headers && Object.keys(ev.resp_headers).length > 0;
   const hasFacets = !isSQL && facetFields.length > 0;
-  const hasSections = hasFacets || hasReq || hasResp || hasReqH || hasRespH;
+  const hasResult = !isSQL && resultFields.length > 0;
+  const hasSections = hasFacets || hasResult || hasReq || hasResp || hasReqH || hasRespH;
 
   return (
     <Shell
@@ -158,6 +160,11 @@ export function RequestDetailPage({ id, agents }: { id: string; agents: Agent[] 
           {hasFacets && (
             <Section title="Request">
               <Facets rows={facetFields} />
+            </Section>
+          )}
+          {hasResult && (
+            <Section title="Result">
+              <Facets rows={resultFields} />
             </Section>
           )}
           {hasReqH && (
@@ -569,6 +576,29 @@ function facetDetailRows(ev: EventRecord, schema: FacetSchema | undefined): Face
       facet: `${schema.name}.${f.name}`,
       description: f.description || f.label || "",
       value: v,
+    });
+  }
+  return out;
+}
+
+// resultDetailRows returns the rows shown in the "result" section —
+// the facet's result-field schema (e.g. the action's status). The
+// only value available today is the action's status, which maps to
+// the result field flagged `title`; the remaining declared fields
+// have no per-field value yet, so they're skipped.
+function resultDetailRows(ev: EventRecord, schema: FacetSchema | undefined): FacetRow[] {
+  const fields = schema?.result_fields;
+  if (!fields || fields.length === 0) return [];
+  const status = ev.status ?? "";
+  if (!status) return [];
+  const out: FacetRow[] = [];
+  for (const f of fields) {
+    if (!f.title) continue;
+    out.push({
+      key: f.name,
+      facet: `${schema!.name}.${f.name}`,
+      description: f.description || f.label || "",
+      value: status,
     });
   }
   return out;

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -632,6 +632,9 @@ export type FacetSchema = {
   hitl_query_label?: string;
   host_is_resource: boolean;
   report_fields: Array<FacetField>;
+  // result_fields declares the after-the-fact result schema (e.g. the
+  // action's status). Only emitted by facets that have one.
+  result_fields?: Array<FacetField>;
 };
 
 export async function getFacets(): Promise<FacetSchema[]> {

--- a/internal/config/extplugin/facet.go
+++ b/internal/config/extplugin/facet.go
@@ -58,6 +58,7 @@ func (p *pluginFacet) Transport() string                     { return "" }
 func (p *pluginFacet) HITLQueryLabel() string                { return "Action" }
 func (p *pluginFacet) HostIsResource() bool                  { return false }
 func (p *pluginFacet) ReportFields() []facet.ReportFieldSpec { return p.reportFields }
+func (p *pluginFacet) ResultFields() []facet.ReportFieldSpec { return p.resultFields }
 func (p *pluginFacet) PrepareRequest(*match.Request)         {}
 func (p *pluginFacet) Report(*match.Request) map[string]any  { return nil }
 


### PR DESCRIPTION
Follow-up rendering fixes after the status feature shipped.

* The activity-log verb column was a fixed `w-11` sized for HTTP methods;
  facet-title verbs like `s3:GetBucketLocation` overflowed and overlapped
  the host. Widen to `w-44 truncate` with a full-value tooltip, and drop
  the `uppercase` transform so IAM actions render naturally.
* The request detail page rendered only a Request facet section. Add a
  Result section mirroring it, showing the facet's result-field schema —
  currently the action status mapped onto the result field marked `title`.
  Plumbed via `result_fields` on `/api/facets`, exposed by an optional
  `ResultFields()` accessor on plugin facets (the core facet.Runtime
  interface is unchanged).