### PR TITLE
config: keep <<file:...>> includes inside the config directory

### DIFF
--- a/internal/config/file_include.go
+++ b/internal/config/file_include.go
@@ -63,8 +63,11 @@ type FileIncludeField struct {
 
 // resolveFileIncludes scans s for `<<file:NAME>>` markers and
 // substitutes each with the contents of NAME read relative to
-// configDir. Multiple markers in one string are supported. Markers
-// with absolute paths are read as-is (no configDir join).
+// configDir. Multiple markers in one string are supported. NAME must
+// stay inside configDir: absolute paths and `..` traversal are
+// rejected, so a config writer (the dashboard editor included) cannot
+// turn the include syntax into a read of arbitrary files the gateway
+// process can see.
 func resolveFileIncludes(s, configDir, entityName string, blockRange hcl.Range) (string, hcl.Diagnostics) {
 	if !strings.Contains(s, "<<file:") {
 		return s, nil
@@ -87,9 +90,16 @@ func resolveFileIncludes(s, configDir, entityName string, blockRange hcl.Range) 
 			break
 		}
 		name := out[i+len("<<file:") : i+j]
-		path := name
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(configDir, name)
+		path, err := includePath(configDir, name)
+		if err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Cannot inline file %q", name),
+				Detail:   fmt.Sprintf("Entity %q referenced %q via <<file:...>>: %v.", entityName, name, err),
+				Subject:  &blockRange,
+			})
+			out = out[:i] + out[i+j+2:]
+			continue
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -107,4 +117,26 @@ func resolveFileIncludes(s, configDir, entityName string, blockRange hcl.Range) 
 		out = out[:i] + string(data) + out[i+j+2:]
 	}
 	return out, diags
+}
+
+// includePath resolves an include name against configDir and refuses
+// anything that would escape it. An empty configDir means the
+// current directory.
+func includePath(configDir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty file name")
+	}
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("absolute paths are not allowed; includes must be relative to the config directory")
+	}
+	root := configDir
+	if root == "" {
+		root = "."
+	}
+	path := filepath.Join(root, name)
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes the config directory")
+	}
+	return path, nil
 }

--- a/internal/config/file_include.go
+++ b/internal/config/file_include.go
@@ -120,8 +120,14 @@ func resolveFileIncludes(s, configDir, entityName string, blockRange hcl.Range) 
 }
 
 // includePath resolves an include name against configDir and refuses
-// anything that would escape it. An empty configDir means the
-// current directory.
+// anything that would lexically escape it. An empty configDir means
+// the current directory.
+//
+// Symlinks inside configDir are followed and trusted: the threat here
+// is someone who can write gateway.hcl (the dashboard editor), not
+// someone who can place files or links in the config directory, who
+// already has the gateway user's filesystem access. Operators do keep
+// certificates as symlinks next to the config, and that must work.
 func includePath(configDir, name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("empty file name")

--- a/internal/config/file_include_scope_test.go
+++ b/internal/config/file_include_scope_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+func TestResolveFileIncludesStaysInsideConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ca.pem"), []byte("CERT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "k.pem"), []byte("KEY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(outside, []byte("SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ok := func(marker, want string) {
+		t.Helper()
+		got, diags := resolveFileIncludes("<<file:"+marker+">>", dir, "e", hcl.Range{})
+		if diags.HasErrors() {
+			t.Fatalf("%q: unexpected diagnostics: %v", marker, diags)
+		}
+		if got != want {
+			t.Fatalf("%q: got %q, want %q", marker, got, want)
+		}
+	}
+	ok("ca.pem", "CERT")
+	ok("sub/k.pem", "KEY")
+	ok("sub/../ca.pem", "CERT")
+
+	rejected := func(marker string) {
+		t.Helper()
+		got, diags := resolveFileIncludes("x<<file:"+marker+">>y", dir, "e", hcl.Range{})
+		if !diags.HasErrors() {
+			t.Fatalf("%q: expected a diagnostic, got %q", marker, got)
+		}
+		if strings.Contains(got, "SECRET") || strings.Contains(got, "CERT") {
+			t.Fatalf("%q: file contents leaked into output %q", marker, got)
+		}
+		if got != "xy" {
+			t.Fatalf("%q: marker not removed: %q", marker, got)
+		}
+	}
+	rejected(outside)
+	rejected("../" + filepath.Base(filepath.Dir(outside)) + "/secret")
+	rejected("..")
+	rejected("")
+}


### PR DESCRIPTION
`resolveFileIncludes` accepted absolute paths and relative paths with
`..` traversal, so anyone who can write `gateway.hcl` (the dashboard
config editor included) could make the gateway read any file its
process can see and surface the bytes through diagnostics, the emitted
config, or trust material.

* Reject absolute names and any path that resolves outside the config
  directory, with a diagnostic naming the reason.
* Names inside the directory, including `sub/../ca.pem`, keep working.
* Test covers accepted and rejected shapes and checks no file content
  leaks into the output on rejection.

Fixes #315
