### PR TITLE
extplugin: add --plugin-cache-dir for validate/test

### DIFF
--- a/cmd/clawpatrol/test.go
+++ b/cmd/clawpatrol/test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/denoland/clawpatrol/internal/config"
-	"github.com/denoland/clawpatrol/internal/config/extplugin"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
@@ -54,12 +53,18 @@ func testCmd(args []string) (stdout, stderr string, code int) {
 			return testUsage, "", 0
 		}
 	}
-	if len(args) != 2 {
+	cacheDir, rest, ok := parseVerifyFlags("test", args)
+	if !ok || len(rest) != 2 {
 		return "", testUsage, 2
 	}
-	cfgPath, target := args[0], args[1]
+	cfgPath, target := rest[0], rest[1]
 
-	config.SetPluginLoader(extplugin.New(nil))
+	// No lockfile here, unlike validate: `test` replays policy fixtures and
+	// loads plugins first-use, so a missing/incomplete lockfile doesn't turn
+	// into a spurious permission-escalation error.
+	mgr, cleanup := newVerifyPluginManager(cacheDir)
+	defer cleanup()
+	config.SetPluginLoader(mgr)
 	_, policy, err := loadConfig(cfgPath)
 	if err != nil {
 		return "", fmt.Sprintf("load config: %v", err), 2

--- a/cmd/clawpatrol/validate.go
+++ b/cmd/clawpatrol/validate.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -20,6 +22,48 @@ func runValidate(args []string) {
 	os.Exit(code)
 }
 
+// parseVerifyFlags pulls the shared --plugin-cache-dir flag out of a
+// verification command's args, returning its value and the remaining
+// positional args. ok is false on a parse or -h/--help error, in which
+// case the caller prints usage. The flag lets a caller (e.g. deploy.sh,
+// linting on a machine where the config's state_dir isn't writable) point
+// the plugin binary cache somewhere writable; empty means use the config's
+// state_dir, the same as the gateway.
+func parseVerifyFlags(name string, args []string) (cacheDir string, rest []string, ok bool) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // callers craft their own usage string
+	cd := fs.String("plugin-cache-dir", "", "directory for the plugin binary cache (default: the config's state_dir)")
+	if err := fs.Parse(args); err != nil {
+		return "", nil, false
+	}
+	return *cd, fs.Args(), true
+}
+
+// newVerifyPluginManager builds a plugin manager for the read-only
+// verification commands (validate, test). cacheDir overrides where plugin
+// binaries are cached (empty = the config's state_dir); the verification
+// commands expose it via --plugin-cache-dir so a config can be linted on a
+// machine where its state_dir isn't writable. It verifies build-provenance
+// attestations, matching the gateway-run (main.go) and `plugins` command
+// paths — without it a cold fetch records the plugin as unattested and
+// trips the lockfile's attested=true downgrade guard.
+//
+// The returned cleanup clears the package-global plugin loader (it points
+// at this manager, whose lockfile path is request-scoped; config.Load
+// resets to a no-op loader on nil) and stops the manager.
+func newVerifyPluginManager(cacheDir string) (*extplugin.Manager, func()) {
+	mgr := extplugin.New(nil)
+	if cacheDir != "" {
+		mgr.SetCacheDir(cacheDir)
+	}
+	mgr.VerifyProvenance(true)
+	cleanup := func() {
+		config.SetPluginLoader(nil)
+		mgr.Stop()
+	}
+	return mgr, cleanup
+}
+
 // validateCmd is the pure side: same arg parsing, but returns
 // (output, exitCode) instead of touching stdio. Same pipeline the
 // gateway uses at startup — anything that would crash the daemon
@@ -32,25 +76,28 @@ func runValidate(args []string) {
 // against the facet registry. Catches plugin authoring bugs that
 // the operator's HCL didn't happen to exercise.
 func validateCmd(args []string) (string, int) {
-	if len(args) != 1 || args[0] == "-h" || args[0] == "--help" {
-		return "usage: clawpatrol validate <config.hcl>", 2
+	const usage = "usage: clawpatrol validate [--plugin-cache-dir DIR] <config.hcl>"
+	cacheDir, rest, ok := parseVerifyFlags("validate", args)
+	if !ok || len(rest) != 1 {
+		return usage, 2
 	}
-	mgr := extplugin.New(nil)
-	defer mgr.Stop()
+	cfgPath := rest[0]
+	mgr, cleanup := newVerifyPluginManager(cacheDir)
+	defer cleanup()
 	// Read-only: report a would-be first-load or an escalation as a
 	// diagnostic, but never write the lockfile from `validate`.
-	mgr.SetLockfile(extplugin.LockfilePathFor(args[0]), true)
+	mgr.SetLockfile(extplugin.LockfilePathFor(cfgPath), true)
 	config.SetPluginLoader(mgr)
-	_, cp, err := loadConfig(args[0])
+	_, cp, err := loadConfig(cfgPath)
 	if err != nil {
-		return fmt.Sprintf("%s: %v", args[0], err), 1
+		return fmt.Sprintf("%s: %v", cfgPath, err), 1
 	}
 	if d := mgr.Verify(); d.HasErrors() {
-		return fmt.Sprintf("%s: %s", args[0], d.Error()), 1
+		return fmt.Sprintf("%s: %s", cfgPath, d.Error()), 1
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "ok: %s — %d endpoints across %d profile(s)",
-		args[0], len(cp.Endpoints), len(cp.Profiles))
+		cfgPath, len(cp.Endpoints), len(cp.Profiles))
 	for _, c := range mgr.Plugins() {
 		mf := c.Manifest()
 		if mf == nil {

--- a/internal/config/extplugin/cachedir_test.go
+++ b/internal/config/extplugin/cachedir_test.go
@@ -1,0 +1,78 @@
+package extplugin
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// TestCacheDirLocked covers the cache-root selection: cacheDir when set,
+// otherwise stateDir. stateDir itself (the secret-store / sandbox
+// read_paths boundary) is unaffected by a cache override.
+func TestCacheDirLocked(t *testing.T) {
+	m := New(nil)
+	m.setStateDir("/state")
+	if got := m.cacheDirLocked(); got != "/state" {
+		t.Errorf("unset cacheDir = %q, want /state", got)
+	}
+	m.SetCacheDir("/cache")
+	if got := m.cacheDirLocked(); got != "/cache" {
+		t.Errorf("set cacheDir = %q, want /cache", got)
+	}
+	if got := m.stateDirLocked(); got != "/state" {
+		t.Errorf("stateDirLocked = %q, want /state (cache override must not move it)", got)
+	}
+}
+
+// TestResolvePluginBinaryCacheDirOverride checks that SetCacheDir (the seam
+// behind --plugin-cache-dir) directs the fetched binary to that dir and
+// leaves the secret-store stateDir untouched — this is what lets the
+// verification commands cache somewhere writable instead of a production
+// state_dir.
+func TestResolvePluginBinaryCacheDirOverride(t *testing.T) {
+	srv, sp, payload := newCacheTestRelease(t)
+	m, stateDir := newFetchTestManager(t, srv.URL)
+	cacheDir := t.TempDir()
+	m.SetCacheDir(cacheDir)
+
+	path, _, err := m.resolvePluginBinary(context.Background(), sp, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !strings.HasPrefix(path, cacheDir) {
+		t.Errorf("binary cached at %q, want under cacheDir %q", path, cacheDir)
+	}
+	if got, _ := os.ReadFile(path); !bytes.Equal(got, payload) {
+		t.Errorf("cached binary content = %q, want payload", got)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "plugins")); !os.IsNotExist(err) {
+		t.Errorf("stateDir/plugins exists (err=%v); cache leaked into the secret-store dir", err)
+	}
+}
+
+// newCacheTestRelease stands up a release server serving a single tagged
+// build of github.com/acme/myplugin and returns it with a matching source
+// spec and the binary payload.
+func newCacheTestRelease(t *testing.T) (*httptest.Server, config.PluginSource, []byte) {
+	t.Helper()
+	owner, repo := "acme", "myplugin"
+	plat := platformToken()
+	payload := []byte("plugin-cachedir-payload")
+	archive := tarGz(t, map[string][]byte{repo: payload}, repo)
+	archiveName := fmt.Sprintf("%s_1.2.0_%s.tar.gz", repo, plat)
+	sumsName := fmt.Sprintf("%s_1.2.0_SHA256SUMS", repo)
+	sums := fmt.Sprintf("%s  %s\n", sha256hex(archive), archiveName)
+	srv := newReleaseServer(t, owner, repo, []relSpec{{
+		tag:    "v1.2.0",
+		assets: map[string][]byte{archiveName: archive, sumsName: []byte(sums)},
+	}})
+	sp := config.PluginSource{Name: repo, Source: "github.com/acme/myplugin", Version: "~> 1.2"}
+	return srv, sp, payload
+}

--- a/internal/config/extplugin/fetch.go
+++ b/internal/config/extplugin/fetch.go
@@ -473,7 +473,7 @@ func (m *Manager) resolvePluginBinary(ctx context.Context, sp config.PluginSourc
 		return sp.Source, nil, nil // local path: existing behavior
 	}
 	mode := provenanceModeOf(sp)
-	f := newFetcher(m.stateDirLocked(), m.ghBase, m.prov, m.logger)
+	f := newFetcher(m.cacheDirLocked(), m.ghBase, m.prov, m.logger)
 
 	entry, have := m.lock.get(sp.Name)
 

--- a/internal/config/extplugin/install.go
+++ b/internal/config/extplugin/install.go
@@ -43,7 +43,7 @@ func (m *Manager) Install(ctx context.Context, specs []config.PluginSource, name
 	if err := m.lock.load(); err != nil {
 		return nil, err
 	}
-	f := newFetcher(m.stateDirLocked(), m.ghBase, m.prov, m.logger)
+	f := newFetcher(m.cacheDirLocked(), m.ghBase, m.prov, m.logger)
 
 	var out []InstalledPlugin
 	matched := map[string]bool{}
@@ -161,7 +161,7 @@ func (m *Manager) LockPlatforms(ctx context.Context, specs []config.PluginSource
 	if err := m.lock.load(); err != nil {
 		return nil, err
 	}
-	f := newFetcher(m.stateDirLocked(), m.ghBase, m.prov, m.logger)
+	f := newFetcher(m.cacheDirLocked(), m.ghBase, m.prov, m.logger)
 
 	var out []InstalledPlugin
 	matched := map[string]bool{}
@@ -245,7 +245,7 @@ func (m *Manager) CheckUpdates(ctx context.Context, specs []config.PluginSource)
 		m.logger.Warn("plugin update check: read lockfile", "err", err)
 		return
 	}
-	f := newFetcher(m.stateDirLocked(), m.ghBase, m.prov, m.logger)
+	f := newFetcher(m.cacheDirLocked(), m.ghBase, m.prov, m.logger)
 	updates := map[string]string{}
 	for _, sp := range specs {
 		p, err := pluginSourceFor(sp)

--- a/internal/config/extplugin/manager.go
+++ b/internal/config/extplugin/manager.go
@@ -42,6 +42,15 @@ type Manager struct {
 	logger   hclog.Logger
 	lock     *lockStore
 	stateDir string // gateway secret-store dir; read_paths may not overlap it
+	// cacheDir is the root for cached plugin binaries (<cacheDir>/plugins).
+	// Empty means "use stateDir" — the gateway-run and `plugins
+	// install|update|lock` paths leave it unset, so the cache lands beside
+	// the gateway's state as before. The verification commands (validate,
+	// test) set it via the --plugin-cache-dir flag so a config pointing at
+	// a production state_dir (e.g. /var/lib/clawpatrol) can be linted on a
+	// dev machine without writing there. Distinct from stateDir, which
+	// stays the secret-store dir for the sandbox read_paths-overlap check.
+	cacheDir string
 
 	// blobs backs the per-plugin HostState service (the v2 state service):
 	// a plugin calls into the gateway over the go-plugin broker to persist
@@ -145,6 +154,17 @@ func (m *Manager) setStateDir(d string) {
 // from the resolved config so the cache lands in the same place.
 func (m *Manager) SetStateDir(d string) { m.setStateDir(d) }
 
+// SetCacheDir overrides the root for cached plugin binaries, independent
+// of the gateway state dir. The verification commands set it from
+// --plugin-cache-dir so they can lint a config whose state_dir isn't
+// writable here. LoadPlugins deliberately does not touch cacheDir, so a
+// value set here survives a config load.
+func (m *Manager) SetCacheDir(d string) {
+	m.mu.Lock()
+	m.cacheDir = d
+	m.mu.Unlock()
+}
+
 // SetBlobStore wires the persistent byte store that backs the per-plugin
 // HostState service. Without it, a plugin that calls State gets an error
 // (the gateway main provides one; the CLI install/probe paths leave it
@@ -198,6 +218,19 @@ func (m *Manager) VerifyProvenance(enabled bool) {
 func (m *Manager) stateDirLocked() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.stateDir
+}
+
+// cacheDirLocked returns the root plugin binaries are cached under
+// (<dir>/plugins): cacheDir when set, otherwise stateDir (the historical
+// location). Reads both fields under a single lock — it must not call
+// stateDirLocked, which would re-lock m.mu.
+func (m *Manager) cacheDirLocked() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cacheDir != "" {
+		return m.cacheDir
+	}
 	return m.stateDir
 }
 

--- a/internal/config/extplugin/manifest.go
+++ b/internal/config/extplugin/manifest.go
@@ -155,7 +155,7 @@ func (m *Manager) previewManifest(ctx context.Context, sp config.PluginSource) (
 	if e, ok := m.lock.get(sp.Name); ok {
 		locked = e.Version
 	}
-	f := newFetcher(m.stateDirLocked(), m.ghBase, m.prov, m.logger)
+	f := newFetcher(m.cacheDirLocked(), m.ghBase, m.prov, m.logger)
 	r, _, err := f.gh.resolveVersion(ctx, p, sp.Version)
 	if err != nil {
 		return ManifestPreview{}, err


### PR DESCRIPTION
## Problem

`clawpatrol validate`/`test` start external plugins to schema-check them, caching the binary under `<state_dir>/plugins`. When the config's `state_dir` is the gateway's production path (e.g. `/var/lib/clawpatrol`), linting it on another machine (e.g. `deploy.sh` on an operator's laptop) fails:

```
Plugin "aws" failed to start; ... mkdir /var/lib/clawpatrol: permission denied
```

`state_dir` is the gateway's secret/persistent store (and the sandbox `read_paths`-overlap boundary). The verification commands only need *somewhere* to cache a plugin binary — that location is incidental to config validity.

## Change

- Give the plugin cache a root distinct from `state_dir`, defaulting to `state_dir` so the **gateway run and `plugins install|update|lock` are unchanged**.
- `validate`/`test` expose a **`--plugin-cache-dir DIR`** flag (→ `SetCacheDir`). Default (no flag) stays **strict**: the cache uses the config's `state_dir`, and an unwritable one surfaces as a real error (and a read-only state_dir with an already-pinned binary still serves a cache hit — no probe, no forced refetch). A caller that's linting on a foreign machine passes a scratch dir.
- `validate`/`test` verify build-provenance attestations (`VerifyProvenance(true)`, via the shared verification-manager helper) so a cold fetch reproduces the gateway's load semantics (attestation) instead of tripping the lockfile's `attested=true` downgrade guard.
