### PR TITLE
config: add remote MCP endpoint and facet

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1659,7 +1659,7 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 			ep, authority, certHost := g.httpsMITMEndpoint(profile, dstIP, dstPort)
 			if ep != nil && isHTTPSMITMFamily(ep.Family) {
 				log.Printf("sni-fallback: %s → %s", authority, ep.Name)
-				g.mitmHTTPSWithCertHost(c, authority, certHost, ep)
+				g.mitmHTTPSCandidates(c, authority, certHost, g.httpsMITMCandidates(profile, authority, ep))
 				return
 			}
 		}
@@ -1685,12 +1685,15 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 		return
 	}
 	if isHTTPSMITMFamily(ep.Family) {
-		// Every facet whose Transport() is "https-mitm" — https and
-		// k8s today, future plugins tomorrow — terminates TLS here
+		// Every facet whose Transport() is "https-mitm" — https, k8s,
+		// and mcp today, future plugins tomorrow — terminates TLS here
 		// and runs the request loop through mitmHTTPS. The facet's
 		// PrepareRequest hook derives any per-family metadata
-		// (URL → Meta for k8s) before the matcher walks.
-		g.mitmHTTPSWithCertHost(c, authority, certHost, ep)
+		// (URL → Meta for k8s/mcp) before the matcher walks. Pass the
+		// full candidate set so path-aware selection can route the MCP
+		// path to remote_mcp and the rest of the host to a generic
+		// https endpoint.
+		g.mitmHTTPSCandidates(c, authority, certHost, g.httpsMITMCandidates(profile, authority, ep))
 		return
 	}
 	// External plugin endpoints that terminate TLS themselves (e.g. an
@@ -1732,6 +1735,25 @@ func (g *Gateway) shouldHandleHTTPSMITM(c net.Conn, dstIP string, dstPort uint16
 	return ep != nil && isHTTPSMITMFamily(ep.Family)
 }
 
+// httpsMITMCandidates returns the https-mitm endpoints bound to the
+// authority (host or host:port) for path-aware request selection. Falls
+// back to the single representative endpoint when the candidate index
+// has no entry (wildcard hosts, single-tenant fallbacks), so behavior
+// is unchanged for non-shared hosts.
+func (g *Gateway) httpsMITMCandidates(profile, authority string, rep *config.CompiledEndpoint) []*config.CompiledEndpoint {
+	cands := runtime.HostCandidates(g.Policy(), profile, authority)
+	out := cands[:0:0]
+	for _, ce := range cands {
+		if isHTTPSMITMFamily(ce.Family) {
+			out = append(out, ce)
+		}
+	}
+	if len(out) == 0 && rep != nil {
+		return []*config.CompiledEndpoint{rep}
+	}
+	return out
+}
+
 func (g *Gateway) httpsMITMEndpoint(profile, host string, dstPort uint16) (*config.CompiledEndpoint, string, string) {
 	policy := g.Policy()
 	exact := runtime.HostEndpoint(policy, profile, host)
@@ -1750,6 +1772,79 @@ func (g *Gateway) httpsMITMEndpoint(profile, host string, dstPort uint16) (*conf
 	return nil, host, host
 }
 
+func (g *Gateway) forwardUnmatchedHTTPS(tc net.Conn, req *http.Request, host string, ev Event, start time.Time) {
+	req.URL.Scheme = "https"
+	req.URL.Host = host
+	req.Host = host
+	req.RequestURI = ""
+	stripProxyRequestHeaders(req)
+	tr := g.unmatchedHTTPSTransport()
+	defer tr.CloseIdleConnections()
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		log.Printf("passthrough %s %s: %v", host, req.URL.Path, err)
+		_, _ = fmt.Fprintf(tc, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+		ev.Status = strconv.Itoa(http.StatusBadGateway)
+		ev.Action = "error"
+		ev.Reason = err.Error()
+		ev.Ms = time.Since(start).Milliseconds()
+		g.emitEnd(ev)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	stripAltSvc(resp.Header)
+	stripAuthResponseHeaders(resp.Header)
+	stripAuthResponseHeaders(resp.Trailer)
+	writeErr := resp.Write(tc)
+	ev.Status = strconv.Itoa(resp.StatusCode)
+	if writeErr != nil {
+		log.Printf("passthrough write %s %s: %v", host, req.URL.Path, writeErr)
+		ev.Reason = writeErr.Error()
+	}
+	ev.Ms = time.Since(start).Milliseconds()
+	g.emitEnd(ev)
+}
+
+func (g *Gateway) unmatchedHTTPSTransport() *http.Transport {
+	dialer := g.dialer
+	if dialer == nil {
+		dialer = newUpstreamDialer("")
+	}
+	return &http.Transport{
+		Proxy:       nil,
+		DialContext: dialer.DialContext,
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			h, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				h = addr
+			}
+			td := tls.Dialer{NetDialer: dialer, Config: &tls.Config{ServerName: h, NextProtos: []string{"http/1.1"}}}
+			return td.DialContext(ctx, network, addr)
+		},
+		ForceAttemptHTTP2:   false,
+		IdleConnTimeout:     5 * time.Second,
+		MaxIdleConns:        8,
+		MaxIdleConnsPerHost: 2,
+	}
+}
+
+func stripProxyRequestHeaders(req *http.Request) {
+	req.Header.Del(hitlRetryOperationHeader)
+	if isWSUpgrade(req) {
+		return
+	}
+	for _, h := range []string{
+		"Connection", "Keep-Alive", "Proxy-Authenticate",
+		"Proxy-Authorization", "Te", "Trailers", "Transfer-Encoding", "Upgrade",
+		"Cf-Worker", "Cf-Ray", "Cf-Ew-Via", "Cf-Connecting-Ip", "Cdn-Loop",
+		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "Via",
+		"X-HITL-Thread-TS",
+		"X-HITL-Channel",
+	} {
+		req.Header.Del(h)
+	}
+}
+
 // isHTTPSMITMFamily reports whether the facet registered for family
 // drives its wire through the HTTPS MITM handler. Replaces what used
 // to be a hardcoded `case "http", "k8s"` so new HTTPS-shaped
@@ -1757,11 +1852,7 @@ func (g *Gateway) httpsMITMEndpoint(profile, host string, dstPort uint16) (*conf
 // wants per-family report fields beyond what http_rule offers) drop
 // in without touching the dispatch switch.
 func isHTTPSMITMFamily(family string) bool {
-	if family == "" {
-		return false
-	}
-	f := facet.Lookup(family)
-	return f != nil && f.Transport() == "https-mitm"
+	return facet.IsHTTPSMITMFamily(family)
 }
 
 // handlePostgresConn dispatches an inbound 5432 connection to the
@@ -2290,6 +2381,18 @@ func (g *Gateway) mitmHTTPS(c net.Conn, host string, ep *config.CompiledEndpoint
 }
 
 func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *config.CompiledEndpoint) {
+	g.mitmHTTPSCandidates(c, host, certHost, []*config.CompiledEndpoint{ep})
+}
+
+// mitmHTTPSCandidates terminates TLS for host and runs the request
+// loop, selecting which endpoint owns each request by its URL path.
+// candidates is the set of endpoints bound to the host (every entry is
+// an https-mitm family); path-aware selection lets a path-scoped
+// remote_mcp endpoint share a host with a generic https endpoint. The
+// per-request endpoint drives transport, facet, credential injection,
+// and reporting — so an unrelated same-host REST request never runs the
+// MCP facet.
+func (g *Gateway) mitmHTTPSCandidates(c net.Conn, host, certHost string, candidates []*config.CompiledEndpoint) {
 	agentAddr := peerIP(c)
 	profile := g.profileFor(agentAddr)
 	agentAddr = g.agentIPFor(c)
@@ -2311,13 +2414,6 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 	}
 	defer func() { _ = tc.Close() }()
 
