### PR TITLE
run: report the daemon's own error when it dies during startup

### DIFF
--- a/cmd/clawpatrol/daemon_linux.go
+++ b/cmd/clawpatrol/daemon_linux.go
@@ -257,8 +257,15 @@ func daemonSpawn(_ string) error {
 	// check keeps recent history across a handful of restarts while
 	// bounding total size.
 	logFlags := os.O_CREATE | os.O_APPEND | os.O_WRONLY
-	if fi, err := os.Stat(daemonLogPath()); err == nil && fi.Size() > daemonLogMaxBytes {
-		logFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	// Remember where this daemon's output starts so a boot failure can
+	// be reported from its own log lines, not an earlier daemon's.
+	var logStart int64
+	if fi, err := os.Stat(daemonLogPath()); err == nil {
+		if fi.Size() > daemonLogMaxBytes {
+			logFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+		} else {
+			logStart = fi.Size()
+		}
 	}
 	logf, err := os.OpenFile(daemonLogPath(), logFlags, 0o600)
 	if err != nil {
@@ -291,7 +298,14 @@ func daemonSpawn(_ string) error {
 	br := bufio.NewReader(pr)
 	line, err := br.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("daemon ready: %w (read %q)", err, line)
+		// The daemon boots its transport before it signals ready and
+		// log.Fatalf's on failure, so every transport-boot error
+		// arrives here as a bare EOF. Its last log line is the actual
+		// cause; surface it.
+		if last := lastLogLineSince(daemonLogPath(), logStart); last != "" {
+			return fmt.Errorf("daemon exited during startup: %s\n  (daemon log: %s)", last, daemonLogPath())
+		}
+		return fmt.Errorf("daemon ready: %w (read %q)\n  (daemon log: %s)", err, line, daemonLogPath())
 	}
 	if line != "ready\n" {
 		return fmt.Errorf("daemon ready: unexpected %q", line)

--- a/cmd/clawpatrol/daemon_log.go
+++ b/cmd/clawpatrol/daemon_log.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+)
+
+// lastLogLineSince returns the last non-empty line written to path at
+// or after byte offset off, or "" when there is none or the file
+// cannot be read. daemonSpawn uses it to fold the daemon's own fatal
+// message into the error the user sees: the daemon logs to a file
+// that is shared across respawns and opened O_APPEND, so reading
+// from the offset recorded before the spawn (rather than tailing the
+// whole file) keeps an older daemon's last words out of the report.
+func lastLogLineSince(path string, off int64) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	if off > 0 {
+		if _, err := f.Seek(off, io.SeekStart); err != nil {
+			return ""
+		}
+	}
+	const cap = 64 << 10
+	buf, err := io.ReadAll(io.LimitReader(f, cap))
+	if err != nil && len(buf) == 0 {
+		return ""
+	}
+	buf = bytes.TrimRight(buf, "\r\n")
+	if i := bytes.LastIndexByte(buf, '\n'); i >= 0 {
+		buf = buf[i+1:]
+	}
+	return strings.TrimSpace(string(buf))
+}

--- a/cmd/clawpatrol/daemon_log_test.go
+++ b/cmd/clawpatrol/daemon_log_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLastLogLineSince(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.log")
+	old := "daemon pid=1 starting\ndaemon: old failure\n"
+	if err := os.WriteFile(path, []byte(old), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	off := int64(len(old))
+
+	if got := lastLogLineSince(path, off); got != "" {
+		t.Fatalf("nothing appended yet, got %q", got)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("daemon pid=2 starting\ndaemon: transport: no mode file — re-run `clawpatrol join`\n\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	want := "daemon: transport: no mode file — re-run `clawpatrol join`"
+	if got := lastLogLineSince(path, off); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if got := lastLogLineSince(path, 0); got != want {
+		t.Fatalf("from start: got %q, want %q", got, want)
+	}
+	if got := lastLogLineSince(filepath.Join(t.TempDir(), "absent"), 0); got != "" {
+		t.Fatalf("missing file: got %q", got)
+	}
+}

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -144,7 +144,9 @@ func runRun(args []string) {
 	// none is alive. Hello handshake happens inside daemonConnect.
 	ctrl, err := daemonConnect()
 	if err != nil {
-		fail("daemon connect: %v\n  (if this machine was joined with --whole-machine, run the command directly — `clawpatrol run` isn't needed; traffic already routes through the gateway)", err)
+		// Not a whole-machine join: that case returned above, so the
+		// old hint about it would only mislead here.
+		fail("daemon connect: %v", err)
 	}
 	defer func() { _ = ctrl.Close() }()
 


### PR DESCRIPTION
The per-host daemon boots its transport before signalling ready and
`log.Fatalf`s on failure, so every transport-boot error reached the
user as `daemon ready: EOF` while the real cause sat in `daemon.log`
(#801).

* Record the log offset before spawning and, when the ready read
  fails, fold the last line the new daemon wrote into the error along
  with the log path. Reading from the recorded offset keeps an older
  daemon's last words out of the report (the log is shared across
  respawns and opened `O_APPEND`).
* Drop the unconditional `--whole-machine` hint on daemon connect
  failures: the whole-machine case returns earlier in the same
  function, so the hint was wrong every time it printed.

The helper is platform-independent and unit-tested; the Linux path
was vet-checked with `GOOS=linux`.

Fixes #801
