### PR TITLE
macos: age out idle BypassUDP flows to stop UDP ephemeral-port exhaustion

### DIFF
--- a/macos/ClawpatrolExtension/Provider.swift
+++ b/macos/ClawpatrolExtension/Provider.swift
@@ -878,20 +878,64 @@ private func parentPid(of pid: pid_t) -> pid_t? {
 // r.98382363 race, then pump datagrams between the flow and a real
 // host UDP socket. Caller's UDP socket sees normal traffic; QUIC,
 // mDNS, DNS, NTP, etc. all work unchanged.
+//
+// Flow lifetime: UDP is connectionless, and macOS frequently never
+// signals flow teardown when the originating socket closes — the
+// readDatagrams error path alone therefore leaks one host socket per
+// one-shot exchange (DNS, STUN, NTP), exhausting the ephemeral port
+// range (~16k) after hours of normal traffic. A shared sweeper ages
+// out flows idle longer than idleTimeout; 90s exceeds typical NAT
+// UDP mapping lifetimes, so anything that survives NATs (QUIC,
+// WebRTC) keepalives well within it and is never swept.
 final class BypassUDP {
     private static var live = Set<BypassUDP>()
     private static let liveLock = NSLock()
+    private static let idleTimeout: TimeInterval = 90
+    private static let sweepInterval: TimeInterval = 30
+    private static var sweeper: DispatchSourceTimer?
 
     private let flow: NEAppProxyUDPFlow
     private var sock: Int32 = -1
     private var recvSource: DispatchSourceRead?
     private let recvQueue = DispatchQueue(label: "bypass.udp.recv", qos: .userInitiated)
+    private var lastActivity = Date()   // guarded by BypassUDP.liveLock
+    private var closed = false          // guarded by BypassUDP.liveLock
 
     init(flow: NEAppProxyUDPFlow) { self.flow = flow }
+
+    private func touch() {
+        BypassUDP.liveLock.lock()
+        lastActivity = Date()
+        BypassUDP.liveLock.unlock()
+    }
+
+    // Caller must hold liveLock.
+    private static func ensureSweeper() {
+        guard sweeper == nil else { return }
+        let t = DispatchSource.makeTimerSource(
+            queue: DispatchQueue(label: "bypass.udp.sweep", qos: .utility))
+        t.schedule(deadline: .now() + sweepInterval, repeating: sweepInterval)
+        t.setEventHandler { BypassUDP.sweep() }
+        t.resume()
+        sweeper = t
+    }
+
+    private static func sweep() {
+        let cutoff = Date().addingTimeInterval(-idleTimeout)
+        liveLock.lock()
+        let stale = live.filter { $0.lastActivity < cutoff }
+        let total = live.count
+        liveLock.unlock()
+        guard !stale.isEmpty else { return }
+        os_log("bypass: closing %d idle UDP flows (%d live)",
+               log: log, type: .info, stale.count, total)
+        for f in stale { f.closeAll() }
+    }
 
     func start() {
         BypassUDP.liveLock.lock()
         BypassUDP.live.insert(self)
+        BypassUDP.ensureSweeper()
         BypassUDP.liveLock.unlock()
         // AF_INET6 dual-stack so v4-mapped addresses route correctly.
         sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
@@ -922,6 +966,7 @@ final class BypassUDP {
             if err != nil || data == nil || data!.isEmpty {
                 self.closeAll(); return
             }
+            self.touch()
             for (d, ep) in zip(data!, endpoints ?? []) {
                 guard let host = ep as? NWHostEndpoint else { continue }
                 self.sendOne(d, to: host)
@@ -961,19 +1006,25 @@ final class BypassUDP {
             }
         }
         if n <= 0 { return }
+        touch()
         guard let src = sockaddrToHostEndpoint(&ss) else { return }
         let chunk = Data(bytes: buf, count: n)
         flow.writeDatagrams([chunk], sentBy: [src]) { _ in }
     }
 
     private func closeAll() {
+        BypassUDP.liveLock.lock()
+        if closed {
+            BypassUDP.liveLock.unlock()
+            return
+        }
+        closed = true
+        BypassUDP.live.remove(self)
+        BypassUDP.liveLock.unlock()
         recvSource?.cancel()
         recvSource = nil
         flow.closeReadWithError(nil)
         flow.closeWriteWithError(nil)
-        BypassUDP.liveLock.lock()
-        BypassUDP.live.remove(self)
-        BypassUDP.liveLock.unlock()
     }
 }
 


### PR DESCRIPTION
Fixes #761.

`BypassUDP` opens one real host UDP socket per claimed flow and closes it only on the `readDatagrams` error/EOF path. macOS frequently never signals teardown for connectionless UDP flows, so one-shot exchanges (DNS, STUN, NTP) leak their socket, and the static `live` set pins the object forever. Hosts that also run Tailscale hit ephemeral-port exhaustion (~16k) within hours — at which point every UDP bind on the machine fails (`EADDRNOTAVAIL`) until the extension process is recycled. Full evidence and measurements in #761.

## What this does

- Track `lastActivity` per flow (touched on both datagram directions).
- One shared `DispatchSourceTimer` sweeps `BypassUDP.live` every 30s and closes flows idle longer than 90s. 90s exceeds typical NAT UDP mapping lifetimes, so anything that survives NATs in the wild (QUIC, WebRTC) keepalives well within it and is never swept; one-shot DNS/STUN flows age out instead of leaking.
- `closeAll()` made idempotent via a `closed` flag guarded by the existing `liveLock` — the sweeper and the `readDatagrams` error path can race, and the flag also prevents double `closeReadWithError` on the flow.
- `lastActivity` reads/writes are guarded by the existing static `liveLock` (uncontended lock per datagram batch; negligible next to the syscall cost of the pump).

## Verification

- `swiftc -typecheck` clean against this branch (only the pre-existing `NWHostEndpoint`/`NEProvider` deprecation warnings).
- Leak reproduced and measured on macOS 26 (Darwin 25.5): extension held 5,408 of 5,428 system-wide UDP sockets at 13h uptime, +2 per single `tailscale netcheck`, strictly monotonic — see #761 for the full incident data (netcheck bind failures, magicsock death, recovery only on extension recycle).
- I don't hold Apple NE provisioning for team 2H4KBF436B, so I could not soak-test a signed build of the extension itself; the sweep logic is deliberately minimal and logs `bypass: closing N idle UDP flows (M live)` at info level so a soak on your side is observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