-	// transport is shared across all requests for this endpoint.
-	// Old path allocated a fresh http.Transport per mitmHTTPS call,
-	// which threw away the idle-conn pool and racked up ~10KB of
-	// internal map allocations per request. Per-endpoint cache lets
-	// repeat requests to the same upstream reuse keep-alives.
-	transport := g.transportFor(ep)
-
 	br := bufio.NewReader(tc)
 	for {
 		_ = tc.SetReadDeadline(time.Now().Add(60 * time.Second))
@@ -2332,6 +2428,31 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 
 		start := time.Now()
 		pip := peerIP(c)
+
+		// Path-aware endpoint selection. Now that the request path is
+		// known, pick the endpoint that owns it among the host's
+		// candidates. No match means a path-scoped endpoint (remote_mcp)
+		// holds the host but nothing serves this path and there is no
+		// host-wide fallback — refuse rather than run the wrong facet.
+		ep := runtime.SelectEndpointForPath(candidates, req.URL.Path)
+		if ep == nil {
+			reason := "no endpoint configured for this path; forwarding without policy"
+			log.Printf("mitm %s %s %s: %s", host, req.Method, req.URL.Path, reason)
+			ev := Event{
+				ID: newReqID(), Mode: "mitm", Host: host,
+				Method: req.Method, Path: req.URL.Path, AgentIP: agentAddr,
+				Action: "passthrough", Reason: reason,
+			}
+			g.forwardUnmatchedHTTPS(tc, req, host, ev, start)
+			continue
+		}
+
+		// transport is shared across all requests for this endpoint.
+		// Old path allocated a fresh http.Transport per mitmHTTPS call,
+		// which threw away the idle-conn pool and racked up ~10KB of
+		// internal map allocations per request. Per-endpoint cache lets
+		// repeat requests to the same upstream reuse keep-alives.
+		transport := g.transportFor(ep)
 
 		// Body buffering. Any rule with a `body_json` or
 		// `body_contains` match facet needs the body up-front; we
@@ -2408,7 +2529,17 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		startEv.Action = "in_flight"
 		g.emit(startEv)
 
-		cr := runtime.MatchRequest(ep, mreq)
+		// Protocol-invalid gate. A facet's PrepareRequest can flag a
+		// request as malformed at the protocol level — a malformed,
+		// batched, or truncated MCP RPC POST — in a way that must fail
+		// the whole action closed. Deny it before evaluating rules so
+		// no allow rule (a catch-all, http.method, or mcp.kind allow)
+		// can bypass it. The synthesized deny flows through the same
+		// verdict path below as any policy deny.
+		cr := runtime.ProtocolInvalidDeny(mreq)
+		if cr == nil {
+			cr = runtime.MatchRequest(ep, mreq)
+		}
 		if cr != nil {
 			ev.Rule = cr.Name
 		}

--- a/cmd/clawpatrol/remote_mcp_dispatch_test.go
+++ b/cmd/clawpatrol/remote_mcp_dispatch_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUnmatchedHTTPSTransportIsGatewayOwned(t *testing.T) {
+	tr := (&Gateway{}).unmatchedHTTPSTransport()
+	if tr == nil {
+		t.Fatal("unmatchedHTTPSTransport returned nil")
+	}
+	defer tr.CloseIdleConnections()
+	if tr == http.DefaultTransport {
+		t.Fatal("unmatched HTTPS forwarding must not use http.DefaultTransport")
+	}
+	if tr.Proxy != nil {
+		t.Fatal("unmatched HTTPS forwarding must not inherit environment proxy settings")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("unmatched HTTPS forwarding must use a gateway-owned dialer")
+	}
+	if tr.DialTLSContext == nil {
+		t.Fatal("unmatched HTTPS forwarding must use explicit gateway-owned TLS dialing")
+	}
+	if tr.ForceAttemptHTTP2 {
+		t.Fatal("unmatched HTTPS forwarding should preserve the gateway's HTTP/1.1-only MITM upstream behavior")
+	}
+}
+
+func TestForwardUnmatchedHTTPSFailsClosedOnForwardError(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req, err := http.NewRequest("GET", "https://127.0.0.1:1/v1/users", nil)
+		if err != nil {
+			t.Errorf("new request: %v", err)
+			return
+		}
+		req.RequestURI = "/v1/users"
+		(&Gateway{}).forwardUnmatchedHTTPS(serverConn, req, "127.0.0.1:1", Event{Action: "passthrough"}, time.Now())
+		_ = serverConn.Close()
+	}()
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("response = %d %q, want 502", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("forwardUnmatchedHTTPS did not return")
+	}
+}

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -82,6 +82,7 @@ type CompiledProfile struct {
 	Credentials         []*Entity
 	Endpoints           map[string]*CompiledEndpoint
 	HostIndex           map[string]*CompiledEndpoint
+	HostCandidates      map[string][]*CompiledEndpoint
 	HostPatterns        []HostPattern
 	EndpointCredentials map[string][]*CompiledCredential
 	HITLAsyncGrants     bool
@@ -111,12 +112,24 @@ type HostPattern struct {
 // the placeholder discriminator lives on the profile in v15.
 type CompiledEndpoint struct {
 	Name        string
-	Family      string // "http" | "sql" | "k8s"
+	Family      string // "http" | "sql" | "k8s" | "mcp"
 	Plugin      *Plugin
 	Body        any
 	Hosts       []string
 	Credentials []*Entity       // credentials globally bound to this endpoint
 	Rules       []*CompiledRule // sorted by priority desc
+
+	// PathConstraint, when non-empty, scopes this endpoint to requests
+	// on its host(s) whose URL path matches: exact equality when
+	// PathPrefix is false, or the path plus its path-segment children
+	// when PathPrefix is true. Empty means the endpoint serves the
+	// whole host (the default for https / k8s). Populated from the
+	// endpoint body's optional EndpointPathConstraint() accessor and
+	// consumed by runtime.SelectEndpointForPath so a path-scoped
+	// endpoint (remote_mcp) can share a host with a generic https
+	// endpoint without capturing all of the host's traffic.
+	PathConstraint string
+	PathPrefix     bool
 
 	// Description is the operator-supplied free-text note from the
 	// block's `description = "..."` framework attr, or "" if unset.
@@ -371,6 +384,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			Name:                name,
 			Endpoints:           map[string]*CompiledEndpoint{},
 			HostIndex:           map[string]*CompiledEndpoint{},
+			HostCandidates:      map[string][]*CompiledEndpoint{},
 			EndpointCredentials: map[string][]*CompiledCredential{},
 			HITLAsyncGrants:     pr.HITLAsyncGrants,
 		}
@@ -408,7 +422,9 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 						})
 						continue
 					}
-					profile.HostIndex[strings.ToLower(h)] = ce
+					key := strings.ToLower(h)
+					profile.HostCandidates[key] = append(profile.HostCandidates[key], ce)
+					indexHostEndpoint(profile.HostIndex, key, ce)
 				}
 				profile.EndpointCredentials[epName] = append(
 					profile.EndpointCredentials[epName],
@@ -428,6 +444,9 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			for _, h := range ce.Hosts {
 				if bare, ok := bareHostAlias(ce, h); ok {
 					bare = strings.ToLower(bare)
+					if !containsEndpoint(profile.HostCandidates[bare], ce) {
+						profile.HostCandidates[bare] = append(profile.HostCandidates[bare], ce)
+					}
 					if _, exists := profile.HostIndex[bare]; !exists {
 						profile.HostIndex[bare] = ce
 					}
@@ -537,6 +556,13 @@ func compileEndpoint(name string, ent *Entity, cp *CompiledPolicy) (*CompiledEnd
 	} else {
 		ce.Hosts = extractHosts(ent.Body)
 	}
+	// Path-scoped endpoints (remote_mcp) expose the URL path their
+	// dispatch is restricted to; host-wide endpoints leave it empty.
+	if pc, ok := ent.Body.(interface {
+		EndpointPathConstraint() (string, bool)
+	}); ok {
+		ce.PathConstraint, ce.PathPrefix = pc.EndpointPathConstraint()
+	}
 	if tn := ent.Framework.Ref("tunnel"); tn != "" {
 		ct, ok := cp.Tunnels[tn]
 		if !ok {
@@ -573,8 +599,42 @@ func hasResolvableHostname(hosts []string) bool {
 	return false
 }
 
+// indexHostEndpoint sets idx[key] to ce, preferring a host-wide
+// endpoint over a path-scoped one. A path-scoped endpoint (remote_mcp)
+// must not clobber a generic https endpoint that serves the whole host
+// — the single-endpoint HostIndex is what SNI-time decisions (is this
+// host MITM'd? mint a cert) and legacy single-endpoint callers read,
+// while per-request path selection walks HostCandidates. Two host-wide
+// endpoints on the same key keep the historical last-wins behavior.
+func indexHostEndpoint(idx map[string]*CompiledEndpoint, key string, ce *CompiledEndpoint) {
+	cur := idx[key]
+	switch {
+	case cur == nil:
+		idx[key] = ce
+	case cur.PathConstraint == "" && ce.PathConstraint == "":
+		idx[key] = ce
+	case cur.PathConstraint != "" && ce.PathConstraint == "":
+		idx[key] = ce
+	default:
+		// cur host-wide & ce path-scoped → keep host-wide;
+		// both path-scoped → keep first.
+	}
+}
+
+// containsEndpoint reports whether eps already holds ce (pointer
+// identity). Used to keep HostCandidates free of duplicate entries when
+// the bare-host alias pass revisits an endpoint.
+func containsEndpoint(eps []*CompiledEndpoint, ce *CompiledEndpoint) bool {
+	for _, e := range eps {
+		if e == ce {
+			return true
+		}
+	}
+	return false
+}
+
 func bareHostAlias(ep *CompiledEndpoint, host string) (string, bool) {
-	if ep == nil || (ep.Family != "http" && ep.Family != "k8s") {
+	if ep == nil || (ep.Family != "http" && ep.Family != "k8s" && ep.Family != "mcp") {
 		return "", false
 	}
 	bare, port, err := net.SplitHostPort(host)
@@ -620,17 +680,30 @@ func sortHostPatterns(patterns []HostPattern) {
 	})
 }
 
-// MatchHostPattern is the matcher used at dispatch time. Returns the
-// first endpoint whose pattern matches hostname (patterns must already
-// be sorted by descending pattern length). Hostname must already be
+// MatchHostPattern is the matcher used by legacy single-endpoint dispatch.
+// Returns the first endpoint whose pattern matches hostname (patterns must
+// already be sorted by descending pattern length). Hostname must already be
 // lowercased; patterns are stored lowercased by Compile.
 func MatchHostPattern(patterns []HostPattern, hostname string) *CompiledEndpoint {
+	matches := MatchHostPatterns(patterns, hostname)
+	if len(matches) == 0 {
+		return nil
+	}
+	return matches[0]
+}
+
+// MatchHostPatterns returns every endpoint whose wildcard pattern matches
+// hostname, preserving the sorted HostPattern order. Path-aware HTTPS
+// dispatch needs the full candidate set so a wildcard remote_mcp endpoint
+// and a wildcard host-wide HTTPS endpoint can share a host.
+func MatchHostPatterns(patterns []HostPattern, hostname string) []*CompiledEndpoint {
+	var matches []*CompiledEndpoint
 	for _, p := range patterns {
-		if hostmatch.MatchWildcard(p.Pattern, hostname) {
-			return p.Endpoint
+		if hostmatch.MatchWildcard(p.Pattern, hostname) && !containsEndpoint(matches, p.Endpoint) {
+			matches = append(matches, p.Endpoint)
 		}
 	}
-	return nil
+	return matches
 }
 
 // extractHosts mirrors the per-type hosts field via interface dispatch.

--- a/internal/config/facet/composition.go
+++ b/internal/config/facet/composition.go
@@ -79,6 +79,7 @@ var families = map[string][]string{
 	"sql":  {"sql"},
 	"k8s":  {"http", "k8s"},
 	"ssh":  {"ssh"},
+	"mcp":  {"http", "mcp"},
 }
 
 // Facets returns the facets family composes onto an action, in

--- a/internal/config/facet/facet.go
+++ b/internal/config/facet/facet.go
@@ -162,6 +162,19 @@ func Lookup(name string) Runtime {
 	return registry.byName[name]
 }
 
+// IsHTTPSMITMFamily reports whether the facet registered for family
+// drives its wire through the HTTPS MITM handler (Transport() ==
+// "https-mitm"). The gateway dispatch and config tooling use this to
+// route a TLS connection without switching on hardcoded family strings
+// — http, k8s, and mcp all answer true.
+func IsHTTPSMITMFamily(family string) bool {
+	if family == "" {
+		return false
+	}
+	f := Lookup(family)
+	return f != nil && f.Transport() == "https-mitm"
+}
+
 // All returns every registered facet, sorted by Name. Stable order
 // matters for golden tests and for deterministic config dumps.
 func All() []Runtime {

--- a/internal/config/match/match.go
+++ b/internal/config/match/match.go
@@ -91,6 +91,25 @@ type Request struct {
 	// rejection, not byte-cap truncation, so wire frontends with
 	// no parser leave it false.
 	Unparseable bool
+
+	// ProtocolInvalid is set by a facet's PrepareRequest when the
+	// request is malformed at the protocol level in a way that must
+	// fail the whole action closed — independent of which facet paths
+	// any rule happens to read. The MCP facet sets it for an RPC POST
+	// whose body is not a single well-formed JSON-RPC object (malformed
+	// JSON, a JSON-RPC batch array, or a body truncated at the
+	// inspection buffer).
+	//
+	// This is stronger than Truncated / Unparseable, which only mark
+	// specific CEL paths unknown: a rule keyed on an always-available
+	// facet (a catch-all with no condition, `http.method == "POST"`,
+	// `mcp.kind == "rpc"`) is NOT poisoned by those flags and would
+	// otherwise allow a malformed body through. The dispatcher checks
+	// ProtocolInvalid before evaluating rules and synthesizes a deny,
+	// so no allow rule can bypass it. ProtocolInvalidReason carries a
+	// short, agent-safe cause used as the deny event's reason.
+	ProtocolInvalid       bool
+	ProtocolInvalidReason string
 }
 
 // Result is the three-valued outcome of evaluating a rule's

--- a/internal/config/plugins/all/all.go
+++ b/internal/config/plugins/all/all.go
@@ -15,6 +15,7 @@ import (
 	// time.
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/https"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/k8s"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/mcp"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/sql"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/ssh"
 	_ "github.com/denoland/clawpatrol/internal/config/plugins/rules"

--- a/internal/config/plugins/endpoints/remote_mcp.go
+++ b/internal/config/plugins/endpoints/remote_mcp.go
@@ -1,0 +1,174 @@
+package endpoints
+
+// remote_mcp endpoint: a hosted Model Context Protocol server reached
+// over HTTPS (Streamable HTTP or legacy HTTP+SSE). It carries the full
+// MCP endpoint URL so the gateway can both index its host and scope
+// dispatch to the endpoint's path — a configured URL such as
+// `https://api.grain.com/_/mcp` must not capture every request to
+// `api.grain.com`. The mcp facet (family "mcp") composes the http
+// facet, so rules can match MCP semantics (mcp.kind, mcp.method,
+// mcp.tool_name) alongside http.* fields.
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// RemoteMCPEndpoint is part of the clawpatrol plugin API.
+type RemoteMCPEndpoint struct {
+	// URL is the full MCP endpoint URL (absolute https). Its host is
+	// indexed for SNI dispatch and its path scopes which requests on
+	// that host run the MCP facet.
+	URL string `hcl:"url"`
+	// Transport is an advisory hint about the MCP transport the agent
+	// uses (auto | streamable_http | sse). The gateway never rewrites
+	// the agent's transport; this is reserved for future reporting.
+	Transport string `hcl:"transport,optional"`
+	// ProtocolVersion optionally pins the MCP protocol version for
+	// reporting / documentation.
+	ProtocolVersion string `hcl:"protocol_version,optional"`
+	// Hosts are additional hostnames (or host:port pairs) this endpoint
+	// also intercepts beyond the URL host — an advanced override.
+	Hosts []string `hcl:"hosts,optional"`
+}
+
+// EndpointHosts is part of the clawpatrol plugin API. It returns the
+// URL-derived host first, then any explicit additional hosts. Explicit
+// hosts never remove the URL host.
+func (e *RemoteMCPEndpoint) EndpointHosts() []string {
+	var hosts []string
+	if h := mcpURLHost(e.URL); h != "" {
+		hosts = append(hosts, h)
+	}
+	hosts = append(hosts, e.Hosts...)
+	return hosts
+}
+
+// EndpointPathConstraint is part of the clawpatrol plugin API. It
+// reports the URL path the endpoint is scoped to for path-aware HTTPS
+// dispatch. An empty path (or "/") means the endpoint serves the whole
+// host. A path ending in "/" matches that prefix and its path-segment
+// children; any other path matches exactly.
+func (e *RemoteMCPEndpoint) EndpointPathConstraint() (path string, prefix bool) {
+	u, err := url.Parse(strings.TrimSpace(e.URL))
+	if err != nil {
+		return "", false
+	}
+	p := u.Path
+	if p == "" || p == "/" {
+		return "", false
+	}
+	if strings.HasSuffix(p, "/") {
+		return p, true
+	}
+	return p, false
+}
+
+// mcpURLHost returns the host[:port] of a remote MCP URL, or "" when
+// the URL doesn't parse or carries no host.
+func mcpURLHost(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// RemoteMCPEndpointRuntime detects placeholders in a remote MCP
+// request. Remote MCP is TLS-wrapped HTTP, so the placeholder shapes
+// are identical to the https endpoint (Authorization / decoded Basic /
+// Cookie); reuse that detector directly rather than duplicating it.
+type RemoteMCPEndpointRuntime struct{}
+
+// DetectPlaceholder is part of the clawpatrol plugin API.
+func (RemoteMCPEndpointRuntime) DetectPlaceholder(req *runtime.Request, candidates []string) string {
+	return HTTPSEndpointRuntime{}.DetectPlaceholder(req, candidates)
+}
+
+// remoteMCPValidate checks the URL is an absolute https URL with a
+// host, validates the transport hint, and chains the shared host
+// validation.
+func remoteMCPValidate(d any, name string, ctx *config.BuildCtx) hcl.Diagnostics {
+	e := d.(*RemoteMCPEndpoint)
+	defRange := ctx.Block.DefRange
+	var diags hcl.Diagnostics
+	raw := strings.TrimSpace(e.URL)
+	if raw == "" {
+		return append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Missing url on remote_mcp endpoint %q", name),
+			Detail:   `remote_mcp endpoints require an absolute https url, e.g. url = "https://mcp.example.com/mcp"`,
+			Subject:  &defRange,
+		})
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Malformed url on remote_mcp endpoint %q", name),
+			Detail:   fmt.Sprintf("url %q: %v", raw, err),
+			Subject:  &defRange,
+		})
+	}
+	if u.Scheme != "https" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("remote_mcp endpoint %q url must be https", name),
+			Detail:   fmt.Sprintf("url %q has scheme %q; remote MCP requires https", raw, u.Scheme),
+			Subject:  &defRange,
+		})
+	}
+	if u.Hostname() == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("remote_mcp endpoint %q url is missing a host", name),
+			Detail:   fmt.Sprintf("url %q must include a host, e.g. https://mcp.example.com/mcp", raw),
+			Subject:  &defRange,
+		})
+	}
+	switch e.Transport {
+	case "", "auto", "streamable_http", "sse":
+	default:
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("remote_mcp endpoint %q has an unknown transport", name),
+			Detail:   fmt.Sprintf("transport %q must be one of: auto, streamable_http, sse", e.Transport),
+			Subject:  &defRange,
+		})
+	}
+	return append(diags, validateHosts(e, name, defRange)...)
+}
+
+func init() {
+	var _ runtime.PlaceholderDetector = RemoteMCPEndpointRuntime{}
+	config.Register(&config.Plugin{
+		Kind:     config.KindEndpoint,
+		Type:     "remote_mcp",
+		Family:   "mcp",
+		New:      func() any { return &RemoteMCPEndpoint{} },
+		Runtime:  RemoteMCPEndpointRuntime{},
+		Validate: remoteMCPValidate,
+		Build:    passthroughBuild,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			e := body.(*RemoteMCPEndpoint)
+			b.SetAttributeValue("url", cty.StringVal(e.URL))
+			if e.Transport != "" {
+				b.SetAttributeValue("transport", cty.StringVal(e.Transport))
+			}
+			if e.ProtocolVersion != "" {
+				b.SetAttributeValue("protocol_version", cty.StringVal(e.ProtocolVersion))
+			}
+			if len(e.Hosts) > 0 {
+				b.SetAttributeValue("hosts", config.StringListVal(e.Hosts))
+			}
+		},
+	})
+}

