### PR TITLE
Fix Notion MCP OAuth loopback redirect

### DIFF
--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -684,10 +684,10 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 
 // startDynamicMCPFlow drives auth-code OAuth flows with RFC 7591
 // dynamic client registration. Plugins may pin a provider-accepted
-// redirect URI (Amplitude uses a localhost loopback URI); otherwise we
-// register the dashboard's own /oauth/callback page, which
-// auto-exchanges via /api/oauth/exchange when it loads, with copy-paste
-// from the URL bar as a fallback.
+// redirect URI (e.g. a localhost loopback URI for providers that reject
+// the dashboard's redirect); otherwise we register the dashboard's own
+// /oauth/callback page, which auto-exchanges via /api/oauth/exchange
+// when it loads, with copy-paste from the URL bar as a fallback.
 func (w *webMux) startDynamicMCPFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
 	redirectURI := strings.TrimSpace(flow.OAuth.RedirectURI)
 	if redirectURI == "" {

--- a/dashboard/src/components/ConnectModal.tsx
+++ b/dashboard/src/components/ConnectModal.tsx
@@ -249,20 +249,33 @@ export function ConnectModal({
           </div>
         ) : (
           <div className="space-y-3">
-            <div className="text-sm text-text-muted font-sans leading-relaxed">
-              Browser opened. Log in, then paste the code from the redirect URL bar (after{" "}
-              <code className="text-text">?code=</code>) here:
+            <div id="oauth-code-help" className="text-sm text-text-muted font-sans leading-relaxed">
+              Browser opened. After logging in, this may connect automatically. If it doesn't, paste
+              the redirect URL from the tab opened for this login attempt, or paste the value of the{" "}
+              <code className="text-text">code</code> parameter below. If the redirect lands on a{" "}
+              <code className="text-text">localhost</code> page that fails to connect, that's
+              expected — copy its URL anyway.
             </div>
             <form onSubmit={submit}>
               <input
                 type="text"
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
-                placeholder="paste code here"
+                placeholder="paste full redirect URL or code here"
+                aria-label="Redirect URL or authorization code"
+                aria-describedby={err ? "oauth-code-help oauth-code-error" : "oauth-code-help"}
                 className="w-full text-xs border border-canvas-dark rounded px-2 py-2 focus:outline-none focus:border-text font-mono transition-colors"
                 autoFocus
               />
-              {err && <div className="text-xs text-rust-700 mt-2 break-all">{err}</div>}
+              {err && (
+                <div
+                  id="oauth-code-error"
+                  role="alert"
+                  className="text-xs text-rust-700 mt-2 break-all"
+                >
+                  {err}
+                </div>
+              )}
               <div className="flex gap-2 mt-8 justify-end">
                 <Button variant="outline" onClick={onClose}>
                   cancel

--- a/dashboard/src/components/ConnectModal.tsx
+++ b/dashboard/src/components/ConnectModal.tsx
@@ -330,8 +330,8 @@ export function ConnectModal({
                   .
                 </>
               )}{" "}
-              After logging in, this may connect automatically. If it doesn't, paste the redirect URL
-              from the tab opened for this login attempt, or paste the value of the{" "}
+              After logging in, this may connect automatically. If it doesn't, paste the redirect
+              URL from the tab opened for this login attempt, or paste the value of the{" "}
               <code className="text-text">code</code> parameter below. If the redirect lands on a{" "}
               <code className="text-text">localhost</code> page that fails to connect, that's
               expected — copy its URL anyway.
@@ -343,9 +343,9 @@ export function ConnectModal({
                 onChange={(e) => setCode(e.target.value)}
                 placeholder="paste full redirect URL or code here"
                 aria-label="Redirect URL or authorization code"
-                aria-describedby={state.error
-                  ? "oauth-code-help oauth-code-error"
-                  : "oauth-code-help"}
+                aria-describedby={
+                  state.error ? "oauth-code-help oauth-code-error" : "oauth-code-help"
+                }
                 className="w-full text-xs border border-canvas-dark rounded px-2 py-2 focus:outline-none focus:border-text font-mono transition-colors"
                 autoFocus
               />

--- a/internal/config/plugins/credentials/notion_mcp_oauth.go
+++ b/internal/config/plugins/credentials/notion_mcp_oauth.go
@@ -47,6 +47,17 @@ func (n *NotionMCPOAuth) OAuthFlow() *config.OAuthIntegration {
 			AuthURL:     "https://mcp.notion.com/authorize",
 			TokenURL:    "https://mcp.notion.com/token",
 			RegisterURL: "https://mcp.notion.com/register",
+			// Notion rejects non-loopback redirect URIs over plain HTTP,
+			// and the dashboard may itself be served over plain HTTP (e.g.
+			// on a tailnet/private host), so we can't register the
+			// dashboard's own /oauth/callback page. A localhost loopback
+			// URI is the one plain-HTTP redirect Notion accepts. Nothing
+			// listens on it by design — after authorizing, the operator
+			// copies the full redirected localhost URL out of the browser
+			// address bar (the connection will appear to fail, which is
+			// expected) and pastes it into the dashboard's connect modal,
+			// where the code is parsed server-side.
+			RedirectURI: "http://localhost:8900/callback",
 		},
 	}
 }

--- a/internal/config/plugins/credentials/notion_mcp_oauth_test.go
+++ b/internal/config/plugins/credentials/notion_mcp_oauth_test.go
@@ -1,0 +1,22 @@
+package credentials
+
+import "testing"
+
+// TestNotionMCPOAuthUsesLoopbackRedirectURI pins the loopback redirect
+// URI on the Notion MCP OAuth flow. Notion rejects non-loopback plain
+// HTTP redirects, and the dashboard may run over plain HTTP, so the
+// flow must register the localhost callback rather than the dashboard's
+// own /oauth/callback page. See notion_mcp_oauth.go for the full
+// rationale.
+func TestNotionMCPOAuthUsesLoopbackRedirectURI(t *testing.T) {
+	flow := (&NotionMCPOAuth{}).OAuthFlow()
+	if flow == nil {
+		t.Fatal("OAuthFlow() = nil, want non-nil")
+	}
+	if flow.Flow != "notion_mcp" {
+		t.Errorf("Flow = %q, want %q", flow.Flow, "notion_mcp")
+	}
+	if got, want := flow.OAuth.RedirectURI, "http://localhost:8900/callback"; got != want {
+		t.Errorf("OAuth.RedirectURI = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- register built-in Notion MCP OAuth clients with a fixed `http://localhost:8900/callback` loopback redirect URI
- add a provider-local regression test that pins the Notion MCP redirect URI
- clarify the connect modal fallback copy so users can paste a full redirect URL or code, including expected localhost connection failures
- make the dynamic MCP redirect comment provider-generic without changing the flow behavior

## Testing
- `gofmt -l .`
- `go test ./cmd/clawpatrol -run 'TestNormalizeOAuthExchangeInput|TestStartDynamicMCPFlowUsesConfiguredRedirectURI'`
- `go test ./internal/config/plugins/credentials -run TestNotionMCPOAuthUsesLoopbackRedirectURI`
- `cd dashboard && deno task format`
- `cd dashboard && deno task format:check`
- `cd dashboard && deno task build`
- `cd dashboard && deno task lint`
- `git diff --check`

## Notes
- no localhost listener is added; the Notion loopback redirect is intentionally handled by copy/paste back into the dashboard
- pasted redirect URL `state` handling is unchanged; `/api/oauth/exchange` still uses the dashboard modal's session state
