### PR TITLE
pluginsdk: fix tunnel Dial teardown deadlock on early callback return

### DIFF
--- a/pluginsdk/dial_deadlock_test.go
+++ b/pluginsdk/dial_deadlock_test.go
@@ -30,7 +30,7 @@ func TestDialEarlyReturnDoesNotDeadlock(t *testing.T) {
 		Version: "0.1.0",
 		Tunnels: []TunnelDef{{
 			TypeName: "early_return_tunnel",
-			Dial: func(ctx context.Context, req TunnelDialRequest, upstream net.Conn) error {
+			Dial: func(ctx context.Context, _ TunnelDialRequest, _ net.Conn) error {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()

--- a/pluginsdk/dial_deadlock_test.go
+++ b/pluginsdk/dial_deadlock_test.go
@@ -1,0 +1,111 @@
+package pluginsdk
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	pb "github.com/denoland/clawpatrol/internal/config/extplugin/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TestDialEarlyReturnDoesNotDeadlock pins the teardown ordering of the
+// tunnel Dial handler. When the plugin's Dial callback returns before
+// the gateway closes the conn (an upstream dial refused at the SOCKS
+// layer, a validation failure, ...), the SDK must announce the Close on
+// the Tunnel.Dial stream BEFORE waiting for the gateway to tear the
+// stream down. The opposite order parks both sides in stream.Recv
+// forever: the SDK waits for a message the gateway only sends after
+// seeing our Close, and the gateway (dialConn.Read) waits for bytes
+// that never come. The HandleConn path documents the same ordering
+// requirement at its close announcement.
+func TestDialEarlyReturnDoesNotDeadlock(t *testing.T) {
+	// A tunnel whose Dial callback returns immediately without closing
+	// the conn: the gateway-side conn stays open and idle.
+	p := &Plugin{
+		Name:    "earlyreturn",
+		Version: "0.1.0",
+		Tunnels: []TunnelDef{{
+			TypeName: "early_return_tunnel",
+			Dial: func(ctx context.Context, req TunnelDialRequest, upstream net.Conn) error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
+				return errors.New("socks: connect: connection refused")
+			},
+		}},
+	}
+	srv := newServer(p)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	g := grpc.NewServer()
+	pb.RegisterTunnelServer(g, srv)
+	go func() { _ = g.Serve(lis) }()
+	defer g.Stop()
+
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial sdk server: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	ctx := context.Background()
+	tcli := pb.NewTunnelClient(cc)
+	open, err := tcli.OpenTunnel(ctx, &pb.OpenTunnelRequest{
+		TunnelTypeName: "early_return_tunnel",
+		TunnelInstance: "demo",
+	})
+	if err != nil {
+		t.Fatalf("open tunnel: %v", err)
+	}
+
+	ds, err := tcli.Dial(ctx)
+	if err != nil {
+		t.Fatalf("dial tunnel stream: %v", err)
+	}
+	if err := ds.Send(&pb.DialMessage{Kind: &pb.DialMessage_Init{Init: &pb.DialInit{
+		TunnelHandle: open.GetHandle(),
+		Network:      "tcp",
+		Addr:         "10.0.0.5:8080",
+	}}}); err != nil {
+		t.Fatalf("send init: %v", err)
+	}
+
+	// The gateway side: it sits in dialConn.Read (stream.Recv) waiting
+	// for the tunnel to produce bytes. The plugin's Dial already
+	// returned, so the only thing that can arrive is the SDK's Close.
+	// Once it does, tear the stream down the way dialConn.Close does
+	// when the transport sees the EOF, and expect the handler to
+	// return.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			msg, rerr := ds.Recv()
+			if rerr != nil {
+				return // handler returned; stream ended
+			}
+			if c := msg.GetClose(); c != nil {
+				if c.Reason == "" {
+					t.Errorf("close reason = %q, want the dial error", c.Reason)
+				}
+				_ = ds.CloseSend()
+			}
+		}
+	}()
+	select {
+	case <-done:
+		// The SDK sent its Close before waiting on the recv goroutine,
+		// and returned once the gateway tore the stream down.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Tunnel.Dial deadlocked: no Close frame after the Dial callback returned early")
+	}
+}

--- a/pluginsdk/server.go
+++ b/pluginsdk/server.go
@@ -1184,8 +1184,23 @@ func (s *server) Dial(stream pb.Tunnel_DialServer) error {
 					return
 				}
 			case <-closed:
-				sendErr <- nil
-				return
+				// Flush any bytes the Dial callback wrote just before it
+				// returned (Write only buffers onto `send`), so a partial
+				// handshake isn't truncated by the teardown.
+				for {
+					select {
+					case b := <-send:
+						if err := stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Data{
+							Data: &pb.DialData{Payload: b},
+						}}); err != nil {
+							sendErr <- err
+							return
+						}
+					default:
+						sendErr <- nil
+						return
+					}
+				}
 			}
 		}
 	}()
