### PR TITLE
approvers: honor defaults.llm_fail_mode on model-call failures

### DIFF
--- a/cmd/clawpatrol/llm_fail_mode_test.go
+++ b/cmd/clawpatrol/llm_fail_mode_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config"
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+func TestResolveUndecidedVerdict(t *testing.T) {
+	cases := []struct {
+		name         string
+		policy       *config.CompiledPolicy
+		approverType string
+		in           runtime.ApproveVerdict
+		wantDecision string
+		wantReason   string
+	}{
+		{
+			name:         "llm open allows and keeps the failure reason",
+			policy:       &config.CompiledPolicy{LLMFailMode: "open"},
+			approverType: "llm_approver",
+			in:           runtime.ApproveVerdict{Reason: "llm call: dial tcp: i/o timeout"},
+			wantDecision: "allow",
+			wantReason:   "llm_fail_mode = open: llm call: dial tcp: i/o timeout",
+		},
+		{
+			name:         "llm closed denies",
+			policy:       &config.CompiledPolicy{LLMFailMode: "closed"},
+			approverType: "llm_approver",
+			in:           runtime.ApproveVerdict{Reason: "llm http 503: overloaded"},
+			wantDecision: "deny",
+			wantReason:   "llm http 503: overloaded",
+		},
+		{
+			name:         "llm default (unset) denies",
+			policy:       &config.CompiledPolicy{},
+			approverType: "llm_approver",
+			in:           runtime.ApproveVerdict{Reason: "secret fetch: no such secret"},
+			wantDecision: "deny",
+			wantReason:   "secret fetch: no such secret",
+		},
+		{
+			name:         "open does not apply to human approvers",
+			policy:       &config.CompiledPolicy{LLMFailMode: "open"},
+			approverType: "human_approver",
+			in:           runtime.ApproveVerdict{},
+			wantDecision: "deny",
+			wantReason:   "approver ops timed out",
+		},
+		{
+			name:         "nil policy denies",
+			policy:       nil,
+			approverType: "llm_approver",
+			in:           runtime.ApproveVerdict{Reason: "llm call: eof"},
+			wantDecision: "deny",
+			wantReason:   "llm call: eof",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := resolveUndecidedVerdict(c.policy, "ops", c.approverType, c.in)
+			if got.Decision != c.wantDecision {
+				t.Fatalf("Decision = %q, want %q", got.Decision, c.wantDecision)
+			}
+			if got.Reason != c.wantReason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, c.wantReason)
+			}
+		})
+	}
+}

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3070,17 +3070,34 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 		if err != nil {
 			return runtime.ApproveVerdict{Decision: "deny", Reason: err.Error(), By: "gateway", ApproverName: v.ApproverName, ApproverType: v.ApproverType}
 		}
+		if v.Decision == "" {
+			v = resolveUndecidedVerdict(policy, st.Name, approverType, v)
+		}
 		if v.Decision != "allow" {
-			if v.Decision == "" {
-				v.Decision = "deny"
-				if v.Reason == "" {
-					v.Reason = "approver " + st.Name + " timed out"
-				}
-			}
 			return v
 		}
 	}
 	return runtime.ApproveVerdict{Decision: "allow"}