--- a/internal/config/plugins/endpoints/remote_mcp_test.go
+++ b/internal/config/plugins/endpoints/remote_mcp_test.go
@@ -1,0 +1,452 @@
+package endpoints_test
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/facet"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+const remoteMCPGatewayPrefix = `gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gw.example.test"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+`
+
+func loadRemoteMCP(t *testing.T, src string) (*config.CompiledPolicy, error) {
+	t.Helper()
+	gw, diags := config.LoadBytes([]byte(remoteMCPGatewayPrefix+src), "in.hcl")
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	return config.Compile(gw)
+}
+
+func mustLoadRemoteMCP(t *testing.T, src string) *config.CompiledPolicy {
+	t.Helper()
+	cp, err := loadRemoteMCP(t, src)
+	if err != nil {
+		t.Fatalf("load/compile: %v", err)
+	}
+	return cp
+}
+
+// TestRemoteMCPEndpointHostsFromURL: the compiled endpoint derives its
+// host from the URL and carries family "mcp".
+func TestRemoteMCPEndpointHostsFromURL(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "grain" {
+  url = "https://api.grain.com/_/mcp"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.grain }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	ep := cp.Endpoints["grain"]
+	if ep == nil {
+		t.Fatal("endpoint grain not compiled")
+	}
+	if ep.Family != "mcp" {
+		t.Errorf("family = %q, want mcp", ep.Family)
+	}
+	found := false
+	for _, h := range ep.Hosts {
+		if h == "api.grain.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("hosts = %v, want to include api.grain.com", ep.Hosts)
+	}
+	if ep.PathConstraint != "/_/mcp" || ep.PathPrefix {
+		t.Errorf("path constraint = %q prefix=%v, want /_/mcp exact", ep.PathConstraint, ep.PathPrefix)
+	}
+}
+
+// TestRemoteMCPEndpointRejectsHTTPURL: a non-https url is a config error.
+func TestRemoteMCPEndpointRejectsHTTPURL(t *testing.T) {
+	_, err := loadRemoteMCP(t, `
+endpoint "remote_mcp" "insecure" {
+  url = "http://mcp.example.com/mcp"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.insecure }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	if err == nil {
+		t.Fatal("expected error for http url, got nil")
+	}
+}
+
+// TestRemoteMCPEndpointRejectsMissingHost: a url without a host fails.
+func TestRemoteMCPEndpointRejectsMissingHost(t *testing.T) {
+	_, err := loadRemoteMCP(t, `
+endpoint "remote_mcp" "nohost" {
+  url = "https:///mcp"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.nohost }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	if err == nil {
+		t.Fatal("expected error for missing host, got nil")
+	}
+}
+
+// TestRemoteMCPEndpointRejectsUnknownTransport: transport is only an
+// advisory hint today, but unsupported spellings should fail config
+// validation instead of silently documenting a fake mode.
+func TestRemoteMCPEndpointRejectsUnknownTransport(t *testing.T) {
+	_, err := loadRemoteMCP(t, `
+endpoint "remote_mcp" "bad_transport" {
+  url       = "https://mcp.example.com/mcp"
+  transport = "websocket"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.bad_transport }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	if err == nil {
+		t.Fatal("expected error for unknown transport, got nil")
+	}
+}
+
+// TestRemoteMCPRootURLIsHostWide: an empty/root URL path should behave
+// like a host-wide endpoint rather than a path-scoped endpoint to "/".
+func TestRemoteMCPRootURLIsHostWide(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "root" {
+  url = "https://mcp-root.example.com/"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.root }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	ep := cp.Endpoints["root"]
+	if ep == nil {
+		t.Fatal("endpoint root not compiled")
+	}
+	if ep.PathConstraint != "" || ep.PathPrefix {
+		t.Errorf("path constraint = %q prefix=%v, want host-wide empty constraint", ep.PathConstraint, ep.PathPrefix)
+	}
+	cands := runtime.HostCandidates(cp, "default", "mcp-root.example.com")
+	if got := runtime.SelectEndpointForPath(cands, "/v1/anything"); got == nil || got.Name != "root" {
+		t.Errorf("/v1/anything → %v, want root host-wide endpoint", got)
+	}
+}
+
+// TestRemoteMCPEndpointKeepsExplicitAdditionalHosts: explicit hosts are
+// merged with the URL-derived host; the URL host is never dropped.
+func TestRemoteMCPEndpointKeepsExplicitAdditionalHosts(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "multi" {
+  url   = "https://mcp.example.com/mcp"
+  hosts = ["mcp-alt.example.com"]
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.multi }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	ep := cp.Endpoints["multi"]
+	if ep == nil {
+		t.Fatal("endpoint multi not compiled")
+	}
+	var haveURL, haveExtra bool
+	for _, h := range ep.Hosts {
+		switch h {
+		case "mcp.example.com":
+			haveURL = true
+		case "mcp-alt.example.com":
+			haveExtra = true
+		}
+	}
+	if !haveURL || !haveExtra {
+		t.Errorf("hosts = %v, want both mcp.example.com and mcp-alt.example.com", ep.Hosts)
+	}
+}
+
+// TestRemoteMCPFamilyUsesHTTPSMITMTransport: the mcp facet rides the
+// https-mitm transport.
+func TestRemoteMCPFamilyUsesHTTPSMITMTransport(t *testing.T) {
+	if !facet.IsHTTPSMITMFamily("mcp") {
+		t.Fatal("mcp family should use https-mitm transport")
+	}
+}
+
+// TestRemoteMCPDispatchMatchesConfiguredPathOnly: a request to the
+// configured MCP path lands on the MCP endpoint, while another path on
+// the same host does not.
+func TestRemoteMCPDispatchMatchesConfiguredPathOnly(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "grain" {
+  url = "https://api.grain.com/_/mcp"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.grain }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.grain.com")
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp"); got == nil || got.Name != "grain" {
+		t.Errorf("/_/mcp → %v, want grain", got)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got != nil {
+		t.Errorf("/v1/users → %v, want nil (not the MCP endpoint)", got.Name)
+	}
+}
+
+// TestRemoteMCPDispatchUsesPathSegmentBoundary: an exact path
+// constraint does not match a sibling path that shares a prefix.
+func TestRemoteMCPDispatchUsesPathSegmentBoundary(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "m" {
+  url = "https://mcp.example.com/mcp"
+}
+credential "bearer_token" "tok" { endpoint = remote_mcp.m }
+profile "default" { credentials = [bearer_token.tok] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "mcp.example.com")
+	if got := runtime.SelectEndpointForPath(cands, "/mcp"); got == nil {
+		t.Error("/mcp should match exact constraint /mcp")
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/mcp2"); got != nil {
+		t.Errorf("/mcp2 → %v, want nil (segment boundary)", got.Name)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/mcp/sub"); got != nil {
+		t.Errorf("/mcp/sub → %v, want nil (exact only)", got.Name)
+	}
+}
+
+// TestRemoteMCPSharedHostRequiresPathAwareDispatch: an MCP endpoint and
+// a generic https endpoint can share a host; the path-specific endpoint
+// wins on its path while the rest of the host routes to the host-wide
+// https endpoint.
+func TestRemoteMCPSharedHostRequiresPathAwareDispatch(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "mcp" {
+  url = "https://api.shared.com/_/mcp"
+}
+endpoint "https" "rest" {
+  hosts = ["api.shared.com"]
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.mcp }
+credential "bearer_token" "b" { endpoint = https.rest }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.shared.com")
+	if len(cands) < 2 {
+		t.Fatalf("expected both endpoints as candidates, got %d", len(cands))
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp"); got == nil || got.Name != "mcp" {
+		t.Errorf("/_/mcp → %v, want mcp", got)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "rest" {
+		t.Errorf("/v1/users → %v, want rest (host-wide https)", got)
+	}
+	// HostEndpoint (single) still resolves to the host-wide https
+	// endpoint, not the path-scoped MCP one.
+	if got := runtime.HostEndpoint(cp, "default", "api.shared.com"); got == nil || got.Name != "rest" {
+		t.Errorf("HostEndpoint → %v, want host-wide rest", got)
+	}
+}
+
+// TestRemoteMCPDispatchMostSpecificEndpointWins: the longest matching
+// path constraint wins among path-scoped candidates.
+func TestRemoteMCPSharedHostFallsBackToWildcardHTTPS(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "mcp" {
+  url = "https://api.shared-wildcard.com/_/mcp"
+}
+endpoint "https" "wildcard" {
+  hosts = ["*.shared-wildcard.com"]
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.mcp }
+credential "bearer_token" "b" { endpoint = https.wildcard }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.shared-wildcard.com")
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp"); got == nil || got.Name != "mcp" {
+		t.Errorf("/_/mcp → %v, want mcp", got)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "wildcard" {
+		t.Errorf("/v1/users → %v, want wildcard fallback", got)
+	}
+}
+
+func TestRemoteMCPWildcardSharedHostFallsBackToWildcardHTTPS(t *testing.T) {
+	cases := map[string]string{
+		"mcp first": `
+endpoint "remote_mcp" "mcp" {
+  url = "https://mcp.shared-wildcard-order.com/_/mcp"
+  hosts = ["*.shared-wildcard-order.com"]
+}
+endpoint "https" "rest" {
+  hosts = ["*.shared-wildcard-order.com"]
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.mcp }
+credential "bearer_token" "b" { endpoint = https.rest }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`,
+		"https first": `
+endpoint "https" "rest" {
+  hosts = ["*.shared-wildcard-order.com"]
+}
+endpoint "remote_mcp" "mcp" {
+  url = "https://mcp.shared-wildcard-order.com/_/mcp"
+  hosts = ["*.shared-wildcard-order.com"]
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.mcp }
+credential "bearer_token" "b" { endpoint = https.rest }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`,
+	}
+	for name, hcl := range cases {
+		t.Run(name, func(t *testing.T) {
+			cp := mustLoadRemoteMCP(t, hcl)
+			cands := runtime.HostCandidates(cp, "default", "api.shared-wildcard-order.com")
+			if got := runtime.SelectEndpointForPath(cands, "/_/mcp"); got == nil || got.Name != "mcp" {
+				t.Errorf("/_/mcp → %v, want mcp", got)
+			}
+			if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "rest" {
+				t.Errorf("/v1/users → %v, want rest wildcard fallback", got)
+			}
+		})
+	}
+}
+
+func TestRemoteMCPExactHostWideBeatsWildcardPathScoped(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "https" "api" {
+  hosts = ["api.exact-beats-wild.example"]
+}
+endpoint "remote_mcp" "wild" {
+  url = "https://mcp.exact-beats-wild.example/_/mcp"
+  hosts = ["*.exact-beats-wild.example"]
+}
+credential "bearer_token" "a" { endpoint = https.api }
+credential "bearer_token" "b" { endpoint = remote_mcp.wild }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.exact-beats-wild.example")
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp"); got == nil || got.Name != "api" {
+		t.Errorf("/_/mcp → %v, want exact host-wide api", got)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "api" {
+		t.Errorf("/v1/users → %v, want exact host-wide api", got)
+	}
+}
+
+func TestRemoteMCPExactHostWideBeatsWildcardHostWide(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "https" "api" {
+  hosts = ["api.exact-hostwide.example"]
+}
+endpoint "https" "wild" {
+  hosts = ["*.exact-hostwide.example"]
+}
+credential "bearer_token" "a" { endpoint = https.api }
+credential "bearer_token" "b" { endpoint = https.wild }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.exact-hostwide.example")
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "api" {
+		t.Errorf("/v1/users → %v, want exact host-wide api", got)
+	}
+}
+
+func TestRemoteMCPExactHostWideDuplicatesKeepLastWins(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "https" "first" {
+  hosts = ["api.duplicate-exact.example"]
+}
+endpoint "https" "second" {
+  hosts = ["api.duplicate-exact.example"]
+}
+credential "bearer_token" "a" { endpoint = https.first }
+credential "bearer_token" "b" { endpoint = https.second }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.duplicate-exact.example")
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "second" {
+		t.Errorf("/v1/users → %v, want duplicate exact host-wide last-wins endpoint second", got)
+	}
+	if got := runtime.HostEndpoint(cp, "default", "api.duplicate-exact.example"); got == nil || got.Name != "second" {
+		t.Errorf("HostEndpoint → %v, want second", got)
+	}
+}
+
+func TestRemoteMCPMostSpecificWildcardHostWideWins(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "https" "broad" {
+  hosts = ["*.wild-specific.example"]
+}
+endpoint "https" "specific" {
+  hosts = ["*.api.wild-specific.example"]
+}
+credential "bearer_token" "a" { endpoint = https.broad }
+credential "bearer_token" "b" { endpoint = https.specific }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "foo.api.wild-specific.example")
+	if got := runtime.SelectEndpointForPath(cands, "/v1/users"); got == nil || got.Name != "specific" {
+		t.Errorf("/v1/users → %v, want most-specific wildcard host-wide", got)
+	}
+}
+
+func TestRemoteMCPExactPathScopedFallsBackToWildcardPathScoped(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "exact" {
+  url = "https://api.path-fallback.example/_/mcp"
+}
+endpoint "remote_mcp" "wild" {
+  url = "https://mcp.path-fallback.example/common-mcp"
+  hosts = ["*.path-fallback.example"]
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.exact }
+credential "bearer_token" "b" { endpoint = remote_mcp.wild }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.path-fallback.example")
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp"); got == nil || got.Name != "exact" {
+		t.Errorf("/_/mcp → %v, want exact", got)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/common-mcp"); got == nil || got.Name != "wild" {
+		t.Errorf("/common-mcp → %v, want wildcard path-scoped fallback", got)
+	}
+}
+
+func TestRemoteMCPExactPathScopedBeatsWildcardPathScoped(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "exact" {
+  url = "https://api.path-precedence.example/_/mcp/"
+}
+endpoint "remote_mcp" "wild" {
+  url = "https://mcp.path-precedence.example/_/mcp/deeper"
+  hosts = ["*.path-precedence.example"]
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.exact }
+credential "bearer_token" "b" { endpoint = remote_mcp.wild }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.path-precedence.example")
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp/deeper"); got == nil || got.Name != "exact" {
+		t.Errorf("/_/mcp/deeper → %v, want exact path-scoped endpoint", got)
+	}
+}
+
+func TestRemoteMCPDispatchMostSpecificEndpointWins(t *testing.T) {
+	cp := mustLoadRemoteMCP(t, `
+endpoint "remote_mcp" "deep" {
+  url = "https://api.shared2.com/_/mcp/v2"
+}
+endpoint "remote_mcp" "shallow" {
+  url = "https://api.shared2.com/_/"
+}
+credential "bearer_token" "a" { endpoint = remote_mcp.deep }
+credential "bearer_token" "b" { endpoint = remote_mcp.shallow }
+profile "default" { credentials = [bearer_token.a, bearer_token.b] }
+`)
+	cands := runtime.HostCandidates(cp, "default", "api.shared2.com")
+	if got := runtime.SelectEndpointForPath(cands, "/_/mcp/v2"); got == nil || got.Name != "deep" {
+		t.Errorf("/_/mcp/v2 → %v, want deep (most specific)", got)
+	}
+	if got := runtime.SelectEndpointForPath(cands, "/_/other"); got == nil || got.Name != "shallow" {
+		t.Errorf("/_/other → %v, want shallow (prefix)", got)
+	}
+}

