### PR TITLE
oauth: add remote MCP credential flow

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -649,7 +649,7 @@ func (g *Gateway) reloadConfigFromFileLocked(path string) error {
 		return err
 	}
 	g.policy.Store(policy)
-	registerOAuthCredentials(g.oauth, policy)
+	registerOAuthCredentials(g.oauth, policy, g.blobs)
 	g.connIdx.Store(runtime.BuildConnIndex(policy))
 	if g.tunnels != nil {
 		g.tunnels.SetPolicy(context.Background(), policy)
@@ -3454,7 +3454,7 @@ func runGateway(args []string) {
 	g.hitl.asyncGrantResolver = g.resolveAsyncHITLGrant
 	g.hitl.pendingMessageUpdater = g.updatePendingHITLMessage
 	g.tunnels = NewTunnelManager(g.secrets, stateDir)
-	registerOAuthCredentials(oauthReg, policy)
+	registerOAuthCredentials(oauthReg, policy, blobs)
 	g.policy.Store(policy)
 	g.connIdx.Store(runtime.BuildConnIndex(policy))
 	g.tunnels.SetPolicy(context.Background(), policy)

--- a/cmd/clawpatrol/oauth.go
+++ b/cmd/clawpatrol/oauth.go
@@ -62,8 +62,16 @@ type oauthState struct {
 	// works across gateway restarts.
 	clientID string
 	flow     string
-	db       *sql.DB
-	mu       sync.Mutex
+	// resource is the RFC 8707 resource indicator (the canonical MCP
+	// resource URL) sent on token refresh for remote_mcp_oauth
+	// credentials. Empty for every other flow.
+	resource string
+	// httpClient, when set, is used by hosted-MCP refresh sources so
+	// remote_mcp_oauth can enforce its no-redirect policy while keeping
+	// existing notion_mcp/dynamic_mcp behavior unchanged.
+	httpClient *http.Client
+	db         *sql.DB
+	mu         sync.Mutex
 }
 
 // OAuthRegistry holds all configured OAuth integrations and one token
@@ -169,6 +177,34 @@ func (r *OAuthRegistry) Register(id string, def OAuthIntegration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.integrations[id] = &def
+	if def.Flow == "remote_mcp_oauth" && def.OAuth.TokenURL == "" {
+		// The current policy binding has no matching persisted discovery
+		// metadata. Clear any live state from a previous binding so reloads
+		// fail closed and require a fresh Connect.
+		delete(r.states, id)
+	}
+}
+
+// SetDiscoveredEndpoints stamps the authorize/token URLs + RFC 8707
+// resource indicator discovered for a remote_mcp_oauth credential onto
+// the in-memory integration (and any live token state). Called right
+// before the token exchange so refresh works immediately after the first
+// connect — without it, the integration registered at boot (before the
+// discovery blob existed) carries an empty token URL and refresh fails
+// until the next restart rehydrates it from gateway_blobs.
+func (r *OAuthRegistry) SetDiscoveredEndpoints(id, authURL, tokenURL, resource string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if it, ok := r.integrations[id]; ok {
+		it.OAuth.AuthURL = authURL
+		it.OAuth.TokenURL = tokenURL
+		it.OAuth.ResourceURL = resource
+	}
+	if s := r.states[id]; s != nil {
+		s.cfg.Endpoint.AuthURL = authURL
+		s.cfg.Endpoint.TokenURL = tokenURL
+		s.resource = resource
+	}
 }
 
 // Status returns connected info for the named credential.
@@ -255,6 +291,92 @@ func (r *OAuthRegistry) SetWithClient(ctx context.Context, id string, tok *oauth
 	return nil
 }
 
+// SetRemoteMCPWithClient atomically installs both the newly discovered
+// remote_mcp_oauth endpoints/resource and the freshly exchanged token.
+// Do not call SetDiscoveredEndpoints before exchange: mutating a live
+// refresh source while it still holds an old refresh token can leak that
+// old token to the new endpoint during a concurrent refresh.
+func (r *OAuthRegistry) SetRemoteMCPWithClient(ctx context.Context, id string, tok *oauth2.Token, clientID, authURL, tokenURL, resource string, meta *remoteMCPMeta) error {
+	r.mu.Lock()
+	it, ok := r.integrations[id]
+	if !ok {
+		r.mu.Unlock()
+		return fmt.Errorf("oauth registry: unknown integration: %s", id)
+	}
+	old := r.states[id]
+	s := newState(it, r.db)
+	if old != nil {
+		s.displayName = old.displayName
+		s.avatarURL = old.avatarURL
+	}
+	if r.db != nil && meta != nil {
+		if err := persistRemoteMCPTokenAndMeta(ctx, r.db, id, tok, clientID, *meta); err != nil {
+			r.mu.Unlock()
+			return err
+		}
+	} else {
+		s.persist(tok)
+	}
+	s.cfg.Endpoint.AuthURL = authURL
+	s.cfg.Endpoint.TokenURL = tokenURL
+	s.resource = resource
+	s.httpClient = noRedirectOAuthHTTPClient(http.DefaultClient)
+	if clientID != "" {
+		s.clientID = clientID
+		s.cfg.ClientID = clientID
+	}
+	s.installTokenSource(tok)
+	r.states[id] = s
+	r.mu.Unlock()
+
+	name, avatar := fetchOAuthProfile(ctx, id, tok.AccessToken)
+	if name != "" || avatar != "" {
+		s.persistProfile(name, avatar)
+	}
+	return nil
+}
+
+func persistRemoteMCPTokenAndMeta(ctx context.Context, db *sql.DB, id string, tok *oauth2.Token, clientID string, meta remoteMCPMeta) error {
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("remote_mcp_oauth: encode metadata: %w", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("remote_mcp_oauth: begin token/meta transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var expiryNs int64
+	if !tok.Expiry.IsZero() {
+		expiryNs = tok.Expiry.UnixNano()
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns, client_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			access_token  = excluded.access_token,
+			token_type    = excluded.token_type,
+			refresh_token = excluded.refresh_token,
+			expiry_ns     = excluded.expiry_ns,
+			updated_ns    = excluded.updated_ns,
+			client_id     = excluded.client_id
+	`, id, tok.AccessToken, tok.TokenType, tok.RefreshToken, expiryNs, time.Now().UnixNano(), nullableString(clientID)); err != nil {
+		return fmt.Errorf("remote_mcp_oauth: persist token: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO gateway_blobs (kind, name, value, updated_ns)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(kind, name) DO UPDATE SET
+			value = excluded.value, updated_ns = excluded.updated_ns
+	`, remoteMCPMetaBlobKind, id, metaBytes, time.Now().UnixNano()); err != nil {
+		return fmt.Errorf("remote_mcp_oauth: persist metadata: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("remote_mcp_oauth: commit token/meta transaction: %w", err)
+	}
+	return nil
+}
+
 // OAuthProfile holds the human-identity bits we surface on the
 // dashboard (real name + avatar). Populated after a successful token
 // exchange by hitting the provider's userinfo endpoint.
@@ -331,17 +453,27 @@ func newState(it *OAuthIntegration, db *sql.DB) *oauthState {
 	if prefix == "" && header == "Authorization" {
 		prefix = "Bearer "
 	}
-	return &oauthState{
-		cfg:    cfg,
-		header: header,
-		prefix: prefix,
-		id:     it.ID,
-		flow:   it.Flow,
-		db:     db,
+	state := &oauthState{
+		cfg:      cfg,
+		header:   header,
+		prefix:   prefix,
+		id:       it.ID,
+		flow:     it.Flow,
+		resource: it.OAuth.ResourceURL,
+		db:       db,
 	}
+	if it.Flow == "remote_mcp_oauth" {
+		state.httpClient = noRedirectOAuthHTTPClient(http.DefaultClient)
+	}
+	return state
 }
 
 func (s *oauthState) setToken(tok *oauth2.Token) {
+	s.installTokenSource(tok)
+	s.persist(tok)
+}
+
+func (s *oauthState) installTokenSource(tok *oauth2.Token) {
 	var base oauth2.TokenSource
 	switch {
 	case isAnthropicTokenURL(s.cfg.Endpoint.TokenURL):
@@ -349,13 +481,17 @@ func (s *oauthState) setToken(tok *oauth2.Token) {
 		// (returns "Invalid request format" otherwise). Stdlib oauth2
 		// only sends form-urlencoded.
 		base = &anthropicRefreshSource{cfg: s.cfg, current: tok}
-	case s.flow == "dynamic_mcp" || s.flow == "notion_mcp":
+	case s.flow == "dynamic_mcp" || s.flow == "notion_mcp" || s.flow == "remote_mcp_oauth":
 		// Hosted MCP token endpoints refresh via form-urlencoded body and
 		// expect the dynamically registered client_id (no static
 		// ClientSecret — PKCE-only public client). The flow, not the
 		// provider hostname, selects this behavior so external credential
-		// plugins can supply their own MCP OAuth endpoints.
-		base = &dynamicMCPRefreshSource{cfg: s.cfg, current: tok}
+		// plugins can supply their own MCP OAuth endpoints. remote_mcp_oauth
+		// additionally carries the RFC 8707 resource indicator and refreshes
+		// against the token endpoint discovered + persisted at connect time,
+		// so a later compromise of the resource server cannot substitute the
+		// token endpoint here.
+		base = &dynamicMCPRefreshSource{cfg: s.cfg, current: tok, resource: s.resource, httpClient: s.httpClient}
 	default:
 		base = s.cfg.TokenSource(context.Background(), tok)
 	}
@@ -364,7 +500,6 @@ func (s *oauthState) setToken(tok *oauth2.Token) {
 		&persistingSource{base: base, state: s},
 		60*time.Second,
 	)
-	s.persist(tok)
 }
 
 // anthropicRefreshSource refreshes Anthropic OAuth tokens via JSON
@@ -537,6 +672,12 @@ func (r *OAuthRegistry) loadFromDB() error {
 		if !ok {
 			continue
 		}
+		if it.Flow == "remote_mcp_oauth" && it.OAuth.TokenURL == "" {
+			// No validated metadata matched the currently bound remote_mcp
+			// endpoint at boot. Do not attach a previously stored token to a
+			// potentially different resource; require a fresh Connect.
+			continue
+		}
 		s := newState(it, r.db)
 		// Restore the dynamically-registered client_id BEFORE setToken
 		// so dynamic MCP refresh sources pick it up via s.cfg.
@@ -574,6 +715,18 @@ type oauthSession struct {
 	// Stamped onto the credential row at exchange time so refresh can
 	// replay it.
 	dynClientID string
+	// resource is the RFC 8707 resource indicator (the canonical MCP
+	// resource URL) for remote_mcp_oauth sessions, sent on the token
+	// exchange. Empty for every other flow.
+	resource string
+	// httpClient is set for remote_mcp_oauth so oauth2.Exchange cannot
+	// follow redirects while posting code/verifier/client metadata.
+	httpClient *http.Client
+	// remoteMCPMeta carries pending non-secret discovery/DCR metadata for
+	// remote_mcp_oauth. It is persisted only after token exchange succeeds,
+	// so a failed/abandoned reconnect cannot poison refresh for an existing
+	// stored credential.
+	remoteMCPMeta *remoteMCPMeta
 }
 
 // mergeExtraScopes appends user-selected scopes from the connect-time
@@ -649,6 +802,10 @@ func (w *webMux) apiOAuthStart(rw http.ResponseWriter, r *http.Request) {
 	}
 	if flow.Flow == "openai_device" {
 		w.startOpenAIDeviceFlow(rw, r, id, flow)
+		return
+	}
+	if flow.Flow == "remote_mcp_oauth" {
+		w.startRemoteMCPOAuthFlow(rw, r, id, flow)
 		return
 	}
 	if flow.Flow == "notion_mcp" || flow.Flow == "dynamic_mcp" {
@@ -754,6 +911,16 @@ func (w *webMux) dashboardRedirectURI(r *http.Request, path string) string {
 // against `registerURL`, asking for a public PKCE client bound to the
 // given redirect URI. Returns the issued client_id.
 func registerOAuthClient(ctx context.Context, registerURL, redirectURI string, scopes []string) (string, error) {
+	return registerOAuthClientClient(ctx, http.DefaultClient, registerURL, redirectURI, scopes)
+}
+
+// registerOAuthClientClient is registerOAuthClient with an explicit HTTP
+// client, so remote_mcp_oauth discovery/DCR can run against a test TLS
+// server whose self-signed cert the default client would reject.
+func registerOAuthClientClient(ctx context.Context, client *http.Client, registerURL, redirectURI string, scopes []string) (string, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	bodyMap := map[string]any{
 		"client_name":                "clawpatrol",
 		"redirect_uris":              []string{redirectURI},
@@ -771,7 +938,7 @@ func registerOAuthClient(ctx context.Context, registerURL, redirectURI string, s
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -891,6 +1058,14 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	it := w.g.oauth.Integration(sess.id)
+	if it != nil && it.Flow == "remote_mcp_oauth" {
+		if it.OAuth.ResourceURL == "" || !sameResource(sess.resource, it.OAuth.ResourceURL) {
+			http.Error(rw, "stale remote_mcp_oauth session for current resource binding", http.StatusBadRequest)
+			return
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	tok, err := exchangeOAuthCode(ctx, sess, body.Code, body.State)
@@ -898,9 +1073,19 @@ func (w *webMux) apiOAuthExchange(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "token exchange: "+err.Error(), 400)
 		return
 	}
-	if err := w.g.oauth.SetWithClient(r.Context(), sess.id, tok, sess.dynClientID); err != nil {
-		http.Error(rw, err.Error(), 500)
-		return
+	// remote_mcp_oauth discovers its token endpoint at connect time; stamp
+	// it onto the registry so the freshly-stored token can refresh against
+	// the validated endpoint without waiting for a restart.
+	if it != nil && it.Flow == "remote_mcp_oauth" {
+		if err := w.g.oauth.SetRemoteMCPWithClient(r.Context(), sess.id, tok, sess.dynClientID, sess.cfg.Endpoint.AuthURL, sess.cfg.Endpoint.TokenURL, sess.resource, sess.remoteMCPMeta); err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+	} else {
+		if err := w.g.oauth.SetWithClient(r.Context(), sess.id, tok, sess.dynClientID); err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
 	}
 	writeJSON(rw, map[string]any{"connected": true, "expires": tok.Expiry.Unix()})
 }
@@ -1228,10 +1413,19 @@ func exchangeOAuthCode(ctx context.Context, sess *oauthSession, code, state stri
 	if isAnthropicTokenURL(sess.cfg.Endpoint.TokenURL) {
 		return exchangeAnthropicCode(ctx, sess, code, state)
 	}
-	return sess.cfg.Exchange(ctx, code,
+	opts := []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("code_verifier", sess.verifier),
 		oauth2.SetAuthURLParam("redirect_uri", sess.cfg.RedirectURL),
-	)
+	}
+	// RFC 8707: bind the issued token to the MCP resource for
+	// remote_mcp_oauth. Empty for every other flow.
+	if sess.resource != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("resource", sess.resource))
+	}
+	if sess.httpClient != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, sess.httpClient)
+	}
+	return sess.cfg.Exchange(ctx, code, opts...)
 }
 
 func isAnthropicTokenURL(u string) bool {
@@ -1247,6 +1441,13 @@ type dynamicMCPRefreshSource struct {
 	mu      sync.Mutex
 	cfg     *oauth2.Config
 	current *oauth2.Token
+	// httpClient uses the remote_mcp_oauth redirect policy when set. Nil
+	// preserves existing notion_mcp/dynamic_mcp refresh behavior.
+	httpClient *http.Client
+	// resource, when set, is sent as the RFC 8707 resource indicator on
+	// the refresh request (remote_mcp_oauth). Empty for notion_mcp /
+	// dynamic_mcp, which omit it.
+	resource string
 }
 
 func (d *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
@@ -1265,6 +1466,9 @@ func (d *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", d.current.RefreshToken)
 	form.Set("client_id", d.cfg.ClientID)
+	if d.resource != "" {
+		form.Set("resource", d.resource)
+	}
 	// See anthropicRefreshSource.Token: oauth2 has no ctx on Token(),
 	// so we bound the upstream round-trip here so d.mu stays available
 	// even if the MCP token endpoint hangs.
@@ -1276,7 +1480,11 @@ func (d *dynamicMCPRefreshSource) Token() (*oauth2.Token, error) {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	client := d.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic_mcp refresh: %w", err)
 	}

--- a/cmd/clawpatrol/oauth_remote_mcp.go
+++ b/cmd/clawpatrol/oauth_remote_mcp.go
@@ -1,0 +1,483 @@
+package main
+
+// Generic, strict OAuth for remote MCP servers (Flow="remote_mcp_oauth").
+//
+// Unlike notion_mcp / dynamic_mcp — which hard-code a provider's
+// authorize/token/register URLs — this flow discovers everything from
+// the bound remote_mcp endpoint's resource URL at connect time:
+//
+//  1. RFC 9728 Protected Resource Metadata  → the authorization server(s)
+//  2. RFC 8414 Authorization Server Metadata → authorize/token/register
+//  3. RFC 7591 dynamic client registration   → a PKCE public client_id
+//  4. RFC 7636 PKCE + RFC 8707 resource       → the authorization URL
+//
+// Strictness (no provider_compat shims in this release):
+//   - exactly one authorization server may be advertised (no ambiguity),
+//   - the AS metadata `issuer` must match the advertised issuer exactly,
+//   - the authorize/token/registration endpoints must live on the
+//     issuer's own origin — an AS document cannot point the token
+//     endpoint at a foreign host (endpoint-substitution guard).
+//
+// The discovered, non-secret metadata (issuer + endpoints + resource +
+// client_id) is persisted in gateway_blobs so refresh after a restart
+// uses the same validated token endpoint without re-running discovery
+// against a resource server that may since have been tampered with.
+// Tokens are never written here — they flow through OAuthRegistry and
+// the credentials table like every other OAuth credential.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// remoteMCPMetaBlobKind is the gateway_blobs namespace for persisted
+// remote_mcp_oauth discovery + DCR metadata. Rows are keyed by the
+// credential's bare name.
+const remoteMCPMetaBlobKind = "remote_mcp_oauth_meta"
+
+// remoteMCPMeta is the non-secret discovery + registration result we
+// persist per credential. No token material is ever stored here.
+type remoteMCPMeta struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RegistrationEndpoint  string   `json:"registration_endpoint,omitempty"`
+	Resource              string   `json:"resource"`
+	ClientID              string   `json:"client_id,omitempty"`
+	RedirectURI           string   `json:"redirect_uri,omitempty"`
+	Scopes                []string `json:"scopes,omitempty"`
+}
+
+// protectedResourceMetadata is the RFC 9728 document subset we read.
+type protectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+}
+
+// authServerMetadata is the RFC 8414 / OIDC discovery subset we read.
+type authServerMetadata struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	RegistrationEndpoint  string `json:"registration_endpoint"`
+}
+
+// oauthHTTPClient returns the base HTTP client used for OAuth discovery
+// and dynamic client registration. Tests set w.httpClient to an
+// httptest TLS server's client (which trusts the test cert); production
+// uses the shared default client.
+func (w *webMux) oauthHTTPClient() *http.Client {
+	if w != nil && w.httpClient != nil {
+		return w.httpClient
+	}
+	return http.DefaultClient
+}
+
+// noRedirectOAuthHTTPClient clones base and disables redirect following.
+// remote_mcp_oauth validates discovered endpoints before use; following a
+// provider-controlled redirect would bypass that validation and can leak
+// authorization codes, PKCE verifiers, DCR payloads, refresh tokens, or
+// enable SSRF. Returning http.ErrUseLastResponse makes callers see the
+// 3xx response as a normal non-OK/non-2xx failure without replaying the
+// request to the Location target.
+func noRedirectOAuthHTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	clone := *base
+	clone.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &clone
+}
+
+// startRemoteMCPOAuthFlow drives the strict generic remote MCP OAuth
+// flow: discover, (re)register a client, persist metadata, and return a
+// PKCE authorization URL carrying the resource indicator. The token
+// exchange reuses the shared apiOAuthExchange path (the session carries
+// the discovered token endpoint, client_id, and resource).
+func (w *webMux) startRemoteMCPOAuthFlow(rw http.ResponseWriter, r *http.Request, id string, flow *OAuthIntegration) {
+	resourceURL := strings.TrimSpace(flow.OAuth.ResourceURL)
+	if resourceURL == "" {
+		http.Error(rw, "remote_mcp_oauth: no resource url — bind a remote_mcp endpoint (endpoint = remote_mcp.<name>) or set resource_url", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), oauthUpstreamTimeout)
+	defer cancel()
+
+	client := noRedirectOAuthHTTPClient(w.oauthHTTPClient())
+	meta, err := discoverRemoteMCPMeta(ctx, client, resourceURL, flow.OAuth.Scopes)
+	if err != nil {
+		http.Error(rw, "remote_mcp_oauth discovery: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	// Reuse a previously registered client_id only when the discovered
+	// authorization server is unchanged — if the resource server now
+	// points at a different issuer or token endpoint, re-register so a
+	// rotated/hijacked AS cannot ride a stale client registration.
+	clientID := ""
+	redirectURI := w.dashboardRedirectURI(r, "/oauth/callback")
+	if prior, ok := loadRemoteMCPMeta(w.g.blobs, id); ok &&
+		prior.ClientID != "" &&
+		issuerEqual(prior.Issuer, meta.Issuer) &&
+		prior.TokenEndpoint == meta.TokenEndpoint &&
+		prior.RedirectURI == redirectURI &&
+		stringSlicesEqual(prior.Scopes, flow.OAuth.Scopes) {
+		clientID = prior.ClientID
+	}
+	if clientID == "" {
+		if meta.RegistrationEndpoint == "" {
+			http.Error(rw, "remote_mcp_oauth: provider requires a client_id but advertises no registration_endpoint", http.StatusBadGateway)
+			return
+		}
+		clientID, err = registerOAuthClientClient(ctx, client, meta.RegistrationEndpoint, redirectURI, flow.OAuth.Scopes)
+		if err != nil {
+			http.Error(rw, "remote_mcp_oauth dynamic client registration: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+	}
+	meta.ClientID = clientID
+	meta.RedirectURI = redirectURI
+
+	verifier := randomString(64)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	state := randomString(32)
+	cfg := &oauth2.Config{
+		ClientID:    clientID,
+		Scopes:      flow.OAuth.Scopes,
+		RedirectURL: redirectURI,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   meta.AuthorizationEndpoint,
+			TokenURL:  meta.TokenEndpoint,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+	authURL := cfg.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("code_challenge", challenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		oauth2.SetAuthURLParam("resource", meta.Resource),
+	)
+
+	w.mu.Lock()
+	w.sessions[state] = &oauthSession{
+		verifier:    verifier,
+		state:       state,
+		cfg:         cfg,
+		id:          id,
+		created:     time.Now(),
+		dynClientID: clientID,
+		resource:    meta.Resource,
+		httpClient:  client,
+		remoteMCPMeta: &remoteMCPMeta{
+			Issuer:                meta.Issuer,
+			AuthorizationEndpoint: meta.AuthorizationEndpoint,
+			TokenEndpoint:         meta.TokenEndpoint,
+			RegistrationEndpoint:  meta.RegistrationEndpoint,
+			Resource:              meta.Resource,
+			ClientID:              meta.ClientID,
+			RedirectURI:           meta.RedirectURI,
+			Scopes:                append([]string(nil), meta.Scopes...),
+		},
+	}
+	for k, s := range w.sessions {
+		if time.Since(s.created) > 10*time.Minute {
+			delete(w.sessions, k)
+		}
+	}
+	w.mu.Unlock()
+	writeJSON(rw, map[string]string{"auth_url": authURL, "state": state})
+}
+
+// discoverRemoteMCPMeta runs strict RFC 9728 → RFC 8414 discovery from a
+// resource URL and returns the validated, non-secret metadata (without a
+// client_id). Every deviation from the specs is a hard error.
+func discoverRemoteMCPMeta(ctx context.Context, client *http.Client, resourceURL string, scopes []string) (remoteMCPMeta, error) {
+	var meta remoteMCPMeta
+	ru, err := url.Parse(strings.TrimSpace(resourceURL))
+	if err != nil || ru.Scheme != "https" || ru.Host == "" {
+		return meta, fmt.Errorf("resource url %q must be an absolute https url", resourceURL)
+	}
+
+	prm, err := fetchProtectedResourceMetadata(ctx, client, ru)
+	if err != nil {
+		return meta, err
+	}
+	switch len(prm.AuthorizationServers) {
+	case 1:
+	case 0:
+		return meta, fmt.Errorf("protected resource metadata advertises no authorization_servers")
+	default:
+		return meta, fmt.Errorf("protected resource metadata advertises %d authorization servers; strict mode requires exactly one", len(prm.AuthorizationServers))
+	}
+	issuer := strings.TrimSpace(prm.AuthorizationServers[0])
+	if issuer == "" {
+		return meta, fmt.Errorf("protected resource metadata authorization_servers[0] is empty")
+	}
+
+	// Canonical resource for the RFC 8707 indicator: the metadata's own
+	// `resource` value when present (it is authoritative), else the
+	// configured URL. A declared resource must match the configured
+	// resource exactly enough that path/query tenant boundaries cannot be
+	// crossed by a malicious resource server.
+	resource := strings.TrimSpace(prm.Resource)
+	if resource == "" {
+		resource = canonicalResourceURL(ru)
+	} else if !sameResource(resource, resourceURL) {
+		return meta, fmt.Errorf("protected resource metadata resource %q does not match the configured resource %q", resource, resourceURL)
+	}
+
+	asm, err := fetchAuthServerMetadata(ctx, client, issuer)
+	if err != nil {
+		return meta, err
+	}
+	if !issuerEqual(asm.Issuer, issuer) {
+		return meta, fmt.Errorf("authorization server issuer mismatch: metadata issuer %q != advertised issuer %q", asm.Issuer, issuer)
+	}
+	if asm.AuthorizationEndpoint == "" || asm.TokenEndpoint == "" {
+		return meta, fmt.Errorf("authorization server metadata is missing authorization_endpoint or token_endpoint")
+	}
+	// Endpoint-substitution guard: every endpoint must be https and on
+	// the issuer's own origin. This is what blocks an AS document from
+	// redirecting the token endpoint (and thus the refresh token) to an
+	// attacker-controlled host.
+	for _, ep := range []struct{ name, val string }{
+		{"authorization_endpoint", asm.AuthorizationEndpoint},
+		{"token_endpoint", asm.TokenEndpoint},
+	} {
+		if err := requireIssuerOrigin(ep.name, ep.val, issuer); err != nil {
+			return meta, err
+		}
+	}
+	if asm.RegistrationEndpoint != "" {
+		if err := requireIssuerOrigin("registration_endpoint", asm.RegistrationEndpoint, issuer); err != nil {
+			return meta, err
+		}
+	}
+
+	return remoteMCPMeta{
+		Issuer:                strings.TrimRight(issuer, "/"),
+		AuthorizationEndpoint: asm.AuthorizationEndpoint,
+		TokenEndpoint:         asm.TokenEndpoint,
+		RegistrationEndpoint:  asm.RegistrationEndpoint,
+		Resource:              resource,
+		Scopes:                append([]string(nil), scopes...),
+	}, nil
+}
+
+// fetchProtectedResourceMetadata fetches the RFC 9728 document. The
+// well-known path is constructed by inserting the well-known suffix
+// between host and path; the path-less form is tried as a fallback for
+// servers that serve metadata at the host root.
+func fetchProtectedResourceMetadata(ctx context.Context, client *http.Client, ru *url.URL) (protectedResourceMetadata, error) {
+	base := ru.Scheme + "://" + ru.Host
+	var candidates []string
+	if p := strings.Trim(ru.Path, "/"); p != "" {
+		candidates = append(candidates, base+"/.well-known/oauth-protected-resource/"+p)
+	}
+	candidates = append(candidates, base+"/.well-known/oauth-protected-resource")
+
+	var lastErr error
+	for _, c := range candidates {
+		var doc protectedResourceMetadata
+		if err := getOAuthJSON(ctx, client, c, &doc); err != nil {
+			lastErr = err
+			continue
+		}
+		return doc, nil
+	}
+	return protectedResourceMetadata{}, fmt.Errorf("protected resource metadata discovery failed: %w", lastErr)
+}
+
+// fetchAuthServerMetadata fetches RFC 8414 (oauth-authorization-server)
+// then OIDC (openid-configuration) discovery documents for an issuer,
+// trying the spec's path-aware constructions in order.
+func fetchAuthServerMetadata(ctx context.Context, client *http.Client, issuer string) (authServerMetadata, error) {
+	iu, err := url.Parse(strings.TrimSpace(issuer))
+	if err != nil || iu.Scheme != "https" || iu.Host == "" {
+		return authServerMetadata{}, fmt.Errorf("authorization server issuer %q must be an absolute https url", issuer)
+	}
+	base := iu.Scheme + "://" + iu.Host
+	var candidates []string
+	if p := strings.Trim(iu.Path, "/"); p != "" {
+		candidates = append(candidates,
+			base+"/.well-known/oauth-authorization-server/"+p,
+			base+"/"+p+"/.well-known/openid-configuration",
+			base+"/.well-known/openid-configuration/"+p,
+		)
+	} else {
+		candidates = append(candidates,
+			base+"/.well-known/oauth-authorization-server",
+			base+"/.well-known/openid-configuration",
+		)
+	}
+
+	var lastErr error
+	for _, c := range candidates {
+		var doc authServerMetadata
+		if err := getOAuthJSON(ctx, client, c, &doc); err != nil {
+			lastErr = err
+			continue
+		}
+		return doc, nil
+	}
+	return authServerMetadata{}, fmt.Errorf("authorization server metadata discovery failed: %w", lastErr)
+}
+
+// getOAuthJSON GETs a small JSON document into out, bounding the body
+// size and treating any non-200 as an error.
+func getOAuthJSON(ctx context.Context, client *http.Client, urlStr string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, oauthResponseLimit))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: status %d", urlStr, resp.StatusCode)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("GET %s: decode metadata: %w", urlStr, err)
+	}
+	return nil
+}
+
+// requireIssuerOrigin rejects an endpoint that is not an https URL on
+// the issuer's exact origin (scheme + host + port).
+func requireIssuerOrigin(name, endpoint, issuer string) error {
+	u, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("%s %q must be an absolute https url", name, endpoint)
+	}
+	if !sameOrigin(endpoint, issuer) {
+		return fmt.Errorf("%s %q is not on the issuer origin %q (possible endpoint substitution)", name, endpoint, issuer)
+	}
+	return nil
+}
+
+// sameOrigin reports whether two URLs share scheme and host (incl. port),
+// case-insensitively. Path/query are ignored.
+func sameOrigin(a, b string) bool {
+	ua, err := url.Parse(strings.TrimSpace(a))
+	if err != nil {
+		return false
+	}
+	ub, err := url.Parse(strings.TrimSpace(b))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(ua.Scheme, ub.Scheme) && strings.EqualFold(ua.Host, ub.Host)
+}
+
+func sameResource(a, b string) bool {
+	ua, err := url.Parse(strings.TrimSpace(a))
+	if err != nil {
+		return false
+	}
+	ub, err := url.Parse(strings.TrimSpace(b))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(ua.Scheme, ub.Scheme) &&
+		strings.EqualFold(ua.Host, ub.Host) &&
+		ua.EscapedPath() == ub.EscapedPath() &&
+		ua.RawQuery == ub.RawQuery
+}
+
+func canonicalResourceURL(u *url.URL) string {
+	resource := u.Scheme + "://" + u.Host + u.EscapedPath()
+	if u.RawQuery != "" {
+		resource += "?" + u.RawQuery
+	}
+	return resource
+}
+
+// issuerEqual compares two issuer identifiers, tolerating a single
+// trailing slash difference (RFC 8414 issuers carry no path component
+// for most providers, but some include one).
+func issuerEqual(a, b string) bool {
+	return strings.TrimRight(strings.TrimSpace(a), "/") == strings.TrimRight(strings.TrimSpace(b), "/")
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// loadRemoteMCPMeta reads persisted discovery metadata for a credential.
+func loadRemoteMCPMeta(blobs runtime.BlobStore, id string) (remoteMCPMeta, bool) {
+	var m remoteMCPMeta
+	if blobs == nil {
+		return m, false
+	}
+	b, ok, err := blobs.Get(remoteMCPMetaBlobKind, id)
+	if err != nil || !ok {
+		return m, false
+	}
+	if json.Unmarshal(b, &m) != nil {
+		return remoteMCPMeta{}, false
+	}
+	return m, true
+}
+
+// saveRemoteMCPMeta persists non-secret discovery metadata for a
+// credential. No-op when no blob store is wired (tests without a db).
+func saveRemoteMCPMeta(blobs runtime.BlobStore, id string, m remoteMCPMeta) error {
+	if blobs == nil {
+		return nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return blobs.Put(remoteMCPMetaBlobKind, id, b)
+}
+
+// boundRemoteMCPURL returns the URL of the remote_mcp endpoint a
+// credential binds, or "" when it binds no remote_mcp endpoint. Used to
+// drive discovery from the endpoint the operator already declared,
+// without duplicating the URL on the credential.
+func boundRemoteMCPURL(policy *config.CompiledPolicy, ent *config.Entity) string {
+	if policy == nil || ent == nil {
+		return ""
+	}
+	epName := ent.Framework.Ref("endpoint")
+	if epName == "" {
+		return ""
+	}
+	ep := policy.Endpoints[epName]
+	if ep == nil {
+		return ""
+	}
+	if u, ok := ep.Body.(interface{ RemoteMCPURL() string }); ok {
+		return u.RemoteMCPURL()
+	}
+	return ""
+}

--- a/cmd/clawpatrol/oauth_remote_mcp_test.go
+++ b/cmd/clawpatrol/oauth_remote_mcp_test.go
@@ -1,0 +1,990 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// asMetadataJSON writes a minimal RFC 8414 authorization server metadata
+// document with the given endpoints.
+func asMetadataJSON(issuer, authz, token, register string) string {
+	doc := map[string]any{
+		"issuer":                 issuer,
+		"authorization_endpoint": authz,
+		"token_endpoint":         token,
+	}
+	if register != "" {
+		doc["registration_endpoint"] = register
+	}
+	b, _ := json.Marshal(doc)
+	return string(b)
+}
+
+func TestDiscoverRemoteMCPMetaHappyPath(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", srv.URL+"/register")))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	meta, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/mcp", []string{"mcp:read"})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if meta.Issuer != srv.URL {
+		t.Errorf("issuer = %q, want %q", meta.Issuer, srv.URL)
+	}
+	if meta.TokenEndpoint != srv.URL+"/token" {
+		t.Errorf("token_endpoint = %q", meta.TokenEndpoint)
+	}
+	if meta.AuthorizationEndpoint != srv.URL+"/authorize" {
+		t.Errorf("authorization_endpoint = %q", meta.AuthorizationEndpoint)
+	}
+	if meta.RegistrationEndpoint != srv.URL+"/register" {
+		t.Errorf("registration_endpoint = %q", meta.RegistrationEndpoint)
+	}
+	if meta.Resource != srv.URL+"/mcp" {
+		t.Errorf("resource = %q", meta.Resource)
+	}
+	if len(meta.Scopes) != 1 || meta.Scopes[0] != "mcp:read" {
+		t.Errorf("scopes = %#v", meta.Scopes)
+	}
+}
+
+func TestDiscoverRemoteMCPMetaRejectsMultipleAuthServers(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `","https://other.example.test"]}`))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	_, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/mcp", nil)
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("err = %v, want ambiguous-authorization-server rejection", err)
+	}
+}
+
+func TestDiscoverRemoteMCPMetaRejectsIssuerMismatch(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		// Metadata claims a different issuer than the one we discovered it from.
+		_, _ = w.Write([]byte(asMetadataJSON("https://evil.example.test", srv.URL+"/authorize", srv.URL+"/token", "")))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	_, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/mcp", nil)
+	if err == nil || !strings.Contains(err.Error(), "issuer mismatch") {
+		t.Fatalf("err = %v, want issuer mismatch rejection", err)
+	}
+}
+
+func TestDiscoverRemoteMCPMetaRejectsTokenEndpointSubstitution(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		// authorization_endpoint is on-issuer, but token_endpoint points at
+		// an attacker-controlled host — must be rejected.
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", "https://evil.example.test/token", "")))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	_, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/mcp", nil)
+	if err == nil || !strings.Contains(err.Error(), "substitution") {
+		t.Fatalf("err = %v, want token-endpoint substitution rejection", err)
+	}
+}
+
+func TestStartRemoteMCPOAuthFlow(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	blobs := newGatewayBlobStore(db)
+
+	var srv *httptest.Server
+	var registerHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", srv.URL+"/register")))
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		registerHits++
+		var body struct {
+			RedirectURIs            []string `json:"redirect_uris"`
+			TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.TokenEndpointAuthMethod != "none" {
+			failOAuthTestHandler(t, w, "token_endpoint_auth_method = %q, want none", body.TokenEndpointAuthMethod)
+			return
+		}
+		if len(body.RedirectURIs) != 1 || body.RedirectURIs[0] != "http://dash.example:8080/oauth/callback" {
+			failOAuthTestHandler(t, w, "redirect_uris = %#v", body.RedirectURIs)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"dcr-client-xyz"}`))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	g := &Gateway{blobs: blobs}
+	w := &webMux{g: g, sessions: map[string]*oauthSession{}, httpClient: srv.Client()}
+	flow := &OAuthIntegration{
+		Type:   "oauth2",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+		Flow:   "remote_mcp_oauth",
+		OAuth: OAuthConfig{
+			ResourceURL: srv.URL + "/mcp",
+			Scopes:      []string{"mcp:read"},
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "http://dash.example:8080/api/oauth/start", nil)
+	rr := httptest.NewRecorder()
+	w.startRemoteMCPOAuthFlow(rr, req, "acme-mcp", flow)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if registerHits != 1 {
+		t.Fatalf("register hits = %d, want 1", registerHits)
+	}
+	var resp struct {
+		AuthURL string `json:"auth_url"`
+		State   string `json:"state"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.State == "" {
+		t.Fatal("empty state")
+	}
+	au, err := url.Parse(resp.AuthURL)
+	if err != nil {
+		t.Fatalf("parse auth_url: %v", err)
+	}
+	q := au.Query()
+	if got := q.Get("client_id"); got != "dcr-client-xyz" {
+		t.Errorf("auth_url client_id = %q, want dcr-client-xyz", got)
+	}
+	if got := q.Get("code_challenge_method"); got != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", got)
+	}
+	if q.Get("code_challenge") == "" {
+		t.Error("auth_url missing code_challenge")
+	}
+	if got := q.Get("resource"); got != srv.URL+"/mcp" {
+		t.Errorf("auth_url resource = %q, want %q", got, srv.URL+"/mcp")
+	}
+	if got := q.Get("redirect_uri"); got != "http://dash.example:8080/oauth/callback" {
+		t.Errorf("auth_url redirect_uri = %q", got)
+	}
+
+	// Session captured with the resource indicator + dynamic client id.
+	w.mu.Lock()
+	sess := w.sessions[resp.State]
+	w.mu.Unlock()
+	if sess == nil {
+		t.Fatalf("missing session for state %q", resp.State)
+	}
+	if sess.resource != srv.URL+"/mcp" {
+		t.Errorf("session resource = %q", sess.resource)
+	}
+	if sess.dynClientID != "dcr-client-xyz" {
+		t.Errorf("session dynClientID = %q", sess.dynClientID)
+	}
+	if _, ok := loadRemoteMCPMeta(blobs, "acme-mcp"); ok {
+		t.Fatal("metadata blob persisted before successful token exchange")
+	}
+}
+
+func TestRemoteMCPOAuthExchangeSendsResource(t *testing.T) {
+	var gotResource, gotGrant, gotClient, gotVerifier string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			failOAuthTestHandler(t, w, "parse form: %v", err)
+			return
+		}
+		gotResource = r.Form.Get("resource")
+		gotGrant = r.Form.Get("grant_type")
+		gotClient = r.Form.Get("client_id")
+		gotVerifier = r.Form.Get("code_verifier")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at","refresh_token":"rt","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	sess := &oauthSession{
+		verifier: "the-verifier",
+		state:    "s",
+		resource: "https://mcp.example.test/mcp",
+		cfg: &oauth2.Config{
+			ClientID:    "dcr-client",
+			RedirectURL: "http://dash.example/oauth/callback",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  ts.URL + "/token",
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+		},
+	}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	tok, err := exchangeOAuthCode(ctx, sess, "auth-code", "s")
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if tok.AccessToken != "at" {
+		t.Errorf("access token = %q", tok.AccessToken)
+	}
+	if gotResource != "https://mcp.example.test/mcp" {
+		t.Errorf("resource = %q, want the canonical mcp resource", gotResource)
+	}
+	if gotGrant != "authorization_code" {
+		t.Errorf("grant_type = %q", gotGrant)
+	}
+	if gotClient != "dcr-client" {
+		t.Errorf("client_id = %q", gotClient)
+	}
+	if gotVerifier != "the-verifier" {
+		t.Errorf("code_verifier = %q", gotVerifier)
+	}
+}
+
+func TestRemoteMCPRefreshSourceSendsResource(t *testing.T) {
+	var gotResource, gotGrant, gotClient string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			failOAuthTestHandler(t, w, "parse form: %v", err)
+			return
+		}
+		gotResource = r.Form.Get("resource")
+		gotGrant = r.Form.Get("grant_type")
+		gotClient = r.Form.Get("client_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-at","refresh_token":"new-rt","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	src := &dynamicMCPRefreshSource{
+		cfg: &oauth2.Config{
+			ClientID: "dcr-client",
+			Endpoint: oauth2.Endpoint{TokenURL: ts.URL},
+		},
+		current: &oauth2.Token{
+			AccessToken:  "old-at",
+			RefreshToken: "old-rt",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(-time.Hour),
+		},
+		resource: "https://mcp.example.test/mcp",
+	}
+	tok, err := src.Token()
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if tok.AccessToken != "new-at" {
+		t.Errorf("access token = %q", tok.AccessToken)
+	}
+	if gotResource != "https://mcp.example.test/mcp" {
+		t.Errorf("resource = %q", gotResource)
+	}
+	if gotGrant != "refresh_token" {
+		t.Errorf("grant_type = %q", gotGrant)
+	}
+	if gotClient != "dcr-client" {
+		t.Errorf("client_id = %q", gotClient)
+	}
+}
+
+// TestRemoteMCPOAuthRefreshAfterFirstConnect pins that a token captured
+// on the very first connect (when the boot-time integration still has no
+// token endpoint) can refresh against the discovered endpoint, because
+// the exchange path stamps it onto the registry via SetDiscoveredEndpoints.
+func TestRemoteMCPOAuthRefreshAfterFirstConnect(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	var gotResource, gotClient string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotResource = r.Form.Get("resource")
+		gotClient = r.Form.Get("client_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed-at","refresh_token":"rotated-rt","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	reg, err := NewOAuthRegistry(nil, db)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	// Boot-time registration: no discovered endpoints yet (no blob).
+	reg.Register("acme-mcp", OAuthIntegration{
+		Flow:   "remote_mcp_oauth",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+	})
+	// Exchange path atomically stamps the discovered endpoints and stores the token.
+	if err := reg.SetRemoteMCPWithClient(t.Context(), "acme-mcp", &oauth2.Token{
+		AccessToken:  "first-at",
+		RefreshToken: "first-rt",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, "dcr-client", "https://auth.example.test/authorize", ts.URL+"/token", "https://mcp.example.test/mcp", nil); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	tok, err := reg.Token("acme-mcp")
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if tok != "refreshed-at" {
+		t.Errorf("token = %q, want refreshed-at", tok)
+	}
+	if gotResource != "https://mcp.example.test/mcp" {
+		t.Errorf("refresh resource = %q", gotResource)
+	}
+	if gotClient != "dcr-client" {
+		t.Errorf("refresh client_id = %q", gotClient)
+	}
+}
+
+// fakeRemoteMCPProvider is a minimal credential body implementing
+// config.OAuthFlowProvider as a strict remote_mcp_oauth credential, used
+// to drive registerOAuthCredentials without standing up the full plugin
+// machinery.
+type fakeRemoteMCPProvider struct{ scopes []string }
+
+type fakeRemoteMCPEndpoint struct{ url string }
+
+func (f fakeRemoteMCPEndpoint) RemoteMCPURL() string { return f.url }
+
+func (f fakeRemoteMCPProvider) OAuthFlow() *config.OAuthIntegration {
+	return &config.OAuthIntegration{
+		Type:   "oauth2",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+		Flow:   "remote_mcp_oauth",
+		OAuth:  config.OAuthConfig{Scopes: f.scopes},
+	}
+}
+
+// TestRemoteMCPRefreshAfterRestartUsesPersistedTokenEndpoint simulates a
+// gateway restart: tokens live in the credentials table, discovery
+// metadata lives in gateway_blobs, and registerOAuthCredentials must
+// rebuild a refresh source that hits the *persisted* token endpoint with
+// the resource indicator — never re-discovering it.
+func TestRemoteMCPRefreshAfterRestartUsesPersistedTokenEndpoint(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	blobs := newGatewayBlobStore(db)
+
+	var gotResource, gotClient, gotRefresh string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			failOAuthTestHandler(t, w, "parse form: %v", err)
+			return
+		}
+		gotResource = r.Form.Get("resource")
+		gotClient = r.Form.Get("client_id")
+		gotRefresh = r.Form.Get("refresh_token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed-at","refresh_token":"rotated-rt","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	// Persist discovery metadata (non-secret) as a prior connect would.
+	if err := saveRemoteMCPMeta(blobs, "acme-mcp", remoteMCPMeta{
+		Issuer:                "https://auth.example.test",
+		AuthorizationEndpoint: "https://auth.example.test/authorize",
+		TokenEndpoint:         ts.URL + "/token",
+		Resource:              "https://mcp.example.test/mcp",
+		ClientID:              "dcr-client",
+		RedirectURI:           "http://dash.example/oauth/callback",
+	}); err != nil {
+		t.Fatalf("persist meta: %v", err)
+	}
+	// Seed an expired token row, as the credentials table would hold it.
+	if _, err := db.Exec(`
+		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns, client_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"acme-mcp", "old-at", "Bearer", "stored-rt",
+		time.Now().Add(-time.Hour).UnixNano(), time.Now().UnixNano(), "dcr-client",
+	); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+
+	policy := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{
+			"acme": {Body: fakeRemoteMCPEndpoint{url: "https://mcp.example.test/mcp"}},
+		},
+		Credentials: map[string]*config.Entity{
+			"acme-mcp": {
+				Body:      fakeRemoteMCPProvider{scopes: []string{"mcp:read"}},
+				Framework: config.FrameworkAttrs{Refs: map[string]string{"endpoint": "acme"}},
+			},
+		},
+	}
+
+	reg, err := NewOAuthRegistry(nil, db)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	registerOAuthCredentials(reg, policy, blobs)
+
+	tok, err := reg.Token("acme-mcp")
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if tok != "refreshed-at" {
+		t.Errorf("access token = %q, want refreshed-at", tok)
+	}
+	if gotResource != "https://mcp.example.test/mcp" {
+		t.Errorf("refresh resource = %q", gotResource)
+	}
+	if gotClient != "dcr-client" {
+		t.Errorf("refresh client_id = %q", gotClient)
+	}
+	if gotRefresh != "stored-rt" {
+		t.Errorf("refresh_token = %q, want stored-rt", gotRefresh)
+	}
+}
+
+func TestRemoteMCPOAuthDoesNotFollowDiscoveryRedirect(t *testing.T) {
+	evilHit := false
+	evil := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHit = true
+		_, _ = w.Write([]byte(`{"resource":"https://evil.example/mcp","authorization_servers":["https://evil.example"]}`))
+	}))
+	defer evil.Close()
+
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, evil.URL+"/metadata", http.StatusTemporaryRedirect)
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	_, err := discoverRemoteMCPMeta(t.Context(), noRedirectOAuthHTTPClient(srv.Client()), srv.URL+"/mcp", nil)
+	if err == nil {
+		t.Fatal("discovery succeeded through redirect; want failure")
+	}
+	if evilHit {
+		t.Fatal("redirect target was contacted; OAuth metadata redirects must not be followed")
+	}
+}
+
+func TestRemoteMCPOAuthDoesNotFollowDCRRedirect(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	evilHit := false
+	evil := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHit = true
+		_, _ = w.Write([]byte(`{"client_id":"evil"}`))
+	}))
+	defer evil.Close()
+
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", srv.URL+"/register")))
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, evil.URL+"/register", http.StatusTemporaryRedirect)
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	w := &webMux{g: &Gateway{blobs: newGatewayBlobStore(db)}, sessions: map[string]*oauthSession{}, httpClient: srv.Client()}
+	flow := &OAuthIntegration{Flow: "remote_mcp_oauth", OAuth: OAuthConfig{ResourceURL: srv.URL + "/mcp"}}
+	rr := httptest.NewRecorder()
+	w.startRemoteMCPOAuthFlow(rr, httptest.NewRequest(http.MethodPost, "http://dash.example:8080/api/oauth/start", nil), "acme-mcp", flow)
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if evilHit {
+		t.Fatal("DCR redirect target was contacted; OAuth registration redirects must not be followed")
+	}
+}
+
+func TestRemoteMCPOAuthDoesNotFollowExchangeRedirect(t *testing.T) {
+	evilHit := false
+	evil := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHit = true
+		_, _ = w.Write([]byte(`{"access_token":"evil","token_type":"Bearer"}`))
+	}))
+	defer evil.Close()
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, evil.URL+"/token", http.StatusTemporaryRedirect)
+	}))
+	defer ts.Close()
+
+	sess := &oauthSession{
+		verifier:   "the-verifier",
+		state:      "s",
+		resource:   "https://mcp.example.test/mcp",
+		httpClient: noRedirectOAuthHTTPClient(ts.Client()),
+		cfg: &oauth2.Config{
+			ClientID:    "dcr-client",
+			RedirectURL: "http://dash.example/oauth/callback",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  ts.URL + "/token",
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+		},
+	}
+	_, err := exchangeOAuthCode(context.Background(), sess, "auth-code", "s")
+	if err == nil {
+		t.Fatal("exchange succeeded through token redirect; want failure")
+	}
+	if evilHit {
+		t.Fatal("token redirect target was contacted; OAuth exchange redirects must not be followed")
+	}
+}
+
+func TestRemoteMCPOAuthDoesNotFollowRefreshRedirect(t *testing.T) {
+	evilHit := false
+	evil := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHit = true
+		_, _ = w.Write([]byte(`{"access_token":"evil","token_type":"Bearer"}`))
+	}))
+	defer evil.Close()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, evil.URL+"/token", http.StatusTemporaryRedirect)
+	}))
+	defer ts.Close()
+
+	src := &dynamicMCPRefreshSource{
+		cfg: &oauth2.Config{
+			ClientID: "dcr-client",
+			Endpoint: oauth2.Endpoint{TokenURL: ts.URL},
+		},
+		current: &oauth2.Token{
+			AccessToken:  "old-at",
+			RefreshToken: "old-rt",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(-time.Hour),
+		},
+		resource:   "https://mcp.example.test/mcp",
+		httpClient: noRedirectOAuthHTTPClient(ts.Client()),
+	}
+	_, err := src.Token()
+	if err == nil {
+		t.Fatal("refresh succeeded through token redirect; want failure")
+	}
+	if evilHit {
+		t.Fatal("refresh redirect target was contacted; OAuth refresh redirects must not be followed")
+	}
+}
+
+func TestRemoteMCPOAuthExchangePersistsMetaOnlyAfterSuccess(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	blobs := newGatewayBlobStore(db)
+
+	var tokenHit bool
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		tokenHit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at","refresh_token":"rt","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	reg, err := NewOAuthRegistry([]OAuthIntegration{{
+		ID:     "acme-mcp",
+		Flow:   "remote_mcp_oauth",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+		OAuth:  OAuthConfig{ResourceURL: "https://mcp.example.test/mcp"},
+	}}, db)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	w := &webMux{g: &Gateway{oauth: reg, blobs: blobs}, sessions: map[string]*oauthSession{}}
+	w.sessions["state-1"] = &oauthSession{
+		verifier:    "verifier",
+		state:       "state-1",
+		id:          "acme-mcp",
+		created:     time.Now(),
+		dynClientID: "dcr-client",
+		resource:    "https://mcp.example.test/mcp",
+		httpClient:  noRedirectOAuthHTTPClient(ts.Client()),
+		cfg: &oauth2.Config{
+			ClientID:    "dcr-client",
+			RedirectURL: "http://dash.example/oauth/callback",
+			Endpoint:    oauth2.Endpoint{TokenURL: ts.URL + "/token", AuthStyle: oauth2.AuthStyleInParams},
+		},
+		remoteMCPMeta: &remoteMCPMeta{
+			Issuer:                ts.URL,
+			AuthorizationEndpoint: ts.URL + "/authorize",
+			TokenEndpoint:         ts.URL + "/token",
+			Resource:              "https://mcp.example.test/mcp",
+			ClientID:              "dcr-client",
+			RedirectURI:           "http://dash.example/oauth/callback",
+			Scopes:                []string{"mcp:read"},
+		},
+	}
+	if _, ok := loadRemoteMCPMeta(blobs, "acme-mcp"); ok {
+		t.Fatal("metadata unexpectedly present before exchange")
+	}
+	rr := httptest.NewRecorder()
+	w.apiOAuthExchange(rr, httptest.NewRequest(http.MethodPost, "/api/oauth/exchange", strings.NewReader(`{"state":"state-1","code":"code"}`)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("exchange status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !tokenHit {
+		t.Fatal("token endpoint was not called")
+	}
+	meta, ok := loadRemoteMCPMeta(blobs, "acme-mcp")
+	if !ok {
+		t.Fatal("metadata not persisted after successful exchange")
+	}
+	if meta.TokenEndpoint != ts.URL+"/token" || meta.ClientID != "dcr-client" || meta.RedirectURI != "http://dash.example/oauth/callback" {
+		t.Fatalf("persisted meta = %#v", meta)
+	}
+}
+
+func TestRemoteMCPOAuthStartReregistersWhenRedirectOrScopesChange(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	blobs := newGatewayBlobStore(db)
+
+	var srv *httptest.Server
+	registerHits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", srv.URL+"/register")))
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, _ *http.Request) {
+		registerHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"client-new"}`))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	baseMeta := remoteMCPMeta{
+		Issuer:                srv.URL,
+		AuthorizationEndpoint: srv.URL + "/authorize",
+		TokenEndpoint:         srv.URL + "/token",
+		RegistrationEndpoint:  srv.URL + "/register",
+		Resource:              srv.URL + "/mcp",
+		ClientID:              "client-old",
+		RedirectURI:           "http://old.example/oauth/callback",
+		Scopes:                []string{"mcp:read"},
+	}
+	if err := saveRemoteMCPMeta(blobs, "acme-mcp", baseMeta); err != nil {
+		t.Fatalf("save meta: %v", err)
+	}
+	w := &webMux{g: &Gateway{blobs: blobs}, sessions: map[string]*oauthSession{}, httpClient: srv.Client()}
+	flow := &OAuthIntegration{Flow: "remote_mcp_oauth", OAuth: OAuthConfig{ResourceURL: srv.URL + "/mcp", Scopes: []string{"mcp:read"}}}
+	rr := httptest.NewRecorder()
+	w.startRemoteMCPOAuthFlow(rr, httptest.NewRequest(http.MethodPost, "http://new.example/api/oauth/start", nil), "acme-mcp", flow)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("redirect-change start status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if registerHits != 1 {
+		t.Fatalf("register hits after redirect change = %d, want 1", registerHits)
+	}
+
+	baseMeta.RedirectURI = "http://same.example/oauth/callback"
+	baseMeta.Scopes = []string{"mcp:read"}
+	baseMeta.ClientID = "client-old"
+	if err := saveRemoteMCPMeta(blobs, "acme-mcp", baseMeta); err != nil {
+		t.Fatalf("save meta: %v", err)
+	}
+	flow.OAuth.Scopes = []string{"mcp:read", "mcp:write"}
+	rr = httptest.NewRecorder()
+	w.startRemoteMCPOAuthFlow(rr, httptest.NewRequest(http.MethodPost, "http://same.example/api/oauth/start", nil), "acme-mcp", flow)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("scope-change start status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if registerHits != 2 {
+		t.Fatalf("register hits after scope change = %d, want 2", registerHits)
+	}
+}
+
+func TestRemoteMCPOAuthDoesNotLoadStoredTokenWithoutMatchingMetadata(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns, client_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"acme-mcp", "old-at", "Bearer", "old-rt", time.Now().Add(time.Hour).UnixNano(), time.Now().UnixNano(), "old-client",
+	); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+	reg, err := NewOAuthRegistry([]OAuthIntegration{{
+		ID:   "acme-mcp",
+		Flow: "remote_mcp_oauth",
+		OAuth: OAuthConfig{
+			ResourceURL: "https://new-resource.example.test/mcp",
+			// Empty TokenURL models boot after endpoint rebinding or metadata
+			// mismatch: enrichRemoteMCPOAuthFlow refused the stale blob.
+		},
+	}}, db)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	tok, err := reg.Token("acme-mcp")
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if tok != "" {
+		t.Fatalf("loaded stale token %q for remote_mcp_oauth without matching metadata", tok)
+	}
+}
+
+func TestRemoteMCPOAuthDoesNotLoadStoredTokenForSameOriginDifferentResource(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	blobs := newGatewayBlobStore(db)
+	if err := saveRemoteMCPMeta(blobs, "acme-mcp", remoteMCPMeta{
+		Issuer:                "https://auth.example.test",
+		AuthorizationEndpoint: "https://auth.example.test/authorize",
+		TokenEndpoint:         "https://auth.example.test/token",
+		Resource:              "https://mcp.example.test/old",
+		ClientID:              "old-client",
+	}); err != nil {
+		t.Fatalf("persist meta: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO credentials (id, access_token, token_type, refresh_token, expiry_ns, updated_ns, client_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"acme-mcp", "old-at", "Bearer", "old-rt", time.Now().Add(time.Hour).UnixNano(), time.Now().UnixNano(), "old-client",
+	); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+	policy := &config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{
+			"acme": {Body: fakeRemoteMCPEndpoint{url: "https://mcp.example.test/new"}},
+		},
+		Credentials: map[string]*config.Entity{
+			"acme-mcp": {
+				Body:      fakeRemoteMCPProvider{scopes: []string{"mcp:read"}},
+				Framework: config.FrameworkAttrs{Refs: map[string]string{"endpoint": "acme"}},
+			},
+		},
+	}
+	reg, err := NewOAuthRegistry(nil, db)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	registerOAuthCredentials(reg, policy, blobs)
+	tok, err := reg.Token("acme-mcp")
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if tok != "" {
+		t.Fatalf("loaded same-origin stale token %q for different resource path", tok)
+	}
+}
+
+func TestRemoteMCPOAuthRegisterClearsLiveStateWhenMetadataNoLongerMatches(t *testing.T) {
+	reg, err := NewOAuthRegistry([]OAuthIntegration{{
+		ID:   "acme-mcp",
+		Flow: "remote_mcp_oauth",
+		OAuth: OAuthConfig{
+			AuthURL:     "https://auth.example.test/authorize",
+			TokenURL:    "https://auth.example.test/token",
+			ResourceURL: "https://mcp.example.test/old",
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	if err := reg.SetRemoteMCPWithClient(t.Context(), "acme-mcp", &oauth2.Token{
+		AccessToken: "old-at",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}, "old-client", "https://auth.example.test/authorize", "https://auth.example.test/token", "https://mcp.example.test/old", nil); err != nil {
+		t.Fatalf("set token: %v", err)
+	}
+	if tok, err := reg.Token("acme-mcp"); err != nil || tok != "old-at" {
+		t.Fatalf("precondition token = %q, err = %v", tok, err)
+	}
+	reg.Register("acme-mcp", OAuthIntegration{
+		ID:   "acme-mcp",
+		Flow: "remote_mcp_oauth",
+		OAuth: OAuthConfig{
+			ResourceURL: "https://mcp.example.test/new",
+			// Empty TokenURL models a reload where persisted metadata did not
+			// match the currently bound remote_mcp endpoint.
+		},
+	})
+	if tok, err := reg.Token("acme-mcp"); err != nil || tok != "" {
+		t.Fatalf("stale live token after metadata mismatch reload = %q, err = %v", tok, err)
+	}
+}
+
+func TestDiscoverRemoteMCPMetaRejectsResourceQueryMismatch(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/mcp?tenant=other","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", "")))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	_, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/mcp?tenant=prod", nil)
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("err = %v, want query-sensitive resource mismatch rejection", err)
+	}
+}
+
+func TestDiscoverRemoteMCPMetaFallbackResourcePreservesQuery(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", "")))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	meta, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/mcp?tenant=prod", nil)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if meta.Resource != srv.URL+"/mcp?tenant=prod" {
+		t.Fatalf("resource = %q, want query preserved", meta.Resource)
+	}
+}
+
+func TestRemoteMCPOAuthExchangeRejectsStaleSessionResource(t *testing.T) {
+	var tokenHits int
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		tokenHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"old-at","refresh_token":"old-rt","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer ts.Close()
+	reg, err := NewOAuthRegistry([]OAuthIntegration{{
+		ID:   "acme-mcp",
+		Flow: "remote_mcp_oauth",
+		OAuth: OAuthConfig{
+			ResourceURL: "https://mcp.example.test/new",
+			TokenURL:    ts.URL + "/token",
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	w := &webMux{g: &Gateway{oauth: reg}, sessions: map[string]*oauthSession{}}
+	w.sessions["state-1"] = &oauthSession{
+		verifier: "verifier",
+		state:    "state-1",
+		id:       "acme-mcp",
+		created:  time.Now(),
+		resource: "https://mcp.example.test/old",
+		cfg: &oauth2.Config{
+			ClientID:    "client",
+			RedirectURL: "http://dash.example/oauth/callback",
+			Endpoint:    oauth2.Endpoint{TokenURL: ts.URL + "/token", AuthStyle: oauth2.AuthStyleInParams},
+		},
+		httpClient: noRedirectOAuthHTTPClient(ts.Client()),
+		remoteMCPMeta: &remoteMCPMeta{
+			TokenEndpoint: ts.URL + "/token",
+			Resource:      "https://mcp.example.test/old",
+			ClientID:      "client",
+		},
+	}
+	rr := httptest.NewRecorder()
+	w.apiOAuthExchange(rr, httptest.NewRequest(http.MethodPost, "/api/oauth/exchange", strings.NewReader(`{"state":"state-1","code":"code"}`)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("exchange status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if tokenHits != 0 {
+		t.Fatalf("token endpoint hits = %d, want 0", tokenHits)
+	}
+	if tok, err := reg.Token("acme-mcp"); err != nil || tok != "" {
+		t.Fatalf("stale session installed token = %q, err = %v", tok, err)
+	}
+}
+
+func TestDiscoverRemoteMCPMetaRejectsResourceTrailingSlashMismatch(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/tenant", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"resource":"` + srv.URL + `/tenant/","authorization_servers":["` + srv.URL + `"]}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(asMetadataJSON(srv.URL, srv.URL+"/authorize", srv.URL+"/token", "")))
+	})
+	srv = httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	_, err := discoverRemoteMCPMeta(t.Context(), srv.Client(), srv.URL+"/tenant", nil)
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("err = %v, want trailing-slash-sensitive resource mismatch rejection", err)
+	}
+}

--- a/cmd/clawpatrol/secrets.go
+++ b/cmd/clawpatrol/secrets.go
@@ -235,7 +235,7 @@ func (s *gatewayBlobStore) Put(kind, name string, data []byte) error {
 // registration, so policy reloads / first-boot don't lose tokens
 // that pre-date this gateway process. Idempotent — safe on every
 // config reload.
-func registerOAuthCredentials(reg *OAuthRegistry, policy *config.CompiledPolicy) {
+func registerOAuthCredentials(reg *OAuthRegistry, policy *config.CompiledPolicy, blobs runtime.BlobStore) {
 	if reg == nil || policy == nil {
 		return
 	}
@@ -250,9 +250,46 @@ func registerOAuthCredentials(reg *OAuthRegistry, policy *config.CompiledPolicy)
 		}
 		copied := *flow
 		copied.ID = name
+		if copied.Flow == "remote_mcp_oauth" {
+			enrichRemoteMCPOAuthFlow(&copied, policy, ent, blobs)
+		}
 		reg.Register(name, copied)
 	}
 	if err := reg.LoadFromDB(); err != nil {
 		log.Printf("oauth: rehydrate from db: %v", err)
+	}
+}
+
+// enrichRemoteMCPOAuthFlow populates a remote_mcp_oauth integration with
+// the bound endpoint's resource URL and the auth/token/registration
+// endpoints discovered at the last connect (persisted in gateway_blobs).
+// This is what makes refresh work after a restart: newState builds the
+// refresh source from these URLs, so the token endpoint is the validated
+// one captured at connect time — never re-discovered from a resource
+// server that may since have been tampered with.
+func enrichRemoteMCPOAuthFlow(flow *config.OAuthIntegration, policy *config.CompiledPolicy, ent *config.Entity, blobs runtime.BlobStore) {
+	if flow.OAuth.ResourceURL == "" {
+		flow.OAuth.ResourceURL = boundRemoteMCPURL(policy, ent)
+	}
+	boundResource := flow.OAuth.ResourceURL
+	m, ok := loadRemoteMCPMeta(blobs, flow.ID)
+	if !ok {
+		return
+	}
+	if boundResource == "" || m.Resource == "" || !sameResource(m.Resource, boundResource) {
+		// The credential was rebound or the endpoint URL changed since the
+		// token was issued. Do not rehydrate the old token/endpoints for the
+		// new resource; a fresh Connect is required.
+		return
+	}
+	flow.OAuth.AuthURL = m.AuthorizationEndpoint
+	flow.OAuth.TokenURL = m.TokenEndpoint
+	flow.OAuth.RegisterURL = m.RegistrationEndpoint
+	flow.OAuth.ResourceURL = m.Resource
+	// The per-credential client_id is also restored from the credentials
+	// table at LoadFromDB (it wins); setting it here covers the gap before
+	// that load and keeps the registered integration self-consistent.
+	if m.ClientID != "" {
+		flow.OAuth.ClientID = m.ClientID
 	}
 }

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -48,6 +48,10 @@ type webMux struct {
 	sessions  map[string]*oauthSession
 	onboard   *onboardRegistry
 	routeAuth map[string]authRequirement
+	// httpClient, when set, overrides http.DefaultClient for outbound
+	// remote_mcp_oauth discovery / dynamic client registration. Tests
+	// point it at an httptest TLS server's client; nil in production.
+	httpClient *http.Client
 
 	// stateCache: per-caller TTL'd memo for /api/state. RWMutex
 	// because reads vastly outnumber writes — every dashboard tab
@@ -1307,7 +1311,16 @@ func lookupOAuthFlow(policy *config.CompiledPolicy, name string) *config.OAuthIn
 	if !ok {
 		return nil
 	}
-	return fp.OAuthFlow()
+	flow := fp.OAuthFlow()
+	// remote_mcp_oauth discovers from the bound remote_mcp endpoint's
+	// URL. Fill it in here (unless the operator set an explicit
+	// resource_url override) so the start handler has a resource to
+	// discover against. OAuthFlow() returns a fresh value per call, so
+	// mutating it is safe.
+	if flow != nil && flow.Flow == "remote_mcp_oauth" && flow.OAuth.ResourceURL == "" {
+		flow.OAuth.ResourceURL = boundRemoteMCPURL(policy, ent)
+	}
+	return flow
 }
 
 // apiConfig serves the entire gateway.hcl for the global settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1352,6 +1352,26 @@ func validateCredentialBindings(p *Policy) hcl.Diagnostics {
 				Subject:  &ent.Symbol.Block.DefRange,
 			})
 		}
+		if ent.Symbol != nil && ent.Symbol.Type == "remote_mcp_oauth" {
+			if single == "" || len(list) > 0 {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("remote_mcp_oauth credential %q must bind exactly one remote_mcp endpoint", ent.Symbol.Name),
+					Detail:   "Use `endpoint = remote_mcp.<name>`; `endpoints = [...]` and unbound remote_mcp_oauth credentials are not supported because OAuth discovery needs one resource URL.",
+					Subject:  &ent.Symbol.Block.DefRange,
+				})
+				continue
+			}
+			ep := p.Endpoints[single]
+			if ep != nil && ep.Symbol != nil && ep.Symbol.Type != "remote_mcp" {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("remote_mcp_oauth credential %q is bound to non-remote_mcp endpoint %q", ent.Symbol.Name, single),
+					Detail:   fmt.Sprintf("remote_mcp_oauth requires endpoint = remote_mcp.<name>; %q has type %q.", single, ep.Symbol.Type),
+					Subject:  &ent.Symbol.Block.DefRange,
+				})
+			}
+		}
 	}
 	return diags
 }

--- a/internal/config/oauth.go
+++ b/internal/config/oauth.go
@@ -13,6 +13,7 @@ type OAuthConfig struct {
 	DeviceURL    string // used by Flow="device"
 	RegisterURL  string // RFC 7591 dynamic client registration (used by Flow="notion_mcp")
 	RedirectURI  string
+	ResourceURL  string // OAuth Protected Resource URL (used by Flow="remote_mcp_oauth")
 	Scopes       []string
 	RefreshToken string // bootstrap; per-owner tokens override
 }

--- a/internal/config/plugins/credentials/remote_mcp_oauth.go
+++ b/internal/config/plugins/credentials/remote_mcp_oauth.go
@@ -1,0 +1,130 @@
+package credentials
+
+// remote_mcp_oauth: a strict, generic OAuth credential for remote MCP
+// servers that ship standards-conformant authorization metadata
+// (RFC 9728 Protected Resource Metadata + RFC 8414 Authorization
+// Server Metadata, RFC 7591 dynamic client registration, RFC 7636 PKCE,
+// RFC 8707 resource indicators).
+//
+// It binds exactly one `remote_mcp` endpoint and discovers everything
+// else — issuer, authorization/token/registration endpoints, client_id
+// — from the bound resource URL at connect time. No per-provider shims
+// live here: providers that deviate from the specs (e.g. issuer
+// mismatch) are intentionally rejected, and the deferred `provider_compat`
+// follow-up is where such relaxations will land.
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// RemoteMCPOAuth is part of the clawpatrol plugin API.
+type RemoteMCPOAuth struct {
+	// Scopes are sent both during dynamic client registration and the
+	// authorization request. Empty lets the provider choose defaults.
+	Scopes []string `hcl:"scopes,optional"`
+	// ResourceURL is reserved for a follow-up that can safely canonicalize
+	// an alternate Protected Resource Metadata URL against the bound
+	// remote_mcp endpoint. The strict generic credential rejects non-empty
+	// values today so tokens cannot be minted for one resource and injected
+	// into another.
+	ResourceURL string `hcl:"resource_url,optional"`
+	// ProviderCompat is reserved for a follow-up of provider-specific
+	// compatibility shims. The strict generic credential rejects any
+	// non-empty value today (see validateRemoteMCPOAuth).
+	ProviderCompat string `hcl:"provider_compat,optional"`
+}
+
+// InjectHTTP is part of the clawpatrol plugin API. It stamps the OAuth
+// access token (captured by the flow, refreshed by the registry) as a
+// bearer on the bound request only — the dispatcher resolves this
+// credential per (profile, endpoint, request), so the header never
+// leaks onto unrelated traffic.
+func (r *RemoteMCPOAuth) InjectHTTP(_ context.Context, req *http.Request, sec runtime.Secret) error {
+	if len(sec.Bytes) == 0 {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+string(sec.Bytes))
+	return nil
+}
+
+// SecretSlots intentionally returns nothing: the token is captured
+// through the OAuth flow, never pasted by the operator.
+func (*RemoteMCPOAuth) SecretSlots() []config.SecretSlot { return nil }
+
+// OAuthFlow returns the marker flow. The host enriches OAuth.ResourceURL
+// from the bound remote_mcp endpoint (when the operator omits the
+// override) and discovers the auth/token/registration endpoints from it
+// before starting the flow — see cmd/clawpatrol/oauth_remote_mcp.go.
+func (r *RemoteMCPOAuth) OAuthFlow() *config.OAuthIntegration {
+	return &config.OAuthIntegration{
+		Type:   "oauth2",
+		Header: "Authorization",
+		Prefix: "Bearer ",
+		Flow:   "remote_mcp_oauth",
+		OAuth: config.OAuthConfig{
+			Scopes:      append([]string(nil), r.Scopes...),
+			ResourceURL: r.ResourceURL,
+		},
+	}
+}
+
+// validateRemoteMCPOAuth rejects any non-empty provider_compat value.
+// The binding to exactly one remote_mcp endpoint is enforced by the
+// loader's validateCredentialBindings (it needs the resolved endpoint
+// table, which a per-plugin Validate doesn't have).
+func validateRemoteMCPOAuth(d any, _ string, ctx *config.BuildCtx) hcl.Diagnostics {
+	c := d.(*RemoteMCPOAuth)
+	var diags hcl.Diagnostics
+	if c.ResourceURL != "" {
+		r := ctx.Block.DefRange
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsupported resource_url on remote_mcp_oauth credential",
+			Detail:   "remote_mcp_oauth discovers OAuth metadata from its bound remote_mcp endpoint in this release. A separate resource_url override could mint tokens for one resource and inject them into another, so it is reserved for a future canonicalized compatibility change.",
+			Subject:  &r,
+		})
+	}
+	if c.ProviderCompat != "" {
+		r := ctx.Block.DefRange
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsupported provider_compat on remote_mcp_oauth credential",
+			Detail:   "remote_mcp_oauth is strict and generic in this release; provider-specific compatibility (for example Grain issuer-mismatch handling) belongs in a follow-up provider_compat change.",
+			Subject:  &r,
+		})
+	}
+	return diags
+}
+
+func init() {
+	var _ runtime.HTTPCredentialRuntime = (*RemoteMCPOAuth)(nil)
+	config.Register(&config.Plugin{
+		Kind:           config.KindCredential,
+		Type:           "remote_mcp_oauth",
+		Disambiguators: []string{"placeholder"},
+		New:            newer[RemoteMCPOAuth](),
+		Runtime:        (*RemoteMCPOAuth)(nil),
+		Validate:       validateRemoteMCPOAuth,
+		Build:          passthrough,
+		Emit: func(body any, _ string, b *hclwrite.Body) {
+			v := body.(*RemoteMCPOAuth)
+			if len(v.Scopes) > 0 {
+				b.SetAttributeValue("scopes", config.StringListVal(v.Scopes))
+			}
+			if v.ResourceURL != "" {
+				b.SetAttributeValue("resource_url", cty.StringVal(v.ResourceURL))
+			}
+			if v.ProviderCompat != "" {
+				b.SetAttributeValue("provider_compat", cty.StringVal(v.ProviderCompat))
+			}
+		},
+	})
+}