+}
+
+// resolveUndecidedVerdict turns an approver's empty Decision (it could
+// not decide: timeout, model-call failure) into a final verdict. LLM
+// approvers honor defaults.llm_fail_mode: "open" allows and records
+// why; anything else denies. Every other approver type denies.
+func resolveUndecidedVerdict(policy *config.CompiledPolicy, name, approverType string, v runtime.ApproveVerdict) runtime.ApproveVerdict {
+	if v.Reason == "" {
+		v.Reason = "approver " + name + " timed out"
+	}
+	if approverType == "llm_approver" && policy != nil && policy.LLMFailMode == "open" {
+		v.Decision = "allow"
+		v.Reason = "llm_fail_mode = open: " + v.Reason
+		if v.By == "" {
+			v.By = "gateway"
+		}
+		return v
+	}
+	v.Decision = "deny"
+	return v
 }
 
 // ifNotEmpty returns f(v) when v != nil, else "".

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -283,6 +283,11 @@ func Compile(gw *Gateway) (*CompiledPolicy, error) {
 	if d == nil {
 		d = &Defaults{}
 	}
+	switch d.LLMFailMode {
+	case "", "closed", "open":
+	default:
+		return nil, fmt.Errorf("defaults.llm_fail_mode %q must be \"closed\" or \"open\"", d.LLMFailMode)
+	}
 	cp := &CompiledPolicy{
 		UnknownHost:    d.UnknownHost,
 		LLMFailMode:    d.LLMFailMode,

--- a/internal/config/compile_test.go
+++ b/internal/config/compile_test.go
@@ -505,3 +505,31 @@ func TestCompileFullSpec(t *testing.T) {
 		t.Errorf("expected ~50+ rule attachments, got %d", totalRules)
 	}
 }
+
+func TestCompileLLMFailModeValues(t *testing.T) {
+	for _, c := range []struct {
+		value string
+		ok    bool
+	}{
+		{"", true}, {"closed", true}, {"open", true}, {"opne", false}, {"OPEN", false},
+	} {
+		src := testGatewayPrefix
+		if c.value != "" {
+			src += "defaults { llm_fail_mode = \"" + c.value + "\" }\n"
+		}
+		gw, diags := config.LoadBytes([]byte(src), "in.hcl")
+		if diags.HasErrors() {
+			t.Fatalf("%q: load: %v", c.value, diags)
+		}
+		cp, err := config.Compile(gw)
+		if c.ok && err != nil {
+			t.Fatalf("%q: compile: %v", c.value, err)
+		}
+		if !c.ok && err == nil {
+			t.Fatalf("%q: compile accepted an invalid llm_fail_mode", c.value)
+		}
+		if c.ok && cp.LLMFailMode != c.value {
+			t.Fatalf("%q: compiled LLMFailMode = %q", c.value, cp.LLMFailMode)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,9 +329,14 @@ type Defaults struct {
 	// any endpoint. "passthrough" relays it; "deny" closes it.
 	UnknownHost string `hcl:"unknown_host,optional"`
 
-	// LLMFailMode controls requests guarded by LLM approvers when
-	// the model call errors or times out. "closed" denies; "open"
-	// allows.
+	// LLMFailMode controls requests guarded by an llm_approver when
+	// the model call cannot complete: credential fetch or injection
+	// failure, transport error or timeout, non-200 status, or an
+	// undecodable response. "closed" (the default) denies; "open"
+	// allows and records the failure as the reason. A model that
+	// answers, even ambiguously, is not a failure and is judged as
+	// usual. Misconfiguration (missing model or credential, unknown
+	// model family) always denies regardless of this setting.
 	LLMFailMode string `hcl:"llm_fail_mode,optional"`
 
 	// LLMCacheTTL is the LLM decision cache lifetime in seconds.

--- a/internal/config/plugins/approvers/llm.go
+++ b/internal/config/plugins/approvers/llm.go
@@ -95,30 +95,40 @@ func (a *LLMApprover) Approve(ctx context.Context, req runtime.ApproveRequest) (
 	}
 	sec, err := req.Secrets.Get(a.Credential)
 	if err != nil {
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "secret fetch: " + err.Error()}, nil
+		return llmUndecided("secret fetch: " + err.Error()), nil
 	}
 	if err := injector.InjectHTTP(ctx, hreq, sec); err != nil {
 		discardHTTPRedactions(injector, hreq)
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "credential inject: " + err.Error()}, nil
+		return llmUndecided("credential inject: " + err.Error()), nil
 	}
 	discardHTTPRedactions(injector, hreq)
 	c := &http.Client{Timeout: 30 * time.Second}
 	resp, err := c.Do(hreq)
 	if err != nil {
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "llm call: " + err.Error()}, nil
+		return llmUndecided("llm call: " + err.Error()), nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return runtime.ApproveVerdict{Decision: "deny", Reason: fmt.Sprintf("llm http %d: %s", resp.StatusCode, string(body))}, nil
+		return llmUndecided(fmt.Sprintf("llm http %d: %s", resp.StatusCode, string(body))), nil
 	}
 	text, err := decode(resp.Body)
 	if err != nil {
-		return runtime.ApproveVerdict{Decision: "deny", Reason: "llm response decode: " + err.Error()}, nil
+		return llmUndecided("llm response decode: " + err.Error()), nil
 	}
 	verdict, reason := parseJudgeVerdict(text)
 	by := "llm:" + a.Model
 	return runtime.ApproveVerdict{Decision: verdict, Reason: reason, By: by}, nil
+}
+
+// llmUndecided is the verdict for a model call that could not
+// complete: credential fetch/inject failure, transport error, non-200
+// status, or an undecodable body. Decision is left empty so the
+// approve chain applies defaults.llm_fail_mode ("closed" denies,
+// "open" allows). Misconfiguration (no model, undeclared credential,
+// unknown model family) is not a call failure and always denies.
+func llmUndecided(reason string) runtime.ApproveVerdict {
+	return runtime.ApproveVerdict{Decision: "", Reason: reason}
 }
 
 func discardHTTPRedactions(injector runtime.HTTPCredentialRuntime, req *http.Request) {

--- a/internal/config/plugins/approvers/llm_test.go
+++ b/internal/config/plugins/approvers/llm_test.go
@@ -1,10 +1,14 @@
 package approvers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/denoland/clawpatrol/internal/config"
 	"github.com/denoland/clawpatrol/internal/config/runtime"
 )
 
@@ -47,5 +51,46 @@ func TestHITLSummaryJSONContractUsesSubjectLabelSummary(t *testing.T) {
 		if strings.Contains(string(raw), forbidden) {
 			t.Fatalf("marshaled summary contains legacy field %q: %s", forbidden, raw)
 		}
+	}
+}
+
+type failingSecrets struct{}
+
+func (failingSecrets) Get(string) (runtime.Secret, error) {
+	return runtime.Secret{}, errors.New("vault unreachable")
+}
+
+type nopHTTPCredential struct{}
+
+func (nopHTTPCredential) InjectHTTP(context.Context, *http.Request, runtime.Secret) error {
+	return nil
+}
+
+// A model call that cannot complete must leave Decision empty so the
+// approve chain can apply defaults.llm_fail_mode; misconfiguration
+// must deny outright.
+func TestLLMApproverUndecidedOnCallFailure(t *testing.T) {
+	policy := &config.CompiledPolicy{Credentials: map[string]*config.Entity{
+		"judge": {Body: nopHTTPCredential{}},
+	}}
+	a := &LLMApprover{Model: "claude-test", Credential: "judge"}
+	v, err := a.Approve(context.Background(), runtime.ApproveRequest{Policy: policy, Secrets: failingSecrets{}})
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if v.Decision != "" {
+		t.Fatalf("Decision = %q, want empty (undecided)", v.Decision)
+	}
+	if !strings.HasPrefix(v.Reason, "secret fetch: ") {
+		t.Fatalf("Reason = %q", v.Reason)
+	}
+
+	misconfigured := &LLMApprover{Model: "claude-test", Credential: "missing"}
+	v, err = misconfigured.Approve(context.Background(), runtime.ApproveRequest{Policy: policy, Secrets: failingSecrets{}})
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if v.Decision != "deny" {
+		t.Fatalf("misconfigured Decision = %q, want deny", v.Decision)
 	}
 }