--- a/internal/config/plugins/facets/mcp/mcp.go
+++ b/internal/config/plugins/facets/mcp/mcp.go
@@ -1,0 +1,280 @@
+// Package mcp is the Model Context Protocol facet. It owns the mcp CEL
+// environment (kind / method / tool_name / resource_uri / session_id /
+// protocol_version, exposed as fields on the `mcp` variable), the
+// matcher that walks an MCP-over-HTTP request, the Meta type derived
+// from the request, and the per-family report fields the dashboard
+// shows for an MCP call.
+//
+// Remote MCP traffic is HTTPS at the wire level, so the gateway's
+// HTTPS handler populates match.Request.Method/URL/Headers/Body before
+// calling PrepareRequest. PrepareRequest then classifies the request
+// (rpc / listen / terminate / other) from the request line and
+// headers, parses a single JSON-RPC object out of an rpc POST body,
+// and stashes the result on req.Meta for the mcp matcher to read.
+//
+// The mcp family composes the http facet alongside its own (a remote
+// MCP call is an HTTPS request underneath, so it carries http.method /
+// http.path / http.headers / http.body / http.body_json), so a rule of
+// family mcp can read both mcp.* and http.* fields.
+package mcp
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+
+	"github.com/denoland/clawpatrol/internal/config/facet"
+	"github.com/denoland/clawpatrol/internal/config/match"
+
+	// Composed facet: the mcp family adds both the http and mcp facets
+	// to its actions. Blank-importing https here guarantees its init()
+	// (facet.Register) has run before the first mcp rule compiles —
+	// otherwise direct mcp-package imports (tests, downstream code)
+	// silently produce a nil matcher.
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/facets/https"
+)
+
+// Request-classification kinds. Derived purely from the request line
+// and headers, so they are always evaluable — never poisoned by body
+// truncation.
+const (
+	// KindRPC is a JSON-RPC request: a POST carrying a JSON body.
+	KindRPC = "rpc"
+	// KindListen is the Streamable HTTP / SSE server-push channel: a
+	// GET asking for an event stream.
+	KindListen = "listen"
+	// KindTerminate is a Streamable HTTP session teardown: a DELETE
+	// carrying an Mcp-Session-Id header.
+	KindTerminate = "terminate"
+	// KindOther is anything else on an MCP endpoint.
+	KindOther = "other"
+)
+
+// Fields is the CEL-facing view of an MCP request. Exposed as the
+// `mcp` variable in rule conditions (`mcp.kind`, `mcp.method`,
+// `mcp.tool_name`, etc.).
+//
+// kind / protocol_version / session_id are request-line/header
+// derived and therefore always evaluable. method / id / tool_name /
+// resource_uri / prompt_name / is_notification are body-derived and
+// fail closed on a truncated / unparseable / batched body (see
+// CELContrib and PrepareRequest).
+type Fields struct {
+	Kind            string `cel:"kind"`
+	ProtocolVersion string `cel:"protocol_version"`
+	SessionID       string `cel:"session_id"`
+	Method          string `cel:"method"`
+	ID              string `cel:"id"`
+	ToolName        string `cel:"tool_name"`
+	ResourceURI     string `cel:"resource_uri"`
+	PromptName      string `cel:"prompt_name"`
+	IsNotification  bool   `cel:"is_notification"`
+}
+
+// Meta is the per-request MCP metadata PrepareRequest derives from the
+// request line, headers, and (for rpc POSTs) the JSON-RPC body.
+type Meta struct {
+	Kind            string
+	ProtocolVersion string
+	SessionID       string
+	Method          string
+	ID              string
+	ToolName        string
+	ResourceURI     string
+	PromptName      string
+	IsNotification  bool
+
+	// ProtocolInvalid marks an rpc POST whose body could not be parsed
+	// into a single well-formed JSON-RPC object — malformed JSON, a
+	// JSON-RPC batch array, or a body truncated at the inspection
+	// buffer. The dispatcher denies such an action before any allow
+	// rule can match (fail closed); see PrepareRequest and the
+	// gateway's protocol-invalid gate.
+	ProtocolInvalid bool
+	// ProtocolInvalidReason is a short, agent-safe cause for a
+	// ProtocolInvalid request, surfaced as the deny event's reason
+	// (e.g. "mcp_protocol_invalid: JSON-RPC batch arrays are not
+	// supported"). Empty when ProtocolInvalid is false.
+	ProtocolInvalidReason string
+}
+
+// Facet is the MCP facet Runtime. Singleton; held by the registry for
+// the lifetime of the process.
+type Facet struct{}
+
+// Name reports the family identifier this facet handles.
+func (Facet) Name() string { return "mcp" }
+
+// EndpointFamilies enumerates endpoint families an mcp rule may attach
+// to.
+func (Facet) EndpointFamilies() []string { return []string{"mcp"} }
+
+// Transport reports the gateway-side dispatch handler this facet uses.
+// Remote MCP traffic is HTTPS on the wire, so it shares the https-mitm
+// path with the https and k8s facets.
+func (Facet) Transport() string { return "https-mitm" }
+
+// HITLQueryLabel is the dashboard / Slack label for an MCP request.
+func (Facet) HITLQueryLabel() string { return "Method" }
+
+// HostIsResource reports that a remote MCP request's Host is already a
+// meaningful resource label (mcp.notion.com, api.grain.com, etc.).
+func (Facet) HostIsResource() bool { return true }
+
+// ReportFields declares the per-family columns the MCP facet emits.
+func (Facet) ReportFields() []facet.ReportFieldSpec {
+	return []facet.ReportFieldSpec{
+		{Name: "kind", Kind: facet.ReportString, Label: "Kind"},
+		{Name: "method", Kind: facet.ReportString, Label: "Method"},
+		{Name: "tool_name", Kind: facet.ReportString, Label: "Tool"},
+		{Name: "resource_uri", Kind: facet.ReportString, Label: "Resource URI"},
+		{Name: "session_id", Kind: facet.ReportString, Label: "Session"},
+	}
+}
+
+// PrepareRequest classifies the MCP request and (for rpc POSTs) parses
+// a single JSON-RPC object out of the buffered body, stashing the
+// result on req.Meta. Called by the gateway before any matcher runs
+// for an mcp-family request.
+func (Facet) PrepareRequest(req *match.Request) {
+	if req == nil {
+		return
+	}
+	m := &Meta{
+		Kind:            classifyKind(req),
+		ProtocolVersion: header(req, "MCP-Protocol-Version"),
+		SessionID:       header(req, "Mcp-Session-Id"),
+	}
+	if m.Kind == KindRPC {
+		parseRPCBody(req, m)
+	}
+	req.Meta = m
+	// Propagate the MCP-specific protocol-invalid signal to the shared
+	// request flag the dispatcher reads. This is the fail-closed
+	// boundary: it denies the whole action before any allow rule (a
+	// catch-all, http.method, or mcp.kind allow) can match — stronger
+	// than the per-path req.Truncated / req.Unparseable poisoning
+	// parseRPCBody also sets for diagnostics.
+	if m.ProtocolInvalid {
+		req.ProtocolInvalid = true
+		req.ProtocolInvalidReason = m.ProtocolInvalidReason
+	}
+}
+
+// Report extracts the MCP report fields from a request.
+func (Facet) Report(req *match.Request) map[string]any {
+	m, _ := req.Meta.(*Meta)
+	if m == nil {
+		return nil
+	}
+	return map[string]any{
+		"kind":         m.Kind,
+		"method":       m.Method,
+		"tool_name":    m.ToolName,
+		"resource_uri": m.ResourceURI,
+		"session_id":   m.SessionID,
+	}
+}
+
+func init() {
+	facet.Register(Facet{})
+}
+
+// CELContrib declares the MCP facet's CEL contribution: the `mcp`
+// variable backed by Fields, the activation builder that snapshots the
+// parsed Meta into one, and the path lists CompileCondition needs.
+//
+// Body-derived fields (method, id, tool_name, resource_uri,
+// prompt_name, is_notification) are listed in both TruncatablePaths
+// and UnparseablePaths: a truncated body sets req.Truncated and an
+// unparseable/batched body sets req.Unparseable, and either marks
+// these paths CEL-unknown so any rule whose outcome depends on one
+// evaluates Unevaluable. The header-derived fields (kind,
+// protocol_version, session_id) are intentionally absent — they are
+// always available even when the body is missing or capped.
+func (Facet) CELContrib() facet.CELContrib {
+	bodyDerived := []string{
+		"mcp.method", "mcp.id", "mcp.tool_name",
+		"mcp.resource_uri", "mcp.prompt_name", "mcp.is_notification",
+	}
+	return facet.CELContrib{
+		EnvOptions: []cel.EnvOption{
+			ext.NativeTypes(
+				reflect.TypeFor[Fields](),
+				ext.ParseStructTags(true),
+			),
+			cel.Variable("mcp", cel.ObjectType("mcp.Fields")),
+		},
+		AddActivation:    addActivation,
+		LowercasedPaths:  []string{"mcp.kind"},
+		TruncatablePaths: bodyDerived,
+		UnparseablePaths: bodyDerived,
+	}
+}
+
+// NewMatcher compiles a CEL condition into a Matcher. Delegates to the
+// package-level composer so the http facet the mcp family composes
+// layers in — an mcp rule can reference http.method etc. alongside
+// mcp.kind.
+func (f Facet) NewMatcher(condition string) (match.Matcher, error) {
+	m, _, err := facet.Compose(f.Name(), condition)
+	return m, err
+}
+
+func addActivation(req *match.Request, act map[string]any) bool {
+	if req == nil {
+		return false
+	}
+	meta, _ := req.Meta.(*Meta)
+	if meta == nil {
+		return false
+	}
+	act["mcp"] = &Fields{
+		Kind:            strings.ToLower(meta.Kind),
+		ProtocolVersion: meta.ProtocolVersion,
+		SessionID:       meta.SessionID,
+		Method:          meta.Method,
+		ID:              meta.ID,
+		ToolName:        meta.ToolName,
+		ResourceURI:     meta.ResourceURI,
+		PromptName:      meta.PromptName,
+		IsNotification:  meta.IsNotification,
+	}
+	return true
+}
+
+// classifyKind derives mcp.kind from the request line and headers,
+// independent of the body. See the Kind* constants.
+func classifyKind(req *match.Request) string {
+	switch strings.ToUpper(req.Method) {
+	case "POST":
+		return KindRPC
+	case "GET":
+		if acceptsEventStream(req) {
+			return KindListen
+		}
+		return KindOther
+	case "DELETE":
+		if header(req, "Mcp-Session-Id") != "" {
+			return KindTerminate
+		}
+		return KindOther
+	default:
+		return KindOther
+	}
+}
+
+// acceptsEventStream reports whether the request's Accept header opts
+// into a Server-Sent Events stream (the MCP listen channel).
+func acceptsEventStream(req *match.Request) bool {
+	return strings.Contains(strings.ToLower(header(req, "Accept")), "text/event-stream")
+}
+
+func header(req *match.Request, name string) string {
+	if req == nil || req.Headers == nil {
+		return ""
+	}
+	return req.Headers.Get(name)
+}

