### PR TITLE
join: claim the peer api-token on the per-process Linux path

### DIFF
--- a/cmd/clawpatrol/join_claim_linux.go
+++ b/cmd/clawpatrol/join_claim_linux.go
@@ -1,0 +1,103 @@
+//go:build linux
+
+package main
+
+// Peer api-token acquisition for the per-process Linux join path.
+//
+// In Tailscale mode the gateway mints the per-peer bearer inside
+// /api/onboard/claim, not at approve time, because the peer's tailnet
+// IP isn't known until the device actually joins the tailnet (see
+// onboard.go → "Mint the per-peer bearer ... we mint it here instead").
+// The whole-machine path claims after `tailscale up`, using the system
+// tailnet IP. The per-process path has no system tailscale, so it used
+// to skip the claim entirely and never persisted an api-token — leaving
+// the daemon unable to authenticate /api/env-pushdown, so wrapped agents
+// booted with an empty credential set.
+//
+// Bring the daemon's *persistent* tsnet identity up here, one time, to
+// learn the IP it will own, claim against that IP, and persist the
+// token next to ca.crt. The daemon reuses the same state dir (and so
+// the same node identity and IP), which is what makes the gateway's
+// ip→profile mapping from the claim line up with the daemon's later
+// registerTsnetPeer call.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"tailscale.com/tsnet"
+)
+
+// claimPeerAPIToken stands up the daemon's tsnet node, claims the
+// device against its tailnet IP, and writes <caDir>/api-token.
+//
+// The claim POST goes over the gateway's public URL rather than the
+// tailnet: /api/onboard/claim is on the Funnel allowlist, and at this
+// point exit-node routing isn't configured yet.
+func claimPeerAPIToken(gateway, deviceCode, hostname, authKey, controlURL, stateDir, caDir string) error {
+	tsnetDir := filepath.Join(stateDir, "tsnet")
+	if err := os.MkdirAll(tsnetDir, 0o700); err != nil {
+		return fmt.Errorf("tsnet state dir: %w", err)
+	}
+
+	hn := hostname
+	if hn == "" {
+		hn, _ = os.Hostname()
+	}
+
+	// Ephemeral:false and the shared Dir are load-bearing: the daemon
+	// re-opens this exact state and must come up as the same node.
+	s := &tsnet.Server{
+		Hostname:   hn,
+		AuthKey:    authKey,
+		ControlURL: controlURL,
+		Dir:        tsnetDir,
+		Ephemeral:  false,
+		Logf:       func(string, ...any) {},
+	}
+	defer func() { _ = s.Close() }()
+
+	tsIP, err := waitTsnetUp(s)
+	if err != nil {
+		return fmt.Errorf("bring up tsnet node: %w", err)
+	}
+
+	claimURL := fmt.Sprintf("%s/api/onboard/claim?device_code=%s&ip=%s",
+		gateway, neturl.QueryEscape(deviceCode), neturl.QueryEscape(tsIP.String()))
+	if hn != "" {
+		claimURL += "&hostname=" + neturl.QueryEscape(hn)
+	}
+
+	cli := &http.Client{Timeout: 20 * time.Second}
+	resp, err := cli.Post(claimURL, "application/json", nil)
+	if err != nil {
+		return fmt.Errorf("claim %s: %w", tsIP, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 400))
+		return fmt.Errorf("claim %s: status %d: %s", tsIP, resp.StatusCode, string(body))
+	}
+
+	var claimResp map[string]string
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 16<<10)).Decode(&claimResp); err != nil {
+		return fmt.Errorf("decode claim response: %w", err)
+	}
+	tok := claimResp["api_token"]
+	if tok == "" {
+		if why := claimResp["api_token_error"]; why != "" {
+			return fmt.Errorf("gateway could not mint an api_token for %s: %s", tsIP, why)
+		}
+		return fmt.Errorf("gateway returned no api_token for %s (peer token minting failed server-side)", tsIP)
+	}
+	if err := os.WriteFile(filepath.Join(caDir, "api-token"), []byte(tok+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write api-token: %w", err)
+	}
+	return nil
+}

