### PR TITLE
extplugin: fetch attestation bundles served by reference via bundle_url

### DIFF
--- a/internal/config/extplugin/provenance.go
+++ b/internal/config/extplugin/provenance.go
@@ -195,27 +195,41 @@ func (c *ghClient) attestations(ctx context.Context, owner, repo, digest string)
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("github: decode attestations: %w", err)
 	}
+	// Entries are independent: one attestation that fails to fetch or
+	// decode must not discard a sibling that loads — verify() only needs
+	// one valid attestation. Per-entry errors are collected and surface
+	// as a hard error only when nothing loaded at all, so an attestation
+	// that exists but is unretrievable still fails closed rather than
+	// degrading to the errNoAttestation soft miss.
 	var out []*bundle.Bundle
+	var errs []error
 	for _, a := range payload.Attestations {
 		raw := []byte(a.Bundle)
 		if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
 			if a.BundleURL == "" {
 				continue // degenerate entry: nothing inline and nothing by reference
 			}
-			raw, err = c.bundleFromURL(ctx, a.BundleURL)
+			fetched, err := c.bundleFromURL(ctx, a.BundleURL)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
+				continue
 			}
+			raw = fetched
 		}
 		var pb protobundle.Bundle
 		if err := protojson.Unmarshal(raw, &pb); err != nil {
-			return nil, fmt.Errorf("github: decode attestation bundle: %w", err)
+			errs = append(errs, fmt.Errorf("github: decode attestation bundle: %w", err))
+			continue
 		}
 		b, err := bundle.NewBundle(&pb)
 		if err != nil {
-			return nil, fmt.Errorf("github: load attestation bundle: %w", err)
+			errs = append(errs, fmt.Errorf("github: load attestation bundle: %w", err))
+			continue
 		}
 		out = append(out, b)
+	}
+	if len(out) == 0 && len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 	return out, nil
 }
@@ -232,10 +246,12 @@ var snappyFramedMagic = []byte("\xff\x06\x00\x00sNaPpY")
 // bundleFromURL fetches a by-reference attestation bundle. The API's
 // bundle_url is a time-limited pre-signed URL on GitHub's blob storage,
 // not api.github.com, so no auth headers are attached: forwarding the
-// GitHub token to a third-party host would leak it. A failure here is a
-// hard error, not a soft miss — the attestation exists, and treating an
+// GitHub token to a third-party host would leak it. A failure here is
+// never a soft miss — the attestation exists, and treating an
 // unreachable bundle as absent would let whoever can disrupt the blob
 // path downgrade verification to checksum-only under provenance="warn".
