### PR TITLE
mitm: redact injected credentials from response body samples

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3037,7 +3037,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 		reqSnapshot := reqS.snapshot(req.Header.Get("Content-Encoding"))
 		respSnapshot := respS.snapshot(resp.Header.Get("Content-Encoding"))
 		applyRequestBodySnapshot(&ev, reqSnapshot, reqBodySecretRedactions)
-		applyResponseBodySnapshot(&ev, respSnapshot)
+		applyResponseBodySnapshot(&ev, respSnapshot, reqBodySecretRedactions)
 		ev.Ms = time.Since(start).Milliseconds()
 		g.emitEnd(ev)
 		if g.agents != nil && agentAddr != "" {

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -2808,8 +2808,12 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 					switch {
 					case wantsSign:
 						reqBodySecretRedactions = appendCredentialSecretRedactions(reqBodySecretRedactions, sec)
+						headersBefore := req.Header.Clone()
 						if err := signer.SignHTTPRequest(req.Context(), req, sec, ep.Body); err != nil {
 							log.Printf("sign %s: %v", cc.Credential.Symbol.Name, err)
+						}
+						for _, v := range injectedHeaderSecrets(headersBefore, req.Header) {
+							reqBodySecretRedactions = appendCredentialSecretRedaction(reqBodySecretRedactions, v)
 						}
 					case wantsHTTP:
 						reqBodySecretRedactions = appendCredentialSecretRedactions(reqBodySecretRedactions, sec)
@@ -2823,7 +2827,7 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 						// consumes the request body during injection, so on failure the request
 						// is corrupted, not merely un-injected — fail closed instead of
 						// forwarding a half-transformed request.
-						bodyBefore, urlBefore := req.Body, req.URL.String()
+						bodyBefore, urlBefore, headersBefore := req.Body, req.URL.String(), req.Header.Clone()
 						if err := injector.InjectHTTP(req.Context(), req, sec); err != nil {
 							if rewritesRequest {
 								log.Printf("transform %s: %v; failing closed", cc.Credential.Symbol.Name, err)
@@ -2847,6 +2851,9 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 							for _, secret := range rp.ConsumeHTTPRedactions(req) {
 								reqBodySecretRedactions = appendCredentialSecretRedaction(reqBodySecretRedactions, secret)
 							}
+						}
+						for _, v := range injectedHeaderSecrets(headersBefore, req.Header) {
+							reqBodySecretRedactions = appendCredentialSecretRedaction(reqBodySecretRedactions, v)
 						}
 					}
 					if wantsWS && isWSUpgrade(req) {

--- a/cmd/clawpatrol/sample_redact.go
+++ b/cmd/clawpatrol/sample_redact.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"slices"
 	"sort"
 	"strings"
 
@@ -39,4 +41,29 @@ func redactCredentialSample(sample string, secrets []string) string {
 		sample = strings.ReplaceAll(sample, secret, credentialSampleRedaction)
 	}
 	return sample
+}
+
+// injectedHeaderSecrets returns the sensitive values a credential put
+// on the wire that are not the raw secret: every header value that
+// injection or signing added or changed, plus the token part of an
+// Authorization-style "<scheme> <token>" value. Basic auth sends a
+// base64 of user:password, signers mint tokens or signatures, and an
+// upstream that reflects request headers into an error body would
+// otherwise persist those verbatim. Values shorter than eight bytes
+// are skipped: they are not credentials and would shred samples.
+func injectedHeaderSecrets(before, after http.Header) []string {
+	var out []string
+	for key, vals := range after {
+		prev := before[key]
+		for _, v := range vals {
+			if v == "" || len(v) < 8 || slices.Contains(prev, v) {
+				continue
+			}
+			out = appendCredentialSecretRedaction(out, v)
+			if _, tok, ok := strings.Cut(v, " "); ok && len(tok) >= 8 {
+				out = appendCredentialSecretRedaction(out, tok)
+			}
+		}
+	}
+	return out
 }

--- a/cmd/clawpatrol/sample_redact_test.go
+++ b/cmd/clawpatrol/sample_redact_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestInjectedHeaderSecrets(t *testing.T) {
+	before := http.Header{"Accept": {"*/*"}, "Authorization": {"Bearer PH_placeholder_1"}}
+	after := before.Clone()
+	after.Set("Authorization", "Basic dXNlcjpzM2NyZXQtcGFzc3dvcmQ=")
+	after.Set("X-Amz-Date", "20260909T000000Z")
+	after.Set("X-Short", "abc")
+	got := injectedHeaderSecrets(before, after)
+	want := map[string]bool{
+		"Basic dXNlcjpzM2NyZXQtcGFzc3dvcmQ=": true,
+		"dXNlcjpzM2NyZXQtcGFzc3dvcmQ=":       true,
+		"20260909T000000Z":                   true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %q, want %d values", got, len(want))
+	}
+	for _, v := range got {
+		if !want[v] {
+			t.Fatalf("unexpected redaction %q in %q", v, got)
+		}
+	}
+	if s := redactCredentialSample("echo: Authorization: Basic dXNlcjpzM2NyZXQtcGFzc3dvcmQ= ok", got); strings.Contains(s, "dXNlcjpz") {
+		t.Fatalf("derived credential survived redaction: %q", s)
+	}
+}

--- a/cmd/clawpatrol/telegram_request_body_redaction_test.go
+++ b/cmd/clawpatrol/telegram_request_body_redaction_test.go
@@ -59,8 +59,11 @@ rule "allow-telegram" {
 			t.Errorf("read upstream body: %v", err)
 		}
 		upstreamBodies <- string(body)
+		// Echo the request back, the way an API error page or a debug
+		// endpoint reflects what it received, so the response sample
+		// carries the injected token unless it is redacted too.
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("echo: " + string(body)))
 	}))
 	defer upstream.Close()
 
