### PR TITLE
feat(credentials): add signal_cli HITL notifier

### DIFF
--- a/internal/config/plugins/credentials/signal.go
+++ b/internal/config/plugins/credentials/signal.go
@@ -1,0 +1,269 @@
+package credentials
+
+// signal_cli: deliver HITL approval prompts to Signal via a
+// signal-cli-rest-api instance (https://github.com/bbernhard/signal-cli-rest-api).
+//
+// Signal has no bot/HTTP API of its own and no interactive button UI,
+// so this is a notification-only notifier: it POSTs a plain-text prompt
+// ending with an "Open dashboard" link, and the human approves/denies
+// there. It implements HITLNotifier only — there is no HTTP injection
+// runtime and no WebhookProvider callback (contrast slack.go).
+//
+// Config is pasted via the dashboard secret slots:
+//
+//   - api_url: base URL of the signal-cli-rest-api (e.g. http://localhost:8080)
+//   - number:  the registered Signal sender number, E.164 (+15551234567)
+//   - auth:    optional "user:pass" if the REST API is behind HTTP basic auth
+//
+// The recipient is the human_approver block's `channel` — a recipient
+// number (E.164) or a "group.<base64-id>" group identifier.
+//
+// Adding another notification channel is a new credential plugin with
+// its own NotifyHITL — no human_approver / runtime.go changes.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// SignalCLI is part of the clawpatrol plugin API.
+type SignalCLI struct{}
+
+var (
+	signalHTTPClient   = &http.Client{Timeout: 10 * time.Second}
+	signalRetryBackoff = 500 * time.Millisecond
+)
+
+// signalSendPath is the signal-cli-rest-api v2 send endpoint.
+const signalSendPath = "/v2/send"
+
+// signalMessageMax bounds the prompt text. Signal messages can be long,
+// but we keep individual sections trimmed so a giant body/path can't
+// blow up the message; this is a soft overall guard.
+const signalMessageMax = 4000
+
+// SecretSlots is part of the clawpatrol plugin API.
+func (*SignalCLI) SecretSlots() []config.SecretSlot {
+	return []config.SecretSlot{
+		{Name: "api_url", Label: "signal-cli-rest-api URL", Description: "Base URL of the signal-cli-rest-api, e.g. http://localhost:8080"},
+		{Name: "number", Label: "Sender number", Description: "Registered Signal number in E.164 form, e.g. +15551234567"},
+		{Name: "auth", Label: "Basic auth (optional)", Description: "user:pass if the REST API is behind HTTP basic auth"},
+	}
+}
+
+// NotifyHITL posts an approval prompt to the operator's Signal recipient
+// via signal-cli-rest-api's POST /v2/send. api_url + number come from the
+// credential's secret slots (fetched per-call via the request's
+// SecretStore so dashboard rotations apply); the recipient is the
+// approver block's channel.
+func (s *SignalCLI) NotifyHITL(ctx context.Context, req runtime.ApproveRequest, target runtime.HITLTarget) error {
+	if req.Secrets == nil {
+		return fmt.Errorf("no secret store on request")
+	}
+	sec, err := req.Secrets.Get(target.CredentialName)
+	if err != nil {
+		return fmt.Errorf("fetch credential %s: %w", target.CredentialName, err)
+	}
+	apiURL := strings.TrimRight(sec.Extras["api_url"], "/")
+	number := strings.TrimSpace(sec.Extras["number"])
+	if apiURL == "" || number == "" {
+		return fmt.Errorf("credential %s missing api_url or number (paste them via the dashboard)", target.CredentialName)
+	}
+	if strings.TrimSpace(target.Channel) == "" {
+		return fmt.Errorf("human approver %s has no channel (set it to a Signal recipient number or group.<id>)", target.CredentialName)
+	}
+
+	body := map[string]any{
+		"number":     number,
+		"recipients": []string{target.Channel},
+		"message":    signalHITLMessage(req, target),
+	}
+	buf, _ := json.Marshal(body)
+	return signalPostSend(ctx, apiURL+signalSendPath, sec.Extras["auth"], buf)
+}
+
+// signalHITLMessage renders the plain-text prompt. Signal has no rich
+// blocks or buttons, so it is a compact text card ending with the
+// dashboard link where the operator approves or denies.
+func signalHITLMessage(req runtime.ApproveRequest, target runtime.HITLTarget) string {
+	endpoint := runtime.HITLEndpointLabel(req)
+	title := runtime.HITLTitle(req.Method, endpoint)
+
+	var b strings.Builder
+	b.WriteString("clawpatrol: " + signalTrunc(title, 200) + "\n")
+
+	switch {
+	case strings.TrimSpace(target.Message) != "":
+		b.WriteString("\n" + signalTrunc(target.Message, 1500) + "\n")
+	case target.Summary != nil:
+		sm := target.Summary
+		if sm.Subject != "" {
+			b.WriteString("\n" + signalTrunc(sm.Subject, 200) + "\n")
+		}
+		label := sm.Label
+		if sm.Confidence > 0 {
+			if label == "" {
+				label = fmt.Sprintf("%d%% confidence", sm.Confidence)
+			} else {
+				label += fmt.Sprintf(" (%d%%)", sm.Confidence)
+			}
+		}
+		if label != "" {
+			b.WriteString("Label: " + label + "\n")
+		}
+		if sm.Summary != "" {
+			b.WriteString("Summary: " + signalTrunc(sm.Summary, 500) + "\n")
+		}
+	default:
+		if req.Path != "" {
+			b.WriteString("\n" + runtime.HITLQueryLabel(req.Endpoint) + ": " + signalTrunc(req.Path, 800) + "\n")
+		}
+	}
+
+	if req.Profile != "" {
+		b.WriteString("agent: " + signalTrunc(req.Profile, 80) + "\n")
+	}
+	if r := strings.TrimSpace(req.Reason); r != "" {
+		b.WriteString("reason: " + signalTrunc(r, 200) + "\n")
+	}
+	if bs := strings.TrimSpace(req.BodySample); bs != "" {
+		b.WriteString("\nBody:\n" + signalTrunc(bs, 800) + "\n")
+	}
+	if g := signalHITLApprovalGuidance(target); g != "" {
+		b.WriteString("\n" + signalTrunc(g, 1000) + "\n")
+	}
+
+	// Bound the variable content, then append the dashboard link last and
+	// unconditionally — so an overflowing body/summary can never truncate
+	// away the approve/deny link, the actionable part of the prompt.
+	content := strings.TrimRight(signalTrunc(b.String(), signalMessageMax), "\n")
+	link := strings.TrimRight(target.DashboardURL, "/") + "/#hitl/" + target.PendingID
+	return content + "\n\nApprove or deny: " + link
+}
+
+// signalHITLApprovalGuidance mirrors the Slack notifier's guidance line:
+// it tells the operator whether approving executes the upstream call
+// immediately or only authorizes a one-shot retry grant.
+func signalHITLApprovalGuidance(target runtime.HITLTarget) string {
+	if m := strings.TrimSpace(target.ApprovalMessage); m != "" {
+		return m
+	}
+	if target.OperationState == "" && target.ApprovalEffect == "" && !target.UpstreamCalled {
+		return ""
+	}
+	state := target.OperationState
+	if state == "" {
+		state = runtime.HITLOperationStateSyncWaiting
+	}
+	effect := target.ApprovalEffect
+	if effect == "" {
+		effect = runtime.HITLApprovalEffectForOperationState(state)
+	}
+	return runtime.HITLApprovalMessage(state, effect, target.UpstreamCalled)
+}
+
+// signalPostSend POSTs the send request with one retry on transient
+// failure, mirroring the Slack notifier's backoff behavior.
+func signalPostSend(ctx context.Context, endpoint, auth string, buf []byte) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var lastErr error
+	for attempt := 1; attempt <= 2; attempt++ {
+		hreq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(buf))
+		if err != nil {
+			return err
+		}
+		hreq.Header.Set("Content-Type", "application/json")
+		if auth != "" {
+			if user, pass, ok := strings.Cut(auth, ":"); ok {
+				hreq.SetBasicAuth(user, pass)
+			}
+		}
+
+		resp, err := signalHTTPClient.Do(hreq)
+		if err == nil {
+			lastErr = signalDecodeResponse(resp)
+			if closeErr := resp.Body.Close(); lastErr == nil && closeErr != nil {
+				lastErr = closeErr
+			}
+		} else {
+			lastErr = err
+		}
+		if lastErr == nil {
+			return nil
+		}
+		if attempt == 2 || !signalShouldRetry(resp, err) {
+			return lastErr
+		}
+		log.Printf("signal notify: %s failed on attempt %d, retrying once: %v", signalSendPath, attempt, lastErr)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(signalRetryBackoff):
+		}
+	}
+	return lastErr
+}
+
+func signalDecodeResponse(resp *http.Response) error {
+	if resp == nil {
+		return fmt.Errorf("signal %s: missing response", signalSendPath)
+	}
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= 400 {
+		msg := strings.TrimSpace(string(respBody))
+		// signal-cli-rest-api returns {"error":"..."} on failure.
+		var parsed struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(respBody, &parsed) == nil && parsed.Error != "" {
+			msg = parsed.Error
+		}
+		log.Printf("signal notify: %s failed: status=%d error=%q", signalSendPath, resp.StatusCode, signalTrunc(msg, 300))
+		return fmt.Errorf("signal %s error: HTTP %d: %s", signalSendPath, resp.StatusCode, signalTrunc(msg, 300))
+	}
+	return nil
+}
+
+func signalShouldRetry(resp *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+	if resp == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+}
+
+func signalTrunc(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}
+
+func init() {
+	var _ runtime.HITLNotifier = (*SignalCLI)(nil)
+	config.Register(&config.Plugin{
+		Kind: config.KindCredential,
+		Type: "signal_cli",
+		// Notifier-only: no HTTP/SQL/TLS injection runtime, so Runtime is
+		// nil (schema-only). The approver and dashboard read NotifyHITL /
+		// SecretSlots off the built body (ent.Body), not off Runtime.
+		New:   newer[SignalCLI](),
+		Build: passthrough,
+		Emit:  emptyEmit,
+	})
+}

