### PR TITLE
join: commit whole-machine marker after routing succeeds

### DIFF
--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -121,6 +121,9 @@ func runJoin(args []string) {
 				reason)
 		}
 	}
+	if err := beginJoinSetup(); err != nil {
+		fail("join: %v", err)
+	}
 	// Fetch CA BEFORE the VPN goes up. Once `wg-quick up` flips
 	// the default route through the gateway, reaching the
 	// gateway's public URL goes via the tunnel — which can't
@@ -211,7 +214,7 @@ func runJoin(args []string) {
 		if gwHostFile != "" {
 			exitNode = gwHostFile
 		}
-		if err := applyWholeMachineExitNode(exitNode); err != nil {
+		if err := completeWholeMachineTailscaleRouting(exitNode, applyWholeMachineExitNode); err != nil {
 			fail("%v", err)
 		}
 		// Closing message printed here (not in onboardViaDeviceFlow) so
@@ -367,10 +370,52 @@ func preJoinFetchCA(gateway, caDir string, cli *http.Client) (joinSetup, error) 
 // the gateway, so there's no per-process daemon/sandbox to attach to.
 const wholeMachineMarkerName = "whole-machine"
 
+func wholeMachineMarkerPath() string {
+	return filepath.Join(defaultClawpatrolDir(), wholeMachineMarkerName)
+}
+
+func clearWholeMachineMarker() error {
+	err := os.Remove(wholeMachineMarkerPath())
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("remove whole-machine marker: %w", err)
+}
+
+// beginJoinSetup invalidates any previous whole-machine commit before an
+// admitted join mutates local or network state. fail calls os.Exit, so this
+// transition must be synchronous rather than deferred.
+func beginJoinSetup() error {
+	return clearWholeMachineMarker()
+}
+
+func completeWholeMachineRouting(configure func() error) error {
+	if err := configure(); err != nil {
+		return err
+	}
+	return commitWholeMachineMarker()
+}
+
+func completeWholeMachineTailscaleRouting(exitNode string, apply func(string) error) error {
+	return completeWholeMachineRouting(func() error {
+		return apply(exitNode)
+	})
+}
+
+func commitWholeMachineMarker() error {
+	if err := os.MkdirAll(defaultClawpatrolDir(), 0o700); err != nil {
+		return fmt.Errorf("create clawpatrol dir for whole-machine marker: %w", err)
+	}
+	if err := atomicWriteFile(wholeMachineMarkerPath(), []byte("1\n"), 0o600); err != nil {
+		return fmt.Errorf("commit whole-machine marker: %w", err)
+	}
+	return nil
+}
+
 // isWholeMachineJoin reports whether this device was joined with
-// --whole-machine (the marker is written by finishJoinSetup).
+// --whole-machine.
 func isWholeMachineJoin() bool {
-	_, err := os.Stat(filepath.Join(defaultClawpatrolDir(), wholeMachineMarkerName))
+	_, err := os.Stat(wholeMachineMarkerPath())
 	return err == nil
 }
 
@@ -380,15 +425,6 @@ func isWholeMachineJoin() bool {
 // trust a prior join's stale ca.crt (rejoin) or commit a CA that a later fatal
 // step would strand.
 func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine, deferCA bool) {
-	if wholeMachine && s.caPath != "" {
-		// Record the mode so `clawpatrol run` can short-circuit to a
-		// direct exec instead of trying to spawn the per-host daemon.
-		// Written next to the rest of the join state (mode, gateway,
-		// …). `clawpatrol run` reads defaultClawpatrolDir(), the same
-		// dir the daemon assumes — so, like the other state files, the
-		// marker is only found when join used the default --ca-dir.
-		_ = os.WriteFile(filepath.Join(filepath.Dir(s.caPath), wholeMachineMarkerName), []byte("1\n"), 0o600)
-	}
 	if s.caPath == "" {
 		return
 	}
@@ -1368,7 +1404,9 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		} else if runtime.GOOS == "darwin" {
 			printWholeMachineDone("system extension")
 		} else {
-			if err := wgQuickUp(iface, authKey); err != nil {
+			if err := completeWholeMachineRouting(func() error {
+				return wgQuickUp(iface, authKey)
+			}); err != nil {
 				return true, fmt.Errorf("wg-quick up: %w", err)
 			}
 			printWholeMachineDone(iface)

--- a/cmd/clawpatrol/whole_machine_marker_linux_test.go
+++ b/cmd/clawpatrol/whole_machine_marker_linux_test.go
@@ -1,0 +1,256 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestWholeMachineMarkerPerProcessSwitchClearsDirectRunGate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+
+	if err := clearWholeMachineMarker(); err != nil {
+		t.Fatal(err)
+	}
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestWholeMachineMarkerRejoinInvalidatesPreviousCommit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+
+	if err := beginJoinSetup(); err != nil {
+		t.Fatal(err)
+	}
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestFinishJoinSetupDoesNotCommitWholeMachineMarker(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := os.MkdirAll(defaultClawpatrolDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	setup := joinSetup{caPath: filepath.Join(defaultClawpatrolDir(), "ca.crt")}
+	finishJoinSetup(&setup, true, true, true)
+
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestCompleteWholeMachineRoutingFailureLeavesRunSandboxed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	routingErr := errors.New("wg-quick failed")
+
+	err := completeWholeMachineRouting(func() error {
+		assertWholeMachineMarkerAbsent(t)
+		return routingErr
+	})
+	if !errors.Is(err, routingErr) {
+		t.Fatalf("complete routing error = %v, want %v", err, routingErr)
+	}
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestCompleteWholeMachineRoutingSuccessCommitsDirectRunGate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	routingRan := false
+
+	if err := completeWholeMachineRouting(func() error {
+		routingRan = true
+		assertWholeMachineMarkerAbsent(t)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !routingRan {
+		t.Fatal("routing callback did not run")
+	}
+	if !isWholeMachineJoin() {
+		t.Fatal("successful routing did not enable direct run gate")
+	}
+	got, err := os.ReadFile(wholeMachineMarkerPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "1\n" {
+		t.Fatalf("marker content = %q, want %q", got, "1\\n")
+	}
+	info, err := os.Stat(wholeMachineMarkerPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("marker mode = %o, want 600", info.Mode().Perm())
+	}
+	temps, err := filepath.Glob(filepath.Join(defaultClawpatrolDir(), ".whole-machine-*.tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(temps) != 0 {
+		t.Fatalf("temporary marker files remain: %v", temps)
+	}
+}
+
+func TestWholeMachineMarkerTailscaleExitNodeFailureLeavesRunSandboxed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+	if err := beginJoinSetup(); err != nil {
+		t.Fatal(err)
+	}
+	routingErr := errors.New("tailscale set failed")
+
+	err := completeWholeMachineTailscaleRouting("gateway-node", func(exitNode string) error {
+		if exitNode != "gateway-node" {
+			t.Fatalf("exit node = %q, want gateway-node", exitNode)
+		}
+		assertWholeMachineMarkerAbsent(t)
+		return routingErr
+	})
+	if !errors.Is(err, routingErr) {
+		t.Fatalf("complete Tailscale routing error = %v, want %v", err, routingErr)
+	}
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestWholeMachineMarkerWGRejoinFailureDoesNotRestoreOldCommit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+	if err := beginJoinSetup(); err != nil {
+		t.Fatal(err)
+	}
+
+	routingErr := errors.New("wg-quick failed")
+	if err := completeWholeMachineRouting(func() error { return routingErr }); !errors.Is(err, routingErr) {
+		t.Fatalf("complete routing error = %v, want %v", err, routingErr)
+	}
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestWholeMachineMarkerTailscaleSuccessCommitsAfterExitNode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := completeWholeMachineTailscaleRouting("gateway-node", func(exitNode string) error {
+		if exitNode != "gateway-node" {
+			t.Fatalf("exit node = %q, want gateway-node", exitNode)
+		}
+		assertWholeMachineMarkerAbsent(t)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !isWholeMachineJoin() {
+		t.Fatal("successful Tailscale exit-node setup did not enable direct run gate")
+	}
+}
+
+func TestWholeMachineMarkerPerProcessSuccessNeverCommits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+
+	if err := beginJoinSetup(); err != nil {
+		t.Fatal(err)
+	}
+	// The per-process branch never invokes whole-machine routing completion.
+	assertWholeMachineMarkerAbsent(t)
+}
+
+func TestWholeMachineMarkerCommitFailureLeavesRunSandboxed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(defaultClawpatrolDir(), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := completeWholeMachineRouting(func() error { return nil })
+	if err == nil {
+		t.Fatal("marker commit unexpectedly succeeded")
+	}
+	if isWholeMachineJoin() {
+		t.Fatal("failed marker commit enabled direct run gate")
+	}
+}
+
+func TestWholeMachineMarkerRemovalFailureStopsAdmission(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(wholeMachineMarkerPath(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wholeMachineMarkerPath(), "child"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := beginJoinSetup(); err == nil {
+		t.Fatal("join admission unexpectedly ignored marker removal failure")
+	}
+	if !isWholeMachineJoin() {
+		t.Fatal("failed removal changed existing marker state")
+	}
+}
+
+func TestWholeMachineMarkerInvalidCommandPreservesPreviousCommit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+
+	runRejectedJoinSubprocess(t, "invalid")
+	if !isWholeMachineJoin() {
+		t.Fatal("invalid join command cleared previous whole-machine commit")
+	}
+}
+
+func TestWholeMachineMarkerLocalGatewayRejectionPreservesPreviousCommit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedWholeMachineMarker(t)
+
+	runRejectedJoinSubprocess(t, "local-gateway")
+	if !isWholeMachineJoin() {
+		t.Fatal("local-gateway rejection cleared previous whole-machine commit")
+	}
+}
+
+func TestWholeMachineMarkerRejectedJoinHelper(t *testing.T) {
+	switch os.Getenv("CLAWPATROL_REJECTED_JOIN_HELPER") {
+	case "invalid":
+		runJoin(nil)
+	case "local-gateway":
+		runJoin([]string{"--whole-machine", "http://127.0.0.1:8080"})
+	}
+}
+
+func runRejectedJoinSubprocess(t *testing.T, scenario string) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWholeMachineMarkerRejectedJoinHelper$")
+	cmd.Env = append(os.Environ(), "CLAWPATROL_REJECTED_JOIN_HELPER="+scenario)
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+		t.Fatalf("rejected join exit = %v, want status 2", err)
+	}
+}
+
+func seedWholeMachineMarker(t *testing.T) {
+	t.Helper()
+	if err := os.MkdirAll(defaultClawpatrolDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wholeMachineMarkerPath(), []byte("1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isWholeMachineJoin() {
+		t.Fatal("seeded whole-machine marker did not enable direct run gate")
+	}
+}
+
+func assertWholeMachineMarkerAbsent(t *testing.T) {
+	t.Helper()
+	if isWholeMachineJoin() {
+		t.Fatal("whole-machine marker still enables direct run gate")
+	}
+	if _, err := os.Stat(wholeMachineMarkerPath()); !os.IsNotExist(err) {
+		t.Fatalf("marker should be absent: %v", err)
+	}
+}

--- a/cmd/clawpatrol/whole_machine_marker_linux_test.go
+++ b/cmd/clawpatrol/whole_machine_marker_linux_test.go
@@ -212,7 +212,7 @@ func TestWholeMachineMarkerLocalGatewayRejectionPreservesPreviousCommit(t *testi
 	}
 }
 
-func TestWholeMachineMarkerRejectedJoinHelper(t *testing.T) {
+func TestWholeMachineMarkerRejectedJoinHelper(_ *testing.T) {
 	switch os.Getenv("CLAWPATROL_REJECTED_JOIN_HELPER") {
 	case "invalid":
 		runJoin(nil)


### PR DESCRIPTION
## Summary

Fixes #775.

- invalidate stale whole-machine authority when a validated join begins
- remove the optimistic marker write from `finishJoinSetup`
- atomically commit the marker only after WireGuard or Linux Tailscale routing succeeds
- keep invalid commands and rejected local-gateway joins from disturbing a valid marker
- write to the authoritative state path consumed by `clawpatrol run`, including joins with a custom `--ca-dir`

## Verification

- focused marker lifecycle, WireGuard, Tailscale, rejection, and failure-path tests
- `go test -race ./cmd/clawpatrol -run '^(TestWholeMachineMarker|TestCompleteWholeMachine|TestFinishJoinSetupDoesNotCommitWholeMachineMarker)$' -count=5`
- `go vet ./cmd/clawpatrol`
- `gofmt` and `git diff --check`