--- a/cmd/clawpatrol/join_claim_other.go
+++ b/cmd/clawpatrol/join_claim_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package main
+
+// On macOS the per-process join hands authKey/apiToken to the network
+// extension via macHelper start-tsnet, so there's no CLI-side tsnet node
+// to claim against. See join_claim_linux.go for the Linux path.
+func claimPeerAPIToken(gateway, deviceCode, hostname, authKey, controlURL, stateDir, caDir string) error {
+	return nil
+}

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -1028,11 +1028,46 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 	// Log it here and hand the reason back so the CLI can name it.
 	if token, err := mintAndPersistPeerAPIToken(w.g.db, host); err == nil {
 		resp["api_token"] = token
+		// The per-process path seeded a tsnet-<hostname> placeholder
+		// (device row + placeholder-bound token) at approve time. The
+		// daemon will now present this claim's real-IP token, so the
+		// placeholder promotion in apiPeerTsnetRegister never fires and
+		// the placeholder would linger as a ghost device + orphaned
+		// token row. Retire it now — only on a successful mint, so a
+		// mint failure still leaves the placeholder token as the
+		// daemon's fallback.
+		w.retirePlaceholderForClaim(dc, host)
 	} else {
 		log.Printf("onboard claim: mint peer api-token for %s: %v", host, err)
 		resp["api_token_error"] = err.Error()
 	}
 	writeJSON(rw, resp)
+}
+
+// retirePlaceholderForClaim drops the tsnet-<hostname> placeholder that
+// apiOnboardApprove seeded for device_code dc, once a claim has bound a
+// real-IP token (realIP). No-op when there was no placeholder (e.g. the
+// whole-machine path, which never seeds one). Mirrors the placeholder
+// teardown in apiPeerTsnetRegister.
+func (w *webMux) retirePlaceholderForClaim(dc, realIP string) {
+	s := w.onboard.byDeviceCode(dc)
+	if s == nil {
+		return
+	}
+	placeholderID := tsnetPlaceholderPrefix + dc
+	if s.hostname != "" {
+		placeholderID = tsnetPlaceholderPrefix + s.hostname
+	}
+	if placeholderID == realIP {
+		return
+	}
+	w.onboard.ForgetIP(placeholderID)
+	if w.g.agents != nil {
+		w.g.agents.Delete(placeholderID)
+	}
+	if w.g.db != nil {
+		_, _ = w.g.db.Exec("DELETE FROM peer_api_tokens WHERE peer_ip = ?", placeholderID)
+	}
 }
 
 // apiPeerTsnetRegister is the daemon's one-shot self-registration on

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -1021,8 +1021,16 @@ func (w *webMux) apiOnboardClaim(rw http.ResponseWriter, r *http.Request) {
 	// Mint the per-peer bearer the client uses for gated API calls
 	// (env-pushdown, ephemeral tsnet key). In Tailscale mode the peer IP
 	// isn't known at approve time, so we mint it here instead.
+	//
+	// A mint failure used to be dropped on the floor: the claim still
+	// returned 200, just without api_token, and the operator only found
+	// out hours later via the daemon's "peer api token not persisted".
+	// Log it here and hand the reason back so the CLI can name it.
 	if token, err := mintAndPersistPeerAPIToken(w.g.db, host); err == nil {
 		resp["api_token"] = token
+	} else {
+		log.Printf("onboard claim: mint peer api-token for %s: %v", host, err)
+		resp["api_token_error"] = err.Error()
 	}
 	writeJSON(rw, resp)
 }

--- a/cmd/clawpatrol/onboard_claim_token_test.go
+++ b/cmd/clawpatrol/onboard_claim_token_test.go
@@ -95,3 +95,36 @@ func TestOnboardClaimSurfacesMintFailure(t *testing.T) {
 		t.Errorf("claim response = %v, want owner+ip still populated", resp)
 	}
 }
+
+// The per-process tsnet approve path seeds a tsnet-<hostname> placeholder
+// (device row + placeholder-bound token). Once a claim binds the real-IP
+// token the daemon presents that instead, so the placeholder promotion in
+// apiPeerTsnetRegister never fires. A successful claim must therefore
+// retire the placeholder itself, or it lingers as an orphaned token row.
+func TestOnboardClaimRetiresPlaceholder(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.agents = NewAgentRegistry()
+	w.g.agents.onboard = w.g.onboard
+	h := w.handler()
+
+	code := startOnboardSession(t, h, "?hostname=dev1")
+	dc := w.onboard.byUserCode(code).deviceCode
+
+	// Stand in for the approve-time placeholder mint (tsnet-<hostname>).
+	placeholderID := tsnetPlaceholderPrefix + "dev1"
+	if _, err := mintAndPersistPeerAPIToken(w.g.db, placeholderID); err != nil {
+		t.Fatalf("seed placeholder token: %v", err)
+	}
+
+	w.retirePlaceholderForClaim(dc, "100.64.0.11")
+
+	var n int
+	if err := w.g.db.QueryRow(
+		"SELECT count(*) FROM peer_api_tokens WHERE peer_ip = ?", placeholderID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count placeholder token rows: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("placeholder token rows for %s = %d, want 0 (claim must retire it)", placeholderID, n)
+	}
+}

