### PR TITLE
fix: Run wrapped commands with a sanitized environment by default

### DIFF
--- a/cmd/clawpatrol/integrations.go
+++ b/cmd/clawpatrol/integrations.go
@@ -372,6 +372,7 @@ func applyEnvPushdownVars(vars []pushdownEnvVar) {
 		return
 	}
 	for _, ev := range vars {
+		recordPushedRunEnv(ev.Name, ev.Value)
 		if !clawpatrolCAVarNames[ev.Name] && os.Getenv(ev.Name) != "" {
 			continue
 		}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3170,7 +3170,9 @@ usage:
                   --login                interactive tailnet login for gateways
                                          with no public URL (creds discarded
                                          once join completes)
-  clawpatrol run -- <cmd> [args...]      route one process tree through gateway
+  clawpatrol run [env flags] -- <cmd>    route one process tree through gateway
+                  --env NAME             inherit one variable (repeatable)
+                  --inherit-env          inherit all variables (may expose credentials)
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing

--- a/cmd/clawpatrol/run_darwin.go
+++ b/cmd/clawpatrol/run_darwin.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -80,9 +81,14 @@ func sessionIPC(msg string) error {
 
 func runRun(args []string) {
 	warnIfOnGatewayHost()
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	var envOpts runEnvFlags
+	envOpts.bind(fs)
+	_ = fs.Parse(args)
+	args = fs.Args()
 
 	if mode := strings.TrimSpace(readFileSilent(filepath.Join(defaultClawpatrolDir(), "mode"))); mode == "tailscale" {
-		runRunTsnet(args)
+		runRunTsnet(args, envOpts)
 		return
 	}
 
@@ -110,7 +116,7 @@ func runRun(args []string) {
 	all := append([]string{"run", "--"}, args...)
 	c := exec.Command(macHelperPath, all...)
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
-	c.Env = os.Environ()
+	c.Env = sanitizedChildEnv(os.Environ(), envOpts)
 	if err := c.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/cmd/clawpatrol/run_env.go
+++ b/cmd/clawpatrol/run_env.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"sync"
+)
+
+// runEnvFlags controls the environment inherited by a wrapped command.
+type runEnvFlags struct {
+	inherit bool
+	allow   stringListFlag
+}
+
+func (o *runEnvFlags) bind(fs *flag.FlagSet) {
+	fs.BoolVar(&o.inherit, "inherit-env", false, "inherit the complete parent environment (may expose credentials)")
+	fs.Var(&o.allow, "env", "inherit one environment variable by name (repeatable)")
+}
+
+type stringListFlag []string
+
+func (f *stringListFlag) String() string { return strings.Join(*f, ",") }
+func (f *stringListFlag) Set(v string) error {
+	*f = append(*f, v)
+	return nil
+}
+
+// pushedRunEnv records variables installed by env pushdown. Credential-looking
+// parent values are replaced with these synthetic values instead of inherited.
+var pushedRunEnv = struct {
+	sync.Mutex
+	values map[string]string
+}{values: map[string]string{}}
+
+func recordPushedRunEnv(name, value string) {
+	pushedRunEnv.Lock()
+	pushedRunEnv.values[name] = value
+	pushedRunEnv.Unlock()
+}
+
+func sanitizedChildEnv(env []string, opts runEnvFlags) []string {
+	if opts.inherit {
+		return append([]string(nil), env...)
+	}
+	allowed := map[string]bool{}
+	for _, name := range opts.allow {
+		allowed[name] = true
+	}
+	out := make([]string, 0, len(env))
+	pushedRunEnv.Lock()
+	pushed := make(map[string]string, len(pushedRunEnv.values))
+	for name, value := range pushedRunEnv.values {
+		pushed[name] = value
+	}
+	pushedRunEnv.Unlock()
+	for _, kv := range env {
+		name := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			name = kv[:i]
+		}
+		if credentialEnvName(name) && !allowed[name] {
+			if value, ok := pushed[name]; ok {
+				out = append(out, name+"="+value)
+				delete(pushed, name)
+			}
+			continue
+		}
+		out = append(out, kv)
+		delete(pushed, name)
+	}
+	return out
+}
+
+func credentialEnvName(name string) bool {
+	u := strings.ToUpper(name)
+	if strings.HasPrefix(u, "CLAWPATROL_") {
+		return false
+	}
+	for _, suffix := range []string{"_TOKEN", "_SECRET", "_KEY", "_PASSWORD", "_CREDENTIALS"} {
+		if strings.HasSuffix(u, suffix) {
+			return true
+		}
+	}
+	return u == "AWS_ACCESS_KEY_ID" || u == "AWS_SESSION_TOKEN" || u == "GOOGLE_APPLICATION_CREDENTIALS"
+}

--- a/cmd/clawpatrol/run_env_test.go
+++ b/cmd/clawpatrol/run_env_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSanitizedChildEnv(t *testing.T) {
+	pushedRunEnv.Lock()
+	old := pushedRunEnv.values
+	pushedRunEnv.values = map[string]string{}
+	pushedRunEnv.Unlock()
+	t.Cleanup(func() {
+		pushedRunEnv.Lock()
+		pushedRunEnv.values = old
+		pushedRunEnv.Unlock()
+	})
+
+	in := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/agent",
+		"LANG=C.UTF-8",
+		"TERM=xterm-256color",
+		"AWS_SECRET_ACCESS_KEY=[REDACTED]",
+		"GITHUB_TOKEN=[REDACTED]",
+		"OPENAI_API_KEY=[REDACTED]",
+		"CLAWPATROL_PLACEHOLDER_TOKEN=placeholder",
+		"SSL_CERT_FILE=/clawpatrol/ca-bundle.crt",
+	}
+	want := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/agent",
+		"LANG=C.UTF-8",
+		"TERM=xterm-256color",
+		"CLAWPATROL_PLACEHOLDER_TOKEN=placeholder",
+		"SSL_CERT_FILE=/clawpatrol/ca-bundle.crt",
+	}
+	if got := sanitizedChildEnv(in, runEnvFlags{}); !slices.Equal(got, want) {
+		t.Fatalf("sanitized env = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizedChildEnvUsesPushedPlaceholder(t *testing.T) {
+	pushedRunEnv.Lock()
+	old := pushedRunEnv.values
+	pushedRunEnv.values = map[string]string{"OPENAI_API_KEY": "clawpatrol-placeholder"}
+	pushedRunEnv.Unlock()
+	t.Cleanup(func() {
+		pushedRunEnv.Lock()
+		pushedRunEnv.values = old
+		pushedRunEnv.Unlock()
+	})
+
+	in := []string{"PATH=/usr/bin", "OPENAI_API_KEY=[REDACTED]", "SSL_CERT_FILE=/clawpatrol/ca-bundle.crt"}
+	want := []string{"PATH=/usr/bin", "OPENAI_API_KEY=clawpatrol-placeholder", "SSL_CERT_FILE=/clawpatrol/ca-bundle.crt"}
+	if got := sanitizedChildEnv(in, runEnvFlags{}); !slices.Equal(got, want) {
+		t.Fatalf("sanitized env = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizedChildEnvExplicitAllow(t *testing.T) {
+	in := []string{"PATH=/usr/bin", "GITHUB_TOKEN=[REDACTED]", "OPENAI_API_KEY=[REDACTED]"}
+	got := sanitizedChildEnv(in, runEnvFlags{allow: stringListFlag{"GITHUB_TOKEN"}})
+	want := []string{"PATH=/usr/bin", "GITHUB_TOKEN=[REDACTED]"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("sanitized env = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizedChildEnvInherit(t *testing.T) {
+	in := []string{"PATH=/usr/bin", "OPENAI_API_KEY=[REDACTED]"}
+	if got := sanitizedChildEnv(in, runEnvFlags{inherit: true}); !slices.Equal(got, in) {
+		t.Fatalf("inherited env = %q, want %q", got, in)
+	}
+}

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -105,11 +105,13 @@ func runRun(args []string) {
 	warnIfOnGatewayHost()
 
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	var envOpts runEnvFlags
+	envOpts.bind(fs)
 	noAutoExpose := fs.Bool("no-auto-expose", false, "disable the seccomp relay (mirrors TCP listeners inside the netns back to the host AND forwards wrapped-cmd connections to 127.0.0.1 out to host loopback services)")
 	_ = fs.Parse(args)
 	cmd := fs.Args()
 	if len(cmd) == 0 {
-		fail("usage: clawpatrol run [--no-auto-expose] -- <cmd> [args...]")
+		fail("usage: clawpatrol run [--no-auto-expose] [--inherit-env] [--env NAME] -- <cmd> [args...]")
 	}
 
 	// Whole-machine join: the host already routes all traffic through
@@ -117,7 +119,7 @@ func runRun(args []string) {
 	// credential env and exec the command directly (this also works as
 	// root, unlike the unprivileged-userns path below).
 	if isWholeMachineJoin() {
-		runWholeMachineDirect(cmd)
+		runWholeMachineDirect(cmd, envOpts)
 		return
 	}
 
@@ -126,7 +128,7 @@ func runRun(args []string) {
 	// keeps real uids and `sudo` works inside it. Opt out with
 	// CLAWPATROL_NO_SUDO.
 	if sudoSetupAvailable() {
-		runViaSudo(cmd)
+		runViaSudo(cmd, envOpts)
 		return
 	}
 
@@ -194,7 +196,7 @@ func runRun(args []string) {
 		fail("self path: %v", err)
 	}
 	child := exec.Command(self, append([]string{"run"}, cmd...)...)
-	child.Env = append(os.Environ(), runChildEnv+"=1")
+	child.Env = append(sanitizedChildEnv(os.Environ(), envOpts), runChildEnv+"=1")
 	child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
 	child.ExtraFiles = []*os.File{cSock, tunUpR}
 	child.SysProcAttr = &syscall.SysProcAttr{
@@ -325,7 +327,7 @@ func runRun(args []string) {
 // the credential env and exec the command. Env is fetched straight
 // from the gateway — the daemon fetcher would try to spawn the
 // per-host daemon, which whole-machine mode doesn't run.
-func runWholeMachineDirect(cmd []string) {
+func runWholeMachineDirect(cmd []string, envOpts runEnvFlags) {
 	if os.Getenv("CLAWPATROL_NO_ENV") != "1" {
 		applyEnvPushdownVars(wholeMachineEnvVars(defaultClawpatrolDir()))
 	}
@@ -334,7 +336,7 @@ func runWholeMachineDirect(cmd []string) {
 		fail("%s: %v", cmd[0], err)
 	}
 	fmt.Fprintln(os.Stderr, "[clawpatrol] whole-machine join — traffic already routes through the gateway; running directly (no sandbox)")
-	if err := syscall.Exec(bin, cmd, os.Environ()); err != nil {
+	if err := syscall.Exec(bin, cmd, sanitizedChildEnv(os.Environ(), envOpts)); err != nil {
 		fail("exec %s: %v", bin, err)
 	}
 }

--- a/cmd/clawpatrol/run_sudo_linux.go
+++ b/cmd/clawpatrol/run_sudo_linux.go
@@ -64,7 +64,7 @@ func sudoSetupAvailable() bool {
 
 // runViaSudo ensures the per-host daemon is up (as this user), then
 // launches the privileged setup helper under sudo and waits on it.
-func runViaSudo(cmd []string) {
+func runViaSudo(cmd []string, envOpts runEnvFlags) {
 	// The helper connects to the daemon but must never spawn one (a
 	// root-spawned daemon would own state in the wrong home). Ensure
 	// it's running here, as this user. The daemon is persistent
@@ -80,7 +80,7 @@ func runViaSudo(cmd []string) {
 	// user's env. Capture it — after the OAuth shim, so CLAUDE_CONFIG_DIR
 	// is included — into a 0600 file the helper reads and deletes.
 	installClaudeCodeOAuthShim(cmd)
-	envFile, err := writePrivilegedEnvFile(os.Environ())
+	envFile, err := writePrivilegedEnvFile(sanitizedChildEnv(os.Environ(), envOpts))
 	if err != nil {
 		fail("env file: %v", err)
 	}

--- a/cmd/clawpatrol/run_tsnet_darwin.go
+++ b/cmd/clawpatrol/run_tsnet_darwin.go
@@ -45,7 +45,7 @@ func init() {
 	envPushdownGatewayFetcher = fetchEnvPushdownViaNESessionSock
 }
 
-func runRunTsnet(args []string) {
+func runRunTsnet(args []string, envOpts runEnvFlags) {
 	warnIfOnGatewayHost()
 
 	if _, err := os.Stat(macHelperPath); err != nil {
@@ -135,7 +135,7 @@ func runRunTsnet(args []string) {
 	all := append([]string{"run", "--"}, args...)
 	c := exec.Command(macHelperPath, all...)
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
-	c.Env = os.Environ()
+	c.Env = sanitizedChildEnv(os.Environ(), envOpts)
 	if err := c.Run(); err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {


### PR DESCRIPTION
Fixes #321.

## Summary

Run wrapped commands with a sanitized environment by default

## Validation

- Mechanical gate: +184/-13, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->