--- a/internal/config/plugins/credentials/remote_mcp_oauth_test.go
+++ b/internal/config/plugins/credentials/remote_mcp_oauth_test.go
@@ -1,0 +1,51 @@
+package credentials
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func TestRemoteMCPOAuthInjectHTTPSetsBearer(t *testing.T) {
+	c := &RemoteMCPOAuth{}
+	req, _ := http.NewRequest(http.MethodPost, "https://mcp.example.test/mcp", nil)
+	if err := c.InjectHTTP(t.Context(), req, runtime.Secret{Kind: "oauth_bearer", Bytes: []byte("access-token-123")}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer access-token-123" {
+		t.Errorf("Authorization = %q, want bearer", got)
+	}
+}
+
+func TestRemoteMCPOAuthInjectHTTPNoTokenIsNoop(t *testing.T) {
+	c := &RemoteMCPOAuth{}
+	req, _ := http.NewRequest(http.MethodPost, "https://mcp.example.test/mcp", nil)
+	if err := c.InjectHTTP(t.Context(), req, runtime.Secret{}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty when no token", got)
+	}
+}
+
+func TestRemoteMCPOAuthFlowShape(t *testing.T) {
+	c := &RemoteMCPOAuth{Scopes: []string{"mcp:read", "offline_access"}, ResourceURL: "https://mcp.example.test/mcp"}
+	flow := c.OAuthFlow()
+	if flow.Flow != "remote_mcp_oauth" {
+		t.Errorf("flow = %q", flow.Flow)
+	}
+	if flow.Header != "Authorization" || flow.Prefix != "Bearer " {
+		t.Errorf("header/prefix = %q/%q", flow.Header, flow.Prefix)
+	}
+	if flow.OAuth.ResourceURL != "https://mcp.example.test/mcp" {
+		t.Errorf("resource url = %q", flow.OAuth.ResourceURL)
+	}
+	if len(flow.OAuth.Scopes) != 2 {
+		t.Errorf("scopes = %#v", flow.OAuth.Scopes)
+	}
+	// SecretSlots is intentionally empty — the token is OAuth-captured.
+	if len(c.SecretSlots()) != 0 {
+		t.Errorf("SecretSlots = %#v, want none", c.SecretSlots())
+	}
+}