--- a/internal/config/plugins/facets/mcp/mcp_test.go
+++ b/internal/config/plugins/facets/mcp/mcp_test.go
@@ -1,0 +1,394 @@
+package mcp_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/facet"
+	"github.com/denoland/clawpatrol/internal/config/match"
+	mcpfacet "github.com/denoland/clawpatrol/internal/config/plugins/facets/mcp"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// prep builds an mcp-family request from method/path/headers/body and
+// runs the facet's PrepareRequest, exactly as the gateway does before
+// matching. set truncated to simulate a body capped at the inspection
+// buffer.
+func prep(method, path string, headers map[string]string, body string, truncated bool) *match.Request {
+	u, _ := url.Parse("https://mcp.example.com" + path)
+	h := http.Header{}
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	req := &match.Request{
+		Family:    "mcp",
+		Method:    method,
+		URL:       u,
+		Headers:   h,
+		Body:      []byte(body),
+		Truncated: truncated,
+	}
+	facet.Lookup("mcp").PrepareRequest(req)
+	return req
+}
+
+func meta(t *testing.T, req *match.Request) *mcpfacet.Meta {
+	t.Helper()
+	m, ok := req.Meta.(*mcpfacet.Meta)
+	if !ok {
+		t.Fatalf("req.Meta = %T, want *mcp.Meta", req.Meta)
+	}
+	return m
+}
+
+func matchResult(t *testing.T, condition string, req *match.Request) match.Result {
+	t.Helper()
+	m, err := facet.NewMatcher("mcp", condition)
+	if err != nil {
+		t.Fatalf("NewMatcher(%q): %v", condition, err)
+	}
+	return m.Match(req).Result
+}
+
+const jsonHeaders = "application/json"
+
+// TestMCPFacetExtractsToolCall: a tools/call JSON-RPC POST exposes
+// mcp.method and mcp.tool_name to rules.
+func TestMCPFacetExtractsToolCall(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup_customer"}}`, false)
+
+	m := meta(t, req)
+	if m.Kind != mcpfacet.KindRPC || m.Method != "tools/call" || m.ToolName != "lookup_customer" {
+		t.Fatalf("meta = %+v, want kind=rpc method=tools/call tool_name=lookup_customer", m)
+	}
+	if m.ID != "1" || m.IsNotification {
+		t.Errorf("id = %q is_notification = %v, want id=1 not a notification", m.ID, m.IsNotification)
+	}
+	if got := matchResult(t, `mcp.method == "tools/call" && mcp.tool_name == "lookup_customer"`, req); got != match.Matched {
+		t.Errorf("tool-call rule = %v, want Matched", got)
+	}
+	if got := matchResult(t, `mcp.tool_name == "delete_page"`, req); got != match.NoMatch {
+		t.Errorf("wrong-tool rule = %v, want NoMatch", got)
+	}
+}
+
+// TestMCPFacetExtractsResourceRead: a resources/read POST exposes
+// mcp.resource_uri.
+// TestMCPFacetExplicitNullIDIsNotNotification: the spec defines an MCP
+// notification by an absent id; an explicit JSON null id is still present
+// and must not be collapsed into the absent-id case.
+func TestMCPFacetExplicitNullIDIsNotNotification(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":null,"method":"tools/list"}`, false)
+
+	m := meta(t, req)
+	if m.IsNotification {
+		t.Fatal("explicit id:null was treated as a notification; only absent id should be notification")
+	}
+	if m.ID != "null" {
+		t.Errorf("id = %q, want null", m.ID)
+	}
+}
+
+func TestMCPFacetExtractsResourceRead(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":"abc","method":"resources/read","params":{"uri":"file:///etc/passwd"}}`, false)
+
+	m := meta(t, req)
+	if m.Method != "resources/read" || m.ResourceURI != "file:///etc/passwd" {
+		t.Fatalf("meta = %+v, want method=resources/read resource_uri=file:///etc/passwd", m)
+	}
+	if m.ID != "abc" {
+		t.Errorf("id = %q, want abc (string id preserved)", m.ID)
+	}
+	if got := matchResult(t, `mcp.method == "resources/read" && mcp.resource_uri == "file:///etc/passwd"`, req); got != match.Matched {
+		t.Errorf("resource-read rule = %v, want Matched", got)
+	}
+}
+
+// TestMCPFacetExtractsPromptGet: prompts/get exposes params.name as
+// mcp.prompt_name so policy can gate prompt template reads separately
+// from tools/resources.
+func TestMCPFacetExtractsPromptGet(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"incident-summary"}}`, false)
+
+	m := meta(t, req)
+	if m.Method != "prompts/get" || m.PromptName != "incident-summary" {
+		t.Fatalf("meta = %+v, want method=prompts/get prompt_name=incident-summary", m)
+	}
+	if got := matchResult(t, `mcp.method == "prompts/get" && mcp.prompt_name == "incident-summary"`, req); got != match.Matched {
+		t.Errorf("prompt-get rule = %v, want Matched", got)
+	}
+}
+
+// TestMCPFacetClassifiesKind: kind is derived from the request line and
+// headers, independent of the body.
+func TestMCPFacetClassifiesKind(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		headers map[string]string
+		body    string
+		want    string
+	}{
+		{"post json is rpc", "POST", map[string]string{"Content-Type": jsonHeaders}, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`, mcpfacet.KindRPC},
+		{"get sse is listen", "GET", map[string]string{"Accept": "text/event-stream"}, "", mcpfacet.KindListen},
+		{"delete with session is terminate", "DELETE", map[string]string{"Mcp-Session-Id": "s1"}, "", mcpfacet.KindTerminate},
+		{"get without sse is other", "GET", nil, "", mcpfacet.KindOther},
+		{"delete without session is other", "DELETE", nil, "", mcpfacet.KindOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := prep(tc.method, "/mcp", tc.headers, tc.body, false)
+			if got := meta(t, req).Kind; got != tc.want {
+				t.Errorf("kind = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMCPFacetListenStreamFieldsEvaluableAndEmpty: a GET listen stream
+// has no JSON-RPC body, so body-derived fields evaluate to zero values
+// and are evaluable (NOT unknown). This is what lets an allowlist admit
+// the Streamable HTTP control channel.
+func TestMCPFacetListenStreamFieldsEvaluableAndEmpty(t *testing.T) {
+	req := prep("GET", "/mcp", map[string]string{"Accept": "text/event-stream"}, "", false)
+
+	if got := matchResult(t, `mcp.kind != "rpc"`, req); got != match.Matched {
+		t.Errorf(`mcp.kind != "rpc" = %v, want Matched`, got)
+	}
+	// The body-derived field is empty AND evaluable — not Unevaluable.
+	if got := matchResult(t, `mcp.method == ""`, req); got != match.Matched {
+		t.Errorf(`mcp.method == "" = %v, want Matched (evaluable empty, not unknown)`, got)
+	}
+	if req.ProtocolInvalid {
+		t.Error("listen stream must not be flagged protocol-invalid")
+	}
+}
+
+// TestMCPFacetReadsSessionAndProtocolHeaders: header-derived fields are
+// always available.
+func TestMCPFacetReadsSessionAndProtocolHeaders(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{
+		"Content-Type":         jsonHeaders,
+		"MCP-Protocol-Version": "2025-06-18",
+		"Mcp-Session-Id":       "sess-xyz",
+	}, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`, false)
+
+	if got := matchResult(t, `mcp.protocol_version == "2025-06-18" && mcp.session_id == "sess-xyz"`, req); got != match.Matched {
+		t.Errorf("header rule = %v, want Matched", got)
+	}
+}
+
+// TestMCPFacetBodyDerivedFieldsFailClosedOnTruncation: a truncated body
+// makes body-derived rules Unevaluable (the dispatcher fails closed),
+// while header-derived rules still evaluate.
+func TestMCPFacetBodyDerivedFieldsFailClosedOnTruncation(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":1,"method":"tools/ca`, true)
+
+	if got := matchResult(t, `mcp.method == "tools/call"`, req); got != match.Unevaluable {
+		t.Errorf("body-derived rule on truncated body = %v, want Unevaluable", got)
+	}
+	if got := matchResult(t, `mcp.kind == "rpc"`, req); got != match.Matched {
+		t.Errorf("header-derived rule on truncated body = %v, want Matched", got)
+	}
+	if !req.ProtocolInvalid {
+		t.Error("truncated rpc POST must be flagged protocol-invalid")
+	}
+}
+
+// TestMCPFacetBodyDerivedFieldsFailClosedOnMalformedJSON: invalid JSON
+// makes body-derived rules Unevaluable.
+func TestMCPFacetBodyDerivedFieldsFailClosedOnMalformedJSON(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{not valid json`, false)
+
+	if got := matchResult(t, `mcp.method == "tools/call"`, req); got != match.Unevaluable {
+		t.Errorf("body-derived rule on malformed JSON = %v, want Unevaluable", got)
+	}
+	if !req.ProtocolInvalid {
+		t.Error("malformed rpc POST must be flagged protocol-invalid")
+	}
+}
+
+// TestMCPFacetBodyDerivedFieldsFailClosedOnBatchArray: a JSON-RPC batch
+// must not let a tools/call slip past a tool-name rule by leaving
+// mcp.tool_name empty. The body-derived field is Unevaluable, not an
+// empty string that NoMatches.
+func TestMCPFacetBodyDerivedFieldsFailClosedOnTrailingGarbage(t *testing.T) {
+	cases := map[string]string{
+		"trailing garbage":    `{"jsonrpc":"2.0","id":1,"method":"tools/list"} garbage`,
+		"concatenated object": `{"jsonrpc":"2.0","id":1,"method":"tools/list"}{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_page"}}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, body, false)
+			if got := matchResult(t, `mcp.method == "tools/list"`, req); got != match.Unevaluable {
+				t.Errorf("body-derived rule on %s = %v, want Unevaluable", name, got)
+			}
+			if !req.ProtocolInvalid {
+				t.Fatalf("%s rpc POST must be flagged protocol-invalid", name)
+			}
+			if deny := runtime.ProtocolInvalidDeny(req); deny == nil || deny.Outcome.Verdict != "deny" {
+				t.Fatalf("ProtocolInvalidDeny(%s) = %v, want deny", name, deny)
+			}
+		})
+	}
+}
+
+func TestMCPFacetBodyDerivedFieldsFailClosedOnBatchArray(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_page"}}]`, false)
+
+	// The rev-1 bypass: a deny rule on the tool name must not silently
+	// miss because the batch left the field empty.
+	if got := matchResult(t, `mcp.tool_name == "delete_page"`, req); got != match.Unevaluable {
+		t.Errorf(`mcp.tool_name == "delete_page" on batch = %v, want Unevaluable`, got)
+	}
+	if got := matchResult(t, `mcp.tool_name == ""`, req); got != match.Unevaluable {
+		t.Errorf(`mcp.tool_name == "" on batch = %v, want Unevaluable (no empty-but-evaluable state)`, got)
+	}
+	if !req.ProtocolInvalid {
+		t.Error("batch rpc POST must be flagged protocol-invalid")
+	}
+}
+
+// invalidBodies enumerates the three protocol-invalid rpc POST shapes
+// the gate must catch.
+func invalidRequests() map[string]*match.Request {
+	return map[string]*match.Request{
+		"malformed":       prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{not json`, false),
+		"empty body":      prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, ``, false),
+		"batch":           prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `[{"method":"tools/call"}]`, false),
+		"trailing junk":   prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{"method":"tools/list"} trailing`, false),
+		"missing jsonrpc": prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{"method":"tools/list"}`, false),
+		"missing method":  prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{"jsonrpc":"2.0","id":1}`, false),
+		"wrong jsonrpc":   prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{"jsonrpc":"1.0","method":"tools/list"}`, false),
+		"truncated":       prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders}, `{"method":"too`, true),
+	}
+}
+
+func assertGateDeniesDespiteAllow(t *testing.T, ep *config.CompiledEndpoint) {
+	t.Helper()
+	for name, req := range invalidRequests() {
+		t.Run(name, func(t *testing.T) {
+			// The matcher alone would allow this request — that is the
+			// whole point: the gate, not the rule set, is what denies.
+			if cr := runtime.MatchRequest(ep, req); cr == nil || cr.Outcome.Verdict != "allow" {
+				t.Fatalf("precondition: MatchRequest = %v, want the allow rule (so the gate is the only thing denying)", cr)
+			}
+			deny := runtime.ProtocolInvalidDeny(req)
+			if deny == nil {
+				t.Fatal("ProtocolInvalidDeny = nil, want a synthesized deny")
+			}
+			if deny.Outcome.Verdict != "deny" {
+				t.Errorf("verdict = %q, want deny", deny.Outcome.Verdict)
+			}
+			if !strings.HasPrefix(deny.Outcome.Reason, "mcp_protocol_invalid") {
+				t.Errorf("reason = %q, want mcp_protocol_invalid prefix", deny.Outcome.Reason)
+			}
+		})
+	}
+}
+
+func allowRule(t *testing.T, name, condition string) *config.CompiledRule {
+	t.Helper()
+	var m match.Matcher
+	if condition != "" {
+		var err error
+		if m, err = facet.NewMatcher("mcp", condition); err != nil {
+			t.Fatalf("NewMatcher(%q): %v", condition, err)
+		}
+	}
+	return &config.CompiledRule{Name: name, Matcher: m, Outcome: config.Outcome{Verdict: "allow"}}
+}
+
+// TestMCPFacetProtocolInvalidDeniesCatchAllAllow: an unconditional allow
+// rule (nil matcher) does not let a malformed/batch/truncated MCP POST
+// through.
+func TestMCPFacetProtocolInvalidDeniesCatchAllAllow(t *testing.T) {
+	ep := &config.CompiledEndpoint{Family: "mcp", Name: "m", Rules: []*config.CompiledRule{
+		allowRule(t, "catch-all", ""),
+	}}
+	assertGateDeniesDespiteAllow(t, ep)
+}
+
+// TestMCPFacetProtocolInvalidDeniesHTTPPostAllow: an http.method allow
+// rule does not let a malformed/batch/truncated MCP POST through.
+func TestMCPFacetProtocolInvalidDeniesHTTPPostAllow(t *testing.T) {
+	ep := &config.CompiledEndpoint{Family: "mcp", Name: "m", Rules: []*config.CompiledRule{
+		allowRule(t, "http-post", `http.method == "POST"`),
+	}}
+	assertGateDeniesDespiteAllow(t, ep)
+}
+
+// TestMCPFacetProtocolInvalidDeniesKindRPCAllow: an mcp.kind allow rule
+// does not let a malformed/batch/truncated MCP POST through.
+func TestMCPFacetProtocolInvalidDeniesKindRPCAllow(t *testing.T) {
+	ep := &config.CompiledEndpoint{Family: "mcp", Name: "m", Rules: []*config.CompiledRule{
+		allowRule(t, "kind-rpc", `mcp.kind == "rpc"`),
+	}}
+	assertGateDeniesDespiteAllow(t, ep)
+
+	// Specificity: a well-formed rpc POST is allowed by the same rule
+	// and the gate does not fire.
+	valid := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, false)
+	if runtime.ProtocolInvalidDeny(valid) != nil {
+		t.Error("gate fired on a valid rpc POST")
+	}
+	if cr := runtime.MatchRequest(ep, valid); cr == nil || cr.Outcome.Verdict != "allow" {
+		t.Errorf("valid rpc POST = %v, want allow", cr)
+	}
+}
+
+// TestMCPFacetAllowsHTTPFields: the mcp family composes the http facet,
+// so an mcp rule can read http.* alongside mcp.*.
+func TestMCPFacetAllowsHTTPFields(t *testing.T) {
+	req := prep("POST", "/mcp", map[string]string{"Content-Type": jsonHeaders},
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, false)
+	if got := matchResult(t, `mcp.kind == "rpc" && http.path == "/mcp"`, req); got != match.Matched {
+		t.Errorf("compound mcp+http rule = %v, want Matched", got)
+	}
+}
+
+// TestHTTPFamilyCannotReadMCPFields: the http family does not compose
+// the mcp facet, so referencing mcp.* in an http rule is a compile
+// error.
+func TestHTTPFamilyCannotReadMCPFields(t *testing.T) {
+	if _, err := facet.NewMatcher("http", `mcp.kind == "rpc"`); err == nil {
+		t.Error("expected http-family rule referencing mcp.* to fail compilation")
+	}
+}
+
+// TestMCPFacetReportFields: the per-family report carries the
+// dashboard-facing fields for representative RPC and control requests.
+func TestMCPFacetReportFields(t *testing.T) {
+	fac := facet.Lookup("mcp")
+
+	rpc := prep("POST", "/mcp", map[string]string{
+		"Content-Type":   jsonHeaders,
+		"Mcp-Session-Id": "sess-1",
+	}, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup_customer"}}`, false)
+	got := fac.Report(rpc)
+	want := map[string]any{
+		"kind": "rpc", "method": "tools/call", "tool_name": "lookup_customer",
+		"resource_uri": "", "session_id": "sess-1",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("rpc report[%q] = %v, want %v", k, got[k], v)
+		}
+	}
+
+	term := prep("DELETE", "/mcp", map[string]string{"Mcp-Session-Id": "sess-2"}, "", false)
+	tr := fac.Report(term)
+	if tr["kind"] != "terminate" || tr["session_id"] != "sess-2" || tr["method"] != "" {
+		t.Errorf("terminate report = %v, want kind=terminate session_id=sess-2 method=''", tr)
+	}
+}