--- a/site/doc/rules.md
+++ b/site/doc/rules.md
@@ -402,6 +402,14 @@ before a final allow decision, Claw Patrol does **not** call upstream.
 Deny and timeout responses are gateway-generated failures, not upstream
 responses.
 
+For `llm_approver`, a model call that cannot complete (credential
+fetch or injection failure, transport error or timeout, non-200
+status, undecodable response) is resolved by `defaults.llm_fail_mode`:
+`"closed"` (the default) denies, `"open"` allows and records the
+failure as the reason. A model that answers is judged as usual, and
+an ambiguous answer denies. Misconfiguration, such as a missing
+credential, always denies.
+
 For `human_approver`, [set `timeout` to the maximum time Claw Patrol
 should wait for a human decision](/docs/config-reference/#approver-human_approver-name).
 


### PR DESCRIPTION
`llm_fail_mode` was parsed, compiled and emitted but never read; the
LLM approver denied on every failure class regardless of the setting.

* The approver returns an undecided verdict (empty `Decision`) when
  the model call cannot complete: credential fetch or injection
  failure, transport error, non-200 status, undecodable response.
* The approve chain resolves undecided verdicts through the policy:
  `"open"` allows and records the failure as the reason; anything
  else denies. Misconfiguration (missing model or credential, unknown
  model family) still denies outright. A model that answers is judged
  as before.
* Compile rejects values other than `"closed"` and `"open"`.
* Doc comment and rules.md describe the exact failure classes.

Fixes #803
