### PR TITLE
wireguard: fall back to unbatched sends when the path MTU is small

### DIFF
--- a/cmd/clawpatrol/daemon_transport_wg_linux.go
+++ b/cmd/clawpatrol/daemon_transport_wg_linux.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
 	wgtun "golang.zx2c4.com/wireguard/tun"
 	"gvisor.dev/gvisor/pkg/buffer"
@@ -143,7 +142,7 @@ func startWGTransport() (daemonTransport, error) {
 		return nil, fmt.Errorf("netTUN: %w", err)
 	}
 	logger := device.NewLogger(device.LogLevelError, "[clawpatrol daemon wg] ")
-	dev := device.NewDevice(tun, conn.NewDefaultBind(), logger)
+	dev := device.NewDevice(tun, newGSOFallbackBind("daemon: wg"), logger)
 
 	if err := dev.IpcSet(buildDaemonWGIpc(cfg)); err != nil {
 		_ = tun.Close()

--- a/cmd/clawpatrol/wg_bind.go
+++ b/cmd/clawpatrol/wg_bind.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"log"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -25,9 +26,23 @@ import (
 // arrives fine.
 //
 // The wrapper sends batches as usual; the first EMSGSIZE switches
-// it to one datagram per send for the life of the bind. Nothing else
-// changes: MTU stays 1420, IPv6 inside the tunnel keeps working, and
-// paths that can carry full batches never pay for it.
+// it to one datagram per send for the life of the bind. MTU stays
+// 1420, IPv6 inside the tunnel keeps working, and paths that can
+// carry full batches never pay for it.
+//
+// One known cost: wireguard-go starts its Linux route-change
+// listener (device/sticky_linux.go) only when the bind is the
+// concrete *conn.StdNetBind, so wrapping it loses that listener.
+// Its job is to drop a peer's cached source address when the route
+// to it changes; without it the address is still refreshed by every
+// received packet and by the handshake-retry timers, so after an
+// interface change a silent peer can see stale-source sends for a
+// few seconds instead of none. The proper fix is upstream (treat
+// EMSGSIZE like EIO in conn/errors_linux.go); until then this is the
+// smaller trade.
+//
+// Only Linux coalesces with GSO, so other platforms get the plain
+// bind.
 type gsoFallbackBind struct {
 	conn.Bind
 	single   atomic.Bool
@@ -36,7 +51,11 @@ type gsoFallbackBind struct {
 }
 
 func newGSOFallbackBind(describe string) conn.Bind {
-	return &gsoFallbackBind{Bind: conn.NewDefaultBind(), describe: describe}
+	b := conn.NewDefaultBind()
+	if runtime.GOOS != "linux" {
+		return b
+	}
+	return &gsoFallbackBind{Bind: b, describe: describe}
 }
 
 func (b *gsoFallbackBind) Send(bufs [][]byte, ep conn.Endpoint) error {
@@ -55,8 +74,11 @@ func (b *gsoFallbackBind) Send(bufs [][]byte, ep conn.Endpoint) error {
 }
 
 // sendEach sends every buffer as its own datagram. A single-buffer
-// Send never carries a GSO header, so the kernel fragments it when
-// the route is narrower than the packet.
+// Send never carries a GSO header (bind_std.go coalesceMessages only
+// sets one when it merged two or more datagrams), so the kernel
+// fragments it when the route is narrower than the packet. When a
+// batch failed part-way, the datagrams the kernel already accepted
+// are sent again; WireGuard's receiver drops them as replays.
 func (b *gsoFallbackBind) sendEach(bufs [][]byte, ep conn.Endpoint) error {
 	for _, buf := range bufs {
 		if err := b.Bind.Send([][]byte{buf}, ep); err != nil {

--- a/cmd/clawpatrol/wg_bind.go
+++ b/cmd/clawpatrol/wg_bind.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+// gsoFallbackBind wraps wireguard-go's default UDP bind so a path
+// narrower than the WireGuard packet size does not black-hole the
+// tunnel.
+//
+// On Linux the default bind coalesces same-size packets into one
+// sendmsg with UDP_SEGMENT (GSO). The kernel refuses a GSO segment
+// larger than the route MTU with EMSGSIZE, and wireguard-go only
+// turns GSO off on EIO, so over a 1280-byte path (a gateway reached
+// through Tailscale, for example) every full-size batch fails
+// forever: small requests work, anything past ~16 KiB stalls, and
+// the log fills with "sendmmsg: message too long" (#790). A plain
+// datagram over the same route is fragmented by the kernel and
+// arrives fine.
+//
+// The wrapper sends batches as usual; the first EMSGSIZE switches
+// it to one datagram per send for the life of the bind. Nothing else
+// changes: MTU stays 1420, IPv6 inside the tunnel keeps working, and
+// paths that can carry full batches never pay for it.
+type gsoFallbackBind struct {
+	conn.Bind
+	single   atomic.Bool
+	logOnce  sync.Once
+	describe string
+}
+
+func newGSOFallbackBind(describe string) conn.Bind {
+	return &gsoFallbackBind{Bind: conn.NewDefaultBind(), describe: describe}
+}
+
+func (b *gsoFallbackBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+	if len(bufs) <= 1 || b.single.Load() {
+		return b.sendEach(bufs, ep)
+	}
+	err := b.Bind.Send(bufs, ep)
+	if err == nil || !errors.Is(err, syscall.EMSGSIZE) {
+		return err
+	}
+	b.single.Store(true)
+	b.logOnce.Do(func() {
+		log.Printf("%s: path MTU is smaller than a batched WireGuard packet; sending one datagram per syscall from now on", b.describe)
+	})
+	return b.sendEach(bufs, ep)
+}
+
+// sendEach sends every buffer as its own datagram. A single-buffer
+// Send never carries a GSO header, so the kernel fragments it when
+// the route is narrower than the packet.
+func (b *gsoFallbackBind) sendEach(bufs [][]byte, ep conn.Endpoint) error {
+	for _, buf := range bufs {
+		if err := b.Bind.Send([][]byte{buf}, ep); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/clawpatrol/wg_bind_test.go
+++ b/cmd/clawpatrol/wg_bind_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+// fakeBind refuses batched sends the way the kernel refuses a GSO
+// segment wider than the route, and accepts single datagrams.
+type fakeBind struct {
+	conn.Bind
+	calls [][]int // lengths per Send call
+}
+
+func (f *fakeBind) Send(bufs [][]byte, _ conn.Endpoint) error {
+	lens := make([]int, len(bufs))
+	for i, b := range bufs {
+		lens[i] = len(b)
+	}
+	f.calls = append(f.calls, lens)
+	if len(bufs) > 1 {
+		return &os.SyscallError{Syscall: "sendmmsg", Err: syscall.EMSGSIZE}
+	}
+	return nil
+}
+
+func TestGSOFallbackBindDegradesToSingleSends(t *testing.T) {
+	inner := &fakeBind{}
+	b := &gsoFallbackBind{Bind: inner, describe: "test"}
+	batch := [][]byte{make([]byte, 1500), make([]byte, 1500), make([]byte, 700)}
+
+	if err := b.Send(batch, nil); err != nil {
+		t.Fatalf("first batch: %v", err)
+	}
+	// One failed batched attempt, then three single sends.
+	if len(inner.calls) != 4 || len(inner.calls[0]) != 3 {
+		t.Fatalf("calls after first batch = %v", inner.calls)
+	}
+	for _, c := range inner.calls[1:] {
+		if len(c) != 1 {
+			t.Fatalf("expected single sends after fallback, got %v", inner.calls)
+		}
+	}
+
+	// Sticky: the next batch is never tried as a batch again.
+	inner.calls = nil
+	if err := b.Send(batch, nil); err != nil {
+		t.Fatalf("second batch: %v", err)
+	}
+	if len(inner.calls) != 3 {
+		t.Fatalf("expected 3 single sends, got %v", inner.calls)
+	}
+}
+
+func TestGSOFallbackBindPassesOtherErrorsThrough(t *testing.T) {
+	inner := &errBind{err: &os.SyscallError{Syscall: "sendmmsg", Err: syscall.ENETUNREACH}}
+	b := &gsoFallbackBind{Bind: inner, describe: "test"}
+	err := b.Send([][]byte{make([]byte, 10), make([]byte, 10)}, nil)
+	if !errors.Is(err, syscall.ENETUNREACH) {
+		t.Fatalf("err = %v, want ENETUNREACH passed through", err)
+	}
+	if b.single.Load() {
+		t.Fatal("fell back on an unrelated error")
+	}
+}
+
+type errBind struct {
+	conn.Bind
+	err error
+}
+
+func (e *errBind) Send([][]byte, conn.Endpoint) error { return e.err }

--- a/cmd/clawpatrol/wg_bind_test.go
+++ b/cmd/clawpatrol/wg_bind_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"net"
 	"os"
 	"syscall"
 	"testing"
@@ -23,7 +24,8 @@ func (f *fakeBind) Send(bufs [][]byte, _ conn.Endpoint) error {
 	}
 	f.calls = append(f.calls, lens)
 	if len(bufs) > 1 {
-		return &os.SyscallError{Syscall: "sendmmsg", Err: syscall.EMSGSIZE}
+		// The real chain from x/net: *net.OpError wrapping the syscall error.
+		return &net.OpError{Op: "write", Net: "udp", Err: os.NewSyscallError("sendmmsg", syscall.EMSGSIZE)}
 	}
 	return nil
 }
@@ -74,3 +76,23 @@ type errBind struct {
 }
 
 func (e *errBind) Send([][]byte, conn.Endpoint) error { return e.err }
+
+// A single buffer never goes through the batched attempt, and a
+// failure while sending singly stops at that buffer.
+func TestGSOFallbackBindSingleBufferAndStopOnError(t *testing.T) {
+	inner := &fakeBind{}
+	b := &gsoFallbackBind{Bind: inner, describe: "test"}
+	if err := b.Send([][]byte{make([]byte, 1500)}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(inner.calls) != 1 || len(inner.calls[0]) != 1 || b.single.Load() {
+		t.Fatalf("single buffer took the batched path: %v single=%v", inner.calls, b.single.Load())
+	}
+
+	failing := &errBind{err: &net.OpError{Op: "write", Err: os.NewSyscallError("sendmsg", syscall.ENETUNREACH)}}
+	b = &gsoFallbackBind{Bind: failing, describe: "test"}
+	b.single.Store(true)
+	if err := b.Send([][]byte{{1}, {2}, {3}}, nil); !errors.Is(err, syscall.ENETUNREACH) {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/cmd/clawpatrol/wireguard.go
+++ b/cmd/clawpatrol/wireguard.go
@@ -37,7 +37,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/curve25519"
-	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
 	wgtun "golang.zx2c4.com/wireguard/tun"
 	"gvisor.dev/gvisor/pkg/buffer"
@@ -338,7 +337,7 @@ func StartWGServer(ts JoinConfig) (*WGServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	dev := device.NewDevice(tun, conn.NewDefaultBind(),
+	dev := device.NewDevice(tun, newGSOFallbackBind("wireguard"),
 		device.NewLogger(device.LogLevelError, "[wg] "))
 	if err := dev.IpcSet(fmt.Sprintf("private_key=%s\nlisten_port=%d\n", priv, listenPort)); err != nil {
 		return nil, fmt.Errorf("wg ipc: %w", err)

--- a/site/doc/configure-gateway.md
+++ b/site/doc/configure-gateway.md
@@ -91,6 +91,19 @@ wireguard {
 }
 ```
 
+### WireGuard over a narrower path
+
+Peers that reach the gateway through a path with a smaller MTU than
+Ethernet, most commonly a Tailscale address (1280-byte interface),
+need no configuration. The gateway sends WireGuard packets in
+batches; if the kernel refuses a batch because the path cannot carry
+full-size segments, the gateway logs one line and switches to one
+datagram per send for that device, which the kernel then fragments
+as needed. Linux per-process clients do the same on their side. The
+symptom this replaces, on older versions, was a steady trickle of
+`sendmmsg: message too long` in the gateway log and transfers over
+about 16 KiB that never finished.
+
 ### Single-host (loopback) WireGuard
 
 Running the gateway and `clawpatrol run` on the same machine — the


### PR DESCRIPTION
A gateway reached over Tailscale (a 1280-byte interface) delivered
0.6 to 1.5 KB/s and never completed a transfer over about 16 KiB,
logging `sendmmsg: message too long` a few times a second (#790).

The cause is not the WireGuard MTU, which is why #822 is withdrawn.
wireguard-go on Linux coalesces same-size packets into one `sendmsg`
with `UDP_SEGMENT` (GSO); the kernel refuses a GSO segment larger
than the route MTU with `EMSGSIZE`, and wireguard-go only turns GSO
off on `EIO`, so every full-size batch fails forever. A plain
datagram over the same route is fragmented by the kernel and arrives
fine.

* `gsoFallbackBind` wraps the default bind on Linux: batches are sent
  as usual, and the first `EMSGSIZE` switches the bind to one
  datagram per send for its lifetime, with one log line. MTU stays
  1420 and IPv6 inside the tunnel keeps working.
* Used by the gateway device and the Linux per-process daemon; other
  platforms have no UDP GSO and get the plain bind.
* Known trade-off: wireguard-go only starts its Linux route-change
  listener for the concrete `*conn.StdNetBind`, so the wrapper loses
  it. A peer's cached source address is still refreshed by every
  received packet and by the handshake-retry timers, so an interface
  change can cost a few seconds of stale-source sends to a silent
  peer instead of none. The proper fix is upstream (treat `EMSGSIZE`
  like `EIO` in `conn/errors_linux.go`); this is the smaller trade
  until then.
* Unit tests use the real `*net.OpError` chain and cover fallback,
  stickiness, single-buffer sends, stop-on-error, and pass-through of
  other errors. A short docs note describes the behaviour.

Reproduced and verified on a Linux host (kernel 6.8): gateway and a
kernel-WireGuard client at MTU 1420 in two network namespaces joined
by a 1280-byte veth, downloading 4 MiB through the tunnel.

| binary | bytes in 60 s | speed | EMSGSIZE |
| --- | --- | --- | --- |
| main | 82,750 (stalled) | 1.4 KB/s | 60 |
| this PR | 4,194,304 in 0.18 s | 23.8 MB/s | 1 (the trigger) |

Fixes #790
