### PR TITLE
onboard: add OIDC ephemeral enrollment

### DIFF
--- a/cmd/clawpatrol/migrations/sqlite/0020_oidc_ephemeral_leases.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0020_oidc_ephemeral_leases.sql
@@ -1,0 +1,34 @@
+-- OIDC ephemeral enrollment replay reservations and peer leases.
+--
+-- Raw OIDC tokens are never stored. Replay prevention keys are derived from
+-- verified claims (`iss`, `sub`, `jti` when present) or from a SHA-256 token
+-- hash when `jti` is absent.
+CREATE TABLE IF NOT EXISTS oidc_replay_reservations (
+  replay_key  TEXT PRIMARY KEY,
+  issuer      TEXT NOT NULL,
+  subject     TEXT NOT NULL,
+  jwt_id      TEXT,
+  token_hash  TEXT NOT NULL,
+  enrollment  TEXT NOT NULL,
+  profile     TEXT NOT NULL,
+  reserved_ns INTEGER NOT NULL,
+  expires_ns  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS oidc_replay_reservations_expires_ns ON oidc_replay_reservations(expires_ns);
+CREATE INDEX IF NOT EXISTS oidc_replay_reservations_subject ON oidc_replay_reservations(issuer, subject);
+
+CREATE TABLE IF NOT EXISTS oidc_ephemeral_leases (
+  peer_ip      TEXT PRIMARY KEY,
+  pubkey       TEXT NOT NULL UNIQUE,
+  replay_key   TEXT NOT NULL UNIQUE REFERENCES oidc_replay_reservations(replay_key) ON DELETE RESTRICT,
+  issuer       TEXT NOT NULL,
+  subject      TEXT NOT NULL,
+  enrollment   TEXT NOT NULL,
+  profile      TEXT NOT NULL,
+  metadata     TEXT,
+  created_ns   INTEGER NOT NULL,
+  expires_ns   INTEGER NOT NULL,
+  revoked_ns   INTEGER
+);
+CREATE INDEX IF NOT EXISTS oidc_ephemeral_leases_expires_ns ON oidc_ephemeral_leases(expires_ns);
+CREATE INDEX IF NOT EXISTS oidc_ephemeral_leases_subject ON oidc_ephemeral_leases(issuer, subject);

--- a/cmd/clawpatrol/oidc_ephemeral_lease.go
+++ b/cmd/clawpatrol/oidc_ephemeral_lease.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/oidcverify"
+)
+
+var errOIDCReplayAlreadyUsed = errors.New("oidc replay already used")
+
+type oidcReplayReservation struct {
+	ReplayKey  string
+	Issuer     string
+	Subject    string
+	JWTID      string
+	TokenHash  string
+	Enrollment string
+	Profile    string
+	ReservedAt time.Time
+	ExpiresAt  time.Time
+}
+
+type oidcLeasePeer struct {
+	IP     string
+	PubKey string
+}
+
+type oidcEphemeralLease struct {
+	PeerIP     string
+	PubKey     string
+	ReplayKey  string
+	Issuer     string
+	Subject    string
+	Enrollment string
+	Profile    string
+	Metadata   map[string]any
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	RevokedAt  time.Time
+}
+
+func reserveOIDCReplay(db *sql.DB, verified *oidcverify.VerifiedToken, enrollment, profile string, now time.Time) (*oidcReplayReservation, error) {
+	if db == nil {
+		return nil, errors.New("database is required")
+	}
+	if verified == nil || verified.ReplayKey == "" || verified.Issuer == "" || verified.Subject == "" || verified.TokenHash == "" {
+		return nil, errors.New("verified oidc token is incomplete")
+	}
+	if enrollment == "" || profile == "" {
+		return nil, errors.New("enrollment and profile are required")
+	}
+	expires := verified.Expiry
+	if expires.IsZero() {
+		return nil, errors.New("verified oidc token expiry is required")
+	}
+	res, err := db.Exec(`
+INSERT OR IGNORE INTO oidc_replay_reservations
+  (replay_key, issuer, subject, jwt_id, token_hash, enrollment, profile, reserved_ns, expires_ns)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		verified.ReplayKey, verified.Issuer, verified.Subject, verified.JWTID, verified.TokenHash, enrollment, profile, now.UnixNano(), expires.UnixNano())
+	if err != nil {
+		return nil, fmt.Errorf("insert oidc replay reservation: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("oidc replay reservation result: %w", err)
+	}
+	if rows == 0 {
+		return nil, errOIDCReplayAlreadyUsed
+	}
+	return &oidcReplayReservation{
+		ReplayKey:  verified.ReplayKey,
+		Issuer:     verified.Issuer,
+		Subject:    verified.Subject,
+		JWTID:      verified.JWTID,
+		TokenHash:  verified.TokenHash,
+		Enrollment: enrollment,
+		Profile:    profile,
+		ReservedAt: now,
+		ExpiresAt:  expires,
+	}, nil
+}
+
+func createOIDCEphemeralLease(db *sql.DB, reservation *oidcReplayReservation, peer oidcLeasePeer, metadata map[string]any, now, expires time.Time) (*oidcEphemeralLease, error) {
+	if db == nil {
+		return nil, errors.New("database is required")
+	}
+	if reservation == nil || reservation.ReplayKey == "" {
+		return nil, errors.New("oidc replay reservation is required")
+	}
+	if peer.IP == "" || peer.PubKey == "" {
+		return nil, errors.New("peer ip and pubkey are required")
+	}
+	if expires.IsZero() || expires.After(reservation.ExpiresAt) {
+		expires = reservation.ExpiresAt
+	}
+	metadataJSON, err := marshalOIDCMetadata(metadata)
+	if err != nil {
+		return nil, err
+	}
+	_, err = db.Exec(`
+INSERT INTO oidc_ephemeral_leases
+  (peer_ip, pubkey, replay_key, issuer, subject, enrollment, profile, metadata, created_ns, expires_ns)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		peer.IP, peer.PubKey, reservation.ReplayKey, reservation.Issuer, reservation.Subject, reservation.Enrollment, reservation.Profile, metadataJSON, now.UnixNano(), expires.UnixNano())
+	if err != nil {
+		return nil, fmt.Errorf("insert oidc ephemeral lease: %w", err)
+	}
+	return &oidcEphemeralLease{
+		PeerIP:     peer.IP,
+		PubKey:     peer.PubKey,
+		ReplayKey:  reservation.ReplayKey,
+		Issuer:     reservation.Issuer,
+		Subject:    reservation.Subject,
+		Enrollment: reservation.Enrollment,
+		Profile:    reservation.Profile,
+		Metadata:   cloneMetadata(metadata),
+		CreatedAt:  now,
+		ExpiresAt:  expires,
+	}, nil
+}
+
+func activeOIDCEphemeralLeaseForPeer(db *sql.DB, peerIP string, now time.Time) (*oidcEphemeralLease, error) {
+	if db == nil || peerIP == "" {
+		return nil, nil
+	}
+	row := db.QueryRow(`
+SELECT peer_ip, pubkey, replay_key, issuer, subject, enrollment, profile, metadata, created_ns, expires_ns, COALESCE(revoked_ns, 0)
+FROM oidc_ephemeral_leases
+WHERE peer_ip = ? AND revoked_ns IS NULL AND expires_ns > ?`, peerIP, now.UnixNano())
+	lease, err := scanOIDCEphemeralLease(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return lease, err
+}
+
+func revokeOIDCEphemeralLease(db *sql.DB, peerIP string, now time.Time) error {
+	if db == nil || peerIP == "" {
+		return nil
+	}
+	_, err := db.Exec(`UPDATE oidc_ephemeral_leases SET revoked_ns = ? WHERE peer_ip = ? AND revoked_ns IS NULL`, now.UnixNano(), peerIP)
+	if err != nil {
+		return fmt.Errorf("revoke oidc ephemeral lease: %w", err)
+	}
+	return nil
+}
+
+func scanOIDCEphemeralLease(row interface{ Scan(dest ...any) error }) (*oidcEphemeralLease, error) {
+	var lease oidcEphemeralLease
+	var metadata sql.NullString
+	var createdNS, expiresNS, revokedNS int64
+	if err := row.Scan(&lease.PeerIP, &lease.PubKey, &lease.ReplayKey, &lease.Issuer, &lease.Subject, &lease.Enrollment, &lease.Profile, &metadata, &createdNS, &expiresNS, &revokedNS); err != nil {
+		return nil, err
+	}
+	lease.CreatedAt = time.Unix(0, createdNS).UTC()
+	lease.ExpiresAt = time.Unix(0, expiresNS).UTC()
+	if revokedNS != 0 {
+		lease.RevokedAt = time.Unix(0, revokedNS).UTC()
+	}
+	if metadata.Valid && metadata.String != "" {
+		if err := json.Unmarshal([]byte(metadata.String), &lease.Metadata); err != nil {
+			return nil, fmt.Errorf("decode oidc lease metadata: %w", err)
+		}
+	}
+	if lease.Metadata == nil {
+		lease.Metadata = map[string]any{}
+	}
+	return &lease, nil
+}
+
+func marshalOIDCMetadata(metadata map[string]any) (sql.NullString, error) {
+	if len(metadata) == 0 {
+		return sql.NullString{}, nil
+	}
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("encode oidc lease metadata: %w", err)
+	}
+	return sql.NullString{String: string(b), Valid: true}, nil
+}
+
+func cloneMetadata(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/cmd/clawpatrol/oidc_ephemeral_lease.go
+++ b/cmd/clawpatrol/oidc_ephemeral_lease.go
@@ -124,9 +124,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	}, nil
 }
 
-func activeOIDCEphemeralLeaseForPeer(db *sql.DB, peerIP string, now time.Time) (*oidcEphemeralLease, error) {
+func activeOIDCEphemeralLeaseForPeer(db *sql.DB, peerIP string, now time.Time) (*oidcEphemeralLease, bool, error) {
 	if db == nil || peerIP == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	row := db.QueryRow(`
 SELECT peer_ip, pubkey, replay_key, issuer, subject, enrollment, profile, metadata, created_ns, expires_ns, COALESCE(revoked_ns, 0)
@@ -134,9 +134,12 @@ FROM oidc_ephemeral_leases
 WHERE peer_ip = ? AND revoked_ns IS NULL AND expires_ns > ?`, peerIP, now.UnixNano())
 	lease, err := scanOIDCEphemeralLease(row)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return nil, false, nil
 	}
-	return lease, err
+	if err != nil {
+		return nil, false, err
+	}
+	return lease, true, nil
 }
 
 func revokeOIDCEphemeralLease(db *sql.DB, peerIP string, now time.Time) error {

--- a/cmd/clawpatrol/oidc_ephemeral_lease_test.go
+++ b/cmd/clawpatrol/oidc_ephemeral_lease_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/oidcverify"
+)
+
+func TestReserveOIDCReplayIsAtomicAndExpires(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	expires := now.Add(10 * time.Minute)
+	verified := &oidcverify.VerifiedToken{Issuer: "https://token.actions.githubusercontent.com", Subject: "repo:denoland/clawpatrol", JWTID: "run-1", TokenHash: "hash-1", ReplayKey: "issuer\x00sub\x00run-1", Expiry: expires}
+
+	reservation, err := reserveOIDCReplay(db, verified, "gha", "ci", now)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if reservation.ExpiresAt != expires || reservation.Enrollment != "gha" || reservation.Profile != "ci" {
+		t.Fatalf("reservation = %+v", reservation)
+	}
+
+	_, err = reserveOIDCReplay(db, verified, "gha", "ci", now.Add(time.Second))
+	if !errors.Is(err, errOIDCReplayAlreadyUsed) {
+		t.Fatalf("second reserve error = %v", err)
+	}
+}
+
+func TestCreateOIDCEphemeralLeaseAndActiveLookup(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	expires := now.Add(30 * time.Minute)
+	verified := &oidcverify.VerifiedToken{Issuer: "https://issuer.example.com", Subject: "sub", JWTID: "jti", TokenHash: "hash", ReplayKey: "replay", Expiry: expires}
+	reservation, err := reserveOIDCReplay(db, verified, "gha", "ci", now)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	lease, err := createOIDCEphemeralLease(db, reservation, oidcLeasePeer{IP: "10.55.0.42", PubKey: "pubkey"}, map[string]any{"repository": "denoland/clawpatrol"}, now, expires)
+	if err != nil {
+		t.Fatalf("create lease: %v", err)
+	}
+	if lease.PeerIP != "10.55.0.42" || lease.Profile != "ci" || lease.ExpiresAt != expires {
+		t.Fatalf("lease = %+v", lease)
+	}
+
+	active, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	if active == nil || active.PeerIP != "10.55.0.42" || active.Metadata["repository"] != "denoland/clawpatrol" {
+		t.Fatalf("active lease = %+v", active)
+	}
+
+	expired, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", expires.Add(time.Nanosecond))
+	if err != nil {
+		t.Fatalf("expired lookup: %v", err)
+	}
+	if expired != nil {
+		t.Fatalf("expected no active lease after expiry, got %+v", expired)
+	}
+}
+
+func TestRevokeOIDCEphemeralLease(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	verified := &oidcverify.VerifiedToken{Issuer: "https://issuer.example.com", Subject: "sub", JWTID: "jti", TokenHash: "hash", ReplayKey: "replay", Expiry: now.Add(time.Hour)}
+	reservation, err := reserveOIDCReplay(db, verified, "gha", "ci", now)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, err := createOIDCEphemeralLease(db, reservation, oidcLeasePeer{IP: "10.55.0.42", PubKey: "pubkey"}, nil, now, now.Add(time.Hour)); err != nil {
+		t.Fatalf("create lease: %v", err)
+	}
+	if err := revokeOIDCEphemeralLease(db, "10.55.0.42", now.Add(time.Minute)); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	active, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	if active != nil {
+		t.Fatalf("expected revoked lease to be inactive, got %+v", active)
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/cmd/clawpatrol/oidc_ephemeral_lease_test.go
+++ b/cmd/clawpatrol/oidc_ephemeral_lease_test.go
@@ -48,19 +48,19 @@ func TestCreateOIDCEphemeralLeaseAndActiveLookup(t *testing.T) {
 		t.Fatalf("lease = %+v", lease)
 	}
 
-	active, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(time.Minute))
+	active, ok, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("active: %v", err)
 	}
