### PR TITLE
credentials: keep ClickHouse and Gemini secrets out of URL queries

### DIFF
--- a/internal/config/plugins/credentials/clickhouse.go
+++ b/internal/config/plugins/credentials/clickhouse.go
@@ -59,10 +59,15 @@ func (c *ClickhouseCredential) InjectHTTP(_ context.Context, req *http.Request, 
 	}
 	password := string(sec.Bytes)
 	req.SetBasicAuth(c.User, password)
-	q := req.URL.Query()
-	q.Set("user", c.User)
-	q.Set("password", password)
-	req.URL.RawQuery = q.Encode()
+	// Auth goes in the header only. ClickHouse accepts ?user=&password=
+	// too, but a secret in the URL ends up in upstream access logs,
+	// proxy logs and error strings. Strip any copy the agent sent so a
+	// placeholder never reaches the server either.
+	if q := req.URL.Query(); q.Has("user") || q.Has("password") {
+		q.Del("user")
+		q.Del("password")
+		req.URL.RawQuery = q.Encode()
+	}
 	return nil
 }
 

--- a/internal/config/plugins/credentials/clickhouse.go
+++ b/internal/config/plugins/credentials/clickhouse.go
@@ -1,9 +1,9 @@
 package credentials
 
-// clickhouse_credential: HTTPS API takes user + password as query
-// params (?user=…&password=…) or basic-auth header. We populate both
-// — basic-auth handles default-auth ClickHouse setups, query params
-// handle setups that disable header auth.
+// clickhouse_credential: the HTTPS API accepts user + password as a
+// basic-auth header or as ?user=…&password=… query params. Only the
+// header is used: a secret in the URL ends up in access and proxy
+// logs, so any query copy (placeholder or not) is stripped.
 
 import (
 	"context"

--- a/internal/config/plugins/credentials/gemini.go
+++ b/internal/config/plugins/credentials/gemini.go
@@ -1,10 +1,9 @@
 package credentials
 
 // gemini_api_key: Google Gemini accepts the API key in either the
-// `x-goog-api-key` header or the `?key=` query parameter. Always
-// overwrite both — agents that send placeholder values get them
-// swapped; agents that don't send anything get the real key stamped
-// in.
+// `x-goog-api-key` header or the `?key=` query parameter. Only the
+// header is used: a `?key=` the agent sent (a placeholder) is removed
+// rather than swapped, so the real key never travels in the URL.
 
 import (
 	"context"

--- a/internal/config/plugins/credentials/gemini.go
+++ b/internal/config/plugins/credentials/gemini.go
@@ -24,12 +24,12 @@ func (g *GeminiAPIKey) InjectHTTP(_ context.Context, req *http.Request, sec runt
 	}
 	key := string(sec.Bytes)
 	req.Header.Set("x-goog-api-key", key)
-	q := req.URL.Query()
-	if q.Get("key") != "" {
-		// Only rewrite the param when the agent set one — otherwise
-		// header injection above is sufficient and we don't want to
-		// surprise the agent with an extra param.
-		q.Set("key", key)
+	// The header is sufficient for every Gemini endpoint. An agent
+	// that put a placeholder in ?key= gets it removed rather than
+	// replaced: the real key must not travel in the URL, where
+	// upstream and proxy logs record it.
+	if q := req.URL.Query(); q.Has("key") {
+		q.Del("key")
 		req.URL.RawQuery = q.Encode()
 	}
 	return nil

--- a/internal/config/plugins/credentials/query_secret_test.go
+++ b/internal/config/plugins/credentials/query_secret_test.go
@@ -1,0 +1,55 @@
+package credentials
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/denoland/clawpatrol/internal/config/runtime"
+)
+
+// Secrets must travel in headers, never in the URL, and a placeholder
+// the agent put in the query string must not reach upstream.
+func TestClickhouseInjectKeepsSecretOutOfQuery(t *testing.T) {
+	req, _ := http.NewRequest("POST", "https://ch.example.test/?query=SELECT+1&user=PH_user&password=PH_pw", strings.NewReader("SELECT 1"))
+	c := &ClickhouseCredential{User: "svc"}
+	if err := c.InjectHTTP(context.Background(), req, runtime.Secret{Bytes: []byte("s3cret")}); err != nil {
+		t.Fatal(err)
+	}
+	if u, p, ok := req.BasicAuth(); !ok || u != "svc" || p != "s3cret" {
+		t.Fatalf("basic auth = %q %q %v", u, p, ok)
+	}
+	q := req.URL.Query()
+	if q.Has("user") || q.Has("password") {
+		t.Fatalf("query still carries auth: %q", req.URL.RawQuery)
+	}
+	if q.Get("query") != "SELECT 1" {
+		t.Fatalf("unrelated query param lost: %q", req.URL.RawQuery)
+	}
+	if strings.Contains(req.URL.String(), "s3cret") {
+		t.Fatalf("secret in URL: %s", req.URL)
+	}
+}
+
+func TestGeminiInjectKeepsSecretOutOfQuery(t *testing.T) {
+	for _, raw := range []string{
+		"https://generativelanguage.googleapis.com/v1beta/models?key=PH_gemini",
+		"https://generativelanguage.googleapis.com/v1beta/models",
+	} {
+		req, _ := http.NewRequest("GET", raw, nil)
+		g := &GeminiAPIKey{}
+		if err := g.InjectHTTP(context.Background(), req, runtime.Secret{Bytes: []byte("AIza-secret")}); err != nil {
+			t.Fatal(err)
+		}
+		if req.Header.Get("x-goog-api-key") != "AIza-secret" {
+			t.Fatalf("%s: header not set", raw)
+		}
+		if req.URL.Query().Has("key") {
+			t.Fatalf("%s: ?key survived: %q", raw, req.URL.RawQuery)
+		}
+		if strings.Contains(req.URL.String(), "secret") {
+			t.Fatalf("%s: secret in URL", raw)
+		}
+	}
+}


### PR DESCRIPTION
ClickHouse injection set the password both as Basic auth and as
`?user=&password=`; Gemini rewrote an agent-supplied `?key=`
placeholder to the real key. A secret in the URL ends up in upstream
access logs, proxy logs and error strings, which a header does not.

* ClickHouse: Basic auth only; `user` and `password` query parameters
  are removed (both accepted by ClickHouse, the header is sufficient).
* Gemini: `x-goog-api-key` only; an agent's `?key=` is removed rather
  than replaced.
* Tests assert the header is set, the query no longer carries auth,
  unrelated parameters survive, and the secret never appears in the
  URL.

Fixes #317