+// The caller skips the failed entry if a sibling attestation loads, and
+// fails closed otherwise.
 func (c *ghClient) bundleFromURL(ctx context.Context, u string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {

--- a/internal/config/extplugin/provenance.go
+++ b/internal/config/extplugin/provenance.go
@@ -1,6 +1,7 @@
 package extplugin
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/klauspost/compress/snappy"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
@@ -186,7 +188,8 @@ func (c *ghClient) attestations(ctx context.Context, owner, repo, digest string)
 	}
 	var payload struct {
 		Attestations []struct {
-			Bundle json.RawMessage `json:"bundle"`
+			Bundle    json.RawMessage `json:"bundle"`
+			BundleURL string          `json:"bundle_url"`
 		} `json:"attestations"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -194,11 +197,18 @@ func (c *ghClient) attestations(ctx context.Context, owner, repo, digest string)
 	}
 	var out []*bundle.Bundle
 	for _, a := range payload.Attestations {
-		if len(a.Bundle) == 0 {
-			continue
+		raw := []byte(a.Bundle)
+		if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+			if a.BundleURL == "" {
+				continue // degenerate entry: nothing inline and nothing by reference
+			}
+			raw, err = c.bundleFromURL(ctx, a.BundleURL)
+			if err != nil {
+				return nil, err
+			}
 		}
 		var pb protobundle.Bundle
-		if err := protojson.Unmarshal(a.Bundle, &pb); err != nil {
+		if err := protojson.Unmarshal(raw, &pb); err != nil {
 			return nil, fmt.Errorf("github: decode attestation bundle: %w", err)
 		}
 		b, err := bundle.NewBundle(&pb)
@@ -208,4 +218,75 @@ func (c *ghClient) attestations(ctx context.Context, owner, repo, digest string)
 		out = append(out, b)
 	}
 	return out, nil
+}
+
+// maxBundleBytes caps a by-reference attestation bundle, both as
+// downloaded and after decompression (the same cap as the attestations
+// response body above).
+const maxBundleBytes = 16 << 20
+
+// snappyFramedMagic is the stream-identifier chunk that opens the
+// snappy framing format.
+var snappyFramedMagic = []byte("\xff\x06\x00\x00sNaPpY")
+
+// bundleFromURL fetches a by-reference attestation bundle. The API's
+// bundle_url is a time-limited pre-signed URL on GitHub's blob storage,
+// not api.github.com, so no auth headers are attached: forwarding the
+// GitHub token to a third-party host would leak it. A failure here is a
+// hard error, not a soft miss — the attestation exists, and treating an
+// unreachable bundle as absent would let whoever can disrupt the blob
+// path downgrade verification to checksum-only under provenance="warn".
+func (c *ghClient) bundleFromURL(ctx context.Context, u string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch attestation bundle: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch attestation bundle: %w", err)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBundleBytes))
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch attestation bundle: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: fetch attestation bundle: HTTP %d", resp.StatusCode)
+	}
+	return decodeBundlePayload(body)
+}
+
+// decodeBundlePayload returns bundle JSON from a bundle_url response
+// body: a snappy framed stream, raw JSON, or a snappy block (what
+// GitHub serves today, Content-Type application/x-snappy). Sniffing '{'
+// for raw JSON is safe: a snappy block starting with 0x7b would declare
+// a decoded length of exactly 123 bytes (a one-byte varint), far below
+// any real bundle.
+func decodeBundlePayload(data []byte) ([]byte, error) {
+	switch {
+	case bytes.HasPrefix(data, snappyFramedMagic):
+		out, err := io.ReadAll(io.LimitReader(snappy.NewReader(bytes.NewReader(data)), maxBundleBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("github: decompress attestation bundle: %w", err)
+		}
+		if len(out) > maxBundleBytes {
+			return nil, fmt.Errorf("github: attestation bundle too large (> %d bytes decompressed)", maxBundleBytes)
+		}
+		return out, nil
+	case len(data) > 0 && data[0] == '{':
+		return data, nil
+	default:
+		n, err := snappy.DecodedLen(data)
+		if err != nil {
+			return nil, fmt.Errorf("github: decompress attestation bundle: %w", err)
+		}
+		if n > maxBundleBytes {
+			return nil, fmt.Errorf("github: attestation bundle too large (> %d bytes decompressed)", maxBundleBytes)
+		}
+		out, err := snappy.Decode(nil, data)
+		if err != nil {
+			return nil, fmt.Errorf("github: decompress attestation bundle: %w", err)
+		}
+		return out, nil
+	}
 }

--- a/internal/config/extplugin/provenance_test.go
+++ b/internal/config/extplugin/provenance_test.go
@@ -265,6 +265,31 @@ func TestAttestationsBundleURL(t *testing.T) {
 		}
 	})
 
+	t.Run("valid_inline_then_unreachable_url", func(t *testing.T) {
+		// A loadable bundle must survive a sibling entry whose blob is
+		// temporarily unavailable: verify() applies its one-valid-
+		// attestation-is-enough policy, so dropping everything over one
+		// unreachable entry is an availability failure that buys no
+		// authenticity.
+		apiJSON := `{"attestations":[{"bundle":` + minimalBundleJSON + `},{"bundle":null,"bundle_url":"%s"}]}`
+		c, _, _ := bundleURLServers(t, http.StatusForbidden, []byte("gone"), apiJSON)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 1 {
+			t.Fatalf("bundles=%d err=%v, want the valid inline bundle despite the unreachable sibling", len(bundles), err)
+		}
+	})
+
+	t.Run("unreachable_url_then_valid_inline", func(t *testing.T) {
+		// Same as above with the entry order flipped: the failing
+		// entry comes first and must not short-circuit the loop.
+		apiJSON := `{"attestations":[{"bundle":null,"bundle_url":"%s"},{"bundle":` + minimalBundleJSON + `}]}`
+		c, _, _ := bundleURLServers(t, http.StatusForbidden, []byte("gone"), apiJSON)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 1 {
+			t.Fatalf("bundles=%d err=%v, want the valid inline bundle despite the unreachable sibling", len(bundles), err)
+		}
+	})
+
 	t.Run("mixed_inline_and_by_reference", func(t *testing.T) {
 		apiJSON := `{"attestations":[{"bundle":null,"bundle_url":"%s"},{"bundle":` + minimalBundleJSON + `}]}`
 		body := snappy.Encode(nil, []byte(minimalBundleJSON))

--- a/internal/config/extplugin/provenance_test.go
+++ b/internal/config/extplugin/provenance_test.go
@@ -1,6 +1,7 @@
 package extplugin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/klauspost/compress/snappy"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 
@@ -110,6 +112,168 @@ func TestAttestationsAPIParsing(t *testing.T) {
 	if _, err := c.attestations(context.Background(), "o", "r", "sha256:abc"); err == nil {
 		t.Error("malformed bundle should error")
 	}
+}
+
+// minimalBundleJSON is the smallest bundle JSON that survives both
+// protojson decoding and bundle.NewBundle validation: a v0.3 media type,
+// a public-key verification material, a message signature, and no tlog
+// entries (so no inclusion proof is required). It would never verify
+// cryptographically — these tests stop at the parsing layer.
+const minimalBundleJSON = `{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json",` +
+	`"verificationMaterial":{"publicKey":{"hint":"test"}},` +
+	`"messageSignature":{"messageDigest":{"algorithm":"SHA2_256",` +
+	`"digest":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"signature":"c2ln"}}`
+
+// bundleURLServers fakes the two hosts involved in a by-reference
+// attestation: a blob host serving blobBody with blobStatus, and a
+// GitHub API host answering the attestations endpoint with apiJSON
+// (a fmt template whose single %s receives the blob URL). The returned
+// client carries a token so tests can prove it reaches the API host but
+// never the blob host. blobAuth records the Authorization header the
+// blob host received; blobHits counts its requests.
+func bundleURLServers(t *testing.T, blobStatus int, blobBody []byte, apiJSON string) (c *ghClient, blobAuth *string, blobHits *int) {
+	t.Helper()
+	blobAuth, blobHits = new(string), new(int)
+	blob := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*blobAuth = r.Header.Get("Authorization")
+		*blobHits++
+		w.Header().Set("Content-Type", "application/x-snappy")
+		w.WriteHeader(blobStatus)
+		_, _ = w.Write(blobBody)
+	}))
+	t.Cleanup(blob.Close)
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("API host got Authorization %q, want \"Bearer tok\"", got)
+		}
+		_, _ = fmt.Fprintf(w, apiJSON, blob.URL+"/attestations/1234.json.sn")
+	}))
+	t.Cleanup(api.Close)
+	return &ghClient{http: api.Client(), base: api.URL, token: "tok"}, blobAuth, blobHits
+}
+
+// TestAttestationsBundleURL covers attestations delivered by reference:
+// GitHub now returns "bundle": null plus a bundle_url pointing at blob
+// storage, where the bundle is served snappy-compressed (issue #769).
+func TestAttestationsBundleURL(t *testing.T) {
+	ctx := context.Background()
+	const nullWithURL = `{"attestations":[{"bundle":null,"bundle_url":"%s"}]}`
+
+	t.Run("snappy_block", func(t *testing.T) {
+		// What GitHub serves today. Also the token-leak guard: the blob
+		// host is a pre-signed third-party URL and must not receive the
+		// GitHub token (the API-host assertion in the helper proves the
+		// client does send it where it belongs).
+		body := snappy.Encode(nil, []byte(minimalBundleJSON))
+		c, blobAuth, _ := bundleURLServers(t, http.StatusOK, body, nullWithURL)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 1 {
+			t.Fatalf("bundles=%d err=%v, want 1 bundle", len(bundles), err)
+		}
+		if *blobAuth != "" {
+			t.Errorf("blob host got Authorization %q; the GitHub token must not leak to blob storage", *blobAuth)
+		}
+	})
+
+	t.Run("snappy_framed", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := snappy.NewBufferedWriter(&buf)
+		if _, err := w.Write([]byte(minimalBundleJSON)); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		c, _, _ := bundleURLServers(t, http.StatusOK, buf.Bytes(), nullWithURL)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 1 {
+			t.Fatalf("bundles=%d err=%v, want 1 bundle", len(bundles), err)
+		}
+	})
+
+	t.Run("uncompressed_json", func(t *testing.T) {
+		c, _, _ := bundleURLServers(t, http.StatusOK, []byte(minimalBundleJSON), nullWithURL)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 1 {
+			t.Fatalf("bundles=%d err=%v, want 1 bundle", len(bundles), err)
+		}
+	})
+
+	t.Run("null_bundle_no_url", func(t *testing.T) {
+		// A degenerate entry with neither field carries nothing to
+		// verify: skip it, so verify() reports errNoAttestation (soft
+		// miss) rather than a hard decode failure.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"attestations":[{"bundle":null}]}`))
+		}))
+		t.Cleanup(srv.Close)
+		c := &ghClient{http: srv.Client(), base: srv.URL}
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || bundles != nil {
+			t.Fatalf("null bundle without bundle_url should be skipped: bundles=%v err=%v", bundles, err)
+		}
+	})
+
+	t.Run("bundle_url_http_error", func(t *testing.T) {
+		// The attestation exists but its bundle is unretrievable (e.g.
+		// an expired SAS URL): fail closed, not a soft miss — otherwise
+		// blocking the blob path would downgrade verification.
+		c, _, _ := bundleURLServers(t, http.StatusForbidden, []byte("gone"), nullWithURL)
+		_, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err == nil || !strings.Contains(err.Error(), "HTTP 403") {
+			t.Fatalf("blob HTTP error should be a hard error naming the status, got: %v", err)
+		}
+		if errors.Is(err, errNoAttestation) {
+			t.Error("blob fetch failure must not be classified as a soft miss")
+		}
+	})
+
+	t.Run("block_bomb_rejected", func(t *testing.T) {
+		body := snappy.Encode(nil, make([]byte, 17<<20))
+		c, _, _ := bundleURLServers(t, http.StatusOK, body, nullWithURL)
+		_, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("oversized block bundle should be rejected before allocation, got: %v", err)
+		}
+	})
+
+	t.Run("framed_bomb_rejected", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := snappy.NewBufferedWriter(&buf)
+		if _, err := w.Write(make([]byte, 17<<20)); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		c, _, _ := bundleURLServers(t, http.StatusOK, buf.Bytes(), nullWithURL)
+		_, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("oversized framed bundle should be rejected, got: %v", err)
+		}
+	})
+
+	t.Run("inline_preferred_over_url", func(t *testing.T) {
+		apiJSON := `{"attestations":[{"bundle":` + minimalBundleJSON + `,"bundle_url":"%s"}]}`
+		c, _, blobHits := bundleURLServers(t, http.StatusOK, []byte("garbage"), apiJSON)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 1 {
+			t.Fatalf("bundles=%d err=%v, want 1 bundle", len(bundles), err)
+		}
+		if *blobHits != 0 {
+			t.Errorf("blob host was hit %d times; an inline bundle must not trigger a fetch", *blobHits)
+		}
+	})
+
+	t.Run("mixed_inline_and_by_reference", func(t *testing.T) {
+		apiJSON := `{"attestations":[{"bundle":null,"bundle_url":"%s"},{"bundle":` + minimalBundleJSON + `}]}`
+		body := snappy.Encode(nil, []byte(minimalBundleJSON))
+		c, _, _ := bundleURLServers(t, http.StatusOK, body, apiJSON)
+		bundles, err := c.attestations(ctx, "o", "r", "sha256:abc")
+		if err != nil || len(bundles) != 2 {
+			t.Fatalf("bundles=%d err=%v, want 2 bundles", len(bundles), err)
+		}
+	})
 }
 
 // TestProvenanceVerifyIfPresentFallback checks the fetcher behavior: a


