### PR TITLE
dashboard: narrow the activity-log verb column (w-44 -> w-28)

### DIFF
--- a/dashboard/src/components/LiveRequests.tsx
+++ b/dashboard/src/components/LiveRequests.tsx
@@ -250,7 +250,7 @@ function Row({ ev, schema }: { ev: RowState; schema: FacetSchema | undefined }) 
         <span className="text-2xs tabular-nums text-text-subtle shrink-0">{time}</span>
         <ApprovalStatusIcon ev={ev} inFlight={inFlight} />
         <span
-          className="font-mono text-2xs font-semibold text-text-muted shrink-0 w-44 truncate flex items-center"
+          className="font-mono text-2xs font-semibold text-text-muted shrink-0 w-28 truncate flex items-center"
           title={inspected ? verb : undefined}
         >
           {inspected ? verb : <LockGlyph />}


### PR DESCRIPTION
The verb column was widened to w-44 to fit facet-title verbs, but that left a large gap after short HTTP verbs (GET/POST). w-28 still fits the common AWS actions (GetCallerIdentity etc.) and truncates rare longer ones with the full value in the tooltip.