### PR TITLE
gateway: treat zero-valued retention as keep-forever, reject negatives

### DIFF
--- a/cmd/clawpatrol/actions_retention.go
+++ b/cmd/clawpatrol/actions_retention.go
@@ -29,10 +29,10 @@ const actionsDeleteBatch = 5000
 //
 // defaultKeep is the global default (gateway.actions_keep). Each
 // endpoint may override it with its own `retention`. A keep of 0 (from
-// "0" / "off") means keep forever: for the global default it disables
-// the catch-all sweep; for an endpoint it exempts that endpoint's rows
-// from pruning entirely. Per-endpoint overrides run even when the
-// global default is disabled.
+// "0" / "off", or any zero-valued duration like "0s") means keep
+// forever: for the global default it disables the catch-all sweep; for
+// an endpoint it exempts that endpoint's rows from pruning entirely.
+// Per-endpoint overrides run even when the global default is disabled.
 func (g *Gateway) startActionsSweeper(defaultKeep time.Duration) {
 	if g.db == nil {
 		return
@@ -67,15 +67,28 @@ func (g *Gateway) sweepActions(defaultKeep time.Duration) {
 				continue
 			}
 			d, err := time.ParseDuration(raw)
-			if err != nil {
-				// A malformed retention must NOT silently mean "keep
-				// forever" — that's the disk-growth direction this whole
-				// feature exists to prevent. Leave it out of overrides so
-				// the global default still prunes the endpoint, and log
-				// loudly. (actions_keep / session_keep are validated at
-				// config load; per-endpoint retention isn't reachable there
-				// yet, so guard it here.)
-				log.Printf("actions: endpoint %q has an invalid retention %q: %v — applying the default sweep instead", name, raw, err)
+			if err != nil || d < 0 {
+				// A malformed (or negative) retention must NOT silently
+				// mean "keep forever" — that's the disk-growth direction
+				// this whole feature exists to prevent. Leave it out of
+				// overrides so the global default still prunes the
+				// endpoint, and log loudly. Config load rejects these too;
+				// this guard covers policies swapped in through any path
+				// that skipped that validation.
+				if err == nil {
+					log.Printf("actions: endpoint %q has a negative retention %q — applying the default sweep instead", name, raw)
+				} else {
+					log.Printf("actions: endpoint %q has an invalid retention %q: %v — applying the default sweep instead", name, raw, err)
+				}
+				continue
+			}
+			if d == 0 {
+				// Zero-valued durations ("0s", "0h", …) carry the same
+				// intent as the "0" / "off" sentinels: keep forever. They
+				// must NOT fall through to the delete below, where
+				// cutoff = now would wipe the endpoint's entire history —
+				// the exact inverse of what the operator asked for.
+				overrides = append(overrides, name)
 				continue
 			}
 			overrides = append(overrides, name)

--- a/cmd/clawpatrol/actions_retention_test.go
+++ b/cmd/clawpatrol/actions_retention_test.go
@@ -107,9 +107,11 @@ func TestSweepActionsGlobalDisabledKeepsPerEndpointOverrides(t *testing.T) {
 	}
 }
 
-// A malformed per-endpoint retention (e.g. a missing unit) must fall
-// back to the global default sweep, not silently keep the endpoint's
-// rows forever — that would defeat the whole point on a typo.
+// A malformed per-endpoint retention (e.g. a missing unit) or a
+// negative one must fall back to the global default sweep — not
+// silently keep the endpoint's rows forever (defeats the point on a
+// typo), and not treat the cutoff as being in the future (a negative
+// duration would otherwise delete the endpoint's entire history).
 func TestSweepActionsInvalidRetentionFallsBackToDefault(t *testing.T) {
 	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
@@ -119,17 +121,50 @@ func TestSweepActionsInvalidRetentionFallsBackToDefault(t *testing.T) {
 	g := &Gateway{db: db}
 	g.policy.Store(&config.CompiledPolicy{
 		Endpoints: map[string]*config.CompiledEndpoint{
-			"typo": {Name: "typo", Retention: "30"}, // missing unit → invalid
+			"typo": {Name: "typo", Retention: "30"},  // missing unit → invalid
+			"neg":  {Name: "neg", Retention: "-24h"}, // negative → invalid
 		},
 	})
 
 	insertAction(t, g, "typo", 48*time.Hour) // older than the default → must be pruned
 	insertAction(t, g, "typo", time.Hour)    // within the default → kept
+	insertAction(t, g, "neg", 48*time.Hour)  // older than the default → must be pruned
+	insertAction(t, g, "neg", time.Hour)     // within the default → MUST survive a negative retention
 
 	g.sweepActions(24 * time.Hour)
 
 	if got := countActions(t, g, "endpoint = 'typo'"); got != 1 {
 		t.Errorf("typo-retention rows = %d, want 1 (invalid retention must fall back to the default sweep)", got)
+	}
+	if got := countActions(t, g, "endpoint = 'neg'"); got != 1 {
+		t.Errorf("negative-retention rows = %d, want 1 (negative retention must fall back to the default sweep, not wipe the endpoint)", got)
+	}
+}
+
+// A zero-valued duration ("0s", "0h") is the "0" sentinel spelled
+// differently and must mean keep-forever. Before the d == 0 guard it
+// fell through to the delete with cutoff = now, wiping the endpoint's
+// entire history — the exact inverse of what the operator asked for.
+func TestSweepActionsZeroDurationRetentionIsExempt(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	g := &Gateway{db: db}
+	g.policy.Store(&config.CompiledPolicy{
+		Endpoints: map[string]*config.CompiledEndpoint{
+			"zero": {Name: "zero", Retention: "0s"},
+		},
+	})
+
+	insertAction(t, g, "zero", 9000*time.Hour) // far past the default → still kept
+	insertAction(t, g, "zero", time.Minute)
+
+	g.sweepActions(24 * time.Hour)
+
+	if got := countActions(t, g, "endpoint = 'zero'"); got != 2 {
+		t.Errorf("zero-retention rows = %d, want 2 (\"0s\" must mean keep forever, same as \"0\")", got)
 	}
 }
 

--- a/internal/config/actions_retention_test.go
+++ b/internal/config/actions_retention_test.go
@@ -3,15 +3,19 @@ package config
 import "testing"
 
 func TestValidateRetentionDuration(t *testing.T) {
-	valid := []string{"", "0", "off", "720h", "30m", "1h30m", " 24h "}
+	// Zero-valued durations ("0s", "0h") are the "0" sentinel spelled
+	// differently and must stay valid: they mean disable / keep forever.
+	valid := []string{"", "0", "off", "720h", "30m", "1h30m", " 24h ", "0s", "0h"}
 	for _, v := range valid {
 		if d := validateRetentionDuration("actions_keep", v); len(d) != 0 {
 			t.Errorf("validateRetentionDuration(%q) = %v, want no diagnostics", v, d)
 		}
 	}
 	// A bare number, a spaced phrase, or garbage must be rejected at load
-	// rather than silently disabling pruning at runtime.
-	invalid := []string{"30", "1 week", "abc", "24hours"}
+	// rather than silently disabling pruning at runtime. Negative
+	// durations parse fine but would put the sweep cutoff in the future
+	// (delete everything), so they are rejected too.
+	invalid := []string{"30", "1 week", "abc", "24hours", "-24h", "-1ns"}
 	for _, v := range invalid {
 		if d := validateRetentionDuration("actions_keep", v); !d.HasErrors() {
 			t.Errorf("validateRetentionDuration(%q) = %v, want an error diagnostic", v, d)

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -126,7 +126,8 @@ type CompiledEndpoint struct {
 	// Retention is the raw `retention = "..."` framework attr, or "" if
 	// unset. When set it overrides gateway.actions_keep for this
 	// endpoint's rows in the action-log sweeper. time.ParseDuration
-	// format; "0" / "off" keeps this endpoint's rows forever.
+	// format; "0" / "off" (or any zero-valued duration like "0s") keeps
+	// this endpoint's rows forever. Validated at compile.
 	Retention string
 
 	// InspectsTruncatable is true when any rule on this endpoint reads a
@@ -533,6 +534,12 @@ func compileEndpoint(name string, ent *Entity, cp *CompiledPolicy) (*CompiledEnd
 		Body:        ent.Body,
 		Description: ent.Framework.Str("description"),
 		Retention:   ent.Framework.Str("retention"),
+	}
+	// Reject a malformed retention at compile rather than letting the
+	// action-log sweeper fall back at runtime — same policy as the
+	// gateway-level actions_keep / session_keep validation.
+	if diags := validateRetentionDuration("retention", ce.Retention); diags.HasErrors() {
+		return nil, fmt.Errorf("endpoint %q: %s", name, diags[0].Detail)
 	}
 	// Hosts live on the plugin's typed body. We cross-cut via a small
 	// interface so the compile pass doesn't have to know every

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1127,18 +1127,29 @@ func validateOperational(gw *Gateway) hcl.Diagnostics {
 }
 
 // validateRetentionDuration flags a retention setting that is neither
-// empty, the "0" / "off" disable sentinels, nor a valid
-// time.ParseDuration string.
+// empty, the "0" / "off" disable sentinels, nor a valid non-negative
+// time.ParseDuration string. Zero-valued durations ("0s") are allowed
+// and mean the same as "0": disable / keep forever. Negative durations
+// are rejected — downstream they would put the sweep cutoff in the
+// future and delete everything, the inverse of a retention floor.
 func validateRetentionDuration(name, val string) hcl.Diagnostics {
 	v := strings.TrimSpace(val)
 	if v == "" || v == "0" || v == "off" {
 		return nil
 	}
-	if _, err := time.ParseDuration(v); err != nil {
+	d, err := time.ParseDuration(v)
+	if err != nil {
 		return hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid " + name,
 			Detail:   fmt.Sprintf("%s = %q: %v. Use a time.ParseDuration string like %q or %q, or %q / %q to disable.", name, val, err, "720h", "30m", "0", "off"),
+		}}
+	}
+	if d < 0 {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid " + name,
+			Detail:   fmt.Sprintf("%s = %q: negative durations are not allowed. Use a positive duration like %q, or %q / %q to disable.", name, val, "720h", "0", "off"),
 		}}
 	}
 	return nil

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -186,8 +186,9 @@ var frameworkAttrsByKind = map[Kind][]FrameworkAttrSpec{
 		{Name: "description", Optional: true},
 		// Per-endpoint action-log retention. Overrides the global
 		// gateway.actions_keep default for this endpoint's rows.
-		// time.ParseDuration format ("168h"); "0" / "off" keeps this
-		// endpoint's rows forever.
+		// time.ParseDuration format ("168h"); "0" / "off" (or any
+		// zero-valued duration like "0s") keeps this endpoint's rows
+		// forever. Negative values are rejected at compile.
 		{Name: "retention", Optional: true},
 	},
 	// credential→endpoint binding lives on the credential block. A

--- a/internal/config/retention_compile_test.go
+++ b/internal/config/retention_compile_test.go
@@ -1,0 +1,44 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// Per-endpoint `retention` must be validated at compile — a typo has to
+// fail config load like a bad gateway actions_keep does, instead of
+// surfacing only as an hourly sweeper log line at runtime.
+func TestCompileValidatesEndpointRetention(t *testing.T) {
+	load := func(t *testing.T, retention string) (*config.CompiledPolicy, error) {
+		t.Helper()
+		src := `
+endpoint "https" "x" {
+  hosts     = ["example.com"]
+  retention = "` + retention + `"
+}
+credential "bearer_token" "tok" {
+  endpoint = https.x
+}
+profile "p" { credentials = [bearer_token.tok] }
+`
+		gw, diags := config.LoadBytes([]byte(testGatewayPrefix+src), "in.hcl")
+		if diags.HasErrors() {
+			t.Fatalf("load with retention %q: %v", retention, diags)
+		}
+		return config.Compile(gw)
+	}
+
+	// "0s" is keep-forever (same as "0"), not an error.
+	for _, ok := range []string{"168h", "0", "0s", "off"} {
+		if _, err := load(t, ok); err != nil {
+			t.Errorf("Compile with retention %q: unexpected error: %v", ok, err)
+		}
+	}
+	// A bare number, garbage, or a negative duration must fail compile.
+	for _, bad := range []string{"30", "1 week", "-24h"} {
+		if _, err := load(t, bad); err == nil {
+			t.Errorf("Compile with retention %q: want error, got nil", bad)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #759, addressing the [review comments](https://github.com/denoland/clawpatrol/pull/759#pullrequestreview-4668523887) that landed after the merge.

## Problem

The keep-forever sentinels are exact string matches (`"0"` / `"off"`), but `time.ParseDuration` accepts other spellings of zero and negative values, which fell through to the per-endpoint delete:

- `retention = "0s"` → `d = 0` → cutoff = now → **the endpoint's entire history is deleted on the next sweep** — the exact inverse of "keep forever", on the keep-my-LLM-logs path the override exists for.
- `retention = "-24h"` → cutoff lands in the future → same total wipe.
- Gateway-level: `actions_keep = "-24h"` passed validation, then `parseDurationOr` returned a negative and the `defaultKeep <= 0` guard silently disabled the sweep — reads as "prune aggressively", acts as "keep forever".

## Fix

- **sweeper**: a parsed `d == 0` is exempt, same as `"0"`; `d < 0` is invalid → loud log + fall back to the default sweep, like a parse error. Invalid must not mean "keep forever" (disk growth) and must not mean "wipe" (data loss).
- **config load**: `validateRetentionDuration` rejects negative durations. Zero-valued durations stay valid and mean disable / keep forever.
- **compile**: per-endpoint `retention` is now validated in `compileEndpoint`, so a typo fails config load the same way a bad `actions_keep` does, instead of surfacing only as an hourly sweeper log line. The runtime guard stays as belt-and-braces for policies swapped in through any path that skips validation.

## Verification

- New tests: `"0s"` keeps all rows (regression for the wipe), `-24h` falls back to the default sweep (recent rows survive), load-time rejection of `-24h` / `-1ns`, compile-time accept (`168h`, `0`, `0s`, `off`) / reject (`30`, `1 week`, `-24h`).
- Full `./internal/config/...` and `./cmd/clawpatrol` suites pass; `gofmt -l` clean.