### PR TITLE
dnsvip: return cacheable NODATA for the synthesised A/AAAA path

### DIFF
--- a/cmd/clawpatrol/dnsvip/dnsvip.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip.go
@@ -771,9 +771,12 @@ func (a *Allocator) lazyAllocateForPattern(hostname string) bool {
 // records) and matches operator intent — if the agent's resolv.conf
 // names a specific resolver, that resolver answers TXT lookups.
 //
-// Errors collapse to NXDOMAIN (synthesised path) or SERVFAIL (relay
-// path). The split keeps the synth path's "name doesn't exist"
-// signal distinct from the relay path's "upstream unreachable".
+// The synth path classifies an empty result: a transient resolver
+// failure is SERVFAIL (uncached), a name with no record of the queried
+// family but records of the other is NODATA, and a name that resolves in
+// no family is NXDOMAIN — the latter two carrying an SOA so they
+// negative-cache. The relay path collapses any failure to SERVFAIL
+// ("upstream unreachable").
 func (a *Allocator) forwardUpstream(q *dns.Msg, dstIP string) *dns.Msg {
 	if len(q.Question) == 0 {
 		return errorResp(q, dns.RcodeFormatError)
@@ -822,10 +825,17 @@ func synthIPResponse(q *dns.Msg, network string) *dns.Msg {
 		if network == "ip6" {
 			other = "ip4"
 		}
-		if oips, oerr := lookupIP(ctx, other, name); oerr == nil && len(oips) > 0 {
+		oips, oerr := lookupIP(ctx, other, name)
+		switch {
+		case oerr == nil && len(oips) > 0:
 			return negResponse(q, dns.RcodeSuccess) // NODATA: exists in the other family
+		case oerr != nil && !(errors.As(oerr, &de) && de.IsNotFound):
+			// The other-family probe failed transiently — we can't prove the
+			// name is absent, so don't cache a negative. SERVFAIL is uncached.
+			return errorResp(q, dns.RcodeServerFailure)
+		default:
+			return negResponse(q, dns.RcodeNameError) // NXDOMAIN: resolves in no family
 		}
-		return negResponse(q, dns.RcodeNameError) // NXDOMAIN: resolves in no family
 	}
 	resp := new(dns.Msg)
 	resp.SetReply(q)

--- a/cmd/clawpatrol/dnsvip/dnsvip.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip.go
@@ -817,8 +817,7 @@ func synthIPResponse(q *dns.Msg, network string) *dns.Msg {
 		// re-ran the doomed AAAA lookup on every connection. Probe the other
 		// family to classify, and attach a synthetic SOA so the negative
 		// result caches (RFC 2308).
-		var de *net.DNSError
-		if err != nil && !(errors.As(err, &de) && de.IsNotFound) {
+		if err != nil && !isNotFound(err) {
 			return errorResp(q, dns.RcodeServerFailure)
 		}
 		other := "ip6"
@@ -829,7 +828,7 @@ func synthIPResponse(q *dns.Msg, network string) *dns.Msg {
 		switch {
 		case oerr == nil && len(oips) > 0:
 			return negResponse(q, dns.RcodeSuccess) // NODATA: exists in the other family
-		case oerr != nil && !(errors.As(oerr, &de) && de.IsNotFound):
+		case oerr != nil && !isNotFound(oerr):
 			// The other-family probe failed transiently — we can't prove the
 			// name is absent, so don't cache a negative. SERVFAIL is uncached.
 			return errorResp(q, dns.RcodeServerFailure)
@@ -886,6 +885,15 @@ func errorResp(q *dns.Msg, rcode int) *dns.Msg {
 	r := new(dns.Msg)
 	r.SetRcode(q, rcode)
 	return r
+}
+
+// isNotFound reports whether err is the resolver's authoritative "no such
+// record" signal (NXDOMAIN / NODATA), as opposed to a transient failure
+// (SERVFAIL / timeout). Go folds the not-found cases into net.DNSError with
+// IsNotFound set; everything else is treated as transient.
+func isNotFound(err error) bool {
+	var de *net.DNSError
+	return errors.As(err, &de) && de.IsNotFound
 }
 
 // negTTL bounds how long downstream resolvers cache a negative (NODATA /

--- a/cmd/clawpatrol/dnsvip/dnsvip.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -49,6 +50,12 @@ import (
 // own lookup onto the agent's in-flight tunnelled query and deadlock
 // both — the same hardening unclaw landed in dns.ts.
 var hostResolver = &net.Resolver{PreferGo: true}
+
+// lookupIP is the A/AAAA resolution the synth path uses. A package var so
+// tests can substitute deterministic results for the host resolver.
+var lookupIP = func(ctx context.Context, network, host string) ([]net.IP, error) {
+	return hostResolver.LookupIP(ctx, network, host)
+}
 
 // RequiresVIP is the marker an endpoint plugin's body implements when
 // its hostnames need DNS-VIP interception (because the wire protocol
@@ -790,15 +797,35 @@ func synthIPResponse(q *dns.Msg, network string) *dns.Msg {
 	name := strings.TrimSuffix(qd.Name, ".")
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	ips, err := hostResolver.LookupIP(ctx, network, name)
-	if err != nil || len(ips) == 0 {
-		// LookupIP folds DNS error codes (NXDOMAIN, SERVFAIL,
-		// timeout) into a single error type. Treat any failure as
-		// NXDOMAIN — the gateway has already exhausted its local
-		// resolver chain, and there's nowhere else to consult that
-		// would know about an internal name the operator's machine
-		// doesn't know about either.
-		return errorResp(q, dns.RcodeNameError)
+	ips, err := lookupIP(ctx, network, name)
+	if len(ips) == 0 {
+		// No address of the requested family. Go's resolver collapses three
+		// cases into one error, but they need different answers — and getting
+		// it wrong defeats negative caching:
+		//
+		//   transient (SERVFAIL / timeout)               → SERVFAIL, uncached.
+		//   NODATA (name exists, no record of this type) → NOERROR + SOA.
+		//   NXDOMAIN (name exists in no family)          → NXDOMAIN + SOA.
+		//
+		// The common case is an IPv4-only host (api.github.com and most of the
+		// internet) queried for AAAA: that is NODATA, not NXDOMAIN. The old
+		// code returned a bare NXDOMAIN there — wrong (the name has an A
+		// record) and, with no SOA, uncacheable, so a downstream resolver
+		// re-ran the doomed AAAA lookup on every connection. Probe the other
+		// family to classify, and attach a synthetic SOA so the negative
+		// result caches (RFC 2308).
+		var de *net.DNSError
+		if err != nil && !(errors.As(err, &de) && de.IsNotFound) {
+			return errorResp(q, dns.RcodeServerFailure)
+		}
+		other := "ip6"
+		if network == "ip6" {
+			other = "ip4"
+		}
+		if oips, oerr := lookupIP(ctx, other, name); oerr == nil && len(oips) > 0 {
+			return negResponse(q, dns.RcodeSuccess) // NODATA: exists in the other family
+		}
+		return negResponse(q, dns.RcodeNameError) // NXDOMAIN: resolves in no family
 	}
 	resp := new(dns.Msg)
 	resp.SetReply(q)
@@ -822,11 +849,9 @@ func synthIPResponse(q *dns.Msg, network string) *dns.Msg {
 		}
 	}
 	if len(resp.Answer) == 0 {
-		// Resolver returned addresses but none matched the query
-		// family (e.g. AAAA query, IPv4-only host). Empty NOERROR
-		// response — same shape DNS servers use for "name exists,
-		// no records of this type."
-		return resp
+		// Resolver returned addresses but none matched the query family.
+		// NODATA with a synthetic SOA so the negative result caches.
+		return negResponse(q, dns.RcodeSuccess)
 	}
 	return resp
 }
@@ -851,4 +876,56 @@ func errorResp(q *dns.Msg, rcode int) *dns.Msg {
 	r := new(dns.Msg)
 	r.SetRcode(q, rcode)
 	return r
+}
+
+// negTTL bounds how long downstream resolvers cache a negative (NODATA /
+// NXDOMAIN) answer, via the synthetic SOA below. Matches the positive
+// answer TTL: long enough to collapse a burst of connections to a v4-only
+// host into a single AAAA lookup, short enough that a host gaining IPv6 is
+// noticed promptly.
+const negTTL = 30
+
+// negResponse builds a cacheable negative answer: NODATA when rcode is
+// RcodeSuccess ("the name exists, but has no record of this type"), NXDOMAIN
+// when RcodeNameError. It carries a synthetic SOA in the authority section so
+// downstream resolvers can derive a negative-cache TTL (RFC 2308) — without
+// one the answer is uncacheable and the query repeats on every connection.
+func negResponse(q *dns.Msg, rcode int) *dns.Msg {
+	r := new(dns.Msg)
+	r.SetRcode(q, rcode)
+	r.RecursionAvailable = true
+	if len(q.Question) > 0 {
+		r.Ns = []dns.RR{negSOA(q.Question[0].Name)}
+	}
+	return r
+}
+
+// negSOA mints a minimal SOA for negative-cache signalling. The owner names
+// the zone the negative answer covers — it must be an *ancestor* of the
+// queried name, not the name itself: downstream resolvers (systemd-resolved)
+// only negative-cache when the SOA owner is a proper enclosing zone. Strip
+// the leftmost label, matching what real authoritative servers return
+// (`api.github.com` AAAA → owner `github.com.`). MNAME / RNAME are
+// placeholders (the record exists only to carry a TTL, never to be
+// followed); Minttl and the header TTL bound the cache.
+func negSOA(name string) *dns.SOA {
+	owner := name
+	if i := strings.IndexByte(name, '.'); i >= 0 && i < len(name)-1 {
+		owner = name[i+1:]
+	}
+	return &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   owner,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    negTTL,
+		},
+		Ns:      "clawpatrol.invalid.",
+		Mbox:    "clawpatrol.invalid.",
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   600,
+		Expire:  86400,
+		Minttl:  negTTL,
+	}
 }

--- a/cmd/clawpatrol/dnsvip/dnsvip_test.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip_test.go
@@ -1,6 +1,7 @@
 package dnsvip
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net"
@@ -667,5 +668,104 @@ func TestPersistLockedWrapsErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "dnsvip:") {
 		t.Errorf("persist error not wrapped with dnsvip prefix: %v", err)
+	}
+}
+
+// findSOA returns the first SOA in a message's authority section, or nil.
+func findSOA(m *dns.Msg) *dns.SOA {
+	for _, rr := range m.Ns {
+		if soa, ok := rr.(*dns.SOA); ok {
+			return soa
+		}
+	}
+	return nil
+}
+
+// TestSynthAAAANodataForV4OnlyHost is the regression for the negative-cache
+// bug: an AAAA query for a host that has an A record but no AAAA must be
+// answered NODATA (NOERROR, empty answer) with an SOA whose owner is the
+// parent zone — not the old bare NXDOMAIN, which was both wrong (the name
+// exists) and uncacheable (no SOA), so resolvers re-ran the lookup on every
+// connection.
+func TestSynthAAAANodataForV4OnlyHost(t *testing.T) {
+	restore := lookupIP
+	t.Cleanup(func() { lookupIP = restore })
+	lookupIP = func(_ context.Context, network, _ string) ([]net.IP, error) {
+		if network == "ip4" {
+			return []net.IP{net.IPv4(140, 82, 112, 5)}, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: "api.github.com", IsNotFound: true}
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("api.github.com.", dns.TypeAAAA)
+	resp := synthIPResponse(q, "ip6")
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("rcode = %s, want NOERROR (NODATA)", dns.RcodeToString[resp.Rcode])
+	}
+	if len(resp.Answer) != 0 {
+		t.Fatalf("want empty answer, got %d records", len(resp.Answer))
+	}
+	soa := findSOA(resp)
+	if soa == nil {
+		t.Fatal("NODATA response carries no SOA — downstream resolvers can't negative-cache it")
+	}
+	if soa.Hdr.Name != "github.com." {
+		t.Errorf("SOA owner = %q, want github.com. (the parent zone)", soa.Hdr.Name)
+	}
+	if soa.Hdr.Ttl == 0 || soa.Minttl == 0 {
+		t.Errorf("SOA TTL/Minttl must be > 0 for negative caching; got ttl=%d minttl=%d", soa.Hdr.Ttl, soa.Minttl)
+	}
+}
+
+// TestSynthNXDomainWhenNoFamilyResolves: a name that resolves in neither
+// family is a true NXDOMAIN — and it too must carry an SOA so the negative
+// caches.
+func TestSynthNXDomainWhenNoFamilyResolves(t *testing.T) {
+	restore := lookupIP
+	t.Cleanup(func() { lookupIP = restore })
+	lookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return nil, &net.DNSError{Err: "no such host", IsNotFound: true}
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("nope.example.", dns.TypeAAAA)
+	resp := synthIPResponse(q, "ip6")
+	if resp.Rcode != dns.RcodeNameError {
+		t.Fatalf("rcode = %s, want NXDOMAIN", dns.RcodeToString[resp.Rcode])
+	}
+	if findSOA(resp) == nil {
+		t.Error("NXDOMAIN response carries no SOA — it won't negative-cache")
+	}
+}
+
+// TestSynthServfailOnTransientError: a transient resolver failure (not a
+// not-found) must surface as SERVFAIL, never a cached NXDOMAIN — caching a
+// transient outage would persist it for the whole negative TTL.
+func TestSynthServfailOnTransientError(t *testing.T) {
+	restore := lookupIP
+	t.Cleanup(func() { lookupIP = restore })
+	lookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return nil, &net.DNSError{Err: "server misbehaving", IsTemporary: true}
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("api.github.com.", dns.TypeAAAA)
+	resp := synthIPResponse(q, "ip6")
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("rcode = %s, want SERVFAIL", dns.RcodeToString[resp.Rcode])
+	}
+}
+
+// TestNegSOAOwnerIsParentZone pins the owner-name derivation: the SOA owner
+// must be an ancestor of the queried name (the parent zone), which is what
+// makes systemd-resolved negative-cache the answer.
+func TestNegSOAOwnerIsParentZone(t *testing.T) {
+	cases := map[string]string{
+		"api.github.com.": "github.com.",
+		"github.com.":     "com.",
+		"com.":            "com.", // no parent to strip to; keep as-is
+	}
+	for in, want := range cases {
+		if got := negSOA(in).Hdr.Name; got != want {
+			t.Errorf("negSOA(%q) owner = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/cmd/clawpatrol/dnsvip/dnsvip_test.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip_test.go
@@ -769,3 +769,25 @@ func TestNegSOAOwnerIsParentZone(t *testing.T) {
 		}
 	}
 }
+
+// TestSynthServfailWhenOtherFamilyProbeIsTransient: the queried family is a
+// genuine not-found, but the other-family probe (used to tell NODATA from
+// NXDOMAIN) fails transiently. We can't prove the name is absent, so the
+// answer must be SERVFAIL — never a cached NXDOMAIN for a name that might
+// exist in the other family.
+func TestSynthServfailWhenOtherFamilyProbeIsTransient(t *testing.T) {
+	restore := lookupIP
+	t.Cleanup(func() { lookupIP = restore })
+	lookupIP = func(_ context.Context, network, _ string) ([]net.IP, error) {
+		if network == "ip6" { // queried family: genuine not-found
+			return nil, &net.DNSError{Err: "no such host", IsNotFound: true}
+		}
+		return nil, &net.DNSError{Err: "server misbehaving", IsTemporary: true} // probe: transient
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("api.github.com.", dns.TypeAAAA)
+	resp := synthIPResponse(q, "ip6")
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("rcode = %s, want SERVFAIL (a transient probe failure must not cache NXDOMAIN)", dns.RcodeToString[resp.Rcode])
+	}
+}

--- a/cmd/clawpatrol/dnsvip/dnsvip_test.go
+++ b/cmd/clawpatrol/dnsvip/dnsvip_test.go
@@ -791,3 +791,25 @@ func TestSynthServfailWhenOtherFamilyProbeIsTransient(t *testing.T) {
 		t.Fatalf("rcode = %s, want SERVFAIL (a transient probe failure must not cache NXDOMAIN)", dns.RcodeToString[resp.Rcode])
 	}
 }
+
+// TestSynthNodataWhenAddressesDontMatchFamily covers the defensive branch
+// where the resolver returns addresses but none match the queried family
+// (so the answer loop emits nothing): the result must be NODATA with an SOA,
+// not an empty NOERROR that fails to cache nor a mis-typed answer.
+func TestSynthNodataWhenAddressesDontMatchFamily(t *testing.T) {
+	restore := lookupIP
+	t.Cleanup(func() { lookupIP = restore })
+	lookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return []net.IP{net.IPv4(140, 82, 112, 5)}, nil // v4 returned for an AAAA query
+	}
+	q := new(dns.Msg)
+	q.SetQuestion("api.github.com.", dns.TypeAAAA)
+	resp := synthIPResponse(q, "ip6")
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) != 0 {
+		t.Fatalf("want NODATA (NOERROR, no answer); got rcode=%s answers=%d",
+			dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+	if findSOA(resp) == nil {
+		t.Error("wrong-family NODATA must carry an SOA")
+	}
+}


### PR DESCRIPTION
The gateway's DNS synth path collapsed every empty/error A/AAAA result
into a bare `NXDOMAIN` with no SOA. For the common case — an IPv4-only
host (`api.github.com` and most of the internet) queried for AAAA — that
is wrong twice over:

* the name exists (it has an A record), so the correct answer is NODATA,
  not NXDOMAIN; and
* with no SOA in the authority section the negative is uncacheable, so a
  downstream resolver re-runs the doomed AAAA lookup on **every**
  connection (measured ~40ms each through the gateway).

Classify instead of conflating:

* transient resolver failure → SERVFAIL (uncached)
* name exists in the other family → NODATA (NOERROR + SOA)
* resolves in neither family → NXDOMAIN (+ SOA)

All negatives now carry a synthetic SOA whose owner is the parent zone,
so resolvers can derive a negative-cache TTL (RFC 2308). Adds an
injectable lookup seam plus tests for the three-way classification and
the parent-zone SOA owner.

Verified on a gateway built from this branch: `resolvectl` goes from
reporting NXDOMAIN to a correct NODATA for `api.github.com AAAA`, with the
SOA owner `github.com.`. (Note: a separate, host-side resolver quirk on
one test box prevents it from negative-caching even correct responses, so
the end-to-end latency win depends on the client honoring the now-correct
negative — which standard resolvers do.)