--- a/internal/config/plugins/credentials/signal_test.go
+++ b/internal/config/plugins/credentials/signal_test.go
@@ -1,0 +1,200 @@
+package credentials
+
+// Tests for the signal_cli HITL notifier. testSecretStore is defined in
+// slack_notify_test.go (same package) and reused here.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func signalTestReq(store testSecretStore) runtime.ApproveRequest {
+	return runtime.ApproveRequest{
+		Secrets: store,
+		Method:  "POST",
+		Host:    "gitlab.com",
+		Path:    "/api/v4/projects/1/issues",
+		Profile: "uninfo",
+	}
+}
+
+// withSignalClient points the notifier at a test server and disables the
+// retry backoff, restoring both on cleanup.
+func withSignalClient(t *testing.T, c *http.Client) {
+	t.Helper()
+	oldClient, oldBackoff := signalHTTPClient, signalRetryBackoff
+	signalHTTPClient, signalRetryBackoff = c, 0
+	t.Cleanup(func() { signalHTTPClient, signalRetryBackoff = oldClient, oldBackoff })
+}
+
+func TestSignalNotifyHITLSendsToV2Send(t *testing.T) {
+	var gotPath, gotAuth string
+	var payload struct {
+		Number     string   `json:"number"`
+		Recipients []string `json:"recipients"`
+		Message    string   `json:"message"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	withSignalClient(t, server.Client())
+
+	err := (&SignalCLI{}).NotifyHITL(context.Background(), signalTestReq(testSecretStore{
+		"signal-ops": {Extras: map[string]string{"api_url": server.URL, "number": "+15550000000"}},
+	}), runtime.HITLTarget{
+		CredentialName: "signal-ops",
+		Channel:        "+15551112222",
+		PendingID:      "pending-9",
+		DashboardURL:   "https://gateway.example",
+	})
+	if err != nil {
+		t.Fatalf("NotifyHITL: %v", err)
+	}
+	if gotPath != "/v2/send" {
+		t.Fatalf("path = %q, want /v2/send", gotPath)
+	}
+	if gotAuth != "" {
+		t.Fatalf("unexpected Authorization header %q (no auth configured)", gotAuth)
+	}
+	if payload.Number != "+15550000000" {
+		t.Fatalf("number = %q, want +15550000000", payload.Number)
+	}
+	if len(payload.Recipients) != 1 || payload.Recipients[0] != "+15551112222" {
+		t.Fatalf("recipients = %v, want [+15551112222]", payload.Recipients)
+	}
+	for _, want := range []string{"clawpatrol:", "https://gateway.example/#hitl/pending-9"} {
+		if !strings.Contains(payload.Message, want) {
+			t.Fatalf("message = %q, want substring %q", payload.Message, want)
+		}
+	}
+}
+
+func TestSignalNotifyHITLBasicAuth(t *testing.T) {
+	var user, pass string
+	var ok bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok = r.BasicAuth()
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	withSignalClient(t, server.Client())
+
+	err := (&SignalCLI{}).NotifyHITL(context.Background(), signalTestReq(testSecretStore{
+		"signal-ops": {Extras: map[string]string{"api_url": server.URL, "number": "+15550000000", "auth": "rest:secretpw"}},
+	}), runtime.HITLTarget{CredentialName: "signal-ops", Channel: "+15551112222", PendingID: "p1", DashboardURL: "https://gw"})
+	if err != nil {
+		t.Fatalf("NotifyHITL: %v", err)
+	}
+	if !ok || user != "rest" || pass != "secretpw" {
+		t.Fatalf("basic auth = %q/%q ok=%v, want rest/secretpw", user, pass, ok)
+	}
+}
+
+func TestSignalNotifyHITLRetriesTransient5xx(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, `{"error":"busy"}`, http.StatusBadGateway)
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	withSignalClient(t, server.Client())
+
+	err := (&SignalCLI{}).NotifyHITL(context.Background(), signalTestReq(testSecretStore{
+		"signal-ops": {Extras: map[string]string{"api_url": server.URL, "number": "+15550000000"}},
+	}), runtime.HITLTarget{CredentialName: "signal-ops", Channel: "+15551112222", PendingID: "p1", DashboardURL: "https://gw"})
+	if err != nil {
+		t.Fatalf("NotifyHITL after retry: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestSignalNotifyHITLNoRetryOn4xx(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		http.Error(w, `{"error":"invalid recipient"}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+	withSignalClient(t, server.Client())
+
+	err := (&SignalCLI{}).NotifyHITL(context.Background(), signalTestReq(testSecretStore{
+		"signal-ops": {Extras: map[string]string{"api_url": server.URL, "number": "+15550000000"}},
+	}), runtime.HITLTarget{CredentialName: "signal-ops", Channel: "bad", PendingID: "p1", DashboardURL: "https://gw"})
+	if err == nil {
+		t.Fatal("NotifyHITL error = nil, want 4xx error")
+	}
+	if !strings.Contains(err.Error(), "invalid recipient") {
+		t.Fatalf("error = %v, want the signal error body surfaced", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (4xx must not retry)", attempts)
+	}
+}
+
+func TestSignalNotifyHITLRequiresConfig(t *testing.T) {
+	cases := map[string]struct {
+		extras  map[string]string
+		channel string
+	}{
+		"missing api_url": {map[string]string{"number": "+15550000000"}, "+15551112222"},
+		"missing number":  {map[string]string{"api_url": "http://signal.invalid"}, "+15551112222"},
+		"missing channel": {map[string]string{"api_url": "http://signal.invalid", "number": "+15550000000"}, ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := (&SignalCLI{}).NotifyHITL(context.Background(), signalTestReq(testSecretStore{
+				"signal-ops": {Extras: tc.extras},
+			}), runtime.HITLTarget{CredentialName: "signal-ops", Channel: tc.channel, PendingID: "p1", DashboardURL: "https://gw"})
+			if err == nil {
+				t.Fatalf("%s: expected an error, got nil", name)
+			}
+		})
+	}
+}
+
+func TestSignalHITLMessageRendersSummaryAndLink(t *testing.T) {
+	msg := signalHITLMessage(runtime.ApproveRequest{
+		Method:  "POST",
+		Host:    "gitlab.com",
+		Path:    "/api/v4/projects/1/issues",
+		Profile: "uninfo",
+	}, runtime.HITLTarget{
+		PendingID:    "abc",
+		DashboardURL: "https://gateway.example/",
+		Summary: &runtime.HITLSummary{
+			Subject:    "POST /api/v4/projects/1/issues",
+			Label:      "write",
+			Confidence: 90,
+			Summary:    "creates an issue",
+		},
+	})
+	for _, want := range []string{
+		"clawpatrol:",
+		"POST /api/v4/projects/1/issues",
+		"Label: write (90%)",
+		"Summary: creates an issue",
+		"agent: uninfo",
+		"https://gateway.example/#hitl/abc",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message missing %q:\n%s", want, msg)
+		}
+	}
+}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -142,8 +142,8 @@ Targets one channel. Timeout / require_approvers
 override the global defaults block on a per-approver basis.
 
 Credential references a credential whose body satisfies HITLNotifier