### PR DESCRIPTION
## Summary

Fixes #769.

GitHub's attestations API can now return `"bundle": null` plus a `bundle_url` pointing at blob storage, where the Sigstore bundle is served snappy-compressed (`Content-Type: application/x-snappy`, `.json.sn`). `attestations()` only read the inline `bundle`, so the literal JSON `null` reached `protojson.Unmarshal` and every affected plugin failed provenance verification with `proto: syntax error (line 1:1): unexpected token null` — fail closed even under `provenance = "warn"`, because the attestation entry exists.

## Changes

- When the inline bundle is empty or `null` and `bundle_url` is set, fetch the URL and decode the payload into the existing `protojson → bundle.NewBundle` path. Three payload shapes are handled: snappy block (what GitHub serves today), snappy framed stream, and raw JSON. Uses `github.com/klauspost/compress/snappy`, already a direct dependency — no go.mod change.
- Decompressed size is capped at 16 MiB (consistent with the existing response-body cap), checked via `snappy.DecodedLen` **before** allocating, so a compressed bomb is rejected cheaply.
- **No auth headers on the `bundle_url` fetch**: it is a pre-signed, time-limited URL on a third-party blob host; forwarding the GitHub token there would leak it. This is why the fetch does not reuse `getBytes` (which attaches the bearer token).
- **A `bundle_url` fetch/decode failure stays a hard error**, not a soft miss: the attestation exists, and treating an unreachable bundle as absent would let anyone who can disrupt the blob path downgrade an attested plugin to checksum-only verification under `provenance = "warn"`.
- A `null` bundle with no `bundle_url` is skipped, preserving the `errNoAttestation` soft-miss semantics. Inline bundles keep taking precedence; no fetch happens when one is present.

## Tests

Written first (TDD): `TestAttestationsBundleURL` with nine subtests — snappy block happy path (also asserting the GitHub token is sent to the API host but **not** the blob host), framed stream, uncompressed JSON, null-with-no-URL soft miss, blob HTTP error → hard fail, block/framed decompression bombs rejected, inline preferred over URL (blob never hit), and mixed inline + by-reference entries. Before the fix, eight of nine failed with the exact error from the issue.

`go test ./internal/config/extplugin/`, `go vet`, `gofmt`, and the full `go test ./...` (with the dashboard bundle built) all pass.