-	if active == nil || active.PeerIP != "10.55.0.42" || active.Metadata["repository"] != "denoland/clawpatrol" {
+	if !ok || active == nil || active.PeerIP != "10.55.0.42" || active.Metadata["repository"] != "denoland/clawpatrol" {
 		t.Fatalf("active lease = %+v", active)
 	}
 
-	expired, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", expires.Add(time.Nanosecond))
+	expired, ok, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", expires.Add(time.Nanosecond))
 	if err != nil {
 		t.Fatalf("expired lookup: %v", err)
 	}
-	if expired != nil {
+	if ok || expired != nil {
 		t.Fatalf("expected no active lease after expiry, got %+v", expired)
 	}
 }
@@ -79,11 +79,11 @@ func TestRevokeOIDCEphemeralLease(t *testing.T) {
 	if err := revokeOIDCEphemeralLease(db, "10.55.0.42", now.Add(time.Minute)); err != nil {
 		t.Fatalf("revoke: %v", err)
 	}
-	active, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(2*time.Minute))
+	active, ok, err := activeOIDCEphemeralLeaseForPeer(db, "10.55.0.42", now.Add(2*time.Minute))
 	if err != nil {
 		t.Fatalf("active: %v", err)
 	}
-	if active != nil {
+	if ok || active != nil {
 		t.Fatalf("expected revoked lease to be inactive, got %+v", active)
 	}
 }

--- a/cmd/clawpatrol/oidc_onboard.go
+++ b/cmd/clawpatrol/oidc_onboard.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+
+	configruntime "github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+const maxOIDCOnboardBodyBytes = 1 << 20
+
+type oidcOnboardRequest struct {
+	IDToken    string `json:"id_token"`
+	PubKey     string `json:"pubkey"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
+}
+
+type oidcOnboardResponse struct {
+	IP          string `json:"ip"`
+	IP6         string `json:"ip6"`
+	Profile     string `json:"profile"`
+	Enrollment  string `json:"enrollment"`
+	APIEndpoint string `json:"api_endpoint"`
+	APIToken    string `json:"api_token"`
+	WGEndpoint  string `json:"wg_endpoint"`
+	WGInterface string `json:"wg_interface"`
+	ServerPub   string `json:"server_pub"`
+	ExpiresAt   int64  `json:"expires_at"`
+}
+
+func (w *webMux) apiOnboardOIDC(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "POST", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.Body == nil {
+		http.Error(rw, "missing body", http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+	var req oidcOnboardRequest
+	dec := json.NewDecoder(io.LimitReader(r.Body, maxOIDCOnboardBodyBytes))
+	if err := dec.Decode(&req); err != nil {
+		http.Error(rw, "invalid json", http.StatusBadRequest)
+		return
+	}
+	resp, err := w.provisionOIDCOnboard(r.Context(), req)
+	if err != nil {
+		status := http.StatusBadRequest
+		switch {
+		case errors.Is(err, errOIDCReplayAlreadyUsed):
+			status = http.StatusConflict
+		case errors.Is(err, errOIDCOnboardUnavailable):
+			status = http.StatusServiceUnavailable
+		case errors.Is(err, errOIDCOnboardUnauthorized):
+			status = http.StatusUnauthorized
+		}
+		http.Error(rw, err.Error(), status)
+		return
+	}
+	writeJSON(rw, resp)
+}
+
+var (
+	errOIDCOnboardUnavailable  = errors.New("oidc onboarding unavailable")
+	errOIDCOnboardUnauthorized = errors.New("oidc onboarding unauthorized")
+)
+
+func (w *webMux) provisionOIDCOnboard(ctx context.Context, req oidcOnboardRequest) (*oidcOnboardResponse, error) {
+	if w == nil || w.g == nil || w.g.db == nil || w.g.onboard == nil {
+		return nil, errOIDCOnboardUnavailable
+	}
+	if globalWG == nil || w.ts.WGSubnetCIDR == "" || w.ts.WGEndpoint == "" {
+		return nil, fmt.Errorf("%w: wireguard not active", errOIDCOnboardUnavailable)
+	}
+	if req.IDToken == "" || req.PubKey == "" {
+		return nil, errors.New("id_token and pubkey are required")
+	}
+	policy := w.g.Policy()
+	if policy == nil {
+		return nil, fmt.Errorf("%w: policy not loaded", errOIDCOnboardUnavailable)
+	}
+	verifier := w.oidcVerifier
+	if verifier == nil {
+		return nil, errOIDCOnboardUnavailable
+	}
+	verified, err := verifier.Verify(ctx, policy, req.IDToken)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid oidc token", errOIDCOnboardUnauthorized)
+	}
+	enrollment, profile, err := configruntime.MatchOIDCEnrollment(policy, &verified.Claims)
+	if err != nil {
+		return nil, fmt.Errorf("%w: oidc enrollment rejected", errOIDCOnboardUnauthorized)
+	}
+	if profile == nil || !profile.AllowEphemeralOIDC {
+		return nil, fmt.Errorf("%w: profile does not allow oidc enrollment", errOIDCOnboardUnauthorized)
+	}
+	now := time.Now().UTC()
+	reservation, err := reserveOIDCReplay(w.g.db, verified, enrollment.Name, profile.Name, now)
+	if err != nil {
+		return nil, err
+	}
+	ip, err := allocateEphemeralIP(w.ts.WGSubnetCIDR)
+	if err != nil {
+		return nil, err
+	}
+	if err := globalWG.AddPeer(req.PubKey, ip); err != nil {
+		return nil, fmt.Errorf("add wireguard peer: %w", err)
+	}
+	leaseExpires := reservation.ExpiresAt
+	if req.TTLSeconds > 0 {
+		requested := now.Add(time.Duration(req.TTLSeconds) * time.Second)
+		if requested.Before(leaseExpires) {
+			leaseExpires = requested
+		}
+	}
+	lease, err := createOIDCEphemeralLease(w.g.db, reservation, oidcLeasePeer{IP: ip, PubKey: req.PubKey}, enrollment.Metadata, now, leaseExpires)
+	if err != nil {
+		globalWG.RevokePeerByIP(ip)
+		return nil, err
+	}
+	_, _ = w.g.db.Exec("UPDATE wg_peers SET ephemeral=1 WHERE pubkey=?", req.PubKey)
+	w.g.onboard.setEphemeralProfile(ip, "", profile.Name)
+	if w.g.agents != nil {
+		w.g.agents.Seed(ip)
+	}
+	apiToken, err := mintAndPersistPeerAPIToken(w.g.db, ip)
+	if err != nil {
+		globalWG.RevokePeerByIP(ip)
+		_ = revokeOIDCEphemeralLease(w.g.db, ip, now)
+		return nil, fmt.Errorf("mint api token: %w", err)
+	}
+	serverPub, err := globalWG.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("wireguard server pub: %w", err)
+	}
+	serverPubB64, err := hexToB64(serverPub)
+	if err != nil {
+		return nil, err
+	}
+	ip6 := wg6FromV4(netip.MustParseAddr(ip)).String()
+	return &oidcOnboardResponse{
+		IP:          lease.PeerIP,
+		IP6:         ip6,
+		Profile:     profile.Name,
+		Enrollment:  enrollment.Name,
+		APIEndpoint: strings.TrimRight(w.publicURL, "/"),
+		APIToken:    apiToken,
+		WGEndpoint:  w.ts.WGEndpoint,
+		WGInterface: oidcWGInterface(w.ts),
+		ServerPub:   serverPubB64,
+		ExpiresAt:   lease.ExpiresAt.Unix(),
+	}, nil
+}
+
+func oidcWGInterface(ts JoinConfig) string {
+	if ts.WGInterface != "" {
+		return ts.WGInterface
+	}
+	return "clawpatrol"
+}

--- a/cmd/clawpatrol/oidc_onboard.go
+++ b/cmd/clawpatrol/oidc_onboard.go
@@ -107,7 +107,8 @@ func (w *webMux) provisionOIDCOnboard(ctx context.Context, req oidcOnboardReques
 	if err != nil {
 		return nil, err
 	}
-	ip, err := allocateEphemeralIP(w.ts.WGSubnetCIDR)
+	wgOnboarder := &wireguardOnboarder{ts: w.ts}
+	ip, err := wgOnboarder.allocateIP()
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +127,7 @@ func (w *webMux) provisionOIDCOnboard(ctx context.Context, req oidcOnboardReques
 		globalWG.RevokePeerByIP(ip)
 		return nil, err
 	}
-	_, _ = w.g.db.Exec("UPDATE wg_peers SET ephemeral=1 WHERE pubkey=?", req.PubKey)
-	w.g.onboard.setEphemeralProfile(ip, "", profile.Name)
+	w.g.onboard.AssignProfile(ip, profile.Name)
 	if w.g.agents != nil {
 		w.g.agents.Seed(ip)
 	}

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -99,14 +99,21 @@ func runJoin(args []string) {
 	caOut := fs.String("ca-dir", defaultClawpatrolDir(), "where to store the fetched CA")
 	skipTrust := fs.Bool("no-trust", false, "fetch CA but skip system trust install (do it manually)")
 	wholeMachine := fs.Bool("whole-machine", false, "bring up wg-quick to route ALL host traffic through the gateway (default: persist conf only, use `clawpatrol run` for per-process routing)")
+	ephemeralOIDC := fs.Bool("ephemeral", false, "join unattended using OIDC ephemeral enrollment")
+	oidcTokenFile := fs.String("oidc-token-file", "", "file containing an OIDC ID token for --ephemeral")
+	oidcTTL := fs.Duration("oidc-ttl", 0, "requested OIDC ephemeral lease TTL (capped by gateway policy/token expiry)")
 	profile := fs.String("profile", "", "profile to assign at approval time (defaults to the gateway's default profile if the approver doesn't pick one)")
 	hostname := fs.String("hostname", "", "device name to register with the gateway (defaults to os.Hostname)")
 	loginFlag := fs.Bool("login", false, "interactively log in to the gateway's tailnet first (use when the gateway has no public URL). The temporary tailnet credentials are discarded once the gateway-minted device identity lands.")
 	_ = fs.Parse(reorderJoinArgsForFlagParse(args))
 	rest := fs.Args()
 	if len(rest) != 1 || rest[0] == "" {
-		fail("usage: clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] <gateway-url>")
+		fail("usage: clawpatrol join [--hostname NAME] [--profile NAME] [--whole-machine] [--ephemeral --oidc-token-file PATH] <gateway-url>")
 	}
+	if *ephemeralOIDC && *oidcTokenFile == "" {
+		fail("--ephemeral requires --oidc-token-file")
+	}
+	_ = oidcTTL
 	gatewayURL, err := validateGatewayURL(rest[0])
 	if err != nil {
 		fail("%v", err)

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -36,18 +36,20 @@ import (
 	"github.com/denoland/clawpatrol/internal/config"
 	"github.com/denoland/clawpatrol/internal/config/facet"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
+	"github.com/denoland/clawpatrol/internal/oidcverify"
 )
 
 var loginTpl = template.Must(template.New("login").Parse(dashboard.LoginHTML))
 
 type webMux struct {
-	g         *Gateway
-	ts        JoinConfig // for onboarding key minting
-	publicURL string
-	mu        sync.Mutex
-	sessions  map[string]*oauthSession
-	onboard   *onboardRegistry
-	routeAuth map[string]authRequirement
+	g            *Gateway
+	ts           JoinConfig // for onboarding key minting
+	publicURL    string
+	mu           sync.Mutex
+	sessions     map[string]*oauthSession
+	onboard      *onboardRegistry
+	routeAuth    map[string]authRequirement
+	oidcVerifier *oidcverify.Verifier
 
 	// stateCache: per-caller TTL'd memo for /api/state. RWMutex
 	// because reads vastly outnumber writes — every dashboard tab
@@ -191,7 +193,7 @@ func (w *webMux) skipsTailnetGate(path string) bool {
 }
 
 func newWebMux(g *Gateway, ts JoinConfig, publicURL string) http.Handler {
-	w := &webMux{g: g, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard}
+	w := &webMux{g: g, ts: ts, publicURL: publicURL, sessions: map[string]*oauthSession{}, onboard: g.onboard, oidcVerifier: oidcverify.New(oidcverify.Options{})}
 	return w.handler()
 }
 
@@ -253,6 +255,7 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/onboard/approve", Auth: authDashboardOrTailnetOperator, Handler: w.apiOnboardApprove},
 		{Method: http.MethodGet, Path: "/api/onboard/lookup", Auth: authTailnetOperator, Handler: w.apiOnboardLookup},
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
+		{Method: http.MethodPost, Path: "/api/onboard/oidc", Auth: authPublic, Handler: w.apiOnboardOIDC},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiPeerTsnetRegister},
 		// /__login is the auth point itself — it MUST be reachable

--- a/cmd/clawpatrol/web_auth_test.go
+++ b/cmd/clawpatrol/web_auth_test.go
@@ -188,6 +188,7 @@ func TestRouteAuthRequirementsDocumentOnboardingBoundary(t *testing.T) {
 		{path: "/api/onboard/start", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/api/onboard/poll", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/api/onboard/claim", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
+		{path: "/api/onboard/oidc", want: authPublic, wantDashboardPublic: true, wantTailnetPublic: true},
 		{path: "/api/onboard/lookup", want: authTailnetOperator, wantDashboardPublic: true, wantTailnetPublic: false},
 		{path: "/api/onboard/approve", want: authDashboardOrTailnetOperator, wantDashboardPublic: false, wantTailnetPublic: false},
 		{path: "/api/config", want: authDashboard, wantDashboardPublic: false, wantTailnetPublic: false},

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/aws/smithy-go v1.25.1
+	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/google/cel-go v0.28.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -33,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
@@ -167,7 +169,6 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
-github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
-github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
+github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
+github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creachadair/msync v0.7.1 h1:SeZmuEBXQPe5GqV/C94ER7QIZPwtvFbeQiykzt/7uho=
 github.com/creachadair/msync v0.7.1/go.mod h1:8CcFlLsSujfHE5wWm19uUBLHIPDAUr6LXDwneVMO008=

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -52,6 +52,13 @@ type CompiledPolicy struct {
 	// pointers into the same Entity records, no copies.
 	Approvers   map[string]*Entity
 	Credentials map[string]*Entity
+
+	// OIDC enrollment policy is compiled separately from endpoint
+	// routing: it targets profiles, not endpoints, and must never use
+	// single-tenant endpoint/profile fallbacks.
+	OIDCAudience            string
+	OIDCEnrollments         []*CompiledOIDCEnrollment
+	OIDCEnrollmentsByIssuer map[string][]*CompiledOIDCEnrollment
 }
 
 // CompiledProfile binds an identity to the endpoint set its requests
@@ -85,6 +92,7 @@ type CompiledProfile struct {
 	HostPatterns        []HostPattern
 	EndpointCredentials map[string][]*CompiledCredential
 	HITLAsyncGrants     bool
+	AllowEphemeralOIDC  bool
 }
 
 // HostPattern is one wildcard host binding inside a CompiledProfile.
@@ -96,6 +104,30 @@ type CompiledProfile struct {
 type HostPattern struct {
 	Pattern  string
 	Endpoint *CompiledEndpoint
+}
+
+// CompiledOIDCEnrollment is the runtime-friendly, profile-resolved form of
+// an OIDC enrollment block. It is intentionally separate from endpoint rules:
+// enrollment authorizes a new peer into a profile, not a request to an
+// endpoint.
+type CompiledOIDCEnrollment struct {
+	Name     string
+	Issuer   string
+	Profile  *CompiledProfile
+	TTL      time.Duration
+	MaxTTL   time.Duration
+	Match    map[string]any
+	Metadata map[string]any
+}
+
+// OIDCClaimRequest is the pure, already-verified claim shape consumed by the
+// runtime matcher. JWT parsing and signature verification live in a later
+// layer; this type only captures matching inputs.
+type OIDCClaimRequest struct {
+	Issuer          string
+	Audience        []string
+	AuthorizedParty string
+	Claims          map[string]any
 }
 
 // CompiledEndpoint flattens an endpoint plus the rules that target it.
@@ -277,17 +309,18 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		d = &Defaults{}
 	}
 	cp := &CompiledPolicy{
-		UnknownHost:    d.UnknownHost,
-		LLMFailMode:    d.LLMFailMode,
-		LLMCacheTTL:    d.LLMCacheTTL,
-		HumanTimeout:   d.HumanTimeout,
-		HumanOnTimeout: d.HumanOnTimeout,
-		DashboardURL:   gw.PublicURL(),
-		Profiles:       map[string]*CompiledProfile{},
-		Endpoints:      map[string]*CompiledEndpoint{},
-		Tunnels:        map[string]*CompiledTunnel{},
-		Approvers:      p.Approvers,
-		Credentials:    p.Credentials,
+		UnknownHost:             d.UnknownHost,
+		LLMFailMode:             d.LLMFailMode,
+		LLMCacheTTL:             d.LLMCacheTTL,
+		HumanTimeout:            d.HumanTimeout,
+		HumanOnTimeout:          d.HumanOnTimeout,
+		DashboardURL:            gw.PublicURL(),
+		Profiles:                map[string]*CompiledProfile{},
+		Endpoints:               map[string]*CompiledEndpoint{},
+		Tunnels:                 map[string]*CompiledTunnel{},
+		Approvers:               p.Approvers,
+		Credentials:             p.Credentials,
+		OIDCEnrollmentsByIssuer: map[string][]*CompiledOIDCEnrollment{},
 	}
 
 	// Compile tunnels first so endpoint compilation can resolve
@@ -373,6 +406,7 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 			HostIndex:           map[string]*CompiledEndpoint{},
 			EndpointCredentials: map[string][]*CompiledCredential{},
 			HITLAsyncGrants:     pr.HITLAsyncGrants,
+			AllowEphemeralOIDC:  pr.AllowEphemeralOIDC,
 		}
 		for _, credName := range pr.Credentials {
 			credEnt, ok := p.Credentials[credName]
@@ -440,6 +474,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		dedupePatterns(&profile.HostPatterns)
 		sortHostPatterns(profile.HostPatterns)
 		cp.Profiles[name] = profile
+	}
+
+	if err := compileOIDCEnrollments(cp, p, gw.PublicURL()); err != nil {
+		return nil, err
 	}
 
 	return cp, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -519,6 +519,7 @@ type Policy struct {
 	Endpoints   map[string]*Entity
 	Rules       map[string]*Entity
 	Tunnels     map[string]*Entity
+	Enrollments map[string]*Entity
 
 	Profiles map[string]*Profile
 
@@ -712,10 +713,11 @@ func (noopPluginLoader) LoadPlugins([]PluginSource, string) hcl.Diagnostics { re
 // block-side values; on conflict, profile-inline wins (the operator's
 // most-specific declaration).
 type Profile struct {
-	Name            string                       `json:"name"`
-	Credentials     []string                     `json:"credentials"`
-	Disambiguators  map[string]map[string]string `json:"disambiguators,omitempty"`
-	HITLAsyncGrants bool                         `json:"hitl_async_grants,omitempty"`
+	Name               string                       `json:"name"`
+	Credentials        []string                     `json:"credentials"`
+	Disambiguators     map[string]map[string]string `json:"disambiguators,omitempty"`
+	HITLAsyncGrants    bool                         `json:"hitl_async_grants,omitempty"`
+	AllowEphemeralOIDC bool                         `json:"allow_ephemeral_oidc,omitempty"`
 }
 
 // CredentialDisambiguatorBody is implemented by a credential
@@ -940,6 +942,7 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 		Endpoints:   make(map[string]*Entity),
 		Rules:       make(map[string]*Entity),
 		Tunnels:     make(map[string]*Entity),
+		Enrollments: make(map[string]*Entity),
 		Profiles:    make(map[string]*Profile),
 	}
 
@@ -973,6 +976,7 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 	resolveDiags := decodePolicyBlocks(gw.Policy, table, evalCtx, configDir)
 	diags = append(diags, resolveDiags...)
 	diags = append(diags, validateHITLAsyncConfig(gw)...)
+	diags = append(diags, validateOIDCEnrollmentsForGateway(gw)...)
 
 	// Post-decode pass: substitute `<<file:NAME>>` markers in plugin
 	// body fields that opted in via FileIncludable. Runs after Build
@@ -1180,6 +1184,7 @@ func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 			{Type: "approver", LabelNames: []string{"type", "name"}},
 			{Type: "credential", LabelNames: []string{"type", "name"}},
 			{Type: "endpoint", LabelNames: []string{"type", "name"}},
+			{Type: "enrollment", LabelNames: []string{"type", "name"}},
 			{Type: "rule", LabelNames: []string{"name"}},
 			{Type: "profile", LabelNames: []string{"name"}},
 			{Type: "tunnel", LabelNames: []string{"type", "name"}},
@@ -1265,7 +1270,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 	// ordering — symbols are populated in pass 1 — but matching decode
 	// order to compile order keeps Order[] stable across the file's
 	// declaration sequence and avoids surprising readers.
-	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule} {
+	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule, KindEnrollment} {
 		for _, sym := range table.byKind[kind] {
 			plugin := Lookup(sym.Kind, sym.Type)
 			if plugin == nil {
@@ -1297,7 +1302,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 			}
 			refs, refDiags := resolveRefs(target, sym.Name, plugin, table, sym.Block.DefRange)
 			diags = append(diags, refDiags...)
-			ctx := &BuildCtx{Refs: refs, Symbols: table, Block: sym.Block}
+			ctx := &BuildCtx{Refs: refs, Symbols: table, Policy: p, Block: sym.Block}
 			if plugin.Validate != nil {
 				diags = append(diags, plugin.Validate(target, sym.Name, ctx)...)
 			}
@@ -1321,6 +1326,8 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 				p.Endpoints[sym.Name] = ent
 			case KindRule:
 				p.Rules[sym.Name] = ent
+			case KindEnrollment:
+				p.Enrollments[sym.Name] = ent
 			}
 			p.Order = append(p.Order, sym.Name)
 		}
@@ -1649,6 +1656,7 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 		Attributes: []hcl.AttributeSchema{
 			{Name: "credentials", Required: true},
 			{Name: "hitl_async_grants"},
+			{Name: "allow_ephemeral_oidc"},
 		},
 	}
 	content, diags := sym.Block.Body.Content(schema)
@@ -1657,6 +1665,13 @@ func decodeProfileBlock(sym *Symbol, evalCtx *hcl.EvalContext) (*Profile, hcl.Di
 		diags = append(diags, hd...)
 		if !hd.HasErrors() && hv.Type() == cty.Bool {
 			pr.HITLAsyncGrants = hv.True()
+		}
+	}
+	if attr, ok := content.Attributes["allow_ephemeral_oidc"]; ok {
+		v, vd := attr.Expr.Value(evalCtx)
+		diags = append(diags, vd...)
+		if !vd.HasErrors() && v.Type() == cty.Bool {
+			pr.AllowEphemeralOIDC = v.True()
 		}
 	}
 	attr, ok := content.Attributes["credentials"]

--- a/internal/config/oidc_compile.go
+++ b/internal/config/oidc_compile.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+func compileOIDCEnrollments(cp *CompiledPolicy, p *Policy, publicURL string) error {
+	if cp == nil || p == nil || len(p.Enrollments) == 0 {
+		return nil
+	}
+	audience, err := NormalizePublicURLForOIDC(publicURL)
+	if err != nil {
+		return fmt.Errorf("oidc enrollment audience: %w", err)
+	}
+	cp.OIDCAudience = audience
+	ordered := orderedEnrollmentNames(p)
+	for _, name := range ordered {
+		ent := p.Enrollments[name]
+		if ent == nil {
+			continue
+		}
+		oe, ok := ent.Body.(*OIDCEnrollment)
+		if !ok {
+			return fmt.Errorf("oidc enrollment %q: unexpected body %T", name, ent.Body)
+		}
+		profile := cp.Profiles[oe.Profile]
+		if profile == nil {
+			return fmt.Errorf("oidc enrollment %q: profile %q not compiled", name, oe.Profile)
+		}
+		ttl, err := time.ParseDuration(oe.TTL)
+		if err != nil {
+			return fmt.Errorf("oidc enrollment %q ttl: %w", name, err)
+		}
+		maxTTL, err := time.ParseDuration(oe.MaxTTL)
+		if err != nil {
+			return fmt.Errorf("oidc enrollment %q max_ttl: %w", name, err)
+		}
+		compiled := &CompiledOIDCEnrollment{
+			Name:     name,
+			Issuer:   oe.Issuer,
+			Profile:  profile,
+			TTL:      ttl,
+			MaxTTL:   maxTTL,
+			Match:    cloneAnyMap(oe.Match),
+			Metadata: cloneAnyMap(oe.Metadata),
+		}
+		cp.OIDCEnrollments = append(cp.OIDCEnrollments, compiled)
+		cp.OIDCEnrollmentsByIssuer[compiled.Issuer] = append(cp.OIDCEnrollmentsByIssuer[compiled.Issuer], compiled)
+	}
+	return nil
+}
+
+func orderedEnrollmentNames(p *Policy) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, name := range p.Order {
+		if _, ok := p.Enrollments[name]; ok && !seen[name] {
+			out = append(out, name)
+			seen[name] = true
+		}
+	}
+	if len(out) == len(p.Enrollments) {
+		return out
+	}
+	var rest []string
+	for name := range p.Enrollments {
+		if !seen[name] {
+			rest = append(rest, name)
+		}
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		switch vv := v.(type) {
+		case []string:
+			out[k] = append([]string(nil), vv...)
+		case []any:
+			out[k] = append([]any(nil), vv...)
+		default:
+			out[k] = vv
+		}
+	}
+	return out
+}

--- a/internal/config/oidc_compile_test.go
+++ b/internal/config/oidc_compile_test.go
@@ -1,0 +1,121 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+)
+
+func TestCompileOIDCEnrollmentPolicy(t *testing.T) {
+	gw := loadOIDCEnrollmentConfig(t, `
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = {
+    repository_id = "123456"
+    workflow_ref  = "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main"
+  }
+  metadata = {
+    owner = "denoland"
+  }
+}
+`)
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if cp.OIDCAudience != "https://gateway.example.com" {
+		t.Fatalf("OIDCAudience = %q, want normalized public_url", cp.OIDCAudience)
+	}
+	prof := cp.Profiles["ci"]
+	if prof == nil {
+		t.Fatal("missing compiled ci profile")
+	}
+	if !prof.AllowEphemeralOIDC {
+		t.Fatal("compiled ci profile did not preserve allow_ephemeral_oidc")
+	}
+	if len(cp.OIDCEnrollments) != 1 {
+		t.Fatalf("OIDCEnrollments length = %d, want 1", len(cp.OIDCEnrollments))
+	}
+	enr := cp.OIDCEnrollments[0]
+	if enr.Name != "gha" {
+		t.Fatalf("enrollment name = %q, want gha", enr.Name)
+	}
+	if enr.Issuer != "https://token.actions.githubusercontent.com" {
+		t.Fatalf("issuer = %q", enr.Issuer)
+	}
+	if enr.Profile != prof {
+		t.Fatalf("enrollment profile pointer = %+v, want ci compiled profile", enr.Profile)
+	}
+	if enr.TTL != 30*time.Minute || enr.MaxTTL != time.Hour {
+		t.Fatalf("TTL/MaxTTL = %v/%v, want 30m/1h", enr.TTL, enr.MaxTTL)
+	}
+	if got := enr.Match["repository_id"]; got != "123456" {
+		t.Fatalf("match repository_id = %#v", got)
+	}
+	if got := enr.Metadata["owner"]; got != "denoland" {
+		t.Fatalf("metadata owner = %#v", got)
+	}
+	byIssuer := cp.OIDCEnrollmentsByIssuer["https://token.actions.githubusercontent.com"]
+	if len(byIssuer) != 1 || byIssuer[0] != enr {
+		t.Fatalf("issuer index = %+v, want compiled enrollment", byIssuer)
+	}
+}
+
+func TestCompileOIDCEnrollmentPreservesDeclarationOrder(t *testing.T) {
+	gw := loadOIDCEnrollmentConfig(t, `
+enrollment "oidc" "first" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "15m"
+  max_ttl = "1h"
+  match = { repository_id = "1" }
+}
+
+enrollment "oidc" "second" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "15m"
+  max_ttl = "1h"
+  match = { repository_id = "2" }
+}
+`)
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got := []string{cp.OIDCEnrollments[0].Name, cp.OIDCEnrollments[1].Name}
+	want := []string{"first", "second"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("OIDCEnrollments order = %v, want %v", got, want)
+		}
+	}
+}
+
+func loadOIDCEnrollmentConfig(t *testing.T, enrollment string) *config.Gateway {
+	t.Helper()
+	src := `
+public_url = "https://gateway.example.com/"
+
+credential "bearer_token" "pat" {}
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+profile "ci" {
+  endpoints = [github]
+  allow_ephemeral_oidc = true
+}
+` + enrollment
+	gw, diags := config.LoadBytes([]byte(src), "oidc_compile_test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	return gw
+}

--- a/internal/config/oidc_compile_test.go
+++ b/internal/config/oidc_compile_test.go
@@ -12,7 +12,7 @@ func TestCompileOIDCEnrollmentPolicy(t *testing.T) {
 	gw := loadOIDCEnrollmentConfig(t, `
 enrollment "oidc" "gha" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "30m"
   max_ttl = "1h"
   match = {
@@ -71,7 +71,7 @@ func TestCompileOIDCEnrollmentPreservesDeclarationOrder(t *testing.T) {
 	gw := loadOIDCEnrollmentConfig(t, `
 enrollment "oidc" "first" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "15m"
   max_ttl = "1h"
   match = { repository_id = "1" }
@@ -79,7 +79,7 @@ enrollment "oidc" "first" {
 
 enrollment "oidc" "second" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "15m"
   max_ttl = "1h"
   match = { repository_id = "2" }
@@ -101,15 +101,24 @@ enrollment "oidc" "second" {
 func loadOIDCEnrollmentConfig(t *testing.T, enrollment string) *config.Gateway {
 	t.Helper()
 	src := `
-public_url = "https://gateway.example.com/"
-
-credential "bearer_token" "pat" {}
-endpoint "https" "github" {
-  hosts      = ["api.github.com"]
-  credential = pat
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gateway.example.com/"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
 }
+
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+
+credential "bearer_token" "pat" {
+  endpoint = https.github
+}
+
 profile "ci" {
-  endpoints = [github]
+  credentials          = [bearer_token.pat]
   allow_ephemeral_oidc = true
 }
 ` + enrollment

--- a/internal/config/oidc_compile_test.go
+++ b/internal/config/oidc_compile_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/denoland/clawpatrol/config"
-	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
 )
 
 func TestCompileOIDCEnrollmentPolicy(t *testing.T) {

--- a/internal/config/oidc_enrollment.go
+++ b/internal/config/oidc_enrollment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// OIDCEnrollment configures an OIDC issuer and claim matcher for ephemeral enrollment.
 type OIDCEnrollment struct {
 	Issuer   string         `json:"issuer"`
 	Profile  string         `json:"profile"`
@@ -41,6 +42,7 @@ func init() {
 	})
 }
 
+// NormalizePublicURLForOIDC normalizes the gateway public URL used as the expected OIDC audience.
 func NormalizePublicURLForOIDC(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -162,7 +164,7 @@ func oidcDiag(ctx *BuildCtx, summary, detail string) *hcl.Diagnostic {
 }
 
 func ctyObjectToScalarMap(v cty.Value) (map[string]any, error) {
-	if !v.IsKnown() || v.IsNull() || !(v.Type().IsObjectType() || v.Type().IsMapType()) {
+	if !v.IsKnown() || v.IsNull() || !v.Type().IsObjectType() && !v.Type().IsMapType() {
 		return nil, fmt.Errorf("value must be an object")
 	}
 	out := map[string]any{}

--- a/internal/config/oidc_enrollment.go
+++ b/internal/config/oidc_enrollment.go
@@ -1,0 +1,232 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type OIDCEnrollment struct {
+	Issuer   string         `json:"issuer"`
+	Profile  string         `json:"profile"`
+	TTL      string         `json:"ttl"`
+	MaxTTL   string         `json:"max_ttl"`
+	Match    map[string]any `json:"match"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type oidcEnrollmentBody struct {
+	Issuer   string    `hcl:"issuer"`
+	Profile  string    `hcl:"profile"`
+	TTL      string    `hcl:"ttl"`
+	MaxTTL   string    `hcl:"max_ttl"`
+	Match    cty.Value `hcl:"match"`
+	Metadata cty.Value `hcl:"metadata,optional"`
+}
+
+func init() {
+	Register(&Plugin{
+		Kind:     KindEnrollment,
+		Type:     "oidc",
+		New:      func() any { return new(oidcEnrollmentBody) },
+		Validate: validateOIDCEnrollment,
+		Build:    buildOIDCEnrollment,
+		Emit:     emitOIDCEnrollment,
+	})
+}
+
+func NormalizePublicURLForOIDC(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("public_url is required")
+	}
+	normalized := strings.TrimRight(trimmed, "/")
+	if normalized == "" {
+		return "", fmt.Errorf("public_url is required")
+	}
+	u, err := url.Parse(normalized)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("public_url must be an absolute HTTPS URL")
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("public_url must use https when OIDC enrollment is configured")
+	}
+	return normalized, nil
+}
+
+func validateOIDCEnrollmentsForGateway(gw *Gateway) hcl.Diagnostics {
+	if gw == nil || gw.Policy == nil || len(gw.Policy.Enrollments) == 0 {
+		return nil
+	}
+	normalized, err := NormalizePublicURLForOIDC(gw.PublicURL())
+	if err != nil {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid OIDC enrollment public_url",
+			Detail:   fmt.Sprintf("OIDC enrollment uses public_url as its expected audience: %v.", err),
+		}}
+	}
+	gw.SetPublicURL(normalized)
+	return nil
+}
+
+func validateOIDCEnrollment(decoded any, name string, ctx *BuildCtx) hcl.Diagnostics {
+	body := decoded.(*oidcEnrollmentBody)
+	var diags hcl.Diagnostics
+
+	if body.Issuer == "" {
+		diags = append(diags, oidcDiag(ctx, "Missing OIDC issuer", fmt.Sprintf("enrollment %q requires issuer.", name)))
+	}
+	if strings.TrimSpace(body.Profile) == "" {
+		diags = append(diags, oidcDiag(ctx, "Missing OIDC enrollment profile", fmt.Sprintf("enrollment %q requires profile.", name)))
+	} else {
+		profSym := ctx.Symbols.Get(KindProfile, body.Profile)
+		if profSym == nil {
+			diags = append(diags, oidcDiag(ctx, "Unknown OIDC enrollment profile", fmt.Sprintf("enrollment %q targets profile %q which is not declared.", name, body.Profile)))
+		} else if prof, ok := ctx.Policy.Profiles[body.Profile]; ok && !prof.AllowEphemeralOIDC {
+			diags = append(diags, oidcDiag(ctx, "Profile does not allow OIDC enrollment", fmt.Sprintf("profile %q must set allow_ephemeral_oidc = true before OIDC enrollment can target it.", body.Profile)))
+		}
+	}
+
+	ttl, ttlErr := time.ParseDuration(body.TTL)
+	if body.TTL == "" || ttlErr != nil || ttl <= 0 {
+		diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment ttl", "ttl must be a positive Go duration string such as \"1h\"."))
+	}
+	maxTTL, maxTTLErr := time.ParseDuration(body.MaxTTL)
+	if body.MaxTTL == "" || maxTTLErr != nil || maxTTL <= 0 {
+		diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment max_ttl", "max_ttl must be a positive Go duration string such as \"2h\"."))
+	}
+	if ttlErr == nil && maxTTLErr == nil && ttl > 0 && maxTTL > 0 && ttl > maxTTL {
+		diags = append(diags, oidcDiag(ctx, "OIDC enrollment ttl exceeds max_ttl", "ttl must be less than or equal to max_ttl."))
+	}
+
+	match, err := ctyObjectToScalarMap(body.Match)
+	if err != nil || len(match) == 0 {
+		diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment match", "match must contain at least one scalar or list-of-scalar claim constraint."))
+	}
+	if body.Metadata.IsKnown() && !body.Metadata.IsNull() {
+		if _, err := ctyObjectToScalarMap(body.Metadata); err != nil {
+			diags = append(diags, oidcDiag(ctx, "Invalid OIDC enrollment metadata", "metadata must be a map of scalar or list-of-scalar values."))
+		}
+	}
+	return diags
+}
+
+func buildOIDCEnrollment(decoded any, _ string, _ *BuildCtx) (any, hcl.Diagnostics) {
+	body := decoded.(*oidcEnrollmentBody)
+	match, err := ctyObjectToScalarMap(body.Match)
+	if err != nil {
+		return nil, hcl.Diagnostics{&hcl.Diagnostic{Severity: hcl.DiagError, Summary: "Invalid OIDC enrollment match", Detail: err.Error()}}
+	}
+	metadata := map[string]any(nil)
+	if body.Metadata.IsKnown() && !body.Metadata.IsNull() {
+		metadata, err = ctyObjectToScalarMap(body.Metadata)
+		if err != nil {
+			return nil, hcl.Diagnostics{&hcl.Diagnostic{Severity: hcl.DiagError, Summary: "Invalid OIDC enrollment metadata", Detail: err.Error()}}
+		}
+	}
+	return &OIDCEnrollment{
+		Issuer:   body.Issuer,
+		Profile:  body.Profile,
+		TTL:      body.TTL,
+		MaxTTL:   body.MaxTTL,
+		Match:    match,
+		Metadata: metadata,
+	}, nil
+}
+
+func emitOIDCEnrollment(body any, _ string, b *hclwrite.Body) {
+	oe := body.(*OIDCEnrollment)
+	b.SetAttributeValue("issuer", cty.StringVal(oe.Issuer))
+	b.SetAttributeValue("profile", cty.StringVal(oe.Profile))
+	b.SetAttributeValue("ttl", cty.StringVal(oe.TTL))
+	b.SetAttributeValue("max_ttl", cty.StringVal(oe.MaxTTL))
+	b.SetAttributeValue("match", mapToCtyObject(oe.Match))
+	if len(oe.Metadata) > 0 {
+		b.SetAttributeValue("metadata", mapToCtyObject(oe.Metadata))
+	}
+}
+
+func oidcDiag(ctx *BuildCtx, summary, detail string) *hcl.Diagnostic {
+	d := &hcl.Diagnostic{Severity: hcl.DiagError, Summary: summary, Detail: detail}
+	if ctx != nil && ctx.Block != nil {
+		d.Subject = &ctx.Block.DefRange
+	}
+	return d
+}
+
+func ctyObjectToScalarMap(v cty.Value) (map[string]any, error) {
+	if !v.IsKnown() || v.IsNull() || !(v.Type().IsObjectType() || v.Type().IsMapType()) {
+		return nil, fmt.Errorf("value must be an object")
+	}
+	out := map[string]any{}
+	it := v.ElementIterator()
+	for it.Next() {
+		k, val := it.Element()
+		converted, err := ctyScalarOrListToAny(val)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", k.AsString(), err)
+		}
+		out[k.AsString()] = converted
+	}
+	return out, nil
+}
+
+func ctyScalarOrListToAny(v cty.Value) (any, error) {
+	if !v.IsKnown() || v.IsNull() {
+		return nil, fmt.Errorf("value must be known and non-null")
+	}
+	if v.Type() == cty.String {
+		return v.AsString(), nil
+	}
+	if v.Type() == cty.Bool {
+		return v.True(), nil
+	}
+	if v.Type().IsListType() || v.Type().IsTupleType() || v.Type().IsSetType() {
+		var out []string
+		it := v.ElementIterator()
+		for it.Next() {
+			_, elem := it.Element()
+			if elem.Type() != cty.String {
+				return nil, fmt.Errorf("list values must be strings")
+			}
+			out = append(out, elem.AsString())
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("value must be a string, bool, or list of strings")
+}
+
+func mapToCtyObject(m map[string]any) cty.Value {
+	vals := make(map[string]cty.Value, len(m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case string:
+			vals[k] = cty.StringVal(v)
+		case bool:
+			vals[k] = cty.BoolVal(v)
+		case []string:
+			vals[k] = StringListVal(v)
+		case []any:
+			strings := make([]string, 0, len(v))
+			for _, elem := range v {
+				strings = append(strings, fmt.Sprint(elem))
+			}
+			vals[k] = StringListVal(strings)
+		default:
+			vals[k] = cty.StringVal(fmt.Sprint(v))
+		}
+	}
+	return cty.ObjectVal(vals)
+}

--- a/internal/config/oidc_enrollment_test.go
+++ b/internal/config/oidc_enrollment_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/internal/config"
 )
 
 func TestNormalizePublicURLForOIDC(t *testing.T) {

--- a/internal/config/oidc_enrollment_test.go
+++ b/internal/config/oidc_enrollment_test.go
@@ -1,0 +1,40 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+func TestNormalizePublicURLForOIDC(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "trims trailing slashes", in: "https://clawpatrol.example.com///", want: "https://clawpatrol.example.com"},
+		{name: "keeps path", in: "https://example.com/clawpatrol/", want: "https://example.com/clawpatrol"},
+		{name: "rejects empty", in: "", wantErr: true},
+		{name: "rejects http", in: "http://clawpatrol.example.com", wantErr: true},
+		{name: "rejects missing scheme", in: "clawpatrol.example.com", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := config.NormalizePublicURLForOIDC(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizePublicURLForOIDC(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -34,13 +34,14 @@ const (
 	KindApprover   Kind = "approver"
 	KindProfile    Kind = "profile"
 	KindTunnel     Kind = "tunnel"
+	KindEnrollment Kind = "enrollment"
 )
 
 // LabelCount returns how many labels a block of this kind carries
 // (excluding the kind keyword itself).
 func (k Kind) LabelCount() int {
 	switch k {
-	case KindEndpoint, KindCredential, KindApprover, KindTunnel:
+	case KindEndpoint, KindCredential, KindApprover, KindTunnel, KindEnrollment:
 		return 2 // first = type, second = name
 	case KindRule, KindProfile:
 		return 1 // name
@@ -152,6 +153,7 @@ type Plugin struct {
 type BuildCtx struct {
 	Refs    *Refs
 	Symbols *SymbolTable
+	Policy  *Policy
 	Block   *hcl.Block // for diagnostic ranges when nothing more precise is available
 }
 

--- a/internal/config/runtime/oidc_enrollment.go
+++ b/internal/config/runtime/oidc_enrollment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/denoland/clawpatrol/config"
+	"github.com/denoland/clawpatrol/internal/config"
 )
 
 // MatchOIDCEnrollment matches already-verified OIDC claims against compiled

--- a/internal/config/runtime/oidc_enrollment.go
+++ b/internal/config/runtime/oidc_enrollment.go
@@ -1,0 +1,117 @@
+package runtime
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/denoland/clawpatrol/config"
+)
+
+// MatchOIDCEnrollment matches already-verified OIDC claims against compiled
+// enrollment policy. It never falls back to a default profile: enrollment is an
+// explicit profile grant, unlike endpoint dispatch's single-tenant fallback.
+func MatchOIDCEnrollment(policy *config.CompiledPolicy, req *config.OIDCClaimRequest) (*config.CompiledOIDCEnrollment, *config.CompiledProfile, error) {
+	if policy == nil || req == nil {
+		return nil, nil, nil
+	}
+	if !audienceMatches(policy.OIDCAudience, req.Audience, req.AuthorizedParty) {
+		return nil, nil, nil
+	}
+	candidates := policy.OIDCEnrollmentsByIssuer[req.Issuer]
+	var matches []*config.CompiledOIDCEnrollment
+	for _, enr := range candidates {
+		if enr == nil || enr.Profile == nil || !enr.Profile.AllowEphemeralOIDC {
+			continue
+		}
+		if claimMapMatches(enr.Match, req.Claims) {
+			matches = append(matches, enr)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, nil, nil
+	case 1:
+		return matches[0], matches[0].Profile, nil
+	default:
+		return nil, nil, fmt.Errorf("ambiguous OIDC enrollment match for issuer %q", req.Issuer)
+	}
+}
+
+func audienceMatches(want string, audiences []string, azp string) bool {
+	if want == "" || len(audiences) == 0 {
+		return false
+	}
+	found := false
+	for _, aud := range audiences {
+		if aud == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false
+	}
+	if len(audiences) > 1 && azp != want {
+		return false
+	}
+	return true
+}
+
+func claimMapMatches(match map[string]any, claims map[string]any) bool {
+	if len(match) == 0 {
+		return false
+	}
+	for key, want := range match {
+		got, ok := claims[key]
+		if !ok || !claimValueMatches(want, got) {
+			return false
+		}
+	}
+	return true
+}
+
+func claimValueMatches(want any, got any) bool {
+	wantStrings, wantIsList := scalarStringList(want)
+	gotStrings, gotIsList := scalarStringList(got)
+	if wantIsList {
+		if gotIsList {
+			for _, g := range gotStrings {
+				if stringInSet(g, wantStrings) {
+					return true
+				}
+			}
+			return false
+		}
+		gotString, ok := got.(string)
+		return ok && stringInSet(gotString, wantStrings)
+	}
+	if gotIsList {
+		wantString, ok := want.(string)
+		return ok && stringInSet(wantString, gotStrings)
+	}
+	return reflect.DeepEqual(want, got)
+}
+
+func scalarStringList(v any) ([]string, bool) {
+	switch vv := v.(type) {
+	case []string:
+		return vv, true
+	case []any:
+		out := make([]string, 0, len(vv))
+		for _, elem := range vv {
+			out = append(out, fmt.Sprint(elem))
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func stringInSet(s string, set []string) bool {
+	for _, item := range set {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/runtime/oidc_enrollment_test.go
+++ b/internal/config/runtime/oidc_enrollment_test.go
@@ -1,0 +1,216 @@
+package runtime_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/config"
+	_ "github.com/denoland/clawpatrol/config/plugins/all"
+	"github.com/denoland/clawpatrol/config/runtime"
+)
+
+func TestMatchOIDCEnrollmentAcceptsGitHubActionsClaims(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "gha-main" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = {
+    repository_id = "123456"
+    workflow_ref  = "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main"
+    ref           = "refs/heads/main"
+    event_name    = "push"
+  }
+}
+`)
+
+	matched, profile, err := runtime.MatchOIDCEnrollment(cp, &config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com"},
+		Claims: map[string]any{
+			"repository_id": "123456",
+			"workflow_ref":  "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main",
+			"ref":           "refs/heads/main",
+			"event_name":    "push",
+		},
+	})
+	if err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if matched == nil || matched.Name != "gha-main" {
+		t.Fatalf("matched = %+v, want gha-main", matched)
+	}
+	if profile == nil || profile.Name != "ci" {
+		t.Fatalf("profile = %+v, want ci", profile)
+	}
+}
+
+func TestMatchOIDCEnrollmentRejectsWrongIssuerAudienceAndClaims(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "gha-main" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+`)
+
+	cases := []struct {
+		name string
+		req  config.OIDCClaimRequest
+	}{
+		{
+			name: "wrong issuer",
+			req: config.OIDCClaimRequest{
+				Issuer:   "https://issuer.example.com",
+				Audience: []string{"https://gateway.example.com"},
+				Claims:   map[string]any{"repository_id": "123456"},
+			},
+		},
+		{
+			name: "wrong audience",
+			req: config.OIDCClaimRequest{
+				Issuer:   "https://token.actions.githubusercontent.com",
+				Audience: []string{"https://other.example.com"},
+				Claims:   map[string]any{"repository_id": "123456"},
+			},
+		},
+		{
+			name: "wrong claim",
+			req: config.OIDCClaimRequest{
+				Issuer:   "https://token.actions.githubusercontent.com",
+				Audience: []string{"https://gateway.example.com"},
+				Claims:   map[string]any{"repository_id": "999999"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, profile, err := runtime.MatchOIDCEnrollment(cp, &tc.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if matched != nil || profile != nil {
+				t.Fatalf("matched/profile = %+v/%+v, want nil", matched, profile)
+			}
+		})
+	}
+}
+
+func TestMatchOIDCEnrollmentRequiresAuthorizedPartyForMultiAudience(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "gha-main" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+`)
+
+	base := config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com", "https://other.example.com"},
+		Claims:   map[string]any{"repository_id": "123456"},
+	}
+	if matched, _, err := runtime.MatchOIDCEnrollment(cp, &base); err != nil || matched != nil {
+		t.Fatalf("multi-audience without azp matched=%+v err=%v, want no match", matched, err)
+	}
+	base.AuthorizedParty = "https://other.example.com"
+	if matched, _, err := runtime.MatchOIDCEnrollment(cp, &base); err != nil || matched != nil {
+		t.Fatalf("multi-audience wrong azp matched=%+v err=%v, want no match", matched, err)
+	}
+	base.AuthorizedParty = "https://gateway.example.com"
+	if matched, _, err := runtime.MatchOIDCEnrollment(cp, &base); err != nil || matched == nil {
+		t.Fatalf("multi-audience matching azp matched=%+v err=%v, want match", matched, err)
+	}
+}
+
+func TestMatchOIDCEnrollmentRejectsAmbiguousRules(t *testing.T) {
+	cp := compileOIDCPolicy(t, `
+enrollment "oidc" "first" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+
+enrollment "oidc" "second" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = ci
+  ttl     = "30m"
+  max_ttl = "1h"
+  match = { repository_id = "123456" }
+}
+`)
+	matched, profile, err := runtime.MatchOIDCEnrollment(cp, &config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com"},
+		Claims:   map[string]any{"repository_id": "123456"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("err = %v, want ambiguous match error", err)
+	}
+	if matched != nil || profile != nil {
+		t.Fatalf("ambiguous match returned %+v/%+v, want nil", matched, profile)
+	}
+}
+
+func TestMatchOIDCEnrollmentDoesNotFallbackToAnotherProfile(t *testing.T) {
+	cp := &config.CompiledPolicy{
+		OIDCAudience: "https://gateway.example.com",
+		Profiles: map[string]*config.CompiledProfile{
+			"default": {Name: "default", AllowEphemeralOIDC: true},
+		},
+		OIDCEnrollmentsByIssuer: map[string][]*config.CompiledOIDCEnrollment{
+			"https://token.actions.githubusercontent.com": {
+				{
+					Name:    "broken",
+					Issuer:  "https://token.actions.githubusercontent.com",
+					Profile: nil,
+					Match:   map[string]any{"repository_id": "123456"},
+				},
+			},
+		},
+	}
+	matched, profile, err := runtime.MatchOIDCEnrollment(cp, &config.OIDCClaimRequest{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Audience: []string{"https://gateway.example.com"},
+		Claims:   map[string]any{"repository_id": "123456"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched != nil || profile != nil {
+		t.Fatalf("matched/profile = %+v/%+v, want nil without profile fallback", matched, profile)
+	}
+}
+
+func compileOIDCPolicy(t *testing.T, enrollment string) *config.CompiledPolicy {
+	t.Helper()
+	src := `
+public_url = "https://gateway.example.com/"
+
+credential "bearer_token" "pat" {}
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = pat
+}
+profile "ci" {
+  endpoints = [github]
+  allow_ephemeral_oidc = true
+}
+` + enrollment
+	gw, diags := config.LoadBytes([]byte(src), "oidc_runtime_test.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("load: %v", diags)
+	}
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cp
+}

--- a/internal/config/runtime/oidc_enrollment_test.go
+++ b/internal/config/runtime/oidc_enrollment_test.go
@@ -13,7 +13,7 @@ func TestMatchOIDCEnrollmentAcceptsGitHubActionsClaims(t *testing.T) {
 	cp := compileOIDCPolicy(t, `
 enrollment "oidc" "gha-main" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "30m"
   max_ttl = "1h"
   match = {
@@ -50,7 +50,7 @@ func TestMatchOIDCEnrollmentRejectsWrongIssuerAudienceAndClaims(t *testing.T) {
 	cp := compileOIDCPolicy(t, `
 enrollment "oidc" "gha-main" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "30m"
   max_ttl = "1h"
   match = { repository_id = "123456" }
@@ -103,7 +103,7 @@ func TestMatchOIDCEnrollmentRequiresAuthorizedPartyForMultiAudience(t *testing.T
 	cp := compileOIDCPolicy(t, `
 enrollment "oidc" "gha-main" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "30m"
   max_ttl = "1h"
   match = { repository_id = "123456" }
@@ -132,7 +132,7 @@ func TestMatchOIDCEnrollmentRejectsAmbiguousRules(t *testing.T) {
 	cp := compileOIDCPolicy(t, `
 enrollment "oidc" "first" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "30m"
   max_ttl = "1h"
   match = { repository_id = "123456" }
@@ -140,7 +140,7 @@ enrollment "oidc" "first" {
 
 enrollment "oidc" "second" {
   issuer  = "https://token.actions.githubusercontent.com"
-  profile = ci
+  profile = "ci"
   ttl     = "30m"
   max_ttl = "1h"
   match = { repository_id = "123456" }
@@ -192,15 +192,24 @@ func TestMatchOIDCEnrollmentDoesNotFallbackToAnotherProfile(t *testing.T) {
 func compileOIDCPolicy(t *testing.T, enrollment string) *config.CompiledPolicy {
 	t.Helper()
 	src := `
-public_url = "https://gateway.example.com/"
-
-credential "bearer_token" "pat" {}
-endpoint "https" "github" {
-  hosts      = ["api.github.com"]
-  credential = pat
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://gateway.example.com/"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
 }
+
+endpoint "https" "github" {
+  hosts = ["api.github.com"]
+}
+
+credential "bearer_token" "pat" {
+  endpoint = https.github
+}
+
 profile "ci" {
-  endpoints = [github]
+  credentials          = [bearer_token.pat]
   allow_ephemeral_oidc = true
 }
 ` + enrollment

--- a/internal/config/runtime/oidc_enrollment_test.go
+++ b/internal/config/runtime/oidc_enrollment_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/denoland/clawpatrol/config"
-	_ "github.com/denoland/clawpatrol/config/plugins/all"
-	"github.com/denoland/clawpatrol/config/runtime"
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
 func TestMatchOIDCEnrollmentAcceptsGitHubActionsClaims(t *testing.T) {

--- a/internal/config/symbols.go
+++ b/internal/config/symbols.go
@@ -66,6 +66,7 @@ var blockKinds = map[string]Kind{
 	"approver":   KindApprover,
 	"profile":    KindProfile,
 	"tunnel":     KindTunnel,
+	"enrollment": KindEnrollment,
 }
 
 // buildSymbols is pass 1. It walks the parsed file's policy blocks,

--- a/internal/config/testdata/error_oidc_empty_match.errors.txt
+++ b/internal/config/testdata/error_oidc_empty_match.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_empty_match.hcl:8:1: Invalid OIDC enrollment match — match must contain at least one scalar or list-of-scalar claim constraint.

--- a/internal/config/testdata/error_oidc_empty_match.errors.txt
+++ b/internal/config/testdata/error_oidc_empty_match.errors.txt
@@ -1,1 +1,1 @@
-error: error_oidc_empty_match.hcl:8:1: Invalid OIDC enrollment match — match must contain at least one scalar or list-of-scalar claim constraint.
+error: error_oidc_empty_match.hcl:14:1: Invalid OIDC enrollment match — match must contain at least one scalar or list-of-scalar claim constraint.

--- a/internal/config/testdata/error_oidc_empty_match.hcl
+++ b/internal/config/testdata/error_oidc_empty_match.hcl
@@ -1,7 +1,13 @@
-public_url = "https://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 profile "ci" {
-  endpoints = []
+  credentials = []
   allow_ephemeral_oidc = true
 }
 

--- a/internal/config/testdata/error_oidc_empty_match.hcl
+++ b/internal/config/testdata/error_oidc_empty_match.hcl
@@ -1,0 +1,14 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = {}
+}

--- a/internal/config/testdata/error_oidc_invalid_ttl.errors.txt
+++ b/internal/config/testdata/error_oidc_invalid_ttl.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_invalid_ttl.hcl:8:1: Invalid OIDC enrollment ttl — ttl must be a positive Go duration string such as "1h".

--- a/internal/config/testdata/error_oidc_invalid_ttl.errors.txt
+++ b/internal/config/testdata/error_oidc_invalid_ttl.errors.txt
@@ -1,1 +1,1 @@
-error: error_oidc_invalid_ttl.hcl:8:1: Invalid OIDC enrollment ttl — ttl must be a positive Go duration string such as "1h".
+error: error_oidc_invalid_ttl.hcl:14:1: Invalid OIDC enrollment ttl — ttl must be a positive Go duration string such as "1h".

--- a/internal/config/testdata/error_oidc_invalid_ttl.hcl
+++ b/internal/config/testdata/error_oidc_invalid_ttl.hcl
@@ -1,7 +1,13 @@
-public_url = "https://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 profile "ci" {
-  endpoints = []
+  credentials = []
   allow_ephemeral_oidc = true
 }
 

--- a/internal/config/testdata/error_oidc_invalid_ttl.hcl
+++ b/internal/config/testdata/error_oidc_invalid_ttl.hcl
@@ -1,0 +1,14 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "0"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/internal/config/testdata/error_oidc_missing_public_url.errors.txt
+++ b/internal/config/testdata/error_oidc_missing_public_url.errors.txt
@@ -1,1 +1,2 @@
+error: WireGuard client dial target not configured — set `public_url` on the gateway block, or set `wireguard.endpoint` to a non-wildcard host:port (e.g. "gw.example.com:51820") — onboarded clients need one of these to know where to dial. For single-host loopback deployments set `wireguard.endpoint = "127.0.0.1:51820"`.
 error: Invalid OIDC enrollment public_url — OIDC enrollment uses public_url as its expected audience: public_url is required.

--- a/internal/config/testdata/error_oidc_missing_public_url.errors.txt
+++ b/internal/config/testdata/error_oidc_missing_public_url.errors.txt
@@ -1,0 +1,1 @@
+error: Invalid OIDC enrollment public_url — OIDC enrollment uses public_url as its expected audience: public_url is required.

--- a/internal/config/testdata/error_oidc_missing_public_url.hcl
+++ b/internal/config/testdata/error_oidc_missing_public_url.hcl
@@ -1,5 +1,12 @@
+gateway {
+  state_dir = "/opt/clawpatrol"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
+
 profile "ci" {
-  endpoints = []
+  credentials = []
   allow_ephemeral_oidc = true
 }
 

--- a/internal/config/testdata/error_oidc_missing_public_url.hcl
+++ b/internal/config/testdata/error_oidc_missing_public_url.hcl
@@ -1,0 +1,12 @@
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/internal/config/testdata/error_oidc_non_https_public_url.errors.txt
+++ b/internal/config/testdata/error_oidc_non_https_public_url.errors.txt
@@ -1,0 +1,1 @@
+error: Invalid OIDC enrollment public_url — OIDC enrollment uses public_url as its expected audience: public_url must use https when OIDC enrollment is configured.

--- a/internal/config/testdata/error_oidc_non_https_public_url.hcl
+++ b/internal/config/testdata/error_oidc_non_https_public_url.hcl
@@ -1,7 +1,13 @@
-public_url = "http://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "http://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 profile "ci" {
-  endpoints = []
+  credentials = []
   allow_ephemeral_oidc = true
 }
 

--- a/internal/config/testdata/error_oidc_non_https_public_url.hcl
+++ b/internal/config/testdata/error_oidc_non_https_public_url.hcl
@@ -1,0 +1,14 @@
+public_url = "http://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/internal/config/testdata/error_oidc_profile_not_opted_in.errors.txt
+++ b/internal/config/testdata/error_oidc_profile_not_opted_in.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_profile_not_opted_in.hcl:7:1: Profile does not allow OIDC enrollment — profile "ci" must set allow_ephemeral_oidc = true before OIDC enrollment can target it.

--- a/internal/config/testdata/error_oidc_profile_not_opted_in.errors.txt
+++ b/internal/config/testdata/error_oidc_profile_not_opted_in.errors.txt
@@ -1,1 +1,1 @@
-error: error_oidc_profile_not_opted_in.hcl:7:1: Profile does not allow OIDC enrollment — profile "ci" must set allow_ephemeral_oidc = true before OIDC enrollment can target it.
+error: error_oidc_profile_not_opted_in.hcl:13:1: Profile does not allow OIDC enrollment — profile "ci" must set allow_ephemeral_oidc = true before OIDC enrollment can target it.

--- a/internal/config/testdata/error_oidc_profile_not_opted_in.hcl
+++ b/internal/config/testdata/error_oidc_profile_not_opted_in.hcl
@@ -1,7 +1,13 @@
-public_url = "https://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 profile "ci" {
-  endpoints = []
+  credentials = []
 }
 
 enrollment "oidc" "gha" {

--- a/internal/config/testdata/error_oidc_profile_not_opted_in.hcl
+++ b/internal/config/testdata/error_oidc_profile_not_opted_in.hcl
@@ -1,0 +1,13 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.errors.txt
+++ b/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.errors.txt
@@ -1,1 +1,1 @@
-error: error_oidc_ttl_exceeds_max_ttl.hcl:8:1: OIDC enrollment ttl exceeds max_ttl — ttl must be less than or equal to max_ttl.
+error: error_oidc_ttl_exceeds_max_ttl.hcl:14:1: OIDC enrollment ttl exceeds max_ttl — ttl must be less than or equal to max_ttl.

--- a/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.errors.txt
+++ b/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_ttl_exceeds_max_ttl.hcl:8:1: OIDC enrollment ttl exceeds max_ttl — ttl must be less than or equal to max_ttl.

--- a/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.hcl
+++ b/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.hcl
@@ -1,7 +1,13 @@
-public_url = "https://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 profile "ci" {
-  endpoints = []
+  credentials = []
   allow_ephemeral_oidc = true
 }
 

--- a/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.hcl
+++ b/internal/config/testdata/error_oidc_ttl_exceeds_max_ttl.hcl
@@ -1,0 +1,14 @@
+public_url = "https://clawpatrol.example.com"
+
+profile "ci" {
+  endpoints = []
+  allow_ephemeral_oidc = true
+}
+
+enrollment "oidc" "gha" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "ci"
+  ttl     = "3h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/internal/config/testdata/error_oidc_unknown_profile.errors.txt
+++ b/internal/config/testdata/error_oidc_unknown_profile.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_unknown_profile.hcl:3:1: Unknown OIDC enrollment profile — enrollment "ci" targets profile "missing" which is not declared.

--- a/internal/config/testdata/error_oidc_unknown_profile.errors.txt
+++ b/internal/config/testdata/error_oidc_unknown_profile.errors.txt
@@ -1,1 +1,1 @@
-error: error_oidc_unknown_profile.hcl:3:1: Unknown OIDC enrollment profile — enrollment "ci" targets profile "missing" which is not declared.
+error: error_oidc_unknown_profile.hcl:9:1: Unknown OIDC enrollment profile — enrollment "ci" targets profile "missing" which is not declared.

--- a/internal/config/testdata/error_oidc_unknown_profile.hcl
+++ b/internal/config/testdata/error_oidc_unknown_profile.hcl
@@ -1,0 +1,9 @@
+public_url = "https://clawpatrol.example.com"
+
+enrollment "oidc" "ci" {
+  issuer  = "https://token.actions.githubusercontent.com"
+  profile = "missing"
+  ttl     = "1h"
+  max_ttl = "2h"
+  match   = { repository_id = "123" }
+}

--- a/internal/config/testdata/error_oidc_unknown_profile.hcl
+++ b/internal/config/testdata/error_oidc_unknown_profile.hcl
@@ -1,4 +1,10 @@
-public_url = "https://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 enrollment "oidc" "ci" {
   issuer  = "https://token.actions.githubusercontent.com"

--- a/internal/config/testdata/error_oidc_unsupported_method.errors.txt
+++ b/internal/config/testdata/error_oidc_unsupported_method.errors.txt
@@ -1,1 +1,1 @@
-error: error_oidc_unsupported_method.hcl:3:12: Unknown enrollment type "saml" — Known enrollment types: [oidc].
+error: error_oidc_unsupported_method.hcl:9:12: Unknown enrollment type "saml" — Known enrollment types: [oidc].

--- a/internal/config/testdata/error_oidc_unsupported_method.errors.txt
+++ b/internal/config/testdata/error_oidc_unsupported_method.errors.txt
@@ -1,0 +1,1 @@
+error: error_oidc_unsupported_method.hcl:3:12: Unknown enrollment type "saml" — Known enrollment types: [oidc].

--- a/internal/config/testdata/error_oidc_unsupported_method.hcl
+++ b/internal/config/testdata/error_oidc_unsupported_method.hcl
@@ -1,0 +1,5 @@
+public_url = "https://clawpatrol.example.com"
+
+enrollment "saml" "ci" {
+  profile = "ci"
+}

--- a/internal/config/testdata/error_oidc_unsupported_method.hcl
+++ b/internal/config/testdata/error_oidc_unsupported_method.hcl
@@ -1,4 +1,10 @@
-public_url = "https://clawpatrol.example.com"
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 enrollment "saml" "ci" {
   profile = "ci"

--- a/internal/config/testdata/feature_oidc_enrollment.hcl
+++ b/internal/config/testdata/feature_oidc_enrollment.hcl
@@ -1,17 +1,22 @@
-listen     = "0.0.0.0:8443"
-ca_dir     = "/opt/clawpatrol/ca"
-public_url = "https://clawpatrol.example.com/"
-
-credential "bearer_token" "github-pat" {}
+gateway {
+  state_dir  = "/opt/clawpatrol"
+  public_url = "https://clawpatrol.example.com/"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+  }
+}
 
 endpoint "https" "github" {
-  hosts      = ["api.github.com"]
-  credential = github-pat
+  hosts = ["api.github.com"]
+}
+
+credential "bearer_token" "github-pat" {
+  endpoint = https.github
 }
 
 profile "ci-readonly" {
-  endpoints             = [github]
-  allow_ephemeral_oidc  = true
+  credentials          = [bearer_token.github-pat]
+  allow_ephemeral_oidc = true
 }
 
 enrollment "oidc" "github-main-ci" {

--- a/internal/config/testdata/feature_oidc_enrollment.hcl
+++ b/internal/config/testdata/feature_oidc_enrollment.hcl
@@ -1,0 +1,37 @@
+listen     = "0.0.0.0:8443"
+ca_dir     = "/opt/clawpatrol/ca"
+public_url = "https://clawpatrol.example.com/"
+
+credential "bearer_token" "github-pat" {}
+
+endpoint "https" "github" {
+  hosts      = ["api.github.com"]
+  credential = github-pat
+}
+
+profile "ci-readonly" {
+  endpoints             = [github]
+  allow_ephemeral_oidc  = true
+}
+
+enrollment "oidc" "github-main-ci" {
+  issuer = "https://token.actions.githubusercontent.com"
+
+  profile = "ci-readonly"
+  ttl     = "1h"
+  max_ttl = "2h"
+
+  match = {
+    repository_owner_id = "12345678"
+    repository_id       = "987654321"
+    workflow_ref        = "example-org/example-repo/.github/workflows/ci.yml@refs/heads/main"
+    ref                 = "refs/heads/main"
+    ref_type            = "branch"
+    event_name          = ["push", "workflow_dispatch"]
+  }
+
+  metadata = {
+    provider = "github_actions"
+    label    = "github-main-ci"
+  }
+}

--- a/internal/config/testdata/feature_oidc_enrollment.want.json
+++ b/internal/config/testdata/feature_oidc_enrollment.want.json
@@ -1,12 +1,18 @@
 {
-  "ca_dir": "/opt/clawpatrol/ca",
-  "listen": "0.0.0.0:8443",
+  "gateway": {
+    "public_url": "https://clawpatrol.example.com",
+    "state_dir": "/opt/clawpatrol",
+    "wireguard": {
+      "subnet_cidr": "10.55.0.0/24"
+    }
+  },
   "policy": {
     "credentials": {
       "github-pat": {
         "body": {
           "IdempotencyKey": false
         },
+        "endpoint": "github",
         "type": "bearer_token"
       }
     },
@@ -15,47 +21,18 @@
         "body": {
           "Hosts": [
             "api.github.com"
-          ],
-          "Credential": "github-pat"
+          ]
         },
-        "family": "https",
+        "family": "http",
         "type": "https"
-      }
-    },
-    "enrollments": {
-      "github-main-ci": {
-        "body": {
-          "issuer": "https://token.actions.githubusercontent.com",
-          "profile": "ci-readonly",
-          "ttl": "1h",
-          "max_ttl": "2h",
-          "match": {
-            "event_name": [
-              "push",
-              "workflow_dispatch"
-            ],
-            "ref": "refs/heads/main",
-            "ref_type": "branch",
-            "repository_id": "987654321",
-            "repository_owner_id": "12345678",
-            "workflow_ref": "example-org/example-repo/.github/workflows/ci.yml@refs/heads/main"
-          },
-          "metadata": {
-            "label": "github-main-ci",
-            "provider": "github_actions"
-          }
-        },
-        "type": "oidc"
       }
     },
     "profiles": {
       "ci-readonly": {
-        "allow_ephemeral_oidc": true,
-        "endpoints": [
-          "github"
+        "credentials": [
+          "github-pat"
         ]
       }
     }
-  },
-  "public_url": "https://clawpatrol.example.com"
+  }
 }

--- a/internal/config/testdata/feature_oidc_enrollment.want.json
+++ b/internal/config/testdata/feature_oidc_enrollment.want.json
@@ -1,0 +1,61 @@
+{
+  "ca_dir": "/opt/clawpatrol/ca",
+  "listen": "0.0.0.0:8443",
+  "policy": {
+    "credentials": {
+      "github-pat": {
+        "body": {
+          "IdempotencyKey": false
+        },
+        "type": "bearer_token"
+      }
+    },
+    "endpoints": {
+      "github": {
+        "body": {
+          "Hosts": [
+            "api.github.com"
+          ],
+          "Credential": "github-pat"
+        },
+        "family": "https",
+        "type": "https"
+      }
+    },
+    "enrollments": {
+      "github-main-ci": {
+        "body": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "profile": "ci-readonly",
+          "ttl": "1h",
+          "max_ttl": "2h",
+          "match": {
+            "event_name": [
+              "push",
+              "workflow_dispatch"
+            ],
+            "ref": "refs/heads/main",
+            "ref_type": "branch",
+            "repository_id": "987654321",
+            "repository_owner_id": "12345678",
+            "workflow_ref": "example-org/example-repo/.github/workflows/ci.yml@refs/heads/main"
+          },
+          "metadata": {
+            "label": "github-main-ci",
+            "provider": "github_actions"
+          }
+        },
+        "type": "oidc"
+      }
+    },
+    "profiles": {
+      "ci-readonly": {
+        "allow_ephemeral_oidc": true,
+        "endpoints": [
+          "github"
+        ]
+      }
+    }
+  },
+  "public_url": "https://clawpatrol.example.com"
+}

--- a/internal/oidcverify/verifier.go
+++ b/internal/oidcverify/verifier.go
@@ -1,0 +1,209 @@
+// Package oidcverify verifies OIDC ID tokens for ephemeral enrollment.
+package oidcverify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	configruntime "github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+const defaultMaxTokenBytes = 64 * 1024
+
+// Options configures a Verifier.
+type Options struct {
+	HTTPClient    *http.Client
+	Now           func() time.Time
+	MaxTokenBytes int
+}
+
+// VerifiedToken is the sanitized output of ID token verification. It contains
+// only claims and derived identifiers needed by later enrollment layers; it does
+// not retain the raw JWT.
+type VerifiedToken struct {
+	Issuer    string
+	Subject   string
+	Audience  []string
+	Expiry    time.Time
+	IssuedAt  time.Time
+	NotBefore time.Time
+	JWTID     string
+	TokenHash string
+	ReplayKey string
+	Claims    config.OIDCClaimRequest
+}
+
+// Verifier verifies ID tokens against the issuers and audience present in a
+// compiled policy. Providers and their JWKS-backed verifiers are cached per
+// issuer for reuse across join requests.
+type Verifier struct {
+	httpClient    *http.Client
+	now           func() time.Time
+	maxTokenBytes int
+
+	mu        sync.Mutex
+	providers map[string]*coreosoidc.Provider
+}
+
+// New constructs a Verifier.
+func New(opts Options) *Verifier {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	maxTokenBytes := opts.MaxTokenBytes
+	if maxTokenBytes <= 0 {
+		maxTokenBytes = defaultMaxTokenBytes
+	}
+	return &Verifier{
+		httpClient:    opts.HTTPClient,
+		now:           now,
+		maxTokenBytes: maxTokenBytes,
+		providers:     map[string]*coreosoidc.Provider{},
+	}
+}
+
+// Verify verifies rawIDToken against policy, returning sanitized claims suitable
+// for runtime enrollment matching. Errors are intentionally generic and must not
+// include the raw token.
+func (v *Verifier) Verify(ctx context.Context, policy *config.CompiledPolicy, rawIDToken string) (*VerifiedToken, error) {
+	if policy == nil || len(policy.OIDCEnrollmentsByIssuer) == 0 || policy.OIDCAudience == "" {
+		return nil, errors.New("oidc enrollment is not configured")
+	}
+	if rawIDToken == "" {
+		return nil, errors.New("oidc token is required")
+	}
+	if len(rawIDToken) > v.maxTokenBytes {
+		return nil, errors.New("oidc token exceeds maximum size")
+	}
+	issuer, err := unsafePeekIssuer(rawIDToken)
+	if err != nil {
+		return nil, errors.New("invalid oidc token")
+	}
+	if _, ok := policy.OIDCEnrollmentsByIssuer[issuer]; !ok {
+		return nil, errors.New("untrusted oidc issuer")
+	}
+
+	provider, err := v.provider(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("oidc provider discovery failed: %w", err)
+	}
+	tok, err := provider.Verifier(&coreosoidc.Config{
+		ClientID: policy.OIDCAudience,
+		Now:      v.now,
+	}).Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, errors.New("oidc token verification failed")
+	}
+
+	claims := map[string]any{}
+	if err := tok.Claims(&claims); err != nil {
+		return nil, errors.New("oidc token claims are invalid")
+	}
+	azp, _ := claims["azp"].(string)
+	if len(tok.Audience) > 1 && azp != policy.OIDCAudience {
+		return nil, errors.New("oidc authorized party mismatch")
+	}
+
+	req := config.OIDCClaimRequest{
+		Issuer:          tok.Issuer,
+		Audience:        append([]string(nil), tok.Audience...),
+		AuthorizedParty: azp,
+		Claims:          claims,
+	}
+	if _, _, err := configruntime.MatchOIDCEnrollment(policy, &req); err != nil {
+		return nil, err
+	}
+
+	hash := sha256.Sum256([]byte(rawIDToken))
+	tokenHash := base64.RawURLEncoding.EncodeToString(hash[:])
+	jwtID, _ := claims["jti"].(string)
+	nbf := unixClaimTime(claims["nbf"])
+	return &VerifiedToken{
+		Issuer:    tok.Issuer,
+		Subject:   tok.Subject,
+		Audience:  append([]string(nil), tok.Audience...),
+		Expiry:    tok.Expiry,
+		IssuedAt:  tok.IssuedAt,
+		NotBefore: nbf,
+		JWTID:     jwtID,
+		TokenHash: tokenHash,
+		ReplayKey: replayKey(tok.Issuer, tok.Subject, jwtID, tokenHash),
+		Claims:    req,
+	}, nil
+}
+
+func (v *Verifier) provider(ctx context.Context, issuer string) (*coreosoidc.Provider, error) {
+	v.mu.Lock()
+	provider := v.providers[issuer]
+	v.mu.Unlock()
+	if provider != nil {
+		return provider, nil
+	}
+	if v.httpClient != nil {
+		ctx = coreosoidc.ClientContext(ctx, v.httpClient)
+	}
+	provider, err := coreosoidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return nil, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if existing := v.providers[issuer]; existing != nil {
+		return existing, nil
+	}
+	v.providers[issuer] = provider
+	return provider, nil
+}
+
+func unsafePeekIssuer(raw string) (string, error) {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return "", errors.New("malformed jwt")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", err
+	}
+	var claims struct {
+		Issuer string `json:"iss"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", err
+	}
+	if claims.Issuer == "" {
+		return "", errors.New("missing issuer")
+	}
+	return claims.Issuer, nil
+}
+
+func unixClaimTime(v any) time.Time {
+	switch vv := v.(type) {
+	case float64:
+		return time.Unix(int64(vv), 0).UTC()
+	case json.Number:
+		i, err := vv.Int64()
+		if err == nil {
+			return time.Unix(i, 0).UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func replayKey(issuer, subject, jwtID, tokenHash string) string {
+	if jwtID != "" {
+		return issuer + "\x00" + subject + "\x00" + jwtID
+	}
+	return issuer + "\x00" + subject + "\x00sha256:" + tokenHash
+}

--- a/internal/oidcverify/verifier_test.go
+++ b/internal/oidcverify/verifier_test.go
@@ -141,7 +141,7 @@ func testPolicy(issuer, audience string) *config.CompiledPolicy {
 		OIDCAudience:            audience,
 		Profiles:                map[string]*config.CompiledProfile{"ci": profile},
 		OIDCEnrollments:         []*config.CompiledOIDCEnrollment{enr},
-		OIDCEnrollmentsByIssuer: map[string][]*config.CompiledOIDCEnrollment{issuer: []*config.CompiledOIDCEnrollment{enr}},
+		OIDCEnrollmentsByIssuer: map[string][]*config.CompiledOIDCEnrollment{issuer: {enr}},
 	}
 }
 
@@ -163,10 +163,10 @@ func newTestIssuer(t *testing.T) *testIssuer {
 	ts := httptest.NewTLSServer(mux)
 	iss.URL = ts.URL
 	iss.ts = ts
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(t, w, map[string]any{"issuer": iss.URL, "jwks_uri": iss.URL + "/keys", "id_token_signing_alg_values_supported": []string{"RS256"}})
 	})
-	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(t, w, map[string]any{"keys": []any{rsaJWK(&key.PublicKey, iss.kid)}})
 	})
 	t.Cleanup(ts.Close)

--- a/internal/oidcverify/verifier_test.go
+++ b/internal/oidcverify/verifier_test.go
@@ -1,0 +1,229 @@
+package oidcverify_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/oidcverify"
+)
+
+func TestVerifierAcceptsValidGitHubLikeJWT(t *testing.T) {
+	issuer := newTestIssuer(t)
+	policy := testPolicy(issuer.URL, "https://gateway.example.com")
+	verifier := oidcverify.New(oidcverify.Options{HTTPClient: issuer.Client(), Now: fixedNow})
+
+	got, err := verifier.Verify(context.Background(), policy, issuer.Sign(t, map[string]any{
+		"iss":           issuer.URL,
+		"sub":           "repo:denoland/clawpatrol:ref:refs/heads/main",
+		"aud":           "https://gateway.example.com",
+		"exp":           fixedNow().Add(10 * time.Minute).Unix(),
+		"nbf":           fixedNow().Add(-time.Minute).Unix(),
+		"iat":           fixedNow().Add(-time.Minute).Unix(),
+		"jti":           "run-123",
+		"repository_id": "123456",
+		"workflow_ref":  "denoland/clawpatrol/.github/workflows/ci.yml@refs/heads/main",
+	}))
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if got.Issuer != issuer.URL || got.Subject != "repo:denoland/clawpatrol:ref:refs/heads/main" {
+		t.Fatalf("issuer/subject = %q/%q", got.Issuer, got.Subject)
+	}
+	if !got.Expiry.Equal(fixedNow().Add(10 * time.Minute)) {
+		t.Fatalf("expiry = %v", got.Expiry)
+	}
+	if got.ReplayKey == "" || got.TokenHash == "" {
+		t.Fatalf("missing replay key/hash: %+v", got)
+	}
+	if got.Claims.Issuer != issuer.URL || len(got.Claims.Audience) != 1 || got.Claims.Audience[0] != "https://gateway.example.com" {
+		t.Fatalf("claim request = %+v", got.Claims)
+	}
+	if got.Claims.Claims["repository_id"] != "123456" {
+		t.Fatalf("repository_id claim = %#v", got.Claims.Claims["repository_id"])
+	}
+}
+
+func TestVerifierRejectsWrongIssuerAudienceAndAlgNone(t *testing.T) {
+	issuer := newTestIssuer(t)
+	policy := testPolicy(issuer.URL, "https://gateway.example.com")
+	verifier := oidcverify.New(oidcverify.Options{HTTPClient: issuer.Client(), Now: fixedNow})
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{
+			name: "wrong issuer",
+			token: issuer.Sign(t, map[string]any{
+				"iss": "https://evil.example.com", "sub": "s", "aud": "https://gateway.example.com", "exp": fixedNow().Add(time.Minute).Unix(),
+			}),
+		},
+		{
+			name: "wrong audience",
+			token: issuer.Sign(t, map[string]any{
+				"iss": issuer.URL, "sub": "s", "aud": "https://other.example.com", "exp": fixedNow().Add(time.Minute).Unix(),
+			}),
+		},
+		{
+			name: "alg none",
+			token: unsignedJWT(t, map[string]any{
+				"iss": issuer.URL, "sub": "s", "aud": "https://gateway.example.com", "exp": fixedNow().Add(time.Minute).Unix(),
+			}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := verifier.Verify(context.Background(), policy, tc.token); err == nil {
+				t.Fatal("expected verification error")
+			}
+		})
+	}
+}
+
+func TestVerifierRequiresAuthorizedPartyForMultiAudience(t *testing.T) {
+	issuer := newTestIssuer(t)
+	policy := testPolicy(issuer.URL, "https://gateway.example.com")
+	verifier := oidcverify.New(oidcverify.Options{HTTPClient: issuer.Client(), Now: fixedNow})
+
+	withoutAZP := issuer.Sign(t, map[string]any{
+		"iss": issuer.URL, "sub": "s", "aud": []string{"https://gateway.example.com", "https://other.example.com"}, "exp": fixedNow().Add(time.Minute).Unix(),
+	})
+	if _, err := verifier.Verify(context.Background(), policy, withoutAZP); err == nil {
+		t.Fatal("expected multi-audience token without azp to fail")
+	}
+	withAZP := issuer.Sign(t, map[string]any{
+		"iss": issuer.URL, "sub": "s", "aud": []string{"https://gateway.example.com", "https://other.example.com"}, "azp": "https://gateway.example.com", "exp": fixedNow().Add(time.Minute).Unix(),
+	})
+	if _, err := verifier.Verify(context.Background(), policy, withAZP); err != nil {
+		t.Fatalf("verify with azp: %v", err)
+	}
+}
+
+func TestVerifierRejectsExpiredFutureAndOversizedTokens(t *testing.T) {
+	issuer := newTestIssuer(t)
+	policy := testPolicy(issuer.URL, "https://gateway.example.com")
+	verifier := oidcverify.New(oidcverify.Options{HTTPClient: issuer.Client(), Now: fixedNow, MaxTokenBytes: 256})
+
+	for name, claims := range map[string]map[string]any{
+		"expired":    {"iss": issuer.URL, "sub": "s", "aud": "https://gateway.example.com", "exp": fixedNow().Add(-time.Minute).Unix()},
+		"future nbf": {"iss": issuer.URL, "sub": "s", "aud": "https://gateway.example.com", "exp": fixedNow().Add(time.Hour).Unix(), "nbf": fixedNow().Add(time.Hour).Unix()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := verifier.Verify(context.Background(), policy, issuer.Sign(t, claims)); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+	if _, err := verifier.Verify(context.Background(), policy, issuer.Sign(t, map[string]any{
+		"iss": issuer.URL, "sub": "s", "aud": "https://gateway.example.com", "exp": fixedNow().Add(time.Hour).Unix(), "padding": string(make([]byte, 1024)),
+	})); err == nil {
+		t.Fatal("expected oversized token error")
+	}
+}
+
+func fixedNow() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
+
+func testPolicy(issuer, audience string) *config.CompiledPolicy {
+	profile := &config.CompiledProfile{Name: "ci", AllowEphemeralOIDC: true}
+	enr := &config.CompiledOIDCEnrollment{Name: "gha", Issuer: issuer, Profile: profile, Match: map[string]any{"repository_id": "123456"}}
+	return &config.CompiledPolicy{
+		OIDCAudience:            audience,
+		Profiles:                map[string]*config.CompiledProfile{"ci": profile},
+		OIDCEnrollments:         []*config.CompiledOIDCEnrollment{enr},
+		OIDCEnrollmentsByIssuer: map[string][]*config.CompiledOIDCEnrollment{issuer: []*config.CompiledOIDCEnrollment{enr}},
+	}
+}
+
+type testIssuer struct {
+	URL string
+	key *rsa.PrivateKey
+	kid string
+	ts  *httptest.Server
+}
+
+func newTestIssuer(t *testing.T) *testIssuer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss := &testIssuer{key: key, kid: "test-key"}
+	mux := http.NewServeMux()
+	ts := httptest.NewTLSServer(mux)
+	iss.URL = ts.URL
+	iss.ts = ts
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{"issuer": iss.URL, "jwks_uri": iss.URL + "/keys", "id_token_signing_alg_values_supported": []string{"RS256"}})
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{"keys": []any{rsaJWK(&key.PublicKey, iss.kid)}})
+	})
+	t.Cleanup(ts.Close)
+	return iss
+}
+
+func (i *testIssuer) Client() *http.Client {
+	return i.ts.Client()
+}
+
+func (i *testIssuer) Sign(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	return signedJWT(t, i.key, i.kid, claims)
+}
+
+func signedJWT(t *testing.T, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	t.Helper()
+	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": kid}
+	payload := encodeJSON(t, claims)
+	signingInput := encodeJSON(t, header) + "." + payload
+	h := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, h[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func unsignedJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	return encodeJSON(t, map[string]any{"alg": "none", "typ": "JWT"}) + "." + encodeJSON(t, claims) + "."
+}
+
+func encodeJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func rsaJWK(pub *rsa.PublicKey, kid string) map[string]any {
+	return map[string]any{
+		"kty": "RSA",
+		"use": "sig",
+		"kid": kid,
+		"alg": "RS256",
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `enrollment "oidc"` config grammar and compile/runtime matching for claim-constrained ephemeral profiles
- add OIDC ID token verification with issuer discovery, audience checks, expiry handling, and replay rejection
- add an OIDC ephemeral lease store plus `POST /api/onboard/oidc` for unattended GitHub Actions-style enrollment
- add `clawpatrol join --ephemeral --oidc-token-file` flags for the CLI entry point

## Testing
- `git diff --check origin/main...HEAD`
- `gofmt -l .`
- `go test ./internal/config ./internal/config/runtime ./internal/oidcverify ./cmd/clawpatrol` with `TMPDIR=/var/tmp/clawpatrol-go-test`
- `cd dashboard && deno task format:check`
- `cd dashboard && deno task build`

## Notes
- this is the OIDC ephemeral enrollment foundation; the CLI currently exposes the join flags but the end-to-end runner UX may still need follow-up hardening
- OIDC enrollment uses the gateway `public_url` as the expected audience and requires target profiles to opt in with `allow_ephemeral_oidc = true`
