### PR TITLE
approvers: keep the fail-open reason on the final allow

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2614,6 +2614,9 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 			ev.Approver = v.ApproverName
 			ev.ApproverType = v.ApproverType
 			ev.ApproverBy = v.By
+			// Non-empty only when the chain allowed for a reason worth
+			// recording, such as llm_fail_mode = "open".
+			ev.Reason = v.Reason
 		}
 
 		// Verdict.

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3020,6 +3020,11 @@ type runApproveCtx struct {
 // `dashboard` is handled inline (no policy entity needed).
 func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveStage, c runApproveCtx) runtime.ApproveVerdict {
 	policy := g.Policy()
+	// failOpen remembers a stage that allowed only because
+	// llm_fail_mode = "open" resolved an undecided verdict, so the
+	// final allow carries that reason and attribution into the
+	// action log instead of looking like a clean model decision.
+	var failOpen *runtime.ApproveVerdict
 	for _, st := range stages {
 		var ar runtime.ApproverRuntime
 		approverType := ""
@@ -3090,10 +3095,17 @@ func (g *Gateway) runApproveChain(ctx context.Context, stages []config.ApproveSt
 		}
 		if v.Decision == "" {
 			v = resolveUndecidedVerdict(policy, st.Name, approverType, v)
+			if v.Decision == "allow" && failOpen == nil {
+				fo := v
+				failOpen = &fo
+			}
 		}
 		if v.Decision != "allow" {
 			return v
 		}
+	}
+	if failOpen != nil {
+		return *failOpen
 	}
 	return runtime.ApproveVerdict{Decision: "allow"}
 }

--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -713,7 +713,8 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 		}
 		if !shadow {
 			emit(ch, runtime.ConnEvent{
-				Action: "approved", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
+				Action: "approved", Reason: v.Reason,
+				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 				Approver: v.ApproverName, ApproverType: v.ApproverType, ApproverBy: v.By,
 			})
 		}

--- a/internal/config/plugins/endpoints/ssh.go
+++ b/internal/config/plugins/endpoints/ssh.go
@@ -969,7 +969,8 @@ func (rt *SSHEndpointRuntime) makeGate(ch *runtime.ConnHandle, emit func(runtime
 				return true, reason
 			}
 			emit(runtime.ConnEvent{
-				Action: "approved", Verb: m.Verb, Summary: summary, Facets: facets, Rule: rule,
+				Action: "approved", Reason: v.Reason,
+				Verb: m.Verb, Summary: summary, Facets: facets, Rule: rule,
 				Approver: v.ApproverName, ApproverType: v.ApproverType, ApproverBy: v.By,
 			})
 			return false, ""


### PR DESCRIPTION
Follow-up to #805. When `llm_fail_mode = "open"` resolved an undecided LLM verdict, the chain went on to return a fresh allow with no reason or approver attribution, so the action log could not show that the request was allowed because the model was unavailable. Remember the fail-open verdict and return it when every stage allows.