--- a/cmd/clawpatrol/onboard_claim_token_test.go
+++ b/cmd/clawpatrol/onboard_claim_token_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// claimForTest drives start → approve → claim and returns the decoded
+// claim response body. Status is asserted 200 by the caller's contract:
+// a claim that resolves an owner succeeds even when token minting does
+// not, which is exactly the case these tests pin down.
+//
+// beforeClaim (optional) runs after approval and before the claim, so a
+// test can break minting without also breaking approve — which needs
+// the db for its dashboard session.
+func claimForTest(t *testing.T, w *webMux, ip string, beforeClaim func()) map[string]string {
+	t.Helper()
+	h := w.handler()
+	code := startOnboardSession(t, h, "?hostname=dev1")
+
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code="+url.QueryEscape(code), nil)
+	approveReq.AddCookie(authTestSessionCookie(t, w))
+	approveRR := httptest.NewRecorder()
+	h.ServeHTTP(approveRR, approveReq)
+	if approveRR.Code != http.StatusOK {
+		t.Fatalf("approve status = %d; body = %q", approveRR.Code, approveRR.Body.String())
+	}
+
+	dc := w.onboard.byUserCode(code).deviceCode
+	if beforeClaim != nil {
+		beforeClaim()
+	}
+	claimReq := httptest.NewRequest(http.MethodPost,
+		"/api/onboard/claim?device_code="+url.QueryEscape(dc)+"&ip="+url.QueryEscape(ip)+"&hostname=dev1", nil)
+	claimRR := httptest.NewRecorder()
+	h.ServeHTTP(claimRR, claimReq)
+	if claimRR.Code != http.StatusOK {
+		t.Fatalf("claim status = %d; body = %q", claimRR.Code, claimRR.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(claimRR.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode claim response: %v", err)
+	}
+	return resp
+}
+
+// A healthy claim mints the per-peer bearer. In Tailscale mode this is
+// the only place it's minted, so `clawpatrol join` has nothing to
+// persist as ~/.clawpatrol/api-token without it.
+func TestOnboardClaimMintsAPIToken(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.agents = NewAgentRegistry()
+	w.g.agents.onboard = w.g.onboard
+
+	resp := claimForTest(t, w, "100.64.0.9", nil)
+
+	if resp["api_token"] == "" {
+		t.Fatalf("claim response missing api_token: %v", resp)
+	}
+	if got := resp["api_token_error"]; got != "" {
+		t.Errorf("api_token_error = %q, want empty on the success path", got)
+	}
+	if ip := peerIPForAPIToken(w.g.db, resp["api_token"]); ip != "100.64.0.9" {
+		t.Errorf("peerIPForAPIToken = %q, want 100.64.0.9 (token must be persisted)", ip)
+	}
+}
+
+// Regression: a mint failure used to be swallowed — the claim returned
+// 200 with no api_token and no explanation, and the operator only found
+// out much later via the daemon's "peer api token not persisted",
+// with no way to tell a token-less gateway from a broken database.
+// The reason must travel back to the CLI.
+func TestOnboardClaimSurfacesMintFailure(t *testing.T) {
+	w := newOnboardAuthTestWebMux(t)
+	w.g.agents = NewAgentRegistry()
+	w.g.agents.onboard = w.g.onboard
+
+	// Cheapest deterministic mint failure: mintAndPersistPeerAPIToken
+	// rejects a nil db before it touches rand or sqlite. Drop it only
+	// after approve, which needs the db for its dashboard session.
+	resp := claimForTest(t, w, "100.64.0.10", func() { w.g.db = nil })
+
+	if tok := resp["api_token"]; tok != "" {
+		t.Fatalf("api_token = %q, want empty when minting fails", tok)
+	}
+	if resp["api_token_error"] == "" {
+		t.Fatalf("claim response must explain why minting failed: %v", resp)
+	}
+	// The claim itself still did its job: the IP is bound to the owner.
+	if resp["ip"] != "100.64.0.10" || resp["owner"] == "" {
+		t.Errorf("claim response = %v, want owner+ip still populated", resp)
+	}
+}

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -1304,6 +1304,14 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			if err := os.WriteFile(filepath.Join(stateDir, "auth-key"), []byte(authKey+"\n"), 0o600); err != nil {
 				return false, fmt.Errorf("write auth-key: %w", err)
 			}
+			// Claim against the tailnet IP the daemon will own, so the
+			// gateway mints the per-peer bearer. Without it the daemon
+			// can't authenticate /api/env-pushdown and every wrapped
+			// agent boots with an empty credential set (no GH_TOKEN).
+			if err := claimPeerAPIToken(gateway, start.DeviceCode, hn, authKey,
+				tailnetControlURL, stateDir, filepath.Dir(setup.caPath)); err != nil {
+				return false, fmt.Errorf("claim peer api-token: %w", err)
+			}
 		}
 		items := setupSummaryItems(*setup)
 		items = append(items, "✓ joined gateway")
@@ -1384,11 +1392,20 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		return false, nil
 	}
 	var claimResp map[string]string