--- a/internal/config/plugins/endpoints/remote_mcp.go
+++ b/internal/config/plugins/endpoints/remote_mcp.go
@@ -40,6 +40,10 @@ type RemoteMCPEndpoint struct {
 	Hosts []string `hcl:"hosts,optional"`
 }
 
+// RemoteMCPURL returns the configured resource URL for generic remote
+// MCP OAuth discovery.
+func (e *RemoteMCPEndpoint) RemoteMCPURL() string { return e.URL }
+
 // EndpointHosts is part of the clawpatrol plugin API. It returns the
 // URL-derived host first, then any explicit additional hosts. Explicit
 // hosts never remove the URL host.

--- a/internal/config/remote_mcp_oauth_test.go
+++ b/internal/config/remote_mcp_oauth_test.go
@@ -1,0 +1,121 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	_ "github.com/denoland/clawpatrol/internal/config/plugins/all"
+)
+
+// loadRemoteMCPOAuth loads an inline policy fragment wrapped in the
+// minimal gateway prefix and returns the error-level diagnostics
+// (warnings such as the legacy-grammar notice are ignored).
+func loadRemoteMCPOAuth(t *testing.T, src string) hclDiagSummaries {
+	t.Helper()
+	_, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+	out := make(hclDiagSummaries, 0, len(diags))
+	for _, d := range diags {
+		if d.Severity != hcl.DiagError {
+			continue
+		}
+		out = append(out, d.Summary+": "+d.Detail)
+	}
+	return out
+}
+
+type hclDiagSummaries []string
+
+func (s hclDiagSummaries) contains(sub string) bool {
+	for _, m := range s {
+		if strings.Contains(m, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRemoteMCPOAuthBindingValid(t *testing.T) {
+	src := `
+endpoint "remote_mcp" "acme" {
+  url = "https://mcp.acme.test/mcp"
+}
+credential "remote_mcp_oauth" "acme" {
+  endpoint = remote_mcp.acme
+  scopes   = ["mcp:read"]
+}
+profile "p" { credentials = [remote_mcp_oauth.acme] }
+`
+	if diags := loadRemoteMCPOAuth(t, src); len(diags) > 0 {
+		t.Fatalf("expected no diagnostics, got: %v", diags)
+	}
+}
+
+func TestRemoteMCPOAuthBindingRejectsUnbound(t *testing.T) {
+	src := `
+credential "remote_mcp_oauth" "acme" {
+  scopes = ["mcp:read"]
+}
+profile "p" { credentials = [remote_mcp_oauth.acme] }
+`
+	if diags := loadRemoteMCPOAuth(t, src); !diags.contains("must bind exactly one remote_mcp endpoint") {
+		t.Fatalf("expected unbound rejection, got: %v", diags)
+	}
+}
+
+func TestRemoteMCPOAuthBindingRejectsEndpointsList(t *testing.T) {
+	src := `
+endpoint "remote_mcp" "a" { url = "https://mcp.a.test/mcp" }
+endpoint "remote_mcp" "b" { url = "https://mcp.b.test/mcp" }
+credential "remote_mcp_oauth" "acme" {
+  endpoints = [remote_mcp.a, remote_mcp.b]
+}
+profile "p" { credentials = [remote_mcp_oauth.acme] }
+`
+	if diags := loadRemoteMCPOAuth(t, src); !diags.contains("must bind exactly one remote_mcp endpoint") {
+		t.Fatalf("expected endpoints-list rejection, got: %v", diags)
+	}
+}
+
+func TestRemoteMCPOAuthBindingRejectsNonRemoteMCP(t *testing.T) {
+	src := `
+endpoint "https" "web" { hosts = ["api.acme.test"] }
+credential "remote_mcp_oauth" "acme" {
+  endpoint = https.web
+}
+profile "p" { credentials = [remote_mcp_oauth.acme] }
+`
+	if diags := loadRemoteMCPOAuth(t, src); !diags.contains("non-remote_mcp endpoint") {
+		t.Fatalf("expected non-remote_mcp rejection, got: %v", diags)
+	}
+}
+
+func TestRemoteMCPOAuthRejectsProviderCompat(t *testing.T) {
+	src := `
+endpoint "remote_mcp" "acme" { url = "https://mcp.acme.test/mcp" }
+credential "remote_mcp_oauth" "acme" {
+  endpoint        = remote_mcp.acme
+  provider_compat = "grain"
+}
+profile "p" { credentials = [remote_mcp_oauth.acme] }
+`
+	if diags := loadRemoteMCPOAuth(t, src); !diags.contains("Unsupported provider_compat") {
+		t.Fatalf("expected provider_compat rejection, got: %v", diags)
+	}
+}
+
+func TestRemoteMCPOAuthRejectsResourceURLOverride(t *testing.T) {
+	src := `
+endpoint "remote_mcp" "acme" { url = "https://mcp.acme.test/mcp" }
+credential "remote_mcp_oauth" "acme" {
+  endpoint     = remote_mcp.acme
+  resource_url = "https://other.example.test/mcp"
+}
+profile "p" { credentials = [remote_mcp_oauth.acme] }
+`
+	if diags := loadRemoteMCPOAuth(t, src); !diags.contains("Unsupported resource_url") {
+		t.Fatalf("expected resource_url rejection, got: %v", diags)
+	}
+}

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -186,7 +186,7 @@ approver "llm_approver" "example" {
 
 Block syntax: `credential "<type>" "<name>" { ... }`
 
-Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`basic_auth`](#credential-basicauth), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`passthrough`](#credential-passthrough), [`postgres_credential`](#credential-postgrescredential), [`slack_tokens`](#credential-slacktokens), [`ssh_key`](#credential-sshkey), [`tailscale_auth`](#credential-tailscaleauth), [`telegram_bot_token`](#credential-telegrambottoken).
+Registered types: [`anthropic_manual_key`](#credential-anthropicmanualkey), [`anthropic_oauth_subscription`](#credential-anthropicoauthsubscription), [`aws_credential`](#credential-awscredential), [`basic_auth`](#credential-basicauth), [`bearer_token`](#credential-bearertoken), [`clickhouse_credential`](#credential-clickhousecredential), [`cookie_token`](#credential-cookietoken), [`discord_bot_token`](#credential-discordbottoken), [`gemini_api_key`](#credential-geminiapikey), [`github_oauth`](#credential-githuboauth), [`google_gke_credential`](#credential-googlegkecredential), [`header_token`](#credential-headertoken), [`mtls_credential`](#credential-mtlscredential), [`notion_mcp_oauth`](#credential-notionmcpoauth), [`notion_oauth`](#credential-notionoauth), [`openai_codex_oauth`](#credential-openaicodexoauth), [`passthrough`](#credential-passthrough), [`postgres_credential`](#credential-postgrescredential), [`remote_mcp_oauth`](#credential-remotemcpoauth), [`slack_tokens`](#credential-slacktokens), [`ssh_key`](#credential-sshkey), [`tailscale_auth`](#credential-tailscaleauth), [`telegram_bot_token`](#credential-telegrambottoken).
 
 ### `credential "anthropic_manual_key" "<name>"`
 
@@ -395,6 +395,18 @@ the catchall (one allowed per (profile, endpoint)).
 
 ```hcl
 credential "postgres_credential" "example" {}
+```
+
+### `credential "remote_mcp_oauth" "<name>"`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scopes` | `[]string` | no | Sent both during dynamic client registration and the authorization request. Empty lets the provider choose defaults. |
+| `resource_url` | `string` | no | Reserved for a follow-up that can safely canonicalize an alternate Protected Resource Metadata URL against the bound remote_mcp endpoint. The strict generic credential rejects non-empty values today so tokens cannot be minted for one resource and injected into another. |
+| `provider_compat` | `string` | no | Reserved for a follow-up of provider-specific compatibility shims. The strict generic credential rejects any non-empty value today (see validateRemoteMCPOAuth). |
+
+```hcl
+credential "remote_mcp_oauth" "example" {}
 ```
 
 ### `credential "slack_tokens" "<name>"`


### PR DESCRIPTION
## Summary
- add a `remote_mcp_oauth` credential plugin bound to exactly one `remote_mcp` endpoint
- discover protected-resource and authorization-server metadata, perform dynamic client registration, and start PKCE OAuth with the MCP resource indicator
- persist discovered non-secret OAuth metadata in `gateway_blobs` while keeping tokens in the existing OAuth credential store
- inject refreshed bearer tokens through the existing credential runtime path and fail closed on issuer/metadata ambiguity or endpoint substitution

## Testing
- `git diff --check`
- `gofmt -l .`
- `TMPDIR=/home/exedev/tmp-go-test go test ./...`
- `go run ./internal/tools/docgen --check -o site/doc/config-reference.md`

## Notes
- stacked on #752 (`agent/generic-remote-mcp-oauth`) because it uses the new `remote_mcp` endpoint and MCP facet foundation
- this intentionally implements the strict generic OAuth path only; provider-specific compatibility shims such as Grain issuer-mismatch handling remain a follow-up
