### PR TITLE
join: stage WireGuard CA until setup succeeds

### DIFF
--- a/cmd/clawpatrol/fetch_ca_test.go
+++ b/cmd/clawpatrol/fetch_ca_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -23,38 +21,30 @@ func TestFetchCAHTTPRejectsAppendedCA(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	dst := filepath.Join(t.TempDir(), "ca.crt")
-	if _, err := fetchCAHTTP(srv.URL, dst, nil); err == nil {
+	if _, _, err := fetchCAHTTP(srv.URL, nil); err == nil {
 		t.Fatal("expected fetchCAHTTP to reject an appended second CA")
-	}
-	if _, err := os.Stat(dst); err == nil {
-		t.Error("ca.crt must not be written when the payload is rejected")
 	}
 }
 
-// TestFetchCAHTTPPersistsCanonicalSingleCert: a valid single-CA payload is
-// persisted as the canonical certificate the fingerprint was computed over.
-func TestFetchCAHTTPPersistsCanonicalSingleCert(t *testing.T) {
+// TestFetchCAHTTPReturnsCanonicalSingleCert: a valid single-CA payload is
+// returned as the canonical certificate the fingerprint was computed over.
+func TestFetchCAHTTPReturnsCanonicalSingleCert(t *testing.T) {
 	_, certPEM := inMemoryCertCache(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(certPEM)
 	}))
 	defer srv.Close()
 
-	dst := filepath.Join(t.TempDir(), "ca.crt")
-	if _, err := fetchCAHTTP(srv.URL, dst, nil); err != nil {
+	got, _, err := fetchCAHTTP(srv.URL, nil)
+	if err != nil {
 		t.Fatalf("fetchCAHTTP: %v", err)
 	}
-	got, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
 	if !bytes.Equal(bytes.TrimSpace(got), bytes.TrimSpace(certPEM)) {
-		t.Error("persisted ca.crt is not the canonical single certificate")
+		t.Error("returned CA is not the canonical single certificate")
 	}
 }
 
-func TestFetchCAHTTPReturnsFingerprintAndPersistsCert(t *testing.T) {
+func TestFetchCAHTTPReturnsFingerprintAndCert(t *testing.T) {
 	_, certPEM := inMemoryCertCache(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/x-pem-file")
@@ -67,16 +57,15 @@ func TestFetchCAHTTPReturnsFingerprintAndPersistsCert(t *testing.T) {
 		t.Fatalf("expected fp: %v", err)
 	}
 
-	dst := filepath.Join(t.TempDir(), "ca.crt")
-	got, err := fetchCAHTTP(srv.URL, dst, nil)
+	gotCert, got, err := fetchCAHTTP(srv.URL, nil)
 	if err != nil {
 		t.Fatalf("fetchCAHTTP: %v", err)
 	}
 	if got != want {
 		t.Fatalf("returned fingerprint %q, want %q", got, want)
 	}
-	if _, err := os.Stat(dst); err != nil {
-		t.Fatalf("dst missing after successful fetch: %v", err)
+	if !bytes.Equal(bytes.TrimSpace(gotCert), bytes.TrimSpace(certPEM)) {
+		t.Fatal("returned certificate does not match fetched certificate")
 	}
 }
 
@@ -85,14 +74,7 @@ func TestFetchCAHTTPRejectsNonPEMBody(t *testing.T) {
 		_, _ = w.Write([]byte("hello, not a certificate"))
 	}))
 	defer srv.Close()
-	dst := filepath.Join(t.TempDir(), "ca.crt")
-	if _, err := fetchCAHTTP(srv.URL, dst, nil); err == nil {
+	if _, _, err := fetchCAHTTP(srv.URL, nil); err == nil {
 		t.Fatal("expected error for non-pem body")
-	}
-	// installCATrust must never see a malformed file. If a future
-	// refactor wrote the body before parsing we'd silently trust
-	// garbage.
-	if _, err := os.Stat(dst); err == nil {
-		t.Fatal("dst should not exist after parse error")
 	}
 }

--- a/cmd/clawpatrol/setup.go
+++ b/cmd/clawpatrol/setup.go
@@ -147,9 +147,8 @@ func runJoin(args []string) {
 	// returns, so the human credentials never persist on disk — the
 	// agent's permanent identity is the gateway-minted tagged key.
 	//
-	// Trust install + shell-rc updates are deferred to
-	// finishJoinSetup, which runs only after the operator's
-	// dashboard approval click.
+	// The fetched CA remains staged in memory until onboarding's fatal setup
+	// succeeds. Shell-rc setup also waits for dashboard approval.
 	ctx := context.Background()
 	var bootstrap *tailnetBootstrap
 	defer func() {
@@ -298,7 +297,8 @@ func applyWholeMachineExitNode(gwName string) error {
 type joinSetup struct {
 	caInstalled   bool   // installed into system trust
 	installedCAFP string // fingerprint of the CA installed into system trust
-	caPath        string // on-disk path to the fetched cert
+	caPath        string // active on-disk CA destination
+	candidateCA   []byte // staged canonical CA awaiting approved join completion
 	caHint        string // manual-trust hint when caInstalled == false
 	caFingerprint string // SHA-256 of the fetched cert (operator-readable)
 	shellRC       bool   // shell rc updated with `eval "$(clawpatrol env)"`
@@ -311,11 +311,10 @@ func isCaNotExposed(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "status 404")
 }
 
-// preJoinFetchCA downloads the gateway's CA into caDir and computes
-// its SHA-256 fingerprint, but stops short of installing it into
-// the system trust store. Trust install + shell-rc updates land in
-// finishJoinSetup, which runs only once the operator has approved
-// the device on the dashboard.
+// preJoinFetchCA downloads and canonicalizes the gateway's CA into an
+// in-memory candidate and computes its SHA-256 fingerprint. caPath remains the
+// active destination and is not created or replaced until onboarding commits
+// the approved candidate after fatal setup succeeds.
 //
 // Splitting the flow this way puts the visual-fingerprint compare
 // in the loop: an on-path attacker who served a substitute CA over
@@ -344,19 +343,18 @@ func preJoinFetchCA(gateway, caDir string, cli *http.Client) (joinSetup, error) 
 	_ = os.WriteFile(filepath.Join(caDir, "gateway"),
 		[]byte(strings.TrimRight(gateway, "/")+"\n"), 0o644)
 	s.caPath = filepath.Join(caDir, "ca.crt")
-	fp, err := fetchCAHTTP(gateway, s.caPath, cli)
+	canonicalCA, fp, err := fetchCAHTTP(gateway, cli)
 	if err != nil {
 		return s, fmt.Errorf("fetch CA: %w", err)
 	}
+	s.candidateCA = append([]byte(nil), canonicalCA...)
 	s.caFingerprint = fp
 	return s, nil
 }
 
-// finishJoinSetup runs the trust-install + shell-rc steps that
-// were held back from preJoinFetchCA. The caller invokes this
-// only after the operator's dashboard approval has confirmed the
-// CA fingerprint matches — so the CA we install can't be one
-// substituted by an on-path attacker at fetch time.
+// finishJoinSetup runs post-approval shell setup and retains the legacy eager
+// trust path for callers that do not defer CA activation. Device onboarding
+// defers both WireGuard and Tailscale CA activation to commitApprovedCA.
 //
 // installShellRC fires only in --whole-machine mode. In
 // per-process mode every agent picks up CA + push-down vars
@@ -419,8 +417,8 @@ func isWholeMachineJoin() bool {
 	return err == nil
 }
 
-// deferCA (Tailscale mode) tells finishJoinSetup NOT to install any CA now: the
-// approved CA is committed and trusted at the END of the join via
+// deferCA tells finishJoinSetup NOT to install any CA now: the approved CA is
+// committed and trusted at the END of the join via
 // commitApprovedCA, after fatal platform setup. Installing here would either
 // trust a prior join's stale ca.crt (rejoin) or commit a CA that a later fatal
 // step would strand.
@@ -429,7 +427,7 @@ func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine, deferCA bool) {
 		return
 	}
 	if deferCA {
-		// Tailscale: CA committed + trusted at the end of the join.
+		// CA committed + trusted at the end of the join.
 		if wholeMachine {
 			installShellRC() //nolint:errcheck
 		}
@@ -451,12 +449,12 @@ func finishJoinSetup(s *joinSetup, skipTrust, wholeMachine, deferCA bool) {
 	}
 }
 
-// fetchCAHTTP downloads the CA from gateway, writes it to dst,
-// and returns the SHA-256 fingerprint of the cert it received.
+// fetchCAHTTP downloads the CA from gateway and returns the canonical
+// certificate and its SHA-256 fingerprint without making it active.
 // The fingerprint flows back to the CLI's stdout so the operator
 // can compare it against what the dashboard shows during the
 // approval step.
-func fetchCAHTTP(gateway, dst string, cli *http.Client) (string, error) {
+func fetchCAHTTP(gateway string, cli *http.Client) ([]byte, string, error) {
 	url := strings.TrimRight(gateway, "/") + "/ca.crt"
 	c := cli
 	if c == nil {
@@ -473,34 +471,31 @@ func fetchCAHTTP(gateway, dst string, cli *http.Client) (string, error) {
 	}
 	resp, err := c.Get(url)
 	if err != nil {
-		return "", fmt.Errorf("fetch ca: get %s: %w", url, err)
+		return nil, "", fmt.Errorf("fetch ca: get %s: %w", url, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("fetch ca: %s status %d", url, resp.StatusCode)
+		return nil, "", fmt.Errorf("fetch ca: %s status %d", url, resp.StatusCode)
 	}
 	// 256 KiB cap. A PEM-encoded CA cert is <4 KiB; the cap stops a
 	// hostile gateway from streaming gigabytes into a TOFU client
 	// before the fingerprint check rejects it.
 	b, err := io.ReadAll(io.LimitReader(resp.Body, 256<<10))
 	if err != nil {
-		return "", fmt.Errorf("fetch ca: read %s: %w", url, err)
+		return nil, "", fmt.Errorf("fetch ca: read %s: %w", url, err)
 	}
-	// Require exactly one usable CA and persist/fingerprint that canonical
+	// Require exactly one usable CA and return/fingerprint that canonical
 	// certificate — not the raw payload — so an appended attacker CA can't ride
 	// in behind the legitimate first-cert fingerprint the operator confirms.
 	canonical, err := canonicalMITMCAPEM(b)
 	if err != nil {
-		return "", fmt.Errorf("fetch ca from %s: %w", url, err)
+		return nil, "", fmt.Errorf("fetch ca from %s: %w", url, err)
 	}
 	fp, err := caFingerprintFromPEM(canonical)
 	if err != nil {
-		return "", fmt.Errorf("fetch ca: fingerprint from %s: %w", url, err)
+		return nil, "", fmt.Errorf("fetch ca: fingerprint from %s: %w", url, err)
 	}
-	if err := atomicWriteFile(dst, canonical, 0o644); err != nil {
-		return "", fmt.Errorf("fetch ca: write %s: %w", dst, err)
-	}
-	return fp, nil
+	return canonical, fp, nil
 }
 
 // installShellRC appends `eval "$(clawpatrol env)"` to the user's shell
@@ -862,8 +857,8 @@ func (s *joinSetup) warnCATrustFailed() {
 
 // commitApprovedCA atomically writes the approved canonical CA and installs it
 // into system trust from that same immutable snapshot. Called at the END of
-// onboardViaDeviceFlow's Tailscale paths — after every fatal step INSIDE
-// onboarding has succeeded — so an onboarding failure never leaves a rejoin
+// onboardViaDeviceFlow's WireGuard and Tailscale paths — after every fatal step
+// inside onboarding has succeeded — so an onboarding failure never leaves a rejoin
 // with the new CA trusted while routing/credentials still belong to the old
 // gateway. (Linux whole-machine also runs `applyWholeMachineExitNode` in
 // runJoin afterward; that routing step is separately recoverable by re-running
@@ -1076,12 +1071,10 @@ func wgAddressFromConf(conf string) string {
 // non-empty, overrides os.Hostname() for the device name registered
 // with the gateway.
 //
-// setup carries the CA fetched by preJoinFetchCA. Once approval
-// lands, finishJoinSetup installs that CA into the system trust
-// store — the approval click is the operator's confirmation that
-// the fingerprint the dashboard showed matched what the CLI
-// printed, so the CA we install can't be one a MITM substituted
-// during the unauthenticated /ca.crt fetch.
+// setup carries the CA staged by preJoinFetchCA. The approval click is the
+// operator's confirmation that the fingerprint the dashboard showed matched
+// what the CLI printed. The exact staged snapshot becomes active and trusted
+// only after the selected control plane's fatal setup succeeds.
 //
 // httpCli is the HTTP client to use for /api/onboard/{start,poll,claim};
 // pass nil for the default TOFU-permissive client. The tailnet
@@ -1328,12 +1321,17 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 			return false, fmt.Errorf("gateway CA rejected: %w", verr)
 		}
 		canonicalCA = cc
+	} else {
+		if setup == nil || len(setup.candidateCA) == 0 {
+			return false, fmt.Errorf("internal: no staged WireGuard CA")
+		}
+		canonicalCA = append([]byte(nil), setup.candidateCA...)
 	}
 	// Approval click ⇒ operator visually confirmed the CA
 	// fingerprint on the dashboard matched what the CLI
-	// printed. finishJoinSetup installs the WireGuard-mode prefetched CA here;
-	// tailscale mode defers install to commitApprovedCA (deferCA=tsnetJoin).
-	finishJoinSetup(setup, skipTrust, wholeMachine, tsnetJoin)
+	// printed. Both control planes defer the CA write and trust install to
+	// commitApprovedCA after their fatal setup has succeeded.
+	finishJoinSetup(setup, skipTrust, wholeMachine, true)
 	// Persist the per-peer bearer the gateway minted alongside the
 	// wg conf. Lives next to ca.crt — same dir the env-pushdown
 	// fetcher reads. Best-effort; missing file means env-pushdown
@@ -1395,6 +1393,16 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		if runtime.GOOS == "darwin" {
 			macErr = macHelperInstall(wholeMachine)
 		}
+		if wholeMachine && runtime.GOOS != "darwin" {
+			if err := completeWholeMachineRouting(func() error {
+				return wgQuickUpFn(iface, authKey)
+			}); err != nil {
+				return true, fmt.Errorf("wg-quick up: %w", err)
+			}
+		}
+		if err := setup.commitApprovedCA(canonicalCA, skipTrust); err != nil {
+			return true, err
+		}
 		items := setupSummaryItems(*setup)
 		items = append(items, "✓ joined gateway")
 		printChecklist(items)
@@ -1404,11 +1412,6 @@ func onboardViaDeviceFlow(gateway string, wholeMachine bool, profile, hostname s
 		} else if runtime.GOOS == "darwin" {
 			printWholeMachineDone("system extension")
 		} else {
-			if err := completeWholeMachineRouting(func() error {
-				return wgQuickUp(iface, authKey)
-			}); err != nil {
-				return true, fmt.Errorf("wg-quick up: %w", err)
-			}
 			printWholeMachineDone(iface)
 		}
 		if persistErr != nil {
@@ -1785,6 +1788,8 @@ func writeUserWGConf(conf string) error {
 // wgQuickUp writes the supplied wireguard config to
 // /etc/wireguard/<iface>.conf and brings the interface up via
 // `wg-quick up`. Installs `wireguard-tools` if missing on linux.
+var wgQuickUpFn = wgQuickUp
+
 func wgQuickUp(iface, conf string) error {
 	if _, err := exec.LookPath("wg-quick"); err != nil {
 		if runtime.GOOS == "linux" {

--- a/cmd/clawpatrol/testmain_test.go
+++ b/cmd/clawpatrol/testmain_test.go
@@ -13,5 +13,10 @@ import (
 // has at the top of main().
 func TestMain(m *testing.M) {
 	sandbox.Stage1()
-	os.Exit(m.Run())
+	startWireGuardCAStageServer()
+	code := m.Run()
+	if sharedWireGuardCAStageServer != nil {
+		sharedWireGuardCAStageServer.server.Close()
+	}
+	os.Exit(code)
 }

--- a/cmd/clawpatrol/wireguard_ca_stage_linux_test.go
+++ b/cmd/clawpatrol/wireguard_ca_stage_linux_test.go
@@ -1,0 +1,127 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWireGuardCAStageWholeMachineRejoinCommitsOnlyAfterWGSetup(t *testing.T) {
+	caA, _, _ := mintCA(t, "active-ca-a", 7764)
+	caB, _, _ := mintCA(t, "candidate-ca-b", 7765)
+	canonicalA, err := canonicalMITMCAPEM(caA)
+	if err != nil {
+		t.Fatalf("canonicalize CA-A: %v", err)
+	}
+	canonicalB, err := canonicalMITMCAPEM(caB)
+	if err != nil {
+		t.Fatalf("canonicalize CA-B: %v", err)
+	}
+	const iface = "clawpatrol-stage-test"
+	const conf = "[Interface]\nPrivateKey = test-private\nAddress = 10.0.0.2/32\n\n[Peer]\nPublicKey = test-public\nAllowedIPs = 0.0.0.0/0\nEndpoint = 192.0.2.1:51820\n"
+	setupErr := errors.New("wg setup failed")
+
+	tests := []struct {
+		name      string
+		callback  error
+		wantError bool
+	}{
+		{name: "setup-fails", callback: setupErr, wantError: true},
+		{name: "setup-succeeds"},
+	}
+	h := newWireGuardCAStageServer(t, caB, 5, func(w http.ResponseWriter) {
+		writeWireGuardPollSuccess(w, iface, conf)
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h.start, h.polls, h.claims = 0, 0, 0
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			binDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(binDir, "wg-quick"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", binDir)
+			installed := recordInstalls(t)
+			caDir := t.TempDir()
+			caPath := filepath.Join(caDir, "ca.crt")
+			if err := os.WriteFile(caPath, canonicalA, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			setup, err := preJoinFetchCA(h.server.URL, caDir, h.server.Client())
+			if err != nil {
+				t.Fatalf("preJoinFetchCA: %v", err)
+			}
+
+			called := false
+			previous := wgQuickUpFn
+			wgQuickUpFn = func(gotIface, gotConf string) error {
+				called = true
+				if gotIface != iface || gotConf != conf {
+					t.Fatalf("wg setup got iface=%q conf=%q", gotIface, gotConf)
+				}
+				active, err := os.ReadFile(caPath)
+				if err != nil {
+					t.Fatalf("read CA during wg setup: %v", err)
+				}
+				if !bytes.Equal(active, canonicalA) {
+					t.Fatal("CA-B became active before fatal WireGuard setup completed")
+				}
+				if len(*installed) != 0 {
+					t.Fatal("CA trust changed before fatal WireGuard setup completed")
+				}
+				assertWholeMachineMarkerAbsent(t)
+				return tt.callback
+			}
+			t.Cleanup(func() { wgQuickUpFn = previous })
+
+			wgMode, err := onboardViaDeviceFlow(h.server.URL, true, "", "stage-test", &setup, false, h.server.Client(), false)
+			if !called {
+				t.Fatal("WireGuard setup callback was not reached")
+			}
+			if !wgMode {
+				t.Fatal("onboardViaDeviceFlow returned wgMode=false")
+			}
+			if h.start != 1 || h.polls == 0 || h.claims != 1 {
+				t.Fatalf("request counts start=%d poll=%d claim=%d, want 1, >0, 1", h.start, h.polls, h.claims)
+			}
+			active, readErr := os.ReadFile(caPath)
+			if readErr != nil {
+				t.Fatalf("read active CA after onboarding: %v", readErr)
+			}
+			if tt.wantError {
+				if !errors.Is(err, setupErr) {
+					t.Fatalf("onboarding error = %v, want wrapping %v", err, setupErr)
+				}
+				if !bytes.Equal(active, canonicalA) {
+					t.Fatal("failed WireGuard setup replaced active CA-A")
+				}
+				if len(*installed) != 0 {
+					t.Fatalf("failed setup trust installs = %d, want 0", len(*installed))
+				}
+				assertWholeMachineMarkerAbsent(t)
+				return
+			}
+			if err != nil {
+				t.Fatalf("onboardViaDeviceFlow: %v", err)
+			}
+			if !bytes.Equal(active, canonicalB) {
+				t.Fatal("successful setup did not activate exact staged CA-B")
+			}
+			if len(*installed) != 1 || !bytes.Equal((*installed)[0], canonicalB) {
+				t.Fatalf("successful setup trust installs = %d with exact CA-B=%v", len(*installed), len(*installed) == 1 && bytes.Equal((*installed)[0], canonicalB))
+			}
+			if !isWholeMachineJoin() {
+				t.Fatal("successful setup did not commit whole-machine marker")
+			}
+			if temps, err := filepath.Glob(filepath.Join(caDir, ".ca.crt-*.tmp")); err != nil || len(temps) != 0 {
+				t.Fatalf("CA temp files = %v, err=%v", temps, err)
+			}
+		})
+	}
+}

--- a/cmd/clawpatrol/wireguard_ca_stage_test.go
+++ b/cmd/clawpatrol/wireguard_ca_stage_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type wireGuardCAStageServer struct {
+	server    *httptest.Server
+	caPEM     []byte
+	expiresIn int
+	poll      func(http.ResponseWriter)
+	start     int
+	polls     int
+	claims    int
+}
+
+var sharedWireGuardCAStageServer *wireGuardCAStageServer
+
+func startWireGuardCAStageServer() {
+	if sharedWireGuardCAStageServer != nil {
+		return
+	}
+	h := &wireGuardCAStageServer{}
+	h.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ca.crt":
+			_, _ = w.Write(h.caPEM)
+		case "/api/onboard/start":
+			h.start++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code": "device-code",
+				"user_code":   "USER-CODE",
+				"verify_url":  "http://100.64.0.1/approve",
+				"interval":    -1,
+				"expires_in":  h.expiresIn,
+			})
+		case "/api/onboard/poll":
+			h.polls++
+			h.poll(w)
+		case "/api/onboard/claim":
+			h.claims++
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	sharedWireGuardCAStageServer = h
+}
+
+func newWireGuardCAStageServer(t *testing.T, caPEM []byte, expiresIn int, poll func(http.ResponseWriter)) *wireGuardCAStageServer {
+	t.Helper()
+	startWireGuardCAStageServer()
+	h := sharedWireGuardCAStageServer
+	h.caPEM = caPEM
+	h.expiresIn = expiresIn
+	h.poll = poll
+	h.start, h.polls, h.claims = 0, 0, 0
+	return h
+}
+
+func TestWireGuardCAStagePreservesActiveCAOnPreApprovalFailure(t *testing.T) {
+	caA, _, _ := mintCA(t, "active-ca-a", 7761)
+	caB, _, _ := mintCA(t, "candidate-ca-b", 7762)
+	canonicalA, err := canonicalMITMCAPEM(caA)
+	if err != nil {
+		t.Fatalf("canonicalize CA-A: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		expiresIn int
+		poll      func(http.ResponseWriter)
+		wantErr   string
+		wantPolls bool
+	}{
+		{
+			name:      "rejected",
+			expiresIn: 5,
+			poll: func(w http.ResponseWriter) {
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":  "access_denied",
+					"detail": "operator rejected request",
+				})
+			},
+			wantErr:   "poll: access_denied",
+			wantPolls: true,
+		},
+		{
+			name:      "timeout",
+			expiresIn: 0,
+			poll: func(w http.ResponseWriter) {
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+			},
+			wantErr: "timed out waiting for approval",
+		},
+	}
+	h := newWireGuardCAStageServer(t, caB, 5, tests[0].poll)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h.expiresIn = tt.expiresIn
+			h.poll = tt.poll
+			h.start, h.polls, h.claims = 0, 0, 0
+			installed := recordInstalls(t)
+			caDir := t.TempDir()
+			caPath := filepath.Join(caDir, "ca.crt")
+			if err := os.WriteFile(caPath, canonicalA, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			setup, err := preJoinFetchCA(h.server.URL, caDir, h.server.Client())
+			if err != nil {
+				t.Fatalf("preJoinFetchCA: %v", err)
+			}
+			activeAfterPrefetch, readErr := os.ReadFile(caPath)
+			prefetchPreserved := readErr == nil && bytes.Equal(activeAfterPrefetch, canonicalA)
+
+			_, err = onboardViaDeviceFlow(h.server.URL, false, "", "stage-test", &setup, false, h.server.Client(), false)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("onboardViaDeviceFlow error = %v, want containing %q", err, tt.wantErr)
+			}
+			if h.start != 1 {
+				t.Fatalf("start requests = %d, want 1", h.start)
+			}
+			if tt.wantPolls && h.polls == 0 {
+				t.Fatal("poll endpoint was not reached")
+			}
+			if !prefetchPreserved {
+				t.Errorf("preJoinFetchCA replaced active ca.crt before approval")
+			}
+			active, err := os.ReadFile(caPath)
+			if err != nil {
+				t.Fatalf("read active ca.crt: %v", err)
+			}
+			if !bytes.Equal(active, canonicalA) {
+				t.Errorf("active ca.crt changed on %s: got candidate=%v", tt.name, bytes.Equal(active, caB))
+			}
+			if len(*installed) != 0 {
+				t.Fatalf("trust installs = %d, want 0", len(*installed))
+			}
+			if h.claims != 0 {
+				t.Fatalf("claim requests = %d before approval, want 0", h.claims)
+			}
+		})
+	}
+}
+
+func TestWireGuardCAStageRejectsMissingCandidateBeforeWGState(t *testing.T) {
+	installed := recordInstalls(t)
+	t.Setenv("HOME", t.TempDir())
+	caB, _, _ := mintCA(t, "candidate-ca-b", 7766)
+	conf := "[Interface]\nAddress = 10.0.0.2/32\n"
+	h := newWireGuardCAStageServer(t, caB, 5, func(w http.ResponseWriter) {
+		writeWireGuardPollSuccess(w, "clawpatrol-test", conf)
+	})
+	caDir := t.TempDir()
+	setup := joinSetup{caPath: filepath.Join(caDir, "ca.crt")}
+
+	_, err := onboardViaDeviceFlow(h.server.URL, false, "", "stage-test", &setup, false, h.server.Client(), false)
+	if err == nil || !strings.Contains(err.Error(), "no staged WireGuard CA") {
+		t.Fatalf("onboardViaDeviceFlow error = %v, want missing staged CA", err)
+	}
+	if h.start != 1 || h.polls == 0 {
+		t.Fatalf("request counts start=%d poll=%d, want 1, >0", h.start, h.polls)
+	}
+	if h.claims != 0 {
+		t.Fatalf("claim requests = %d, want 0 before WireGuard state mutation", h.claims)
+	}
+	if _, err := os.Stat(filepath.Join(caDir, "mode")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("mode file exists before candidate validation: %v", err)
+	}
+	if len(*installed) != 0 {
+		t.Fatalf("trust installs = %d, want 0", len(*installed))
+	}
+}
+
+func TestWireGuardCAStageFreshJoinCommitsApprovedSnapshot(t *testing.T) {
+	installed := recordInstalls(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	caB, _, _ := mintCA(t, "candidate-ca-b", 7763)
+	canonicalB, err := canonicalMITMCAPEM(caB)
+	if err != nil {
+		t.Fatalf("canonicalize CA-B: %v", err)
+	}
+	conf := "[Interface]\nPrivateKey = test-private\nAddress = 10.0.0.2/32\n\n[Peer]\nPublicKey = test-public\nAllowedIPs = 0.0.0.0/0\nEndpoint = 192.0.2.1:51820\n"
+	h := newWireGuardCAStageServer(t, caB, 5, func(w http.ResponseWriter) {
+		writeWireGuardPollSuccess(w, "clawpatrol-test", conf)
+	})
+	caDir := t.TempDir()
+	caPath := filepath.Join(caDir, "ca.crt")
+
+	setup, err := preJoinFetchCA(h.server.URL, caDir, h.server.Client())
+	if err != nil {
+		t.Fatalf("preJoinFetchCA: %v", err)
+	}
+	_, prefetchErr := os.Stat(caPath)
+	prefetchLeftAbsent := errors.Is(prefetchErr, os.ErrNotExist)
+
+	wgMode, err := onboardViaDeviceFlow(h.server.URL, false, "", "stage-test", &setup, false, h.server.Client(), false)
+	if err != nil {
+		t.Fatalf("onboardViaDeviceFlow: %v", err)
+	}
+	if !wgMode {
+		t.Fatal("onboardViaDeviceFlow returned wgMode=false")
+	}
+	if !prefetchLeftAbsent {
+		t.Error("preJoinFetchCA created active ca.crt before approval")
+	}
+	if h.start != 1 || h.polls == 0 || h.claims != 1 {
+		t.Fatalf("request counts start=%d poll=%d claim=%d, want 1, >0, 1", h.start, h.polls, h.claims)
+	}
+	active, err := os.ReadFile(caPath)
+	if err != nil {
+		t.Fatalf("read active ca.crt: %v", err)
+	}
+	if !bytes.Equal(active, canonicalB) {
+		t.Fatal("active ca.crt does not equal staged approved CA-B")
+	}
+	info, err := os.Stat(caPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("ca.crt mode = %o, want 644", info.Mode().Perm())
+	}
+	if len(*installed) != 1 || !bytes.Equal((*installed)[0], canonicalB) {
+		t.Fatalf("trust installs = %d and exact candidate match = %v, want 1 and true", len(*installed), len(*installed) == 1 && bytes.Equal((*installed)[0], canonicalB))
+	}
+	if temps, err := filepath.Glob(filepath.Join(caDir, ".ca.crt-*.tmp")); err != nil || len(temps) != 0 {
+		t.Fatalf("CA temp files = %v, err=%v", temps, err)
+	}
+}
+
+func writeWireGuardPollSuccess(w http.ResponseWriter, iface, conf string) {
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"auth_key":     conf,
+		"login_server": fmt.Sprintf("wireguard://%s", iface),
+		"api_token":    "test-api-token",
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #776.

- stage the WireGuard onboarding CA in memory instead of replacing the active CA before approval
- atomically activate and trust the exact approved CA only after fatal WireGuard setup succeeds
- preserve the previous active CA and trust on rejection, timeout, or failed whole-machine setup
- keep the existing Tailscale late-commit behavior

## Verification

- `go test ./cmd/clawpatrol -run '^TestWireGuardCAStage' -count=1 -v`
- `go test -race ./cmd/clawpatrol -run '^TestWireGuardCAStage' -count=1`
- `go vet ./cmd/clawpatrol`
- `make lint`
- `gofmt` and `git diff --check`

The package-wide suite still encounters the same host/network/plugin-dependent failures seen on unchanged `9edbeb0`; the issue-focused tests are green.
