### PR TITLE
feat: workload enrollment for ephemeral k8s peers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!clawpatrol

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,8 @@ jobs:
       - run: make fmt-check
       - run: cd dashboard && deno task lint:github
       - run: make test
-      - name: validate HCL examples
-        run: |
-          go build -o /tmp/clawpatrol ./cmd/clawpatrol
-          for f in examples/*.hcl; do
-            echo "validating $f"
-            /tmp/clawpatrol validate "$f"
-          done
+      - name: validate example + e2e configs
+        run: make validate-examples
 
   # Exercise the Landlock fallback backend: keep AppArmor's userns
   # restriction in place (the runner default) and force the backend so

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ macos/netstack/libwgnetstack.h
 macos/netstack/wgnetstack
 *.swp
 /plugin-example/plugin-example
+e2e/.e2e-runtime.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Runtime image for a prebuilt clawpatrol binary.
+#
+# Build a Linux binary first, then build the image from the same directory:
+#   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build
+#   docker build -t clawpatrol:dev .
+FROM debian:stable-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    iproute2 \
+    netcat-openbsd \
+    sqlite3 \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY clawpatrol /usr/local/bin/clawpatrol
+
+ENTRYPOINT ["/usr/local/bin/clawpatrol"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,23 @@
-.PHONY: build release dashboard test fmt fmt-check lint go-lint dashboard-lint clean install
+.PHONY: build release dashboard test fmt fmt-check lint go-lint dashboard-lint validate-examples e2e clean install
 
 build: dashboard
 	go build -o clawpatrol ./cmd/clawpatrol
+
+# validate-examples compiles every example/e2e gateway config. These HCLs
+# are the source of truth for the Kubernetes ConfigMaps (generated via
+# kustomize configMapGenerator), so validating them keeps "what CI checks"
+# equal to "what deploys" — not just a standalone sample.
+validate-examples: dashboard
+	@set -e; bin="$$(mktemp)"; trap 'rm -f "$$bin"' EXIT; \
+	go build -o "$$bin" ./cmd/clawpatrol; \
+	git ls-files '*.hcl' | grep -E '^(examples|e2e)/' | while read -r f; do \
+		echo "validate $$f"; "$$bin" validate "$$f"; \
+	done
+
+# e2e drives the Kubernetes WireGuard enrollment flow against a local kind
+# cluster (see e2e/kubernetes-wireguard-e2e.sh for prerequisites + knobs).
+e2e:
+	./e2e/kubernetes-wireguard-e2e.sh
 
 # release mirrors .github/workflows/release.yml: strip the symbol
 # table and DWARF (-s -w) and rewrite source paths (-trimpath). On

--- a/cmd/clawpatrol/bridge.go
+++ b/cmd/clawpatrol/bridge.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// kubernetesDefaultTokenPath is the projected ServiceAccount token the
+// kubernetes_token_review provider presents by default.
+const kubernetesDefaultTokenPath = "/var/run/secrets/tokens/clawpatrol-token"
+
+// bridgeOptions configures `clawpatrol bridge`: a resident, foreground,
+// privileged data plane that self-enrolls through an authorizer, hosts a
+// userspace WireGuard tunnel, and routes the whole network namespace through
+// the gateway — bridging the netns to the gateway. It stays up for the netns
+// lifetime (the userspace device dies with the process) and deregisters
+// best-effort on SIGTERM. The execution workload runs in a sibling,
+// unprivileged container that shares this netns and reads the handoff files
+// below.
+type bridgeOptions struct {
+	GatewayURL string
+
+	// AuthorizerType/Name mirror the gateway's two-label enrollment block
+	// `enrollment "<type>" "<name>"`. Type selects the client-side claims
+	// provider (how identity is gathered); Name is what's sent on the wire
+	// to pick the server authorizer.
+	AuthorizerType string
+	AuthorizerName string
+
+	// KubeTokenPath is the kubernetes_token_review provider's credential.
+	// Provider-scoped on purpose — not every authorizer authenticates with
+	// a token file.
+	KubeTokenPath string
+
+	// Sibling-handoff outputs: files the unprivileged workload container
+	// reads off the shared volume once the tunnel is up.
+	EnvOut    string
+	CAOut     string
+	ReadyFile string
+
+	Iface string
+	MTU   int
+
+	// LocalResetMisses is how many missed keepalives trigger an in-place
+	// tunnel rebuild before the server-dictated reconnect horizon. A
+	// client-side knob — the reap horizon comes from the gateway, but how
+	// eagerly to attempt a cheap local recovery first is the sidecar's call.
+	// Capped below the reconnect horizon; 0 disables the local rebuild.
+	LocalResetMisses int
+
+	// RouteProto is the rt_proto tag stamped on the control-plane host routes
+	// the bridge pins to the underlay, and the filter used to recover them on
+	// an in-process reconnect. Escape hatch: override only if the default collides
+	// with a route protocol another component already uses in the netns.
+	RouteProto string
+}
+
+// defaultRouteProto is the rt_proto the bridge tags its underlay pins with by
+// default (overridable via --route-proto). Arbitrary and unregistered; it only
+// has to be stable and unlikely to collide with the CNI's own routes.
+const defaultRouteProto = "111"
+
+// runBridge parses the `clawpatrol bridge` flags and dispatches to the
+// platform implementation. Kept cross-platform (no wireguard imports) so
+// the flag surface and validation errors are identical everywhere; bridgeRun
+// is linux-only.
+func runBridge(args []string) {
+	fs := flag.NewFlagSet("bridge", flag.ExitOnError)
+	var (
+		authorizer string
+		opt        bridgeOptions
+	)
+	fs.StringVar(&opt.GatewayURL, "gateway-url", "", "gateway API URL, e.g. https://clawpatrol.clawpatrol.svc:8443")
+	fs.StringVar(&authorizer, "authorizer", "", "enrollment authorizer to register through, as <type>/<name> (e.g. kubernetes_token_review/agents)")
+	fs.StringVar(&opt.KubeTokenPath, "kubernetes-token-path", kubernetesDefaultTokenPath, "kubernetes_token_review: projected ServiceAccount token path")
+	fs.StringVar(&opt.EnvOut, "env-out", "/clawpatrol/env", "path to write shell exports for the workload container")
+	fs.StringVar(&opt.CAOut, "ca-out", "/clawpatrol/ca.crt", "path to write the gateway CA bundle")
+	fs.StringVar(&opt.ReadyFile, "ready-file", "/clawpatrol/ready", "path to touch after network and env setup succeed")
+	fs.StringVar(&opt.Iface, "iface", "clawpatrol0", "TUN interface name")
+	fs.IntVar(&opt.MTU, "mtu", enrollmentDefaultMTU, "TUN MTU")
+	fs.IntVar(&opt.LocalResetMisses, "local-reset-missed", bridgeWatchdogDefaultResetMisses,
+		"missed keepalives before an in-place tunnel rebuild; 0 disables it, and a value at or above the gateway's reconnect threshold skips directly to re-enrollment")
+	fs.StringVar(&opt.RouteProto, "route-proto", defaultRouteProto,
+		"rt_proto tag for the underlay control-plane pins (gateway + DNS); override only if it collides with another component's routes")
+	_ = fs.Parse(args)
+
+	if len(fs.Args()) > 0 {
+		fail("clawpatrol bridge does not take a command; the workload runs in a sibling container sharing this netns")
+	}
+	if strings.TrimSpace(opt.GatewayURL) == "" {
+		fail("clawpatrol bridge: --gateway-url is required")
+	}
+	if err := validateRouteProto(opt.RouteProto); err != nil {
+		fail("clawpatrol bridge: %v", err)
+	}
+	typ, name, err := parseBridgeAuthorizer(authorizer)
+	if err != nil {
+		fail("%v", err)
+	}
+	opt.AuthorizerType, opt.AuthorizerName = typ, name
+
+	if err := bridgeRun(context.Background(), opt); err != nil {
+		log.Printf("bridge: %v", err)
+		os.Exit(1)
+	}
+}
+
+// preferV4 returns the first IPv4 address (unmapped), falling back to the
+// first address of any family when there is no IPv4. The agent pins IPv4
+// host routes by default and the gateway WireGuard endpoint is reached over
+// IPv4 in typical clusters; dialing an IPv6 endpoint while only IPv4 is
+// route-pinned would blackhole the handshake once the default route flips
+// to the tunnel.
+func preferV4(ips []netip.Addr) (netip.Addr, bool) {
+	if len(ips) == 0 {
+		return netip.Addr{}, false
+	}
+	for _, ip := range ips {
+		if ip.Unmap().Is4() {
+			return ip.Unmap(), true
+		}
+	}
+	return ips[0].Unmap(), true
+}
+
+// validateRouteProto checks the --route-proto value. iproute2 accepts either
+// a numeric rt_proto (1–255) or a name defined in /etc/iproute2/rt_protos; we
+// only reject the clearly invalid cases (empty, or a number out of range) and
+// leave name resolution to `ip` at runtime.
+func validateRouteProto(p string) error {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return fmt.Errorf("--route-proto must not be empty")
+	}
+	if n, err := strconv.Atoi(p); err == nil && (n < 1 || n > 255) {
+		return fmt.Errorf("--route-proto %q must be in 1..255 (or an rt_protos name)", p)
+	}
+	return nil
+}
+
+// parseBridgeAuthorizer splits the `--authorizer <type>/<name>` value,
+// mirroring the gateway's `enrollment "<type>" "<name>"` block. The type
+// selects the client claims provider; the name is sent on the wire.
+func parseBridgeAuthorizer(s string) (typ, name string, err error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", "", fmt.Errorf("--authorizer is required (form: <type>/<name>, e.g. kubernetes_token_review/agents)")
+	}
+	typ, name, ok := strings.Cut(s, "/")
+	typ, name = strings.TrimSpace(typ), strings.TrimSpace(name)
+	if !ok || typ == "" || name == "" {
+		return "", "", fmt.Errorf("--authorizer %q must be <type>/<name>, e.g. kubernetes_token_review/agents", s)
+	}
+	if typ != enrollmentAuthorizerKubernetesTokenRev {
+		return "", "", fmt.Errorf("unsupported authorizer type %q (supported: %s)", typ, enrollmentAuthorizerKubernetesTokenRev)
+	}
+	return typ, name, nil
+}

--- a/cmd/clawpatrol/bridge_handoff_linux_test.go
+++ b/cmd/clawpatrol/bridge_handoff_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteTunFilesBuildsBundleAfterWritingFreshCA(t *testing.T) {
+	systemCA, _, _ := mintCA(t, "system-root", 1)
+	gatewayCA, _, _ := mintCA(t, "gateway-root", 2)
+	prev := systemRootsReader
+	systemRootsReader = func() ([]byte, bool) { return systemCA, true }
+	t.Cleanup(func() { systemRootsReader = prev })
+
+	dir := t.TempDir()
+	opt := bridgeOptions{
+		EnvOut:    filepath.Join(dir, "env"),
+		CAOut:     filepath.Join(dir, "ca.crt"),
+		ReadyFile: filepath.Join(dir, "ready"),
+	}
+	if err := writeTunFiles(opt, []pushdownEnvVar{{Name: "EXAMPLE", Value: "value"}}, string(gatewayCA)); err != nil {
+		t.Fatalf("writeTunFiles: %v", err)
+	}
+
+	bundlePath := filepath.Join(dir, "ca-bundle.crt")
+	bundle, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatalf("read CA bundle: %v", err)
+	}
+	if !bytes.Contains(bundle, systemCA) || !bytes.Contains(bundle, gatewayCA) {
+		t.Fatal("CA bundle does not contain both system and freshly enrolled gateway roots")
+	}
+	env, err := os.ReadFile(opt.EnvOut)
+	if err != nil {
+		t.Fatalf("read env handoff: %v", err)
+	}
+	if !strings.Contains(string(env), `export SSL_CERT_FILE="`+bundlePath+`"`) {
+		t.Fatalf("SSL_CERT_FILE does not reference fresh combined bundle:\n%s", env)
+	}
+}

--- a/cmd/clawpatrol/bridge_linux.go
+++ b/cmd/clawpatrol/bridge_linux.go
@@ -1,0 +1,633 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/netip"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	wgtun "golang.zx2c4.com/wireguard/tun"
+)
+
+// bridgeState is the sidecar's retained in-memory state.
+type bridgeState struct {
+	reconnects     int
+	bringUpFails   int
+	handoffWritten bool
+}
+
+// bridgeSession is one live tunnel: the userspace WireGuard device, its TUN,
+// and the peer API token for deregister.
+type bridgeSession struct {
+	dev          *device.Device
+	tun          wgtun.Device
+	apiToken     string
+	stopWatchdog context.CancelFunc
+	reconnect    chan struct{}
+}
+
+func (s *bridgeSession) close() {
+	if s.stopWatchdog != nil {
+		s.stopWatchdog()
+	}
+	if s.dev != nil {
+		s.dev.Close()
+	}
+	if s.tun != nil {
+		_ = s.tun.Close()
+	}
+}
+
+// bridgeRun is the resident, privileged data plane behind `clawpatrol bridge`.
+func bridgeRun(ctx context.Context, opt bridgeOptions) error {
+	sigCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	st := &bridgeState{}
+	backoff := time.Second
+	for {
+		sess, err := bridgeBringUp(sigCtx, opt, st)
+		if err != nil {
+			if sigCtx.Err() != nil {
+				return nil
+			}
+			st.bringUpFails++
+			log.Printf("bridge: bring-up failed (attempt %d): %v — retrying in %s", st.bringUpFails, err, backoff)
+			select {
+			case <-sigCtx.Done():
+				return nil
+			case <-time.After(backoff):
+			}
+			backoff = minDuration(backoff*2, 30*time.Second)
+			continue
+		}
+		st.bringUpFails = 0
+		backoff = time.Second
+
+		select {
+		case <-sigCtx.Done():
+			// Graceful shutdown: best-effort deregister (bounded so a hung
+			// gateway/DNS call can't delay pod termination past the grace
+			// period), then tear the tunnel down. The netns goes with the pod.
+			delCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			enrollmentDeregister(delCtx, opt.GatewayURL, sess.apiToken)
+			cancel()
+			sess.close()
+			return nil
+		case <-sess.reconnect:
+			// The watchdog gave up on this session. Tear it down — egress fails
+			// closed during the gap — and loop: bring-up re-discovers DNS +
+			// underlay and reconciles the tagged pins before re-enrolling. Skip
+			// deregister: the peer is either reaped already or reused by IP.
+			st.reconnects++
+			log.Printf("bridge: liveness lost — reconnecting in-process (reconnect #%d)", st.reconnects)
+			sess.close()
+		}
+	}
+}
+
+// bridgeBringUp performs one enroll + tunnel bring-up and returns a live
+// session. It is re-callable: every call re-reads /etc/resolv.conf and
+// re-discovers the underlay.
+func bridgeBringUp(ctx context.Context, opt bridgeOptions, st *bridgeState) (_ *bridgeSession, err error) {
+	claims, credential, err := gatherEnrollmentClaims(opt.AuthorizerType, opt.KubeTokenPath)
+	if err != nil {
+		return nil, err
+	}
+	clientPrivB64, _, clientPubB64, err := wgGenKeypair()
+	if err != nil {
+		return nil, fmt.Errorf("generate wireguard keypair: %w", err)
+	}
+
+	// Underlay route: the pod's pre-tunnel default on first boot, or a surviving
+	// tagged pin after an in-process reconnect / genuine restart (clawpatrol0 is
+	// gone, so there is no default route).
+	route4, src4, ok4 := discoverUnderlayRoute("-4", opt.RouteProto)
+	if !ok4 {
+		return nil, fmt.Errorf("no usable underlay route: neither a default route nor a tagged clawpatrol pin was found")
+	}
+	// IPv6 is optional: present only when the pod already has a v6 underlay route.
+	route6, _, have6 := discoverUnderlayRoute("-6", opt.RouteProto)
+
+	if st.reconnects == 0 && st.bringUpFails == 0 {
+		if src4 == "pin" {
+			log.Printf("bridge: no default route at start — recovered underlay gateway via %s dev %s from tagged pins (proto %s); recovery boot, re-enrolling", route4.Via, route4.Dev, opt.RouteProto)
+		} else {
+			log.Printf("bridge: starting; underlay gateway via %s dev %s, enrolling with %s", route4.Via, route4.Dev, opt.AuthorizerName)
+		}
+	}
+
+	// Re-read resolv.conf every bring-up (it may have swapped).
+	resolverIPs := resolvConfNameservers()
+	_ = pinHosts(resolverIPs, route4, route6, have6, opt.RouteProto, false)
+
+	apiURL, err := url.Parse(opt.GatewayURL)
+	if err != nil {
+		return nil, fmt.Errorf("gateway-url: %w", err)
+	}
+
+	apiIPs, err := lookupHostIPs(apiURL.Hostname())
+	if err != nil {
+		return nil, fmt.Errorf("resolve gateway api host %q: %w", apiURL.Hostname(), err)
+	}
+	if err := pinHosts(apiIPs, route4, route6, have6, opt.RouteProto, true); err != nil {
+		return nil, err
+	}
+
+	registerResp, err := enrollmentRegister(ctx, opt.GatewayURL, credential, enrollmentRegisterRequest{
+		Transport:          enrollmentTransportWireGuard,
+		Authorizer:         opt.AuthorizerName,
+		WireGuardPublicKey: clientPubB64,
+		Claims:             claims,
+		// The sidecar is the sole authoritative keepalive sender; request the
+		// resolved interval + reap count so it can keepalive and size its
+		// watchdog escalation. The gateway should not keepalive back.
+		Keepalive: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if registerResp.MTU != 0 {
+		opt.MTU = registerResp.MTU
+	}
+	log.Printf("bridge: enrolled peer_ip=%s keepalive=%ds reap_count=%d gateway_tunnel_ip=%s",
+		registerResp.PeerIP, registerResp.KeepaliveIntervalSeconds, registerResp.KeepaliveReapCount, registerResp.GatewayTunnelIP)
+
+	endpointIP, endpointAddr, err := resolveWGEndpoint(registerResp.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if err := pinHosts([]netip.Addr{endpointIP}, route4, route6, have6, opt.RouteProto, true); err != nil {
+		return nil, fmt.Errorf("pin wg endpoint: %w", err)
+	}
+	// Now that the full desired set is known, prune any tagged pin no longer needed
+	want := map[netip.Addr]bool{endpointIP: true}
+	for _, ip := range resolverIPs {
+		want[ip] = true
+	}
+	for _, ip := range apiIPs {
+		want[ip] = true
+	}
+	pruneStalePins(want, opt.RouteProto)
+
+	gwTunIP, err := netip.ParseAddr(strings.TrimSpace(registerResp.GatewayTunnelIP))
+	if err != nil {
+		return nil, fmt.Errorf("gateway did not return a usable tunnel IP %q: %w", registerResp.GatewayTunnelIP, err)
+	}
+
+	tunDev, err := wgtun.CreateTUN(opt.Iface, opt.MTU)
+	if err != nil {
+		return nil, fmt.Errorf("create tun: %w", err)
+	}
+	ok := false
+	defer func() {
+		if !ok {
+			_ = tunDev.Close()
+		}
+	}()
+	ifaceName, err := tunDev.Name()
+	if err != nil {
+		return nil, fmt.Errorf("tun name: %w", err)
+	}
+	logger := device.NewLogger(device.LogLevelError, "[clawpatrol tun wg] ")
+	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
+	defer func() {
+		if !ok {
+			dev.Close()
+		}
+	}()
+
+	if err := setupTunDevice(ifaceName, opt.MTU, registerResp.PeerIP, registerResp.PeerIPv6); err != nil {
+		return nil, err
+	}
+	keepaliveSecs := registerResp.KeepaliveIntervalSeconds
+	if keepaliveSecs <= 0 {
+		keepaliveSecs = 25
+	}
+	ipc, err := buildTunWGIpc(clientPrivB64, registerResp.ServerPublicKey, endpointAddr, keepaliveSecs)
+	if err != nil {
+		return nil, err
+	}
+	if err := dev.IpcSet(ipc); err != nil {
+		return nil, fmt.Errorf("wg IpcSet: %w", err)
+	}
+	if err := dev.Up(); err != nil {
+		return nil, fmt.Errorf("wg up: %w", err)
+	}
+	if err := replaceDefaultRoutes(ifaceName, have6); err != nil {
+		return nil, err
+	}
+
+	// env + CA handoff only on the first successful bring-up: the workload reads
+	// it once, and it does not change across reconnects for the same subject.
+	if !st.handoffWritten {
+		envVars, err := enrollmentFetchEnv(ctx, opt.GatewayURL, registerResp.APIToken)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeTunFiles(opt, envVars, registerResp.CAPEM); err != nil {
+			return nil, err
+		}
+		st.handoffWritten = true
+	}
+
+	// Watchdog: rx_bytes is the cheap positive signal, an ICMP echo to the
+	// gateway tunnel IP is the active probe when rx goes quiet. Cadence and
+	// escalation reuse the keepalive interval and the server-dictated reap
+	// count so the client stays in lock-step with the reaper.
+	keepalive := time.Duration(keepaliveSecs) * time.Second
+	reconnectAfter := registerResp.KeepaliveReapCount
+	rekeyAfter := bridgeWatchdogResetMisses(opt.LocalResetMisses, reconnectAfter)
+
+	wdCtx, stopWatchdog := context.WithCancel(context.Background())
+	sess := &bridgeSession{
+		dev:          dev,
+		tun:          tunDev,
+		apiToken:     registerResp.APIToken,
+		stopWatchdog: stopWatchdog,
+		reconnect:    make(chan struct{}, 1),
+	}
+	ticker := time.NewTicker(bridgeWatchdogPoll)
+	go func() {
+		defer ticker.Stop()
+		runBridgeWatchdogLoop(wdCtx, bridgeWatchdogConfig{
+			rx: func() uint64 {
+				uapi, err := dev.IpcGet()
+				if err != nil {
+					return 0
+				}
+				if s := parsePeerStats(uapi); s != nil {
+					return s.rxBytes
+				}
+				return 0
+			},
+			probe: func() error { return pingGatewayTunnel(gwTunIP, wgProbeTimeout) },
+			rekey: func() error { return dev.IpcSet(ipc) },
+			reconnect: func() {
+				select {
+				case sess.reconnect <- struct{}{}:
+				default:
+				}
+			},
+			tick: ticker.C,
+			now:  time.Now,
+
+			probeAfter:          keepalive,
+			probeInterval:       keepalive,
+			rekeyAfterFails:     rekeyAfter,
+			reconnectAfterFails: reconnectAfter,
+		})
+	}()
+	ok = true
+	return sess, nil
+}
+
+// pinHosts pins each host to its family's underlay route, tagged with proto.
+// When fatal, the first pin error aborts (an unpinned control-plane host
+// blackholes the path); otherwise pins are best-effort. Hosts of a family with
+// no underlay route are skipped.
+func pinHosts(hosts []netip.Addr, route4, route6 linuxDefaultRoute, have6 bool, proto string, fatal bool) error {
+	for _, ip := range hosts {
+		if !ip.Is4() && !have6 {
+			continue
+		}
+		if err := pinHostRoute(ip, route4, route6, have6, proto); err != nil {
+			if fatal {
+				return fmt.Errorf("pin host route %s: %w", ip, err)
+			}
+			log.Printf("bridge: pin route %s: %v — continuing", ip, err)
+		}
+	}
+	return nil
+}
+
+// pruneStalePins deletes every proto-tagged route whose destination host is
+// not in want. The proto tag makes the pinned set self-identifying, so the
+// bridge can rebuild its control-plane routes without ever touching CNI ones.
+func pruneStalePins(want map[netip.Addr]bool, proto string) {
+	for _, fam := range []string{"-4", "-6"} {
+		for _, ip := range listPinnedHosts(fam, proto) {
+			if want[ip] {
+				continue
+			}
+			dst := ip.String() + "/32"
+			if ip.Is6() {
+				dst = ip.String() + "/128"
+			}
+			_ = runIP("ip", fam, "route", "del", dst, "proto", proto)
+		}
+	}
+}
+
+// listPinnedHosts returns the destination host of every proto-tagged route in
+// the given family ("-4"/"-6") — the bridge's own control-plane pins.
+func listPinnedHosts(family, proto string) []netip.Addr {
+	out, err := exec.Command("ip", family, "route", "show", "proto", proto).Output()
+	if err != nil {
+		return nil
+	}
+	var hosts []netip.Addr
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		dst, _, _ := strings.Cut(fields[0], "/")
+		if ip, err := netip.ParseAddr(dst); err == nil {
+			hosts = append(hosts, ip)
+		}
+	}
+	return hosts
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func buildTunWGIpc(privateKeyB64, serverPublicKeyB64, endpoint string, keepaliveSeconds int) (string, error) {
+	privHex, err := base64DecodeToHex(privateKeyB64)
+	if err != nil {
+		return "", fmt.Errorf("private key: %w", err)
+	}
+	pubRaw, err := normalizeWGPublicKey(serverPublicKeyB64)
+	if err != nil {
+		return "", fmt.Errorf("server public key: %w", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "private_key=%s\n", privHex)
+	fmt.Fprintf(&b, "replace_peers=true\n")
+	fmt.Fprintf(&b, "public_key=%s\n", pubRaw)
+	fmt.Fprintf(&b, "endpoint=%s\n", endpoint)
+	// The gateway returns the client keepalive cadence at enrollment. Fall back
+	// to 25s for compatibility with older responses.
+	if keepaliveSeconds <= 0 {
+		keepaliveSeconds = 25
+	}
+	fmt.Fprintf(&b, "persistent_keepalive_interval=%d\n", keepaliveSeconds)
+	fmt.Fprintf(&b, "allowed_ip=0.0.0.0/0\n")
+	fmt.Fprintf(&b, "allowed_ip=::/0\n")
+	return b.String(), nil
+}
+
+func setupTunDevice(iface string, mtu int, peerIP, peerIPv6 string) error {
+	steps := [][]string{
+		{"ip", "link", "set", "dev", iface, "mtu", strconv.Itoa(mtu), "up"},
+		{"ip", "addr", "replace", peerIP + "/32", "dev", iface},
+	}
+	for _, step := range steps {
+		if err := runIP(step...); err != nil {
+			return err
+		}
+	}
+	// IPv6 is best-effort: a netns without IPv6 (e.g. the host booted with
+	// ipv6.disable=1) must still bring up the v4 tunnel. This mirrors the
+	// optional v6 default route in replaceDefaultRoutes and the child-netns
+	// degradation in run_linux.go — never let a missing v6 stack be fatal.
+	if peerIPv6 != "" {
+		if err := runIP("ip", "-6", "addr", "replace", peerIPv6+"/128", "dev", iface); err != nil {
+			log.Printf("bridge: ip -6 addr replace %s/128 dev %s: %v — continuing without IPv6 in the sandbox", peerIPv6, iface, err)
+		}
+	}
+	return nil
+}
+
+// discoverUnderlayRoute resolves the pod's pre-tunnel route for a family
+// ("-4" / "-6"). It prefers the live default route (the normal first-boot
+// case) and falls back to a surviving tagged clawpatrol pin, which is how an
+// in-process reconnect recovers the underlay gateway when there is no default
+// route left. The middle return value is the source: "default" when it came
+// from the live default route (normal first boot) or "pin" when it was
+// recovered from a tagged pin (an in-process reconnect). Source "" with ok=false
+// means neither was available — for v4 that's fatal to bring-up; for v6 it
+// just means "no IPv6 underlay", same as before.
+func discoverUnderlayRoute(family, proto string) (linuxDefaultRoute, string, bool) {
+	if out, err := exec.Command("ip", family, "route", "show", "default").Output(); err == nil {
+		if r, err := parseDefaultRoute(out); err == nil && r.Dev != "" {
+			return r, "default", true
+		}
+	}
+	// No usable default during reconnect. Recover via/dev from a pin we
+	// tagged on first boot; they live on the underlay device and survive.
+	out, err := exec.Command("ip", family, "route", "show", "proto", proto).Output()
+	if err != nil {
+		return linuxDefaultRoute{}, "", false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if r, err := parsePinnedRoute(line); err == nil && r.Dev != "" {
+			return r, "pin", true
+		}
+	}
+	return linuxDefaultRoute{}, "", false
+}
+
+// parsePinnedRoute extracts the via/dev from one `ip route show proto` line
+// (e.g. "10.96.0.1 via 10.244.0.1 dev eth0 proto 111"). Unlike a default
+// route, the leading token is the pinned host, so we only read via/dev.
+func parsePinnedRoute(line string) (linuxDefaultRoute, error) {
+	fields := strings.Fields(line)
+	var r linuxDefaultRoute
+	for i := 0; i < len(fields)-1; i++ {
+		switch fields[i] {
+		case "via":
+			r.Via = fields[i+1]
+		case "dev":
+			r.Dev = fields[i+1]
+		}
+	}
+	if r.Dev == "" {
+		return linuxDefaultRoute{}, fmt.Errorf("no dev in route line %q", line)
+	}
+	return r, nil
+}
+
+// resolvConfNameservers returns the nameserver IPs from /etc/resolv.conf.
+// resolv.conf nameservers are always IP literals, so each parses cleanly; a
+// missing or nameserver-less file yields nil (DNS pinning is best-effort).
+func resolvConfNameservers() []netip.Addr {
+	data, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		return nil
+	}
+	var out []netip.Addr
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "nameserver" {
+			if ip, err := netip.ParseAddr(fields[1]); err == nil {
+				out = append(out, ip)
+			}
+		}
+	}
+	return out
+}
+
+func replaceDefaultRoutes(iface string, replace6 bool) error {
+	if err := runIP("ip", "route", "replace", "default", "dev", iface); err != nil {
+		return err
+	}
+	if replace6 {
+		// Only tunnel v6 when the pod already had a v6 default route — never
+		// create one, which would blackhole v6 that previously had no route.
+		_ = runIP("ip", "-6", "route", "replace", "default", "dev", iface)
+	}
+	return nil
+}
+
+type linuxDefaultRoute struct {
+	Dev string
+	Via string
+}
+
+func parseDefaultRoute(out []byte) (linuxDefaultRoute, error) {
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return linuxDefaultRoute{}, fmt.Errorf("no default route")
+	}
+	var r linuxDefaultRoute
+	for i := 0; i < len(fields)-1; i++ {
+		switch fields[i] {
+		case "via":
+			r.Via = fields[i+1]
+		case "dev":
+			r.Dev = fields[i+1]
+		}
+	}
+	if r.Dev == "" {
+		return linuxDefaultRoute{}, fmt.Errorf("default route has no dev: %s", strings.TrimSpace(string(out)))
+	}
+	return r, nil
+}
+
+func pinHostRoute4(ip netip.Addr, route linuxDefaultRoute, proto string) error {
+	dst := ip.String() + "/32"
+	args := []string{"ip", "route", "replace", dst}
+	if route.Via != "" {
+		args = append(args, "via", route.Via)
+	}
+	args = append(args, "dev", route.Dev, "proto", proto)
+	return runIP(args...)
+}
+
+func pinHostRoute6(ip netip.Addr, route linuxDefaultRoute, proto string) error {
+	dst := ip.String() + "/128"
+	args := []string{"ip", "-6", "route", "replace", dst}
+	if route.Via != "" {
+		args = append(args, "via", route.Via)
+	}
+	args = append(args, "dev", route.Dev, "proto", proto)
+	return runIP(args...)
+}
+
+// pinHostRoute pins ip to its family's pre-tunnel default route, tagged with
+// proto so it can be recovered during an in-process reconnect.
+func pinHostRoute(ip netip.Addr, route4, route6 linuxDefaultRoute, have6 bool, proto string) error {
+	if ip.Is4() {
+		return pinHostRoute4(ip, route4, proto)
+	}
+	if !have6 {
+		return fmt.Errorf("no IPv6 default route to pin %s", ip)
+	}
+	return pinHostRoute6(ip, route6, proto)
+}
+
+// resolveWGEndpoint resolves the WireGuard endpoint host:port to a concrete
+// ip:port, preferring IPv4 (see preferV4). Returns the chosen IP so the
+// caller can pin a host route to it before the default route flips to the
+// tunnel.
+func resolveWGEndpoint(endpoint string) (netip.Addr, string, error) {
+	host, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return netip.Addr{}, "", fmt.Errorf("endpoint %q: %w", endpoint, err)
+	}
+	ips, err := lookupHostIPs(host)
+	if err != nil {
+		return netip.Addr{}, "", fmt.Errorf("resolve endpoint %q: %w", host, err)
+	}
+	ip, ok := preferV4(ips)
+	if !ok {
+		return netip.Addr{}, "", fmt.Errorf("resolve endpoint %q: no A/AAAA records", host)
+	}
+	return ip, net.JoinHostPort(ip.String(), port), nil
+}
+
+func lookupHostIPs(host string) ([]netip.Addr, error) {
+	if host == "" {
+		return nil, nil
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{ip.Unmap()}, nil
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		if addr, ok := netip.AddrFromSlice(ip); ok {
+			// Unmap 4-in-6 so Is4()/family checks and route pinning behave.
+			out = append(out, addr.Unmap())
+		}
+	}
+	return out, nil
+}
+
+func runIP(args ...string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func writeTunFiles(opt bridgeOptions, vars []pushdownEnvVar, caPEM string) error {
+	if err := os.MkdirAll(filepath.Dir(opt.EnvOut), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(opt.CAOut), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(opt.ReadyFile), 0o755); err != nil {
+		return err
+	}
+	if caPEM != "" {
+		if err := os.WriteFile(opt.CAOut, []byte(caPEM), 0o644); err != nil {
+			return fmt.Errorf("write ca: %w", err)
+		}
+	}
+	vars = append(caPathPushdownVars(opt.CAOut), vars...)
+	var buf bytes.Buffer
+	for _, ev := range vars {
+		if ev.Name == "" {
+			continue
+		}
+		fmt.Fprintf(&buf, "export %s=%q\n", ev.Name, ev.Value)
+	}
+	if err := os.WriteFile(opt.EnvOut, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write env: %w", err)
+	}
+	if err := os.WriteFile(opt.ReadyFile, []byte(time.Now().UTC().Format(time.RFC3339Nano)+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write ready: %w", err)
+	}
+	return nil
+}

--- a/cmd/clawpatrol/bridge_other.go
+++ b/cmd/clawpatrol/bridge_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func bridgeRun(_ context.Context, _ bridgeOptions) error {
+	return fmt.Errorf("clawpatrol bridge is only supported on Linux")
+}

--- a/cmd/clawpatrol/bridge_probe_linux.go
+++ b/cmd/clawpatrol/bridge_probe_linux.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// wgProbeTimeout bounds one liveness probe round trip. Well under the
+// keepalive-interval probe cadence, so a lost probe is a prompt failure.
+const wgProbeTimeout = 3 * time.Second
+
+// pingGatewayTunnel sends one ICMP echo to the gateway's tunnel address and
+// waits up to timeout for the reply. It uses an unprivileged ICMP datagram
+// socket (SOCK_DGRAM / IPPROTO_ICMP), which needs no CAP_NET_RAW as long as
+// the pod netns permits it (net.ipv4.ping_group_range) — the same path the
+// workload's `ping` uses. A reply proves both directions of the tunnel in one
+// round trip: the request advanced the gateway peer's rx, the reply advanced
+// ours.
+func pingGatewayTunnel(gwIP netip.Addr, timeout time.Duration) error {
+	network, listen := "udp4", "0.0.0.0"
+	echoType := icmp.Type(ipv4.ICMPTypeEcho)
+	proto := ipv4.ICMPTypeEcho.Protocol()
+	if gwIP.Is6() {
+		network, listen = "udp6", "::"
+		echoType = ipv6.ICMPTypeEchoRequest
+		proto = ipv6.ICMPTypeEchoRequest.Protocol()
+	}
+	c, err := icmp.ListenPacket(network, listen)
+	if err != nil {
+		return fmt.Errorf("open icmp socket: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	msg := icmp.Message{
+		Type: echoType,
+		Code: 0,
+		Body: &icmp.Echo{ID: os.Getpid() & 0xffff, Seq: 1, Data: []byte("clawpatrol-bridge")},
+	}
+	b, err := msg.Marshal(nil)
+	if err != nil {
+		return err
+	}
+	if err := c.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return err
+	}
+	if _, err := c.WriteTo(b, &net.UDPAddr{IP: net.IP(gwIP.AsSlice())}); err != nil {
+		return fmt.Errorf("send echo: %w", err)
+	}
+	// The socket only receives replies to its own echoes (the kernel demuxes on
+	// the ID it assigned), so any echo reply we read is ours.
+	buf := make([]byte, 1500)
+	for {
+		n, _, err := c.ReadFrom(buf)
+		if err != nil {
+			return fmt.Errorf("await echo reply: %w", err)
+		}
+		rm, err := icmp.ParseMessage(proto, buf[:n])
+		if err != nil {
+			continue
+		}
+		switch rm.Type {
+		case ipv4.ICMPTypeEchoReply, ipv6.ICMPTypeEchoReply:
+			return nil
+		}
+	}
+}

--- a/cmd/clawpatrol/bridge_test.go
+++ b/cmd/clawpatrol/bridge_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestPreferV4(t *testing.T) {
+	v4 := netip.MustParseAddr("10.55.0.2")
+	v6 := netip.MustParseAddr("fd00::1")
+	v4in6 := netip.MustParseAddr("::ffff:10.55.0.2")
+
+	if got, ok := preferV4([]netip.Addr{v6, v4}); !ok || got != v4 {
+		t.Fatalf("preferV4([v6,v4]) = %v (ok=%v), want %v", got, ok, v4)
+	}
+	if got, ok := preferV4([]netip.Addr{v6}); !ok || got != v6 {
+		t.Fatalf("preferV4(v6-only) = %v (ok=%v), want %v", got, ok, v6)
+	}
+	if got, ok := preferV4([]netip.Addr{v4in6}); !ok || !got.Is4() || got != v4 {
+		t.Fatalf("preferV4(4-in-6) = %v (ok=%v), want unmapped %v", got, ok, v4)
+	}
+	if _, ok := preferV4(nil); ok {
+		t.Fatal("preferV4(nil) should be ok=false")
+	}
+}
+
+func TestParseBridgeAuthorizer(t *testing.T) {
+	typ, name, err := parseBridgeAuthorizer("kubernetes_token_review/agents")
+	if err != nil || typ != "kubernetes_token_review" || name != "agents" {
+		t.Fatalf("parse = %q %q %v", typ, name, err)
+	}
+	for _, bad := range []string{"", "agents", "kubernetes_token_review/", "/agents", "oidc/agents"} {
+		if _, _, err := parseBridgeAuthorizer(bad); err == nil {
+			t.Errorf("parseBridgeAuthorizer(%q) expected error", bad)
+		}
+	}
+}
+
+func TestValidateRouteProto(t *testing.T) {
+	for _, ok := range []string{defaultRouteProto, "1", "255", "static", "clawpatrol"} {
+		if err := validateRouteProto(ok); err != nil {
+			t.Errorf("validateRouteProto(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "  ", "0", "256", "-1"} {
+		if err := validateRouteProto(bad); err == nil {
+			t.Errorf("validateRouteProto(%q) expected error", bad)
+		}
+	}
+}

--- a/cmd/clawpatrol/bridge_watchdog.go
+++ b/cmd/clawpatrol/bridge_watchdog.go
@@ -1,0 +1,158 @@
+package main
+
+// Liveness self-heal for an enrolled bridge peer's WireGuard tunnel.
+//
+// This is deliberately separate from wg_watchdog.go, which preserves the
+// upstream handshake-state-machine recovery path. The bridge watchdog reasons
+// about an enrolled peer's rx/probe/re-enrollment lifecycle instead.
+//
+// The sidecar is the sole (authoritative) keepalive sender — the gateway does
+// not keepalive back (see registerEnrolledPeer) — so the sidecar's own
+// rx_bytes is normally quiet on an idle tunnel. The watchdog therefore uses
+// rx_bytes only as a cheap positive signal: while it advances, inbound works
+// and nothing is done. When it goes quiet, the watchdog actively probes the
+// gateway's tunnel address with an ICMP echo to disambiguate "healthy but
+// idle" from "actually broken" — a round-trip reply proves both directions.
+//
+// On sustained probe failure it escalates:
+//
+//   - at rekeyAfterFails consecutive failures: rebuild the peer in place
+//     (IpcSet). Cheap; clears a transient local wedge.
+//   - at reconnectAfterFails consecutive failures: trigger a full in-process
+//     teardown + re-enroll (reconnect), then return so a fresh watchdog runs
+//     with the new session.
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+const (
+	// bridgeWatchdogPoll is how often the loop samples rx_bytes. Small so the
+	// watchdog reacts promptly when real inbound traffic resumes.
+	bridgeWatchdogPoll = 5 * time.Second
+	// bridgeWatchdogDefaultResetMisses is the default for
+	// --local-reset-missed: how many consecutive failed probes trigger the
+	// cheap in-place rekey before the full reconnect. Clamped below the
+	// reconnect threshold.
+	bridgeWatchdogDefaultResetMisses = 2
+)
+
+// bridgeWatchdogConfig captures the runBridgeWatchdogLoop dependencies so the
+// loop is testable without a real wireguard-go device or a real network.
+type bridgeWatchdogConfig struct {
+	// rx returns the peer's current WireGuard rx_bytes (0 if unavailable).
+	rx func() uint64
+	// probe sends one liveness probe (ICMP echo to the gateway tunnel IP) and
+	// returns nil on a reply, an error on failure/timeout.
+	probe func() error
+	// rekey rebuilds the peer in place (IpcSet) — the cheap first escalation.
+	rekey func() error
+	// reconnect triggers a full in-process teardown + re-enroll. After it is
+	// called the loop returns; a fresh watchdog starts with the new session.
+	reconnect func()
+	logf      func(string, ...any)
+	tick      <-chan time.Time
+	now       func() time.Time
+	// probeAfter is how long rx must be quiet before the first probe;
+	// probeInterval rate-limits probes once quiet. Both are the keepalive
+	// interval in practice.
+	probeAfter    time.Duration
+	probeInterval time.Duration
+	// rekeyAfterFails / reconnectAfterFails are consecutive-probe-failure
+	// counts. rekeyAfterFails == 0 disables the in-place rekey stage;
+	// reconnectAfterFails <= 0 leaves the whole loop inert (reaping disabled).
+	rekeyAfterFails     int
+	reconnectAfterFails int
+}
+
+// bridgeWatchdogResetMisses resolves the configured local-reset threshold
+// against the reconnect horizon: 0 (or a value >= the horizon) disables the
+// in-place rekey stage, otherwise the configured value is used.
+func bridgeWatchdogResetMisses(configured, reconnectAfter int) int {
+	if configured <= 0 || configured >= reconnectAfter {
+		return 0
+	}
+	return configured
+}
+
+func runBridgeWatchdogLoop(ctx context.Context, c bridgeWatchdogConfig) {
+	logf := c.logf
+	if logf == nil {
+		logf = log.Printf
+	}
+	// Inert when reaping is disabled server-side: nothing to escalate to.
+	if c.reconnectAfterFails <= 0 {
+		return
+	}
+	var (
+		tracking  bool
+		lastRx    uint64
+		lastLive  time.Time
+		lastProbe time.Time
+		fails     int
+		rekeyed   bool
+		rekeys    int
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.tick:
+		}
+		now := c.now()
+		rx := c.rx()
+		if !tracking {
+			tracking, lastRx, lastLive = true, rx, now
+			continue
+		}
+		if rx > lastRx {
+			// Positive inbound signal — the tunnel is healthy, no probe needed.
+			if fails > 0 || rekeyed {
+				logf("bridge watchdog: WG rx resumed — tunnel healthy again")
+			}
+			lastRx, lastLive, fails, rekeyed = rx, now, 0, false
+			continue
+		}
+		// rx is quiet. Act only once it has been quiet long enough, and
+		// rate-limit the probe to the probe interval.
+		if now.Sub(lastLive) < c.probeAfter {
+			continue
+		}
+		if !lastProbe.IsZero() && now.Sub(lastProbe) < c.probeInterval {
+			continue
+		}
+
+		lastProbe = now
+		err := c.probe()
+		if err == nil {
+			// Healthy but idle. The reply also advances rx (handled next tick),
+			// but count the success as liveness now.
+			if fails > 0 || rekeyed {
+				logf("bridge watchdog: gateway probe recovered — tunnel healthy again")
+			}
+			lastRx, lastLive, fails, rekeyed = c.rx(), now, 0, false
+			continue
+		}
+		fails++
+		logf("bridge watchdog: gateway liveness probe failed (%d/%d): %v", fails, c.reconnectAfterFails, err)
+
+		if fails >= c.reconnectAfterFails {
+			logf("bridge watchdog: %d consecutive probe failures — tearing down and reconnecting in-process", fails)
+			if c.reconnect != nil {
+				c.reconnect()
+			}
+			return
+		}
+		if c.rekeyAfterFails > 0 && fails >= c.rekeyAfterFails && !rekeyed {
+			rekeys++
+			logf("bridge watchdog: %d consecutive probe failures — rebuilding peer in place (rekey #%d)", fails, rekeys)
+			if err := c.rekey(); err != nil {
+				logf("bridge watchdog: peer rekey failed: %v", err)
+			} else {
+				rekeyed = true
+			}
+		}
+	}
+}

--- a/cmd/clawpatrol/bridge_watchdog_test.go
+++ b/cmd/clawpatrol/bridge_watchdog_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func discardBridgeWatchdogLog(string, ...any) {}
+
+func waitSignal(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("expected %s", what)
+	}
+}
+
+func assertNoSignal(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("unexpected %s", what)
+	case <-time.After(80 * time.Millisecond):
+	}
+}
+
+// TestBridgeWatchdogProbeEscalates drives the escalation ladder: rx is flat
+// (the sidecar is the sole keepalive sender, so quiet inbound is normal), so
+// once rx has been quiet past probeAfter the watchdog probes; consecutive
+// probe failures rekey, then reconnect.
+func TestBridgeWatchdogProbeEscalates(t *testing.T) {
+	clk := &fakeClock{}
+	t0 := time.Unix(3_000_000, 0)
+	clk.Set(t0)
+
+	tick := make(chan time.Time)
+	probeCalls := make(chan struct{}, 16)
+	probe := func() error { probeCalls <- struct{}{}; return errors.New("no reply") }
+	rekeyCalls := make(chan struct{}, 8)
+	rekey := func() error { rekeyCalls <- struct{}{}; return nil }
+	reconnectCalls := make(chan struct{}, 1)
+	reconnect := func() {
+		select {
+		case reconnectCalls <- struct{}{}:
+		default:
+		}
+	}
+	rx := func() uint64 { return 1000 } // flat
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		runBridgeWatchdogLoop(ctx, bridgeWatchdogConfig{
+			rx: rx, probe: probe, rekey: rekey, reconnect: reconnect,
+			logf: discardBridgeWatchdogLog, tick: tick, now: clk.Now,
+			probeAfter: 25 * time.Second, probeInterval: 25 * time.Second,
+			rekeyAfterFails: 2, reconnectAfterFails: 3,
+		})
+		close(done)
+	}()
+
+	// Tick 1 seeds rx tracking — no probe (rx quiet only just observed).
+	tick <- clk.Now()
+	assertNoSignal(t, probeCalls, "probe on seed tick")
+
+	// +25s: rx quiet past probeAfter → probe #1, fails (1) — no rekey yet.
+	clk.Set(t0.Add(25 * time.Second))
+	tick <- clk.Now()
+	waitSignal(t, probeCalls, "probe #1")
+	assertNoSignal(t, rekeyCalls, "rekey after a single failure")
+
+	// +50s: probe #2, second consecutive failure → in-place rekey.
+	clk.Set(t0.Add(50 * time.Second))
+	tick <- clk.Now()
+	waitSignal(t, probeCalls, "probe #2")
+	waitSignal(t, rekeyCalls, "rekey at 2 consecutive failures")
+
+	// +75s: probe #3, third failure → reconnect, loop returns.
+	clk.Set(t0.Add(75 * time.Second))
+	tick <- clk.Now()
+	waitSignal(t, probeCalls, "probe #3")
+	waitSignal(t, reconnectCalls, "reconnect at 3 consecutive failures")
+	<-done
+}
+
+// TestBridgeWatchdogRxHealthyNoProbe confirms advancing rx (real inbound
+// traffic) is treated as liveness on its own, without generating a probe.
+func TestBridgeWatchdogRxHealthyNoProbe(t *testing.T) {
+	clk := &fakeClock{}
+	t0 := time.Unix(6_000_000, 0)
+	clk.Set(t0)
+
+	tick := make(chan time.Time)
+	var rxv atomic.Uint64
+	rxv.Store(1000)
+	probeCalls := make(chan struct{}, 8)
+	probe := func() error { probeCalls <- struct{}{}; return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		runBridgeWatchdogLoop(ctx, bridgeWatchdogConfig{
+			rx:        func() uint64 { return rxv.Load() },
+			probe:     probe,
+			rekey:     func() error { return nil },
+			reconnect: func() {},
+			logf:      discardBridgeWatchdogLog, tick: tick, now: clk.Now,
+			probeAfter: 25 * time.Second, probeInterval: 25 * time.Second,
+			rekeyAfterFails: 2, reconnectAfterFails: 3,
+		})
+		close(done)
+	}()
+
+	tick <- clk.Now() // seed
+	for i := 1; i <= 4; i++ {
+		clk.Set(t0.Add(time.Duration(i) * 40 * time.Second))
+		rxv.Add(32)
+		tick <- clk.Now()
+	}
+	assertNoSignal(t, probeCalls, "probe while rx is advancing")
+	cancel()
+	<-done
+}
+
+// TestBridgeWatchdogProbeSuccessIdle confirms that on a healthy-but-idle
+// tunnel (rx flat, probe replies) the watchdog probes on cadence but never
+// escalates.
+func TestBridgeWatchdogProbeSuccessIdle(t *testing.T) {
+	clk := &fakeClock{}
+	t0 := time.Unix(7_000_000, 0)
+	clk.Set(t0)
+
+	tick := make(chan time.Time)
+	probeCalls := make(chan struct{}, 16)
+	probe := func() error { probeCalls <- struct{}{}; return nil }
+	rekeyCalls := make(chan struct{}, 8)
+	rekey := func() error { rekeyCalls <- struct{}{}; return nil }
+	reconnectCalls := make(chan struct{}, 1)
+	reconnect := func() {
+		select {
+		case reconnectCalls <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		runBridgeWatchdogLoop(ctx, bridgeWatchdogConfig{
+			rx: func() uint64 { return 1000 }, probe: probe, rekey: rekey, reconnect: reconnect,
+			logf: discardBridgeWatchdogLog, tick: tick, now: clk.Now,
+			probeAfter: 25 * time.Second, probeInterval: 25 * time.Second,
+			rekeyAfterFails: 2, reconnectAfterFails: 3,
+		})
+		close(done)
+	}()
+
+	tick <- clk.Now() // seed
+	for i := 1; i <= 5; i++ {
+		clk.Set(t0.Add(time.Duration(i) * 25 * time.Second))
+		tick <- clk.Now()
+		waitSignal(t, probeCalls, "idle liveness probe")
+	}
+	assertNoSignal(t, rekeyCalls, "rekey while probes succeed")
+	assertNoSignal(t, reconnectCalls, "reconnect while probes succeed")
+	cancel()
+	<-done
+}
+
+// TestBridgeWatchdogInertWhenReapingDisabled confirms the loop returns
+// immediately when reaping is disabled server-side.
+func TestBridgeWatchdogInertWhenReapingDisabled(t *testing.T) {
+	clk := &fakeClock{}
+	clk.Set(time.Unix(4_000_000, 0))
+	probeCalls := make(chan struct{}, 4)
+
+	done := make(chan struct{})
+	go func() {
+		runBridgeWatchdogLoop(context.Background(), bridgeWatchdogConfig{
+			rx:        func() uint64 { return 1000 },
+			probe:     func() error { probeCalls <- struct{}{}; return errors.New("no reply") },
+			rekey:     func() error { return nil },
+			reconnect: func() {},
+			logf:      discardBridgeWatchdogLog, tick: make(chan time.Time), now: clk.Now,
+			probeAfter: 25 * time.Second, probeInterval: 25 * time.Second,
+			rekeyAfterFails: 0, reconnectAfterFails: 0,
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("inert watchdog should return immediately when reaping is disabled")
+	}
+	assertNoSignal(t, probeCalls, "probe with reaping disabled")
+}
+
+func TestBridgeWatchdogResetMisses(t *testing.T) {
+	for _, c := range []struct{ configured, reconnectAfter, want int }{
+		{2, 3, 2},
+		{2, 5, 2},
+		{4, 10, 4},
+		{2, 2, 0},
+		{5, 3, 0},
+		{0, 3, 0},
+		{-1, 3, 0},
+	} {
+		if got := bridgeWatchdogResetMisses(c.configured, c.reconnectAfter); got != c.want {
+			t.Errorf("bridgeWatchdogResetMisses(%d, %d) = %d, want %d", c.configured, c.reconnectAfter, got, c.want)
+		}
+	}
+}

--- a/cmd/clawpatrol/daemon_transport_wg_linux.go
+++ b/cmd/clawpatrol/daemon_transport_wg_linux.go
@@ -106,17 +106,26 @@ func (t *wgTransport) Close() error {
 	return nil
 }
 
-// startWGTransport reads the user wg.conf written by `clawpatrol join`,
-// brings up a wireguard-go device + gVisor stack, and waits for the
-// first handshake to complete so the first user flow doesn't race
-// the initial wg negotiation.
+// startWGTransport reads the user wg.conf written by `clawpatrol join`
+// and brings up the transport. The device bring-up itself lives in
+// newWGTransportFromConf so it can also be driven from an in-memory
+// runConf (e.g. an enrollment registration result) without a wg.conf
+// on disk.
 func startWGTransport() (daemonTransport, error) {
 	confPath := defaultRunConf()
 	cfg, err := parseRunConf(confPath)
 	if err != nil {
 		return nil, fmt.Errorf("wg conf %s: %w (re-run `clawpatrol join`)", confPath, err)
 	}
+	return newWGTransportFromConf(cfg)
+}
 
+// newWGTransportFromConf brings up a wireguard-go device + gVisor stack
+// from a parsed runConf and waits for the first handshake so the first
+// user flow doesn't race the initial wg negotiation. The config source
+// (persisted wg.conf vs runtime enrollment registration) is the
+// caller's concern.
+func newWGTransportFromConf(cfg *runConf) (daemonTransport, error) {
 	addrs := splitWGAddresses(cfg.Address)
 	var clientIP, clientIP6 netip.Addr
 	for _, a := range addrs {

--- a/cmd/clawpatrol/enrollment.go
+++ b/cmd/clawpatrol/enrollment.go
@@ -1,0 +1,1156 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/netip"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+const (
+	enrollmentRegisterPath                 = "/api/enrollment/register"
+	enrollmentTransportWireGuard           = "wireguard"
+	enrollmentAuthorizerKubernetesTokenRev = "kubernetes_token_review"
+	enrollmentDefaultMTU                   = 1420
+	// enrollmentReaperInterval is how often the reaper wakes to sample each
+	// enrolled peer's WireGuard rx and revoke peers past their liveness
+	// window.
+	enrollmentReaperInterval = 20 * time.Second
+	// enrollmentDefaultLiveness is the fallback WireGuard-quiet grace
+	// window used only when a peer's authorizer can no longer be resolved
+	// (e.g. removed from the policy on reload) — orphaned peers still get
+	// reaped.
+	enrollmentDefaultLiveness = 75 * time.Second
+)
+
+type enrollmentRegisterRequest struct {
+	Transport          string          `json:"transport"`
+	Authorizer         string          `json:"authorizer"`
+	WireGuardPublicKey string          `json:"wireguard_public_key,omitempty"`
+	Claims             json.RawMessage `json:"claims,omitempty"`
+	// Keepalive is set by resident tunnel hosts (clawpatrol bridge) that run
+	// a liveness watchdog. It asks the gateway to return the authorizer's
+	// resolved keepalive interval and reap count so the client can configure
+	// its tunnel and recovery thresholds.
+	Keepalive bool `json:"keepalive,omitempty"`
+}
+
+type enrollmentRegisterResponse struct {
+	Transport       string   `json:"transport"`
+	PeerIP          string   `json:"peer_ip"`
+	PeerIPv6        string   `json:"peer_ipv6"`
+	ServerPublicKey string   `json:"server_public_key"`
+	Endpoint        string   `json:"endpoint"`
+	AllowedIPs      []string `json:"allowed_ips"`
+	MTU             int      `json:"mtu"`
+	APIToken        string   `json:"api_token"`
+	CAPEM           string   `json:"ca_pem,omitempty"`
+	// KeepaliveIntervalSeconds is the persistent-keepalive interval the
+	// sidecar applies to its tunnel.
+	KeepaliveIntervalSeconds int `json:"keepalive_interval_s,omitempty"`
+	// KeepaliveReapCount is how many missed keepalives the gateway waits
+	// before reaping; the sidecar sizes its watchdog rekey/reconnect
+	// escalation from it. 0 disables reaping and the sidecar's self-heal.
+	KeepaliveReapCount int `json:"keepalive_reap_count,omitempty"`
+	// GatewayTunnelIP is the gateway's address inside the WireGuard subnet.
+	// The sidecar sends ICMP echo to it as its bidirectional liveness probe:
+	// a reply proves both directions of the tunnel in one round trip.
+	GatewayTunnelIP string `json:"gateway_tunnel_ip,omitempty"`
+}
+
+// enrollmentIdentity is the normalized identity an authorizer returns
+// after verifying a workload. Profile is server-derived (e.g. from a Pod
+// label), never submitted by the client.
+type enrollmentIdentity struct {
+	SubjectKey     string
+	ReplacementKey string
+	DisplayName    string
+	Owner          string
+	Profile        string
+	Metadata       map[string]string
+}
+
+type enrollmentAuthorizer interface {
+	Type() string
+	Name() string
+	Authorize(ctx context.Context, token string, claims json.RawMessage) (enrollmentIdentity, error)
+}
+
+// enrolledPeer is the enrollment metadata stored alongside a WireGuard
+// peer in the wg_peers table (enrolled=1). There is no separate lease
+// table; liveness is observed from the WG device (rx_bytes progress), so
+// there is no stored expiry.
+type enrolledPeer struct {
+	PeerIP         string
+	PubKeyHex      string
+	SubjectKey     string
+	ReplacementKey string
+	DisplayName    string
+	Owner          string
+	Profile        string
+	AuthorizerType string
+	AuthorizerName string
+	MetadataJSON   string
+	AddedNS        int64
+}
+
+// enrollmentLiveness tracks per-peer WireGuard receive progress so the
+// reaper can revoke peers whose tunnel has gone quiet past its liveness window.
+type enrollmentLiveness struct {
+	lastRx       uint64
+	lastProgress time.Time
+}
+
+// enrolledPeerView is the dashboard/API shape of an enrolled peer.
+type enrolledPeerView struct {
+	PeerIP         string            `json:"peer_ip"`
+	Transport      string            `json:"transport"`
+	AuthorizerType string            `json:"authorizer_type"`
+	AuthorizerName string            `json:"authorizer_name"`
+	SubjectKey     string            `json:"subject_key"`
+	DisplayName    string            `json:"display_name"`
+	Owner          string            `json:"owner"`
+	Profile        string            `json:"profile"`
+	PublicKey      string            `json:"public_key,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	CreatedAt      string            `json:"created_at"`
+	LastHandshake  string            `json:"last_handshake,omitempty"`
+
+	// Liveness surface for the dashboard.
+	KeepaliveIntervalSeconds int    `json:"keepalive_interval_seconds,omitempty"`
+	ReapCount                int    `json:"reap_count,omitempty"`
+	LastRxAt                 string `json:"last_rx_at,omitempty"`
+}
+
+var errEnrollmentConflict = errors.New("enrollment conflict")
+
+func (w *webMux) apiEnrollmentRegister(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost && r.Method != http.MethodDelete {
+		http.Error(rw, "POST or DELETE", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.Method == http.MethodDelete {
+		w.apiEnrollmentDelete(rw, r)
+		return
+	}
+	cfg := w.g.cfg.Load()
+	if cfg == nil || !cfg.IsEnrollmentEnabled() {
+		http.NotFound(rw, r)
+		return
+	}
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	if token == "" {
+		http.Error(rw, "missing bearer token", http.StatusUnauthorized)
+		return
+	}
+	var req enrollmentRegisterRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(rw, "bad json", http.StatusBadRequest)
+		return
+	}
+	authorizer, err := w.g.enrollmentAuthorizerFor(cfg, req.Transport, req.Authorizer)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusForbidden)
+		return
+	}
+	identity, err := authorizer.Authorize(r.Context(), token, req.Claims)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusForbidden)
+		return
+	}
+	if err := w.g.enrollmentProfileExists(identity.Profile); err != nil {
+		http.Error(rw, err.Error(), http.StatusForbidden)
+		return
+	}
+	resp, err := w.g.registerEnrolledPeer(r.Context(), cfg, authorizer, identity, req)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errEnrollmentConflict) {
+			status = http.StatusConflict
+		}
+		http.Error(rw, err.Error(), status)
+		return
+	}
+	writeJSON(rw, resp)
+}
+
+func (w *webMux) apiEnrollmentDelete(rw http.ResponseWriter, r *http.Request) {
+	cfg := w.g.cfg.Load()
+	if cfg == nil || !cfg.IsEnrollmentEnabled() {
+		http.NotFound(rw, r)
+		return
+	}
+	token := bearerFromAuthHeader(r.Header.Get("Authorization"))
+	peerIP := peerIPForAPIToken(w.g.db, token)
+	if peerIP == "" {
+		http.Error(rw, "unknown or missing peer api token", http.StatusUnauthorized)
+		return
+	}
+	w.g.enrollmentMu.Lock()
+	defer w.g.enrollmentMu.Unlock()
+	// Only a peer that actually holds an enrollment may drive this teardown.
+	// A regular onboarded device can also carry a peer API token; without
+	// this guard it could revoke its own WireGuard peer + forget its device
+	// row by hitting the enrollment delete path.
+	if _, err := w.g.enrolledPeerByIP(peerIP); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.NotFound(rw, r)
+		} else {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	if err := w.g.cleanupEnrolledPeerLocked(context.Background(), peerIP); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+// apiEnrollmentList lists every enrolled peer for operator observability.
+// Not gated on the feature flag — peers can still be draining after the
+// feature is turned off, and an empty list is a fine answer.
+func (w *webMux) apiEnrollmentList(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(rw, http.MethodGet, http.StatusMethodNotAllowed)
+		return
+	}
+	views, err := w.g.listEnrolledPeerViews()
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(rw, views)
+}
+
+func (g *Gateway) listEnrolledPeerViews() ([]enrolledPeerView, error) {
+	peers, err := g.listEnrolledPeers()
+	if err != nil {
+		return nil, err
+	}
+	var stats map[string]wgDevPeerStat
+	if globalWG != nil {
+		stats = globalWG.PeerStats()
+	}
+	policy := g.Policy()
+
+	// Read-only snapshot of the reaper-maintained liveness trackers. The
+	// reaper is the sole writer of enrollLive (sampled on its own loop); we
+	// only copy lastProgress out, so the critical section is a handful of
+	// map lookups with no I/O held under the lock.
+	live := make(map[string]time.Time, len(peers))
+	g.enrollmentMu.Lock()
+	for _, p := range peers {
+		if l, ok := g.enrollLive[p.PubKeyHex]; ok {
+			live[p.PubKeyHex] = l.lastProgress
+		}
+	}
+	g.enrollmentMu.Unlock()
+
+	views := make([]enrolledPeerView, 0, len(peers))
+	for _, p := range peers {
+		keepalive, reapCount := enrollmentKeepaliveConfig(policy, p.AuthorizerName)
+		v := enrolledPeerView{
+			PeerIP:                   p.PeerIP,
+			Transport:                enrollmentTransportWireGuard,
+			AuthorizerType:           p.AuthorizerType,
+			AuthorizerName:           p.AuthorizerName,
+			SubjectKey:               p.SubjectKey,
+			DisplayName:              p.DisplayName,
+			Owner:                    p.Owner,
+			Profile:                  p.Profile,
+			PublicKey:                p.PubKeyHex,
+			CreatedAt:                time.Unix(0, p.AddedNS).UTC().Format(time.RFC3339Nano),
+			KeepaliveIntervalSeconds: int(keepalive.Seconds()),
+			ReapCount:                reapCount,
+		}
+		if lp, ok := live[p.PubKeyHex]; ok && !lp.IsZero() {
+			v.LastRxAt = lp.UTC().Format(time.RFC3339Nano)
+		}
+		if p.MetadataJSON != "" && p.MetadataJSON != "{}" {
+			_ = json.Unmarshal([]byte(p.MetadataJSON), &v.Metadata)
+		}
+		if st, ok := stats[p.PubKeyHex]; ok && !st.lastHandshake.IsZero() {
+			v.LastHandshake = st.lastHandshake.UTC().Format(time.RFC3339Nano)
+		}
+		views = append(views, v)
+	}
+	return views, nil
+}
+
+func (g *Gateway) enrollmentAuthorizerFor(cfg *config.Gateway, transport, name string) (enrollmentAuthorizer, error) {
+	if strings.TrimSpace(transport) != enrollmentTransportWireGuard {
+		return nil, fmt.Errorf("unsupported enrollment transport %q", transport)
+	}
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("enrollment authorizer is required")
+	}
+	if cfg == nil || !cfg.IsEnrollmentEnabled() {
+		return nil, fmt.Errorf("enrollment is not enabled")
+	}
+	// Authorizers resolve from the compiled policy — the same place every
+	// other compiled runtime shape is read from — not the raw HCL.
+	policy := g.Policy()
+	if policy == nil {
+		return nil, fmt.Errorf("policy not loaded")
+	}
+	enrollment := policy.EnrollmentsByName[name]
+	if enrollment == nil {
+		return nil, fmt.Errorf("enrollment authorizer %q is not configured", name)
+	}
+	switch enrollment.Type {
+	case enrollmentAuthorizerKubernetesTokenRev:
+		enr, ok := enrollment.Body.(*config.CompiledK8sEnrollment)
+		if !ok {
+			return nil, fmt.Errorf("enrollment authorizer %q has unexpected compiled body %T", name, enrollment.Body)
+		}
+		return &kubernetesTokenReviewAuthorizer{
+			name:     enrollment.Name,
+			enr:      enr,
+			verifier: g.k8sVerifier,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported enrollment authorizer type %q", enrollment.Type)
+	}
+}
+
+func (g *Gateway) enrollmentProfileExists(profile string) error {
+	if profile == "" {
+		return fmt.Errorf("enrollment profile is empty")
+	}
+	policy := g.Policy()
+	if policy == nil {
+		return fmt.Errorf("policy not loaded")
+	}
+	if _, ok := policy.Profiles[profile]; !ok {
+		return fmt.Errorf("profile %q is not declared", profile)
+	}
+	return nil
+}
+
+// registerEnrolledPeer provisions (or reuses) a WireGuard peer for a
+// verified identity and records the enrollment on its wg_peers row.
+func (g *Gateway) registerEnrolledPeer(ctx context.Context, cfg *config.Gateway, authorizer enrollmentAuthorizer, identity enrollmentIdentity, req enrollmentRegisterRequest) (enrollmentRegisterResponse, error) {
+	pubHex, err := normalizeWGPublicKey(req.WireGuardPublicKey)
+	if err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	if identity.SubjectKey == "" || identity.ReplacementKey == "" || identity.Profile == "" {
+		return enrollmentRegisterResponse{}, fmt.Errorf("enrollment authorizer returned incomplete identity")
+	}
+	if globalWG == nil {
+		return enrollmentRegisterResponse{}, fmt.Errorf("wireguard server not started")
+	}
+	join := cfg.Join()
+	serverPubHex, err := globalWG.PublicKey()
+	if err != nil {
+		return enrollmentRegisterResponse{}, fmt.Errorf("wg server pub: %w", err)
+	}
+	serverPubB64, err := hexToB64(serverPubHex)
+	if err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	endpoint, err := wgClientEndpoint(join.WGEndpoint, join.PublicURL, join.WGListenPort)
+	if err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	metaJSON := "{}"
+	if len(identity.Metadata) > 0 {
+		meta, err := json.Marshal(identity.Metadata)
+		if err != nil {
+			return enrollmentRegisterResponse{}, err
+		}
+		metaJSON = string(meta)
+	}
+
+	g.enrollmentMu.Lock()
+	defer g.enrollmentMu.Unlock()
+
+	existing, err := g.findEnrolledPeers(identity.ReplacementKey, pubHex)
+	if err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	var reuseIP string
+	for _, p := range existing {
+		switch {
+		case p.SubjectKey == identity.SubjectKey:
+			// Same authenticated subject (e.g. a sidecar that restarted with
+			// a fresh key): reuse its IP, let AddPeer swap the key.
+			reuseIP = p.PeerIP
+		case p.ReplacementKey == identity.ReplacementKey:
+			// Same logical workload, new instance (pod recreated under the
+			// same name with a new UID): retire the old instance.
+			if err := g.cleanupEnrolledPeerLocked(ctx, p.PeerIP); err != nil {
+				return enrollmentRegisterResponse{}, err
+			}
+		case p.PubKeyHex == pubHex:
+			// A different subject is holding this public key.
+			return enrollmentRegisterResponse{}, fmt.Errorf("%w: wireguard public key is already registered to another enrolled peer", errEnrollmentConflict)
+		}
+	}
+
+	peerIP := reuseIP
+	if peerIP == "" {
+		peerIP, err = globalWG.allocatePeer(join, pubHex)
+		if err != nil {
+			return enrollmentRegisterResponse{}, fmt.Errorf("wg allocate peer: %w", err)
+		}
+	} else if err := globalWG.AddPeer(pubHex, peerIP); err != nil {
+		return enrollmentRegisterResponse{}, fmt.Errorf("wg add peer: %w", err)
+	}
+	peerAddr, err := netip.ParseAddr(peerIP)
+	if err != nil {
+		return enrollmentRegisterResponse{}, fmt.Errorf("invalid allocated peer IP %q: %w", peerIP, err)
+	}
+	// The client (clawpatrol bridge) is the sole authoritative keepalive
+	// sender. The gateway does NOT keepalive back: wireguard-go rearms the
+	// persistent-keepalive timer on any authenticated packet — including
+	// received ones — so with both sides sending, one direction's traffic
+	// perpetually postpones the other's keepalive, and a healthy idle peer can
+	// show flat rx in one direction and be falsely reaped.
+	var keepalive time.Duration
+	var reapCount int
+	if req.Keepalive {
+		keepalive, reapCount = enrollmentKeepaliveConfig(g.Policy(), authorizer.Name())
+	}
+	// Roll back the transport peer + token on any failure before the
+	// enrollment row is committed.
+	committed := false
+	defer func() {
+		if !committed {
+			globalWG.RevokePeerByIP(peerIP)
+			if err := deletePeerAPITokensForIP(g.db, peerIP); err != nil {
+				log.Printf("enrollment: rollback peer api tokens for %s: %v", peerIP, err)
+			}
+		}
+	}()
+
+	if err := deletePeerAPITokensForIP(g.db, peerIP); err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	apiToken, err := mintAndPersistPeerAPIToken(g.db, peerIP)
+	if err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+
+	resp := enrollmentRegisterResponse{
+		Transport:       enrollmentTransportWireGuard,
+		PeerIP:          peerIP,
+		PeerIPv6:        wg6FromV4(peerAddr).String(),
+		ServerPublicKey: serverPubB64,
+		Endpoint:        endpoint,
+		AllowedIPs:      []string{"0.0.0.0/0", "::/0"},
+		MTU:             enrollmentDefaultMTU,
+		APIToken:        apiToken,
+
+		KeepaliveIntervalSeconds: int(keepalive.Seconds()),
+		KeepaliveReapCount:       reapCount,
+		GatewayTunnelIP:          globalWG.GatewayTunnelIP().String(),
+	}
+	if g.certs != nil {
+		resp.CAPEM = string(g.certs.CertPEM())
+	}
+	if err := markEnrolledPeer(g.db, enrolledPeer{
+		PeerIP:         peerIP,
+		PubKeyHex:      pubHex,
+		SubjectKey:     identity.SubjectKey,
+		ReplacementKey: identity.ReplacementKey,
+		DisplayName:    identity.DisplayName,
+		Owner:          identity.Owner,
+		Profile:        identity.Profile,
+		AuthorizerType: authorizer.Type(),
+		AuthorizerName: authorizer.Name(),
+		MetadataJSON:   metaJSON,
+	}); err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	committed = true
+	g.noteEnrolledLiveLocked(pubHex)
+
+	log.Printf("enrollment: registered peer ip=%s name=%q subject=%s authorizer=%s reused_ip=%t",
+		peerIP, identity.DisplayName, identity.SubjectKey, authorizer.Name(), reuseIP != "")
+	if g.onboard != nil {
+		g.onboard.AssignProfile(peerIP, identity.Profile)
+		g.onboard.SetOwner(peerIP, identity.Owner)
+		g.onboard.SetHostname(peerIP, identity.DisplayName)
+	}
+	if g.agents != nil {
+		g.agents.Seed(peerIP)
+	}
+	return resp, nil
+}
+
+// --- enrollment store (wg_peers, enrolled=1) ---------------------------
+
+const enrolledPeerCols = `pubkey, ip, subject_key, replacement_key, display_name, owner, profile, authorizer_type, authorizer_name, metadata_json, added_ns`
+
+func scanEnrolledPeer(s interface{ Scan(...any) error }) (enrolledPeer, error) {
+	var (
+		p                                                                 enrolledPeer
+		subject, replacement, display, owner, profile, authT, authN, meta sql.NullString
+	)
+	if err := s.Scan(&p.PubKeyHex, &p.PeerIP, &subject, &replacement, &display, &owner, &profile, &authT, &authN, &meta, &p.AddedNS); err != nil {
+		return enrolledPeer{}, err
+	}
+	p.SubjectKey, p.ReplacementKey, p.DisplayName = subject.String, replacement.String, display.String
+	p.Owner, p.Profile = owner.String, profile.String
+	p.AuthorizerType, p.AuthorizerName = authT.String, authN.String
+	p.MetadataJSON = meta.String
+	return p, nil
+}
+
+func (g *Gateway) findEnrolledPeers(replacementKey, pubHex string) ([]enrolledPeer, error) {
+	rows, err := g.db.Query(`SELECT `+enrolledPeerCols+` FROM wg_peers
+		WHERE enrolled = 1 AND (replacement_key = ? OR pubkey = ?)`, replacementKey, pubHex)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []enrolledPeer
+	for rows.Next() {
+		p, err := scanEnrolledPeer(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (g *Gateway) enrolledPeerByIP(peerIP string) (enrolledPeer, error) {
+	return scanEnrolledPeer(g.db.QueryRow(`SELECT `+enrolledPeerCols+` FROM wg_peers
+		WHERE ip = ? AND enrolled = 1`, peerIP))
+}
+
+func (g *Gateway) listEnrolledPeers() ([]enrolledPeer, error) {
+	rows, err := g.db.Query(`SELECT ` + enrolledPeerCols + ` FROM wg_peers WHERE enrolled = 1 ORDER BY added_ns DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := []enrolledPeer{}
+	for rows.Next() {
+		p, err := scanEnrolledPeer(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// markEnrolledPeer stamps enrollment metadata onto the wg_peers row that
+// AddPeer just created/updated for pubHex.
+func markEnrolledPeer(db *sql.DB, p enrolledPeer) error {
+	if p.MetadataJSON == "" {
+		p.MetadataJSON = "{}"
+	}
+	res, err := db.Exec(`UPDATE wg_peers SET
+		enrolled = 1, subject_key = ?, replacement_key = ?, display_name = ?,
+		owner = ?, profile = ?, authorizer_type = ?, authorizer_name = ?, metadata_json = ?
+		WHERE pubkey = ?`,
+		p.SubjectKey, p.ReplacementKey, p.DisplayName, p.Owner, p.Profile,
+		p.AuthorizerType, p.AuthorizerName, p.MetadataJSON, p.PubKeyHex)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("wg_peers row for pubkey not found")
+	}
+	return nil
+}
+
+// cleanupEnrolledPeerLocked revokes the WireGuard peer (which also deletes
+// its wg_peers row, clearing the enrollment), its API tokens, and its
+// device/agent registry entries. Caller holds enrollmentMu.
+func (g *Gateway) cleanupEnrolledPeerLocked(_ context.Context, peerIP string) error {
+	if peerIP == "" {
+		return nil
+	}
+	p, _ := g.enrolledPeerByIP(peerIP)
+	// Revoke the bearer first. If that fails, leave the peer intact so the
+	// caller can report/retry cleanup without creating an authorized token
+	// whose peer and registry records have already disappeared.
+	if err := deletePeerAPITokensForIP(g.db, peerIP); err != nil {
+		return err
+	}
+	if globalWG != nil {
+		globalWG.RevokePeerByIP(peerIP) // removes the wg_peers row too
+	}
+	if g.onboard != nil {
+		g.onboard.ForgetIP(peerIP)
+	}
+	if g.agents != nil {
+		g.agents.Delete(peerIP)
+	}
+	if p.PubKeyHex != "" && g.enrollLive != nil {
+		delete(g.enrollLive, p.PubKeyHex)
+	}
+	return nil
+}
+
+// --- liveness reaper ---------------------------------------------------
+
+func (g *Gateway) noteEnrolledLiveLocked(pubHex string) {
+	if g.enrollLive == nil {
+		g.enrollLive = map[string]enrollmentLiveness{}
+	}
+	g.enrollLive[pubHex] = enrollmentLiveness{lastProgress: time.Now()}
+}
+
+// enrollmentLivenessTimeout resolves the WireGuard-quiet grace window for an
+// enrolled peer from its authorizer's derived liveness window.
+func enrollmentLivenessTimeout(policy *config.CompiledPolicy, authorizerName string) time.Duration {
+	if policy != nil && authorizerName != "" {
+		if enrollment := policy.EnrollmentsByName[authorizerName]; enrollment != nil {
+			return enrollment.Liveness.LivenessWindow() // derived; 0 == reaping disabled
+		}
+	}
+	return enrollmentDefaultLiveness
+}
+
+// enrollmentKeepaliveConfig resolves the WireGuard persistent-keepalive
+// interval and the missed-keepalive reap count for an authorizer.
+func enrollmentKeepaliveConfig(policy *config.CompiledPolicy, authorizerName string) (time.Duration, int) {
+	if policy != nil && authorizerName != "" {
+		if enrollment := policy.EnrollmentsByName[authorizerName]; enrollment != nil {
+			return enrollment.Liveness.KeepaliveInterval, enrollment.Liveness.ReapCount
+		}
+	}
+	return config.EnrollmentDefaultKeepalive, config.EnrollmentDefaultReapCount
+}
+
+func (g *Gateway) startEnrollmentReaper(ctx context.Context) {
+	ticker := time.NewTicker(enrollmentReaperInterval)
+	defer ticker.Stop()
+	for {
+		g.reapStaleEnrolledPeers(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// reapStaleEnrolledPeers revokes enrolled peers whose WireGuard receive
+// counter has not advanced within its authorizer's liveness window
+// (keepalive_interval * keepalive_reap_count). A freshly enrolled peer
+// gets a full liveness window before it is eligible.
+func (g *Gateway) reapStaleEnrolledPeers(_ context.Context) {
+	if g == nil || g.db == nil || globalWG == nil {
+		return
+	}
+	policy := g.Policy()
+	// PeerStats (a wireguard-go UAPI dump) is identity-independent liveness
+	// data, so reading a slightly stale snapshot outside the lock is safe —
+	// at worst it delays a reap by one tick, and a peer that's new since the
+	// snapshot is seeded fresh below rather than mis-reaped.
+	stats := globalWG.PeerStats()
+
+	g.enrollmentMu.Lock()
+	defer g.enrollmentMu.Unlock()
+
+	peers, err := g.listEnrolledPeers()
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	if g.enrollLive == nil {
+		g.enrollLive = map[string]enrollmentLiveness{}
+	}
+	// Observe rx progress: seed newly seen peers with a full grace window
+	// (lastProgress = now), advance lastProgress whenever a peer's rx has
+	// moved since the last sample, and drop trackers for peers that are
+	// gone.
+	seen := make(map[string]bool, len(peers))
+	for _, p := range peers {
+		seen[p.PubKeyHex] = true
+		st, ok := stats[p.PubKeyHex]
+		live, tracked := g.enrollLive[p.PubKeyHex]
+		switch {
+		case !tracked:
+			rx := uint64(0)
+			if ok {
+				rx = st.rxBytes
+			}
+			g.enrollLive[p.PubKeyHex] = enrollmentLiveness{lastRx: rx, lastProgress: now}
+		case ok && st.rxBytes > live.lastRx:
+			g.enrollLive[p.PubKeyHex] = enrollmentLiveness{lastRx: st.rxBytes, lastProgress: now}
+		}
+	}
+	for pub := range g.enrollLive {
+		if !seen[pub] {
+			delete(g.enrollLive, pub)
+		}
+	}
+	// Reap peers whose rx has been quiet past their liveness window.
+	var stale []string
+	for _, p := range peers {
+		live := g.enrollLive[p.PubKeyHex]
+		// A non-positive window means reaping is disabled for this
+		// authorizer (keepalive_reap_count = 0) — never reap.
+		if to := enrollmentLivenessTimeout(policy, p.AuthorizerName); to > 0 && now.Sub(live.lastProgress) > to {
+			// The gateway's view of a lost peer: one line per real death (a
+			// healthy peer never crosses the full window), with how long its
+			// WG rx was quiet. Correlates with the sidecar's exit/re-enroll.
+			log.Printf("enrollment: reaping peer ip=%s name=%q subject=%s authorizer=%s: no WG rx for %s (> %s)",
+				p.PeerIP, p.DisplayName, p.SubjectKey, p.AuthorizerName, now.Sub(live.lastProgress).Round(time.Second), to)
+			stale = append(stale, p.PeerIP)
+		}
+	}
+	for _, ip := range stale {
+		if err := g.cleanupEnrolledPeerLocked(context.Background(), ip); err != nil {
+			log.Printf("enrollment: reap cleanup for %s: %v", ip, err)
+		}
+	}
+}
+
+// --- restart reconcile -------------------------------------------------
+
+// reconcileEnrolledPeers restores the onboard/agent registry view for
+// persisted enrolled peers after a gateway restart (the WireGuard device's
+// trie is rebuilt from wg_peers by loadPeers) and seeds liveness tracking
+// with a fresh grace window.
+func (g *Gateway) reconcileEnrolledPeers(_ context.Context) (int, error) {
+	if g == nil || g.db == nil {
+		return 0, nil
+	}
+	peers, err := g.listEnrolledPeers()
+	if err != nil {
+		return 0, err
+	}
+	if len(peers) == 0 {
+		return 0, nil
+	}
+	g.enrollmentMu.Lock()
+	defer g.enrollmentMu.Unlock()
+	if g.enrollLive == nil {
+		g.enrollLive = map[string]enrollmentLiveness{}
+	}
+	now := time.Now()
+	for _, p := range peers {
+		if g.onboard != nil {
+			g.onboard.AssignProfile(p.PeerIP, p.Profile)
+			g.onboard.SetOwner(p.PeerIP, p.Owner)
+			g.onboard.SetHostname(p.PeerIP, p.DisplayName)
+		}
+		if g.agents != nil {
+			g.agents.Seed(p.PeerIP)
+		}
+		g.enrollLive[p.PubKeyHex] = enrollmentLiveness{lastProgress: now}
+	}
+	return len(peers), nil
+}
+
+func (g *Gateway) logEnrollmentReconcile(ctx context.Context) {
+	restored, err := g.reconcileEnrolledPeers(ctx)
+	if err != nil {
+		log.Printf("enrollment: restoring persisted peers: %v", err)
+		return
+	}
+	if restored > 0 {
+		log.Printf("enrollment: restored %d persisted peer(s)", restored)
+	}
+}
+
+func normalizeWGPublicKey(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("wireguard_public_key is required")
+	}
+	if len(s) == 64 {
+		b, err := hex.DecodeString(s)
+		if err == nil && len(b) == 32 {
+			return strings.ToLower(s), nil
+		}
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil || len(b) != 32 {
+		return "", fmt.Errorf("wireguard_public_key must be a 32-byte WireGuard public key in base64 or hex")
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// --- kubernetes_token_review authorizer --------------------------------
+
+type k8sEnrollmentClaims struct {
+	PodName      string `json:"pod_name"`
+	PodNamespace string `json:"pod_namespace"`
+	PodUID       string `json:"pod_uid"`
+	NodeName     string `json:"node_name"`
+}
+
+type k8sVerifiedPod struct {
+	Namespace      string
+	Name           string
+	UID            string
+	ServiceAccount string
+	Profile        string
+	NodeName       string
+}
+
+type k8sRegistrationVerifier interface {
+	VerifyPod(ctx context.Context, token string, claims k8sEnrollmentClaims, enr *config.CompiledK8sEnrollment) (k8sVerifiedPod, error)
+}
+
+type kubernetesTokenReviewAuthorizer struct {
+	name     string
+	enr      *config.CompiledK8sEnrollment
+	verifier k8sRegistrationVerifier
+}
+
+func (a *kubernetesTokenReviewAuthorizer) Type() string {
+	return enrollmentAuthorizerKubernetesTokenRev
+}
+func (a *kubernetesTokenReviewAuthorizer) Name() string { return a.name }
+
+func (a *kubernetesTokenReviewAuthorizer) Authorize(ctx context.Context, token string, claims json.RawMessage) (enrollmentIdentity, error) {
+	var parsed k8sEnrollmentClaims
+	if len(claims) == 0 {
+		return enrollmentIdentity{}, fmt.Errorf("claims are required")
+	}
+	if err := json.Unmarshal(claims, &parsed); err != nil {
+		return enrollmentIdentity{}, fmt.Errorf("claims decode: %w", err)
+	}
+	if parsed.PodName == "" || parsed.PodNamespace == "" || parsed.PodUID == "" {
+		return enrollmentIdentity{}, fmt.Errorf("pod_name, pod_namespace, and pod_uid are required")
+	}
+	verifier := a.verifier
+	if verifier == nil {
+		v, err := newInClusterK8sClient()
+		if err != nil {
+			return enrollmentIdentity{}, err
+		}
+		verifier = v
+	}
+	pod, err := verifier.VerifyPod(ctx, token, parsed, a.enr)
+	if err != nil {
+		return enrollmentIdentity{}, err
+	}
+	displayName := pod.Namespace + "/" + pod.Name
+	owner := "system:serviceaccount:" + pod.Namespace + ":" + pod.ServiceAccount
+	return enrollmentIdentity{
+		SubjectKey:     "kubernetes:" + pod.Namespace + ":" + pod.UID,
+		ReplacementKey: "kubernetes:" + pod.Namespace + ":" + pod.Name,
+		DisplayName:    displayName,
+		Owner:          owner,
+		Profile:        pod.Profile,
+		Metadata: map[string]string{
+			"pod_namespace":   pod.Namespace,
+			"pod_name":        pod.Name,
+			"pod_uid":         pod.UID,
+			"service_account": pod.ServiceAccount,
+			"node_name":       pod.NodeName,
+		},
+	}, nil
+}
+
+type inClusterK8sClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func newInClusterK8sClient() (*inClusterK8sClient, error) {
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return nil, fmt.Errorf("kubernetes service environment is not available")
+	}
+	token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return nil, fmt.Errorf("read gateway serviceaccount token: %w", err)
+	}
+	roots, _ := x509.SystemCertPool()
+	if roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if ca, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"); err == nil {
+		roots.AppendCertsFromPEM(ca)
+	}
+	return &inClusterK8sClient{
+		baseURL: "https://" + net.JoinHostPort(host, port),
+		token:   strings.TrimSpace(string(token)),
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: roots},
+			},
+		},
+	}, nil
+}
+
+func (c *inClusterK8sClient) VerifyPod(ctx context.Context, token string, claims k8sEnrollmentClaims, enr *config.CompiledK8sEnrollment) (k8sVerifiedPod, error) {
+	if enr == nil {
+		return k8sVerifiedPod{}, fmt.Errorf("enrollment authorizer is not configured")
+	}
+	user, err := c.tokenReview(ctx, token, enr.Audience)
+	if err != nil {
+		return k8sVerifiedPod{}, err
+	}
+	tokenPodName, ok := singleTokenReviewExtra(user.Extra, "authentication.kubernetes.io/pod-name")
+	if !ok {
+		return k8sVerifiedPod{}, fmt.Errorf("token is not bound to a pod name")
+	}
+	tokenPodUID, ok := singleTokenReviewExtra(user.Extra, "authentication.kubernetes.io/pod-uid")
+	if !ok {
+		return k8sVerifiedPod{}, fmt.Errorf("token is not bound to a pod UID")
+	}
+	if tokenPodName != claims.PodName || tokenPodUID != claims.PodUID {
+		return k8sVerifiedPod{}, fmt.Errorf("token pod binding does not match submitted pod")
+	}
+	ns, sa, ok := serviceAccountFromUsername(user.Username)
+	if !ok {
+		return k8sVerifiedPod{}, fmt.Errorf("token is not a serviceaccount token")
+	}
+	if ns != claims.PodNamespace {
+		return k8sVerifiedPod{}, fmt.Errorf("token namespace does not match pod_namespace")
+	}
+	pod, err := c.getPod(ctx, claims.PodNamespace, claims.PodName)
+	if err != nil {
+		return k8sVerifiedPod{}, err
+	}
+	if pod.UID != claims.PodUID {
+		return k8sVerifiedPod{}, fmt.Errorf("pod UID mismatch")
+	}
+	if pod.ServiceAccountName != sa {
+		return k8sVerifiedPod{}, fmt.Errorf("token serviceaccount does not match pod serviceaccount")
+	}
+	profile, err := k8sResolveProfile(enr, ns, sa, pod.Labels)
+	if err != nil {
+		return k8sVerifiedPod{}, err
+	}
+	return k8sVerifiedPod{
+		Namespace:      claims.PodNamespace,
+		Name:           claims.PodName,
+		UID:            claims.PodUID,
+		ServiceAccount: sa,
+		Profile:        profile,
+		NodeName:       pod.NodeName,
+	}, nil
+}
+
+type tokenReviewUser struct {
+	Username string
+	Extra    map[string][]string
+}
+
+func (c *inClusterK8sClient) tokenReview(ctx context.Context, podToken, audience string) (tokenReviewUser, error) {
+	if strings.TrimSpace(audience) == "" {
+		return tokenReviewUser{}, fmt.Errorf("tokenreview audience is required")
+	}
+	body := map[string]any{
+		"apiVersion": "authentication.k8s.io/v1",
+		"kind":       "TokenReview",
+		"spec": map[string]any{
+			"token":     podToken,
+			"audiences": []string{audience},
+		},
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		return tokenReviewUser{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/apis/authentication.k8s.io/v1/tokenreviews", &buf)
+	if err != nil {
+		return tokenReviewUser{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return tokenReviewUser{}, fmt.Errorf("tokenreview: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return tokenReviewUser{}, fmt.Errorf("tokenreview status %d", resp.StatusCode)
+	}
+	var out struct {
+		Status struct {
+			Authenticated bool `json:"authenticated"`
+			User          struct {
+				Username string              `json:"username"`
+				Extra    map[string][]string `json:"extra"`
+			} `json:"user"`
+			Audiences []string `json:"audiences"`
+			Error     string   `json:"error"`
+		} `json:"status"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return tokenReviewUser{}, fmt.Errorf("tokenreview decode: %w", err)
+	}
+	if !out.Status.Authenticated {
+		if out.Status.Error != "" {
+			return tokenReviewUser{}, fmt.Errorf("tokenreview rejected token: %s", out.Status.Error)
+		}
+		return tokenReviewUser{}, fmt.Errorf("tokenreview rejected token")
+	}
+	if !slices.Contains(out.Status.Audiences, audience) {
+		return tokenReviewUser{}, fmt.Errorf("tokenreview response does not include audience %q", audience)
+	}
+	return tokenReviewUser{
+		Username: out.Status.User.Username,
+		Extra:    out.Status.User.Extra,
+	}, nil
+}
+
+func singleTokenReviewExtra(extra map[string][]string, key string) (string, bool) {
+	values := extra[key]
+	if len(values) != 1 || values[0] == "" {
+		return "", false
+	}
+	return values[0], true
+}
+
+type k8sPodInfo struct {
+	UID                string
+	Labels             map[string]string
+	ServiceAccountName string
+	NodeName           string
+}
+
+func (c *inClusterK8sClient) getPod(ctx context.Context, namespace, name string) (k8sPodInfo, error) {
+	url := c.baseURL + "/api/v1/namespaces/" + pathEscape(namespace) + "/pods/" + pathEscape(name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return k8sPodInfo{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return k8sPodInfo{}, fmt.Errorf("get pod: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return k8sPodInfo{}, fmt.Errorf("pod not found")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return k8sPodInfo{}, fmt.Errorf("get pod status %d", resp.StatusCode)
+	}
+	var out struct {
+		Metadata struct {
+			UID    string            `json:"uid"`
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Spec struct {
+			ServiceAccountName string `json:"serviceAccountName"`
+			NodeName           string `json:"nodeName"`
+		} `json:"spec"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return k8sPodInfo{}, fmt.Errorf("pod decode: %w", err)
+	}
+	return k8sPodInfo{
+		UID:                out.Metadata.UID,
+		Labels:             out.Metadata.Labels,
+		ServiceAccountName: out.Spec.ServiceAccountName,
+		NodeName:           out.Spec.NodeName,
+	}, nil
+}
+
+func pathEscape(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "%", "%25"), "/", "%2F")
+}
+
+func serviceAccountFromUsername(username string) (namespace, serviceAccount string, ok bool) {
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(username, prefix)
+	parts := strings.Split(rest, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// k8sResolveProfile derives the pod's clawpatrol profile from the match
+// rule keyed on namespace + service_account: it reads the pod label named
+// by that rule's profile_label (the plugin defaults it to
+// K8sDefaultProfileLabel at build time) and requires the value to be in
+// the rule's profiles allowlist. The profile is always server-derived
+// from the live Pod object; clients never submit it.
+func k8sResolveProfile(enr *config.CompiledK8sEnrollment, namespace, serviceAccount string, labels map[string]string) (string, error) {
+	matched := false
+	for _, rule := range enr.Matches {
+		if rule.Namespace != namespace || rule.ServiceAccount != serviceAccount {
+			continue
+		}
+		matched = true
+		label := rule.ProfileLabel
+		if label == "" {
+			label = config.K8sDefaultProfileLabel
+		}
+		profile := strings.TrimSpace(labels[label])
+		if profile == "" {
+			return "", fmt.Errorf("pod is missing profile label %q", label)
+		}
+		if slices.Contains(rule.Profiles, profile) {
+			return profile, nil
+		}
+	}
+	if matched {
+		return "", fmt.Errorf("pod profile is not in the match allowlist")
+	}
+	return "", fmt.Errorf("namespace/serviceaccount is not allowed")
+}
+
+// parseAllPeerStats parses a wireguard-go IpcGet (UAPI) dump into per-peer
+// receive + handshake stats, keyed by hex public key.
+func parseAllPeerStats(uapi string) map[string]wgDevPeerStat {
+	out := map[string]wgDevPeerStat{}
+	var cur string
+	var st wgDevPeerStat
+	var secs, nsec int64
+	flush := func() {
+		if cur != "" {
+			if secs != 0 || nsec != 0 {
+				st.lastHandshake = time.Unix(secs, nsec)
+			}
+			out[cur] = st
+		}
+		st = wgDevPeerStat{}
+		secs, nsec = 0, 0
+	}
+	sc := bufio.NewScanner(strings.NewReader(uapi))
+	for sc.Scan() {
+		k, v, ok := strings.Cut(sc.Text(), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "public_key":
+			flush()
+			cur = v
+		case "rx_bytes":
+			st.rxBytes, _ = strconv.ParseUint(v, 10, 64)
+		case "last_handshake_time_sec":
+			secs, _ = strconv.ParseInt(v, 10, 64)
+		case "last_handshake_time_nsec":
+			nsec, _ = strconv.ParseInt(v, 10, 64)
+		}
+	}
+	flush()
+	return out
+}

--- a/cmd/clawpatrol/enrollment_client.go
+++ b/cmd/clawpatrol/enrollment_client.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const enrollmentHTTPTimeout = 15 * time.Second
+
+var enrollmentHTTPClient = &http.Client{Timeout: enrollmentHTTPTimeout}
+
+// Enrollment client core used by `clawpatrol bridge`: register through the
+// configured authorizer, fetch the env-pushdown, and best-effort deregister
+// on shutdown. There is no heartbeat — the gateway observes liveness from
+// the WireGuard device (rx_bytes), so keepalive traffic is the liveness
+// signal.
+
+func enrollmentRegister(ctx context.Context, gatewayURL, token string, reqBody enrollmentRegisterRequest) (enrollmentRegisterResponse, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(reqBody); err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(gatewayURL, "/")+enrollmentRegisterPath, &buf)
+	if err != nil {
+		return enrollmentRegisterResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := enrollmentHTTPClient.Do(req)
+	if err != nil {
+		return enrollmentRegisterResponse{}, fmt.Errorf("register: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return enrollmentRegisterResponse{}, fmt.Errorf("register status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out enrollmentRegisterResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return enrollmentRegisterResponse{}, fmt.Errorf("register decode: %w", err)
+	}
+	if out.Transport != enrollmentTransportWireGuard {
+		return enrollmentRegisterResponse{}, fmt.Errorf("register response has unsupported transport %q", out.Transport)
+	}
+	if out.PeerIP == "" || out.ServerPublicKey == "" || out.Endpoint == "" || out.APIToken == "" {
+		return enrollmentRegisterResponse{}, fmt.Errorf("register response missing peer_ip, server_public_key, endpoint, or api_token")
+	}
+	return out, nil
+}
+
+func enrollmentFetchEnv(ctx context.Context, gatewayURL, apiToken string) ([]pushdownEnvVar, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(gatewayURL, "/")+"/api/env-pushdown", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	resp, err := enrollmentHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch env-pushdown: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch env-pushdown status %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	return parseEnvPushdownJSON(raw)
+}
+
+func enrollmentDeregister(ctx context.Context, gatewayURL, apiToken string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, strings.TrimRight(gatewayURL, "/")+enrollmentRegisterPath, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	resp, err := enrollmentHTTPClient.Do(req)
+	if err == nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+	}
+}
+
+// gatherEnrollmentClaims dispatches on the type label from the gateway's
+// `enrollment "<type>" "<name>"` block. It returns the claims and credential
+// produced by the matching client provider. v1 ships one provider.
+func gatherEnrollmentClaims(authorizerType, kubeTokenPath string) (json.RawMessage, string, error) {
+	switch authorizerType {
+	case enrollmentAuthorizerKubernetesTokenRev:
+		return kubernetesProviderClaims(kubeTokenPath)
+	default:
+		return nil, "", fmt.Errorf("unsupported enrollment authorizer type %q", authorizerType)
+	}
+}
+
+// kubernetesProviderClaims gathers the kubernetes_token_review identity:
+// claims from the downward-API POD_* env, credential from the projected
+// ServiceAccount token.
+func kubernetesProviderClaims(kubeTokenPath string) (json.RawMessage, string, error) {
+	podName := os.Getenv("POD_NAME")
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	podUID := os.Getenv("POD_UID")
+	nodeName := os.Getenv("NODE_NAME")
+	if podName == "" || podNamespace == "" || podUID == "" {
+		return nil, "", fmt.Errorf("POD_NAME, POD_NAMESPACE, and POD_UID must be supplied by the Downward API")
+	}
+	tokenBytes, err := os.ReadFile(kubeTokenPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("read serviceaccount token: %w", err)
+	}
+	claims, err := json.Marshal(k8sEnrollmentClaims{
+		PodName:      podName,
+		PodNamespace: podNamespace,
+		PodUID:       podUID,
+		NodeName:     nodeName,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return claims, strings.TrimSpace(string(tokenBytes)), nil
+}

--- a/cmd/clawpatrol/enrollment_client_test.go
+++ b/cmd/clawpatrol/enrollment_client_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEnrollmentHTTPClientHasTimeout(t *testing.T) {
+	if enrollmentHTTPClient.Timeout != enrollmentHTTPTimeout {
+		t.Fatalf("HTTP client timeout = %s, want %s", enrollmentHTTPClient.Timeout, enrollmentHTTPTimeout)
+	}
+	if enrollmentHTTPClient.Timeout <= 0 || enrollmentHTTPClient.Timeout > 30*time.Second {
+		t.Fatalf("HTTP client timeout = %s, want a bounded bootstrap request", enrollmentHTTPClient.Timeout)
+	}
+}
+
+func TestEnrollmentRegisterRequest(t *testing.T) {
+	var gotAuth, gotContentType string
+	var gotBody enrollmentRegisterRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(rw).Encode(enrollmentRegisterResponse{
+			Transport:       enrollmentTransportWireGuard,
+			PeerIP:          "10.55.0.2",
+			ServerPublicKey: "srv-pub",
+			Endpoint:        "ep.example:51820",
+			APIToken:        "peer-token",
+		})
+	}))
+	defer srv.Close()
+
+	claims, err := json.Marshal(k8sEnrollmentClaims{
+		PodName:      "agent-1",
+		PodNamespace: "agents",
+		PodUID:       "uid-1",
+		NodeName:     "kind-worker",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := enrollmentRegister(context.Background(), srv.URL+"/", "sa-token", enrollmentRegisterRequest{
+		Transport:          enrollmentTransportWireGuard,
+		Authorizer:         "agents",
+		WireGuardPublicKey: keyA,
+		Claims:             claims,
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if resp.PeerIP != "10.55.0.2" || resp.APIToken != "peer-token" {
+		t.Fatalf("unexpected response %+v", resp)
+	}
+	if gotAuth != "Bearer sa-token" {
+		t.Fatalf("Authorization = %q, want Bearer sa-token", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type = %q", gotContentType)
+	}
+	if gotBody.Transport != enrollmentTransportWireGuard || gotBody.Authorizer != "agents" || gotBody.WireGuardPublicKey != keyA {
+		t.Fatalf("unexpected request body %+v", gotBody)
+	}
+	var gotClaims k8sEnrollmentClaims
+	if err := json.Unmarshal(gotBody.Claims, &gotClaims); err != nil {
+		t.Fatalf("claims decode: %v", err)
+	}
+	if gotClaims.PodUID != "uid-1" || gotClaims.PodNamespace != "agents" || gotClaims.PodName != "agent-1" || gotClaims.NodeName != "kind-worker" {
+		t.Fatalf("claims = %+v", gotClaims)
+	}
+}
+
+func TestEnrollmentRegisterRejectsErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		http.Error(rw, "namespace/serviceaccount/profile is not allowed", http.StatusForbidden)
+	}))
+	defer srv.Close()
+	if _, err := enrollmentRegister(context.Background(), srv.URL, "sa-token", enrollmentRegisterRequest{
+		Transport: enrollmentTransportWireGuard, Authorizer: "agents", WireGuardPublicKey: keyA,
+	}); err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestEnrollmentRegisterRejectsIncompleteResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		// Valid transport but missing peer_ip / server_public_key / token.
+		_ = json.NewEncoder(rw).Encode(enrollmentRegisterResponse{
+			Transport: enrollmentTransportWireGuard,
+		})
+	}))
+	defer srv.Close()
+	if _, err := enrollmentRegister(context.Background(), srv.URL, "sa-token", enrollmentRegisterRequest{
+		Transport: enrollmentTransportWireGuard, Authorizer: "agents", WireGuardPublicKey: keyA,
+	}); err == nil {
+		t.Fatal("expected error for incomplete response")
+	}
+}
+
+func TestGatherEnrollmentClaimsKubernetes(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("  sa-token-value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("POD_NAME", "agent-1")
+	t.Setenv("POD_NAMESPACE", "agents")
+	t.Setenv("POD_UID", "uid-1")
+	t.Setenv("NODE_NAME", "kind-worker")
+
+	claims, cred, err := gatherEnrollmentClaims(enrollmentAuthorizerKubernetesTokenRev, tokenPath)
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	if cred != "sa-token-value" {
+		t.Fatalf("credential = %q, want trimmed token", cred)
+	}
+	var got k8sEnrollmentClaims
+	if err := json.Unmarshal(claims, &got); err != nil {
+		t.Fatalf("claims decode: %v", err)
+	}
+	if got.PodName != "agent-1" || got.PodNamespace != "agents" || got.PodUID != "uid-1" || got.NodeName != "kind-worker" {
+		t.Fatalf("claims = %+v", got)
+	}
+
+	if _, _, err := gatherEnrollmentClaims("oidc", tokenPath); err == nil {
+		t.Fatal("expected error for unsupported authorizer type")
+	}
+}

--- a/cmd/clawpatrol/enrollment_test.go
+++ b/cmd/clawpatrol/enrollment_test.go
@@ -1,0 +1,639 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+// keyA and keyB are distinct, well-formed 32-byte WireGuard public keys
+// rendered as 64-char hex (what normalizeWGPublicKey returns).
+const (
+	keyA = "abababababababababababababababababababababababababababababababab"
+	keyB = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+)
+
+func newEnrollmentTestGateway(t *testing.T) *Gateway {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	g := &Gateway{db: db, onboard: newOnboardRegistry(), agents: NewAgentRegistry()}
+	if err := g.onboard.Load(db); err != nil {
+		t.Fatalf("onboard load: %v", err)
+	}
+	return g
+}
+
+// startEnrollmentTestWGServer starts a real userspace WGServer for tests
+// that exercise AddPeer / RevokePeerByIP / PeerStats. The sandbox cannot
+// always bind a UDP socket, so the test is skipped (not failed) when the
+// device won't start; CI runs it for real.
+func startEnrollmentTestWGServer(t *testing.T, g *Gateway) *WGServer {
+	t.Helper()
+	prevDB := globalDB
+	prevWG := globalWG
+	globalDB = g.db
+	wg, err := StartWGServer(JoinConfig{
+		WGSubnetCIDR: "10.55.0.0/24",
+		WGListenPort: freeUDPPort(t),
+		PublicURL:    "https://gateway.example.com",
+	})
+	if err != nil {
+		globalDB = prevDB
+		t.Skipf("WGServer unavailable in this environment: %v", err)
+	}
+	setWGServer(wg)
+	t.Cleanup(func() {
+		wg.dev.Close()
+		globalWG = prevWG
+		globalDB = prevDB
+	})
+	return wg
+}
+
+func wgPeerRowsForIP(t *testing.T, g *Gateway, ip string) int {
+	t.Helper()
+	var count int
+	if err := g.db.QueryRow("SELECT count(*) FROM wg_peers WHERE ip = ?", ip).Scan(&count); err != nil {
+		t.Fatalf("count wg_peers: %v", err)
+	}
+	return count
+}
+
+// seedEnrolledPeer inserts an enrolled wg_peers row directly, for tests that
+// exercise the store / reconcile path without a live WireGuard device.
+func seedEnrolledPeer(t *testing.T, g *Gateway, ip, pub, subject, replacement string) {
+	t.Helper()
+	if _, err := g.db.Exec(`INSERT INTO wg_peers
+		(pubkey, ip, added_ns, enrolled, subject_key, replacement_key,
+		 display_name, owner, profile, authorizer_type, authorizer_name, metadata_json)
+		VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		pub, ip, time.Now().UnixNano(), subject, replacement,
+		"agents/x", "system:serviceaccount:agents:agent-runner", "default",
+		enrollmentAuthorizerKubernetesTokenRev, "agents", "{}"); err != nil {
+		t.Fatalf("seed enrolled peer: %v", err)
+	}
+}
+
+type fakeEnrollmentAuthorizer struct{ typ, name string }
+
+func (f fakeEnrollmentAuthorizer) Type() string { return f.typ }
+func (f fakeEnrollmentAuthorizer) Name() string { return f.name }
+func (f fakeEnrollmentAuthorizer) Authorize(context.Context, string, json.RawMessage) (enrollmentIdentity, error) {
+	return enrollmentIdentity{}, nil
+}
+
+// registerFor drives registerEnrolledPeer with a synthesized identity, the
+// way the HTTP handler would after the authorizer ran. Requires a live
+// WGServer (AddPeer); callers start one via startEnrollmentTestWGServer.
+func registerFor(t *testing.T, g *Gateway, subjectKey, replacementKey, pub string) (enrollmentRegisterResponse, error) {
+	t.Helper()
+	id := enrollmentIdentity{
+		SubjectKey:     subjectKey,
+		ReplacementKey: replacementKey,
+		DisplayName:    "agents/x",
+		Owner:          "system:serviceaccount:agents:agent-runner",
+		Profile:        "default",
+		Metadata:       map[string]string{"subject": subjectKey},
+	}
+	auth := fakeEnrollmentAuthorizer{typ: enrollmentAuthorizerKubernetesTokenRev, name: "agents"}
+	return g.registerEnrolledPeer(context.Background(), enabledEnrollmentCfg(), auth, id, enrollmentRegisterRequest{
+		Transport:          enrollmentTransportWireGuard,
+		WireGuardPublicKey: pub,
+	})
+}
+
+func TestRegisterEnrolledPeerFresh(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	resp, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if resp.PeerIP == "" || resp.Transport != enrollmentTransportWireGuard {
+		t.Fatalf("unexpected response %+v", resp)
+	}
+	if resp.APIToken == "" || resp.ServerPublicKey == "" || resp.Endpoint == "" {
+		t.Fatalf("response missing fields %+v", resp)
+	}
+	p, err := g.enrolledPeerByIP(resp.PeerIP)
+	if err != nil {
+		t.Fatalf("enrolled peer not persisted: %v", err)
+	}
+	if p.PubKeyHex != keyA {
+		t.Fatalf("enrolled pubkey = %q, want %q", p.PubKeyHex, keyA)
+	}
+	if peerIPForAPIToken(g.db, resp.APIToken) != resp.PeerIP {
+		t.Fatal("api token does not resolve to peer ip")
+	}
+	if g.onboard.ProfileForIP(resp.PeerIP) != "default" {
+		t.Fatalf("profile = %q, want default", g.onboard.ProfileForIP(resp.PeerIP))
+	}
+}
+
+// A sidecar that restarts in place keeps its pod UID but generates a fresh
+// WireGuard key. The same subject must reuse its own slot (reuse the IP, swap
+// the key) instead of being locked out.
+func TestRegisterEnrolledPeerSameSubjectNewKey(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	first, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA)
+	if err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	second, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyB)
+	if err != nil {
+		t.Fatalf("same-subject key rotation should not conflict: %v", err)
+	}
+	if second.PeerIP != first.PeerIP {
+		t.Fatalf("peer_ip = %q, want reuse of %q", second.PeerIP, first.PeerIP)
+	}
+	p, err := g.enrolledPeerByIP(second.PeerIP)
+	if err != nil {
+		t.Fatalf("enrolled peer lookup: %v", err)
+	}
+	if p.PubKeyHex != keyB {
+		t.Fatalf("enrolled pubkey = %q, want rotated key %q", p.PubKeyHex, keyB)
+	}
+	if got := wgPeerRowsForIP(t, g, second.PeerIP); got != 1 {
+		t.Fatalf("wg_peers rows for reused IP = %d, want 1", got)
+	}
+}
+
+// A different subject presenting a live peer's public key is a conflict.
+func TestRegisterEnrolledPeerPublicKeyConflict(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	if _, err := registerFor(t, g, "kubernetes:agents:uid-other", "kubernetes:agents:other-pod", keyA); err != nil {
+		t.Fatalf("seed register: %v", err)
+	}
+	_, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA)
+	if !errors.Is(err, errEnrollmentConflict) {
+		t.Fatalf("err = %v, want conflict", err)
+	}
+}
+
+// A pod recreated under the same name (new UID) retires the prior instance.
+// The old instance is torn down before the new one is provisioned, so its
+// freed IP may be handed straight back — the takeover is observable in the
+// revoked token and the swapped enrollment, not the address.
+func TestRegisterEnrolledPeerReplacementTakeover(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	old, err := registerFor(t, g, "kubernetes:agents:uid-old", "kubernetes:agents:agent-1", keyA)
+	if err != nil {
+		t.Fatalf("seed register: %v", err)
+	}
+	fresh, err := registerFor(t, g, "kubernetes:agents:uid-new", "kubernetes:agents:agent-1", keyB)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if peerIPForAPIToken(g.db, old.APIToken) != "" {
+		t.Fatal("old instance api token should have been revoked")
+	}
+	peers, err := g.findEnrolledPeers("kubernetes:agents:agent-1", keyB)
+	if err != nil {
+		t.Fatalf("find enrolled: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("enrolled peers for replacement key = %d, want 1 (old retired)", len(peers))
+	}
+	if peers[0].SubjectKey != "kubernetes:agents:uid-new" || peers[0].PubKeyHex != keyB {
+		t.Fatalf("surviving enrollment = %+v, want the new instance", peers[0])
+	}
+	if peerIPForAPIToken(g.db, fresh.APIToken) != fresh.PeerIP {
+		t.Fatal("new instance api token should resolve")
+	}
+}
+
+// When persistence fails after the WireGuard peer is provisioned, the
+// register path rolls back the transport peer + API token so nothing leaks.
+func TestRegisterEnrolledPeerRollbackOnPersistFailure(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	// Drop the token table so mintAndPersistPeerAPIToken fails after AddPeer
+	// has already provisioned the peer.
+	if _, err := g.db.Exec("DROP TABLE peer_api_tokens"); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	if _, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA); err == nil {
+		t.Fatal("expected register to fail")
+	}
+	if n := wgPeerRowsForIP(t, g, "10.55.0.2"); n != 0 {
+		t.Fatalf("wg_peers rows after rollback = %d, want 0", n)
+	}
+}
+
+func TestRegisterEnrolledPeerValidatesResponseBeforeProvisioning(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	cfg := enabledEnrollmentCfg()
+	cfg.Settings.WireGuard.Endpoint = "missing-port"
+	id := enrollmentIdentity{
+		SubjectKey:     "kubernetes:agents:uid-1",
+		ReplacementKey: "kubernetes:agents:agent-1",
+		DisplayName:    "agents/agent-1",
+		Owner:          "system:serviceaccount:agents:agent-runner",
+		Profile:        "default",
+	}
+	auth := fakeEnrollmentAuthorizer{typ: enrollmentAuthorizerKubernetesTokenRev, name: "agents"}
+
+	_, err := g.registerEnrolledPeer(context.Background(), cfg, auth, id, enrollmentRegisterRequest{
+		Transport:          enrollmentTransportWireGuard,
+		WireGuardPublicKey: keyA,
+	})
+	if err == nil {
+		t.Fatal("expected malformed endpoint to reject registration")
+	}
+	if n := wgPeerRowsForIP(t, g, "10.55.0.2"); n != 0 {
+		t.Fatalf("wg_peers rows after response validation failure = %d, want 0", n)
+	}
+	var tokenCount int
+	if err := g.db.QueryRow("SELECT count(*) FROM peer_api_tokens").Scan(&tokenCount); err != nil {
+		t.Fatalf("count peer api tokens: %v", err)
+	}
+	if tokenCount != 0 {
+		t.Fatalf("peer api tokens after response validation failure = %d, want 0", tokenCount)
+	}
+}
+
+func TestAllocateWGPeerPersistsBeforeUnlock(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	wg := startEnrollmentTestWGServer(t, g)
+	start := make(chan struct{})
+	type result struct {
+		ip  string
+		err error
+	}
+	results := make(chan result, 2)
+	var workers sync.WaitGroup
+	join := enabledEnrollmentCfg().Join()
+	for _, pubkey := range []string{keyA, keyB} {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			ip, err := wg.allocatePeer(join, pubkey)
+			results <- result{ip: ip, err: err}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	var ips []string
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("allocate peer: %v", result.err)
+		}
+		ips = append(ips, result.ip)
+	}
+	if len(ips) != 2 || ips[0] == ips[1] {
+		t.Fatalf("concurrent allocations = %v, want two distinct addresses", ips)
+	}
+	for _, ip := range ips {
+		if got := wgPeerRowsForIP(t, g, ip); got != 1 {
+			t.Fatalf("wg_peers rows for %s = %d, want 1", ip, got)
+		}
+	}
+}
+
+func TestAllocateWGPeerFailsClosedOnAllocationReadError(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	wg := startEnrollmentTestWGServer(t, g)
+	if _, err := g.db.Exec("DROP TABLE wg_peers"); err != nil {
+		t.Fatalf("drop wg_peers: %v", err)
+	}
+	if _, err := wg.allocatePeer(enabledEnrollmentCfg().Join(), keyA); err == nil {
+		t.Fatal("allocation should fail when the persisted allocation set cannot be read")
+	}
+}
+
+// reapStaleEnrolledPeers revokes an enrolled peer whose receive counter has
+// not advanced within its liveness window. We register a real peer, then
+// backdate its liveness tracker so the reaper sees no progress past the window.
+func TestReapStaleEnrolledPeers(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	g.cfg.Store(enabledEnrollmentCfg())
+	g.policy.Store(enabledEnrollmentPolicy(t)) // reaper reads the liveness window from the compiled policy
+	startEnrollmentTestWGServer(t, g)
+	resp, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	// Backdate progress well beyond the default 3m TTL with a high lastRx so
+	// no real keepalive could have advanced past it during the test.
+	g.enrollmentMu.Lock()
+	g.enrollLive[keyA] = enrollmentLiveness{lastRx: 1 << 40, lastProgress: time.Now().Add(-time.Hour)}
+	g.enrollmentMu.Unlock()
+
+	g.reapStaleEnrolledPeers(context.Background())
+
+	if _, err := g.enrolledPeerByIP(resp.PeerIP); err == nil {
+		t.Fatal("stale enrolled peer should have been reaped")
+	}
+	if peerIPForAPIToken(g.db, resp.APIToken) != "" {
+		t.Fatal("reaped peer api token should be revoked")
+	}
+	if g.onboard.HasDevice(resp.PeerIP) {
+		t.Fatal("reaped peer device row should be forgotten")
+	}
+}
+
+func TestReconcileEnrolledPeersRestoresRuntimeState(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	const ip = "10.55.0.22"
+	seedEnrolledPeer(t, g, ip, keyA, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1")
+
+	restored, err := g.reconcileEnrolledPeers(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restored != 1 {
+		t.Fatalf("restored = %d, want 1", restored)
+	}
+	if !g.onboard.HasDevice(ip) {
+		t.Fatal("reconcile should restore device row")
+	}
+	if got := g.onboard.ProfileForIP(ip); got != "default" {
+		t.Fatalf("profile = %q, want default", got)
+	}
+	if got := g.onboard.OwnerForIP(ip); got != "system:serviceaccount:agents:agent-runner" {
+		t.Fatalf("owner = %q, want service account owner", got)
+	}
+	if got := g.onboard.HostnameForIP(ip); got != "agents/x" {
+		t.Fatalf("hostname = %q, want agents/x", got)
+	}
+	found := false
+	for _, agent := range g.agents.snapshot() {
+		if agent.IP == ip {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("reconcile should seed agent registry")
+	}
+	g.enrollmentMu.Lock()
+	_, tracked := g.enrollLive[keyA]
+	g.enrollmentMu.Unlock()
+	if !tracked {
+		t.Fatal("reconcile should seed liveness tracking")
+	}
+}
+
+func TestApiEnrollmentList(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	w := &webMux{g: g}
+
+	seedEnrolledPeer(t, g, "10.55.0.2", keyA, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1")
+	seedEnrolledPeer(t, g, "10.55.0.3", keyB, "kubernetes:agents:uid-2", "kubernetes:agents:agent-2")
+
+	postRec := httptest.NewRecorder()
+	w.apiEnrollmentList(postRec, httptest.NewRequest(http.MethodPost, "/api/enrollment/peers", nil))
+	if postRec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST -> %d, want 405", postRec.Code)
+	}
+
+	rec := httptest.NewRecorder()
+	w.apiEnrollmentList(rec, httptest.NewRequest(http.MethodGet, "/api/enrollment/peers", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET -> %d, want 200", rec.Code)
+	}
+	var views []enrolledPeerView
+	if err := json.NewDecoder(rec.Body).Decode(&views); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("want 2 enrolled peers, got %d", len(views))
+	}
+	byIP := map[string]enrolledPeerView{}
+	for _, v := range views {
+		byIP[v.PeerIP] = v
+	}
+	one := byIP["10.55.0.2"]
+	if one.Profile != "default" || one.PublicKey != keyA {
+		t.Fatalf("unexpected view %+v", one)
+	}
+	if one.DisplayName != "agents/x" || one.AuthorizerType != enrollmentAuthorizerKubernetesTokenRev {
+		t.Fatalf("unexpected metadata %+v", one)
+	}
+	if one.CreatedAt == "" || one.Transport != enrollmentTransportWireGuard {
+		t.Fatalf("missing fields %+v", one)
+	}
+}
+
+// enabledEnrollmentCfg parses the top-level enrollment grammar so
+// the returned *config.Gateway has a populated Policy.Enrollments (which is
+// what IsEnrollmentEnabled and the runtime lookups read).
+const enabledEnrollmentHCL = `gateway {
+  public_url = "https://gateway.example.com"
+  wireguard { subnet_cidr = "10.55.0.0/24" }
+}
+
+enrollment "kubernetes_token_review" "agents" {
+  audience = "clawpatrol"
+  match {
+    namespace       = "agents"
+    service_account = "agent-runner"
+    profile_label   = "clawpatrol.dev/profile"
+    profiles        = ["default"]
+  }
+}
+
+profile "default" { credentials = [] }
+`
+
+func enabledEnrollmentCfg() *config.Gateway {
+	gw, diags := config.LoadBytes([]byte(enabledEnrollmentHCL), "enabled-enrollment.hcl")
+	if diags.HasErrors() {
+		panic("enabledEnrollmentCfg: " + diags.Error())
+	}
+	return gw
+}
+
+// enabledEnrollmentPolicy compiles enabledEnrollmentCfg so tests can seed
+// g.policy with the compiled enrollment the runtime looks authorizers up in.
+func enabledEnrollmentPolicy(t *testing.T) *config.CompiledPolicy {
+	t.Helper()
+	cp, err := config.Compile(enabledEnrollmentCfg())
+	if err != nil {
+		t.Fatalf("compile enrollment policy: %v", err)
+	}
+	return cp
+}
+
+func doRegister(w *webMux, method, bearer, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, enrollmentRegisterPath, strings.NewReader(body))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	w.apiEnrollmentRegister(rec, req)
+	return rec
+}
+
+func TestApiEnrollmentRegisterGuards(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	g.cfg.Store(enabledEnrollmentCfg())
+	g.policy.Store(enabledEnrollmentPolicy(t))
+	// Verifier resolves any token to a pod in the "ghost" profile, which is
+	// not declared in the policy above.
+	g.k8sVerifier = fakeK8sVerifier(func(_ context.Context, _ string, claims k8sEnrollmentClaims, _ *config.CompiledK8sEnrollment) (k8sVerifiedPod, error) {
+		return k8sVerifiedPod{
+			Namespace:      claims.PodNamespace,
+			Name:           claims.PodName,
+			UID:            claims.PodUID,
+			ServiceAccount: "agent-runner",
+			Profile:        "ghost",
+		}, nil
+	})
+	w := &webMux{g: g}
+
+	validBody := `{"transport":"wireguard","authorizer":"agents","wireguard_public_key":"` + keyA + `","claims":{"pod_name":"a","pod_namespace":"agents","pod_uid":"u"}}`
+
+	if rec := doRegister(w, http.MethodGet, "tok", ""); rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET -> %d, want 405", rec.Code)
+	}
+	if rec := doRegister(w, http.MethodPost, "", validBody); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing bearer -> %d, want 401", rec.Code)
+	}
+	if rec := doRegister(w, http.MethodPost, "tok", "{not json"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad json -> %d, want 400", rec.Code)
+	}
+	unknownAuthz := `{"transport":"wireguard","authorizer":"nope","wireguard_public_key":"` + keyA + `","claims":{"pod_name":"a","pod_namespace":"agents","pod_uid":"u"}}`
+	if rec := doRegister(w, http.MethodPost, "tok", unknownAuthz); rec.Code != http.StatusForbidden {
+		t.Fatalf("unknown authorizer -> %d, want 403", rec.Code)
+	}
+	badTransport := `{"transport":"carrier-pigeon","authorizer":"agents","claims":{}}`
+	if rec := doRegister(w, http.MethodPost, "tok", badTransport); rec.Code != http.StatusForbidden {
+		t.Fatalf("bad transport -> %d, want 403", rec.Code)
+	}
+	// Authorize succeeds but the resolved profile is not declared.
+	if rec := doRegister(w, http.MethodPost, "tok", validBody); rec.Code != http.StatusForbidden {
+		t.Fatalf("undeclared profile -> %d, want 403", rec.Code)
+	}
+
+	// Disabled feature hides the endpoint entirely.
+	g.cfg.Store(&config.Gateway{Settings: &config.GatewaySettings{WireGuard: &config.WireGuardBlock{}}})
+	if rec := doRegister(w, http.MethodPost, "tok", validBody); rec.Code != http.StatusNotFound {
+		t.Fatalf("disabled -> %d, want 404", rec.Code)
+	}
+}
+
+// A regular onboarded peer carrying a peer API token must not be able to
+// drive the enrollment delete teardown when it holds no enrollment.
+func TestApiEnrollmentDeleteRequiresEnrollment(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	g.cfg.Store(enabledEnrollmentCfg())
+	w := &webMux{g: g}
+
+	const ip = "10.55.0.50"
+	g.onboard.AssignProfile(ip, "default")
+	g.onboard.SetHostname(ip, "regular-device")
+	token, err := mintAndPersistPeerAPIToken(g.db, ip)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, enrollmentRegisterPath, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	w.apiEnrollmentRegister(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("delete without enrollment -> %d, want 404", rec.Code)
+	}
+	if peerIPForAPIToken(g.db, token) != ip {
+		t.Fatal("regular peer api token was wrongly revoked")
+	}
+	if !g.onboard.HasDevice(ip) {
+		t.Fatal("regular peer device row was wrongly forgotten")
+	}
+}
+
+func TestApiEnrollmentDeleteWithEnrollment(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	g.cfg.Store(enabledEnrollmentCfg())
+	startEnrollmentTestWGServer(t, g)
+	w := &webMux{g: g}
+
+	resp, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, enrollmentRegisterPath, nil)
+	req.Header.Set("Authorization", "Bearer "+resp.APIToken)
+	rec := httptest.NewRecorder()
+	w.apiEnrollmentRegister(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete with enrollment -> %d, want 204", rec.Code)
+	}
+	if _, err := g.enrolledPeerByIP(resp.PeerIP); err == nil {
+		t.Fatal("enrollment should be gone after delete")
+	}
+	if peerIPForAPIToken(g.db, resp.APIToken) != "" {
+		t.Fatal("api token should be revoked after delete")
+	}
+	if g.onboard.HasDevice(resp.PeerIP) {
+		t.Fatal("device row should be forgotten after delete")
+	}
+}
+
+// TestRegisterEnrolledPeerKeepaliveGating verifies that client keepalive and
+// watchdog settings are only returned when the client requests them —
+// i.e. the clawpatrol bridge (Keepalive: true), not other enrollment clients.
+func TestRegisterEnrolledPeerKeepaliveGating(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+	auth := fakeEnrollmentAuthorizer{typ: enrollmentAuthorizerKubernetesTokenRev, name: "agents"}
+	id := func(uid, name string) enrollmentIdentity {
+		return enrollmentIdentity{
+			SubjectKey:     "kubernetes:agents:" + uid,
+			ReplacementKey: "kubernetes:agents:" + name,
+			DisplayName:    "agents/" + name,
+			Owner:          "system:serviceaccount:agents:agent-runner",
+			Profile:        "default",
+		}
+	}
+
+	// Bridge: requests keepalive → gateway echoes the derived cadence (the
+	// package defaults, since the test policy sets no explicit knobs).
+	bridge, err := g.registerEnrolledPeer(context.Background(), enabledEnrollmentCfg(), auth,
+		id("uid-bridge", "bridge"), enrollmentRegisterRequest{
+			Transport: enrollmentTransportWireGuard, WireGuardPublicKey: keyA, Keepalive: true,
+		})
+	if err != nil {
+		t.Fatalf("bridge register: %v", err)
+	}
+	wantKA := int(config.EnrollmentDefaultKeepalive.Seconds())
+	if bridge.KeepaliveIntervalSeconds != wantKA || bridge.KeepaliveReapCount != config.EnrollmentDefaultReapCount {
+		t.Fatalf("bridge keepalive passdown = %ds/%d, want %ds/%d",
+			bridge.KeepaliveIntervalSeconds, bridge.KeepaliveReapCount, wantKA, config.EnrollmentDefaultReapCount)
+	}
+
+	// Non-bridge: no request flag → no gateway keepalive, no passdown.
+	other, err := g.registerEnrolledPeer(context.Background(), enabledEnrollmentCfg(), auth,
+		id("uid-other", "other"), enrollmentRegisterRequest{
+			Transport: enrollmentTransportWireGuard, WireGuardPublicKey: keyB,
+		})
+	if err != nil {
+		t.Fatalf("non-bridge register: %v", err)
+	}
+	if other.KeepaliveIntervalSeconds != 0 || other.KeepaliveReapCount != 0 {
+		t.Fatalf("non-bridge keepalive passdown = %ds/%d, want 0/0",
+			other.KeepaliveIntervalSeconds, other.KeepaliveReapCount)
+	}
+}

--- a/cmd/clawpatrol/k8s_registration_test.go
+++ b/cmd/clawpatrol/k8s_registration_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+)
+
+func TestNormalizeWGPublicKey(t *testing.T) {
+	_, pubHex, pubB64, err := wgGenKeypair()
+	if err != nil {
+		t.Fatalf("wgGenKeypair: %v", err)
+	}
+	if got, err := normalizeWGPublicKey(pubHex); err != nil || got != pubHex {
+		t.Fatalf("hex normalize = %q, %v; want %q", got, err, pubHex)
+	}
+	if got, err := normalizeWGPublicKey(pubB64); err != nil || got != pubHex {
+		t.Fatalf("base64 normalize = %q, %v; want %q", got, err, pubHex)
+	}
+	if _, err := normalizeWGPublicKey("not-a-key"); err == nil {
+		t.Fatal("invalid key accepted")
+	}
+}
+
+func TestK8sServiceAccountAndAllowlist(t *testing.T) {
+	ns, sa, ok := serviceAccountFromUsername("system:serviceaccount:agents:agent-runner")
+	if !ok || ns != "agents" || sa != "agent-runner" {
+		t.Fatalf("serviceAccountFromUsername = %q, %q, %v", ns, sa, ok)
+	}
+	if _, _, ok := serviceAccountFromUsername("alice@example.com"); ok {
+		t.Fatal("non-serviceaccount username accepted")
+	}
+	enr := &config.CompiledK8sEnrollment{
+		Matches: []config.CompiledK8sMatch{{
+			Namespace:      "agents",
+			ServiceAccount: "agent-runner",
+			ProfileLabel:   config.K8sDefaultProfileLabel,
+			Profiles:       []string{"default", "prod"},
+		}},
+	}
+	labels := map[string]string{config.K8sDefaultProfileLabel: "prod"}
+	if got, err := k8sResolveProfile(enr, "agents", "agent-runner", labels); err != nil || got != "prod" {
+		t.Fatalf("resolve profile = %q, %v; want prod", got, err)
+	}
+	if _, err := k8sResolveProfile(enr, "agents", "other", labels); err == nil {
+		t.Fatal("wrong serviceaccount allowed")
+	}
+	adminLabels := map[string]string{config.K8sDefaultProfileLabel: "admin"}
+	if _, err := k8sResolveProfile(enr, "agents", "agent-runner", adminLabels); err == nil {
+		t.Fatal("wrong profile allowed")
+	}
+	if _, err := k8sResolveProfile(enr, "agents", "agent-runner", nil); err == nil {
+		t.Fatal("missing profile label accepted")
+	}
+}
+
+type fakeK8sVerifier func(context.Context, string, k8sEnrollmentClaims, *config.CompiledK8sEnrollment) (k8sVerifiedPod, error)
+
+func (f fakeK8sVerifier) VerifyPod(ctx context.Context, token string, claims k8sEnrollmentClaims, enr *config.CompiledK8sEnrollment) (k8sVerifiedPod, error) {
+	return f(ctx, token, claims, enr)
+}
+
+func TestKubernetesTokenReviewAuthorizerIdentity(t *testing.T) {
+	enr := &config.CompiledK8sEnrollment{}
+	claims, err := json.Marshal(k8sEnrollmentClaims{
+		PodName:      "agent-1",
+		PodNamespace: "agents",
+		PodUID:       "uid-1",
+		NodeName:     "kind-worker",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth := &kubernetesTokenReviewAuthorizer{
+		name: "agents",
+		enr:  enr,
+		verifier: fakeK8sVerifier(func(_ context.Context, token string, got k8sEnrollmentClaims, _ *config.CompiledK8sEnrollment) (k8sVerifiedPod, error) {
+			if token != "pod-token" {
+				t.Fatalf("token = %q, want pod-token", token)
+			}
+			if got.PodUID != "uid-1" {
+				t.Fatalf("claims = %+v", got)
+			}
+			return k8sVerifiedPod{
+				Namespace:      got.PodNamespace,
+				Name:           got.PodName,
+				UID:            got.PodUID,
+				ServiceAccount: "agent-runner",
+				Profile:        "default",
+				NodeName:       got.NodeName,
+			}, nil
+		}),
+	}
+	id, err := auth.Authorize(context.Background(), "pod-token", claims)
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if id.SubjectKey != "kubernetes:agents:uid-1" {
+		t.Fatalf("subject key = %q", id.SubjectKey)
+	}
+	if id.ReplacementKey != "kubernetes:agents:agent-1" {
+		t.Fatalf("replacement key = %q", id.ReplacementKey)
+	}
+	if id.DisplayName != "agents/agent-1" || id.Owner != "system:serviceaccount:agents:agent-runner" || id.Profile != "default" {
+		t.Fatalf("identity = %+v", id)
+	}
+}
+
+func TestInClusterK8sClientVerifiesBoundPodToken(t *testing.T) {
+	var gotAudience string
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apis/authentication.k8s.io/v1/tokenreviews":
+			var review struct {
+				Spec struct {
+					Token     string   `json:"token"`
+					Audiences []string `json:"audiences"`
+				} `json:"spec"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
+				t.Errorf("decode TokenReview: %v", err)
+				http.Error(rw, "bad review", http.StatusBadRequest)
+				return
+			}
+			if review.Spec.Token != "pod-token" || len(review.Spec.Audiences) != 1 {
+				t.Errorf("TokenReview spec = %+v", review.Spec)
+			} else {
+				gotAudience = review.Spec.Audiences[0]
+			}
+			_ = json.NewEncoder(rw).Encode(map[string]any{"status": map[string]any{
+				"authenticated": true,
+				"audiences":     []string{"clawpatrol"},
+				"user": map[string]any{
+					"username": "system:serviceaccount:agents:agent-runner",
+					"extra": map[string][]string{
+						"authentication.kubernetes.io/pod-name": {"agent-1"},
+						"authentication.kubernetes.io/pod-uid":  {"uid-1"},
+					},
+				},
+			}})
+		case "/api/v1/namespaces/agents/pods/agent-1":
+			_ = json.NewEncoder(rw).Encode(map[string]any{
+				"metadata": map[string]any{
+					"uid":    "uid-1",
+					"labels": map[string]string{config.K8sDefaultProfileLabel: "default"},
+				},
+				"spec": map[string]string{
+					"serviceAccountName": "agent-runner",
+					"nodeName":           "kind-worker",
+				},
+			})
+		default:
+			http.NotFound(rw, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := &inClusterK8sClient{baseURL: srv.URL, token: "gateway-token", client: srv.Client()}
+	pod, err := client.VerifyPod(context.Background(), "pod-token", k8sEnrollmentClaims{
+		PodName:      "agent-1",
+		PodNamespace: "agents",
+		PodUID:       "uid-1",
+	}, testCompiledK8sEnrollment())
+	if err != nil {
+		t.Fatalf("VerifyPod: %v", err)
+	}
+	if gotAudience != "clawpatrol" {
+		t.Fatalf("TokenReview audience = %q, want clawpatrol", gotAudience)
+	}
+	if pod.UID != "uid-1" || pod.ServiceAccount != "agent-runner" || pod.Profile != "default" {
+		t.Fatalf("verified pod = %+v", pod)
+	}
+}
+
+func TestInClusterK8sClientRejectsUnboundTokenReview(t *testing.T) {
+	tests := []struct {
+		name       string
+		audiences  []string
+		extra      map[string][]string
+		wantErrSub string
+	}{
+		{
+			name:       "wrong audience",
+			audiences:  []string{"kubernetes"},
+			extra:      boundPodTokenExtra("agent-1", "uid-1"),
+			wantErrSub: "does not include audience",
+		},
+		{
+			name:       "missing pod binding",
+			audiences:  []string{"clawpatrol"},
+			wantErrSub: "not bound to a pod name",
+		},
+		{
+			name:       "different pod binding",
+			audiences:  []string{"clawpatrol"},
+			extra:      boundPodTokenExtra("other-agent", "other-uid"),
+			wantErrSub: "does not match submitted pod",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(rw).Encode(map[string]any{"status": map[string]any{
+					"authenticated": true,
+					"audiences":     tc.audiences,
+					"user": map[string]any{
+						"username": "system:serviceaccount:agents:agent-runner",
+						"extra":    tc.extra,
+					},
+				}})
+			}))
+			defer srv.Close()
+			client := &inClusterK8sClient{baseURL: srv.URL, token: "gateway-token", client: srv.Client()}
+			_, err := client.VerifyPod(context.Background(), "pod-token", k8sEnrollmentClaims{
+				PodName:      "agent-1",
+				PodNamespace: "agents",
+				PodUID:       "uid-1",
+			}, testCompiledK8sEnrollment())
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("VerifyPod error = %v, want substring %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func testCompiledK8sEnrollment() *config.CompiledK8sEnrollment {
+	return &config.CompiledK8sEnrollment{
+		Audience: "clawpatrol",
+		Matches: []config.CompiledK8sMatch{{
+			Namespace:      "agents",
+			ServiceAccount: "agent-runner",
+			ProfileLabel:   config.K8sDefaultProfileLabel,
+			Profiles:       []string{"default"},
+		}},
+	}
+}
+
+func boundPodTokenExtra(name, uid string) map[string][]string {
+	return map[string][]string{
+		"authentication.kubernetes.io/pod-name": {name},
+		"authentication.kubernetes.io/pod-uid":  {uid},
+	}
+}
+
+// cleanupEnrolledPeerLocked tears down every trace of an enrolled peer:
+// the WireGuard peer (and its wg_peers row), the API token, and the
+// device/agent registry entries.
+func TestCleanupEnrolledPeer(t *testing.T) {
+	g := newEnrollmentTestGateway(t)
+	startEnrollmentTestWGServer(t, g)
+
+	resp, err := registerFor(t, g, "kubernetes:agents:uid-1", "kubernetes:agents:agent-1", keyA)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := g.enrolledPeerByIP(resp.PeerIP); err != nil {
+		t.Fatalf("precondition: enrolled peer not present: %v", err)
+	}
+
+	g.enrollmentMu.Lock()
+	if err := g.cleanupEnrolledPeerLocked(context.Background(), resp.PeerIP); err != nil {
+		t.Fatalf("cleanup enrolled peer: %v", err)
+	}
+	g.enrollmentMu.Unlock()
+
+	if _, err := g.enrolledPeerByIP(resp.PeerIP); err == nil {
+		t.Fatal("enrolled peer still present after cleanup")
+	}
+	if got := wgPeerRowsForIP(t, g, resp.PeerIP); got != 0 {
+		t.Fatalf("wg_peers rows after cleanup = %d, want 0", got)
+	}
+	if got := peerIPForAPIToken(g.db, resp.APIToken); got != "" {
+		t.Fatalf("peer API token still resolves to %q", got)
+	}
+	if g.onboard.HasDevice(resp.PeerIP) {
+		t.Fatal("device row still present after cleanup")
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -375,11 +375,20 @@ type Gateway struct {
 	blobs runtime.BlobStore
 	// pluginMgr supervises the external plugin subprocesses; the
 	// dashboard reads it for the Plugins page.
-	pluginMgr *extplugin.Manager
-	oauth     *OAuthRegistry
-	agents    *AgentRegistry
-	hitl      *HITLRegistry
-	onboard   *onboardRegistry
+	pluginMgr    *extplugin.Manager
+	oauth        *OAuthRegistry
+	agents       *AgentRegistry
+	hitl         *HITLRegistry
+	onboard      *onboardRegistry
+	enrollmentMu sync.Mutex
+	// enrollLive tracks per-peer WireGuard rx_bytes progress for the
+	// enrollment liveness reaper. Guarded by enrollmentMu.
+	enrollLive map[string]enrollmentLiveness
+	// k8sVerifier lets tests inject a fake Kubernetes verifier. In
+	// production it stays nil and each register request builds a
+	// short-lived in-cluster client, which re-reads the rotating
+	// ServiceAccount token, so there is nothing to cache here.
+	k8sVerifier k8sRegistrationVerifier
 	// secrets hands credential plugins the secret bytes they inject
 	// at request time. gatewaySecretStore stacks the credential_secrets
 	// table (dashboard slots), OAuthRegistry (refreshed access tokens),
@@ -3059,6 +3068,10 @@ func main() {
 		runJoin(os.Args[2:])
 	case "run":
 		runRun(os.Args[2:])
+	case "bridge":
+		// Foreground data plane: self-enroll through an authorizer, bring up
+		// and host a userspace WireGuard tunnel, route the netns, stay up.
+		runBridge(os.Args[2:])
 	case "daemon-internal":
 		// internal: re-exec'd by `clawpatrol run` (Linux only) to host
 		// the per-user tsnet daemon. Hidden from usage(); name carries
@@ -3171,6 +3184,9 @@ usage:
                                          with no public URL (creds discarded
                                          once join completes)
   clawpatrol run -- <cmd> [args...]      route one process tree through gateway
+  clawpatrol bridge --authorizer <type>/<name> [flags]
+                                         resident sidecar: self-enroll, host the
+                                         WireGuard tunnel, route the netns
   clawpatrol status                      report install + tunnel state
   clawpatrol uninstall                   remove local join state and tunnel config
   clawpatrol env                         print shell exports for sourcing
@@ -3438,6 +3454,16 @@ func runGateway(args []string) {
 			log.Fatalf("wireguard: %v", err)
 		}
 		setWGServer(wg)
+		// Restore any persisted enrolled peers into the device + registry,
+		// then run the liveness reaper. Both are always-on once WireGuard is
+		// up: enrollment can be turned on by a later config reload, and any
+		// peers left behind must keep getting reaped after the feature is
+		// turned off. The reaper is a cheap no-op while there are none.
+		g.logEnrollmentReconcile(context.Background())
+		go g.startEnrollmentReaper(context.Background())
+		if cfg.IsEnrollmentEnabled() {
+			log.Printf("enrollment: enabled")
+		}
 		dashMux := newWebMux(g, cfg.Join(), cfg.PublicURL())
 		dashPort := portOf(dashListen)
 		tcpDispatch := func(c net.Conn, dstIP string, dstPort uint16) {

--- a/cmd/clawpatrol/migrations/sqlite/0020_wg_peer_enrollment.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0020_wg_peer_enrollment.sql
@@ -1,0 +1,19 @@
+-- Enrollment columns on wg_peers.
+--
+-- Workloads self-enroll as transient WireGuard peers through a configured
+-- authorizer (see the top-level enrollment block). enrolled marks
+-- reaper-managed peers, so durable onboarded devices (enrolled=0) are never
+-- reaped. Liveness is observed from the WireGuard device (rx_bytes
+-- progress), so there is no stored expiry.
+ALTER TABLE wg_peers ADD COLUMN enrolled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE wg_peers ADD COLUMN subject_key TEXT;
+ALTER TABLE wg_peers ADD COLUMN replacement_key TEXT;
+ALTER TABLE wg_peers ADD COLUMN display_name TEXT;
+ALTER TABLE wg_peers ADD COLUMN owner TEXT;
+ALTER TABLE wg_peers ADD COLUMN profile TEXT;
+ALTER TABLE wg_peers ADD COLUMN authorizer_type TEXT;
+ALTER TABLE wg_peers ADD COLUMN authorizer_name TEXT;
+ALTER TABLE wg_peers ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS wg_peers_subject ON wg_peers(subject_key);
+CREATE INDEX IF NOT EXISTS wg_peers_replacement ON wg_peers(replacement_key);

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -500,6 +500,7 @@ func (r *onboardRegistry) ForgetIP(ip string) {
 	delete(r.profileByIP, ip)
 	delete(r.extV4ByIP, ip)
 	delete(r.extV6ByIP, ip)
+	delete(r.knownDeviceIPs, ip)
 	// Drop the IP from the alias graph too — both as an alias and as a
 	// canonical. Otherwise a stale alias outlives the device and, after
 	// IP reuse, AssignProfile's alias fan-out could re-stamp a profile
@@ -1065,8 +1066,8 @@ func (w *webMux) retirePlaceholderForClaim(dc, realIP string) {
 	if w.g.agents != nil {
 		w.g.agents.Delete(placeholderID)
 	}
-	if w.g.db != nil {
-		_, _ = w.g.db.Exec("DELETE FROM peer_api_tokens WHERE peer_ip = ?", placeholderID)
+	if err := deletePeerAPITokensForIP(w.g.db, placeholderID); err != nil {
+		log.Printf("onboard: retire placeholder api tokens for %s: %v", placeholderID, err)
 	}
 }
 

--- a/cmd/clawpatrol/peer_api_tokens.go
+++ b/cmd/clawpatrol/peer_api_tokens.go
@@ -57,6 +57,16 @@ func peerIPForAPIToken(db *sql.DB, token string) string {
 	return ip
 }
 
+func deletePeerAPITokensForIP(db *sql.DB, peerIP string) error {
+	if db == nil || peerIP == "" {
+		return nil
+	}
+	if _, err := db.Exec(`DELETE FROM peer_api_tokens WHERE peer_ip = ?`, peerIP); err != nil {
+		return fmt.Errorf("delete peer_api_tokens for %s: %w", peerIP, err)
+	}
+	return nil
+}
+
 // hashPeerAPIToken hashes a raw bearer for the lookup table.
 // SHA-256 is fine here — the token is a uniformly-random 256-bit
 // value, not a password, so we don't need a password hash.

--- a/cmd/clawpatrol/peer_api_tokens_test.go
+++ b/cmd/clawpatrol/peer_api_tokens_test.go
@@ -43,6 +43,31 @@ func TestPeerAPITokenRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDeletePeerAPITokensForIP(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	token, err := mintAndPersistPeerAPIToken(db, "10.55.0.42")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if err := deletePeerAPITokensForIP(db, "10.55.0.42"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := peerIPForAPIToken(db, token); got != "" {
+		t.Fatalf("deleted token resolved to %q", got)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := deletePeerAPITokensForIP(db, "10.55.0.42"); err == nil {
+		t.Fatal("delete on closed db returned nil")
+	}
+}
+
 // TestBearerFromAuthHeader covers the trivial parser.
 func TestBearerFromAuthHeader(t *testing.T) {
 	cases := []struct {

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -255,6 +255,8 @@ func (w *webMux) routes() []webRoute {
 		{Method: http.MethodPost, Path: "/api/onboard/claim", Auth: authPublic, Handler: w.apiOnboardClaim},
 		{Method: http.MethodGet, Path: "/api/env-pushdown", Auth: authSelfAuthenticating, Handler: w.apiEnvPushdown},
 		{Method: http.MethodPost, Path: "/api/peer/tsnet/register", Auth: authSelfAuthenticating, Handler: w.apiPeerTsnetRegister},
+		{Method: http.MethodPost, Path: enrollmentRegisterPath, Auth: authSelfAuthenticating, Handler: w.apiEnrollmentRegister},
+		{Method: http.MethodGet, Path: "/api/enrollment/peers", Auth: authDashboard, Handler: w.apiEnrollmentList},
 		// /__login is the auth point itself — it MUST be reachable
 		// without a credential. The handler dispatches on r.Method
 		// (GET renders the form, POST validates + mints a session
@@ -1157,6 +1159,7 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 		"whoami":                  w.whoamiData(r),
 		"integrations":            w.statusList(r),
 		"agents":                  w.agentsList(),
+		"enrolled_peers":          w.enrolledPeersForState(),
 		"update":                  currentUpdateBanner.Load(),
 		"config_file":             filepath.Base(w.g.cfgPath),
 		"dashboard_config_writes": w.g.cfg.Load().DashboardConfigWrites(),
@@ -1177,6 +1180,18 @@ func (w *webMux) apiState(rw http.ResponseWriter, r *http.Request) {
 	w.stateCacheMu.Unlock()
 
 	serveState(rw, r, body, tag)
+}
+
+// enrolledPeersForState returns the enrolled-peer views bundled into
+// /api/state for the dashboard. Errors (and the no-enrollment case)
+// degrade to an empty slice so a DB hiccup never blanks the whole
+// dashboard, and the JSON is always [] rather than null.
+func (w *webMux) enrolledPeersForState() []enrolledPeerView {
+	views, err := w.g.listEnrolledPeerViews()
+	if err != nil || views == nil {
+		return []enrolledPeerView{}
+	}
+	return views
 }
 
 const stateCacheTTL = 1 * time.Second

--- a/cmd/clawpatrol/wireguard.go
+++ b/cmd/clawpatrol/wireguard.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"expvar"
@@ -53,6 +54,9 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 	"gvisor.dev/gvisor/pkg/waiter"
 )
+
+// allocateWGPeerMu serializes selection with WireGuard and database updates.
+var allocateWGPeerMu sync.Mutex
 
 // defaultWGListenPort is the UDP port the gateway binds for WG peers
 // when wireguard.listen_port is unset. Also the port advertised to
@@ -309,6 +313,9 @@ var (
 func setWGServer(s *WGServer) { globalWG = s }
 func setDB(d *sql.DB)         { globalDB = d }
 
+// GatewayTunnelIP is the gateway's own address inside the WireGuard subnet
+func (s *WGServer) GatewayTunnelIP() netip.Addr { return s.serverIP }
+
 // StartWGServer brings up a userspace WG endpoint listening on
 // 0.0.0.0:<ListenPort>. Server private key is read from the
 // wg_server_key sqlite row; if missing, generated and persisted on
@@ -376,23 +383,23 @@ func StartWGServer(ts JoinConfig) (*WGServer, error) {
 // onboards otherwise win the trie race on restart and silently drop
 // the current client's traffic.
 func (s *WGServer) AddPeer(pubkeyHex, peerIP string) error {
+	allocateWGPeerMu.Lock()
+	defer allocateWGPeerMu.Unlock()
+	return s.addPeerLocked(pubkeyHex, peerIP)
+}
+
+// addPeerLocked updates the WireGuard device and persists its allocation.
+// Caller holds allocateWGPeerMu.
+func (s *WGServer) addPeerLocked(pubkeyHex, peerIP string) error {
 	if s.db != nil {
-		rows, err := s.db.Query("SELECT pubkey FROM wg_peers WHERE ip = ? AND pubkey != ?", peerIP, pubkeyHex)
-		if err == nil {
-			defer func() { _ = rows.Close() }()
-			var stale []string
-			for rows.Next() {
-				var k string
-				if rows.Scan(&k) == nil {
-					stale = append(stale, k)
-				}
-			}
-			if err := rows.Err(); err != nil {
-				stale = nil
-			}
-			for _, k := range stale {
-				_ = s.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", k))
-				_, _ = s.db.Exec("DELETE FROM wg_peers WHERE pubkey = ?", k)
+		stale, err := peerKeysForIPExcept(s.db, peerIP, pubkeyHex)
+		if err != nil {
+			return fmt.Errorf("query existing peer for %s: %w", peerIP, err)
+		}
+		for _, k := range stale {
+			_ = s.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", k))
+			if _, err := s.db.Exec("DELETE FROM wg_peers WHERE pubkey = ?", k); err != nil {
+				return fmt.Errorf("delete replaced peer %s: %w", k, err)
 			}
 		}
 	}
@@ -408,9 +415,99 @@ func (s *WGServer) AddPeer(pubkeyHex, peerIP string) error {
 			INSERT INTO wg_peers (pubkey, ip, added_ns) VALUES (?, ?, ?)
 			ON CONFLICT(pubkey) DO UPDATE SET ip = excluded.ip
 		`, pubkeyHex, peerIP, time.Now().UnixNano())
+		if err != nil {
+			_ = s.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", pubkeyHex))
+		}
 		return err
 	}
 	return nil
+}
+
+func peerKeysForIPExcept(db *sql.DB, peerIP, exceptPubkey string) ([]string, error) {
+	rows, err := db.Query("SELECT pubkey FROM wg_peers WHERE ip = ? AND pubkey != ?", peerIP, exceptPubkey)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+// allocatePeer selects and persists a free client /32 as one critical section.
+func (s *WGServer) allocatePeer(ts JoinConfig, pubkeyHex string) (string, error) {
+	allocateWGPeerMu.Lock()
+	defer allocateWGPeerMu.Unlock()
+	ip, err := allocateWGPeerIPLocked(s.db, ts)
+	if err != nil {
+		return "", err
+	}
+	if err := s.addPeerLocked(pubkeyHex, ip); err != nil {
+		return "", fmt.Errorf("add peer %s: %w", ip, err)
+	}
+	return ip, nil
+}
+
+// allocateWGPeerIPLocked returns the next free client /32 from WGSubnetCIDR.
+// Caller holds allocateWGPeerMu, and must persist the result before releasing
+// it so another caller cannot select the same address.
+func allocateWGPeerIPLocked(db *sql.DB, ts JoinConfig) (string, error) {
+	used := map[string]bool{}
+	if db != nil {
+		var err error
+		used, err = usedWGPeerIPs(db)
+		if err != nil {
+			return "", fmt.Errorf("read wireguard peer allocations: %w", err)
+		}
+	}
+	_, cidr, err := net.ParseCIDR(ts.WGSubnetCIDR)
+	if err != nil {
+		return "", err
+	}
+	base := cidr.IP.To4()
+	if base == nil {
+		return "", fmt.Errorf("wireguard subnet must be IPv4")
+	}
+	ones, _ := cidr.Mask.Size()
+	size := uint32(1) << uint(32-ones)
+	if size < 4 {
+		return "", fmt.Errorf("wireguard subnet %s is too small", ts.WGSubnetCIDR)
+	}
+	network := binary.BigEndian.Uint32(base)
+	// Skip the network address (offset 0), the gateway's own .1 (offset 1),
+	// and the broadcast (offset size-1).
+	for off := uint32(2); off < size-1; off++ {
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], network+off)
+		ip := net.IP(b[:]).String()
+		if !used[ip] {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("wireguard subnet %s exhausted", ts.WGSubnetCIDR)
+}
+
+func usedWGPeerIPs(db *sql.DB) (map[string]bool, error) {
+	rows, err := db.Query("SELECT ip FROM wg_peers")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	used := map[string]bool{}
+	for rows.Next() {
+		var ip string
+		if err := rows.Scan(&ip); err != nil {
+			return nil, err
+		}
+		used[ip] = true
+	}
+	return used, rows.Err()
 }
 
 // wg6FromV4 derives the per-peer IPv6 address from a peer's wg v4
@@ -625,6 +722,25 @@ func relayUDP(c net.Conn, dstIP string, dstPort uint16) {
 	<-done
 }
 
+// wgDevPeerStat is the per-peer liveness subset of the device's IpcGet
+type wgDevPeerStat struct {
+	rxBytes       uint64
+	lastHandshake time.Time
+}
+
+// PeerStats returns per-peer receive + handshake stats keyed by hex public
+// key, parsed from the device's UAPI dump. nil when the device is down.
+func (s *WGServer) PeerStats() map[string]wgDevPeerStat {
+	if s == nil || s.dev == nil {
+		return nil
+	}
+	uapi, err := s.dev.IpcGet()
+	if err != nil {
+		return nil
+	}
+	return parseAllPeerStats(uapi)
+}
+
 func (s *WGServer) loadPeers() map[string]string {
 	out := map[string]string{}
 	if s.db == nil {
@@ -656,6 +772,13 @@ func (s *WGServer) loadPeers() map[string]string {
 // device from the dashboard so the tunnel + the trie entry don't
 // linger after the (owner, hostname) row is gone.
 func (s *WGServer) RevokePeerByIP(ip string) {
+	allocateWGPeerMu.Lock()
+	defer allocateWGPeerMu.Unlock()
+	s.revokePeerByIPLocked(ip)
+}
+
+// revokePeerByIPLocked removes an allocation while holding allocateWGPeerMu.
+func (s *WGServer) revokePeerByIPLocked(ip string) {
 	if s == nil || s.db == nil {
 		return
 	}
@@ -764,7 +887,6 @@ func hexToB64(h string) (string, error) {
 
 type wireguardOnboarder struct {
 	ts JoinConfig
-	mu sync.Mutex
 }
 
 // wgClientEndpoint returns the host:port string clients should put in
@@ -839,14 +961,14 @@ func (w *wireguardOnboarder) MintKey(_ context.Context, reuseIP string, _ bool) 
 		// one row per device. AddPeer evicts the stale pubkey on the same
 		// IP from both the wg-go trie and wg_peers.
 		ip = reuseIP
+		if err := globalWG.AddPeer(clientPubHex, ip); err != nil {
+			return "", "", "", fmt.Errorf("wg add peer: %w", err)
+		}
 	} else {
-		ip, err = w.allocateIP()
+		ip, err = globalWG.allocatePeer(w.ts, clientPubHex)
 		if err != nil {
 			return "", "", "", err
 		}
-	}
-	if err := globalWG.AddPeer(clientPubHex, ip); err != nil {
-		return "", "", "", fmt.Errorf("wg add peer: %w", err)
 	}
 	serverPub, err := globalWG.PublicKey()
 	if err != nil {
@@ -882,40 +1004,4 @@ func (w *wireguardOnboarder) iface() string {
 		return w.ts.WGInterface
 	}
 	return "clawpatrol"
-}
-
-// allocateIP grabs the next free IP from WGSubnetCIDR. The allocation
-// set is derived from wg_peers (one row per active peer); a fresh DB
-// = a fresh subnet. AddPeer commits the (pubkey, ip) row.
-func (w *wireguardOnboarder) allocateIP() (string, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	used := map[string]bool{}
-	if globalDB != nil {
-		rows, err := globalDB.Query("SELECT ip FROM wg_peers")
-		if err == nil {
-			defer func() { _ = rows.Close() }()
-			for rows.Next() {
-				var ip string
-				if rows.Scan(&ip) == nil {
-					used[ip] = true
-				}
-			}
-			if err := rows.Err(); err != nil {
-				used = map[string]bool{}
-			}
-		}
-	}
-	_, cidr, err := net.ParseCIDR(w.ts.WGSubnetCIDR)
-	if err != nil {
-		return "", err
-	}
-	first := cidr.IP.To4()
-	for i := 2; i < 255; i++ {
-		ip := net.IPv4(first[0], first[1], first[2], byte(i)).String()
-		if !used[ip] {
-			return ip, nil
-		}
-	}
-	return "", fmt.Errorf("wireguard subnet %s exhausted", w.ts.WGSubnetCIDR)
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -14,7 +14,14 @@ import { PageTitle } from "./components/PageTitle";
 import { PluginsPage } from "./components/PluginsPage";
 import { RequestDetailPage } from "./components/RequestDetailPage";
 import { SettingsPage } from "./components/SettingsPage";
-import { getState, type Agent, type Integration, type UpdateBanner, type Whoami } from "./lib/api";
+import {
+  getState,
+  type Agent,
+  type EnrolledPeer,
+  type Integration,
+  type UpdateBanner,
+  type Whoami,
+} from "./lib/api";
 
 type Route =
   | { name: "main" }
@@ -56,6 +63,7 @@ function parseRoute(): Route {
 export default function App() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
+  const [enrolledPeers, setEnrolledPeers] = useState<EnrolledPeer[]>([]);
   const [whoami, setWhoami] = useState<Whoami | null>(null);
   const [update, setUpdate] = useState<UpdateBanner | null>(null);
   const [configFile, setConfigFile] = useState<string>("gateway.hcl");
@@ -76,6 +84,7 @@ export default function App() {
       const s = await getState();
       setIntegrations(s.integrations || []);
       setAgents(s.agents || []);
+      setEnrolledPeers(s.enrolled_peers || []);
       setWhoami(s.whoami);
       setUpdate(s.update ?? null);
       if (s.config_file) setConfigFile(s.config_file);
@@ -137,6 +146,7 @@ export default function App() {
         <DevicePage
           ip={route.ip}
           agents={agents}
+          enrolledPeers={enrolledPeers}
           integrations={integrations}
           configFile={configFile}
           onBack={() => navigate("")}

--- a/dashboard/src/components/DevicePage.tsx
+++ b/dashboard/src/components/DevicePage.tsx
@@ -5,10 +5,12 @@ import {
   listProfiles,
   setDeviceProfile,
   type Agent,
+  type EnrolledPeer,
   type Integration,
 } from "../lib/api";
 import { fmtBytes } from "../lib/format";
 import { Button } from "./Button";
+import { EnrollmentPanel } from "./EnrollmentPanel";
 import { HITLBar } from "./HITLBar";
 import { IntegrationsCards } from "./IntegrationsCards";
 import { LiveRequests } from "./LiveRequests";
@@ -23,6 +25,7 @@ import { Sparkline } from "./Sparkline";
 export function DevicePage({
   ip,
   agents,
+  enrolledPeers,
   integrations,
   configFile,
   onBack,
@@ -31,6 +34,7 @@ export function DevicePage({
 }: {
   ip: string;
   agents: Agent[];
+  enrolledPeers: EnrolledPeer[];
   integrations: Integration[];
   configFile: string;
   onBack: () => void;
@@ -38,6 +42,14 @@ export function DevicePage({
   onRefresh: () => void;
 }) {
   const a = useMemo(() => agents.find((x) => x.ip === ip) ?? null, [agents, ip]);
+  // Self-enrolled peers are reaper-managed: their profile is assigned
+  // from the pod label (not editable here) and they auto-reap when the
+  // pod dies, so the manual profile picker and the delete action are
+  // suppressed in favor of the read-only enrollment panel below.
+  const peer = useMemo(
+    () => enrolledPeers.find((x) => x.peer_ip === ip) ?? null,
+    [enrolledPeers, ip],
+  );
   const [profiles, setProfiles] = useState<string[]>([]);
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileErr, setProfileErr] = useState<string | null>(null);
@@ -104,17 +116,21 @@ export function DevicePage({
         trail={[{ label: "Devices", href: "#/devices" }, { label: dev.hostname || dev.ip }]}
         actions={
           <>
-            <ProfilePicker
-              current={a.profile ?? ""}
-              profiles={profiles}
-              saving={profileSaving}
-              err={profileErr}
-              onPick={(next) => {
-                if (!next || next === a.profile) return;
-                setProfileErr(null);
-                setPendingProfile(next);
-              }}
-            />
+            {peer ? (
+              <LockedProfile profile={peer.profile || a.profile || "—"} />
+            ) : (
+              <ProfilePicker
+                current={a.profile ?? ""}
+                profiles={profiles}
+                saving={profileSaving}
+                err={profileErr}
+                onPick={(next) => {
+                  if (!next || next === a.profile) return;
+                  setProfileErr(null);
+                  setPendingProfile(next);
+                }}
+              />
+            )}
             <a
               href={`#/analytics/${encodeURIComponent(ip)}`}
               title="analytics"
@@ -134,29 +150,31 @@ export function DevicePage({
                 <path d="m7 16 4-8 4 4 4-6" />
               </svg>
             </a>
-            <button
-              type="button"
-              onClick={remove}
-              title="forget this device"
-              className="w-8 h-8 squircle-md flex items-center justify-center hover:bg-danger-400 transition-colors cursor-pointer"
-            >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+            {!peer && (
+              <button
+                type="button"
+                onClick={remove}
+                title="forget this device"
+                className="w-8 h-8 squircle-md flex items-center justify-center hover:bg-danger-400 transition-colors cursor-pointer"
               >
-                <path d="M3 6h18" />
-                <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                <path d="M10 11v6" />
-                <path d="M14 11v6" />
-              </svg>
-            </button>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M3 6h18" />
+                  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                </svg>
+              </button>
+            )}
           </>
         }
       />
@@ -200,6 +218,9 @@ export function DevicePage({
           </div>
         </div>
       </section>
+
+      {/* enrollment panel — only for self-enrolled (reaper-managed) peers */}
+      {peer && <EnrollmentPanel peer={peer} />}
 
       {/* pending approvals awaiting a decision for this device — same
           cards as the home page, scoped to this device's agent IP.
@@ -332,6 +353,38 @@ function ConfirmProfileChange({
         </div>
       </div>
     </Modal>
+  );
+}
+
+// LockedProfile replaces the profile picker for enrolled peers: their
+// profile is assigned from the pod label at enrollment and can't be
+// changed from the dashboard.
+function LockedProfile({ profile }: { profile: string }) {
+  return (
+    <div
+      title="profile is assigned from the pod label — not editable here"
+      className={
+        "inline-flex items-center gap-1.5 min-w-40 pl-2.5 pr-2.5 py-1 " +
+        "border-1.5 border-navy bg-canvas text-sm text-text-muted"
+      }
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className="shrink-0"
+      >
+        <rect x="3" y="11" width="18" height="11" rx="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </svg>
+      <span className="font-mono text-xs uppercase tracking-wider truncate">{profile}</span>
+    </div>
   );
 }
 

--- a/dashboard/src/components/EnrollmentPanel.tsx
+++ b/dashboard/src/components/EnrollmentPanel.tsx
@@ -1,0 +1,111 @@
+// Enrollment panel — shown on the device page for self-enrolled
+// (reaper-managed) WireGuard peers. Regular onboarded devices don't get
+// this; the caller only renders it when an EnrolledPeer matches the IP.
+
+import type { ReactNode } from "react";
+import type { EnrolledPeer } from "../lib/api";
+import { fmtAge, fmtDateTime } from "../lib/format";
+import { Tag } from "./Tag";
+
+// last_rx_at advances on the gateway's 20s sampling cadence. Allow one
+// keepalive interval beyond that cadence before flagging the peer as stale.
+const gatewayRxSampleIntervalSeconds = 20;
+
+// missedIntervals derives how many keepalive intervals have elapsed since
+// the gateway last saw the peer's rx advance.
+function missedIntervals(p: EnrolledPeer): number {
+  const ka = p.keepalive_interval_seconds ?? 0;
+  const last = p.last_rx_at ? Date.parse(p.last_rx_at) : 0;
+  if (ka <= 0 || !last) return 0;
+  return Math.max(0, Math.floor((Date.now() - last) / 1000 / ka));
+}
+
+function ago(t: string | undefined): string {
+  const a = fmtAge(t);
+  return a === "—" ? a : a + " ago";
+}
+
+export function EnrollmentPanel({ peer }: { peer: EnrolledPeer }) {
+  const missed = missedIntervals(peer);
+  const ka = peer.keepalive_interval_seconds ?? 0;
+  const staleThreshold =
+    ka > 0 ? Math.ceil(gatewayRxSampleIntervalSeconds / ka) + 1 : Number.POSITIVE_INFINITY;
+  const stale = missed >= staleThreshold;
+  const reap = peer.reap_count ?? 0;
+  // Liveness window is derived, not sent: keepalive × reap_count.
+  const window = ka * reap;
+
+  return (
+    <section className="bg-canvas border-1.5 border-navy overflow-hidden">
+      <div className="flex items-center px-4 py-2.5 bg-navy-100 border-b border-navy gap-2">
+        <div className="font-mono text-xs uppercase tracking-wider text-navy font-bold">
+          Enrollment
+        </div>
+        <Tag tone={stale ? "warning" : "success"}>
+          <span aria-hidden="true">●</span> {stale ? "stale" : "live"}
+        </Tag>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3">
+        <Field label="Authorizer" className="border-b border-canvas-muted sm:border-r">
+          <span className="font-mono">{peer.authorizer_name || "—"}</span>
+          {peer.authorizer_type && (
+            <>
+              {" "}
+              <span className="text-text-muted">·</span>{" "}
+              <Tag tone="neutral">{peer.authorizer_type}</Tag>
+            </>
+          )}
+        </Field>
+        <Field label="Subject" className="border-b border-canvas-muted sm:border-r">
+          <span className="font-mono text-xs break-all">{peer.subject_key || "—"}</span>
+        </Field>
+        <Field label="Enrolled" className="border-b border-canvas-muted">
+          <div className="tabular-nums">{ago(peer.created_at)}</div>
+          <div className="text-text-muted text-2xs tabular-nums mt-0.5">
+            {fmtDateTime(peer.created_at)}
+          </div>
+        </Field>
+
+        <Field label="Keepalive" className="sm:border-r border-canvas-muted">
+          <span className="tabular-nums">{ka ? ka + "s" : "—"}</span>
+        </Field>
+        <Field label="Liveness window" className="sm:border-r border-canvas-muted">
+          <span className="tabular-nums">{window ? window + "s" : "—"}</span>
+          {ka > 0 && reap > 0 ? (
+            <span className="text-text-muted text-xs ml-1.5">
+              {ka}s × {reap}
+            </span>
+          ) : null}
+        </Field>
+        <Field label="Last liveness check">
+          <span className="tabular-nums">{peer.last_rx_at ? ago(peer.last_rx_at) : "—"}</span>
+          {stale && (
+            <Tag tone="warning" className="ml-1.5">
+              {missed} missed
+            </Tag>
+          )}
+        </Field>
+      </div>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={"px-4 py-3 " + className}>
+      <div className="font-mono text-2xs uppercase tracking-wider text-text-subtle mb-1">
+        {label}
+      </div>
+      <div className="text-sm text-text">{children}</div>
+    </div>
+  );
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -414,7 +414,10 @@ export type Whoami = {
 };
 
 export async function logout(): Promise<void> {
-  const r = await fetch("/__logout", { method: "POST", credentials: "same-origin" });
+  const r = await fetch("/__logout", {
+    method: "POST",
+    credentials: "same-origin",
+  });
   if (!r.ok && r.status !== 401) throw new Error(await r.text());
 }
 
@@ -426,7 +429,9 @@ export async function getStatus(profile?: string): Promise<Integration[]> {
 }
 
 export async function deleteAgent(ip: string): Promise<void> {
-  const r = await api(`/api/agents/delete?ip=${encodeURIComponent(ip)}`, { method: "POST" });
+  const r = await api(`/api/agents/delete?ip=${encodeURIComponent(ip)}`, {
+    method: "POST",
+  });
   if (!r.ok) throw new Error(await r.text());
 }
 
@@ -445,10 +450,35 @@ export type UpdateBanner = {
   advisory?: string;
 };
 
+// EnrolledPeer mirrors the backend enrolledPeerView bundled into
+// /api/state. Enrolled (self-registered) WireGuard peers are keyed by
+// their wg IP, same as an Agent — join on peer_ip === agent.ip. The
+// liveness window (keepalive_interval_seconds × reap_count) and the
+// missed-interval count are derived in the UI; last_rx_at is when the
+// gateway last saw the peer's rx advance.
+export type EnrolledPeer = {
+  peer_ip: string;
+  transport: string;
+  authorizer_type: string;
+  authorizer_name: string;
+  subject_key: string;
+  display_name: string;
+  owner: string;
+  profile: string;
+  public_key?: string;
+  metadata?: Record<string, string>;
+  created_at: string;
+  last_handshake?: string;
+  keepalive_interval_seconds?: number;
+  reap_count?: number;
+  last_rx_at?: string;
+};
+
 type StateResp = {
   whoami: Whoami;
   integrations: Integration[];
   agents: Agent[];
+  enrolled_peers?: EnrolledPeer[];
   update?: UpdateBanner | null;
   // Basename of the gateway config file (e.g. "gateway.hcl",
   // "dev.hcl"). Surfaced in UI hints so operators see the actual

--- a/doc/kubernetes-enrollment-design.md
+++ b/doc/kubernetes-enrollment-design.md
@@ -1,0 +1,256 @@
+# Kubernetes enrollment implementation design
+
+This note documents the implementation and invariants behind transient
+Kubernetes workload enrollment. It is for contributors changing the config
+compiler, gateway, WireGuard transport, bridge, dashboard, or tests.
+
+For deployment instructions, supported configuration, manifests, tuning, and
+operator-visible behavior, use the
+[public Kubernetes Enrollment guide](https://clawpatrol.dev/docs/kubernetes-enrollment/)
+and the examples under [`examples/kubernetes/`](../examples/kubernetes/).
+
+## Scope and invariants
+
+- Enrollment currently provisions only WireGuard peers.
+- The gateway and enrolled workloads are expected to share a Kubernetes
+  cluster.
+- One active gateway owns the WireGuard device and peer-address pool.
+- The client never submits its profile. The gateway derives it from the live
+  Pod and the configured allowlist.
+- The agent container never receives the projected ServiceAccount token,
+  WireGuard private key, or peer API token.
+- Reaping is limited to peers explicitly marked as enrolled; normally
+  onboarded devices are never reaped.
+- Registration, replacement, cleanup, and reaping serialize through the
+  gateway enrollment lock.
+
+## Configuration model
+
+The in-tree `kubernetes_token_review` enrollment plugin is registered as
+`KindEnrollment` in
+[`internal/config/k8s_enrollment.go`](../internal/config/k8s_enrollment.go).
+Its build output contains:
+
+- the TokenReview audience,
+- one or more namespace and ServiceAccount match rules,
+- the Pod label used to select a profile,
+- the profile allowlist, and
+- raw keepalive and reap settings.
+
+Validation requires an audience, at least one complete match, and declared
+profiles. Gateway-level validation also requires a `wireguard` block whenever
+an enrollment block exists.
+
+[`internal/config/k8s_compile.go`](../internal/config/k8s_compile.go) lowers
+the plugin body into `CompiledK8sEnrollment` and indexes authorizers by
+instance name. Keepalive settings are compiled separately into the common
+`EnrollmentLivenessByName` map so registration and reaping do not need a
+Kubernetes-specific type switch.
+
+[`internal/config/enrollment_liveness.go`](../internal/config/enrollment_liveness.go)
+owns the shared defaults and validation:
+
+- default keepalive: 25 seconds,
+- minimum keepalive: 10 seconds,
+- default reap count: 3,
+- minimum non-zero reap count: 2, and
+- reap count 0: reaping and client liveness recovery disabled.
+
+The liveness window is always derived as keepalive multiplied by reap count.
+
+## Registration and authorization
+
+The bridge gathers claims from the Downward API and reads the projected
+ServiceAccount token in
+[`cmd/clawpatrol/enrollment_client.go`](../cmd/clawpatrol/enrollment_client.go).
+It sends:
+
+- transport and authorizer name,
+- its newly generated WireGuard public key,
+- Pod name, namespace, UID, and node name, and
+- a request for the authorizer's resolved liveness settings.
+
+The registration handler and Kubernetes authorizer live in
+[`cmd/clawpatrol/enrollment.go`](../cmd/clawpatrol/enrollment.go). Authorization
+is fail-closed:
+
+1. Resolve the named authorizer from the compiled policy.
+2. Submit the projected token to Kubernetes TokenReview with the configured
+   audience.
+3. Require the TokenReview response to include that audience and the bound Pod
+   name and UID.
+4. Require a `system:serviceaccount:<namespace>:<name>` identity.
+5. Require the token namespace and bound Pod identity to match the submitted
+   claims.
+6. Read the live Pod with the gateway ServiceAccount.
+7. Require the live Pod UID and ServiceAccount to match the verified token.
+8. Read the configured profile label from the live Pod.
+9. Require that profile to appear in the matching rule's allowlist and in the
+   compiled policy.
+
+The normalized identity uses:
+
+- subject key: `kubernetes:<namespace>:<pod UID>`,
+- replacement key: `kubernetes:<namespace>:<pod name>`,
+- display name: `<namespace>/<pod name>`, and
+- owner: `system:serviceaccount:<namespace>:<service account>`.
+
+The subject key identifies one Pod instance. The replacement key identifies
+the logical workload name across Pod recreation.
+
+## Peer allocation and persistence
+
+Enrollment and dashboard onboarding share one allocator. A process-wide mutex
+holds address selection, WireGuard programming, and `wg_peers` persistence in
+one critical section so concurrent callers cannot claim the same address.
+
+The allocator reads all addresses in `wg_peers`, walks the configured IPv4
+subnet from the first client address, and skips:
+
+- the network address,
+- the gateway address at offset 1, and
+- the broadcast address.
+
+The first unused address is returned. A database read failure must not be
+treated as an empty allocation set; doing so can select an occupied address
+and displace its peer.
+
+Registration handles existing peers as follows:
+
+- **Same subject, new public key:** Reuse the existing IP and replace the
+  transport key.
+- **Same replacement key, new subject:** Retire the old Pod instance before
+  provisioning the replacement.
+- **Same public key, different subject:** Reject with a conflict.
+- **No match:** Allocate the next free address.
+
+`WGServer.AddPeer` installs the public key and IPv4/IPv6 allowed addresses in
+wireguard-go and persists `(pubkey, ip, added_ns)` in `wg_peers`. Migration
+[`0020_wg_peer_enrollment.sql`](../cmd/clawpatrol/migrations/sqlite/0020_wg_peer_enrollment.sql)
+adds the enrollment marker, identity keys, display metadata, profile,
+authorizer, and arbitrary metadata to that row.
+
+After the peer is installed, registration rotates its peer API token, stamps
+the enrollment metadata, seeds the device/agent registries, and returns the
+client configuration and CA bundle. Any failure before the enrollment row is
+committed rolls back the transport peer and token.
+
+## Gateway liveness and reaping
+
+The bridge is the only persistent-keepalive sender. The gateway deliberately
+does not keepalive back: wireguard-go rearms a peer's keepalive timer after
+authenticated traffic in either direction. If both peers send keepalives,
+one direction can continually postpone the other and make receive progress an
+ambiguous liveness signal.
+
+The gateway reaper:
+
+1. samples WireGuard peer receive counters every 20 seconds,
+2. seeds a new or restored peer with a full grace window,
+3. advances `lastProgress` whenever its receive counter increases, and
+4. revokes an enrolled peer once receive progress has been quiet longer than
+   its authorizer's derived liveness window.
+
+The in-memory tracker is keyed by WireGuard public key. Reap count 0 produces
+a zero window and is never reaped. If a persisted peer's authorizer no longer
+exists in the compiled policy, the reaper uses a 75-second fallback so
+orphaned peers still drain.
+
+Cleanup removes the WireGuard peer, database row, peer API tokens, device
+ownership/profile entry, agent registry entry, and liveness tracker.
+
+## Bridge recovery and fail-closed routing
+
+The Linux implementation is in
+[`cmd/clawpatrol/bridge_linux.go`](../cmd/clawpatrol/bridge_linux.go) and
+[`cmd/clawpatrol/bridge_watchdog.go`](../cmd/clawpatrol/bridge_watchdog.go).
+
+Before replacing the Pod's default route, the bridge:
+
+- discovers the original IPv4 route and optional IPv6 route,
+- resolves the gateway API and WireGuard endpoint,
+- reads the current DNS resolvers, and
+- pins those control-plane destinations to the underlay using route protocol
+  111 by default.
+
+The pinned routes keep enrollment, DNS, and the WireGuard handshake reachable
+after all normal Pod traffic is default-routed through the TUN device.
+
+The bridge watchdog samples its receive counter every 5 seconds. Because an
+idle tunnel may have no inbound traffic, receive silence alone is not treated
+as failure. After one keepalive interval of silence, the watchdog probes the
+gateway's tunnel address:
+
+- successful traffic or a successful probe resets the failure count,
+- `--local-reset-missed` failed probes rebuild the peer configuration in
+  place, and
+- failures reaching the server-provided reap count close the session and
+  trigger in-process re-enrollment.
+
+Re-enrollment creates a new keypair and registration but keeps the IP for the
+same authenticated subject. The bridge re-reads resolver and underlay state on
+each attempt and reconciles its tagged routes.
+
+The process does not exit during recovery. Closing the TUN removes the Pod's
+default route, so general egress fails closed until the next session is ready.
+The environment, CA, and ready handoff are written only after the first
+successful bring-up; subsequent sessions reuse the same workload handoff.
+
+On SIGTERM, the bridge performs a bounded best-effort deregistration before
+closing the session.
+
+## Restart and policy reload
+
+`WGServer.loadPeers` restores persisted WireGuard peers when the gateway
+starts. `reconcileEnrolledPeers` then restores their profile, owner, hostname,
+agent registry entry, and a fresh liveness grace window.
+
+The reaper starts whenever the WireGuard server starts, even if enrollment is
+currently absent from the policy. This allows persisted enrolled peers to
+drain after enrollment is removed or temporarily disabled.
+
+Registration resolves the authorizer and liveness settings from the current
+compiled policy, so config reloads affect new registrations immediately.
+Existing peers use their stored authorizer name to resolve the current
+liveness settings on each reap cycle.
+
+## Dashboard data path
+
+`listEnrolledPeerViews` joins persisted enrollment metadata with current
+WireGuard stats and the reaper's in-memory liveness snapshot. The view is
+included in `/api/state` as `enrolled_peers`.
+
+The dashboard joins an enrolled peer to its existing Agent entry by peer IP.
+It then:
+
+- replaces profile editing with the server-assigned profile,
+- hides manual deletion,
+- renders authorizer and subject metadata, and
+- derives the liveness window and missed-interval display from the returned
+  keepalive, reap count, and last receive-progress time.
+
+The dedicated dashboard endpoint `/api/enrollment/peers` exposes the same
+operator view.
+
+## Tests
+
+Focused unit coverage lives in:
+
+- [`enrollment_test.go`](../cmd/clawpatrol/enrollment_test.go): registration,
+  replacement, rollback, reaping, reconciliation, and HTTP guards;
+- [`k8s_registration_test.go`](../cmd/clawpatrol/k8s_registration_test.go):
+  key normalization, ServiceAccount matching, profile allowlists, identity,
+  and cleanup;
+- [`enrollment_client_test.go`](../cmd/clawpatrol/enrollment_client_test.go):
+  request/response and claim gathering;
+- [`bridge_test.go`](../cmd/clawpatrol/bridge_test.go): bridge flag and
+  authorizer parsing;
+- [`bridge_watchdog_test.go`](../cmd/clawpatrol/bridge_watchdog_test.go): receive
+  progress, probes, escalation, and disabled recovery; and
+- [`internal/config/compile_test.go`](../internal/config/compile_test.go):
+  enrollment validation and liveness compilation.
+
+The kind-based
+[`kubernetes-wireguard-e2e.sh`](../e2e/kubernetes-wireguard-e2e.sh) validates
+the explicit Pod contract, tunneled traffic, liveness, in-process recovery,
+fail-closed routing, and cleanup.

--- a/doc/wireguard.md
+++ b/doc/wireguard.md
@@ -5,6 +5,10 @@ kernel module, no `wg-quick` lifecycle on the gateway, no systemd
 unit for the WG interface, no `/etc/hosts` pinning on clients. The
 clawpatrol binary IS the WG endpoint and the L3 forwarder.
 
+For Kubernetes deployments where the gateway and stateless agent pods
+run in-cluster, see the
+[Kubernetes enrollment implementation design](kubernetes-enrollment-design.md).
+
 ## How it works
 
 The gateway runs an embedded **wireguard-go** + a **gVisor netstack**

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,76 @@
+# End-to-end tests
+
+This directory contains repo-level end-to-end validation flows. The
+Kubernetes WireGuard enrollment test is the main one today.
+
+## Kubernetes WireGuard enrollment
+
+Run from the repo root:
+
+```bash
+./e2e/kubernetes-wireguard-e2e.sh
+```
+
+The test expects a local kind cluster named `kind` and a reachable
+`kind-kind` kubectl context. It builds the current workspace binary,
+packages it with the root `Dockerfile`, loads the image into kind, and
+applies the checked-in overlay at
+`e2e/kubernetes-wireguard-e2e-overlay`.
+
+The overlay reuses the example base at
+`examples/kubernetes/kustomization` and changes it to use:
+
+- `clawpatrol-e2e` and `agents-e2e` namespaces,
+- the local `clawpatrol-kind-e2e:dev` image,
+- a short liveness window (a small `keepalive_interval`),
+- an e2e HTTP target used to prove tunneled data-path traffic.
+
+The script validates:
+
+- gateway rollout,
+- workload enrollment through the authorizer,
+- env and CA handoff from the sidecar,
+- restricted agent container contract,
+- tunnel routing through the WireGuard interface,
+- a TCP request through the tunnel,
+- the enrolled `wg_peers` row and WireGuard peer state,
+- rx_bytes liveness (a live tunnel holds its peer past the liveness window),
+- sidecar self-heal (a severed tunnel drives in-process re-enrollment with a
+  fresh key at the reused peer IP and no container restart),
+- graceful deregistration and peer revocation.
+
+By default the script deletes the e2e namespaces and cluster-scoped RBAC
+objects at both start and exit so each run starts from fresh cluster
+state.
+
+## Prerequisites
+
+- `go`
+- `docker`
+- `kind`
+- `kubectl`
+- a running kind cluster named `kind`
+- access to Docker and the kind Kubernetes API from the current shell
+
+The script uses `make build` for the Linux binary and then runs
+`docker build` against the root `Dockerfile`.
+
+## Useful knobs
+
+```bash
+CLAWPATROL_E2E_CLUSTER=kind-dev ./e2e/kubernetes-wireguard-e2e.sh
+CLAWPATROL_E2E_CONTEXT=kind-kind-dev ./e2e/kubernetes-wireguard-e2e.sh
+CLAWPATROL_E2E_SKIP_BUILD=1 ./e2e/kubernetes-wireguard-e2e.sh
+CLAWPATROL_E2E_KEEP_RESOURCES=1 ./e2e/kubernetes-wireguard-e2e.sh
+CLAWPATROL_E2E_CHECK_LIVENESS=0 ./e2e/kubernetes-wireguard-e2e.sh
+CLAWPATROL_E2E_CHECK_EXPIRY=1 ./e2e/kubernetes-wireguard-e2e.sh
+CLAWPATROL_E2E_GOARCH=arm64 ./e2e/kubernetes-wireguard-e2e.sh
+```
+
+`CLAWPATROL_E2E_SKIP_BUILD=1` assumes `clawpatrol-kind-e2e:dev` is
+already loaded into the kind cluster. `CLAWPATROL_E2E_KEEP_RESOURCES=1`
+keeps namespaces and RBAC objects around for debugging; clean them up
+manually afterward.
+
+Image tag, namespace names, RBAC names, and enrollment keepalive tuning are
+owned by the overlay files, not by the shell script.

--- a/e2e/kubernetes-wireguard-e2e-overlay/gateway.hcl
+++ b/e2e/kubernetes-wireguard-e2e-overlay/gateway.hcl
@@ -1,0 +1,33 @@
+# e2e gateway config. Same shape as the base example but scoped to the
+# isolated *-e2e namespaces with a short peer TTL so the e2e exercises
+# enrollment + liveness reaping quickly. The overlay mounts this in place
+# of the base config via a configMapGenerator with `behavior: replace`.
+gateway {
+  dashboard_listen = "0.0.0.0:8080"
+  state_dir        = "/opt/clawpatrol"
+
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    listen_port = 51820
+    endpoint    = "clawpatrol-wg.clawpatrol-e2e.svc:51820"
+  }
+}
+
+enrollment "kubernetes_token_review" "agents" {
+  audience = "clawpatrol"
+
+  match {
+    namespace       = "agents-e2e"
+    service_account = "agent-runner"
+    profile_label   = "clawpatrol.dev/profile"
+    profiles        = ["default"]
+  }
+
+  # Fast reap for the e2e: 10s keepalive × 3 missed = 30s liveness window.
+  keepalive_interval = "10s"
+  keepalive_reap_count = 3
+}
+
+profile "default" {
+  credentials = []
+}

--- a/e2e/kubernetes-wireguard-e2e-overlay/http-echo.yaml
+++ b/e2e/kubernetes-wireguard-e2e-overlay/http-echo.yaml
@@ -1,0 +1,49 @@
+# e2e-only TCP target. The agent curls this through the tunnel to prove the
+# WireGuard data path (not just the control plane). Uses the clawpatrol image
+# (rewritten to the local kind tag by the overlay's images: transformer) for
+# its netcat; the image name must match so the transformer catches it.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clawpatrol-e2e-http
+  namespace: agents-e2e
+  labels:
+    app: clawpatrol-e2e-http
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: http
+      image: ghcr.io/denoland/clawpatrol:latest
+      command: ["/bin/sh", "-lc"]
+      args:
+        - |
+          set -eu
+          while true; do
+            printf 'HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nok\n' | nc -l -p 8081 -q 1
+          done
+      ports:
+        - name: http
+          containerPort: 8081
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clawpatrol-e2e-http
+  namespace: agents-e2e
+spec:
+  selector:
+    app: clawpatrol-e2e-http
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http

--- a/e2e/kubernetes-wireguard-e2e-overlay/kustomization.yaml
+++ b/e2e/kubernetes-wireguard-e2e-overlay/kustomization.yaml
@@ -1,0 +1,79 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../examples/kubernetes/kustomization
+  - http-echo.yaml
+
+# Swap the gateway config for the e2e one (short liveness window + *-e2e namespaces).
+# behavior: replace targets the base configMapGenerator by name+namespace;
+# the namespace is then renamed to clawpatrol-e2e by the patch below.
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: clawpatrol-config
+    namespace: clawpatrol
+    behavior: replace
+    files:
+      - gateway.hcl
+
+# Use the locally-built kind image instead of the published one. Applies to
+# every resource that references it (gateway StatefulSet, agent sidecar,
+# http-echo).
+images:
+  - name: ghcr.io/denoland/clawpatrol
+    newName: clawpatrol-kind-e2e
+    newTag: dev
+
+patches:
+  - target: { version: v1, kind: Namespace, name: clawpatrol }
+    patch: |-
+      - { op: replace, path: /metadata/name, value: clawpatrol-e2e }
+  - target: { version: v1, kind: Namespace, name: agents }
+    patch: |-
+      - { op: replace, path: /metadata/name, value: agents-e2e }
+  - target: { version: v1, kind: ConfigMap, name: clawpatrol-config }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: clawpatrol-e2e }
+  - target: { version: v1, kind: ServiceAccount, name: clawpatrol-gateway }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: clawpatrol-e2e }
+  - target: { version: v1, kind: ServiceAccount, name: agent-runner }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: agents-e2e }
+  - target: { group: apps, version: v1, kind: StatefulSet, name: clawpatrol-gateway }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: clawpatrol-e2e }
+  - target: { version: v1, kind: Service, name: clawpatrol-api }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: clawpatrol-e2e }
+  - target: { version: v1, kind: Service, name: clawpatrol-wg }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: clawpatrol-e2e }
+  - target: { group: rbac.authorization.k8s.io, version: v1, kind: ClusterRole, name: clawpatrol-tokenreview }
+    patch: |-
+      - { op: replace, path: /metadata/name, value: clawpatrol-tokenreview-e2e }
+  - target: { group: rbac.authorization.k8s.io, version: v1, kind: ClusterRoleBinding, name: clawpatrol-tokenreview }
+    patch: |-
+      - { op: replace, path: /metadata/name, value: clawpatrol-tokenreview-e2e }
+      - { op: replace, path: /roleRef/name, value: clawpatrol-tokenreview-e2e }
+      - { op: replace, path: /subjects/0/namespace, value: clawpatrol-e2e }
+  - target: { group: rbac.authorization.k8s.io, version: v1, kind: Role, name: clawpatrol-pod-reader }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: agents-e2e }
+  - target: { group: rbac.authorization.k8s.io, version: v1, kind: RoleBinding, name: clawpatrol-pod-reader }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: agents-e2e }
+      - { op: replace, path: /subjects/0/namespace, value: clawpatrol-e2e }
+  # Reuse the base sample agent as the e2e agent: move it to agents-e2e,
+  # repoint the sidecar initContainer at the e2e gateway, and give
+  # the agent container (container 0) the clawpatrol image so the in-pod
+  # assertions have ip/curl/nc (the base example keeps a minimal workload
+  # image). The images: transformer rewrites it to the local kind tag.
+  - target: { version: v1, kind: Pod, name: clawpatrol-agent-example }
+    patch: |-
+      - { op: replace, path: /metadata/namespace, value: agents-e2e }
+      - op: replace
+        path: /spec/initContainers/0/args/1
+        value: --gateway-url=http://clawpatrol-api.clawpatrol-e2e.svc:8080
+      - { op: replace, path: /spec/containers/0/image, value: ghcr.io/denoland/clawpatrol:latest }

--- a/e2e/kubernetes-wireguard-e2e.sh
+++ b/e2e/kubernetes-wireguard-e2e.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Kubernetes WireGuard enrollment e2e against a local kind cluster.
+#
+# Builds the workspace into a kind-loaded image, applies the e2e kustomize
+# overlay (examples base + *-e2e isolation), and drives the full lifecycle:
+# enroll -> handoff -> restricted-agent contract -> tunnel data path ->
+# wg_peers enrollment row -> rx_bytes liveness -> deregister/reap ->
+# peer revocation.
+#
+# The manifests are the source of truth (examples/kubernetes/kustomization +
+# e2e/kubernetes-wireguard-e2e-overlay); this script only builds the image,
+# applies the overlay, and asserts. It does not template YAML.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OVERLAY="${ROOT}/e2e/kubernetes-wireguard-e2e-overlay"
+DOCKERFILE="${ROOT}/Dockerfile"
+
+CLUSTER_NAME="${CLAWPATROL_E2E_CLUSTER:-kind}"
+KUBE_CONTEXT="${CLAWPATROL_E2E_CONTEXT:-kind-${CLUSTER_NAME}}"
+TIMEOUT="${CLAWPATROL_E2E_TIMEOUT:-180s}"
+SKIP_BUILD="${CLAWPATROL_E2E_SKIP_BUILD:-0}"
+KEEP_RESOURCES="${CLAWPATROL_E2E_KEEP_RESOURCES:-0}"
+CHECK_LIVENESS="${CLAWPATROL_E2E_CHECK_LIVENESS:-1}"
+CHECK_EXPIRY="${CLAWPATROL_E2E_CHECK_EXPIRY:-0}"
+CHECK_ESCALATION="${CLAWPATROL_E2E_CHECK_ESCALATION:-1}"
+GOARCH_OVERRIDE="${CLAWPATROL_E2E_GOARCH:-}"
+
+# These are fixed by the overlay (images: transformer, namespaces, RBAC
+# names, gateway.hcl). Keep them in sync with the overlay if you change it.
+IMAGE="clawpatrol-kind-e2e:dev"
+GATEWAY_NS="clawpatrol-e2e"
+AGENTS_NS="agents-e2e"
+CLUSTER_ROLE_NAME="clawpatrol-tokenreview-e2e"
+E2E_POD="clawpatrol-agent-example"
+E2E_HTTP="clawpatrol-e2e-http"
+
+KUBECTL=(kubectl --context "${KUBE_CONTEXT}")
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/clawpatrol-k8s-e2e.XXXXXX")"
+
+# PEER_TTL is read from the overlay config (in preflight, after the files
+# are confirmed to exist) so the liveness/reap waits stay in sync with what
+# the gateway actually enforces.
+PEER_TTL="30s"
+
+usage() {
+  cat <<'USAGE'
+Run the Kubernetes WireGuard enrollment e2e against a local kind cluster.
+
+  ./e2e/kubernetes-wireguard-e2e.sh
+
+Environment knobs:
+  CLAWPATROL_E2E_CLUSTER         kind cluster name, default: kind
+  CLAWPATROL_E2E_CONTEXT         kubectl context, default: kind-${cluster}
+  CLAWPATROL_E2E_TIMEOUT         kubectl wait timeout, default: 180s
+  CLAWPATROL_E2E_SKIP_BUILD      set 1 to skip go/docker build + kind load
+  CLAWPATROL_E2E_KEEP_RESOURCES  set 1 to skip final namespace cleanup
+  CLAWPATROL_E2E_CHECK_LIVENESS  set 0 to skip the rx_bytes liveness check
+  CLAWPATROL_E2E_CHECK_EXPIRY    set 1 to test reap cleanup (force-delete sidecar)
+  CLAWPATROL_E2E_CHECK_ESCALATION set 0 to skip the sidecar self-heal check
+                                 (gateway → 0 → ICMP probe fails → sidecar fails
+                                 closed and re-enrolls in process with a fresh
+                                 key, no container restart)
+  CLAWPATROL_E2E_GOARCH          override node arch for the Linux build
+
+Image tag, namespaces, peer TTL, and RBAC names live in the overlay
+(e2e/kubernetes-wireguard-e2e-overlay); edit there, not here.
+USAGE
+}
+
+log() { printf '[e2e] %s\n' "$*"; }
+fail() {
+  printf '[e2e] error: %s\n' "$*" >&2
+  exit 1
+}
+need() { command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"; }
+
+seconds_from_duration() {
+  case "$1" in
+    *s) printf '%s\n' "${1%s}" ;;
+    *m) printf '%s\n' "$(( ${1%m} * 60 ))" ;;
+    *h) printf '%s\n' "$(( ${1%h} * 3600 ))" ;;
+    *) printf '30\n' ;;
+  esac
+}
+
+wait_until() {
+  local desc="$1" timeout_s="$2"
+  shift 2
+  local deadline=$((SECONDS + timeout_s))
+  until "$@"; do
+    if (( SECONDS >= deadline )); then
+      return 1
+    fi
+    sleep 2
+  done
+  log "${desc}"
+}
+
+cleanup_cluster() {
+  "${KUBECTL[@]}" delete clusterrolebinding "${CLUSTER_ROLE_NAME}" --ignore-not-found >/dev/null 2>&1 || true
+  "${KUBECTL[@]}" delete clusterrole "${CLUSTER_ROLE_NAME}" --ignore-not-found >/dev/null 2>&1 || true
+  "${KUBECTL[@]}" delete namespace "${AGENTS_NS}" "${GATEWAY_NS}" --ignore-not-found --wait=true --timeout="${TIMEOUT}" >/dev/null 2>&1 || true
+}
+
+on_exit() {
+  local status=$?
+  [[ "${KEEP_RESOURCES}" == "1" ]] || cleanup_cluster
+  rm -rf "${WORKDIR}"
+  exit "${status}"
+}
+trap on_exit EXIT
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+cd "${ROOT}"
+
+need kubectl
+need kind
+need sed
+if [[ "${SKIP_BUILD}" != "1" ]]; then
+  need go
+  need docker
+fi
+[[ -f "${OVERLAY}/kustomization.yaml" ]] || fail "e2e overlay not found: ${OVERLAY}"
+[[ -f "${OVERLAY}/gateway.hcl" ]] || fail "e2e gateway config not found: ${OVERLAY}/gateway.hcl"
+[[ -f "${DOCKERFILE}" ]] || fail "Dockerfile not found: ${DOCKERFILE}"
+
+# Keep the liveness/reap waits in sync with the window the gateway enforces.
+# Liveness is derived: keepalive_interval × keepalive_reap_count.
+KEEPALIVE_INTERVAL="$(sed -n 's/.*keepalive_interval[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "${OVERLAY}/gateway.hcl" | head -1)"
+KEEPALIVE_REAP_COUNT="$(sed -n 's/.*keepalive_reap_count[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*/\1/p' "${OVERLAY}/gateway.hcl" | head -1)"
+KEEPALIVE_INTERVAL="${KEEPALIVE_INTERVAL:-10s}"
+KEEPALIVE_REAP_COUNT="${KEEPALIVE_REAP_COUNT:-3}"
+PEER_TTL="$(( $(seconds_from_duration "${KEEPALIVE_INTERVAL}") * KEEPALIVE_REAP_COUNT ))s"
+
+if ! kind get clusters | grep -Fxq "${CLUSTER_NAME}"; then
+  fail "kind cluster ${CLUSTER_NAME} not found"
+fi
+if ! "${KUBECTL[@]}" get nodes >/dev/null; then
+  fail "kubectl context ${KUBE_CONTEXT} is not reachable"
+fi
+
+log "cleaning previous e2e resources in ${GATEWAY_NS}/${AGENTS_NS}"
+cleanup_cluster
+
+NODE_ARCH="$("${KUBECTL[@]}" get node -o jsonpath='{.items[0].status.nodeInfo.architecture}')"
+GOARCH="${GOARCH_OVERRIDE:-${NODE_ARCH}}"
+case "${GOARCH}" in
+  amd64|arm64) ;;
+  *) fail "unsupported node architecture ${GOARCH}; set CLAWPATROL_E2E_GOARCH" ;;
+esac
+
+if [[ "${SKIP_BUILD}" != "1" ]]; then
+  log "building Linux/${GOARCH} clawpatrol binary"
+  CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" make build
+  cp "${ROOT}/clawpatrol" "${WORKDIR}/clawpatrol"
+
+  log "building image ${IMAGE}"
+  DOCKER_BUILDKIT=0 docker build --platform "linux/${GOARCH}" -f "${DOCKERFILE}" -t "${IMAGE}" "${WORKDIR}"
+
+  log "loading image ${IMAGE} into kind cluster ${CLUSTER_NAME}"
+  kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+else
+  log "skipping image build/load; expecting ${IMAGE} to exist in kind"
+fi
+
+log "applying e2e overlay into ${GATEWAY_NS}/${AGENTS_NS}"
+"${KUBECTL[@]}" apply -k "${OVERLAY}"
+"${KUBECTL[@]}" -n "${GATEWAY_NS}" rollout restart statefulset/clawpatrol-gateway
+
+log "waiting for gateway rollout"
+"${KUBECTL[@]}" -n "${GATEWAY_NS}" rollout status statefulset/clawpatrol-gateway --timeout="${TIMEOUT}"
+"${KUBECTL[@]}" -n "${GATEWAY_NS}" wait --for=condition=Ready pod -l app=clawpatrol-gateway --timeout="${TIMEOUT}"
+
+# Recreate the agent after the gateway rollout so the enrollment assertions
+# start from a clean sidecar session without startup retries.
+log "recreating agent pod against the ready gateway"
+"${KUBECTL[@]}" -n "${AGENTS_NS}" delete pod "${E2E_POD}" --ignore-not-found --wait=true >/dev/null
+"${KUBECTL[@]}" apply -k "${OVERLAY}"
+
+"${KUBECTL[@]}" -n "${AGENTS_NS}" wait --for=condition=Ready "pod/${E2E_HTTP}" --timeout="${TIMEOUT}"
+
+GATEWAY_POD="$("${KUBECTL[@]}" -n "${GATEWAY_NS}" get pod -l app=clawpatrol-gateway -o jsonpath='{.items[0].metadata.name}')"
+HTTP_CLUSTER_IP="$("${KUBECTL[@]}" -n "${AGENTS_NS}" get svc "${E2E_HTTP}" -o jsonpath='{.spec.clusterIP}')"
+
+agent_exec() { "${KUBECTL[@]}" -n "${AGENTS_NS}" exec "${E2E_POD}" -c agent -- "$@"; }
+gateway_exec() { "${KUBECTL[@]}" -n "${GATEWAY_NS}" exec "${GATEWAY_POD}" -c gateway -- "$@"; }
+sqlite_query() { gateway_exec sqlite3 -cmd '.timeout 5000' /opt/clawpatrol/clawpatrol.db "$1"; }
+
+# Enrollment state lives on the wg_peers row (enrolled = 1); there is no
+# separate lease table. The reaper only ever touches enrolled rows.
+enrolled_count() { sqlite_query "SELECT count(*) FROM wg_peers WHERE enrolled = 1 AND display_name = '${AGENTS_NS}/${E2E_POD}';" 2>/dev/null; }
+enrolled_present() { [[ "$(enrolled_count || printf '0')" -ge 1 ]]; }
+enrolled_absent() { [[ "$(enrolled_count || printf '1')" -eq 0 ]]; }
+
+log "waiting for sidecar handoff files"
+wait_until "sidecar wrote ready/env/ca files" 120 \
+  agent_exec sh -lc 'test -f /clawpatrol/ready && test -s /clawpatrol/env && test -s /clawpatrol/ca.crt'
+
+log "checking handoff content (fresh CA is present in the pushed combined bundle)"
+# The sidecar writes the gateway CA and an env file the workload sources; the
+# CA-path pushdown must use the combined system+gateway bundle created after
+# ca.crt is written. NODE_EXTRA_CA_CERTS remains pointed at the gateway CA.
+agent_exec sh -lc 'head -1 /clawpatrol/ca.crt | grep -q "^-----BEGIN CERTIFICATE-----"'
+agent_exec sh -lc '. /clawpatrol/env; test "$SSL_CERT_FILE" = /clawpatrol/ca-bundle.crt; test -s "$SSL_CERT_FILE"; test "$(grep -c "^-----BEGIN CERTIFICATE-----" "$SSL_CERT_FILE")" -gt 1; lines="$(wc -l < /clawpatrol/ca.crt)"; tail -n "$lines" "$SSL_CERT_FILE" | cmp - /clawpatrol/ca.crt'
+agent_exec sh -lc '. /clawpatrol/env; test "$NODE_EXTRA_CA_CERTS" = /clawpatrol/ca.crt'
+
+log "checking restricted agent container contract"
+agent_exec sh -lc 'test ! -e /var/run/secrets/kubernetes.io/serviceaccount/token'
+agent_exec sh -lc 'test ! -e /var/run/secrets/tokens/clawpatrol-token'
+agent_exec sh -lc 'test ! -e /dev/net/tun'
+agent_exec sh -lc 'test "$(awk "/CapEff:/ {print \$2}" /proc/self/status)" = "0000000000000000"'
+agent_exec sh -lc '! ip route add blackhole 198.51.100.0/24 2>/tmp/route.err'
+agent_exec sh -lc '! sh -c "printf x >/clawpatrol/agent-write-test" 2>/tmp/write.err'
+agent_exec sh -lc "! grep -R -i -E 'api_token|private_key|wireguard_private' /clawpatrol 2>/dev/null"
+agent_exec sh -lc 'ip route show default | grep -q "dev clawpatrol0"'
+
+log "checking tunnel route and a relayed TCP request"
+agent_exec sh -lc "ip route get '${HTTP_CLUSTER_IP}' | grep -q 'dev clawpatrol0'"
+agent_exec sh -lc "test \"\$(curl -sS --max-time 10 'http://${HTTP_CLUSTER_IP}:8081/')\" = 'ok'"
+
+log "checking the gateway path is pinned off the tunnel"
+# The sidecar pins the gateway API (+ WG endpoint) to the pod's original
+# default route before flipping the default to clawpatrol0, so enroll /
+# env-pushdown / deregister don't loop back through the tunnel. The API
+# ClusterIP must therefore NOT route via clawpatrol0.
+API_CLUSTER_IP="$("${KUBECTL[@]}" -n "${GATEWAY_NS}" get svc clawpatrol-api -o jsonpath='{.spec.clusterIP}')"
+[[ -n "${API_CLUSTER_IP}" ]] || fail "could not resolve clawpatrol-api ClusterIP"
+agent_exec sh -lc "! ip route get '${API_CLUSTER_IP}' | grep -q 'dev clawpatrol0'"
+# The control-plane pins carry the clawpatrol route protocol (111) so an
+# in-process reconnect (or a genuine restart) can recover the underlay gateway
+# from them when there is no default route. The gateway API pin must show that tag.
+agent_exec sh -lc "ip route show proto 111 | grep -q '${API_CLUSTER_IP}'"
+# The pod's resolver is pinned to the underlay with the same tag, so DNS keeps
+# working across a reconnect (the gateway is resolved by name; SNI/Host stay
+# correct). Read the agent's actual nameserver and require it be pinned.
+AGENT_DNS_IP="$(agent_exec sh -lc "awk '/^nameserver/{print \$2; exit}' /etc/resolv.conf" | tr -d '[:space:]')"
+[[ -n "${AGENT_DNS_IP}" ]] || fail "agent has no resolv.conf nameserver"
+agent_exec sh -lc "ip route show proto 111 | grep -q '${AGENT_DNS_IP}'"
+
+log "checking enrolled peer row and WireGuard peer tables"
+gateway_exec sh -lc 'command -v sqlite3 >/dev/null'
+wait_until "enrolled peer row is present" 60 enrolled_present
+PEER_IP="$(sqlite_query "SELECT ip FROM wg_peers WHERE enrolled = 1 AND display_name = '${AGENTS_NS}/${E2E_POD}' LIMIT 1;")"
+[[ -n "${PEER_IP}" ]] || fail "enrolled peer row did not include an ip"
+sqlite_query "SELECT count(*) FROM wg_peers WHERE ip = '${PEER_IP}';" | grep -qx '1'
+log "enrolled peer ${PEER_IP}"
+
+if [[ "${CHECK_LIVENESS}" == "1" ]]; then
+  # No app-level heartbeat: the gateway drives liveness from WireGuard
+  # rx_bytes movement (persistent-keepalive every keepalive_interval). A live
+  # tunnel must keep its enrolled row past peer_ttl without being reaped.
+  TTL_SECONDS="$(seconds_from_duration "${PEER_TTL}")"
+  SLEEP_SECONDS=$(( TTL_SECONDS + 30 ))
+  log "waiting ${SLEEP_SECONDS}s (> peer_ttl) to confirm keepalive liveness holds the peer"
+  sleep "${SLEEP_SECONDS}"
+  enrolled_present || fail "live peer was reaped despite an active tunnel (rx_bytes liveness regressed)"
+  log "live peer survived past peer_ttl"
+fi
+
+if [[ "${CHECK_ESCALATION}" == "1" ]]; then
+  # Client self-heal, in-process. Scale the gateway to 0 so the sidecar's
+  # liveness probe (ICMP echo to the gateway tunnel IP) fails. The sidecar
+  # rekeys, then tears the tunnel down and re-enrolls — all WITHOUT exiting the
+  # container (a native-sidecar restart lands in the same pod sandbox and buys
+  # nothing a device rebuild doesn't). While the gateway is down it stays
+  # fail-closed: clawpatrol0 is gone, so there is no default route (general
+  # egress is blocked, not leaking untunnelled) while the tagged control-plane
+  # pins survive on the underlay. When the gateway returns it re-enrolls in
+  # place with a fresh key, reusing its peer IP — and the container restart
+  # count never moves.
+  sidecar_restarts() {
+    "${KUBECTL[@]}" -n "${AGENTS_NS}" get pod "${E2E_POD}" \
+      -o jsonpath='{.status.initContainerStatuses[?(@.name=="clawpatrol-bridge")].restartCount}' 2>/dev/null
+  }
+  BEFORE_RESTARTS="$(sidecar_restarts)"
+  BEFORE_RESTARTS="${BEFORE_RESTARTS:-0}"
+  BEFORE_PUBKEY="$(sqlite_query "SELECT pubkey FROM wg_peers WHERE enrolled = 1 AND display_name = '${AGENTS_NS}/${E2E_POD}' LIMIT 1;")"
+  BEFORE_PEER_IP="${PEER_IP}"
+
+  log "severing liveness: scaling gateway to 0 so the sidecar's ICMP probe fails"
+  "${KUBECTL[@]}" -n "${GATEWAY_NS}" scale statefulset/clawpatrol-gateway --replicas=0 >/dev/null
+  "${KUBECTL[@]}" -n "${GATEWAY_NS}" rollout status statefulset/clawpatrol-gateway --timeout="${TIMEOUT}" >/dev/null 2>&1 || true
+
+  # The sidecar escalates to an in-process reconnect: it tears clawpatrol0 down
+  # (so the default route disappears) and cannot re-enroll while the gateway is
+  # down, so it holds fail-closed. Wait for that torn-down state, then assert
+  # the control-plane pins survive and — crucially — the container has NOT
+  # restarted (recovery is in-process, not a kubelet restart).
+  wait_until "sidecar tore the tunnel down and failed closed (no default route)" 150 \
+    agent_exec sh -lc '! ip route show default | grep -q .'
+  log "checking fail-closed gap: no default route, control-plane pins intact, no container restart"
+  agent_exec sh -lc "ip route show proto 111 | grep -q '${API_CLUSTER_IP}'"
+  [[ "$(sidecar_restarts)" == "${BEFORE_RESTARTS}" ]] ||
+    fail "sidecar container restarted during the gap (was ${BEFORE_RESTARTS}); recovery must be in-process"
+
+  log "restoring gateway"
+  "${KUBECTL[@]}" -n "${GATEWAY_NS}" scale statefulset/clawpatrol-gateway --replicas=1 >/dev/null
+  "${KUBECTL[@]}" -n "${GATEWAY_NS}" rollout status statefulset/clawpatrol-gateway --timeout="${TIMEOUT}"
+  "${KUBECTL[@]}" -n "${GATEWAY_NS}" wait --for=condition=Ready pod -l app=clawpatrol-gateway --timeout="${TIMEOUT}"
+  GATEWAY_POD="$("${KUBECTL[@]}" -n "${GATEWAY_NS}" get pod -l app=clawpatrol-gateway -o jsonpath='{.items[0].metadata.name}')"
+
+  # The gateway's DB persists across the scale, so it re-seeds the OLD peer row
+  # on startup — enrolled_present alone would be satisfied by that stale row
+  # before the sidecar re-enrolls. Wait for the pubkey to actually change,
+  # which only the fresh in-process enrollment (new ephemeral key) produces.
+  peer_reenrolled() {
+    local pk
+    pk="$(sqlite_query "SELECT pubkey FROM wg_peers WHERE enrolled = 1 AND display_name = '${AGENTS_NS}/${E2E_POD}' LIMIT 1;" 2>/dev/null)"
+    [[ -n "${pk}" && "${pk}" != "${BEFORE_PUBKEY}" ]]
+  }
+  wait_until "sidecar re-enrolled in-process with a fresh WireGuard key" 180 peer_reenrolled
+  PEER_IP="$(sqlite_query "SELECT ip FROM wg_peers WHERE enrolled = 1 AND display_name = '${AGENTS_NS}/${E2E_POD}' LIMIT 1;")"
+
+  # Recovery stayed in-process: the container restart count must be unchanged.
+  [[ "$(sidecar_restarts)" == "${BEFORE_RESTARTS}" ]] ||
+    fail "sidecar container restarted during recovery (was ${BEFORE_RESTARTS}, now $(sidecar_restarts)); recovery must be in-process"
+
+  # Same-subject renewal reuses the peer IP: the fresh enrollment swaps the
+  # WireGuard key but the gateway hands the identity back its prior slot.
+  [[ "${PEER_IP}" == "${BEFORE_PEER_IP}" ]] ||
+    fail "self-heal did not reuse the peer IP (was ${BEFORE_PEER_IP}, got ${PEER_IP})"
+
+  wait_until "tunnel restored after self-heal" 60 \
+    agent_exec sh -lc "test \"\$(curl -sS --max-time 10 'http://${HTTP_CLUSTER_IP}:8081/')\" = 'ok'"
+  log "sidecar self-healed in-process: 0 container restarts, re-enrolled ${PEER_IP} with a fresh key"
+fi
+
+if [[ "${CHECK_EXPIRY}" == "1" ]]; then
+  TTL_SECONDS="$(seconds_from_duration "${PEER_TTL}")"
+  log "force deleting sidecar pod to test rx_bytes reap cleanup"
+  "${KUBECTL[@]}" -n "${AGENTS_NS}" delete pod "${E2E_POD}" --force --grace-period=0 --wait=true
+  wait_until "enrolled peer went stale and was reaped" "$((TTL_SECONDS + 90))" enrolled_absent
+else
+  log "deleting e2e pod and checking graceful deregistration"
+  "${KUBECTL[@]}" -n "${AGENTS_NS}" delete pod "${E2E_POD}" --wait=true --timeout=60s
+  wait_until "enrolled peer removed" 45 enrolled_absent
+fi
+
+sqlite_query "SELECT count(*) FROM wg_peers WHERE ip = '${PEER_IP}';" | grep -qx '0'
+log "WireGuard peer ${PEER_IP} was revoked"
+log "e2e passed"

--- a/examples/kubernetes/agent-bridge-mutatingadmissionpolicy.yaml
+++ b/examples/kubernetes/agent-bridge-mutatingadmissionpolicy.yaml
@@ -1,0 +1,356 @@
+# Optional admission-based injection for Clawpatrol agent pods.
+#
+# This example injects the same native sidecar and handoff contract used by
+# examples/kubernetes/kustomization/agent.yaml. It is not required for
+# enrollment; an explicit pod spec remains the portable baseline.
+#
+# REVIEW THESE FIXED DEPLOYMENT ASSUMPTIONS BEFORE APPLYING:
+#
+# Scope and identity:
+#   - Workload namespace: `agents`. The binding selects this namespace by its
+#     standard `kubernetes.io/metadata.name` label.
+#   - Pod scope: every Pod CREATE in that namespace is injected unless the Pod
+#     has `clawpatrol.dev/inject: "false"`.
+#   - Profile label: `clawpatrol.dev/profile`.
+#   - Default profile: `default`, added only when the profile label is absent.
+#   - Target Pods must use a ServiceAccount allowed by the `agents` enrollment
+#     authorizer, and the gateway needs Pod-read RBAC in the target namespace.
+#
+# Gateway and enrollment:
+#   - Gateway URL: `http://clawpatrol-api.clawpatrol.svc:8080`, assuming
+#     Service `clawpatrol-api` in namespace `clawpatrol` on port 8080.
+#   - Authorizer: `kubernetes_token_review/agents`.
+#   - Projected ServiceAccount token audience: `clawpatrol`.
+#   - Projected token lifetime: 600 seconds.
+#
+# Image and pod contract:
+#   - Bridge image: `ghcr.io/denoland/clawpatrol:latest`. Pin an immutable
+#     release or digest for production, and add imagePullSecrets if required.
+#   - Reserved container name: `clawpatrol-bridge`.
+#   - Reserved volume names: `clawpatrol`, `clawpatrol-token`, and
+#     `dev-net-tun`. Existing volumes with these names are reused.
+#   - Reserved paths: `/clawpatrol`, `/var/run/secrets/tokens`, and
+#     `/dev/net/tun`. If changed, update every matching argument, mount, and
+#     probe below together.
+#   - Nodes must expose `/dev/net/tun`; the bridge receives `NET_ADMIN`.
+#
+# The policy mounts the `/clawpatrol` handoff volume read-only into every
+# application container. The bridge startup probe delays application startup
+# until `/clawpatrol/env`, `/clawpatrol/ca.crt`, and `/clawpatrol/ready` exist.
+# The application still needs to source `/clawpatrol/env` before starting its
+# workload.
+#
+# Requires a Kubernetes version that serves MutatingAdmissionPolicy and
+# MutatingAdmissionPolicyBinding as admissionregistration.k8s.io/v1.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: clawpatrol-agent-bridge
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: not-opted-out
+      expression: >-
+        !(has(object.metadata.annotations) &&
+          "clawpatrol.dev/inject" in object.metadata.annotations &&
+          object.metadata.annotations["clawpatrol.dev/inject"] == "false")
+    - name: bridge-not-present
+      expression: >-
+        !(has(object.spec.initContainers) &&
+          object.spec.initContainers.exists(c, c.name == "clawpatrol-bridge"))
+  mutations:
+    # Add the default profile only when the Pod does not already select one.
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          has(object.metadata.labels) && "clawpatrol.dev/profile" in object.metadata.labels
+          ? []
+          : (
+            has(object.metadata.labels)
+            ? [JSONPatch{
+                op: "add",
+                path: "/metadata/labels/" + jsonpatch.escapeKey("clawpatrol.dev/profile"),
+                value: "default"
+              }]
+            : [JSONPatch{
+                op: "add",
+                path: "/metadata/labels",
+                value: {"clawpatrol.dev/profile": "default"}
+              }]
+          )
+
+    # Add the handoff, projected-token, and TUN volumes without replacing
+    # unrelated volumes already declared by the workload.
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          has(object.spec.volumes)
+          ? (
+            (object.spec.volumes.exists(v, v.name == "clawpatrol")
+              ? []
+              : [JSONPatch{
+                  op: "add",
+                  path: "/spec/volumes/-",
+                  value: {
+                    "name": dyn("clawpatrol"),
+                    "emptyDir": dyn({})
+                  }
+                }])
+            +
+            (object.spec.volumes.exists(v, v.name == "clawpatrol-token")
+              ? []
+              : [JSONPatch{
+                  op: "add",
+                  path: "/spec/volumes/-",
+                  value: {
+                    "name": dyn("clawpatrol-token"),
+                    "projected": dyn({
+                      "sources": dyn([{
+                        "serviceAccountToken": dyn({
+                          "path": dyn("clawpatrol-token"),
+                          "audience": dyn("clawpatrol"),
+                          "expirationSeconds": dyn(600)
+                        })
+                      }])
+                    })
+                  }
+                }])
+            +
+            (object.spec.volumes.exists(v, v.name == "dev-net-tun")
+              ? []
+              : [JSONPatch{
+                  op: "add",
+                  path: "/spec/volumes/-",
+                  value: {
+                    "name": dyn("dev-net-tun"),
+                    "hostPath": dyn({
+                      "path": dyn("/dev/net/tun"),
+                      "type": dyn("CharDevice")
+                    })
+                  }
+                }])
+          )
+          : [JSONPatch{
+              op: "add",
+              path: "/spec/volumes",
+              value: [
+                {
+                  "name": dyn("clawpatrol"),
+                  "emptyDir": dyn({})
+                },
+                {
+                  "name": dyn("clawpatrol-token"),
+                  "projected": dyn({
+                    "sources": dyn([{
+                      "serviceAccountToken": dyn({
+                        "path": dyn("clawpatrol-token"),
+                        "audience": dyn("clawpatrol"),
+                        "expirationSeconds": dyn(600)
+                      })
+                    }])
+                  })
+                },
+                {
+                  "name": dyn("dev-net-tun"),
+                  "hostPath": dyn({
+                    "path": dyn("/dev/net/tun"),
+                    "type": dyn("CharDevice")
+                  })
+                }
+              ]
+            }]
+
+    # Insert the restartable init container first so its startup probe gates
+    # later init containers and application containers.
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          has(object.spec.initContainers)
+          ? [JSONPatch{
+              op: "add",
+              path: "/spec/initContainers/0",
+              value: {
+                "name": dyn("clawpatrol-bridge"),
+                "restartPolicy": dyn("Always"),
+                "image": dyn("ghcr.io/denoland/clawpatrol:latest"),
+                "imagePullPolicy": dyn("IfNotPresent"),
+                "args": dyn([
+                  "bridge",
+                  "--gateway-url=http://clawpatrol-api.clawpatrol.svc:8080",
+                  "--authorizer=kubernetes_token_review/agents",
+                  "--kubernetes-token-path=/var/run/secrets/tokens/clawpatrol-token",
+                  "--env-out=/clawpatrol/env",
+                  "--ca-out=/clawpatrol/ca.crt",
+                  "--ready-file=/clawpatrol/ready"
+                ]),
+                "startupProbe": dyn({
+                  "exec": dyn({
+                    "command": dyn(["test", "-f", "/clawpatrol/ready"])
+                  }),
+                  "periodSeconds": dyn(1),
+                  "failureThreshold": dyn(120)
+                }),
+                "securityContext": dyn({
+                  "allowPrivilegeEscalation": dyn(false),
+                  "capabilities": dyn({
+                    "add": dyn(["NET_ADMIN"])
+                  })
+                }),
+                "env": dyn([
+                  {
+                    "name": dyn("POD_NAME"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("metadata.name")})
+                    })
+                  },
+                  {
+                    "name": dyn("POD_NAMESPACE"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("metadata.namespace")})
+                    })
+                  },
+                  {
+                    "name": dyn("POD_UID"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("metadata.uid")})
+                    })
+                  },
+                  {
+                    "name": dyn("NODE_NAME"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("spec.nodeName")})
+                    })
+                  }
+                ]),
+                "volumeMounts": dyn([
+                  {
+                    "name": dyn("clawpatrol"),
+                    "mountPath": dyn("/clawpatrol")
+                  },
+                  {
+                    "name": dyn("clawpatrol-token"),
+                    "mountPath": dyn("/var/run/secrets/tokens"),
+                    "readOnly": dyn(true)
+                  },
+                  {
+                    "name": dyn("dev-net-tun"),
+                    "mountPath": dyn("/dev/net/tun")
+                  }
+                ])
+              }
+            }]
+          : [JSONPatch{
+              op: "add",
+              path: "/spec/initContainers",
+              value: [{
+                "name": dyn("clawpatrol-bridge"),
+                "restartPolicy": dyn("Always"),
+                "image": dyn("ghcr.io/denoland/clawpatrol:latest"),
+                "imagePullPolicy": dyn("IfNotPresent"),
+                "args": dyn([
+                  "bridge",
+                  "--gateway-url=http://clawpatrol-api.clawpatrol.svc:8080",
+                  "--authorizer=kubernetes_token_review/agents",
+                  "--kubernetes-token-path=/var/run/secrets/tokens/clawpatrol-token",
+                  "--env-out=/clawpatrol/env",
+                  "--ca-out=/clawpatrol/ca.crt",
+                  "--ready-file=/clawpatrol/ready"
+                ]),
+                "startupProbe": dyn({
+                  "exec": dyn({
+                    "command": dyn(["test", "-f", "/clawpatrol/ready"])
+                  }),
+                  "periodSeconds": dyn(1),
+                  "failureThreshold": dyn(120)
+                }),
+                "securityContext": dyn({
+                  "allowPrivilegeEscalation": dyn(false),
+                  "capabilities": dyn({
+                    "add": dyn(["NET_ADMIN"])
+                  })
+                }),
+                "env": dyn([
+                  {
+                    "name": dyn("POD_NAME"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("metadata.name")})
+                    })
+                  },
+                  {
+                    "name": dyn("POD_NAMESPACE"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("metadata.namespace")})
+                    })
+                  },
+                  {
+                    "name": dyn("POD_UID"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("metadata.uid")})
+                    })
+                  },
+                  {
+                    "name": dyn("NODE_NAME"),
+                    "valueFrom": dyn({
+                      "fieldRef": dyn({"fieldPath": dyn("spec.nodeName")})
+                    })
+                  }
+                ]),
+                "volumeMounts": dyn([
+                  {
+                    "name": dyn("clawpatrol"),
+                    "mountPath": dyn("/clawpatrol")
+                  },
+                  {
+                    "name": dyn("clawpatrol-token"),
+                    "mountPath": dyn("/var/run/secrets/tokens"),
+                    "readOnly": dyn(true)
+                  },
+                  {
+                    "name": dyn("dev-net-tun"),
+                    "mountPath": dyn("/dev/net/tun")
+                  }
+                ])
+              }]
+            }]
+
+    # Make the handoff files available to every application container.
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            spec: Object.spec{
+              containers: object.spec.containers.map(c, Object.spec.containers{
+                name: c.name,
+                volumeMounts: [
+                  Object.spec.containers.volumeMounts{
+                    name: "clawpatrol",
+                    mountPath: "/clawpatrol",
+                    readOnly: true
+                  }
+                ]
+              })
+            }
+          }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: clawpatrol-agent-bridge
+spec:
+  policyName: clawpatrol-agent-bridge
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: agents
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]

--- a/examples/kubernetes/agent-egress-networkpolicy.yaml
+++ b/examples/kubernetes/agent-egress-networkpolicy.yaml
@@ -1,0 +1,78 @@
+# Recommended (defense-in-depth) egress NetworkPolicy for agent pods.
+#
+# This is NOT part of the default Kustomization base and nothing in the
+# enrollment path depends on it. The bridge already fails closed at the
+# routing layer. This policy adds a second, cluster-enforced layer that allows
+# only the egress paths needed for enrollment and the WireGuard tunnel.
+#
+# REVIEW THESE FIXED DEPLOYMENT ASSUMPTIONS BEFORE APPLYING:
+#
+# Workload selection:
+#   - Policy namespace: `agents`.
+#   - Pod selector: `clawpatrol.dev/profile: default`.
+#   - Every matching Pod becomes default-deny for egress except for the rules
+#     below. Narrow or broaden the selector to match the workloads that should
+#     use Clawpatrol.
+#
+# Gateway path:
+#   - Gateway namespace: `clawpatrol`, selected through the standard
+#     `kubernetes.io/metadata.name` namespace label.
+#   - Gateway Pod label: `app: clawpatrol-gateway`.
+#   - Gateway API: TCP 8080.
+#   - WireGuard endpoint: UDP 51820.
+#
+# DNS path:
+#   - DNS namespace: `kube-system`.
+#   - DNS Pod label: `k8s-app: kube-dns`.
+#   - DNS ports: UDP and TCP 53.
+#   - Replace these selectors if the cluster uses different CoreDNS/kube-dns
+#     labels or an external DNS service.
+#
+# Enforcement behavior:
+#   - The CNI must enforce NetworkPolicy, such as Calico or Cilium. Some CNIs,
+#     including kind's default kindnet, do not; this manifest is inert there.
+#   - Once the tunnel is up, workload traffic leaves the Pod as WireGuard
+#     traffic to the gateway. If the tunnel drops, the bridge removes the
+#     default route, so traffic also fails closed at the routing layer.
+#   - Add explicit rules before applying if matching workloads need other
+#     direct cluster services, metadata endpoints, or control planes.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: clawpatrol-agent-egress
+  namespace: agents
+spec:
+  # Scope to enrollment agents. Narrow this podSelector if the namespace also
+  # runs pods that should keep unrestricted egress.
+  podSelector:
+    matchLabels:
+      clawpatrol.dev/profile: default
+  policyTypes:
+    - Egress
+  egress:
+    # clawpatrol gateway: API + WireGuard endpoint.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: clawpatrol
+          podSelector:
+            matchLabels:
+              app: clawpatrol-gateway
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: UDP
+          port: 51820
+    # Cluster DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/examples/kubernetes/kustomization/agent.yaml
+++ b/examples/kubernetes/kustomization/agent.yaml
@@ -1,0 +1,108 @@
+# Explicit, portable agent Pod contract. Keep its namespace, ServiceAccount,
+# profile label, token audience, authorizer, gateway URL, ports, and image in
+# sync with gateway-config.yaml, gateway-rbac.yaml, gateway-services.yaml, and
+# gateway-statefulset.yaml. The admission-policy example beside this directory
+# provides optional automatic injection of the same bridge contract.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-runner
+  namespace: agents
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clawpatrol-agent-example
+  namespace: agents
+  labels:
+    clawpatrol.dev/profile: default
+spec:
+  serviceAccountName: agent-runner
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  volumes:
+    - name: clawpatrol
+      emptyDir: {}
+    - name: clawpatrol-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: clawpatrol-token
+              audience: clawpatrol
+              expirationSeconds: 600
+    - name: dev-net-tun
+      hostPath:
+        path: /dev/net/tun
+        type: CharDevice
+  initContainers:
+    - name: clawpatrol-bridge
+      restartPolicy: Always
+      image: ghcr.io/denoland/clawpatrol:latest
+      args:
+        - bridge
+        - --gateway-url=http://clawpatrol-api.clawpatrol.svc:8080
+        - --authorizer=kubernetes_token_review/agents
+        - --kubernetes-token-path=/var/run/secrets/tokens/clawpatrol-token
+        - --env-out=/clawpatrol/env
+        - --ca-out=/clawpatrol/ca.crt
+        - --ready-file=/clawpatrol/ready
+      startupProbe:
+        exec:
+          command: ["test", "-f", "/clawpatrol/ready"]
+        periodSeconds: 1
+        failureThreshold: 120
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add: ["NET_ADMIN"]
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      volumeMounts:
+        - name: clawpatrol
+          mountPath: /clawpatrol
+        - name: clawpatrol-token
+          mountPath: /var/run/secrets/tokens
+          readOnly: true
+        - name: dev-net-tun
+          mountPath: /dev/net/tun
+  containers:
+    - name: agent
+      image: debian:stable-slim
+      command: ["/bin/sh", "-lc"]
+      args:
+        - |
+          # Wait for the sidecar to bring up the tunnel + write the handoff,
+          # source the gateway CA + credential env, then run your workload.
+          while [ ! -f /clawpatrol/ready ]; do sleep 0.2; done
+          . /clawpatrol/env
+          echo "clawpatrol: tunnel ready; replace this with your agent command"
+          exec sleep infinity
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - name: clawpatrol
+          mountPath: /clawpatrol
+          readOnly: true

--- a/examples/kubernetes/kustomization/gateway-config.yaml
+++ b/examples/kubernetes/kustomization/gateway-config.yaml
@@ -1,0 +1,43 @@
+# Enrollment values in this file must agree with the Kubernetes resources:
+#   - endpoint/API DNS and ports: gateway-services.yaml and agent.yaml;
+#   - authorizer, audience, namespace, ServiceAccount, and profile:
+#     agent.yaml and gateway-rbac.yaml;
+#   - state_dir: gateway-statefulset.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clawpatrol-config
+  namespace: clawpatrol
+data:
+  gateway.hcl: |
+    gateway {
+      dashboard_listen = "0.0.0.0:8080"
+      state_dir        = "/opt/clawpatrol"
+
+      wireguard {
+        subnet_cidr = "10.55.0.0/24"
+        listen_port = 51820
+        endpoint    = "clawpatrol-wg.clawpatrol.svc:51820"
+      }
+    }
+
+    enrollment "kubernetes_token_review" "agents" {
+      audience = "clawpatrol"
+
+      match {
+        namespace       = "agents"
+        service_account = "agent-runner"
+        profile_label   = "clawpatrol.dev/profile"
+        profiles        = ["default"]
+      }
+
+      # Liveness window is derived: keepalive_interval × keepalive_reap_count.
+      # Here 25s × 3 = 75s. A longer interval means fewer keepalive packets and
+      # a longer window; keepalive_interval has no upper bound (min 10s).
+      keepalive_interval   = "25s"
+      keepalive_reap_count = 3
+    }
+
+    profile "default" {
+      credentials = []
+    }

--- a/examples/kubernetes/kustomization/gateway-rbac.yaml
+++ b/examples/kubernetes/kustomization/gateway-rbac.yaml
@@ -1,0 +1,56 @@
+# RBAC is split across scopes: TokenReview is cluster-wide, while Pod reads are
+# granted only in the `agents` workload namespace. If workloads enroll from
+# more namespaces, create the Pod-reader Role and RoleBinding in each one.
+# ServiceAccount and namespace values must match gateway-config.yaml,
+# gateway-statefulset.yaml, and agent.yaml.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clawpatrol-gateway
+  namespace: clawpatrol
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clawpatrol-tokenreview
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clawpatrol-tokenreview
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clawpatrol-tokenreview
+subjects:
+  - kind: ServiceAccount
+    name: clawpatrol-gateway
+    namespace: clawpatrol
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: clawpatrol-pod-reader
+  namespace: agents
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: clawpatrol-pod-reader
+  namespace: agents
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: clawpatrol-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: clawpatrol-gateway
+    namespace: clawpatrol

--- a/examples/kubernetes/kustomization/gateway-services.yaml
+++ b/examples/kubernetes/kustomization/gateway-services.yaml
@@ -1,0 +1,29 @@
+# Service names, namespaces, and ports are embedded in gateway-config.yaml and
+# agent.yaml. Update all three files together when changing the advertised API
+# or WireGuard endpoint.
+apiVersion: v1
+kind: Service
+metadata:
+  name: clawpatrol-api
+  namespace: clawpatrol
+spec:
+  selector:
+    app: clawpatrol-gateway
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clawpatrol-wg
+  namespace: clawpatrol
+spec:
+  selector:
+    app: clawpatrol-gateway
+  ports:
+    - name: wireguard
+      port: 51820
+      protocol: UDP
+      targetPort: wireguard

--- a/examples/kubernetes/kustomization/gateway-statefulset.yaml
+++ b/examples/kubernetes/kustomization/gateway-statefulset.yaml
@@ -1,0 +1,48 @@
+# The config name/state path must match gateway-config.yaml. The image is also
+# used by the bridge in agent.yaml. The PVC uses the cluster's default
+# StorageClass unless an overlay adds storageClassName.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clawpatrol-gateway
+  namespace: clawpatrol
+spec:
+  serviceName: clawpatrol-gateway
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clawpatrol-gateway
+  template:
+    metadata:
+      labels:
+        app: clawpatrol-gateway
+    spec:
+      serviceAccountName: clawpatrol-gateway
+      containers:
+        - name: gateway
+          image: ghcr.io/denoland/clawpatrol:latest
+          args: ["gateway", "/etc/clawpatrol/gateway.hcl"]
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: wireguard
+              containerPort: 51820
+              protocol: UDP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/clawpatrol
+              readOnly: true
+            - name: state
+              mountPath: /opt/clawpatrol
+      volumes:
+        - name: config
+          configMap:
+            name: clawpatrol-config
+  volumeClaimTemplates:
+    - metadata:
+        name: state
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/examples/kubernetes/kustomization/kustomization.yaml
+++ b/examples/kubernetes/kustomization/kustomization.yaml
@@ -1,0 +1,49 @@
+# Opinionated, runnable Kubernetes example for one Clawpatrol gateway and one
+# agent workload namespace. Adapt it with a Kustomize overlay; the e2e overlay at
+# e2e/kubernetes-wireguard-e2e-overlay/kustomization.yaml demonstrates the
+# required patching pattern.
+#
+# RESOURCE MAP:
+#   - namespaces.yaml: creates the `clawpatrol` gateway namespace and `agents`
+#     workload namespace.
+#   - gateway-rbac.yaml: lets the gateway create TokenReviews and read Pods in
+#     the workload namespace.
+#   - gateway-config.yaml: contains gateway.hcl, enrollment identity matching,
+#     profile selection, WireGuard addressing, and liveness tuning.
+#   - gateway-statefulset.yaml: runs the gateway and persists its state.
+#   - gateway-services.yaml: exposes the HTTP API and WireGuard endpoint.
+#   - agent.yaml: explicit agent Pod contract, including the
+#     `clawpatrol-bridge` native sidecar.
+#
+# FIXED ASSUMPTIONS TO REVIEW:
+#   - Gateway namespace: `clawpatrol`.
+#   - Workload namespace: `agents`.
+#   - Gateway ServiceAccount: `clawpatrol-gateway`.
+#   - Workload ServiceAccount: `agent-runner`.
+#   - API Service: `clawpatrol-api.clawpatrol.svc:8080`.
+#   - WireGuard Service: `clawpatrol-wg.clawpatrol.svc:51820`.
+#   - Enrollment authorizer: `kubernetes_token_review/agents`.
+#   - Projected token audience: `clawpatrol`.
+#   - Profile label/default: `clawpatrol.dev/profile=default`.
+#   - Image: `ghcr.io/denoland/clawpatrol:latest`; pin a release or digest for
+#     production.
+#   - Storage: the gateway PVC relies on the cluster's default StorageClass.
+#
+# Namespace, ServiceAccount, authorizer, audience, profile, Service DNS, and
+# port changes span more than one file. Search this directory for the old value
+# and update every matching declaration/reference in the overlay.
+#
+# Optional hardening examples live beside this directory and are intentionally
+# not part of the runnable base:
+#   - ../agent-bridge-mutatingadmissionpolicy.yaml
+#   - ../agent-egress-networkpolicy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - gateway-rbac.yaml
+  - gateway-config.yaml
+  - gateway-statefulset.yaml
+  - gateway-services.yaml
+  - agent.yaml

--- a/examples/kubernetes/kustomization/namespaces.yaml
+++ b/examples/kubernetes/kustomization/namespaces.yaml
@@ -1,0 +1,12 @@
+# These names are referenced by gateway-config.yaml, gateway-rbac.yaml,
+# gateway-services.yaml, and agent.yaml. Change them through an overlay and
+# update all cross-namespace subjects and Service DNS names at the same time.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clawpatrol
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agents

--- a/examples/wireguard-enrollment-kubernetes.hcl
+++ b/examples/wireguard-enrollment-kubernetes.hcl
@@ -1,0 +1,39 @@
+# WireGuard enrollment for Kubernetes agent pods.
+#
+# The gateway runs the userspace WireGuard server. Agent pods run a
+# privileged native sidecar init container running `clawpatrol bridge`
+# that self-enrolls through the `kubernetes_token_review` authorizer while
+# the execution container stays restricted.
+
+gateway {
+  dashboard_listen = "0.0.0.0:8080"
+  state_dir        = "/opt/clawpatrol"
+
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    listen_port = 51820
+    endpoint    = "clawpatrol-wg.clawpatrol.svc:51820"
+  }
+}
+
+enrollment "kubernetes_token_review" "agents" {
+  audience = "clawpatrol"
+
+  match {
+    namespace       = "agents"
+    service_account = "agent-runner"
+    profile_label   = "clawpatrol.dev/profile"
+    profiles        = ["default"]
+  }
+
+  # Liveness is derived: keepalive_interval × keepalive_reap_count. A peer is
+  # reaped after `keepalive_reap_count` missed keepalives. Here: 25s × 3 = 75s.
+  # A longer interval means fewer keepalive packets and a longer window;
+  # keepalive_interval has no upper bound (minimum 10s).
+  keepalive_interval = "25s"
+  keepalive_reap_count = 3
+}
+
+profile "default" {
+  credentials = []
+}

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -52,6 +52,12 @@ type CompiledPolicy struct {
 	// pointers into the same Entity records, no copies.
 	Approvers   map[string]*Entity
 	Credentials map[string]*Entity
+
+	// Enrollments authorize new peers into profiles independently of endpoint
+	// routing. Each generic envelope carries the plugin-specific compiled body
+	// and the shared liveness policy.
+	Enrollments       []*CompiledEnrollment
+	EnrollmentsByName map[string]*CompiledEnrollment
 }
 
 // CompiledProfile binds an identity to the endpoint set its requests
@@ -295,6 +301,8 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		Tunnels:        map[string]*CompiledTunnel{},
 		Approvers:      p.Approvers,
 		Credentials:    p.Credentials,
+
+		EnrollmentsByName: map[string]*CompiledEnrollment{},
 	}
 
 	// Compile tunnels first so endpoint compilation can resolve
@@ -447,6 +455,10 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 		dedupePatterns(&profile.HostPatterns)
 		sortHostPatterns(profile.HostPatterns)
 		cp.Profiles[name] = profile
+	}
+
+	if err := compileEnrollments(cp, p); err != nil {
+		return nil, err
 	}
 
 	return cp, nil

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -114,6 +114,185 @@ func TestCompile(t *testing.T) {
 	}
 }
 
+func TestEnrollmentConfigValidation(t *testing.T) {
+	// Enrollment is a top-level block (sibling of profile/credential), not
+	// nested in gateway { ... }.
+	const enrollBlock = `enrollment "kubernetes_token_review" "agents" {
+  audience = "clawpatrol"
+
+  match {
+    namespace       = "agents"
+    service_account = "agent-runner"
+    profile_label   = "clawpatrol.dev/profile"
+    profiles        = ["default"]
+  }
+
+  keepalive_interval = "20s"
+  keepalive_reap_count = 6
+}
+`
+	valid := `gateway {
+  state_dir = "/opt/clawpatrol"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "clawpatrol-wg.clawpatrol.svc:51820"
+  }
+}
+
+` + enrollBlock + `
+profile "default" { credentials = [] }
+`
+	gw, diags := config.LoadBytes([]byte(valid), "k8s.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("valid config diagnostics: %v", diags)
+	}
+	if !gw.IsEnrollmentEnabled() {
+		t.Fatal("enrollment should be enabled")
+	}
+	ent, ok := gw.Policy.Enrollments["agents"]
+	if !ok {
+		t.Fatalf("enrollment %q not loaded; have %v", "agents", gw.Policy.Enrollments)
+	}
+	if ent.Plugin.Type != "kubernetes_token_review" {
+		t.Fatalf("enrollment type = %q, want kubernetes_token_review", ent.Plugin.Type)
+	}
+	ke, ok := ent.Body.(*config.K8sEnrollment)
+	if !ok {
+		t.Fatalf("enrollment body = %T, want *config.K8sEnrollment", ent.Body)
+	}
+	if ke.KeepaliveInterval != "20s" || ke.KeepaliveReapCount == nil || *ke.KeepaliveReapCount != 6 {
+		t.Fatalf("keepalive/reap = %q/%v, want 20s/6", ke.KeepaliveInterval, ke.KeepaliveReapCount)
+	}
+	if len(ke.Matches) != 1 || ke.Matches[0].ProfileLabel != "clawpatrol.dev/profile" {
+		t.Fatalf("unexpected matches: %+v", ke.Matches)
+	}
+
+	// The compiled policy exposes the parsed, profile-resolved form.
+	cp, err := config.Compile(gw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	enrollment := cp.EnrollmentsByName["agents"]
+	if enrollment == nil {
+		t.Fatalf("compiled enrollment %q missing", "agents")
+	}
+	if enrollment.Type != "kubernetes_token_review" {
+		t.Fatalf("compiled enrollment type = %q, want kubernetes_token_review", enrollment.Type)
+	}
+	enr, ok := enrollment.Body.(*config.CompiledK8sEnrollment)
+	if !ok {
+		t.Fatalf("compiled enrollment body = %T, want *config.CompiledK8sEnrollment", enrollment.Body)
+	}
+	if enr.Audience != "clawpatrol" || len(enr.Matches) != 1 {
+		t.Fatalf("unexpected compiled enrollment body: %+v", enr)
+	}
+	// Liveness is derived and shared: keepalive_interval × keepalive_reap_count = 20s×6 = 2m.
+	l := enrollment.Liveness
+	if l.KeepaliveInterval != 20*time.Second || l.ReapCount != 6 || l.LivenessWindow() != 2*time.Minute {
+		t.Fatalf("compiled keepalive/reap/liveness = %s/%d/%s, want 20s/6/2m",
+			l.KeepaliveInterval, l.ReapCount, l.LivenessWindow())
+	}
+
+	dump, err := gw.Dump()
+	if err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+	if !strings.Contains(string(dump), `"enrollments"`) {
+		t.Fatalf("dump does not use enrollment shape:\n%s", dump)
+	}
+
+	// profile_label defaults to clawpatrol.dev/profile when omitted.
+	noLabel := strings.Replace(valid, `    profile_label   = "clawpatrol.dev/profile"`+"\n", "", 1)
+	gw2, diags := config.LoadBytes([]byte(noLabel), "k8s-nolabel.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("no-label config diagnostics: %v", diags)
+	}
+	ke2 := gw2.Policy.Enrollments["agents"].Body.(*config.K8sEnrollment)
+	if ke2.Matches[0].ProfileLabel != config.K8sDefaultProfileLabel {
+		t.Fatalf("default profile_label = %q, want %q", ke2.Matches[0].ProfileLabel, config.K8sDefaultProfileLabel)
+	}
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "missing audience",
+			body: strings.Replace(valid, `  audience = "clawpatrol"`+"\n", "", 1),
+			want: `The argument "audience" is required`,
+		},
+		{
+			name: "keepalive_interval below minimum",
+			body: strings.Replace(valid, `keepalive_interval = "20s"`, `keepalive_interval = "5s"`, 1),
+			want: "Invalid enrollment keepalive_interval",
+		},
+		{
+			name: "keepalive_reap_count of 1 rejected",
+			body: strings.Replace(valid, `keepalive_reap_count = 6`, `keepalive_reap_count = 1`, 1),
+			want: "Invalid enrollment keepalive_reap_count",
+		},
+		{
+			name: "missing match",
+			body: strings.Replace(valid, `  match {
+    namespace       = "agents"
+    service_account = "agent-runner"
+    profile_label   = "clawpatrol.dev/profile"
+    profiles        = ["default"]
+  }
+`, "", 1),
+			want: "Missing enrollment match",
+		},
+		{
+			name: "match missing profiles",
+			body: strings.Replace(valid, `    profiles        = ["default"]`+"\n", "", 1),
+			want: `The argument "profiles" is required`,
+		},
+		{
+			name: "unknown profile",
+			body: strings.Replace(valid, `profiles        = ["default"]`, `profiles        = ["ghost"]`, 1),
+			want: "Unknown enrollment profile",
+		},
+		{
+			name: "no wireguard",
+			body: strings.Replace(valid, `  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint = "clawpatrol-wg.clawpatrol.svc:51820"
+  }
+`, "", 1),
+			want: "enrollment requires a wireguard block",
+		},
+		{
+			name: "duplicate enrollment",
+			body: strings.Replace(valid, enrollBlock, enrollBlock+enrollBlock, 1),
+			want: "Duplicate enrollment name",
+		},
+		{
+			name: "unsupported type",
+			body: strings.Replace(valid, `enrollment "kubernetes_token_review" "agents"`, `enrollment "oidc_jwt" "agents"`, 1),
+			want: "Unknown enrollment type",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, diags := config.LoadBytes([]byte(tc.body), tc.name+".hcl")
+			if !diags.HasErrors() {
+				t.Fatalf("expected diagnostics")
+			}
+			found := false
+			for _, d := range diags {
+				if strings.Contains(d.Summary, tc.want) || strings.Contains(d.Detail, tc.want) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("diagnostics = %v, want %q", diags, tc.want)
+			}
+		})
+	}
+}
+
 // TestCompileWildcardHosts verifies that wildcard hosts are accepted,
 // land in HostPatterns (not HostIndex), and that malformed wildcards
 // or within-endpoint duplicates are rejected at load time.
@@ -503,5 +682,95 @@ func TestCompileFullSpec(t *testing.T) {
 	}
 	if totalRules < 50 {
 		t.Errorf("expected ~50+ rule attachments, got %d", totalRules)
+	}
+}
+
+// TestEnrollmentLivenessDerivation covers the derived liveness window:
+// defaults when the knobs are omitted, and keepalive_reap_count = 0 disabling
+// reaping (LivenessWindow() == 0).
+func TestEnrollmentLivenessDerivation(t *testing.T) {
+	base := func(knobs string) string {
+		return `gateway {
+  state_dir = "/opt/clawpatrol"
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    endpoint    = "clawpatrol-wg.clawpatrol.svc:51820"
+  }
+}
+
+enrollment "kubernetes_token_review" "agents" {
+  audience = "clawpatrol"
+  match {
+    namespace       = "agents"
+    service_account = "agent-runner"
+    profiles        = ["default"]
+  }
+` + knobs + `}
+
+profile "default" { credentials = [] }
+`
+	}
+
+	cases := []struct {
+		name           string
+		knobs          string
+		wantKeepalive  time.Duration
+		wantMultiplier int
+		wantLiveness   time.Duration
+	}{
+		{
+			name:           "defaults",
+			knobs:          "",
+			wantKeepalive:  config.EnrollmentDefaultKeepalive,
+			wantMultiplier: config.EnrollmentDefaultReapCount,
+			wantLiveness:   config.EnrollmentDefaultKeepalive * config.EnrollmentDefaultReapCount,
+		},
+		{
+			name:           "explicit",
+			knobs:          "  keepalive_interval = \"20s\"\n  keepalive_reap_count = 5\n",
+			wantKeepalive:  20 * time.Second,
+			wantMultiplier: 5,
+			wantLiveness:   100 * time.Second,
+		},
+		{
+			name:           "disabled",
+			knobs:          "  keepalive_reap_count = 0\n",
+			wantKeepalive:  config.EnrollmentDefaultKeepalive,
+			wantMultiplier: 0,
+			wantLiveness:   0, // reaping disabled
+		},
+		{
+			// No upper bound on keepalive_interval: a long interval is accepted
+			// (the 25s rekey-safety ceiling was lifted once the sidecar became
+			// the sole keepalive sender + ICMP-probe liveness).
+			name:           "long keepalive allowed",
+			knobs:          "  keepalive_interval = \"120s\"\n  keepalive_reap_count = 3\n",
+			wantKeepalive:  120 * time.Second,
+			wantMultiplier: 3,
+			wantLiveness:   6 * time.Minute,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw, diags := config.LoadBytes([]byte(base(tc.knobs)), "k8s.hcl")
+			if diags.HasErrors() {
+				t.Fatalf("diagnostics: %v", diags)
+			}
+			cp, err := config.Compile(gw)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			enrollment := cp.EnrollmentsByName["agents"]
+			if enrollment == nil {
+				t.Fatal("compiled enrollment liveness missing")
+			}
+			l := enrollment.Liveness
+			if l.KeepaliveInterval != tc.wantKeepalive || l.ReapCount != tc.wantMultiplier || l.LivenessWindow() != tc.wantLiveness {
+				t.Fatalf("keepalive/reap/liveness = %s/%d/%s, want %s/%d/%s",
+					l.KeepaliveInterval, l.ReapCount, l.LivenessWindow(),
+					tc.wantKeepalive, tc.wantMultiplier, tc.wantLiveness)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -359,6 +359,14 @@ func (g *Gateway) IsTailscaleEnabled() bool {
 	return g != nil && g.Settings != nil && g.Settings.Tailscale != nil
 }
 
+// IsEnrollmentEnabled reports whether workload self-enrollment is
+// configured. Presence of at least one `enrollment "<type>" "<name>"`
+// block (routed through the config-plugin registry into
+// Policy.Enrollments) enables it.
+func (g *Gateway) IsEnrollmentEnabled() bool {
+	return g != nil && g.Policy != nil && len(g.Policy.Enrollments) > 0
+}
+
 // settings returns g.Settings, or a zero-value pointer when nil so
 // callers can read fields without a nil check. Internal helper —
 // validateOperational rejects configs with a nil Settings block.
@@ -531,6 +539,7 @@ type Policy struct {
 	Endpoints   map[string]*Entity
 	Rules       map[string]*Entity
 	Tunnels     map[string]*Entity
+	Enrollments map[string]*Entity
 
 	Profiles map[string]*Profile
 
@@ -952,6 +961,7 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 		Endpoints:   make(map[string]*Entity),
 		Rules:       make(map[string]*Entity),
 		Tunnels:     make(map[string]*Entity),
+		Enrollments: make(map[string]*Entity),
 		Profiles:    make(map[string]*Profile),
 	}
 
@@ -985,6 +995,10 @@ func loadFiles(files []*hcl.File, configDir string, diags hcl.Diagnostics) (*Gat
 	resolveDiags := decodePolicyBlocks(gw.Policy, table, evalCtx, configDir)
 	diags = append(diags, resolveDiags...)
 	diags = append(diags, validateHITLAsyncConfig(gw)...)
+	// Cross-block precondition: workload enrollment provisions WireGuard
+	// peers, so it requires a wireguard data-plane block. Mirrors how
+	// #753 runs validateOIDCEnrollmentsForGateway after the policy decode.
+	diags = append(diags, validateEnrollmentGateway(gw)...)
 
 	// Post-decode pass: substitute `<<file:NAME>>` markers in plugin
 	// body fields that opted in via FileIncludable. Runs after Build
@@ -1227,6 +1241,7 @@ func extractPolicyBlocks(body hcl.Body) (hcl.Blocks, hcl.Diagnostics) {
 			{Type: "approver", LabelNames: []string{"type", "name"}},
 			{Type: "credential", LabelNames: []string{"type", "name"}},
 			{Type: "endpoint", LabelNames: []string{"type", "name"}},
+			{Type: "enrollment", LabelNames: []string{"type", "name"}},
 			{Type: "rule", LabelNames: []string{"name"}},
 			{Type: "profile", LabelNames: []string{"name"}},
 			{Type: "tunnel", LabelNames: []string{"type", "name"}},
@@ -1312,7 +1327,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 	// ordering — symbols are populated in pass 1 — but matching decode
 	// order to compile order keeps Order[] stable across the file's
 	// declaration sequence and avoids surprising readers.
-	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule} {
+	for _, kind := range []Kind{KindApprover, KindCredential, KindTunnel, KindEndpoint, KindRule, KindEnrollment} {
 		for _, sym := range table.byKind[kind] {
 			plugin := Lookup(sym.Kind, sym.Type)
 			if plugin == nil {
@@ -1344,7 +1359,7 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 			}
 			refs, refDiags := resolveRefs(target, sym.Name, plugin, table, sym.Block.DefRange)
 			diags = append(diags, refDiags...)
-			ctx := &BuildCtx{Refs: refs, Symbols: table, Block: sym.Block}
+			ctx := &BuildCtx{Refs: refs, Symbols: table, Policy: p, Block: sym.Block}
 			if plugin.Validate != nil {
 				diags = append(diags, plugin.Validate(target, sym.Name, ctx)...)
 			}
@@ -1368,6 +1383,8 @@ func decodePolicyBlocks(p *Policy, table *SymbolTable, evalCtx *hcl.EvalContext,
 				p.Endpoints[sym.Name] = ent
 			case KindRule:
 				p.Rules[sym.Name] = ent
+			case KindEnrollment:
+				p.Enrollments[sym.Name] = ent
 			}
 			p.Order = append(p.Order, sym.Name)
 		}

--- a/internal/config/dump.go
+++ b/internal/config/dump.go
@@ -161,6 +161,9 @@ func dumpPolicy(p *Policy) map[string]any {
 	if v := dumpEntityMap(p.Tunnels); v != nil {
 		out["tunnels"] = v
 	}
+	if v := dumpEntityMap(p.Enrollments); v != nil {
+		out["enrollments"] = v
+	}
 	if v := dumpProfiles(p.Profiles); v != nil {
 		out["profiles"] = v
 	}

--- a/internal/config/emit.go
+++ b/internal/config/emit.go
@@ -168,6 +168,7 @@ func Emit(gw *Gateway) ([]byte, error) {
 	emitGroup(body, p, KindTunnel)
 	emitGroup(body, p, KindEndpoint)
 	emitGroup(body, p, KindRule)
+	emitGroup(body, p, KindEnrollment)
 	emitGroup(body, p, KindProfile)
 
 	return f.Bytes(), nil
@@ -350,6 +351,12 @@ func leftoverNames(p *Policy, kind Kind, emitted map[string]bool) []string {
 				out = append(out, n)
 			}
 		}
+	case KindEnrollment:
+		for n := range p.Enrollments {
+			if !emitted[n] {
+				out = append(out, n)
+			}
+		}
 	case KindProfile:
 		for n := range p.Profiles {
 			if !emitted[n] {
@@ -393,6 +400,12 @@ func emitOne(body *hclwrite.Body, p *Policy, kind Kind, name string) bool {
 			return false
 		}
 		emitEntityBlock(body, "tunnel", ent, name)
+	case KindEnrollment:
+		ent, ok := p.Enrollments[name]
+		if !ok {
+			return false
+		}
+		emitEntityBlock(body, "enrollment", ent, name)
 	case KindProfile:
 		pr, ok := p.Profiles[name]
 		if !ok {

--- a/internal/config/enrollment_compile.go
+++ b/internal/config/enrollment_compile.go
@@ -1,0 +1,61 @@
+package config
+
+import "fmt"
+
+// CompiledEnrollment is the type-neutral runtime form of an enrollment block.
+// Body is owned by the enrollment plugin; Liveness is shared framework policy.
+type CompiledEnrollment struct {
+	Name     string
+	Type     string
+	Body     any
+	Liveness EnrollmentLiveness
+}
+
+func compileEnrollments(cp *CompiledPolicy, p *Policy) error {
+	if cp == nil || p == nil || len(p.Enrollments) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	emit := func(name string) error {
+		if seen[name] {
+			return nil
+		}
+		ent, ok := p.Enrollments[name]
+		if !ok || ent == nil {
+			return nil
+		}
+		seen[name] = true
+		if ent.Plugin == nil || ent.Plugin.CompileEnrollment == nil {
+			return fmt.Errorf("enrollment %q type %q has no compiler", name, pluginType(ent.Plugin))
+		}
+		body, liveness, err := ent.Plugin.CompileEnrollment(ent.Body, name, cp.Profiles)
+		if err != nil {
+			return err
+		}
+		compiled := &CompiledEnrollment{
+			Name:     name,
+			Type:     ent.Plugin.Type,
+			Body:     body,
+			Liveness: liveness,
+		}
+		cp.Enrollments = append(cp.Enrollments, compiled)
+		cp.EnrollmentsByName[name] = compiled
+		return nil
+	}
+
+	// Follow declaration order for deterministic list output, then sweep any
+	// enrollment omitted from Order defensively.
+	for _, name := range p.Order {
+		if _, ok := p.Enrollments[name]; ok {
+			if err := emit(name); err != nil {
+				return err
+			}
+		}
+	}
+	for name := range p.Enrollments {
+		if err := emit(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/config/enrollment_liveness.go
+++ b/internal/config/enrollment_liveness.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+// Enrollment liveness is shared across all enrollment authorizer types.
+// The enrolled peer sends WireGuard keepalives, and the gateway reaps it when
+// its receive counter stays quiet for the configured number of keepalive
+// intervals. A new authorizer type reuses these knobs, their derivation, and
+// the reaper by returning an EnrollmentLiveness from its compile hook.
+const (
+	// EnrollmentDefaultKeepalive is the persistent-keepalive interval applied
+	// by enrolled peers when keepalive_interval is omitted.
+	EnrollmentDefaultKeepalive = 25 * time.Second
+	// EnrollmentMinKeepalive keeps the shortest liveness window
+	// (2 × 10s) aligned with the gateway's 20s reaper cadence.
+	EnrollmentMinKeepalive = 10 * time.Second
+	// EnrollmentDefaultReapCount is the number of missed keepalives before an
+	// enrolled peer is reaped when keepalive_reap_count is omitted.
+	EnrollmentDefaultReapCount = 3
+	// EnrollmentMinReapCount is the smallest non-zero reap count. Below 2 a
+	// single dropped keepalive would reap a live peer; 0 disables reaping.
+	EnrollmentMinReapCount = 2
+)
+
+// EnrollmentLiveness is the resolved keepalive/reap tuning carried by each
+// CompiledEnrollment, so shared runtime behavior does not need to understand
+// the plugin-specific compiled body.
+type EnrollmentLiveness struct {
+	// KeepaliveInterval is the resolved persistent-keepalive interval.
+	KeepaliveInterval time.Duration
+	// ReapCount is the resolved missed-keepalive count before reap; 0 means
+	// reaping (and the client's self-heal escalation) is disabled.
+	ReapCount int
+}
+
+// LivenessWindow is the derived rx-quiet grace window before an enrolled peer
+// is reaped (KeepaliveInterval × ReapCount), or 0 when reaping is disabled.
+func (l EnrollmentLiveness) LivenessWindow() time.Duration {
+	if l.ReapCount <= 0 {
+		return 0
+	}
+	return l.KeepaliveInterval * time.Duration(l.ReapCount)
+}
+
+// resolveEnrollmentLiveness applies defaults to the raw keepalive_interval +
+// keepalive_reap_count knobs. Range validation happens at load time via the
+// validateEnrollment* helpers; this only fills in the defaults.
+func resolveEnrollmentLiveness(keepaliveRaw string, reapCount *int) (EnrollmentLiveness, error) {
+	ka, err := parseOptionalDuration(keepaliveRaw)
+	if err != nil {
+		return EnrollmentLiveness{}, err
+	}
+	if ka == 0 {
+		ka = EnrollmentDefaultKeepalive
+	}
+	rc := EnrollmentDefaultReapCount
+	if reapCount != nil {
+		rc = *reapCount
+	}
+	return EnrollmentLiveness{KeepaliveInterval: ka, ReapCount: rc}, nil
+}
+
+// enrollmentDiag builds an hcl error diagnostic anchored at the enrollment
+// block, shared by every authorizer type's validation.
+func enrollmentDiag(ctx *BuildCtx, summary, detail string) *hcl.Diagnostic {
+	d := &hcl.Diagnostic{Severity: hcl.DiagError, Summary: summary, Detail: detail}
+	if ctx != nil && ctx.Block != nil {
+		d.Subject = &ctx.Block.DefRange
+	}
+	return d
+}
+
+// validateEnrollmentKeepaliveInterval accepts an empty string (attr omitted)
+// or a Go duration ≥ EnrollmentMinKeepalive. There is no upper bound (see the
+// EnrollmentMinKeepalive block).
+func validateEnrollmentKeepaliveInterval(ctx *BuildCtx, name, raw string) hcl.Diagnostics {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return hcl.Diagnostics{enrollmentDiag(ctx, "Invalid enrollment keepalive_interval",
+			fmt.Sprintf("enrollment %q keepalive_interval = %q must be a positive Go duration string such as \"25s\".", name, raw))}
+	}
+	if d < EnrollmentMinKeepalive {
+		return hcl.Diagnostics{enrollmentDiag(ctx, "Invalid enrollment keepalive_interval",
+			fmt.Sprintf("enrollment %q keepalive_interval = %q is below the %s minimum.", name, raw, EnrollmentMinKeepalive))}
+	}
+	return nil
+}
+
+// validateEnrollmentReapCount accepts nil (attr omitted), 0 (reaping
+// disabled), or an integer ≥ EnrollmentMinReapCount. A count of 1 would reap
+// a peer after a single missed keepalive, so it is rejected.
+func validateEnrollmentReapCount(ctx *BuildCtx, name string, rc *int) hcl.Diagnostics {
+	if rc == nil || *rc == 0 {
+		return nil
+	}
+	if *rc < EnrollmentMinReapCount {
+		return hcl.Diagnostics{enrollmentDiag(ctx, "Invalid enrollment keepalive_reap_count",
+			fmt.Sprintf("enrollment %q keepalive_reap_count = %d must be 0 (disable reaping) or ≥ %d; a smaller value would reap a live peer after a single missed keepalive.", name, *rc, EnrollmentMinReapCount))}
+	}
+	return nil
+}

--- a/internal/config/k8s_compile.go
+++ b/internal/config/k8s_compile.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// CompiledK8sEnrollment is the plugin-owned runtime body for a
+// kubernetes_token_review enrollment.
+type CompiledK8sEnrollment struct {
+	Audience string
+	Matches  []CompiledK8sMatch
+}
+
+// CompiledK8sMatch is one identity → profile-binding rule.
+type CompiledK8sMatch struct {
+	Namespace      string
+	ServiceAccount string
+	ProfileLabel   string
+	Profiles       []string
+}
+
+func compileK8sEnrollment(body any, name string, profiles map[string]*CompiledProfile) (any, EnrollmentLiveness, error) {
+	ke, ok := body.(*K8sEnrollment)
+	if !ok {
+		return nil, EnrollmentLiveness{}, fmt.Errorf("enrollment %q: unexpected body %T", name, body)
+	}
+	liveness, err := resolveEnrollmentLiveness(ke.KeepaliveInterval, ke.KeepaliveReapCount)
+	if err != nil {
+		return nil, EnrollmentLiveness{}, fmt.Errorf("enrollment %q keepalive_interval: %w", name, err)
+	}
+	compiled := &CompiledK8sEnrollment{Audience: ke.Audience}
+	for _, m := range ke.Matches {
+		for _, prof := range m.Profiles {
+			if _, ok := profiles[prof]; !ok {
+				return nil, EnrollmentLiveness{}, fmt.Errorf("enrollment %q: profile %q not compiled", name, prof)
+			}
+		}
+		compiled.Matches = append(compiled.Matches, CompiledK8sMatch{
+			Namespace:      m.Namespace,
+			ServiceAccount: m.ServiceAccount,
+			ProfileLabel:   m.ProfileLabel,
+			Profiles:       append([]string(nil), m.Profiles...),
+		})
+	}
+	return compiled, liveness, nil
+}
+
+func parseOptionalDuration(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(raw)
+}

--- a/internal/config/k8s_enrollment.go
+++ b/internal/config/k8s_enrollment.go
@@ -1,0 +1,208 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// K8sDefaultProfileLabel is the Pod label a kubernetes_token_review match
+// reads the clawpatrol profile from when `profile_label` is omitted.
+const K8sDefaultProfileLabel = "clawpatrol.dev/profile"
+
+// k8sEnrollmentType is the enrollment plugin type label.
+const k8sEnrollmentType = "kubernetes_token_review"
+
+// K8sEnrollment is the built (canonical) form of a
+// `enrollment "kubernetes_token_review" "<name>" { ... }` block. It is
+// what the plugin's Build returns and what the runtime and emit paths
+// read; the plugin compile hook lowers it into a CompiledK8sEnrollment
+// carried by the generic CompiledEnrollment envelope.
+type K8sEnrollment struct {
+	Audience string     `json:"audience"`
+	Matches  []K8sMatch `json:"match"`
+	// KeepaliveInterval is the raw time.ParseDuration string for the
+	// WireGuard persistent-keepalive interval, empty when omitted (defaults
+	// to EnrollmentDefaultKeepalive). KeepaliveReapCount is the missed-
+	// keepalive count before an enrolled peer is reaped, nil when omitted
+	// (defaults to EnrollmentDefaultReapCount); 0 disables reaping. The
+	// liveness window is derived (keepalive × reap count), never set directly.
+	KeepaliveInterval  string `json:"keepalive_interval,omitempty"`
+	KeepaliveReapCount *int   `json:"keepalive_reap_count,omitempty"`
+}
+
+// K8sMatch is one identity → profile-binding rule. A Pod is matched on
+// namespace + service_account; its profile is then read from the Pod
+// label named by ProfileLabel and must appear in Profiles.
+type K8sMatch struct {
+	Namespace      string   `json:"namespace"`
+	ServiceAccount string   `json:"service_account"`
+	ProfileLabel   string   `json:"profile_label"`
+	Profiles       []string `json:"profiles"`
+}
+
+// k8sEnrollmentBody is the body of an `enrollment
+// "kubernetes_token_review" "<name>"` block. It authorizes Kubernetes
+// workloads to self-enroll as transient WireGuard peers by verifying a
+// projected ServiceAccount token with the Kubernetes TokenReview API.
+type k8sEnrollmentBody struct {
+	// Audience is passed to Kubernetes TokenReview and must match the
+	// projected ServiceAccount token's audience. Required.
+	Audience string `hcl:"audience"`
+	// Matches are the repeated `match { ... }` rules. Each binds one
+	// namespace + service_account identity to a profile allowlist. At
+	// least one is required.
+	Matches []k8sMatchBody `hcl:"match,block"`
+	// KeepaliveInterval is the WireGuard persistent-keepalive interval
+	// (time.ParseDuration) the sidecar applies to enrolled peers and pushed to
+	// it at enroll. Optional; defaults to 25s and must be at least 10s (the
+	// floor is pinned to the gateway reaper's sample cadence). There is no
+	// upper bound: a longer interval just means fewer keepalive packets and a
+	// longer liveness window (keepalive_interval × keepalive_reap_count).
+	KeepaliveInterval string `hcl:"keepalive_interval,optional"`
+	// KeepaliveReapCount is how many missed keepalives elapse before an
+	// enrolled peer is reaped; the liveness window is keepalive_interval ×
+	// keepalive_reap_count. Expressing it as a count keeps the safety ratio
+	// an integer that can't be misconfigured. Optional; defaults to 3. Set to
+	// 0 to disable reaping (and the sidecar's self-heal escalation) entirely;
+	// any other value must be 2 or greater.
+	KeepaliveReapCount *int `hcl:"keepalive_reap_count,optional"`
+}
+
+// k8sMatchBody is one identity → profile-binding rule inside a
+// kubernetes_token_review enrollment.
+type k8sMatchBody struct {
+	// Namespace the pod must run in. Required.
+	Namespace string `hcl:"namespace"`
+	// ServiceAccount the pod's token must belong to. Required.
+	ServiceAccount string `hcl:"service_account"`
+	// ProfileLabel is the Pod label the clawpatrol profile is read from.
+	// Optional; defaults to "clawpatrol.dev/profile".
+	ProfileLabel string `hcl:"profile_label,optional"`
+	// Profiles is the allowlist of profiles a matched pod may bind. The
+	// value of the profile_label pod label must appear here. Required
+	// (at least one), and each must be a declared `profile "<name>"`.
+	Profiles []string `hcl:"profiles"`
+}
+
+func init() {
+	Register(&Plugin{
+		Kind:              KindEnrollment,
+		Type:              k8sEnrollmentType,
+		New:               func() any { return new(k8sEnrollmentBody) },
+		Validate:          validateK8sEnrollment,
+		Build:             buildK8sEnrollment,
+		CompileEnrollment: compileK8sEnrollment,
+		Emit:              emitK8sEnrollment,
+	})
+}
+
+func validateK8sEnrollment(decoded any, name string, ctx *BuildCtx) hcl.Diagnostics {
+	body := decoded.(*k8sEnrollmentBody)
+	var diags hcl.Diagnostics
+
+	if strings.TrimSpace(body.Audience) == "" {
+		diags = append(diags, enrollmentDiag(ctx, "Missing enrollment audience",
+			fmt.Sprintf("enrollment %q requires `audience` so projected ServiceAccount tokens are scoped to clawpatrol.", name)))
+	}
+	if len(body.Matches) == 0 {
+		diags = append(diags, enrollmentDiag(ctx, "Missing enrollment match",
+			fmt.Sprintf("enrollment %q requires at least one `match { namespace = ..., service_account = ..., profiles = [...] }` block.", name)))
+	}
+	for i, m := range body.Matches {
+		if strings.TrimSpace(m.Namespace) == "" {
+			diags = append(diags, enrollmentDiag(ctx, "Invalid enrollment match",
+				fmt.Sprintf("enrollment %q match[%d] is missing `namespace`.", name, i)))
+		}
+		if strings.TrimSpace(m.ServiceAccount) == "" {
+			diags = append(diags, enrollmentDiag(ctx, "Invalid enrollment match",
+				fmt.Sprintf("enrollment %q match[%d] is missing `service_account`.", name, i)))
+		}
+		if len(m.Profiles) == 0 {
+			diags = append(diags, enrollmentDiag(ctx, "Invalid enrollment match",
+				fmt.Sprintf("enrollment %q match[%d] is missing at least one profile.", name, i)))
+		}
+		for j, prof := range m.Profiles {
+			if strings.TrimSpace(prof) == "" {
+				diags = append(diags, enrollmentDiag(ctx, "Invalid enrollment match",
+					fmt.Sprintf("enrollment %q match[%d].profiles[%d] is empty.", name, i, j)))
+				continue
+			}
+			// Each listed profile must resolve to a declared
+			// `profile "<name>"` — resolved through the symbol table like
+			// the OIDC enrollment plugin resolves its target profile.
+			if ctx != nil && ctx.Symbols != nil && ctx.Symbols.Get(KindProfile, prof) == nil {
+				diags = append(diags, enrollmentDiag(ctx, "Unknown enrollment profile",
+					fmt.Sprintf("enrollment %q match[%d] targets profile %q which is not declared.", name, i, prof)))
+			}
+		}
+	}
+
+	diags = append(diags, validateEnrollmentKeepaliveInterval(ctx, name, body.KeepaliveInterval)...)
+	diags = append(diags, validateEnrollmentReapCount(ctx, name, body.KeepaliveReapCount)...)
+	return diags
+}
+
+func buildK8sEnrollment(decoded any, _ string, _ *BuildCtx) (any, hcl.Diagnostics) {
+	body := decoded.(*k8sEnrollmentBody)
+	out := &K8sEnrollment{
+		Audience:           body.Audience,
+		KeepaliveInterval:  body.KeepaliveInterval,
+		KeepaliveReapCount: body.KeepaliveReapCount,
+	}
+	for _, m := range body.Matches {
+		label := strings.TrimSpace(m.ProfileLabel)
+		if label == "" {
+			label = K8sDefaultProfileLabel
+		}
+		out.Matches = append(out.Matches, K8sMatch{
+			Namespace:      m.Namespace,
+			ServiceAccount: m.ServiceAccount,
+			ProfileLabel:   label,
+			Profiles:       append([]string(nil), m.Profiles...),
+		})
+	}
+	return out, nil
+}
+
+func emitK8sEnrollment(body any, _ string, b *hclwrite.Body) {
+	ke := body.(*K8sEnrollment)
+	b.SetAttributeValue("audience", cty.StringVal(ke.Audience))
+	for _, m := range ke.Matches {
+		mb := b.AppendNewBlock("match", nil).Body()
+		mb.SetAttributeValue("namespace", cty.StringVal(m.Namespace))
+		mb.SetAttributeValue("service_account", cty.StringVal(m.ServiceAccount))
+		if m.ProfileLabel != "" {
+			mb.SetAttributeValue("profile_label", cty.StringVal(m.ProfileLabel))
+		}
+		mb.SetAttributeValue("profiles", StringListVal(m.Profiles))
+	}
+	if ke.KeepaliveInterval != "" {
+		b.SetAttributeValue("keepalive_interval", cty.StringVal(ke.KeepaliveInterval))
+	}
+	if ke.KeepaliveReapCount != nil {
+		b.SetAttributeValue("keepalive_reap_count", cty.NumberIntVal(int64(*ke.KeepaliveReapCount)))
+	}
+}
+
+// validateEnrollmentGateway enforces the cross-block invariant that
+// workload enrollment provisions WireGuard peers, so a `wireguard { ... }`
+// data-plane block must be declared whenever any enrollment is configured.
+// Mirrors how the OIDC enrollment plugin validates gateway-level
+// preconditions after per-block decode.
+func validateEnrollmentGateway(gw *Gateway) hcl.Diagnostics {
+	if gw == nil || gw.Policy == nil || len(gw.Policy.Enrollments) == 0 {
+		return nil
+	}
+	if gw.Settings == nil || gw.Settings.WireGuard == nil {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "enrollment requires a wireguard block",
+			Detail:   "`enrollment` provisions WireGuard peers; declare a `wireguard { ... }` block for the data plane.",
+		}}
+	}
+	return nil
+}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -34,13 +34,14 @@ const (
 	KindApprover   Kind = "approver"
 	KindProfile    Kind = "profile"
 	KindTunnel     Kind = "tunnel"
+	KindEnrollment Kind = "enrollment"
 )
 
 // LabelCount returns how many labels a block of this kind carries
 // (excluding the kind keyword itself).
 func (k Kind) LabelCount() int {
 	switch k {
-	case KindEndpoint, KindCredential, KindApprover, KindTunnel:
+	case KindEndpoint, KindCredential, KindApprover, KindTunnel, KindEnrollment:
 		return 2 // first = type, second = name
 	case KindRule, KindProfile:
 		return 1 // name
@@ -103,6 +104,11 @@ type Plugin struct {
 	// interface escape hatch).
 	CompileRule func(body any, name string) (*CompiledRule, []string, error)
 
+	// CompileEnrollment lowers an enrollment plugin's Build output into its
+	// runtime-specific body plus the shared liveness policy. The framework
+	// wraps both in a CompiledEnrollment and indexes it by name.
+	CompileEnrollment func(body any, name string, profiles map[string]*CompiledProfile) (any, EnrollmentLiveness, error)
+
 	// Runtime is type-asserted by callers based on Kind:
 	//   KindEndpoint   → runtime.EndpointRuntime
 	//   KindCredential → runtime.CredentialRuntime
@@ -152,6 +158,7 @@ type Plugin struct {
 type BuildCtx struct {
 	Refs    *Refs
 	Symbols *SymbolTable
+	Policy  *Policy
 	Block   *hcl.Block // for diagnostic ranges when nothing more precise is available
 }
 

--- a/internal/config/symbols.go
+++ b/internal/config/symbols.go
@@ -66,6 +66,7 @@ var blockKinds = map[string]Kind{
 	"approver":   KindApprover,
 	"profile":    KindProfile,
 	"tunnel":     KindTunnel,
+	"enrollment": KindEnrollment,
 }
 
 // buildSymbols is pass 1. It walks the parsed file's policy blocks,

--- a/internal/tools/docgen/docgen_test.go
+++ b/internal/tools/docgen/docgen_test.go
@@ -50,6 +50,46 @@ func TestGatewayPluginBlockIsOptional(t *testing.T) {
 	}
 }
 
+func TestEnrollmentRequiredFields(t *testing.T) {
+	got, err := render.Generate()
+	if err != nil {
+		t.Fatalf("render.Generate: %v", err)
+	}
+	const heading = "### `enrollment \"kubernetes_token_review\" \"<name>\"`"
+	start := strings.Index(got, heading)
+	if start < 0 {
+		t.Fatalf("generated config reference missing %s", heading)
+	}
+	section := got[start:]
+	if end := strings.Index(section, "\n## "); end >= 0 {
+		section = section[:end]
+	}
+	for _, row := range []string{
+		"| `audience` | `string` | yes |",
+		"| `match` | `block` | yes |",
+		"| `keepalive_interval` | `string` | no |",
+		"| `keepalive_reap_count` | `int` | no |",
+		"| `namespace` | `string` | yes |",
+		"| `service_account` | `string` | yes |",
+		"| `profile_label` | `string` | no |",
+		"| `profiles` | `[]string` | yes |",
+	} {
+		if !strings.Contains(section, row) {
+			t.Errorf("generated config reference missing row prefix %q", row)
+		}
+	}
+	if !strings.Contains(section, `enrollment "kubernetes_token_review" "example" {
+  audience = "example"
+  match {
+    namespace = "example"
+    service_account = "example"
+    profiles = ["example"]
+  }
+}`) {
+		t.Error("generated Kubernetes enrollment example omits required fields")
+	}
+}
+
 func firstDiff(a, b []string) string {
 	n := len(a)
 	if len(b) < n {

--- a/internal/tools/docgen/internal/render/render.go
+++ b/internal/tools/docgen/internal/render/render.go
@@ -47,6 +47,7 @@ func (r *renderer) run() (string, error) {
 		config.KindApprover,
 		config.KindCredential,
 		config.KindEndpoint,
+		config.KindEnrollment,
 		config.KindRule,
 		config.KindTunnel,
 	} {
@@ -60,7 +61,7 @@ func (r *renderer) writeHeader() {
 
 A clawpatrol gateway config mixes **operational** settings in the
 required top-level ` + "`gateway { ... }`" + ` block with **policy** blocks.
-Policy blocks (` + "`approver`, `credential`, `tunnel`, `endpoint`, `rule`" + `)
+Policy blocks (` + "`approver`, `credential`, `tunnel`, `endpoint`, `enrollment`, `rule`" + `)
 dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
@@ -77,7 +78,7 @@ Each block section lists the attributes the loader accepts, with:
 - **Required** — ` + "`yes`" + ` if the loader rejects the block when the
   attribute is missing.
 
-Plugin-dispatched kinds (` + "`approver`, `credential`, `tunnel`, `endpoint`, `rule`" + `)
+Plugin-dispatched kinds (` + "`approver`, `credential`, `tunnel`, `endpoint`, `enrollment`, `rule`" + `)
 list one subsection per registered type.
 
 `)
@@ -146,7 +147,7 @@ func upperFirst(s string) string {
 
 func (r *renderer) writeOperational() {
 	r.out.WriteString("## Top-level blocks\n\n")
-	r.out.WriteString("Operational settings live under the required top-level `gateway { ... }` block. The optional `defaults { ... }` block carries policy fallbacks. Labeled policy blocks (`profile`, `approver`, `credential`, `endpoint`, `rule`, `tunnel`) are documented in their own sections.\n\n")
+	r.out.WriteString("Operational settings live under the required top-level `gateway { ... }` block. The optional `defaults { ... }` block carries policy fallbacks. Labeled policy blocks (`profile`, `approver`, `credential`, `endpoint`, `enrollment`, `rule`, `tunnel`) are documented in their own sections.\n\n")
 	r.writeStructTable("config", "Gateway", reflect.TypeOf(config.Gateway{}))
 	r.out.WriteString("## `gateway { ... }`\n\n")
 	r.out.WriteString("The gateway block carries operational settings — listen addresses, the WireGuard / Tailscale transport sub-blocks, session and retention windows, telemetry, and the resolver.\n\n")
@@ -345,6 +346,9 @@ func (r *renderer) collectFields(pkgName, typeName string, rt reflect.Type) []fi
 		if pkgName == "config" && typeName == "Gateway" && f.Name == "Settings" {
 			required = true
 		}
+		if pkgName == "config" && typeName == "k8sEnrollmentBody" && f.Name == "Matches" {
+			required = true
+		}
 		row := fieldRow{
 			Name:        name,
 			Type:        typeStr,
@@ -373,7 +377,7 @@ func skipPublicConfigReferenceField(pkgName, typeName, fieldName string) bool {
 func (r *renderer) fieldRefs(pkgName, typeName string) map[string]string {
 	out := map[string]string{}
 	for _, kind := range []config.Kind{
-		config.KindApprover, config.KindCredential, config.KindTunnel, config.KindEndpoint, config.KindRule,
+		config.KindApprover, config.KindCredential, config.KindTunnel, config.KindEndpoint, config.KindRule, config.KindEnrollment,
 	} {
 		for _, p := range config.AllPlugins(kind) {
 			rt := pluginStructType(p)
@@ -484,6 +488,13 @@ func exampleBody(kind, typ string, rt reflect.Type) string {
 			continue
 		}
 		fmt.Fprintf(&sb, "  %s = %s\n", name, val)
+	}
+	if kind == "enrollment" && typ == "kubernetes_token_review" {
+		fmt.Fprintln(&sb, "  match {")
+		fmt.Fprintln(&sb, `    namespace = "example"`)
+		fmt.Fprintln(&sb, `    service_account = "example"`)
+		fmt.Fprintln(&sb, `    profiles = ["example"]`)
+		fmt.Fprintln(&sb, "  }")
 	}
 	return sb.String()
 }

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -142,6 +142,40 @@ If you're on the unprivileged path and a command needs to act as root:
   command runs in the normal host environment where `sudo` works —
   you run it directly, not through `clawpatrol run`.
 
+### `clawpatrol bridge`
+
+Run the resident Linux data plane used by Kubernetes agent pods. The
+bridge self-enrolls through a configured authorizer, creates a userspace
+WireGuard tunnel, routes the pod network namespace through the gateway,
+and writes the environment and CA handoff files consumed by the
+unprivileged workload container.
+
+```bash
+clawpatrol bridge \
+  --gateway-url=http://clawpatrol-api.clawpatrol.svc:8080 \
+  --authorizer=kubernetes_token_review/agents
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--gateway-url URL` | required | Gateway API URL used for enrollment and env pushdown |
+| `--authorizer TYPE/NAME` | required | Enrollment provider and configured authorizer, for example `kubernetes_token_review/agents` |
+| `--kubernetes-token-path PATH` | `/var/run/secrets/tokens/clawpatrol-token` | Projected ServiceAccount token presented by the Kubernetes enrollment provider |
+| `--env-out PATH` | `/clawpatrol/env` | Shell exports written for the workload container |
+| `--ca-out PATH` | `/clawpatrol/ca.crt` | Gateway CA bundle written for the workload container |
+| `--ready-file PATH` | `/clawpatrol/ready` | Marker written after tunnel and handoff setup succeed |
+| `--iface NAME` | `clawpatrol0` | TUN interface name |
+| `--mtu N` | `1420` | Requested TUN MTU; the gateway's enrollment response can override it |
+| `--local-reset-missed N` | `2` | Failed liveness probes before rebuilding the peer in place; `0` disables the local reset stage |
+| `--route-proto PROTO` | `111` | Route protocol tag used for pinned gateway and DNS underlay routes |
+
+The bridge needs `NET_ADMIN`, `/dev/net/tun`, the projected token, and
+the downward-API `POD_NAME`, `POD_NAMESPACE`, and `POD_UID` environment
+variables. It remains in the foreground, heals a failed tunnel in
+process, and best-effort deregisters on shutdown. See
+[Kubernetes Enrollment](kubernetes-enrollment) for the complete pod
+contract, gateway configuration, and lifecycle.
+
 ### `clawpatrol test`
 
 Replay recorded gateway actions against a candidate HCL policy and

--- a/site/doc/config-reference.md
+++ b/site/doc/config-reference.md
@@ -2,7 +2,7 @@
 
 A clawpatrol gateway config mixes **operational** settings in the
 required top-level `gateway { ... }` block with **policy** blocks.
-Policy blocks (`approver`, `credential`, `tunnel`, `endpoint`, `rule`)
+Policy blocks (`approver`, `credential`, `tunnel`, `endpoint`, `enrollment`, `rule`)
 dispatch to a plugin chosen by the block's first label.
 
 ## How to read this page
@@ -19,12 +19,12 @@ Each block section lists the attributes the loader accepts, with:
 - **Required** — `yes` if the loader rejects the block when the
   attribute is missing.
 
-Plugin-dispatched kinds (`approver`, `credential`, `tunnel`, `endpoint`, `rule`)
+Plugin-dispatched kinds (`approver`, `credential`, `tunnel`, `endpoint`, `enrollment`, `rule`)
 list one subsection per registered type.
 
 ## Top-level blocks
 
-Operational settings live under the required top-level `gateway { ... }` block. The optional `defaults { ... }` block carries policy fallbacks. Labeled policy blocks (`profile`, `approver`, `credential`, `endpoint`, `rule`, `tunnel`) are documented in their own sections.
+Operational settings live under the required top-level `gateway { ... }` block. The optional `defaults { ... }` block carries policy fallbacks. Labeled policy blocks (`profile`, `approver`, `credential`, `endpoint`, `enrollment`, `rule`, `tunnel`) are documented in their own sections.
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -593,6 +593,49 @@ Family: `ssh`.
 ```hcl
 endpoint "ssh" "example" {
   hosts = ["api.example.com"]
+}
+```
+
+## `enrollment` blocks
+
+Block syntax: `enrollment "<type>" "<name>" { ... }`
+
+Registered types: [`kubernetes_token_review`](#enrollment-kubernetestokenreview).
+
+### `enrollment "kubernetes_token_review" "<name>"`
+
+The body of an `enrollment
+"kubernetes_token_review" "<name>"` block. It authorizes Kubernetes
+workloads to self-enroll as transient WireGuard peers by verifying a
+projected ServiceAccount token with the Kubernetes TokenReview API.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `audience` | `string` | yes | Passed to Kubernetes TokenReview and must match the projected ServiceAccount token's audience. Required. |
+| `match` | `block` | yes | The repeated `match { ... }` rules. Each binds one namespace + service_account identity to a profile allowlist. At least one is required. |
+| `keepalive_interval` | `string` | no | The WireGuard persistent-keepalive interval (time.ParseDuration) the sidecar applies to enrolled peers and pushed to it at enroll. Optional; defaults to 25s and must be at least 10s (the floor is pinned to the gateway reaper's sample cadence). There is no upper bound: a longer interval just means fewer keepalive packets and a longer liveness window (keepalive_interval × keepalive_reap_count). |
+| `keepalive_reap_count` | `int` | no | How many missed keepalives elapse before an enrolled peer is reaped; the liveness window is keepalive_interval × keepalive_reap_count. Expressing it as a count keeps the safety ratio an integer that can't be misconfigured. Optional; defaults to 3. Set to 0 to disable reaping (and the sidecar's self-heal escalation) entirely; any other value must be 2 or greater. |
+
+**Nested block `match {}`:**
+
+One identity → profile-binding rule inside a
+kubernetes_token_review enrollment.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | `string` | yes | The pod must run in. Required. |
+| `service_account` | `string` | yes | The pod's token must belong to. Required. |
+| `profile_label` | `string` | no | The Pod label the clawpatrol profile is read from. Optional; defaults to "clawpatrol.dev/profile". |
+| `profiles` | `[]string` | yes | The allowlist of profiles a matched pod may bind. The value of the profile_label pod label must appear here. Required (at least one), and each must be a declared `profile "<name>"`. |
+
+```hcl
+enrollment "kubernetes_token_review" "example" {
+  audience = "example"
+  match {
+    namespace = "example"
+    service_account = "example"
+    profiles = ["example"]
+  }
 }
 ```
 

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -47,6 +47,11 @@ non-tailnet devices reach the gateway over Tailscale Funnel.
 Both blocks can coexist — peers from either transport land in the
 same MITM handler. Drop either block to disable that transport.
 
+For same-cluster Kubernetes deployments with stateless agent pods, use
+[Kubernetes Enrollment](/docs/kubernetes-enrollment/). That mode
+lets each pod self-register as a short-lived WireGuard peer using
+Kubernetes TokenReview while the execution container remains restricted.
+
 #### Required tailnet ACL
 
 The gateway routes client traffic by acting as their **Tailscale

--- a/site/doc/kubernetes-enrollment.md
+++ b/site/doc/kubernetes-enrollment.md
@@ -1,0 +1,315 @@
+# Kubernetes Enrollment
+
+Claw Patrol can run inside Kubernetes with one long-lived gateway pod and
+stateless agent pods that appear only for the lifetime of a job. Each agent
+pod self-enrolls as a transient WireGuard peer using a projected Kubernetes
+ServiceAccount token, so it does not need a pre-created peer or human approval.
+
+This mode is for same-cluster deployments where:
+
+- the gateway runs in Kubernetes,
+- agent pods are created on demand,
+- the agent container must remain restricted, and
+- a privileged networking sidecar is acceptable outside the agent container.
+
+## Architecture
+
+The deployment has three parts:
+
+- **Gateway pod:** Runs `clawpatrol gateway`, the dashboard/API, and the
+  userspace WireGuard server. It can create Kubernetes TokenReviews and read
+  allowed agent Pods.
+- **Clawpatrol bridge:** Runs `clawpatrol bridge` as a restartable native
+  sidecar under `initContainers`. It owns the projected token, `/dev/net/tun`,
+  `NET_ADMIN`, enrollment, and pod routing.
+- **Agent container:** Runs the workload without a Kubernetes token,
+  `/dev/net/tun`, or added capabilities. It receives only a read-only handoff
+  volume from the bridge.
+
+The bridge startup probe checks `/clawpatrol/ready`. Kubernetes does not start
+the agent container until tunnel setup and the environment/CA handoff have
+succeeded.
+
+## Gateway configuration
+
+Enrollment uses a top-level
+`enrollment "kubernetes_token_review" "<name>"` block alongside `profile` and
+`credential` blocks. It requires a `wireguard` block, which is the only
+supported enrollment transport in v1.
+
+```hcl
+gateway {
+  dashboard_listen = "0.0.0.0:8080"
+  state_dir        = "/opt/clawpatrol"
+
+  wireguard {
+    subnet_cidr = "10.55.0.0/24"
+    listen_port = 51820
+    endpoint    = "clawpatrol-wg.clawpatrol.svc:51820"
+  }
+}
+
+enrollment "kubernetes_token_review" "agents" {
+  audience = "clawpatrol"
+
+  match {
+    namespace       = "agents"
+    service_account = "agent-runner"
+    profile_label   = "clawpatrol.dev/profile"
+    profiles        = ["default"]
+  }
+
+  keepalive_interval   = "25s"
+  keepalive_reap_count = 3
+}
+
+profile "default" {
+  credentials = []
+}
+```
+
+The enrollment configuration follows these rules:
+
+- **Authorizer:** The two block labels specify the authorizer type and instance
+  name. Together, they form the `--authorizer <type>/<name>` value used by the
+  bridge.
+- **Identity matching:** Each `match` block allows one Kubernetes namespace
+  and ServiceAccount pairing.
+- **Profile selection:** The gateway reads the profile from the live Pod label
+  named by `profile_label`, which defaults to
+  `clawpatrol.dev/profile`. The value must appear in the match's `profiles`
+  allowlist. The client cannot select its own profile.
+- **Additional identities:** Add more `match` blocks to authorize other
+  namespace and ServiceAccount pairings.
+
+The complete standalone example is
+[`examples/wireguard-enrollment-kubernetes.hcl`](https://github.com/denoland/clawpatrol/blob/main/examples/wireguard-enrollment-kubernetes.hcl).
+
+## Security boundary
+
+The gateway uses userspace WireGuard and does not need kernel WireGuard
+privileges.
+
+The projected ServiceAccount token must be bound to the enrolling Pod. The
+gateway verifies its configured audience and bound Pod name and UID through
+TokenReview, then confirms the same UID and ServiceAccount on the live Pod.
+
+The bridge owns all privileged and enrollment-sensitive state:
+
+- the projected Kubernetes token,
+- the WireGuard private key and peer API token in memory,
+- `/dev/net/tun` and `NET_ADMIN`, and
+- pod routing.
+
+The agent container receives only:
+
+- `/clawpatrol/env`,
+- `/clawpatrol/ca.crt`,
+- `/clawpatrol/ready`, and
+- the network namespace configured by the bridge.
+
+The WireGuard private key and peer API token are never written to the shared
+volume.
+
+## Gateway RBAC
+
+The gateway ServiceAccount needs:
+
+- `create` on `tokenreviews.authentication.k8s.io`, and
+- `get` on Pods in namespaces that can run enrolled agents.
+
+The example RBAC grants only those permissions.
+
+## Agent pod contract
+
+The bridge needs:
+
+- `NET_ADMIN`,
+- `/dev/net/tun`,
+- a projected ServiceAccount token using the configured audience,
+- Downward API values for `POD_NAME`, `POD_NAMESPACE`, `POD_UID`, and
+  `NODE_NAME`, and
+- read-write access to a shared `emptyDir` mounted at `/clawpatrol`.
+
+The agent container should:
+
+- omit the Kubernetes token and `/dev/net/tun`,
+- add no Linux capabilities,
+- mount `/clawpatrol` read-only, and
+- source `/clawpatrol/env` before starting the workload.
+
+```yaml
+initContainers:
+  - name: clawpatrol-bridge
+    restartPolicy: Always
+    image: ghcr.io/denoland/clawpatrol:latest
+    args:
+      - bridge
+      - --gateway-url=http://clawpatrol-api.clawpatrol.svc:8080
+      - --authorizer=kubernetes_token_review/agents
+      - --kubernetes-token-path=/var/run/secrets/tokens/clawpatrol-token
+      - --env-out=/clawpatrol/env
+      - --ca-out=/clawpatrol/ca.crt
+      - --ready-file=/clawpatrol/ready
+    startupProbe:
+      exec:
+        command: ["test", "-f", "/clawpatrol/ready"]
+      periodSeconds: 1
+      failureThreshold: 120
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add: ["NET_ADMIN"]
+```
+
+The complete Pod spec is in
+[`examples/kubernetes/kustomization`](https://github.com/denoland/clawpatrol/tree/main/examples/kubernetes/kustomization).
+
+## Deploy the example
+
+The Kustomize example creates:
+
+- the `clawpatrol` gateway namespace,
+- the `agents` workload namespace,
+- the gateway StatefulSet and services,
+- TokenReview and Pod-read RBAC, and
+- a restricted sample agent Pod with the bridge sidecar.
+
+```bash
+kubectl apply -k examples/kubernetes/kustomization
+```
+
+The example advertises the WireGuard endpoint through same-cluster Service
+DNS:
+
+```hcl
+endpoint = "clawpatrol-wg.clawpatrol.svc:51820"
+```
+
+## Startup and recovery
+
+On startup, the bridge:
+
+1. authenticates the Pod through the configured enrollment authorizer,
+2. receives its WireGuard peer configuration,
+3. brings up the tunnel and routes Pod traffic through it,
+4. fetches the environment and CA handoff, and
+5. writes `/clawpatrol/ready`.
+
+When tunnel connectivity is lost, the bridge first attempts a local tunnel
+rebuild. If connectivity remains unavailable, it re-enrolls without exiting
+the container. Traffic fails closed while the tunnel is unavailable, and a
+re-enrolling bridge keeps its peer IP when it represents the same subject.
+
+Recovery does not increment the container restart count. Use the bridge
+lifecycle logs to observe local rebuilds and re-enrollment.
+
+## Reaper
+
+Kubernetes Pod peers are transient. The bridge sends WireGuard keepalives, and
+the gateway uses them as the peer's liveness signal. There is no separate
+application heartbeat.
+
+### Behavior
+
+- A newly enrolled peer receives a full liveness window before it can be
+  reaped.
+- Normal Pod shutdown triggers best-effort deregistration immediately.
+- If a Pod disappears without deregistering, the gateway revokes it after the
+  liveness window expires.
+- Only self-enrolled peers are reaped. Devices added through normal onboarding
+  are never reaped.
+
+### Tuning
+
+| Setting | Default | Behavior |
+|---|---|---|
+| `keepalive_interval` | `25s` | How often the bridge signals liveness. Minimum `10s`; no maximum. |
+| `keepalive_reap_count` | `3` | Number of missed keepalives allowed before the peer is revoked and the bridge re-enrolls. Set to `0` to disable reaping and liveness recovery. |
+| `--local-reset-missed` | `2` | Number of failed liveness checks before the bridge attempts a local tunnel rebuild. Set to `0` to skip this stage. A value at or above `keepalive_reap_count` also skips it because re-enrollment happens first. |
+
+The effective liveness window is:
+
+```text
+keepalive_interval × keepalive_reap_count
+```
+
+### Disable the reaper
+
+Set `keepalive_reap_count = 0` on each enrollment authorizer for which reaping
+should be disabled:
+
+```hcl
+enrollment "kubernetes_token_review" "agents" {
+  # ...
+  keepalive_reap_count = 0
+}
+```
+
+Graceful Pod shutdown still triggers best-effort deregistration. However, the
+gateway will not remove peers left behind by abrupt Pod termination, and the
+bridge will not automatically rebuild or re-enroll a failed tunnel. A stale
+peer remains until the same workload identity replaces it or reaping is
+enabled again.
+
+## Dashboard
+
+Enrolled peers appear in the Devices list alongside normally onboarded
+devices. Their device page shows:
+
+- enrollment authorizer and subject,
+- enrollment time,
+- assigned profile,
+- keepalive and liveness window,
+- last liveness check and missed-interval count, and
+- live or stale status.
+
+The profile is read-only because it comes from the Pod label. Manual deletion
+is hidden because enrolled peers are managed by deregistration and the reaper.
+
+## Deployment hardening
+
+### Admission-based injection
+
+An explicit Pod spec is the supported baseline and requires no extra
+controllers. A `MutatingAdmissionPolicy` or mutating webhook can inject the
+bridge as an optional ergonomic layer.
+
+A ready-to-adapt policy and binding are in
+[`examples/kubernetes/agent-bridge-mutatingadmissionpolicy.yaml`](https://github.com/denoland/clawpatrol/blob/main/examples/kubernetes/agent-bridge-mutatingadmissionpolicy.yaml).
+Its header lists the namespace, selector, service, image, authorizer, and
+volume assumptions that must be reviewed before applying it.
+
+### Restrict Pod egress (recommended)
+
+The bridge already fails closed at the routing layer. For a second,
+cluster-enforced layer, use a NetworkPolicy that permits only:
+
+- the gateway API and WireGuard endpoint, and
+- cluster DNS.
+
+A ready-to-adapt example is
+[`examples/kubernetes/agent-egress-networkpolicy.yaml`](https://github.com/denoland/clawpatrol/blob/main/examples/kubernetes/agent-egress-networkpolicy.yaml).
+It is optional defense-in-depth and only takes effect on a CNI that enforces
+NetworkPolicy.
+
+## Local e2e
+
+The repository includes a kind-based validation flow:
+
+```bash
+./e2e/kubernetes-wireguard-e2e.sh
+```
+
+It builds the current workspace image, deploys the Kustomize example, checks
+the restricted agent contract and tunneled traffic, exercises reaping and
+in-process recovery, and verifies cleanup.
+
+## Limitations
+
+- v1 assumes the gateway and agents run in the same Kubernetes cluster.
+- v1 assumes a single active gateway replica with persistent state.
+- Enrollment is currently implemented only for WireGuard.
+- Peer capacity is bounded by the configured WireGuard IPv4 subnet.
+- The bridge needs Pod-network privileges; the agent container should remain
+  restricted.

--- a/site/doc/security-model.md
+++ b/site/doc/security-model.md
@@ -94,6 +94,41 @@ the same NAT shares the public v4, so pinning isn’t a standalone
 defence; it’s a blast-radius limiter for credentials that have
 already escaped.
 
+## Kubernetes enrollment (agent pods)
+
+Kubernetes enrollment is a remote-mode variant for stateless
+agent pods. The gateway and agents run in the same cluster, and each
+agent pod self-registers as a short-lived WireGuard peer using a
+projected ServiceAccount token. There is no durable join credential
+and no human approval step for each pod; authorization comes from
+Kubernetes TokenReview plus the gateway's enrollment allowlist.
+
+The pod has two different trust zones:
+
+- The **WireGuard sidecar init container** is privileged for pod
+  networking. It has `NET_ADMIN`, `/dev/net/tun`, the projected
+  ServiceAccount token, the WireGuard private key in memory, and the
+  peer API token used for env pushdown.
+- The **agent container** is the sandboxed execution environment. It
+  should have no added capabilities, no Kubernetes API token, no
+  `/dev/net/tun`, and only a read-only mount of the shared handoff
+  volume.
+
+The shared volume is intentionally narrow. The sidecar writes the CA
+bundle, env exports, and `/clawpatrol/ready`; it must not write the
+WireGuard private key or peer API token where the agent can read them.
+The gateway also derives the pod's profile from the live Pod label,
+not from a client-submitted field, so an agent cannot choose a more
+privileged profile by changing the registration request.
+
+This is still a pod-level network boundary: the sidecar changes routes
+for the whole pod network namespace, so the agent's traffic goes
+through the tunnel once setup is complete. The security bar is that
+the execution container does not receive the Kubernetes token, routing
+capabilities, peer API token, WireGuard private key, gateway
+state, or upstream credentials. Management APIs remain protected by
+the same app-layer dashboard auth described below.
+
 ## Local mode
 
 Agent and Claw Patrol on the same host. No network between them,

--- a/site/doc/toc.json
+++ b/site/doc/toc.json
@@ -2,6 +2,7 @@
   "introduction",
   "getting-started",
   "configure-gateway",
+  "kubernetes-enrollment",
   "credentials",
   "rules",
   "tunnels",


### PR DESCRIPTION
RFC: #709 

## Summary

Lets in-cluster workloads self-enroll as transient WireGuard peers through a pluggable, config-driven authorizer, with no pre-created peer and no per-pod human approval. A workload presents its identity, the gateway verifies it and assigns a profile, and the workload gets a live WireGuard tunnel. When the workload goes away its peer is reaped automatically.

The change has two layers: an authorizer-agnostic enrollment framework, and a `kubernetes_token_review` authorizer built on it.

## Enrollment framework (authorizer-agnostic)

- **Config-plugin model.** `enrollment "<type>" "<name>"` is a top-level, two-label block dispatched through the same `(Kind, Type)` plugin registry as `approver`, `credential`, and `endpoint` (a new `KindEnrollment`). An authorizer type implements a small interface: verify a caller's identity and resolve a profile. Additional types slot into the registry without touching the transport, liveness, or dashboard code.
- **Transport.** Enrollment requires a `wireguard` block and issues a concrete WireGuard peer; there is no transport abstraction in v1. The gateway runs the existing userspace WireGuard server, so it needs no kernel WireGuard privileges.
- **State.** Enrollment folds into `wg_peers` (`enrolled=1` plus identity columns: subject, replacement key, authorizer type/name, metadata). The reaper only ever touches enrolled rows, so durable onboarded devices are never reaped. The reaper is the single writer of the liveness trackers; the dashboard reads them under a short read-only lock.
- **The `clawpatrol bridge` sidecar.** A resident privileged sidecar that generates its WireGuard key locally, self-enrolls (`--authorizer=<type>/<name>`), hosts a userspace WireGuard tunnel, routes the whole pod netns through it, and pins the gateway control path off the tunnel so enroll, handoff, and deregister don't loop back through it. It writes only an env file, CA bundle, and ready marker to a shared volume, keeping the private key and peer API token off the workload-visible filesystem, and best-effort deregisters on `SIGTERM`. Its liveness/self-heal behavior is detailed below.
- **Dashboard and API.** Enrolled peers appear in the existing Devices list, identified by their `authorizer/subject` name prefix. The device detail page adds an Enrollment panel: authorizer, subject, enrolled time, keepalive, derived liveness window, and last heartbeat with a missed-beat counter, plus a live/stale indicator. For enrolled peers the profile picker is a read-only chip and the delete action is hidden, since the profile is server-assigned and the peer is reaper-managed. `POST /api/enrollment/register` and its peer-token-authenticated delete drive the lifecycle; a dashboard-authenticated `GET /api/enrollment/peers` and the `enrolled_peers` slice of `/api/state` back the UI.

### Liveness and self-heal

Liveness is observed from the WireGuard device by two independent observers, one per direction:

**Gateway side — the reaper.** The sidecar is the **sole (authoritative) keepalive sender**; the gateway does not keepalive back. That is deliberate: wireguard-go rearms its persistent-keepalive timer on *any* authenticated packet, including received ones, so with both peers sending, one direction's traffic perpetually postpones the other's keepalive — a healthy idle peer can then show flat `rx_bytes` in one direction and be falsely reaped. With a single sender, `client→gateway` `rx_bytes` advances deterministically every interval, and the reaper (~20s loop) revokes a peer only once its rx stays quiet past the derived window.

- Window = `keepalive_interval × keepalive_reap_count` — an integer multiple that can't be misconfigured.
- `keepalive_interval`: default 25s, minimum 10s (pinned to the reaper's sample cadence), no upper bound.
- `keepalive_reap_count`: default 3, `0` disables reaping. `last_handshake` is diagnostic only.

**Client side — the watchdog.** Because the gateway no longer keepalives back, the sidecar's own `rx_bytes` is normally quiet on an idle tunnel — so `rx_bytes` is only a cheap *positive* signal, and when it goes quiet the sidecar actively probes with an **ICMP echo to the gateway's tunnel address** (a round trip proves both directions). It escalates only on sustained failure, where a client controlled `local-reset-missed`  (default to 2) will rekey the existing tunnel, and upon hitting the end of the liveness window, attempt to re-enroll the client.

```mermaid
flowchart LR
    T["watchdog tick"] --> RX{"rx_bytes advancing?"}
    RX -->|yes| H["healthy — no probe"]
    RX -->|quiet| P{"ICMP echo to gateway tunnel IP"}
    P -->|reply| H
    P -->|no reply| C1{"failures ≥ reap_count?"}
    C1 -->|yes| STEP["re-enroll: fresh key, reuse peer IP"]
    C1 -->|no| C2{"failures == local-reset-missed?"}
    C2 -->|yes| RK["in-place rekey"]
```

- **Fail closed during the gap.** With `clawpatrol0` torn down the pod has no default route, so the workload's general egress is blocked (not leaking untunnelled) until the tunnel is rebuilt.
- **Recovers with no default route.** The control-plane host routes (gateway API + WG endpoint + `resolv.conf` resolvers) are pinned to the underlay and tagged with a route protocol (`--route-proto`, default `111`) so they survive; a reconnect re-reads `resolv.conf`, re-discovers the underlay, reconciles the tagged set (adds current, prunes stale), and resolves the gateway by name (TLS SNI / `Host` stay correct). The same tagged-pin recovery covers genuine restarts (OOM, node reboot, eviction).
- **Restart count stays 0.** Recovery never leaves the process, so lifecycle logs — not restart count — are the operator signal.

## The `kubernetes_token_review` authorizer

- **Identity verification.** Verifies the pod's projected ServiceAccount token with the Kubernetes TokenReview API against the block's required `audience`, then reads the live Pod object for the claims it matches on.
- **Profile binding with `match {}`.** Repeatable `match` blocks each express one identity-to-profile rule: gate on `namespace` plus `service_account`, then take the profile from a Pod label (`profile_label`, default `clawpatrol.dev/profile`) whose value must appear in the block's `profiles` allowlist. The gateway derives the profile from the Pod; the client never submits it. A pod whose namespace/service-account matches no block, or whose label value is not allowlisted, is refused.
- **Deployment.** The sidecar runs as a native sidecar (`initContainers` with `restartPolicy: Always`) and needs `NET_ADMIN`, `/dev/net/tun`, a projected ServiceAccount token with the configured audience, Downward-API env (pod name, namespace, uid, node), and a shared `emptyDir` for the handoff. The ICMP liveness probe uses an unprivileged datagram socket, so no extra capability is required. The workload container mounts none of the token or tun, adds no capabilities, and reads the handoff volume read-only; a startup probe on `/clawpatrol/ready` holds it until the tunnel and env/CA handoff are up.
- **RBAC.** The gateway ServiceAccount needs only `create` on `tokenreviews.authentication.k8s.io` and `get` on pods in agent namespaces.
- **Packaging.** A Kustomize base and an e2e overlay live under `examples/kubernetes/`. The explicit pod spec is the supported baseline; auto-injecting the sidecar with a `MutatingAdmissionPolicy` or webhook is an optional, documented layer that nothing in the enrollment path depends on.
- **Egress hardening (optional).** `examples/kubernetes/agent-egress-networkpolicy.yaml` is a recommended NetworkPolicy that pins agent-pod egress to the gateway (API + WireGuard endpoint) and cluster DNS only — defense-in-depth on top of the in-pod fail-closed routing, not a dependency, and effective only on a CNI that enforces NetworkPolicy.

## Config shape

```hcl
gateway {
  dashboard_listen = "0.0.0.0:8080"
  state_dir        = "/opt/clawpatrol"
  wireguard {
    subnet_cidr = "10.55.0.0/24"
    listen_port = 51820
    endpoint    = "clawpatrol-wg.clawpatrol.svc:51820"
  }
}

# top-level, two labels: <type> selects the authorizer plugin, <name> is the instance
enrollment "kubernetes_token_review" "agents" {
  audience = "clawpatrol"

  match {
    namespace       = "agents"
    service_account = "agent-runner"
    profile_label   = "clawpatrol.dev/profile"   # optional; this is the default
    profiles        = ["default"]                 # allowlist the label value must be in
  }
  # additional match { ... } rules allowed

  # Liveness window is keepalive_interval * keepalive_reap_count (25s * 3 = 75s here).
  keepalive_interval   = "25s"   # default 25s, min 10s, no upper bound; the sidecar is the sole keepalive sender
  keepalive_reap_count = 3       # default 3; 0 disables reaping
}

profile "default" { credentials = [] }
```

Agent-pod sidecar (privileged tunnel host; workload runs in a sibling container):

```yaml
initContainers:
  - name: wireguard-sidecar
    restartPolicy: Always
    args:
      - bridge
      - --gateway-url=http://clawpatrol-api.clawpatrol.svc:8080
      - --authorizer=kubernetes_token_review/agents
      - --kubernetes-token-path=/var/run/secrets/tokens/clawpatrol-token
      - --env-out=/clawpatrol/env
      - --ca-out=/clawpatrol/ca.crt
      - --ready-file=/clawpatrol/ready
    securityContext: { allowPrivilegeEscalation: false, capabilities: { add: ["NET_ADMIN"] } }
```

## Scope (v1)

The gateway and agents run in the same cluster, with a single active WireGuard gateway replica, and WireGuard is the only enrollment transport. The sidecar holds the pod-network privileges while the workload container stays restricted.

## Validation

### Unit tests

- **Config and compile** (`internal/config`): `TestEnrollmentConfigValidation` covers block and `match` validation and rejection of bad values; `TestEnrollmentLivenessDerivation` covers the `keepalive_interval × keepalive_reap_count` window, defaults, the 10s keepalive floor, that a long interval is accepted (no upper bound), the reap-count floor, and `0`-disables; `TestCompileFullSpec` and `TestCompile` cover enrollment blocks compiling into the policy.
- **Registration lifecycle** (`enrollment_test.go`): `TestRegisterEnrolledPeerFresh`, `TestRegisterEnrolledPeerSameSubjectNewKey` (self-heal reuses the IP and swaps the key), `TestRegisterEnrolledPeerPublicKeyConflict`, `TestRegisterEnrolledPeerReplacementTakeover`, `TestRegisterEnrolledPeerRollbackOnPersistFailure` (the WireGuard peer is backed out if the DB write fails), and `TestRegisterEnrolledPeerKeepaliveGating` (the keepalive interval + reap count are returned to bridge enrollments for the client to apply, and omitted otherwise).
- **Reaper and reconcile**: `TestReapStaleEnrolledPeers` (an rx-quiet peer is revoked, a live one is held) and `TestReconcileEnrolledPeersRestoresRuntimeState` (registry and liveness trackers are rebuilt from `wg_peers` after a gateway restart).
- **API endpoints**: `TestApiEnrollmentList`, `TestApiEnrollmentRegisterGuards`, `TestApiEnrollmentDeleteRequiresEnrollment`, and `TestApiEnrollmentDeleteWithEnrollment` (only a peer that holds an enrollment can drive teardown via its peer token).
- **kubernetes_token_review authorizer** (`k8s_registration_test.go`): `TestKubernetesTokenReviewAuthorizerIdentity` (a TokenReview result maps to an identity), `TestK8sServiceAccountAndAllowlist` (namespace/service-account gate plus profile allowlist, including rejection), `TestNormalizeWGPublicKey`, and `TestCleanupEnrolledPeer`.
- **Client watchdog + bridge** (`wg_watchdog_test.go`, `bridge_test.go`): `TestWatchdogProbeEscalates` (rx-quiet → probe → in-place rekey → in-process reconnect), `TestWatchdogRxHealthyNoProbe` (advancing rx is liveness on its own — no probe is generated), `TestWatchdogProbeSuccessIdle` (a replying probe on an idle tunnel never escalates), `TestWatchdogInertWhenReapingDisabled`, `TestWatchdogResetMisses` (threshold resolution and clamping to the server reap count), `TestParsePeerStats` / `TestParsePeerStatsNoHandshake`, and `TestValidateRouteProto` (the `--route-proto` escape hatch).

### End-to-end (`e2e/kubernetes-wireguard-e2e.sh`, kind)

Builds the workspace image, loads it, applies the Kustomize base plus the e2e overlay, and asserts:

- the sidecar writes `ready`/`env`/`ca.crt`, the CA is a real certificate, and the pushed-down env points `SSL_CERT_FILE` / `NODE_EXTRA_CA_CERTS` back into the handoff dir;
- the restricted-agent contract: no ServiceAccount token, no `/dev/net/tun`, no added capabilities, no route edits, no secret material on the handoff volume;
- the tunnel data path relays a TCP request through `clawpatrol0`, the gateway control path is pinned off the tunnel, and the control-plane pin carries the route-protocol tag;
- the enrolled `wg_peers` row exists with a peer IP;
- `rx_bytes` liveness holds a live peer past its window without being reaped;
- in-process fail-closed self-heal: scaling the gateway to 0 makes the sidecar's ICMP probe fail; it tears the tunnel down leaving **no** default route (with the tagged control-plane pins intact) and, with the container restart count **unchanged**, re-enrolls in process with a fresh key at the reused IP once the gateway returns, with the tunnel restored;
- cleanup: a force-deleted pod is reaped after its window, and graceful deletion deregisters immediately, with the WireGuard peer revoked either way.

### Behaviours covered end to end

- A pod enrolls and comes up with the tunnel already routing; the workload container stays unprivileged.
- The profile is taken from the Pod label and refused if not allowlisted; a mismatched namespace or service account is refused.
- A live pod stays enrolled; a dead pod is reaped; a graceful shutdown deregisters immediately.
- A peer that loses liveness self-heals in process (no container restart) without operator involvement and keeps its identity (reused IP, fresh key), while the workload's egress fails closed during the gap.
- Enrolled peers are visible and legible in the dashboard, with controls that don't apply to reaper-managed peers suppressed.

### Gates

`go test ./internal/config/... ./cmd/clawpatrol/`, `gofmt`, `go vet`, docgen-drift, and the dashboard `tsc` / `oxfmt` / `oxlint` checks are green; `examples/` and `e2e/` HCLs validate and `kustomize build` succeeds for the base and the overlay. Validated end-to-end on a kind cluster, including the in-process self-heal path.