-	if err := json.NewDecoder(io.LimitReader(cr.Body, 16<<10)).Decode(&claimResp); err == nil {
-		if tok := claimResp["api_token"]; tok != "" {
-			_ = os.WriteFile(filepath.Join(filepath.Dir(setup.caPath), "api-token"),
-				[]byte(tok+"\n"), 0o600)
+	if err := json.NewDecoder(io.LimitReader(cr.Body, 16<<10)).Decode(&claimResp); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ decode claim response: %v\n", err)
+	} else if tok := claimResp["api_token"]; tok == "" {
+		// Silence here used to surface hours later as the daemon's
+		// "peer api token not persisted" with no hint of the cause.
+		why := claimResp["api_token_error"]
+		if why == "" {
+			why = "gateway returned no api_token"
 		}
+		fmt.Fprintf(os.Stderr, "⚠ %s — env-pushdown (GH_TOKEN, …) will be empty "+
+			"until this is fixed\n", why)
+	} else if err := os.WriteFile(filepath.Join(filepath.Dir(setup.caPath), "api-token"),
+		[]byte(tok+"\n"), 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ write api-token: %v\n", err)
 	}
 
 	// Write mode marker files so `clawpatrol run` can detect Tailscale mode.

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -1308,9 +1308,19 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			// gateway mints the per-peer bearer. Without it the daemon
 			// can't authenticate /api/env-pushdown and every wrapped
 			// agent boots with an empty credential set (no GH_TOKEN).
+			//
+			// Best-effort: at this point auth-key + mode markers are
+			// already written and the single-use key is spent, so a
+			// transient claim failure must not abort the join and leave a
+			// half-configured host. Warn and continue — the daemon still
+			// falls back to the poll-delivered placeholder token (written
+			// above) and the operator can re-run `clawpatrol join`. This
+			// mirrors the whole-machine claim below, which also only warns.
 			if err := claimPeerAPIToken(gateway, start.DeviceCode, hn, authKey,
 				tailnetControlURL, stateDir, filepath.Dir(setup.caPath)); err != nil {
-				return false, fmt.Errorf("claim peer api-token: %w", err)
+				fmt.Fprintf(os.Stderr,
+					"⚠ peer api-token claim failed: %v\n"+
+						"  env-pushdown may be unavailable until you re-run `clawpatrol join`.\n", err)
 			}
 		}
 		items := setupSummaryItems(*setup)


### PR DESCRIPTION
## The bug

On **Linux**, against a **Tailscale-mode gateway**, in the **per-process** configuration (no `--whole-machine` — i.e. the `clawpatrol run` path), `clawpatrol join` never writes `~/.clawpatrol/api-token`.

`onboardViaDeviceFlow` writes `auth-key`, prints `✓ joined gateway` / `Installed! Try: clawpatrol run claude`, and returns — about 70 lines *before* the `/api/onboard/claim` call, which is therefore reachable only on the `--whole-machine` path.

In Tailscale mode that claim is the **only** thing that mints the per-peer bearer. `apiOnboardClaim` says so itself:

> `// Mint the per-peer bearer the client uses for gated API calls`
> `// (env-pushdown, ephemeral tsnet key). In Tailscale mode the peer IP`
> `// isn't known at approve time, so we mint it here instead.`

So the poll response's `api_token` is empty, the client-side `if apiToken != ""` write is a no-op, and no code path produces the file.

## Why it matters

The daemon can't authenticate `/api/env-pushdown`:

```
daemon: register: missing gateway URL or api-token; skipping
daemon: env-pushdown fetch: peer api token not persisted (run `clawpatrol join` first) (continuing with empty set)
```

`(continuing with empty set)` is the sharp edge — the daemon proceeds and hands the wrapped process an **empty** pushdown. Every agent under `clawpatrol run` boots with no `GH_TOKEN` and no injected secrets, and `join` still exits 0.

This bit us on a real deployment. An `agent-loop` fleet went dark: the worker crash-looped on a bare `exit 4` with an empty log (that's `gh`'s auth-failure exit code, killing the script under `set -euo pipefail` before its own "clawpatrol provided no GH_TOKEN" diagnostic could print), and seven agents sat idle for days showing `API Error: Unable to connect to API (ConnectionRefused)`. Nothing anywhere named the missing file.

## The fix

The daemon's tsnet identity is persistent (`Ephemeral: false`, shared `Dir: <stateDir>/tsnet`). So `join` brings that same node up once, learns the IP the daemon will own, claims against it, and closes. The daemon later re-opens the same state and comes up as the same node with the same IP — which is what keeps the gateway's claim-time `ip → owner` mapping in agreement with the daemon's later `registerTsnetPeer`.

The claim POST goes over the gateway's **public** URL rather than the tailnet: `/api/onboard/claim` is on the Funnel allowlist (`funnelAllowsPublicPath`), and exit-node routing isn't configured yet at that point in the flow.

New `join_claim_linux.go`, plus a `!linux` stub — on macOS the NE receives `authKey`/`apiToken` via `macHelper start-tsnet`, so there's no CLI-side tsnet node to claim against.

## Two reasons this took an evening to find, also fixed

**Everything was silent.** The gateway discarded the error from `mintAndPersistPeerAPIToken` and still answered `200` without a token:

```go
if token, err := mintAndPersistPeerAPIToken(w.g.db, host); err == nil {
    resp["api_token"] = token
}   // no else — err vanishes
```

and the whole-machine client dropped both the empty-token case and the `WriteFile` error — directly contradicting its own comment, which promises the operator *"a clear stderr warning instead of a silent fall-through"*. The gateway now logs the failure and returns it as `api_token_error`; both client paths name the reason instead of surfacing hours later as the daemon's opaque `peer api token not persisted`.

**The marker files lie.** `mode`, `hostname`, `control-url`, `tailnet-url`, `tailnet-gateway-ip` are written in *both* branches — once before the early `return`, again after the claim. A fully populated `~/.clawpatrol` therefore proves nothing about whether the claim ran; the directory looks complete apart from the one missing file. Worth deduplicating into a helper in a follow-up.

## Reproduce (before this PR)

```bash
# Linux host, Tailscale-mode gateway, no --whole-machine
clawpatrol join https://<gateway>/ --profile foo --hostname bar --no-trust
ls ~/.clawpatrol/                        # everything except api-token
clawpatrol run -- env | grep GH_TOKEN    # nothing
```

## Tests

`TestOnboardClaimMintsAPIToken` pins the success path (token returned *and* persisted, `api_token_error` empty). `TestOnboardClaimSurfacesMintFailure` is the regression: minting fails, the claim still resolves owner+ip, and the response must carry `api_token_error` rather than a silent tokenless `200`.

`go test ./...` green; builds clean for `linux/amd64` and `darwin/arm64`; `gofmt` and `go vet` clean.

## Open questions for review

- **Should a claim that can't mint still return `200`?** I left the status alone to avoid breaking whole-machine clients that currently tolerate a missing token, and added `api_token_error` instead. A `500` may well be more honest — as written, a client still can't distinguish "this gateway doesn't do peer tokens" from "this gateway's disk is full". Happy to change it.
- Standing up a `tsnet.Server` inside `join` purely to learn an IP costs a few seconds. The alternative — having the daemon claim on first boot — is awkward because `/api/onboard/claim` is keyed by `device_code` and the onboard session expires after 10 minutes, so the daemon would need the code persisted and to boot promptly. The join-time claim avoids that coupling, but I'd like a second opinion.

## Not fixed here

While diagnosing, the affected worker container had accumulated **3,034 zombie `gh` processes**. `clawpatrol run` is PID 1 of the container's PID namespace, so orphaned children reparent to it and are never `wait()`ed. Well under `pids.max`, but unbounded on a long-lived container, and it makes the process table useless for diagnosis. Either `clawpatrol run` should reap when it is PID 1, or the subreaper semantics should be documented so callers know they need their own init. Happy to file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)