@@ -141,6 +144,12 @@ rule "allow-telegram" {
 	}
 	if strings.Contains(end.ReqBody, string(fakeTelegramRequestBodyToken)) {
 		t.Fatal("request body audit sample contains injected Telegram token")
+	}
+	if strings.Contains(end.RespBody, string(fakeTelegramRequestBodyToken)) {
+		t.Fatal("response body audit sample contains injected Telegram token echoed by upstream")
+	}
+	if !strings.HasPrefix(end.RespBody, "echo: ") {
+		t.Fatalf("response body audit sample = %q, want the echoed body", end.RespBody)
 	}
 	if !strings.Contains(end.ReqBody, telegramTestPlaceholder) && !strings.Contains(strings.ToLower(end.ReqBody), "redact") {
 		t.Fatalf("request body audit sample = %q, want placeholder or redaction marker", end.ReqBody)

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -3107,10 +3107,14 @@ func applyRequestBodySnapshot(ev *Event, snapshot samplerSnapshot, redactions []
 	ev.ReqBodyState = snapshot.captureState()
 }
 
-func applyResponseBodySnapshot(ev *Event, snapshot samplerSnapshot) {
+// applyResponseBodySnapshot records the response sample with the same
+// credential redactions as the request: an upstream that echoes the
+// injected secret back (401 bodies, debug pages, error messages)
+// must not get it persisted or displayed.
+func applyResponseBodySnapshot(ev *Event, snapshot samplerSnapshot, redactions []string) {
 	ev.Out = snapshot.n
 	ev.RespSha = snapshot.sha
-	ev.RespBody = snapshot.sample
+	ev.RespBody = redactCredentialSample(snapshot.sample, redactions)
 	ev.RespBodyState = snapshot.captureState()
 }
 


### PR DESCRIPTION
Request samples had the selected credential's secret material
redacted before persistence; response samples did not (#313). An
upstream that reflects the request in an error body or debug page
therefore stored and displayed the real injected secret.

* Apply the same redaction list to the response snapshot.
* The Telegram redaction test now has the upstream echo the request
  and asserts the token is absent from the response sample too.

Fixes #313
