### PR TITLE
run: rename a constant that shadowed the cap builtin

### DIFF
--- a/cmd/clawpatrol/daemon_log.go
+++ b/cmd/clawpatrol/daemon_log.go
@@ -25,8 +25,8 @@ func lastLogLineSince(path string, off int64) string {
 			return ""
 		}
 	}
-	const cap = 64 << 10
-	buf, err := io.ReadAll(io.LimitReader(f, cap))
+	const maxRead = 64 << 10
+	buf, err := io.ReadAll(io.LimitReader(f, maxRead))
 	if err != nil && len(buf) == 0 {
 		return ""
 	}


### PR DESCRIPTION
golangci-lint (revive) rejects redefining built-in identifiers; the lint job failed on #807 because of it. No behavior change.