--- a/internal/config/plugins/facets/mcp/parse.go
+++ b/internal/config/plugins/facets/mcp/parse.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strconv"
+
+	"github.com/denoland/clawpatrol/internal/config/match"
+)
+
+// parseRPCBody parses a single JSON-RPC request object out of an rpc
+// POST body and fills the body-derived fields of m. It enforces the
+// fail-closed contract from the design (§6.3): an rpc POST is either
+// parsed from one well-formed JSON-RPC object, or the whole MCP action
+// is marked protocol-invalid so the dispatcher denies it before any
+// allow rule can match.
+//
+//   - Truncated body: the gateway already set req.Truncated; mark the
+//     action protocol-invalid (body-derived MCP fields are unknown).
+//   - Unparseable body (not valid JSON, or valid JSON that is not a
+//     single JSON-RPC object): set req.Unparseable and mark the action
+//     protocol-invalid.
+//   - JSON-RPC batch array: same protocol-invalid outcome as malformed
+//     JSON — batches were removed from the MCP spec in revision
+//     2025-06-18, and a batched tools/call must not bypass a tool-name
+//     deny rule by leaving mcp.tool_name empty.
+//
+// Body-derived fields are listed in the facet's TruncatablePaths /
+// UnparseablePaths, so marking req.Truncated / req.Unparseable also
+// poisons any rule that reads them — but the security boundary is the
+// ProtocolInvalid signal, which catches catch-all, http.method, and
+// mcp.kind allow rules too.
+func parseRPCBody(req *match.Request, m *Meta) {
+	if req.Truncated {
+		markInvalid(m, "request body truncated at the inspection buffer")
+		return
+	}
+	body := bytes.TrimSpace(req.Body)
+	if len(body) == 0 {
+		// A POST with no body is not a valid JSON-RPC request.
+		markInvalid(m, "body is not a single JSON-RPC request")
+		req.Unparseable = true
+		return
+	}
+	// A JSON-RPC batch is a top-level array. Reject it outright rather
+	// than parsing the first element.
+	if body[0] == '[' {
+		markInvalid(m, "JSON-RPC batch arrays are not supported")
+		req.Unparseable = true
+		return
+	}
+	var obj rpcRequest
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&obj); err != nil {
+		markInvalid(m, "body is not a single JSON-RPC request")
+		req.Unparseable = true
+		return
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		markInvalid(m, "body is not a single JSON-RPC request")
+		req.Unparseable = true
+		return
+	}
+	if obj.JSONRPC != "2.0" || obj.Method == "" {
+		// Valid JSON, but not a JSON-RPC 2.0 request.
+		markInvalid(m, "body is not a single JSON-RPC request")
+		req.Unparseable = true
+		return
+	}
+	m.Method = obj.Method
+	m.IsNotification = len(obj.ID) == 0
+	if !m.IsNotification {
+		m.ID = stringifyID(obj.ID)
+	}
+	switch obj.Method {
+	case "tools/call":
+		m.ToolName = obj.Params.Name
+	case "prompts/get":
+		m.PromptName = obj.Params.Name
+	case "resources/read", "resources/subscribe", "resources/unsubscribe":
+		m.ResourceURI = obj.Params.URI
+	}
+}
+
+// markInvalid flags m protocol-invalid with an agent-safe reason
+// prefixed by the stable "mcp_protocol_invalid" tag the deny event
+// surfaces. The cause names only the category of malformedness (the
+// agent already knows it sent that body), so it leaks nothing about
+// which facets a rule inspects.
+func markInvalid(m *Meta, cause string) {
+	m.ProtocolInvalid = true
+	m.ProtocolInvalidReason = "mcp_protocol_invalid: " + cause
+}
+
+// rpcRequest is the minimal JSON-RPC request shape the facet needs.
+// ID is kept raw so a numeric or string id round-trips without forcing
+// a type, and so an absent id (notification) is distinguishable from a
+// null id.
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  rpcParams       `json:"params"`
+}
+
+// rpcParams carries the params fields the facet extracts. tools/call
+// and prompts/get key on params.name; resources/* key on params.uri.
+type rpcParams struct {
+	Name string `json:"name"`
+	URI  string `json:"uri"`
+}
+
+// stringifyID renders a JSON-RPC id (number or string) as a string for
+// the mcp.id CEL field. A JSON string id keeps its value without the
+// surrounding quotes; any other shape is rendered as its raw JSON.
+func stringifyID(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			return s
+		}
+	}
+	// Numeric ids: normalize through strconv when possible so 1.0 and 1
+	// render consistently; otherwise fall back to the raw token.
+	if f, err := strconv.ParseFloat(string(raw), 64); err == nil {
+		if f == float64(int64(f)) {
+			return strconv.FormatInt(int64(f), 10)
+		}
+	}
+	return string(raw)
+}

