### PR TITLE
run: stop advising users to disable AppArmor's userns restriction

### DIFF
--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -807,8 +807,13 @@ func checkUserNS() {
 	}
 	if b, err := os.ReadFile("/proc/sys/kernel/apparmor_restrict_unprivileged_userns"); err == nil {
 		if strings.TrimSpace(string(b)) == "1" {
-			fmt.Fprintf(os.Stderr, "warning: AppArmor may block TUN in user namespaces.\n"+
-				"  if `clawpatrol run` fails: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\n")
+			self, _ := os.Executable()
+			fmt.Fprintf(os.Stderr, "warning: AppArmor restricts unprivileged user namespaces on this host (Ubuntu 24.04 default).\n"+
+				"  If `clawpatrol run` fails, either give this user passwordless sudo (clawpatrol then\n"+
+				"  sets the namespace up as root and needs no user namespace), or grant this binary\n"+
+				"  the userns permission with an AppArmor profile:\n"+
+				"    https://clawpatrol.dev/docs/cli/#ubuntu-2404-and-apparmor\n"+
+				"  (binary: %s)\n", self)
 		}
 	}
 }

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -155,15 +155,18 @@ the whole system:
   privileged setup path described above and never creates a user
   namespace. This is the simplest option on a single-user machine.
 - **An AppArmor profile for the clawpatrol binary.** This is the
-  mechanism Ubuntu uses for its own browsers. Create
-  `/etc/apparmor.d/clawpatrol` with the path where the binary is
-  installed (`install.sh` puts it in `~/.local/bin`):
+  mechanism Ubuntu uses for its own browsers. The profile attaches
+  by path, and whatever sits at that path runs with the `userns`
+  grant, so put the binary somewhere only root can write (for
+  example `/usr/local/bin/clawpatrol`) and name that exact path; a
+  glob over home directories would hand the grant to any file a
+  user drops there. Create `/etc/apparmor.d/clawpatrol`:
 
   ```
   abi <abi/4.0>,
   include <tunables/global>
 
-  profile clawpatrol /home/*/.local/bin/clawpatrol flags=(unconfined) {
+  profile clawpatrol /usr/local/bin/clawpatrol flags=(unconfined) {
     userns,
     include if exists <local/clawpatrol>
   }
@@ -172,7 +175,8 @@ the whole system:
   then load it with `sudo apparmor_parser -r /etc/apparmor.d/clawpatrol`.
   The profile is unconfined apart from granting `userns`, so it
   changes nothing else about how clawpatrol runs; it has to be
-  reloaded if the binary moves.
+  reloaded if the binary moves. The warning prints the path of the
+  binary that is running.
 
 Setting `kernel.apparmor_restrict_unprivileged_userns=0` also works
 but removes the restriction for every program on the host, which is

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -142,6 +142,42 @@ If you're on the unprivileged path and a command needs to act as root:
   command runs in the normal host environment where `sudo` works —
   you run it directly, not through `clawpatrol run`.
 
+#### Ubuntu 24.04 and AppArmor
+
+Ubuntu 24.04 ships with `kernel.apparmor_restrict_unprivileged_userns=1`,
+which denies unprivileged user namespaces to any program that has no
+AppArmor profile granting them. `clawpatrol run` then prints a
+warning and, without passwordless `sudo`, fails to build its
+namespace. Two ways to run without turning that protection off for
+the whole system:
+
+- **Passwordless `sudo` for the invoking user.** clawpatrol uses the
+  privileged setup path described above and never creates a user
+  namespace. This is the simplest option on a single-user machine.
+- **An AppArmor profile for the clawpatrol binary.** This is the
+  mechanism Ubuntu uses for its own browsers. Create
+  `/etc/apparmor.d/clawpatrol` with the path where the binary is
+  installed (`install.sh` puts it in `~/.local/bin`):
+
+  ```
+  abi <abi/4.0>,
+  include <tunables/global>
+
+  profile clawpatrol /home/*/.local/bin/clawpatrol flags=(unconfined) {
+    userns,
+    include if exists <local/clawpatrol>
+  }
+  ```
+
+  then load it with `sudo apparmor_parser -r /etc/apparmor.d/clawpatrol`.
+  The profile is unconfined apart from granting `userns`, so it
+  changes nothing else about how clawpatrol runs; it has to be
+  reloaded if the binary moves.
+
+Setting `kernel.apparmor_restrict_unprivileged_userns=0` also works
+but removes the restriction for every program on the host, which is
+what it exists to prevent.
+
 ### `clawpatrol test`
 
 Replay recorded gateway actions against a candidate HCL policy and


### PR DESCRIPTION
On Ubuntu 24.04 the warning printed when
`kernel.apparmor_restrict_unprivileged_userns=1` told users to set it
to 0, which removes the protection for every program on the host
(#746). Two ways keep it:

* passwordless `sudo` for the invoking user, after which clawpatrol
  takes the privileged setup path and never creates a user namespace;
* an AppArmor profile granting `userns` to the clawpatrol binary, the
  mechanism Ubuntu uses for its own browsers.

The warning now says so and prints the binary path the profile must
name; the CLI reference documents both options with a ready-to-use
profile and a link the warning points at. Cross-vetted for Linux.

Fixes #746