@@ -1198,14 +1213,26 @@ func (s *server) Dial(stream pb.Tunnel_DialServer) error {
 	}, upstream)
 	_ = upstream.Close()
 	closer()
-	<-recvErr
+
+	// Wait for the send goroutine to flush every queued byte before
+	// announcing the close, so a partial handshake isn't truncated.
 	<-sendErr
 
+	// Then tell the gateway we're done. This must happen before we wait
+	// on the recv goroutine: it is blocked in stream.Recv() and only
+	// unblocks when the gateway tears the stream down — which it does
+	// in response to this Close (dialConn.Read surfaces it as EOF, and
+	// the transport closes the conn, which CloseSends the stream).
+	// Sending it after <-recvErr would deadlock when the Dial callback
+	// returns before the gateway closes the connection (e.g. an
+	// upstream dial was refused), since the gateway is simultaneously
+	// waiting on us to send it. Mirrors the HandleConn close ordering.
+	closeMsg := &pb.DialClose{}
 	if dialErr != nil {
-		_ = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{Reason: dialErr.Error()}}})
-	} else {
-		_ = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: &pb.DialClose{}}})
+		closeMsg.Reason = dialErr.Error()
 	}
+	_ = stream.Send(&pb.DialMessage{Kind: &pb.DialMessage_Close{Close: closeMsg}})
+	<-recvErr
 	return dialErr
 }
 


### PR DESCRIPTION
## What

Fixes a deadlock in the SDK's `Tunnel.Dial` handler
(`pluginsdk/server.go`): when the plugin's `Dial` callback returns before
the gateway closes the conn (e.g. an upstream dial refused at the SOCKS
layer), the SDK waited on its recv goroutine **before** sending the
`DialMessage_Close` frame — while the gateway's `bridgeTransportStream`
waits for that very Close before tearing the stream down. Both sides park
in `stream.Recv()` forever, leaking the stream and goroutines on each side
until the upstream TCP connection dies on its own.

The `HandleConn` path already documents this ordering as load-bearing and
tears down correctly (`Close` before `<-recvErr`); `Dial` had the opposite
order.

## Changes

- `server.Dial`: send the Close frame after flushing the send goroutine and
  **before** waiting on the recv goroutine, mirroring `HandleConn`.
- Drain bytes buffered on the `send` channel at teardown so a partial
  handshake written just before the callback returns isn't truncated.
- New test `pluginsdk/dial_deadlock_test.go`: a tunnel whose `Dial` returns
  immediately (refused-dial shape), driving the real gRPC `Tunnel.Dial`
  service; it deadlocks (5s timeout) before this change and passes in ~4ms
  after.

## Verification

- `go test ./pluginsdk/... ./internal/config/extplugin/...` pass
- `go test -race ./pluginsdk/...` pass
- `gofmt -l .` clean

Closes #793
