### PR TITLE
codex: support codex CLI >=0.142

### DIFF
--- a/internal/config/plugins/credentials/openai_codex.go
+++ b/internal/config/plugins/credentials/openai_codex.go
@@ -17,9 +17,26 @@ import (
 // OpenAICodexOAuth is part of the clawpatrol plugin API.
 type OpenAICodexOAuth struct{}
 
+// codexAuthAPIHost is OpenAI's accounts/auth host. The openai_codex_https
+// endpoint MITMs it (to stub codex >= 0.142 agent task-registration) but
+// forwards everything else there — codex login, token refresh, device
+// auth — which carry their own auth. Injecting the ChatGPT bearer on
+// those would clobber it and break login, so InjectHTTP skips this host.
+const codexAuthAPIHost = "auth.openai.com"
+
 // InjectHTTP is part of the clawpatrol plugin API.
 func (a *OpenAICodexOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
 	if len(sec.Bytes) == 0 {
+		return nil
+	}
+	// Never inject on auth.openai.com: its task-register POST is already
+	// stubbed by the endpoint before injection runs, and its login /
+	// token-refresh traffic is forwarded and must keep its native auth.
+	// Compare case-insensitively: routing lowercases hosts but the raw
+	// SNI/Host reaching here is not normalized, so a mixed-case host
+	// (e.g. "Auth.OpenAI.com") still routes to this credential.
+	if strings.EqualFold(req.Host, codexAuthAPIHost) ||
+		(req.URL != nil && strings.EqualFold(req.URL.Host, codexAuthAPIHost)) {
 		return nil
 	}
 	req.Header.Set("Authorization", "Bearer "+string(sec.Bytes))

--- a/internal/config/plugins/credentials/openai_codex_test.go
+++ b/internal/config/plugins/credentials/openai_codex_test.go
@@ -53,3 +53,36 @@ func TestCodexInjectOverridesAgentAssertion(t *testing.T) {
 		t.Errorf("Chatgpt-Account-Id not overwritten with bearer claim: got %q", got)
 	}
 }
+
+// TestCodexInjectSkipsAuthOpenAIHost confirms the ChatGPT bearer is NOT
+// injected on auth.openai.com. The openai_codex_https endpoint MITMs that
+// host to stub codex >= 0.142 agent task-registration, but forwards codex
+// login / token-refresh traffic there untouched — those carry their own
+// auth, so overwriting Authorization would break `codex login`.
+func TestCodexInjectSkipsAuthOpenAIHost(t *testing.T) {
+	plugin := &OpenAICodexOAuth{}
+	const native = "Bearer codex-native-token"
+	for _, url := range []string{
+		"https://auth.openai.com/oauth/token",
+		"https://auth.openai.com/api/accounts/deviceauth/token",
+		"https://auth.openai.com/oauth/revoke",
+		// Mixed-case host: routing lowercases but the raw SNI/Host does
+		// not, so the guard must match case-insensitively.
+		"https://Auth.OpenAI.com/oauth/token",
+	} {
+		req, err := http.NewRequest("POST", url, strings.NewReader("{}"))
+		if err != nil {
+			t.Fatalf("new req: %v", err)
+		}
+		req.Header.Set("Authorization", native)
+		if err := plugin.InjectHTTP(req.Context(), req, runtime.Secret{Bytes: []byte("real-subscription-token")}); err != nil {
+			t.Fatalf("inject %s: %v", url, err)
+		}
+		if got := req.Header.Get("Authorization"); got != native {
+			t.Errorf("%s: Authorization mutated on auth.openai.com: got %q", url, got)
+		}
+		if got := req.Header.Get("Chatgpt-Account-Id"); got != "" {
+			t.Errorf("%s: chatgpt-account-id stamped on auth.openai.com: got %q", url, got)
+		}
+	}
+}

--- a/internal/config/plugins/endpoints/openai_codex_https.go
+++ b/internal/config/plugins/endpoints/openai_codex_https.go
@@ -1,15 +1,20 @@
 package endpoints
 
-// openai_codex_https endpoint: chatgpt.com path for codex-cli's
-// subscription auth flow. Pushes a synthesized Agent Identity JWT
-// down via env (CODEX_ACCESS_TOKEN / CODEX_AGENT_IDENTITY) so codex
-// enters AgentIdentity mode and routes to chatgpt.com on its own.
-// At MITM time we serve the matching JWKS at
-// `/backend-api/wham/agent-identities/jwks` and stub the agent-task
-// registration POST. Codex's Authorization gets overwritten by the
-// bound credential plugin (openai_codex_oauth) before forwarding
-// upstream, so the AgentAssertion never has to validate against
-// OpenAI's real identity service.
+// openai_codex_https endpoint: the chatgpt.com + auth.openai.com path
+// for codex-cli's subscription auth flow. Pushes a synthesized Agent
+// Identity JWT down via env (CODEX_ACCESS_TOKEN / CODEX_AGENT_IDENTITY)
+// so codex enters AgentIdentity mode on its own. At MITM time we serve
+// the matching JWKS at `/backend-api/wham/agent-identities/jwks`
+// (chatgpt.com) and stub the agent-task registration POST. The
+// registration host depends on codex version: <= 0.141 sent it to
+// chatgpt.com/backend-api/wham (redirected via env), while 0.142+
+// hardcodes auth.openai.com/api/accounts — so this endpoint claims
+// auth.openai.com too (see codexAuthAPIHost) and stubs the
+// task-register path on either host. Codex's Authorization gets
+// overwritten by the bound credential plugin (openai_codex_oauth)
+// before forwarding upstream — except on auth.openai.com, where the
+// credential skips injection so codex login / token refresh keep
+// their native auth.
 //
 // Sample HCL:
 //
@@ -34,6 +39,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -51,15 +57,47 @@ type OpenAICodexHTTPSEndpoint struct {
 	Hosts []string `hcl:"hosts"`
 }
 
-// EndpointHosts is part of the clawpatrol plugin API.
-func (e *OpenAICodexHTTPSEndpoint) EndpointHosts() []string { return e.Hosts }
+// codexAuthAPIHost is OpenAI's accounts/auth host. codex >= 0.142
+// hardcodes agent task-registration to https://auth.openai.com/api/accounts
+// (the env override clawpatrol used on <= 0.141 was removed upstream), so
+// the gateway must MITM this host to keep stubbing task-register. We claim
+// it unconditionally (see EndpointHosts) and stub only the task-register
+// path (see RespondHTTP); every other auth.openai.com path — codex login,
+// token refresh — is forwarded untouched, and the bound credential's
+// InjectHTTP skips this host so it never clobbers their native auth.
+const codexAuthAPIHost = "auth.openai.com"
+
+// codexSyntheticRuntimeID is the agent_runtime_id baked into the JWT we
+// mint (mintCodexAccessToken). The task-register stub keys on it so we
+// only forge a task_id for OUR synthetic identity — a real OpenAI Agent
+// Identity (e.g. the JWT-mint-failure fallback to ~/.codex/auth.json)
+// registers a different runtime id and is forwarded upstream untouched.
+const codexSyntheticRuntimeID = "clawpatrol-codex"
+
+// EndpointHosts is part of the clawpatrol plugin API. It always includes
+// codexAuthAPIHost so the codex >= 0.142 registration host is MITM'd
+// without an HCL edit on upgrade.
+func (e *OpenAICodexHTTPSEndpoint) EndpointHosts() []string {
+	if slices.Contains(e.Hosts, codexAuthAPIHost) {
+		return e.Hosts
+	}
+	return append(slices.Clone(e.Hosts), codexAuthAPIHost)
+}
 
 // EnvVars pushes down a synthetic CODEX_ACCESS_TOKEN so codex enters
 // AgentIdentity mode (which routes it to chatgpt.com). Also pushes
 // CODEX_AGENT_IDENTITY for codex <= 0.128, which read the same JWT
-// from the older env-var name. The auth-api base URL override keeps
-// the per-task registration POST on a host clawpatrol terminates,
-// instead of leaking to auth.openai.com.
+// from the older env-var name.
+//
+// CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL is load-bearing only for codex
+// <= 0.141: it redirected per-task registration onto a host clawpatrol
+// MITMs (chatgpt.com/backend-api/wham). codex 0.142 REMOVED this
+// override and hardcoded registration to auth.openai.com, so for 0.142+
+// the gateway instead MITMs auth.openai.com directly (see
+// codexAuthAPIHost / RespondHTTP). The var is kept here because it's
+// harmless on 0.142 (ignored) and still required on <= 0.141. We do NOT
+// push the 0.142 replacement CODEX_AUTHAPI_BASE_URL: codex host-restricts
+// it to OpenAI hosts, so it can't be pointed at a clawpatrol host anyway.
 func (e *OpenAICodexHTTPSEndpoint) EnvVars() []config.EnvVar {
 	jwt, err := mintCodexAccessToken()
 	if err != nil {
@@ -109,8 +147,14 @@ func (OpenAICodexHTTPSEndpointRuntime) DetectPlaceholder(req *runtime.Request, c
 // RespondHTTP intercepts the two paths codex hits during Agent
 // Identity load: the JWKS that validates the JWT we minted, and the
 // agent-task registration POST that returns a task_id. Both are
-// served from clawpatrol-controlled state — neither reaches the real
-// chatgpt.com.
+// served from clawpatrol-controlled state — neither reaches real
+// OpenAI. The JWKS is on chatgpt.com; the registration host moved to
+// auth.openai.com in codex 0.142 (was chatgpt.com/backend-api/wham on
+// <= 0.141), so the register matcher is deliberately host-agnostic and
+// keys on the stable path shape. This is safe because this endpoint
+// only owns chatgpt.com + auth.openai.com (see EndpointHosts); every
+// other auth.openai.com path (codex login, token refresh) falls
+// through to be forwarded untouched.
 func (OpenAICodexHTTPSEndpointRuntime) RespondHTTP(_ context.Context, req *http.Request) (*http.Response, bool, error) {
 	switch {
 	case req.Method == http.MethodGet && req.URL.Path == "/backend-api/wham/agent-identities/jwks":
@@ -119,8 +163,15 @@ func (OpenAICodexHTTPSEndpointRuntime) RespondHTTP(_ context.Context, req *http.
 			return nil, false, err
 		}
 		return jsonResp(req, http.StatusOK, body), true, nil
-	case req.Method == http.MethodPost && strings.HasPrefix(req.URL.Path, "/backend-api/wham/v1/agent/") &&
-		strings.HasSuffix(req.URL.Path, "/task/register"):
+	// Agent task-register for OUR synthetic identity only. The suffix
+	// match covers both the <= 0.141 path
+	// (/backend-api/wham/v1/agent/clawpatrol-codex/task/register) and the
+	// 0.142+ path (/api/accounts/v1/agent/clawpatrol-codex/task/register)
+	// while scoping to codexSyntheticRuntimeID — a real Agent Identity
+	// (different runtime id) is forwarded upstream untouched, and
+	// /v1/agent/register (agent bootstrap) never matches.
+	case req.Method == http.MethodPost &&
+		strings.HasSuffix(req.URL.Path, "/v1/agent/"+codexSyntheticRuntimeID+"/task/register"):
 		return jsonResp(req, http.StatusOK, []byte(`{"task_id":"clawpatrol-task"}`)), true, nil
 	}
 	return nil, false, nil
@@ -306,7 +357,7 @@ func mintCodexAccessToken() (string, error) {
 		"aud":                        "codex-app-server",
 		"iat":                        now,
 		"exp":                        now + int64(10*365*24*60*60),
-		"agent_runtime_id":           "clawpatrol-codex",
+		"agent_runtime_id":           codexSyntheticRuntimeID,
 		"agent_private_key":          k.Ed25519PKCS8B64,
 		"account_id":                 "clawpatrol",
 		"chatgpt_user_id":            "clawpatrol",

--- a/internal/config/plugins/endpoints/openai_codex_https_test.go
+++ b/internal/config/plugins/endpoints/openai_codex_https_test.go
@@ -12,10 +12,36 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 )
+
+// TestCodexEndpointHosts confirms EndpointHosts always claims
+// auth.openai.com (so codex >= 0.142 task-registration is MITM'd without
+// an HCL edit), and that it doesn't duplicate the host when an operator
+// already listed it.
+func TestCodexEndpointHosts(t *testing.T) {
+	got := (&OpenAICodexHTTPSEndpoint{Hosts: []string{"chatgpt.com"}}).EndpointHosts()
+	if !slices.Contains(got, "chatgpt.com") {
+		t.Errorf("missing configured host chatgpt.com: %v", got)
+	}
+	if !slices.Contains(got, codexAuthAPIHost) {
+		t.Errorf("EndpointHosts did not auto-claim %s: %v", codexAuthAPIHost, got)
+	}
+
+	already := (&OpenAICodexHTTPSEndpoint{Hosts: []string{"chatgpt.com", codexAuthAPIHost}}).EndpointHosts()
+	n := 0
+	for _, h := range already {
+		if h == codexAuthAPIHost {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("auth host duplicated: %v", already)
+	}
+}
 
 // fakeBlobs is an in-memory runtime.BlobStore for tests. Plugins read
 // / write blobs through this in place of the production sqlite-backed
@@ -212,7 +238,12 @@ func TestCodexRespondHTTP(t *testing.T) {
 		handled bool
 	}{
 		{"jwks", "GET", "https://chatgpt.com/backend-api/wham/agent-identities/jwks", 200, true},
-		{"register", "POST", "https://chatgpt.com/backend-api/wham/v1/agent/clawpatrol-codex/task/register", 200, true},
+		{"register legacy wham (<=0.141)", "POST", "https://chatgpt.com/backend-api/wham/v1/agent/clawpatrol-codex/task/register", 200, true},
+		{"register 0.142 auth.openai.com", "POST", "https://auth.openai.com/api/accounts/v1/agent/clawpatrol-codex/task/register", 200, true},
+		{"auth login passthrough", "POST", "https://auth.openai.com/api/accounts/deviceauth/token", 0, false},
+		{"auth oauth token passthrough", "POST", "https://auth.openai.com/oauth/token", 0, false},
+		{"agent-register not stubbed", "POST", "https://auth.openai.com/api/accounts/v1/agent/register", 0, false},
+		{"real-identity register forwarded", "POST", "https://auth.openai.com/api/accounts/v1/agent/some-real-id/task/register", 0, false},
 		{"forward responses", "POST", "https://chatgpt.com/backend-api/codex/responses", 0, false},
 		{"unrelated path", "GET", "https://chatgpt.com/", 0, false},
 	}


### PR DESCRIPTION
## Problem

`clawpatrol run codex` breaks on codex CLI **0.142.0+** with `400 invalid_agent_runtime_id`.

Root cause (codex git diff `rust-v0.141.0...rust-v0.142.0`, `codex-rs/agent-identity/src/lib.rs`) is as follows.

codex ≤0.141 built the agent task-registration URL from the ChatGPT base, which we redirected onto a MITM'd host via `CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL=…/backend-api/wham`.

0.142 removed that override** and hardcoded registration to `https://auth.openai.com/api/accounts` (a new `ChatGptEnvironment` allowlist that `bail!`s on non-OpenAI hosts). We don't MITM `auth.openai.com`, so the synthetic `agent_runtime_id: "clawpatrol-codex"` reaches real OpenAI, thus 400.

The registration path suffix is unchanged (`/v1/agent/{id}/task/register`); only the host moved. JWKS, JWT claims, and the `{"task_id":…}` response shape still work.

## Fix

- `openai_codex_https`: `EndpointHosts()` auto-claims `auth.openai.com` (works on upgrade with no HCL edit). `RespondHTTP()` stubs task-register scoped to our synthetic `clawpatrol-codex` runtime id, matching both the ≤0.141 (`/backend-api/wham/…`) and 0.142 (`/api/accounts/…`) shapes. Real Agent Identities (different runtime id) and `/v1/agent/register` are forwarded untouched.
- `openai_codex_oauth`: `InjectHTTP()` skips `auth.openai.com` (case-insensitive) so forwarded `codex login` / token-refresh keep their native auth instead of being clobbered with the ChatGPT bearer.

## Verification

- End-to-end with codex 0.142.2 through a patched gateway: task-register now served locally (`synth`/200, no `invalid_agent_runtime_id`); a real model turn returns. Auto-claim confirmed (config listed only `chatgpt.com`).
- Regression: ≤0.141 legacy path still stubbed (covered by unit test).
