### PR TITLE
extplugin: plugins can report a capped response body (FACET_STREAM result field)

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2026,6 +2026,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 			}
 			return g.dialUpstream(ctx, network, addr, serverName, ep, profile)
 		},
+		BodyStorageCap: g.cfg.Load().BodyStorageLimit(),
 		Emit: func(ev runtime.ConnEvent) {
 			if g.sink == nil {
 				return
@@ -2040,6 +2041,8 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 				Approver:     ev.Approver,
 				ApproverType: ev.ApproverType,
 				ApproverBy:   ev.ApproverBy,
+				RespBody:     ev.RespBody,
+				RespSha:      ev.RespSha,
 			})
 		},
 		Approve: func(req runtime.ApproveCallRequest) runtime.ApproveVerdict {

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -299,6 +299,21 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 	agentDone := make(chan error, 1)
 	pluginDone := make(chan error, 1)
 
+	// streamDead is the recv-loop-scoped abort signal for in-flight stream
+	// pulls. The recv loop is the ONLY goroutine that routes StreamChunk
+	// frames to a parked pullStream; once it exits — for ANY reason, clean
+	// ConnClose or recv/write error or plugin crash — no chunk can reach a
+	// pull, so a pull waiting on its reply channel would hang until ctx
+	// cancellation (which only fires after HandleConn returns, but HandleConn
+	// can't return because its deferred flush awaits that very pull: a
+	// deadlock). The recv loop closes this via defer on every exit, releasing
+	// any parked pull with its partial body so the end event still emits and
+	// flush unblocks. On a clean ConnClose the loop first drainBodyPulls to
+	// completion (capturing the full capped body), THEN returns and closes
+	// streamDead — by then the pull is already done, so the close is a no-op
+	// for it; the abort only bites on abnormal exits.
+	streamDead := make(chan struct{})
+
 	// agent -> plugin
 	go func() {
 		buf := make([]byte, 32*1024)
@@ -326,6 +341,12 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 
 	// plugin -> agent
 	go func() {
+		// Release any in-flight body pull on EVERY exit from this loop, not
+		// just the ConnClose case: a recv error, an agent conn.Write failure,
+		// EOF, or a plugin crash would otherwise leave a pull parked on a
+		// StreamChunk that can never arrive (this loop is the only router for
+		// it), which deadlocks flush → HandleConn → ctx cancellation.
+		defer close(streamDead)
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
@@ -362,7 +383,7 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 				// Run rule + approve chain off the recv loop so a
 				// HITL-blocking call doesn't stall data flow or
 				// other concurrent evaluations.
-				go handleEvaluate(ctx, ch, rs, k.Evaluate, doSend, streamReply)
+				go handleEvaluate(ctx, ch, rs, k.Evaluate, doSend, streamReply, streamDead)
 			case *pb.ConnMessage_StreamChunk:
 				replyCh := getStreamCh(k.StreamChunk.Handle)
 				select {
@@ -403,15 +424,17 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 				// for StreamChunk, which arrive HERE on this same recv loop. So
 				// the pull MUST run off this goroutine or it deadlocks: finish
 				// spawns it and the end event is emitted from that goroutine.
-				rs.finish(ctx, k.Result, doSend, streamReply)
+				rs.finish(ctx, k.Result, doSend, streamReply, streamDead)
 			case *pb.ConnMessage_Close:
 				// A response-body pull spawned by finish needs this recv loop
 				// to keep routing its StreamChunk frames. The plugin may queue
 				// ConnClose (HandleConn returned) before the pull reaches the
 				// cap/EOF, so don't tear down yet: keep reading and routing
 				// StreamChunks until the pull completes. The pull bounds itself
-				// (cap or EOF, then StreamCancel); ctx cancellation unblocks it
-				// if the stream dies.
+				// (cap or EOF, then StreamCancel). On a clean close drainBodyPull
+				// runs it to completion (full capped body); if the stream dies
+				// mid-drain, the deferred close(streamDead) below releases the
+				// pull with whatever it captured.
 				if done := rs.pullInFlight(); done != nil {
 					drainBodyPull(stream, done, getStreamCh)
 				}
@@ -567,7 +590,7 @@ const streamCapBytesForLog = 1024
 // ConnEvent so the action lands on the dashboard event sink with
 // the action map as the facet payload — plugins don't need to
 // double-emit via Conn.Emit.
-func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, rs *resultState, ev *pb.EvaluateAction, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk) {
+func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, rs *resultState, ev *pb.EvaluateAction, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, streamDead <-chan struct{}) {
 	action, derr := decodeAction(ev.ActionJson)
 	if derr != nil {
 		v := Verdict{Action: "error", Reason: fmt.Sprintf("malformed action_json: %v", derr)}
@@ -597,7 +620,7 @@ func handleEvaluate(ctx context.Context, ch *runtime.ConnHandle, rs *resultState
 			if pf != nil && !needed[fieldName] {
 				limit = streamCapBytesForLog
 			}
-			data, hit := pullStream(ctx, doSend, streamReply, handle, limit)
+			data, hit := pullStream(ctx, doSend, streamReply, streamDead, handle, limit)
 			if hit {
 				truncated = true
 			}
@@ -811,6 +834,12 @@ func (rs *resultState) begin(ev runtime.ConnEvent) {
 	cp := ev
 	rs.pending = &cp
 	rs.ended = false
+	// Clear any stale pull handle from a prior action. flushLocked above
+	// can't reach this case (it no-ops when the prior action already ended,
+	// which a body pull always does), but a defensive clear keeps a second
+	// begin() from leaving pullInFlight pointing at a closed channel that a
+	// later flush/ConnClose would treat as still in flight.
+	rs.pulling = nil
 	if rs.ch.Emit != nil {
 		rs.ch.Emit(ev)
 	}
@@ -829,7 +858,14 @@ func (rs *resultState) begin(ev runtime.ConnEvent) {
 //     own goroutine, records rs.pulling, and that goroutine emits the end
 //     event when the pull completes. flush and the ConnClose handler wait on
 //     rs.pulling so the body isn't truncated and the end isn't double-emitted.
-func (rs *resultState) finish(ctx context.Context, result *pb.ActionResult, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk) {
+//
+// streamDead is the recv-loop abort signal threaded into the pull: the recv
+// loop closes it on EVERY exit, so a pull parked waiting for a StreamChunk
+// that can never arrive (the loop is gone — recv error, agent write failure,
+// plugin crash) is released with its partial body instead of hanging. The end
+// event is still emitted exactly once (here, from the pull goroutine) so the
+// action persists even on an abnormal teardown.
+func (rs *resultState) finish(ctx context.Context, result *pb.ActionResult, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, streamDead <-chan struct{}) {
 	rs.mu.Lock()
 	if rs.pending == nil || rs.ended {
 		rs.mu.Unlock()
@@ -875,7 +911,7 @@ func (rs *resultState) finish(ctx context.Context, result *pb.ActionResult, doSe
 
 	go func() {
 		defer close(done)
-		body, sha := pullBodySample(ctx, doSend, streamReply, handle, cap)
+		body, sha := pullBodySample(ctx, doSend, streamReply, streamDead, handle, cap)
 		end.RespBody = body
 		end.RespSha = sha
 		if emit != nil {
@@ -912,7 +948,9 @@ func (rs *resultState) pullInFlight() <-chan struct{} {
 // ConnClose before the pull reached cap/EOF, so the loop would otherwise tear
 // down with chunks still owed to the pull. Non-StreamChunk frames arriving
 // here (the plugin shutting down) are dropped — the conn is closing. A recv
-// error ends the drain; the pull then unblocks on ctx cancellation.
+// error ends the drain; the recv loop then returns and its deferred
+// close(streamDead) releases the still-parked pull with its partial body (no
+// wait for ctx cancellation).
 func drainBodyPull(stream pb.Endpoint_HandleConnClient, done <-chan struct{}, getStreamCh func(handle string) chan *pb.StreamChunk) {
 	type recvRes struct {
 		msg *pb.ConnMessage
@@ -950,17 +988,23 @@ func drainBodyPull(stream pb.Endpoint_HandleConnClient, done <-chan struct{}, ge
 // pullBodySample pulls a plugin-offered FACET_STREAM response body up to the
 // gateway's body-storage cap, then cancels the stream. It returns the body
 // sample (capped, with the truncation marker appended when the body overran
-// the cap) and the hex SHA-256 of the full streamed bytes — the same shape
-// the built-in HTTP sampler produces, so the dashboard renders it
-// identically. Cancelling a stream the SDK is still serving is graceful: the
-// SDK drops the registered reader and the plugin's source sees a clean close.
-func pullBodySample(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, handle string, capBytes int) (sample, sha string) {
+// the cap) and the hex SHA-256 of the captured sample (at most cap+1 bytes).
+//
+// Unlike the built-in HTTP sampler, this SHA does NOT cover the full upstream
+// body: the gateway deliberately stops pulling at cap+1 and cancels the
+// stream, so it never sees the bytes past the cap and cannot hash them. That
+// is by design — the gateway bounds how much of a plugin response it buffers.
+// The sample's shape (capped preview + truncation marker) still matches the
+// built-in path so the dashboard renders it identically. Cancelling a stream
+// the SDK is still serving is graceful: the SDK drops the registered reader
+// and the plugin's source sees a clean close.
+func pullBodySample(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, streamDead <-chan struct{}, handle string, capBytes int) (sample, sha string) {
 	bs := newBodySampler(capBytes)
 	// Read one extra byte past the cap so we can tell a body that exactly
 	// fills the cap (no marker) from one that overran it (marker), matching
 	// the built-in sampler's n > cap truncation test.
 	pullLimit := capBytes + 1
-	data, _ := pullStream(ctx, doSend, streamReply, handle, pullLimit)
+	data, _ := pullStream(ctx, doSend, streamReply, streamDead, handle, pullLimit)
 	// Always cancel so the plugin can release its source, even on EOF.
 	_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_StreamCancel{StreamCancel: &pb.StreamCancel{Handle: handle}}})
 	bs.write(data)
@@ -1161,7 +1205,16 @@ func streamFieldsNeeded(rules []*config.CompiledRule, _ string) map[string]bool 
 // cap (and not because the stream eof'd). Errors and read failures
 // land here as eof, not truncation — we have no way to tell from
 // outside whether the plugin had more bytes to give.
-func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, handle string, limit int) (data []byte, truncated bool) {
+//
+// streamDead is the recv-loop-scoped abort signal: the recv loop closes it
+// (via defer) on EVERY exit — clean ConnClose, recv error, agent write
+// failure, EOF, plugin crash. Once it's closed no more StreamChunk frames
+// can arrive (the loop that routes them is gone), so a pull parked on its
+// reply channel would hang until ctx cancellation. Selecting on it here
+// releases the pull immediately with whatever bytes it has buffered. We do
+// not flag a streamDead abort as truncation: like a recv error, we can't
+// tell from outside whether the plugin had more bytes to give.
+func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, streamDead <-chan struct{}, handle string, limit int) (data []byte, truncated bool) {
 	if limit <= 0 {
 		return nil, false
 	}
@@ -1174,6 +1227,13 @@ func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamR
 		ch := streamReply(handle)
 		if ch == nil {
 			return out, false
+		}
+		// Bail before issuing another StreamRead if the recv loop is already
+		// gone — no chunk could ever come back for it.
+		select {
+		case <-streamDead:
+			return out, false
+		default:
 		}
 		if err := doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_StreamRead{StreamRead: &pb.StreamRead{
 			Handle: handle, MaxBytes: uint32(want),
@@ -1199,6 +1259,10 @@ func pullStream(ctx context.Context, doSend func(*pb.ConnMessage) error, streamR
 			if chunk.Eof {
 				return out, false
 			}
+		case <-streamDead:
+			// Recv loop exited (clean or abnormal) while we waited for a
+			// chunk: no further chunk can arrive. Return the partial body.
+			return out, false
 		case <-ctx.Done():
 			return out, false
 		}

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -906,12 +906,12 @@ func (rs *resultState) finish(ctx context.Context, result *pb.ActionResult, doSe
 	done := make(chan struct{})
 	rs.pulling = done
 	emit := rs.ch.Emit
-	cap := rs.bodyCap
+	capBytes := rs.bodyCap
 	rs.mu.Unlock()
 
 	go func() {
 		defer close(done)
-		body, sha := pullBodySample(ctx, doSend, streamReply, streamDead, handle, cap)
+		body, sha := pullBodySample(ctx, doSend, streamReply, streamDead, handle, capBytes)
 		end.RespBody = body
 		end.RespSha = sha
 		if emit != nil {

--- a/internal/config/extplugin/adapter.go
+++ b/internal/config/extplugin/adapter.go
@@ -2,7 +2,9 @@ package extplugin
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -395,10 +397,24 @@ func pumpConn(ctx context.Context, conn net.Conn, stream pb.Endpoint_HandleConnC
 			case *pb.ConnMessage_Result:
 				// The plugin reports an action's outcome after the response;
 				// finalize the conn's in-flight action (emit its end event
-				// carrying the status). Synchronous so it completes before the
-				// trailing Close frame, leaving the flush-on-return a no-op.
-				rs.finish(k.Result.ResultJson)
+				// carrying the status). When the result carries a FACET_STREAM
+				// body the gateway pulls it (up to the body cap) before
+				// emitting the end — and that pull issues StreamRead and waits
+				// for StreamChunk, which arrive HERE on this same recv loop. So
+				// the pull MUST run off this goroutine or it deadlocks: finish
+				// spawns it and the end event is emitted from that goroutine.
+				rs.finish(ctx, k.Result, doSend, streamReply)
 			case *pb.ConnMessage_Close:
+				// A response-body pull spawned by finish needs this recv loop
+				// to keep routing its StreamChunk frames. The plugin may queue
+				// ConnClose (HandleConn returned) before the pull reaches the
+				// cap/EOF, so don't tear down yet: keep reading and routing
+				// StreamChunks until the pull completes. The pull bounds itself
+				// (cap or EOF, then StreamCancel); ctx cancellation unblocks it
+				// if the stream dies.
+				if done := rs.pullInFlight(); done != nil {
+					drainBodyPull(stream, done, getStreamCh)
+				}
 				pluginDone <- nil
 				return
 			}
@@ -452,6 +468,84 @@ func halfCloseWrite(c net.Conn) {
 	if cw, ok := c.(interface{ CloseWrite() error }); ok {
 		_ = cw.CloseWrite()
 	}
+}
+
+// bodyTruncatedMarker is appended to a persisted response-body sample when
+// the body exceeded the gateway's body-storage cap. It is byte-for-byte the
+// marker the built-in HTTP sampler emits (cmd/clawpatrol/web.go's
+// bodyTruncatedMarker), so the dashboard's BODY_TRUNCATED_MARKER handling
+// renders a plugin response body's "truncated" badge with no extra wiring.
+const bodyTruncatedMarker = "\n[clawpatrol:body-truncated]"
+
+// bodySampler caps a plugin-streamed response body to the gateway's
+// body-storage limit and hashes the bytes it captured, mirroring the
+// built-in HTTP path's sampler so plugin and built-in response samples look
+// identical on the dashboard. The gateway pulls at most cap+1 bytes (the
+// extra byte distinguishes a body that exactly fills the cap from one that
+// overran it) and cancels the stream, so the SHA covers the captured sample
+// rather than the full upstream body — the gateway never sees more than the
+// cap by design.
+type bodySampler struct {
+	cap int
+	buf []byte
+}
+
+func newBodySampler(capBytes int) *bodySampler {
+	if capBytes < 0 {
+		capBytes = 0
+	}
+	return &bodySampler{cap: capBytes}
+}
+
+func (b *bodySampler) write(p []byte) { b.buf = append(b.buf, p...) }
+
+// truncated reports whether more bytes were pulled than the cap keeps — the
+// caller pulls cap+1 bytes precisely so this is detectable.
+func (b *bodySampler) truncated() bool { return len(b.buf) > b.cap }
+
+// sample returns the capped body preview: the first cap bytes, with the
+// truncation marker appended when the body overran the cap. Binary bodies
+// are rendered as a hex prefix, matching the built-in sampler.
+func (b *bodySampler) sample() string {
+	if len(b.buf) == 0 {
+		return ""
+	}
+	keep := b.buf
+	if len(keep) > b.cap {
+		keep = keep[:b.cap]
+	}
+	var out string
+	if isPrintable(keep) {
+		out = string(keep)
+	} else {
+		out = "binary:" + hex.EncodeToString(keep[:min(64, len(keep))])
+	}
+	if b.truncated() {
+		out += bodyTruncatedMarker
+	}
+	return out
+}
+
+// sha is the hex SHA-256 of the captured sample bytes (at most cap+1). Empty
+// when nothing was captured.
+func (b *bodySampler) sha() string {
+	if len(b.buf) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(b.buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// isPrintable mirrors the built-in sampler's predicate (web.go) so a binary
+// plugin response body is rendered as a hex prefix here too, not as garbled
+// text on the dashboard.
+func isPrintable(b []byte) bool {
+	for _, x := range b {
+		if x == 0 || (x < 0x20 && x != '\n' && x != '\r' && x != '\t') {
+			return false
+		}
+	}
+	return true
 }
 
 // streamCapBytesForRule is how many bytes the gateway pulls from a
@@ -678,19 +772,34 @@ func emitEvaluation(ch *runtime.ConnHandle, rs *resultState, summary string, act
 // connection's current action. Sequential request/response only — begin()
 // flushes any prior unfinished action so it can't be orphaned.
 type resultState struct {
-	mu      sync.Mutex
-	ch      *runtime.ConnHandle
-	title   string // result-schema title field name → Status
-	pending *runtime.ConnEvent
-	ended   bool
+	mu        sync.Mutex
+	ch        *runtime.ConnHandle
+	title     string // result-schema title field name → Status
+	bodyField string // result-schema FACET_STREAM field name → RespBody
+	bodyCap   int    // gateway body-storage cap for the response sample
+	pending   *runtime.ConnEvent
+	ended     bool
+	// pulling, when non-nil, signals an in-flight response-body pull
+	// spawned by finish: it is closed once the pull completes and the end
+	// event has been emitted. flush (deferred on pumpConn return) and the
+	// recv loop's ConnClose handler wait on it so the body pull isn't cut
+	// short and the end event isn't double-emitted. Held under mu.
+	pulling chan struct{}
 }
 
 func newResultState(ch *runtime.ConnHandle) *resultState {
 	rs := &resultState{ch: ch}
-	if ch.Endpoint != nil {
-		if pf := facetFor(ch.Endpoint.Family); pf != nil {
-			rs.title = pf.resultTitle
+	if ch != nil {
+		rs.bodyCap = ch.BodyStorageCap
+		if ch.Endpoint != nil {
+			if pf := facetFor(ch.Endpoint.Family); pf != nil {
+				rs.title = pf.resultTitle
+				rs.bodyField = pf.resultBodyField
+			}
 		}
+	}
+	if rs.bodyCap <= 0 {
+		rs.bodyCap = int(config.DefaultBodyStorageLimit)
 	}
 	return rs
 }
@@ -707,31 +816,163 @@ func (rs *resultState) begin(ev runtime.ConnEvent) {
 	}
 }
 
-// finish emits the end event carrying the plugin-reported status, lifted
-// from the result schema's title field in result_json.
-func (rs *resultState) finish(resultJSON []byte) {
+// finish finalizes the conn's in-flight action from a plugin ActionResult.
+// It lifts the plugin-reported status from the result schema's title field,
+// then:
+//
+//   - With no FACET_STREAM body stream, it emits the end event synchronously
+//     — identical to the status-only path before response bodies existed.
+//   - With a body stream, the gateway must pull it (up to the body cap) and
+//     fold the sample onto the end event. The pull issues StreamRead and
+//     waits for StreamChunk, both of which travel the recv loop that calls
+//     finish; pulling here would deadlock. So finish spawns the pull on its
+//     own goroutine, records rs.pulling, and that goroutine emits the end
+//     event when the pull completes. flush and the ConnClose handler wait on
+//     rs.pulling so the body isn't truncated and the end isn't double-emitted.
+func (rs *resultState) finish(ctx context.Context, result *pb.ActionResult, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk) {
 	rs.mu.Lock()
-	defer rs.mu.Unlock()
 	if rs.pending == nil || rs.ended {
+		rs.mu.Unlock()
 		return
 	}
 	end := *rs.pending
 	end.Phase = "end"
-	if rs.title != "" && len(resultJSON) > 0 {
+	if rs.title != "" && len(result.GetResultJson()) > 0 {
 		var rj map[string]any
-		if json.Unmarshal(resultJSON, &rj) == nil {
+		if json.Unmarshal(result.GetResultJson(), &rj) == nil {
 			if val, ok := rj[rs.title]; ok && val != nil {
 				end.Status = fmt.Sprint(val)
 			}
 		}
 	}
+
+	// Identify the response-body stream handle, if the result offers one.
+	handle := ""
+	if rs.bodyField != "" {
+		handle = result.GetStreams()[rs.bodyField]
+	}
+	if handle == "" {
+		// Status-only path: emit now, no pull. Unchanged from before.
+		rs.ended = true
+		emit := rs.ch.Emit
+		rs.mu.Unlock()
+		if emit != nil {
+			emit(end)
+		}
+		return
+	}
+
+	// Body path: mark the action ended (no other path may emit it) and hand
+	// the end event to a pull goroutine. ended is set under the lock now so
+	// flush/ConnClose can't race a duplicate emit; the goroutine owns the
+	// single emit once the pull finishes.
 	rs.ended = true
-	if rs.ch.Emit != nil {
-		rs.ch.Emit(end)
+	done := make(chan struct{})
+	rs.pulling = done
+	emit := rs.ch.Emit
+	cap := rs.bodyCap
+	rs.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		body, sha := pullBodySample(ctx, doSend, streamReply, handle, cap)
+		end.RespBody = body
+		end.RespSha = sha
+		if emit != nil {
+			emit(end)
+		}
+	}()
+}
+
+// awaitPull blocks until any in-flight response-body pull spawned by finish
+// has completed (its end event emitted). Safe to call when none is in
+// flight. Used by flush and the recv loop's ConnClose handler so the pull —
+// which needs the recv loop alive to receive StreamChunk frames — isn't cut
+// short, and so the end event is emitted exactly once.
+func (rs *resultState) awaitPull() {
+	if done := rs.pullInFlight(); done != nil {
+		<-done
 	}
 }
 
+// pullInFlight returns the completion channel of an in-flight body pull, or
+// nil when none is running.
+func (rs *resultState) pullInFlight() <-chan struct{} {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if rs.pulling == nil {
+		return nil
+	}
+	return rs.pulling
+}
+
+// drainBodyPull keeps reading the plugin stream and routing StreamChunk
+// frames to the in-flight body pull until that pull completes (done closes).
+// It is called from the recv loop's ConnClose handler: the plugin queued
+// ConnClose before the pull reached cap/EOF, so the loop would otherwise tear
+// down with chunks still owed to the pull. Non-StreamChunk frames arriving
+// here (the plugin shutting down) are dropped — the conn is closing. A recv
+// error ends the drain; the pull then unblocks on ctx cancellation.
+func drainBodyPull(stream pb.Endpoint_HandleConnClient, done <-chan struct{}, getStreamCh func(handle string) chan *pb.StreamChunk) {
+	type recvRes struct {
+		msg *pb.ConnMessage
+		err error
+	}
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		ch := make(chan recvRes, 1)
+		go func() {
+			m, err := stream.Recv()
+			ch <- recvRes{m, err}
+		}()
+		select {
+		case <-done:
+			return
+		case r := <-ch:
+			if r.err != nil {
+				return
+			}
+			if sc, ok := r.msg.GetKind().(*pb.ConnMessage_StreamChunk); ok {
+				replyCh := getStreamCh(sc.StreamChunk.Handle)
+				select {
+				case replyCh <- sc.StreamChunk:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// pullBodySample pulls a plugin-offered FACET_STREAM response body up to the
+// gateway's body-storage cap, then cancels the stream. It returns the body
+// sample (capped, with the truncation marker appended when the body overran
+// the cap) and the hex SHA-256 of the full streamed bytes — the same shape
+// the built-in HTTP sampler produces, so the dashboard renders it
+// identically. Cancelling a stream the SDK is still serving is graceful: the
+// SDK drops the registered reader and the plugin's source sees a clean close.
+func pullBodySample(ctx context.Context, doSend func(*pb.ConnMessage) error, streamReply func(handle string) <-chan *pb.StreamChunk, handle string, capBytes int) (sample, sha string) {
+	bs := newBodySampler(capBytes)
+	// Read one extra byte past the cap so we can tell a body that exactly
+	// fills the cap (no marker) from one that overran it (marker), matching
+	// the built-in sampler's n > cap truncation test.
+	pullLimit := capBytes + 1
+	data, _ := pullStream(ctx, doSend, streamReply, handle, pullLimit)
+	// Always cancel so the plugin can release its source, even on EOF.
+	_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_StreamCancel{StreamCancel: &pb.StreamCancel{Handle: handle}}})
+	bs.write(data)
+	return bs.sample(), bs.sha()
+}
+
 func (rs *resultState) flush() {
+	// Wait for any in-flight body pull to emit its end event first, so we
+	// don't race it (it already set rs.ended under the lock, so flushLocked
+	// would no-op — but the pull must still get to run to completion and
+	// emit). After it returns, flushLocked handles the no-result case.
+	rs.awaitPull()
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	rs.flushLocked()

--- a/internal/config/extplugin/facet.go
+++ b/internal/config/extplugin/facet.go
@@ -50,6 +50,10 @@ type pluginFacet struct {
 	// reports no result schema.
 	resultFields []facet.ReportFieldSpec
 	resultTitle  string
+	// resultBodyField is the name of the FACET_STREAM result field — the
+	// response body the gateway pulls (up to its body-storage cap) and
+	// cancels. For v1 a facet declares at most one; "" when none.
+	resultBodyField string
 }
 
 func (p *pluginFacet) Name() string                          { return p.name }
@@ -127,14 +131,22 @@ func registerFacet(pluginName string, decl *pb.FacetDecl) hcl.Diagnostics {
 			break
 		}
 	}
+	resultBodyField := ""
+	for _, rf := range decl.ResultFields {
+		if rf.Kind == pb.FacetKind_FACET_STREAM {
+			resultBodyField = rf.Name
+			break
+		}
+	}
 	pf := &pluginFacet{
-		name:           decl.Name,
-		reportFields:   protoFacetFieldsToSpec(decl.Fields),
-		kindByField:    kindByField,
-		optionalFields: optional,
-		streamFields:   streams,
-		resultFields:   resultFields,
-		resultTitle:    resultTitle,
+		name:            decl.Name,
+		reportFields:    protoFacetFieldsToSpec(decl.Fields),
+		kindByField:     kindByField,
+		optionalFields:  optional,
+		streamFields:    streams,
+		resultFields:    resultFields,
+		resultTitle:     resultTitle,
+		resultBodyField: resultBodyField,
 	}
 	facet.Register(pf)
 	return nil

--- a/internal/config/extplugin/result_status_e2e_test.go
+++ b/internal/config/extplugin/result_status_e2e_test.go
@@ -2,10 +2,13 @@ package extplugin
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"net"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -99,6 +102,9 @@ func registerResultFacet(t *testing.T) {
 		},
 		ResultFields: []*pb.FacetFieldDecl{
 			{Name: "status", Kind: pb.FacetKind_FACET_STRING, Title: true},
+			// body is the FACET_STREAM result field — a response body the
+			// gateway pulls up to its cap and cancels.
+			{Name: "body", Kind: pb.FacetKind_FACET_STREAM},
 		},
 	}); diags.HasErrors() {
 		t.Fatalf("registerFacet: %v", diags)
@@ -122,8 +128,11 @@ func startResultPlugin(t *testing.T, handle func(ctx context.Context, conn *plug
 		Name:    "resulttestplugin",
 		Version: "0.0.1",
 		Facets: []pluginsdk.FacetDef{{
-			Name:         resultFacetName,
-			ResultFields: []pluginsdk.FacetField{{Name: "status", Title: true}},
+			Name: resultFacetName,
+			ResultFields: []pluginsdk.FacetField{
+				{Name: "status", Title: true},
+				{Name: "body", Kind: pluginsdk.FacetStream},
+			},
 		}},
 		Endpoints: []pluginsdk.EndpointDef{endpoint},
 	})
@@ -163,14 +172,22 @@ func startResultPlugin(t *testing.T, handle func(ctx context.Context, conn *plug
 // runResultConn drives one connection through the adapter with the supplied
 // agent behaviour and returns the emitted events.
 func runResultConn(t *testing.T, adapter *endpointAdapter, ep *config.CompiledEndpoint, drive func(agent net.Conn)) []runtime.ConnEvent {
+	return runResultConnCap(t, adapter, ep, 0, drive)
+}
+
+// runResultConnCap is runResultConn with an explicit response-body cap on the
+// ConnHandle (0 = gateway default). The body cap bounds the FACET_STREAM
+// response-body sample the gateway pulls.
+func runResultConnCap(t *testing.T, adapter *endpointAdapter, ep *config.CompiledEndpoint, bodyCap int, drive func(agent net.Conn)) []runtime.ConnEvent {
 	t.Helper()
 	var mu sync.Mutex
 	var events []runtime.ConnEvent
 	ch := &runtime.ConnHandle{
-		Endpoint:     ep,
-		PeerIP:       "1.2.3.4",
-		UpstreamHost: "api.example.test",
-		DstPort:      443,
+		Endpoint:       ep,
+		PeerIP:         "1.2.3.4",
+		UpstreamHost:   "api.example.test",
+		DstPort:        443,
+		BodyStorageCap: bodyCap,
 		Emit: func(ev runtime.ConnEvent) {
 			mu.Lock()
 			events = append(events, ev)
@@ -330,5 +347,150 @@ func TestEndpointSetResultStatusNoResponseBody(t *testing.T) {
 	}
 	if end.Status != "204" {
 		t.Fatalf("end.Status=%q, want \"204\"; events=%+v", end.Status, events)
+	}
+}
+
+// cancelTrackingReader wraps a body reader and records whether the SDK closed
+// it (the graceful response to the gateway's StreamCancel) versus the plugin
+// observing a hard read error. Used to assert that capping/cancelling a
+// response-body stream does not error the plugin.
+type cancelTrackingReader struct {
+	r      io.Reader
+	closed atomic.Bool
+}
+
+func (c *cancelTrackingReader) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *cancelTrackingReader) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+// bodyResultHandle returns a HandleConn that evaluates (allowed), reports its
+// outcome via SetResult with a FACET_STREAM body of the given size, writes a
+// short response, and returns. The reader it offers is recorded so the test
+// can assert the gateway's cancel closed it gracefully.
+func bodyResultHandle(bodySize int, reader **cancelTrackingReader) func(ctx context.Context, conn *pluginsdk.Conn) error {
+	return func(ctx context.Context, conn *pluginsdk.Conn) error {
+		br := bufio.NewReader(conn)
+		if _, err := readHTTPRequestLine(br); err != nil {
+			return err
+		}
+		v, err := conn.Evaluate(ctx, resultFacetName, map[string]any{"verb": "GET"}, "GET /")
+		if err != nil {
+			return err
+		}
+		if v.Action != "allow" && v.Action != "hitl_allow" {
+			return nil
+		}
+		body := bytes.Repeat([]byte("A"), bodySize)
+		ctr := &cancelTrackingReader{r: bytes.NewReader(body)}
+		*reader = ctr
+		if err := conn.SetResult(ctx, map[string]any{
+			"status": "200",
+			"body":   pluginsdk.Stream(ctr),
+		}); err != nil {
+			return err
+		}
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"))
+		return nil
+	}
+}
+
+// TestEndpointSetResultBodyCapped offers a response body LARGER than the cap.
+// The gateway must pull up to the cap, append the truncation marker, and set
+// the sample on the end event — and cancelling the stream must not error the
+// plugin (its reader is closed cleanly, HandleConn returns nil).
+func TestEndpointSetResultBodyCapped(t *testing.T) {
+	const cap = 16
+	var reader *cancelTrackingReader
+	adapter, ep := startResultPlugin(t, bodyResultHandle(cap*8, &reader))
+
+	var handleErr error
+	var mu sync.Mutex
+	var events []runtime.ConnEvent
+	ch := &runtime.ConnHandle{
+		Endpoint:       ep,
+		PeerIP:         "1.2.3.4",
+		UpstreamHost:   "api.example.test",
+		DstPort:        443,
+		BodyStorageCap: cap,
+		Emit: func(ev runtime.ConnEvent) {
+			mu.Lock()
+			events = append(events, ev)
+			mu.Unlock()
+		},
+	}
+	gw, agent := tcpPipe(t)
+	ch.Conn = gw
+	done := make(chan struct{})
+	go func() { handleErr = adapter.HandleConn(context.Background(), ch); close(done) }()
+	go func() {
+		_, _ = agent.Write([]byte("GET / HTTP/1.1\r\nHost: api.example.test\r\n\r\n"))
+		_, _ = io.Copy(io.Discard, agent)
+		_ = agent.Close()
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("HandleConn did not return")
+	}
+
+	mu.Lock()
+	evs := append([]runtime.ConnEvent(nil), events...)
+	mu.Unlock()
+	_, end := startEnd(evs)
+	if end == nil {
+		t.Fatalf("no end event; events=%+v", evs)
+	}
+	if end.Status != "200" {
+		t.Errorf("end.Status=%q, want \"200\"", end.Status)
+	}
+	if !strings.HasSuffix(end.RespBody, bodyTruncatedMarker) {
+		t.Fatalf("RespBody missing truncation marker; got %q", end.RespBody)
+	}
+	prefix := strings.TrimSuffix(end.RespBody, bodyTruncatedMarker)
+	if len(prefix) != cap {
+		t.Errorf("capped prefix len=%d, want %d; RespBody=%q", len(prefix), cap, end.RespBody)
+	}
+	if prefix != strings.Repeat("A", cap) {
+		t.Errorf("capped prefix=%q, want %d A's", prefix, cap)
+	}
+	if end.RespSha == "" {
+		t.Errorf("RespSha empty for a non-empty body")
+	}
+	if handleErr != nil {
+		t.Errorf("plugin HandleConn errored by gateway cancel: %v", handleErr)
+	}
+	if reader == nil || !reader.closed.Load() {
+		t.Errorf("plugin body reader was not closed by the gateway's StreamCancel (graceful cancel)")
+	}
+}
+
+// TestEndpointSetResultBodySmall offers a response body SMALLER than the cap.
+// The full body must surface on the end event with no truncation marker.
+func TestEndpointSetResultBodySmall(t *testing.T) {
+	const cap = 4096
+	const bodyLen = 11
+	want := strings.Repeat("A", bodyLen)
+	var reader *cancelTrackingReader
+	adapter, ep := startResultPlugin(t, bodyResultHandle(bodyLen, &reader))
+
+	events := runResultConnCap(t, adapter, ep, cap, func(agent net.Conn) {
+		_, _ = agent.Write([]byte("GET / HTTP/1.1\r\nHost: api.example.test\r\n\r\n"))
+		_, _ = io.Copy(io.Discard, agent)
+		_ = agent.Close()
+	})
+	_, end := startEnd(events)
+	if end == nil {
+		t.Fatalf("no end event; events=%+v", events)
+	}
+	if end.Status != "200" {
+		t.Errorf("end.Status=%q, want \"200\"", end.Status)
+	}
+	if strings.Contains(end.RespBody, bodyTruncatedMarker) {
+		t.Errorf("small body should not be truncated; RespBody=%q", end.RespBody)
+	}
+	if end.RespBody != want {
+		t.Errorf("RespBody=%q, want %q", end.RespBody, want)
 	}
 }

--- a/internal/config/extplugin/result_status_e2e_test.go
+++ b/internal/config/extplugin/result_status_e2e_test.go
@@ -401,9 +401,9 @@ func bodyResultHandle(bodySize int, reader **cancelTrackingReader) func(ctx cont
 // the sample on the end event — and cancelling the stream must not error the
 // plugin (its reader is closed cleanly, HandleConn returns nil).
 func TestEndpointSetResultBodyCapped(t *testing.T) {
-	const cap = 16
+	const capBytes = 16
 	var reader *cancelTrackingReader
-	adapter, ep := startResultPlugin(t, bodyResultHandle(cap*8, &reader))
+	adapter, ep := startResultPlugin(t, bodyResultHandle(capBytes*8, &reader))
 
 	var handleErr error
 	var mu sync.Mutex
@@ -413,7 +413,7 @@ func TestEndpointSetResultBodyCapped(t *testing.T) {
 		PeerIP:         "1.2.3.4",
 		UpstreamHost:   "api.example.test",
 		DstPort:        443,
-		BodyStorageCap: cap,
+		BodyStorageCap: capBytes,
 		Emit: func(ev runtime.ConnEvent) {
 			mu.Lock()
 			events = append(events, ev)
@@ -449,11 +449,11 @@ func TestEndpointSetResultBodyCapped(t *testing.T) {
 		t.Fatalf("RespBody missing truncation marker; got %q", end.RespBody)
 	}
 	prefix := strings.TrimSuffix(end.RespBody, bodyTruncatedMarker)
-	if len(prefix) != cap {
-		t.Errorf("capped prefix len=%d, want %d; RespBody=%q", len(prefix), cap, end.RespBody)
+	if len(prefix) != capBytes {
+		t.Errorf("capped prefix len=%d, want %d; RespBody=%q", len(prefix), capBytes, end.RespBody)
 	}
-	if prefix != strings.Repeat("A", cap) {
-		t.Errorf("capped prefix=%q, want %d A's", prefix, cap)
+	if prefix != strings.Repeat("A", capBytes) {
+		t.Errorf("capped prefix=%q, want %d A's", prefix, capBytes)
 	}
 	if end.RespSha == "" {
 		t.Errorf("RespSha empty for a non-empty body")
@@ -685,13 +685,13 @@ func TestEndpointSetResultBodyPullConnErrorsNoHang(t *testing.T) {
 // TestEndpointSetResultBodySmall offers a response body SMALLER than the cap.
 // The full body must surface on the end event with no truncation marker.
 func TestEndpointSetResultBodySmall(t *testing.T) {
-	const cap = 4096
+	const capBytes = 4096
 	const bodyLen = 11
 	want := strings.Repeat("A", bodyLen)
 	var reader *cancelTrackingReader
 	adapter, ep := startResultPlugin(t, bodyResultHandle(bodyLen, &reader))
 
-	events := runResultConnCap(t, adapter, ep, cap, func(agent net.Conn) {
+	events := runResultConnCap(t, adapter, ep, capBytes, func(agent net.Conn) {
 		_, _ = agent.Write([]byte("GET / HTTP/1.1\r\nHost: api.example.test\r\n\r\n"))
 		_, _ = io.Copy(io.Discard, agent)
 		_ = agent.Close()

--- a/internal/config/extplugin/result_status_e2e_test.go
+++ b/internal/config/extplugin/result_status_e2e_test.go
@@ -466,6 +466,222 @@ func TestEndpointSetResultBodyCapped(t *testing.T) {
 	}
 }
 
+// blockingBodyReader serves a fixed prefix once, then parks every subsequent
+// Read until release is closed. It signals reading exactly once (the first
+// time the SDK pulls a chunk on the gateway's behalf) so a test can learn the
+// gateway's body pull is genuinely in flight before it tears the transport
+// down. Returning io.EOF after release lets the parked Read unwind cleanly.
+type blockingBodyReader struct {
+	prefix    []byte
+	served    atomic.Bool
+	reading   chan struct{} // closed once, when the first Read lands
+	readingMu sync.Once
+	release   chan struct{} // test closes this to unblock the parked Read
+}
+
+func newBlockingBodyReader(prefix []byte) *blockingBodyReader {
+	return &blockingBodyReader{
+		prefix:  prefix,
+		reading: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (b *blockingBodyReader) Read(p []byte) (int, error) {
+	b.readingMu.Do(func() { close(b.reading) })
+	if b.served.CompareAndSwap(false, true) {
+		n := copy(p, b.prefix)
+		return n, nil
+	}
+	// Park until the test releases us; then report EOF so the SDK reader
+	// goroutine unwinds without leaking.
+	<-b.release
+	return 0, io.EOF
+}
+
+// TestEndpointSetResultBodyPullConnErrorsNoHang is the regression for the
+// mid-pull deadlock: a response-body pull is in flight (the gateway issued a
+// StreamRead and is parked waiting for the next StreamChunk) when the plugin
+// connection dies UNCLEANLY — the transport is torn down, so the recv loop
+// exits via stream.Recv()'s error path, NOT a clean ConnClose. Before the fix
+// the parked pull could only be released by ctx cancellation, which can't fire
+// because HandleConn's deferred flush awaits that very pull: a permanent hang.
+//
+// Asserts: the end event is still emitted exactly once, carrying the status
+// and the partial body captured before the abort, and HandleConn returns —
+// all within a deadline, so a regression hangs the test instead of passing.
+func TestEndpointSetResultBodyPullConnErrorsNoHang(t *testing.T) {
+	registerResultFacet(t)
+
+	body := newBlockingBodyReader([]byte("PARTIAL-BODY"))
+	handlerBlocked := make(chan struct{})
+	handle := func(ctx context.Context, conn *pluginsdk.Conn) error {
+		br := bufio.NewReader(conn)
+		if _, err := readHTTPRequestLine(br); err != nil {
+			return err
+		}
+		v, err := conn.Evaluate(ctx, resultFacetName, map[string]any{"verb": "GET"}, "GET /")
+		if err != nil {
+			return err
+		}
+		if v.Action != "allow" && v.Action != "hitl_allow" {
+			return nil
+		}
+		if err := conn.SetResult(ctx, map[string]any{
+			"status": "200",
+			"body":   pluginsdk.Stream(body),
+		}); err != nil {
+			return err
+		}
+		// Do NOT return: returning would queue a clean ConnClose, which the
+		// drainBodyPull path already handles. We want the recv loop to exit
+		// via the transport-error path instead, so block until torn down.
+		close(handlerBlocked)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// Build the wiring inline (rather than via startResultPlugin) so we keep a
+	// handle on the go-plugin client and can sever the transport mid-pull.
+	endpoint := pluginsdk.EndpointDef{
+		TypeName:   "resulttest_api",
+		Family:     resultFacetName,
+		TLSMode:    pluginsdk.TLSNone,
+		HandleConn: handle,
+	}
+	sdkSrv := pluginsdk.NewEndpointServerForTest(&pluginsdk.Plugin{
+		Name:    "resulttestplugin",
+		Version: "0.0.1",
+		Facets: []pluginsdk.FacetDef{{
+			Name: resultFacetName,
+			ResultFields: []pluginsdk.FacetField{
+				{Name: "status", Title: true},
+				{Name: "body", Kind: pluginsdk.FacetStream},
+			},
+		}},
+		Endpoints: []pluginsdk.EndpointDef{endpoint},
+	})
+	sessions := newSessionRegistry()
+	p := &sdkEndpointPlugin{server: sdkSrv, sessions: sessions}
+	gpClient, _ := goplugin.TestPluginGRPCConn(t, true, map[string]goplugin.Plugin{"x": p})
+	t.Cleanup(func() { _ = gpClient.Close() })
+	raw, err := gpClient.Dispense("x")
+	if err != nil {
+		t.Fatalf("dispense: %v", err)
+	}
+	grpcConn, ok := raw.(*grpc.ClientConn)
+	if !ok {
+		t.Fatalf("dispense returned %T, want *grpc.ClientConn", raw)
+	}
+	client := &Client{endpoint: pb.NewEndpointClient(grpcConn), sessions: sessions}
+	adapter := &endpointAdapter{client: client, typeName: "resulttest_api"}
+
+	m, err := facet.NewMatcher(resultFacetName, "resulttest.verb == 'GET'")
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	ep := &config.CompiledEndpoint{
+		Name:   "resulttest-ep",
+		Family: resultFacetName,
+		Rules: []*config.CompiledRule{
+			{Name: "allow-get", Matcher: m, Outcome: config.Outcome{Verdict: "allow"}},
+		},
+		Plugin: &config.Plugin{Family: resultFacetName},
+		Body:   &dynamicEndpointBody{adapter: adapter, instanceName: "resulttest1"},
+	}
+
+	const bodyCap = 4096
+	var mu sync.Mutex
+	var events []runtime.ConnEvent
+	ch := &runtime.ConnHandle{
+		Endpoint:       ep,
+		PeerIP:         "1.2.3.4",
+		UpstreamHost:   "api.example.test",
+		DstPort:        443,
+		BodyStorageCap: bodyCap,
+		Emit: func(ev runtime.ConnEvent) {
+			mu.Lock()
+			events = append(events, ev)
+			mu.Unlock()
+		},
+	}
+	gw, agent := tcpPipe(t)
+	ch.Conn = gw
+
+	done := make(chan error, 1)
+	go func() { done <- adapter.HandleConn(context.Background(), ch) }()
+	go func() {
+		_, _ = agent.Write([]byte("GET / HTTP/1.1\r\nHost: api.example.test\r\n\r\n"))
+		// Drain in the background; the conn is torn down by the transport
+		// sever below, not the agent.
+		_, _ = io.Copy(io.Discard, agent)
+	}()
+
+	// Wait until the gateway's body pull is genuinely in flight: the SDK's
+	// reader has been invoked (first StreamRead delivered) and the handler is
+	// parked after SetResult.
+	select {
+	case <-body.reading:
+	case <-time.After(5 * time.Second):
+		t.Fatal("body pull never started (reader Read not invoked)")
+	}
+	select {
+	case <-handlerBlocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never reached its post-SetResult block")
+	}
+
+	// Sever the plugin transport. The gateway's stream.Recv() now errors and
+	// the recv loop exits via its NON-ConnClose path, with the pull parked.
+	_ = gpClient.Close()
+	close(body.release)
+	// Close the agent side too so pumpConn's teardown doesn't sit on the
+	// 30s connDrainTimeout waiting for the agent to read a response that the
+	// dead plugin will never produce. This is orthogonal to the deadlock: the
+	// pull is released by streamDead regardless, but closing the agent keeps
+	// the test's deadline tight and exercises the agentDone teardown path
+	// whose deferred flush is exactly where the pre-fix hang lived.
+	_ = agent.Close()
+
+	// The fix must release the parked pull and let HandleConn return. A
+	// regression hangs here instead.
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleConn did not return after mid-pull transport error (deadlock regression)")
+	}
+
+	mu.Lock()
+	evs := append([]runtime.ConnEvent(nil), events...)
+	mu.Unlock()
+
+	start, end := startEnd(evs)
+	if start == nil {
+		t.Fatalf("no start event; events=%+v", evs)
+	}
+	if end == nil {
+		t.Fatalf("no end event — action lost on mid-pull abort; events=%+v", evs)
+	}
+	// Exactly one end event (no double-emit between the pull goroutine and
+	// flush).
+	ends := 0
+	for i := range evs {
+		if evs[i].Phase == "end" {
+			ends++
+		}
+	}
+	if ends != 1 {
+		t.Fatalf("want exactly one end event, got %d; events=%+v", ends, evs)
+	}
+	if end.Status != "200" {
+		t.Errorf("end.Status=%q, want \"200\"; events=%+v", end.Status, evs)
+	}
+	// The partial body captured before the abort surfaces on the end event.
+	if end.RespBody != "PARTIAL-BODY" {
+		t.Errorf("end.RespBody=%q, want %q (partial body before abort)", end.RespBody, "PARTIAL-BODY")
+	}
+}
+
 // TestEndpointSetResultBodySmall offers a response body SMALLER than the cap.
 // The full body must surface on the end event with no truncation marker.
 func TestEndpointSetResultBodySmall(t *testing.T) {

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -268,6 +268,12 @@ type ConnHandle struct {
 	// SNI the client sent. nil when the dispatcher can't mint
 	// (gateway has no CA).
 	MintCert func(host string) (*tls.Certificate, error)
+	// BodyStorageCap is the most response-body the gateway buffers when a
+	// plugin offers a FACET_STREAM result field (cfg.BodyStorageLimit()).
+	// It matches the cap the built-in HTTP sampler uses, so plugin and
+	// built-in response samples are bounded identically. Zero means use the
+	// default (config.DefaultBodyStorageLimit).
+	BodyStorageCap int
 }
 
 // ApproveCallRequest is what a ConnEndpointRuntime hands to
@@ -326,6 +332,19 @@ type ConnEvent struct {
 	// ResultFacets is the after-the-fact report payload (values keyed by
 	// the facet's result_fields). Set on the end event alongside Status.
 	ResultFacets map[string]any
+
+	// RespBody is the plugin-reported, gateway-capped response sample —
+	// the after-the-fact counterpart of a request-side body. The plugin
+	// offers the body as a FACET_STREAM result field; the gateway pulls it
+	// up to its body-storage cap, appends the truncation marker when the
+	// body overran the cap, and cancels the stream. Set on the end event,
+	// it lands on Event.RespBody and renders in the request detail page's
+	// "Response body" section exactly like the built-in HTTP path's sample.
+	RespBody string
+	// RespSha is the hex SHA-256 of the full (uncapped) response body the
+	// plugin streamed, mirroring the built-in HTTP path. Empty when the
+	// plugin reported no body. Set on the end event alongside RespBody.
+	RespSha string
 }
 
 // Secret is what credential plugins receive at injection time. The

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -341,9 +341,12 @@ type ConnEvent struct {
 	// it lands on Event.RespBody and renders in the request detail page's
 	// "Response body" section exactly like the built-in HTTP path's sample.
 	RespBody string
-	// RespSha is the hex SHA-256 of the full (uncapped) response body the
-	// plugin streamed, mirroring the built-in HTTP path. Empty when the
-	// plugin reported no body. Set on the end event alongside RespBody.
+	// RespSha is the hex SHA-256 of the captured response-body sample (at
+	// most cap+1 bytes), NOT the full upstream body. Unlike the built-in HTTP
+	// sampler — which hashes every byte — the plugin path deliberately stops
+	// pulling at the body cap and cancels the stream, so the gateway never
+	// sees the bytes past the cap and cannot hash them. Empty when the plugin
+	// reported no body. Set on the end event alongside RespBody.
 	RespSha string
 }
 

--- a/pluginsdk/sdk.go
+++ b/pluginsdk/sdk.go
@@ -624,8 +624,12 @@ func (c *Conn) Evaluate(ctx context.Context, facet string, action map[string]any
 // action's status on the dashboard. Call it once, after the response is
 // read, for the action this connection just evaluated.
 //
-// (First cut: scalar result fields only. FacetStream result fields — a
-// response body the gateway streams and caps — are a follow-up.)
+// A result field declared FacetStream is a response body: hand it a
+// pluginsdk.Stream(r) value and the gateway pulls the stream up to its
+// body-storage cap, shows the sample in the request detail page, then
+// cancels — the plugin's reader sees the cancel as a clean close and is
+// not errored by it. Scalar fields stay inline in result_json. The plugin
+// has no size opinion; the gateway owns buffering.
 func (c *Conn) SetResult(ctx context.Context, result map[string]any) error {
 	if c.setResult == nil {
 		return errors.New("pluginsdk: Conn.SetResult not wired (running without a gateway?)")

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -518,16 +518,6 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 		return stream.Send(m)
 	}
 
-	conn.setResult = func(_ context.Context, result map[string]any) error {
-		// First cut: scalar result fields only (the body-stream support that
-		// FacetStream result fields will need is a follow-up). The gateway
-		// correlates this to the conn's current action, so no call_id.
-		j, err := json.Marshal(result)
-		if err != nil {
-			return fmt.Errorf("pluginsdk: marshal result: %w", err)
-		}
-		return doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Result{Result: &pb.ActionResult{ResultJson: j}}})
-	}
 	conn.emit = func(ev ConnEvent) {
 		facets, _ := json.Marshal(ev.Facets)
 		_ = doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Event{Event: &pb.ConnEvent{
@@ -557,6 +547,50 @@ func (s *server) HandleConn(stream pb.Endpoint_HandleConnServer) error {
 	var streamsMu sync.Mutex
 	streams := map[string]*streamReg{}
 	var streamSeq atomic.Uint64
+
+	conn.setResult = func(_ context.Context, result map[string]any) error {
+		// Stream-valued result fields (the response body a plugin offers via
+		// pluginsdk.Stream) are split out of result_json into
+		// ActionResult.streams and registered in the same stream table the
+		// request side uses — the gateway pulls them with the identical
+		// StreamRead/StreamChunk loop and StreamCancel. Scalars stay in
+		// result_json. The gateway correlates this to the conn's current
+		// action, so no call_id.
+		resultForJSON := result
+		streamHandles := map[string]string(nil)
+		for k, v := range result {
+			sv, ok := v.(StreamValue)
+			if !ok {
+				continue
+			}
+			if streamHandles == nil {
+				// Lazy clone so we don't mutate the caller's map; nil-out
+				// stream entries in the JSON copy (handles ride in streams).
+				resultForJSON = make(map[string]any, len(result))
+				for kk, vv := range result {
+					if _, isStream := vv.(StreamValue); isStream {
+						resultForJSON[kk] = nil
+					} else {
+						resultForJSON[kk] = vv
+					}
+				}
+				streamHandles = map[string]string{}
+			}
+			handle := fmt.Sprintf("s%d", streamSeq.Add(1))
+			streamsMu.Lock()
+			streams[handle] = &streamReg{r: sv.R}
+			streamsMu.Unlock()
+			streamHandles[k] = handle
+		}
+		j, err := json.Marshal(resultForJSON)
+		if err != nil {
+			return fmt.Errorf("pluginsdk: marshal result: %w", err)
+		}
+		return doSend(&pb.ConnMessage{Kind: &pb.ConnMessage_Result{Result: &pb.ActionResult{
+			ResultJson: j,
+			Streams:    streamHandles,
+		}}})
+	}
 
 	// dials tracks brokered upstream connections (Conn.DialUpstream)
 	// keyed by dial_id. The recv goroutine routes DialUpstreamReply /

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -992,6 +992,15 @@ func callbackPanicError(where string, r any) error {
 // the recv goroutine flips on StreamCancel. The serveStreamRead
 // helper checks cancelled before each read so a slow reader can't
 // re-enable a stream the gateway already abandoned.
+//
+// Note: a streamReg is removed from the streams map only on read EOF/error
+// (serveStreamRead) or StreamCancel. If the gateway pulls a body, finds what
+// it needs, and tears the conn down WITHOUT sending StreamCancel (e.g. an
+// abnormal recv-loop exit on the gateway side), the entry — and its open
+// reader — can linger until the whole conn's recv goroutine returns and the
+// SDK drops the per-conn streams map. Minor: it is conn-scoped, so it is
+// reclaimed when the connection ends, but a long-lived conn that never gets a
+// StreamCancel holds the reader open until then.
 type streamReg struct {
 	r         io.Reader
 	mu        sync.Mutex


### PR DESCRIPTION
A plugin endpoint can now report its response body as a `FACET_STREAM`
result field via `Conn.SetResult`. The gateway pulls that stream up to its
body cap (`gateway.limits.body_storage`, default 4 KiB), buffers it with
the same `[clawpatrol:body-truncated]` marker the built-in HTTP path uses,
cancels the stream, and stores the bytes in `Event.RespBody` — so it logs
and renders in the request detail page exactly like an HTTP response body.
No proto change; reuses `ActionResult.streams`.

The plugin has no size opinion and is never blocked by the gateway's
decision to stop reading: a recv-loop-scoped abort releases any in-flight
pull on every connection exit (clean close, transport error, or crash), so
the action still persists exactly once and the conn never hangs. The pull
runs off the recv loop to avoid deadlocking on its own StreamChunk frames.

* runtime: ConnEvent gains RespBody/RespSha; ConnHandle carries the body
  cap. RespSha covers the captured sample (the gateway never pulls past the
  cap), not the full body.
* pluginsdk: Conn.SetResult splits stream-valued result fields into
  ActionResult.streams, reusing the request-side stream machinery.
* Lifecycle + regression tests, including a mid-pull transport-error case
  that guards against the conn-hang the streamed pull could otherwise cause.