### PR TITLE
onboard: hand out approved auth material exactly once

### DIFF
--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -55,6 +55,12 @@ type onboardSession struct {
 	profile     string // profile assigned at approval time
 	hostname    string // client-supplied (os.Hostname) at /api/onboard/start
 	apiToken    string // per-peer bearer for gated client API calls (env-pushdown)
+	// delivered is set once the approved auth material has been
+	// handed to a poller. The device code is a bearer capability for
+	// one joining client, so the material goes out exactly once; a
+	// later poll gets expired_token, and a client that lost the
+	// response re-runs join.
+	delivered bool
 	// wholeMachine: client asked at /start to install a persistent tailnet
 	// node (system tailscale on linux, NE-routed on macOS) rather than
 	// per-process tsnet. Determines whether the minted auth key is
@@ -1170,6 +1176,11 @@ func (w *webMux) apiOnboardPoll(rw http.ResponseWriter, r *http.Request) {
 		writeJSON(rw, map[string]string{"error": "slow_down"})
 		return
 	}
+	if s.delivered {
+		writeJSON(rw, map[string]string{"error": "expired_token", "detail": "auth material already delivered; re-run clawpatrol join"})
+		return
+	}
+	s.delivered = true
 	resp := map[string]any{
 		"auth_key":     s.authKey,
 		"api_token":    s.apiToken,

--- a/cmd/clawpatrol/onboard_poll_once_test.go
+++ b/cmd/clawpatrol/onboard_poll_once_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The approved auth material is a one-shot: the first poll after
+// approval gets it, every later poll with the same device code is
+// refused.
+func TestOnboardPollDeliversAuthMaterialOnce(t *testing.T) {
+	w := &webMux{onboard: newOnboardRegistry()}
+	s := w.onboard.start()
+	w.onboard.mu.Lock()
+	s.approved = true
+	s.authKey = "wg-key"
+	s.apiToken = "api-token"
+	s.loginServer = "wireguard://wg0"
+	w.onboard.mu.Unlock()
+
+	poll := func() map[string]any {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/onboard/poll?device_code="+s.deviceCode, nil)
+		w.apiOnboardPoll(rec, req)
+		var out map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v: %s", err, rec.Body.String())
+		}
+		return out
+	}
+
+	first := poll()
+	if first["auth_key"] != "wg-key" || first["api_token"] != "api-token" {
+		t.Fatalf("first poll = %v", first)
+	}
+	second := poll()
+	if second["error"] != "expired_token" {
+		t.Fatalf("second poll = %v, want expired_token", second)
+	}
+	if _, leaked := second["auth_key"]; leaked {
+		t.Fatalf("second poll leaked auth material: %v", second)
+	}
+}


### PR DESCRIPTION
`/api/onboard/poll` returned the approved `auth_key` and `api_token`
on every poll until the session was garbage-collected (about ten
minutes). The device code is a bearer capability for one joining
client; if it leaks, a second poller could collect the same material
during that window (#319).

* Deliver it once. A later poll with the same device code gets
  `expired_token` with a hint to re-run `join`, which is also what a
  client that lost the response has to do.
* Test: first poll returns the material, second poll is refused and
  carries none of it.

Fixes #319
