### PR TITLE
web: stop trusting Tailscale-User-Login from loopback proxies

### DIFF
--- a/cmd/clawpatrol/agents.go
+++ b/cmd/clawpatrol/agents.go
@@ -107,11 +107,13 @@ func detectAgentTypeFromHost(host string) string {
 }
 
 type AgentRegistry struct {
-	mu      sync.RWMutex
-	agents  map[string]*Agent
-	lc      *local.Client
-	onboard *onboardRegistry // set by Gateway ctor; supplies hostname/owner overrides in WG mode
-	db      *sql.DB          // optional; persists Session rows. nil → in-memory only.
+	mu     sync.RWMutex
+	agents map[string]*Agent
+	lc     *local.Client
+	// whoisOverride replaces the LocalClient whois in tests.
+	whoisOverride func(ip string) *whoisResult
+	onboard       *onboardRegistry // set by Gateway ctor; supplies hostname/owner overrides in WG mode
+	db            *sql.DB          // optional; persists Session rows. nil → in-memory only.
 
 	// persistState debounces per-session DB writes (see persistSession).
 	// Separate mutex from r.mu so a slow SQLite write doesn't block
@@ -256,6 +258,12 @@ func (r *AgentRegistry) trackUA(remoteAddr, host, ua string, in, out int64) {
 // lookupWhois does a synchronous whois (short timeout). Used for
 // credential-owner derivation per-request. Returns nil on failure.
 func (r *AgentRegistry) lookupWhois(ip string) *whoisResult {
+	if r.whoisOverride != nil {
+		return r.whoisOverride(ip)
+	}
+	if r.lc == nil {
+		return nil
+	}
 	addr, err := netip.ParseAddr(ip)
 	if err != nil {
 		return nil

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1623,10 +1623,6 @@ func (w *webMux) apiHITLDecide(rw http.ResponseWriter, r *http.Request) {
 	writeJSON(rw, result)
 }
 
-func isLoopback(host string) bool {
-	return host == "127.0.0.1" || host == "::1" || strings.HasPrefix(host, "127.")
-}
-
 func (w *webMux) apiEventsSSE(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "text/event-stream")
 	rw.Header().Set("Cache-Control", "no-cache")

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -586,12 +586,14 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 			next.ServeHTTP(rw, r)
 			return
 		}
-		// Two ways to prove tailnet membership:
-		//   1. peer IP whois (direct tailnet → gateway, no proxy).
-		//   2. Tailscale-User-Login header from `tailscale serve` —
-		//      ONLY trusted when the proxy hop is local (127.0.0.1 /
-		//      ::1). Anyone hitting us via funnel can otherwise forge
-		//      the header trivially.
+		// The only proof of tailnet membership is a whois of the
+		// peer address of a direct tailnet connection. Requests that
+		// arrive through a local reverse proxy are anonymous: the
+		// Tailscale-User-Login and X-Forwarded-For headers a
+		// `tailscale serve` hop sets are indistinguishable from ones
+		// an attacker sends through any other proxy on the host, so
+		// they are not consulted. In Tailscale mode the dashboard is
+		// served on the tsnet node itself, which is the direct path.
 		host := r.RemoteAddr
 		if i := strings.LastIndex(host, ":"); i >= 0 {
 			host = host[:i]
@@ -603,12 +605,6 @@ func (w *webMux) tailnetGate(next http.Handler) http.Handler {
 				device = who.Node.StableID
 				displayHost = who.Node.HostName
 			}
-		}
-		if login == "" && isLoopback(host) {
-			// `tailscale serve` proxy hop. The header is authoritative
-			// here because nothing public can reach loopback.
-			login = r.Header.Get("Tailscale-User-Login")
-			displayHost = host
 		}
 		if login == "" {
 			http.Error(rw, "tailnet access required — onboard via `clawpatrol join <gateway>`", http.StatusForbidden)

--- a/cmd/clawpatrol/web_auth_test.go
+++ b/cmd/clawpatrol/web_auth_test.go
@@ -295,13 +295,29 @@ func TestOnboardApproveWithDashboardPasswordInTailscaleModeDoesNotRequireTailnet
 // any tailnet member (including tag:client whois "tagged-devices")
 // approve onboards. The fix requires an explicit allowlist match
 // on operator-class routes; the test config now reflects that.
+
+// withTailnetPeer makes w resolve a direct tailnet connection from
+// 100.64.0.9 to login via whois.
+func withTailnetPeer(w *webMux, login string) {
+	w.g.agents = &AgentRegistry{whoisOverride: func(ip string) *whoisResult {
+		if ip != "100.64.0.9" {
+			return nil
+		}
+		return &whoisResult{Node: whoisNode{StableID: "n1", HostName: "laptop"}, UserProfile: whoisProfile{LoginName: login}}
+	}}
+}
+
+func fromTailnetPeer(req *http.Request) {
+	req.RemoteAddr = "100.64.0.9:12345"
+}
+
 func TestOnboardApproveWithTailnetPrincipalInTailscaleModeReachesHandler(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
 	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"*@example.com"}
+	withTailnetPeer(w, "operator@example.com")
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
-	req.RemoteAddr = "127.0.0.1:12345"
-	req.Header.Set("Tailscale-User-Login", "operator@example.com")
+	fromTailnetPeer(req)
 	rr := httptest.NewRecorder()
 
 	h.ServeHTTP(rr, req)
@@ -317,10 +333,10 @@ func TestOnboardApproveWithTailnetPrincipalInTailscaleModeReachesHandler(t *test
 func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeReachesHandler(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "")
 	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"*@example.com"}
+	withTailnetPeer(w, "operator@example.com")
 	h := w.handler()
 	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
-	req.RemoteAddr = "127.0.0.1:12345"
-	req.Header.Set("Tailscale-User-Login", "operator@example.com")
+	fromTailnetPeer(req)
 	rr := httptest.NewRecorder()
 
 	h.ServeHTTP(rr, req)
@@ -342,12 +358,12 @@ func TestOnboardApproveWithTailnetPrincipalInDefaultTailscaleModeReachesHandler(
 func TestOnboardApproveRejectsTailnetPrincipalNotInOperators(t *testing.T) {
 	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
 	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"*@example.com"}
-	h := w.handler()
-	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
-	req.RemoteAddr = "127.0.0.1:12345"
 	// "tagged-devices" is the tsnet whois reply for a tag:client
 	// peer with no human identity attached.
-	req.Header.Set("Tailscale-User-Login", "tagged-devices")
+	withTailnetPeer(w, "tagged-devices")
+	h := w.handler()
+	req := httptest.NewRequest(http.MethodPost, "/api/onboard/approve?code=NOPE&profile=default", nil)
+	fromTailnetPeer(req)
 	rr := httptest.NewRecorder()
 
 	h.ServeHTTP(rr, req)
@@ -429,15 +445,37 @@ func TestDashboardAuthGateAllowsTailnetOperatorWhenAllowlisted(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			withTailnetPeer(w, tc.login)
 			req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
-			req.RemoteAddr = "127.0.0.1:12345"
-			req.Header.Set("Tailscale-User-Login", tc.login)
+			fromTailnetPeer(req)
 			rr := httptest.NewRecorder()
 			h.ServeHTTP(rr, req)
 			if rr.Code != tc.want {
 				t.Fatalf("status = %d, want %d; body = %q", rr.Code, tc.want, rr.Body.String())
 			}
 		})
+	}
+}
+
+// Headers a `tailscale serve` hop would set carry no weight: a local
+// reverse proxy forwarding public traffic can present the same ones.
+// Identity comes only from a direct tailnet connection.
+func TestDashboardAuthGateIgnoresForwardedTailnetHeaders(t *testing.T) {
+	w := newOnboardAuthTestWebMuxForControl(t, "tailscale")
+	w.g.cfg.Load().Settings.Tailscale.Operators = []string{"alice@example.com"}
+	withTailnetPeer(w, "alice@example.com")
+	h := w.handler()
+
+	for _, remote := range []string{"127.0.0.1:1", "[::1]:1", "203.0.113.7:1"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = remote
+		req.Header.Set("Tailscale-User-Login", "alice@example.com")
+		req.Header.Set("X-Forwarded-For", "100.64.0.9")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("%s: status = %d, want 403; body = %q", remote, rr.Code, rr.Body.String())
+		}
 	}
 }
 


### PR DESCRIPTION
The tailnet gate accepted a `Tailscale-User-Login` header on any
loopback request, on the theory that only a `tailscale serve` hop can
reach loopback. Any other local reverse proxy that forwards public
traffic without stripping the header let a stranger choose their
tailnet identity (#316). Corroborating the header against
`X-Forwarded-For` (the first version of this PR) does not help: a
proxy that forwards headers verbatim forwards that one too, and
tailnet IPs are not secret.

* Drop the header path. Tailnet identity comes only from a whois of
  the peer address of a direct tailnet connection, which in Tailscale
  mode the dashboard already serves on the tsnet node itself.
  Requests through a local proxy are anonymous and fall through to
  the password gate.
* `AgentRegistry` gains a test-only whois override; the tests that
  modelled the serve hop now model a direct tailnet peer, and a new
  test checks that the forwarded headers carry no weight from
  loopback or anywhere else.

Fixes #316
