### PR TITLE
fix(ws): preserve explicit upstream ports (#744)

### DIFF
--- a/cmd/clawpatrol/dial.go
+++ b/cmd/clawpatrol/dial.go
@@ -85,13 +85,7 @@ func (g *Gateway) servePorts() {}
 func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName string, ep *config.CompiledEndpoint, _ string) (net.Conn, error) {
 	cfg := &tls.Config{ServerName: serverName, NextProtos: []string{"http/1.1"}}
 
-	if ep != nil && ep.Body != nil {
-		if cfgr, ok := ep.Body.(runtime.EndpointTLSConfigurer); ok {
-			if err := cfgr.ConfigureUpstreamTLS(cfg); err != nil {
-				log.Printf("upstream tls %s: %v — dialing with default roots", serverName, err)
-			}
-		}
-	}
+	configureEndpointTLS(cfg, serverName, ep)
 
 	if ep != nil {
 		for _, ent := range ep.Credentials {
@@ -127,6 +121,17 @@ func (g *Gateway) dialUpstream(ctx context.Context, network, addr, serverName st
 	return tc, nil
 }
 
+func configureEndpointTLS(cfg *tls.Config, serverName string, ep *config.CompiledEndpoint) {
+	if ep == nil || ep.Body == nil {
+		return
+	}
+	if cfgr, ok := ep.Body.(runtime.EndpointTLSConfigurer); ok {
+		if err := cfgr.ConfigureUpstreamTLS(cfg); err != nil {
+			log.Printf("upstream tls %s: %v — dialing with default roots", serverName, err)
+		}
+	}
+}
+
 // dialBrowserTLS opens a tunnel-aware TCP connection and performs a uTLS
 // handshake using Chrome's TLS fingerprint (HelloChrome_Auto), with ALPN
 // forced to http/1.1. Used for WS upgrades to chatgpt.com — Cloudflare WAF
@@ -140,15 +145,28 @@ func (g *Gateway) dialBrowserTLS(ctx context.Context, network, addr, serverName 
 	if err != nil {
 		return nil, err
 	}
-	return browserTLSOver(ctx, raw, serverName)
+	cfg := &tls.Config{ServerName: serverName}
+	configureEndpointTLS(cfg, serverName, ep)
+	// utls.Config is a distinct type from tls.Config, so the endpoint's
+	// settings have to be copied over by hand. Only the verification-
+	// relevant fields cross: ServerName, RootCAs, and InsecureSkipVerify.
+	// That covers every EndpointTLSConfigurer today (kubernetes sets only
+	// RootCAs). A future configurer that sets MinVersion, Certificates,
+	// VerifyPeerCertificate, etc. would have those silently dropped on the
+	// browser-TLS path — extend the copy here if that ever happens.
+	return browserTLSOver(ctx, raw, &utls.Config{
+		ServerName:         cfg.ServerName,
+		RootCAs:            cfg.RootCAs,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+	})
 }
 
-func browserTLSOver(ctx context.Context, raw net.Conn, serverName string) (net.Conn, error) {
+func browserTLSOver(ctx context.Context, raw net.Conn, cfg *utls.Config) (net.Conn, error) {
 	// HelloChrome_Auto bakes ALPN ["h2","http/1.1"] into the ClientHello.
 	// We need http/1.1 only (WS upgrade requires HTTP/1.1; raw response
 	// reader breaks on h2 SETTINGS frames). Apply preset spec, mutate
 	// ALPNExtension, then handshake.
-	c := utls.UClient(raw, &utls.Config{ServerName: serverName}, utls.HelloCustom)
+	c := utls.UClient(raw, cfg, utls.HelloCustom)
 	spec, err := utls.UTLSIdToSpec(utls.HelloChrome_Auto)
 	if err != nil {
 		_ = raw.Close()

--- a/cmd/clawpatrol/dial_test.go
+++ b/cmd/clawpatrol/dial_test.go
@@ -2,9 +2,17 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
+	"math/big"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +36,17 @@ func (fakeSecretStore) Get(string) (runtime.Secret, error) {
 	return runtime.Secret{}, nil
 }
 
+type fakeEndpointTLSConfigurer struct {
+	configured atomic.Int32
+	rootCAs    *x509.CertPool
+}
+
+func (c *fakeEndpointTLSConfigurer) ConfigureUpstreamTLS(cfg *tls.Config) error {
+	c.configured.Add(1)
+	cfg.RootCAs = c.rootCAs
+	return nil
+}
+
 func endpointWithTunnelAndTLSCredential(name string, tunnel *config.CompiledTunnel, credential *fakeTLSCredential) *config.CompiledEndpoint {
 	return &config.CompiledEndpoint{
 		Name:   name,
@@ -36,6 +55,26 @@ func endpointWithTunnelAndTLSCredential(name string, tunnel *config.CompiledTunn
 			Symbol: &config.Symbol{Name: "mtls"},
 			Body:   credential,
 		}},
+	}
+}
+
+func TestBrowserTLSUsesEndpointTLSConfig(t *testing.T) {
+	server, roots, serverName := newSelfSignedTLSServer(t)
+	defer server.Close()
+
+	tlsConfig := &fakeEndpointTLSConfigurer{rootCAs: roots}
+	ep := &config.CompiledEndpoint{Name: "browser", Body: tlsConfig}
+	g := &Gateway{dialer: &net.Dialer{}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := g.dialBrowserTLS(ctx, "tcp", server.Listener.Addr().String(), serverName, ep)
+	if err != nil {
+		t.Fatalf("dialBrowserTLS: %v", err)
+	}
+	_ = conn.Close()
+	if got := tlsConfig.configured.Load(); got != 1 {
+		t.Fatalf("EndpointTLSConfigurer call count = %d, want 1", got)
 	}
 }
 
@@ -162,6 +201,48 @@ func TestTransportBrowserTLSWithClientCertUsesDialUpstream(t *testing.T) {
 	if got := fake.dialCount.Load(); got != 1 {
 		t.Fatalf("fake tunnel Dial count = %d, want 1", got)
 	}
+}
+
+func newSelfSignedTLSServer(t *testing.T) (*httptest.Server, *x509.CertPool, string) {
+	t.Helper()
+
+	serverName := "kubernetes.test"
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: serverName},
+		DNSNames:              []string{serverName},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	cert := tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  priv,
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(parsed)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"http/1.1"},
+	}
+	server.StartTLS()
+	return server, roots, serverName
 }
 
 func TestDialWSUpstreamWithClientCertUsesDialUpstream(t *testing.T) {

--- a/cmd/clawpatrol/ws.go
+++ b/cmd/clawpatrol/ws.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/hostmatch"
 )
 
 const (
@@ -84,16 +85,30 @@ func isWSUpgrade(req *http.Request) bool {
 	return strings.Contains(conn, "upgrade") && upg == "websocket"
 }
 
+func wsUpstreamAddrAndServerName(upstream string) (addr, serverName string, err error) {
+	host, port, err := hostmatch.SplitHostPort(upstream)
+	if err != nil {
+		return "", "", err
+	}
+	if port == "" {
+		port = "443"
+	}
+	return net.JoinHostPort(host, port), host, nil
+}
+
 // dialWSUpstream opens the upstream TLS connection used by the raw WS bridge.
 // mTLS endpoints keep using dialUpstream so credential plugins can populate the
 // stdlib TLS config; all other WS upstreams use browser TLS while still honoring
 // endpoint tunnel configuration via dialBrowserTLS.
 func (g *Gateway) dialWSUpstream(ctx context.Context, upstream string, ep *config.CompiledEndpoint, profile string) (net.Conn, error) {
-	addr := net.JoinHostPort(upstream, "443")
-	if endpointWantsClientCert(ep) {
-		return g.dialUpstream(ctx, "tcp", addr, upstream, ep, profile)
+	addr, serverName, err := wsUpstreamAddrAndServerName(upstream)
+	if err != nil {
+		return nil, fmt.Errorf("parse websocket upstream %q: %w", upstream, err)
 	}
-	return g.dialBrowserTLS(ctx, "tcp", addr, upstream, ep)
+	if endpointWantsClientCert(ep) {
+		return g.dialUpstream(ctx, "tcp", addr, serverName, ep, profile)
+	}
+	return g.dialBrowserTLS(ctx, "tcp", addr, serverName, ep)
 }
 
 // handleWSUpgrade swaps the http.Transport-driven request loop for a

--- a/cmd/clawpatrol/ws_test.go
+++ b/cmd/clawpatrol/ws_test.go
@@ -7,6 +7,47 @@ import (
 	"testing"
 )
 
+func TestWSUpstreamAddrAndServerName(t *testing.T) {
+	tests := []struct {
+		name       string
+		upstream   string
+		wantAddr   string
+		wantServer string
+	}{
+		{
+			name:       "bare host defaults to HTTPS",
+			upstream:   "api.example.com",
+			wantAddr:   "api.example.com:443",
+			wantServer: "api.example.com",
+		},
+		{
+			name:       "configured port is preserved",
+			upstream:   "10.1.1.100:6443",
+			wantAddr:   "10.1.1.100:6443",
+			wantServer: "10.1.1.100",
+		},
+		{
+			name:       "bracketed IPv6 port is preserved",
+			upstream:   "[fd00::10]:6443",
+			wantAddr:   "[fd00::10]:6443",
+			wantServer: "fd00::10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAddr, gotServer, err := wsUpstreamAddrAndServerName(tt.upstream)
+			if err != nil {
+				t.Fatalf("wsUpstreamAddrAndServerName(%q): %v", tt.upstream, err)
+			}
+			if gotAddr != tt.wantAddr || gotServer != tt.wantServer {
+				t.Fatalf("wsUpstreamAddrAndServerName(%q) = (%q, %q), want (%q, %q)",
+					tt.upstream, gotAddr, gotServer, tt.wantAddr, tt.wantServer)
+			}
+		})
+	}
+}
+
 func TestPumpWSRewritesMaskedClientTextPayload(t *testing.T) {
 	placeholder := []byte("DISCORD_PLACEHOLDER")
 	actual := []byte("real.discord.token")


### PR DESCRIPTION
CI staging branch for #744 (fork PR). Carries the two commits from #744 plus a follow-up doc comment on the tls.Config -> utls.Config field copy. Will be squash-landed to main and closed.

Original author: @rajiteh