### PR TITLE
gateway: enforce unknown_host deny for unmatched HTTPS SNI

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -349,6 +349,11 @@ func newUpstreamDialer(resolver string) *net.Dialer {
 	return d
 }
 
+type gatewayDialer interface {
+	Dial(network, address string) (net.Conn, error)
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
 type Gateway struct {
 	// cfg is the live operational *config.Gateway. Stored as an
 	// atomic pointer because dashboard handlers and the reload loop
@@ -361,7 +366,7 @@ type Gateway struct {
 	db       *sql.DB
 	policy   atomic.Pointer[config.CompiledPolicy]
 	certs    *CertCache
-	dialer   *net.Dialer
+	dialer   gatewayDialer
 	sink     *Sink
 	// blobs is the gateway-side plugin blob store (sqlite-backed).
 	// Used by endpoint plugins that need per-endpoint persistent
@@ -421,7 +426,9 @@ func (g *Gateway) transportFor(ep *config.CompiledEndpoint) *http.Transport {
 		return v.(*http.Transport)
 	}
 	tr := &http.Transport{
-		DialContext: g.dialer.DialContext,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return g.dialer.DialContext(ctx, network, addr)
+		},
 		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			h, _, err := net.SplitHostPort(addr)
 			if err != nil {
@@ -1678,9 +1685,10 @@ func (g *Gateway) handle(raw net.Conn, dstIP string, dstPort uint16) {
 	profile := g.profileFor(pip)
 	ep, authority, certHost := g.httpsMITMEndpoint(profile, host, dstPort)
 	if ep == nil {
-		// Host isn't bound to this profile's endpoint set. Apply the
-		// `defaults.unknown_host` policy: passthrough today (matches
-		// the v14 default). A "deny" mode would close the conn.
+		if policy := g.Policy(); policy != nil && policy.UnknownHost == "deny" {
+			log.Printf("sni: %s: unknown host denied", host)
+			return
+		}
 		g.splice(c, host)
 		return
 	}

--- a/cmd/clawpatrol/sni_dispatch_test.go
+++ b/cmd/clawpatrol/sni_dispatch_test.go
@@ -1,10 +1,182 @@
 package main
 
 import (
+	"context"
+	"crypto/tls"
+	"net"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
+
+const unknownHostSNI = "unmatched.example.test"
+
+type sniDispatchDialer struct {
+	calls     atomic.Int32
+	addresses chan string
+	upstreams chan net.Conn
+}
+
+func newSNIDispatchDialer() *sniDispatchDialer {
+	return &sniDispatchDialer{
+		addresses: make(chan string, 4),
+		upstreams: make(chan net.Conn, 4),
+	}
+}
+
+func (d *sniDispatchDialer) Dial(_ string, address string) (net.Conn, error) {
+	spliceConn, observeConn := net.Pipe()
+	d.calls.Add(1)
+	d.addresses <- address
+	d.upstreams <- observeConn
+	return spliceConn, nil
+}
+
+func (d *sniDispatchDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return d.Dial(network, address)
+	}
+}
+
+func TestSNIDispatchUnknownHostPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		hcl       string
+		wantRelay bool
+	}{
+		{
+			name: "deny",
+			hcl: `
+defaults { unknown_host = "deny" }
+profile "default" { credentials = [] }
+`,
+		},
+		{
+			name: "explicit passthrough",
+			hcl: `
+defaults { unknown_host = "passthrough" }
+profile "default" { credentials = [] }
+`,
+			wantRelay: true,
+		},
+		{
+			name: "defaults block absent",
+			hcl: `
+profile "default" { credentials = [] }
+`,
+			wantRelay: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gatewayWithPolicy(t, tt.hcl)
+			g.onboard = newOnboardRegistry()
+			sink, err := NewSink(nil, 1)
+			if err != nil {
+				t.Fatalf("NewSink: %v", err)
+			}
+			g.sink = sink
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				if err := sink.Close(ctx); err != nil {
+					t.Errorf("close sink: %v", err)
+				}
+			})
+
+			dialer := newSNIDispatchDialer()
+			g.dialer = dialer
+			serverConn, clientConn := net.Pipe()
+			g.onboard.profileByIP[peerIP(serverConn)] = "default"
+			t.Cleanup(func() { _ = clientConn.Close() })
+
+			handlerDone := make(chan struct{})
+			go func() {
+				g.handle(serverConn, "", 443)
+				close(handlerDone)
+			}()
+
+			if err := clientConn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+				t.Fatalf("set client deadline: %v", err)
+			}
+			handshakeDone := make(chan error, 1)
+			go func() {
+				tlsClient := tls.Client(clientConn, &tls.Config{
+					ServerName:         unknownHostSNI,
+					InsecureSkipVerify: true, // The test observes dispatch, not a completed TLS session.
+				})
+				handshakeDone <- tlsClient.Handshake()
+			}()
+
+			if tt.wantRelay {
+				var upstream net.Conn
+				select {
+				case upstream = <-dialer.upstreams:
+				case <-time.After(2 * time.Second):
+					t.Fatal("gateway did not dial passthrough upstream")
+				}
+				if err := upstream.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+					t.Fatalf("set upstream deadline: %v", err)
+				}
+				host, _, err := peekSNI(upstream)
+				if err != nil {
+					_ = upstream.Close()
+					t.Fatalf("read relayed ClientHello: %v", err)
+				}
+				if host != unknownHostSNI {
+					_ = upstream.Close()
+					t.Errorf("relayed SNI = %q, want %q", host, unknownHostSNI)
+				}
+				_ = upstream.Close()
+				_ = clientConn.Close()
+
+				select {
+				case address := <-dialer.addresses:
+					if want := net.JoinHostPort(unknownHostSNI, "443"); address != want {
+						t.Errorf("dial address = %q, want %q", address, want)
+					}
+				default:
+					t.Error("missing dial address")
+				}
+			} else {
+				select {
+				case upstream := <-dialer.upstreams:
+					_ = upstream.Close()
+					t.Error("deny policy dialed an upstream")
+				case <-handlerDone:
+				}
+			}
+
+			select {
+			case <-handlerDone:
+			case <-time.After(2 * time.Second):
+				t.Fatal("gateway handler did not return")
+			}
+			select {
+			case err := <-handshakeDone:
+				if err == nil {
+					t.Fatal("TLS handshake unexpectedly succeeded")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("TLS client handshake did not return")
+			}
+
+			wantDials := int32(0)
+			if tt.wantRelay {
+				wantDials = 1
+			}
+			if got := dialer.calls.Load(); got != wantDials {
+				t.Errorf("upstream dial count = %d, want %d", got, wantDials)
+			}
+		})
+	}
+}
 
 // TestSNIDispatchMarkerExcludesBuiltinConnEndpoints guards the :443 SNI
 // dispatch branch in g.handle. That branch hands a connection to an


### PR DESCRIPTION
## Summary

Fixes #779.

- close unmatched ordinary HTTPS/SNI connections before DNS or upstream dial when `defaults.unknown_host = "deny"`
- preserve explicit passthrough and the existing passthrough default
- cover deny and both passthrough modes through the real SNI dispatch and relay path

## Verification

- `go test ./cmd/clawpatrol -run '^TestSNIDispatch(UnknownHostPolicy|MarkerExcludesBuiltinConnEndpoints)$' -count=1 -v`
- `go test -race ./cmd/clawpatrol -run '^TestSNIDispatchUnknownHostPolicy$' -count=10`
- `go vet ./cmd/clawpatrol`
- `gofmt` and `git diff --check`
