### PR TITLE
docs: add CONTRIBUTING, SECURITY and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Something does not work the way the docs say it should.
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Version and platform
+      description: Output of `clawpatrol --version`, plus the OS on the gateway and on the client if different.
+      placeholder: "0.5.9 on Ubuntu 24.04 (gateway), macOS 15 arm64 (client)"
+    validations:
+      required: true
+  - type: dropdown
+    id: shape
+    attributes:
+      label: Deployment shape
+      options:
+        - clawpatrol gateway
+        - clawpatrol join (whole machine)
+        - clawpatrol run (per process, Linux)
+        - clawpatrol run (per process, macOS)
+        - dashboard
+        - plugin / plugin SDK
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: What you did
+      description: The exact command(s) and the relevant part of gateway.hcl. Replace real hostnames and secrets with placeholders.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: Error output, gateway log lines, and for `clawpatrol run` on Linux the tail of `~/.local/state/clawpatrol/run/daemon.log`.
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/denoland/clawpatrol/security/advisories/new
+    about: Private report. Please do not open a public issue for a vulnerability.
+  - name: Documentation
+    url: https://clawpatrol.dev/docs/
+    about: Getting started, configuration reference, security model.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Something the gateway should be able to do for an operator.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The operator problem
+      description: What you are trying to do with an agent behind the gateway, and what stops you today. Lead with the situation, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Optional. Config shape, CLI, or behaviour you have in mind. Note that integrations with one specific service usually belong in an external plugin.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you tried instead

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to Claw Patrol
+
+Thanks for taking the time. This page says what kind of changes we
+take, how to get them reviewed quickly, and what the checks expect.
+
+## What we are focused on
+
+Claw Patrol is a wire-level policy gateway for agents: real secrets
+stay in the gateway, every credentialed request goes through it, and
+rules decide what is allowed. Current priorities, in order:
+
+1. Reliability of the three deployment shapes (`gateway`, `join`,
+   `run`) on Linux and macOS, including the tunnels under them.
+2. Documentation that matches the code. A documented setting must
+   do what it says.
+3. Security hardening of the gateway itself.
+4. Features that widen what the gateway can broker for agents, such
+   as workload enrollment (Kubernetes and OIDC) and remote MCP.
+
+Things we are not taking on at the moment: Windows support and
+dashboard theming. Integrations with a specific third-party service
+usually belong in an external plugin rather than core; see
+[Plugins](https://clawpatrol.dev/docs/plugins) and the `pluginsdk`
+package.
+
+If you are unsure whether a change fits, open an issue first and
+describe the operator problem it solves. A short issue saves a long
+PR.
+
+## Bug reports
+
+The most useful reports come with the exact command, the version
+(`clawpatrol --version`), the platform, what you expected, and what
+happened. For `clawpatrol run` problems on Linux, the daemon log at
+`~/.local/state/clawpatrol/run/daemon.log` usually holds the real
+cause. Never paste real credentials, tokens, or private hostnames;
+use placeholders.
+
+## Pull requests
+
+- One change per PR, with a title in the form `area: what changed`
+  (`run: ...`, `gateway: ...`, `docs: ...`). The body says what the
+  change does and why; link the issue with `Fixes #N`.
+- Add or extend tests. A fix without a regression test will usually
+  get a request for one.
+- Keep the config format stable. Do not rename or restructure HCL
+  blocks and attributes as part of another change.
+- If you touch a documented HCL field, regenerate the reference:
+  `go run ./internal/tools/docgen`. CI fails when it is stale.
+- If you add a rule branch to `cmd/clawpatrol/testdata/example.hcl`,
+  add fixtures for both arms (see
+  [clawpatrol test](https://clawpatrol.dev/docs/clawpatrol-test)).
+- Small follow-up fixes to your PR may be applied by a maintainer
+  before landing; the commit keeps you as author.
+
+## Checks
+
+Run what CI runs before you push:
+
+```sh
+gofmt -l .                       # must print nothing
+cd dashboard && deno task format:check && cd ..
+make lint                        # golangci-lint + dashboard lint
+make test                        # go test ./...
+go run ./internal/tools/docgen   # then commit any change
+```
+
+`doc/dev-setup.md` covers prerequisites, including the macOS system
+extension build if you are working on `clawpatrol run` for macOS.
+Linux-specific paths (`run` on Linux, the sandbox backends) need a
+Linux host or VM; the CI matrix covers them, so it is fine to lean on
+CI for those if you do not have one.
+
+## Review expectations
+
+A maintainer will respond to a new PR within a week. Reviews are
+direct and specific; they are about the change, not the author. A PR
+that goes quiet for a long time after a review may be closed to keep
+the queue honest; it can be reopened when work resumes.
+
+## Security issues
+
+Do not open a public issue for a vulnerability. See
+[SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately through GitHub's
+[private vulnerability reporting](https://github.com/denoland/clawpatrol/security/advisories/new)
+for this repository. Do not open a public issue or pull request for
+a security problem.
+
+Include what you can: the version, the configuration shape that
+triggers it, steps to reproduce, and what an attacker gains. Use
+placeholder values for any credentials or hostnames.
+
+You will get an acknowledgement within a few days. We will work with
+you on a fix and coordinate disclosure; credit is given in the
+release notes unless you prefer otherwise.
+
+## What is in scope
+
+The guarantee Claw Patrol makes is narrow and is described in the
+[security model](https://clawpatrol.dev/docs/security-model): real
+secrets live only in the gateway, and the only way to make a
+credentialed request is through the gateway, where policy is
+enforced. Reports that break that guarantee are in scope. Examples:
+
+- a way to obtain a real credential from the gateway, a client, or a
+  captured sample;
+- a way to make a credentialed request that bypasses rule evaluation
+  or approval;
+- privilege escalation on the gateway host through configuration,
+  plugins, or the dashboard;
+- authentication or session weaknesses in the dashboard or the
+  onboarding flow.
+
+## What is out of scope
+
+The security model lists what Claw Patrol does not defend against.
+In particular, `clawpatrol run` is not a sandbox: a wrapped process
+has the full local access of its OS user, and per-process traffic
+interception is best-effort. Reports that a wrapped process can read
+local files or the launching shell's environment, or can open
+connections that bypass interception, describe the documented
+boundary rather than a vulnerability.
+
+## Supported versions
+
+Fixes land on `main` and ship in the next release. Only the latest
+release is supported; a gateway with the update checker enabled shows
+a banner in the dashboard when a newer version is available.


### PR DESCRIPTION
The repository had no contributor guide, no security policy and no
issue templates.

* `CONTRIBUTING.md`: what the project is focused on, what a good bug
  report contains, PR conventions (one change, area-prefixed title,
  tests, stable config format, docgen), the checks CI runs, and what
  to expect from review.
* `SECURITY.md`: private reporting through GitHub security advisories
  (now enabled on the repository), what is in and out of scope per
  the security model, and the supported-version policy.
* Issue forms for bug reports and feature requests, plus contact
  links for security reports and the docs.