-(slack_tokens today; future Discord / Telegram / SMTP credentials).
-Leave empty for a dashboard-only approver (no channel notification;
+(slack_tokens and signal_cli today; future Discord / Telegram / SMTP
+credentials). Leave empty for a dashboard-only approver (no channel notification;
 operator clicks approve/deny on the dashboard).
 
 | Attribute | Type | Required | Description |
@@ -186,7 +186,7 @@ approver "llm_approver" "example" {
 
 Block syntax: `credential "<type>" "<name>" { ... }`
 
-Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`basic_auth`](#credential-basicauth), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`passthrough`](#credential-passthrough), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh_key`](#credential-sshkey), [`tailscale_auth`](#credential-tailscaleauth), [`telegram_bot_token`](#credential-telegrambottoken).
+Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`basic_auth`](#credential-basicauth), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`passthrough`](#credential-passthrough), [`postgres_credential`](#credential-postgrescredential), [`signal_cli`](#credential-signalcli), [`slack_tokens`](#credential-slacktokens), [`ssh_key`](#credential-sshkey), [`tailscale_auth`](#credential-tailscaleauth), [`telegram_bot_token`](#credential-telegrambottoken).
 
 ### `credential "anthropic_manual_key" "<name>"`
 
@@ -395,6 +395,33 @@ the catchall (one allowed per (profile, endpoint)).
 
 ```hcl
 credential "postgres_credential" "example" {}
+```
+
+### `credential "signal_cli" "<name>"`
+
+Notification-only HITL notifier (no HTTP injection). Delivers approval
+prompts to Signal via a [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api)
+instance; reference it from a `human_approver`'s `credential`, with the
+recipient set as the approver's `channel` (an E.164 number or `group.<id>`).
+Signal has no interactive buttons, so the prompt carries an "Open dashboard"
+link and the operator approves there.
+
+_No configurable HCL attributes._ Paste the connection details into the
+dashboard secret slots:
+
+| Slot | Description |
+|------|-------------|
+| `api_url` | Base URL of the signal-cli-rest-api, e.g. `http://127.0.0.1:8090`. |
+| `number` | The registered Signal sender number, E.164 (`+15551234567`). |
+| `auth` | Optional `user:pass` if the REST API is behind HTTP basic auth. |
+
+```hcl
+credential "signal_cli" "ops" {}
+
+approver "human_approver" "ops" {
+  channel    = "+15551112222" # recipient number or group.<id>
+  credential = signal_cli.ops
+}
 ```
 
 ### `credential "slack_tokens" "<name>"`


### PR DESCRIPTION
Notification-only Signal notifier via signal-cli-rest-api (POST /v2/send). Implements HITLNotifier; configured through dashboard secret slots (api_url, number, auth) with the recipient set as the approver's channel. Signal has no interactive buttons, so the prompt carries an Open dashboard link. Includes unit tests and a config-reference entry.