--- a/internal/config/runtime/dispatch.go
+++ b/internal/config/runtime/dispatch.go
@@ -55,6 +55,187 @@ func HostEndpoint(policy *config.CompiledPolicy, profile, host string) *config.C
 	return config.MatchHostPattern(prof.HostPatterns, host)
 }
 
+// HostCandidates returns every endpoint bound to host in the profile,
+// in declaration order. Unlike HostEndpoint (which collapses a host to
+// a single endpoint), this preserves the full set so the HTTPS handler
+// can pick the right one per request once the path is known — a
+// path-scoped remote_mcp endpoint and a host-wide https endpoint can
+// share a host. Falls back to the single wildcard match when no exact
+// candidates exist, and appends a wildcard host-wide fallback after exact
+// candidates when one also matches. That lets a path-scoped exact endpoint
+// (remote_mcp on api.example.com/_/mcp) coexist with a wildcard generic HTTPS
+// endpoint (*.example.com) for the rest of the same host without capturing
+// unrelated traffic.
+func HostCandidates(policy *config.CompiledPolicy, profile, host string) []*config.CompiledEndpoint {
+	if policy == nil {
+		return nil
+	}
+	host = strings.ToLower(host)
+	if prof, ok := policy.Profiles[profile]; ok {
+		return hostCandidatesInProfile(prof, host)
+	}
+	// Single-tenant fallback: scan every profile, exact before wildcard,
+	// but keep each profile's wildcard fallback behind its exact candidates.
+	for _, p := range policy.Profiles {
+		if eps := hostCandidatesInProfile(p, host); hasExactHostCandidate(p, host) && len(eps) > 0 {
+			return eps
+		}
+	}
+	for _, p := range policy.Profiles {
+		if eps := hostCandidatesInProfile(p, host); len(eps) > 0 {
+			return eps
+		}
+	}
+	return nil
+}
+
+func hostCandidatesInProfile(prof *config.CompiledProfile, host string) []*config.CompiledEndpoint {
+	exact := orderCandidateGroup(prof.HostCandidates[host], true)
+	wildcards := orderCandidateGroup(config.MatchHostPatterns(prof.HostPatterns, host), false)
+	if len(exact) == 0 {
+		return wildcards
+	}
+	// Exact host declarations preserve legacy exact-over-wildcard
+	// precedence. When an exact host-wide endpoint exists, it owns the
+	// whole host and wildcard candidates must not capture any path. When
+	// the exact candidates are only path-scoped, wildcard path-scoped or
+	// host-wide candidates may still serve paths the exact candidates do
+	// not cover.
+	if hasHostWideEndpoint(exact) {
+		return exact
+	}
+	out := append([]*config.CompiledEndpoint{}, exact...)
+	for _, ep := range wildcards {
+		if !containsEndpointRuntime(out, ep) {
+			out = append(out, ep)
+		}
+	}
+	return out
+}
+
+func orderCandidateGroup(eps []*config.CompiledEndpoint, exact bool) []*config.CompiledEndpoint {
+	if len(eps) == 0 {
+		return nil
+	}
+	pathScoped := make([]*config.CompiledEndpoint, 0, len(eps))
+	hostWide := make([]*config.CompiledEndpoint, 0, len(eps))
+	for _, ep := range eps {
+		if ep == nil {
+			continue
+		}
+		if ep.PathConstraint == "" {
+			hostWide = append(hostWide, ep)
+		} else {
+			pathScoped = append(pathScoped, ep)
+		}
+	}
+	sort.SliceStable(pathScoped, func(i, j int) bool {
+		return len(pathScoped[i].PathConstraint) > len(pathScoped[j].PathConstraint)
+	})
+	if exact && len(hostWide) > 1 {
+		last := hostWide[len(hostWide)-1]
+		copy(hostWide[1:], hostWide[:len(hostWide)-1])
+		hostWide[0] = last
+	}
+	out := make([]*config.CompiledEndpoint, 0, len(pathScoped)+len(hostWide))
+	out = append(out, pathScoped...)
+	out = append(out, hostWide...)
+	return out
+}
+
+func hasHostWideEndpoint(eps []*config.CompiledEndpoint) bool {
+	for _, ep := range eps {
+		if ep != nil && ep.PathConstraint == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEndpointRuntime(eps []*config.CompiledEndpoint, ce *config.CompiledEndpoint) bool {
+	for _, ep := range eps {
+		if ep == ce {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExactHostCandidate(prof *config.CompiledProfile, host string) bool {
+	return len(prof.HostCandidates[host]) > 0
+}
+
+// SelectEndpointForPath picks the endpoint among candidates that serves
+// the given request path. Path-scoped endpoints (a non-empty
+// PathConstraint) win over a host-wide endpoint, and the most-specific
+// (longest) path constraint wins among them; a host-wide endpoint
+// (empty PathConstraint) is the fallback when no path-scoped candidate
+// matches. Returns nil when no candidate matches and there is no
+// host-wide fallback — the caller then applies its unknown-path
+// default rather than running the wrong facet against the request.
+func SelectEndpointForPath(candidates []*config.CompiledEndpoint, path string) *config.CompiledEndpoint {
+	var hostWide *config.CompiledEndpoint
+	for _, ce := range candidates {
+		if ce == nil {
+			continue
+		}
+		if ce.PathConstraint == "" {
+			if hostWide == nil {
+				hostWide = ce
+			}
+			continue
+		}
+		if PathMatchesConstraint(path, ce.PathConstraint, ce.PathPrefix) {
+			return ce
+		}
+	}
+	return hostWide
+}
+
+// PathMatchesConstraint reports whether request path is served by an
+// endpoint whose compiled path constraint is (constraint, prefix). An
+// empty constraint matches every path (host-wide). When prefix is
+// true, the path must equal the constraint (with or without its
+// trailing slash) or fall under it at a path-segment boundary; when
+// false, the match is exact, so `/mcp2` does not match `/mcp`.
+func PathMatchesConstraint(path, constraint string, prefix bool) bool {
+	if constraint == "" {
+		return true
+	}
+	if prefix {
+		base := strings.TrimSuffix(constraint, "/")
+		return path == base || strings.HasPrefix(path, base+"/")
+	}
+	return path == constraint
+}
+
+// ProtocolInvalidDeny returns a synthesized fail-closed deny rule when
+// a facet's PrepareRequest flagged req as ProtocolInvalid, or nil when
+// the request is protocol-valid. The gateway consults it after facet
+// preparation and instead of MatchRequest when it fires, so a
+// protocol-invalid action (e.g. a malformed, batched, or truncated MCP
+// RPC POST) is denied before any allow rule — a catch-all,
+// `http.method == "POST"`, or `mcp.kind == "rpc"` allow — can match.
+//
+// This is the security boundary the per-path req.Truncated /
+// req.Unparseable poisoning cannot provide on its own: those only mark
+// body-derived facet paths unknown, so a rule keyed on an
+// always-available facet would still allow the malformed body through.
+// The synthesized rule carries the facet's agent-safe reason and no
+// rule identity, mirroring the truncation fail-closed deny.
+func ProtocolInvalidDeny(req *match.Request) *config.CompiledRule {
+	if req == nil || !req.ProtocolInvalid {
+		return nil
+	}
+	reason := req.ProtocolInvalidReason
+	if reason == "" {
+		reason = "request is protocol-invalid; failing closed"
+	}
+	return &config.CompiledRule{
+		Outcome: config.Outcome{Verdict: "deny", Reason: reason},
+	}
+}
+
 // MatchRequest walks an endpoint's priority-sorted rule list and
 // returns the first rule whose matcher accepts req. Disabled rules
 // are skipped. nil is returned when no rule fires — the caller then

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -437,7 +437,7 @@ credential "telegram_bot_token" "example" {}
 
 Block syntax: `endpoint "<type>" "<name>" { ... }`
 
-Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`ssh`](#endpoint-ssh).
+Registered types: [`clickhouse_https`](#endpoint-clickhousehttps), [`clickhouse_native`](#endpoint-clickhousenative), [`https`](#endpoint-https), [`kubernetes`](#endpoint-kubernetes), [`openai_codex_https`](#endpoint-openaicodexhttps), [`postgres`](#endpoint-postgres), [`remote_mcp`](#endpoint-remotemcp), [`ssh`](#endpoint-ssh).
 
 ### `endpoint "clickhouse_https" "<name>"`
 
@@ -566,6 +566,23 @@ Family: `sql`.
 ```hcl
 endpoint "postgres" "example" {
   host = "db.internal:5432"
+}
+```
+
+### `endpoint "remote_mcp" "<name>"`
+
+Family: `mcp`.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | `string` | yes | The full MCP endpoint URL (absolute https). Its host is indexed for SNI dispatch and its path scopes which requests on that host run the MCP facet. |
+| `transport` | `string` | no | An advisory hint about the MCP transport the agent uses (auto \| streamable_http \| sse). The gateway never rewrites the agent's transport; this is reserved for future reporting. |
+| `protocol_version` | `string` | no | Optionally pins the MCP protocol version for reporting / documentation. |
+| `hosts` | `[]string` | no | Additional hostnames (or host:port pairs) this endpoint also intercepts beyond the URL host — an advanced override. |
+
+```hcl
+endpoint "remote_mcp" "example" {
+  url = "example"
 }
 ```
 


### PR DESCRIPTION
## Summary
- add path-aware HTTPS MITM dispatch so a path-scoped endpoint can share a host with a generic HTTPS endpoint without capturing unrelated traffic
- add a `remote_mcp` endpoint plugin plus MCP CEL facet fields for request kind, JSON-RPC method/id, tool/resource/prompt names, session id, and protocol version
- fail closed before policy matching for malformed, batched, truncated, or otherwise invalid MCP JSON-RPC POST bodies
- refresh the generated config reference for `endpoint "remote_mcp"`

## Testing
- `git diff --check origin/main...HEAD`
- `gofmt -l .`
- `TMPDIR=/home/exedev/tmp-go-test go test ./...`

## Notes
- this is the remote MCP routing/policy foundation only; it does not add `remote_mcp_oauth` credential support yet
- OAuth-backed hosted MCP providers such as Grain still need a follow-up credential/connect-flow PR
