### PR TITLE
postgres: send agents a generic upstream-auth failure

### DIFF
--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -299,7 +299,11 @@ func (PostgresEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnH
 	// Step 5 + 6: drive upstream auth, replay post-auth to agent.
 	postAuth, err := pgPerformAuth(upstream, realUser, realPassword)
 	if err != nil {
-		pgWriteError(ch.Conn, "upstream auth: "+err.Error())
+		// The upstream's own error text names the real user and often
+		// the database or host; the agent must not learn either. Log
+		// the detail for the operator, send a generic failure.
+		log.Printf("pg-upstream-auth %s: credential %q: %v", ch.PeerIP, cc.Credential.Symbol.Name, err)
+		pgWriteError(ch.Conn, "upstream authentication failed (details in the gateway log)")
 		return err
 	}
 	if err := pgWriteAuthOK(ch.Conn, postAuth); err != nil {


### PR DESCRIPTION
The upstream's own error text (`password authentication failed for
user ...`) names the real user and often the database or host, and it
was forwarded verbatim to the agent as `upstream auth: ...`.

* Log the detail (peer, credential name, upstream error) on the
  gateway.
* Send the agent `upstream authentication failed (details in the
  gateway log)`.

Fixes #312
