### PR TITLE
fixes from a second review pass over today's changes

### DIFF
--- a/cmd/clawpatrol/daemon_log.go
+++ b/cmd/clawpatrol/daemon_log.go
@@ -20,12 +20,18 @@ func lastLogLineSince(path string, off int64) string {
 		return ""
 	}
 	defer func() { _ = f.Close() }()
+	// Read the last maxRead bytes written since off: a verbose boot
+	// can log far more than that before it dies, and the reason is
+	// at the end.
+	const maxRead = 64 << 10
+	if fi, err := f.Stat(); err == nil && fi.Size()-off > maxRead {
+		off = fi.Size() - maxRead
+	}
 	if off > 0 {
 		if _, err := f.Seek(off, io.SeekStart); err != nil {
 			return ""
 		}
 	}
-	const maxRead = 64 << 10
 	buf, err := io.ReadAll(io.LimitReader(f, maxRead))
 	if err != nil && len(buf) == 0 {
 		return ""

--- a/cmd/clawpatrol/daemon_log_test.go
+++ b/cmd/clawpatrol/daemon_log_test.go
@@ -38,3 +38,23 @@ func TestLastLogLineSince(t *testing.T) {
 		t.Fatalf("missing file: got %q", got)
 	}
 }
+
+func TestLastLogLineSinceReadsTheTailOfALongBoot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.log")
+	if err := os.WriteFile(path, []byte("old daemon\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	off := int64(len("old daemon\n"))
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2000; i++ {
+		_, _ = f.WriteString("debug: a chatty line of startup output that repeats\n") // ~100 KiB total
+	}
+	_, _ = f.WriteString("daemon: transport: the real reason\n")
+	_ = f.Close()
+	if got := lastLogLineSince(path, off); got != "daemon: transport: the real reason" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/cmd/clawpatrol/onboard.go
+++ b/cmd/clawpatrol/onboard.go
@@ -911,10 +911,18 @@ func (w *webMux) apiOnboardApprove(rw http.ResponseWriter, r *http.Request) {
 			w.onboard.mu.Unlock()
 			return
 		}
-		s.authKey = key
-		s.loginServer = loginServer
 		dc := s.deviceCode
 		w.onboard.mu.Unlock()
+		// Publish the key last, after the peer is claimed and its api
+		// token minted below. The poll hands the material out exactly
+		// once; a poll landing between key and token would deliver a
+		// key with no token, and the client would have to re-join.
+		defer func() {
+			w.onboard.mu.Lock()
+			s.authKey = key
+			s.loginServer = loginServer
+			w.onboard.mu.Unlock()
+		}()
 		// WG path: server allocated peerIP and knows the approver, so
 		// register the (ip → owner) mapping right here. Saves the CLI
 		// from making a /api/onboard/claim round-trip after wg-quick

--- a/doc/multi-file-config.md
+++ b/doc/multi-file-config.md
@@ -65,6 +65,10 @@ relative to the **directory passed to `Load`**. For directory
 mode, that's the config directory itself. For single-file mode,
 it's `filepath.Dir(path)`. In both cases markers and the files
 they reference live alongside the `.hcl` files that wield them.
+Absolute paths and paths that resolve outside that directory are
+rejected at load time (a dashboard config writer must not be able
+to read arbitrary files through the include syntax); symlinks
+inside the directory are followed.
 
 ## What's intentionally out of scope (v1)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,13 +344,15 @@ type Defaults struct {
 	UnknownHost string `hcl:"unknown_host,optional"`
 
 	// LLMFailMode controls requests guarded by an llm_approver when
-	// the model call cannot complete: credential fetch or injection
-	// failure, transport error or timeout, non-200 status, or an
-	// undecodable response. "closed" (the default) denies; "open"
-	// allows and records the failure as the reason. A model that
-	// answers, even ambiguously, is not a failure and is judged as
-	// usual. Misconfiguration (missing model or credential, unknown
-	// model family) always denies regardless of this setting.
+	// the model call cannot complete: the credential's secret cannot
+	// be fetched or injected, transport error or timeout, any
+	// non-200 status (including 401/403 from a revoked judge key),
+	// or an undecodable response. "closed" (the default) denies;
+	// "open" allows and records the failure as the reason. A model
+	// that answers, even ambiguously, is not a failure and is judged
+	// as usual. Misconfiguration (no model, a credential that is not
+	// declared, unknown model family) always denies regardless of
+	// this setting.
 	LLMFailMode string `hcl:"llm_fail_mode,optional"`
 
 	// LLMCacheTTL is the LLM decision cache lifetime in seconds.

--- a/internal/config/plugins/credentials/clickhouse.go
+++ b/internal/config/plugins/credentials/clickhouse.go
@@ -68,6 +68,11 @@ func (c *ClickhouseCredential) InjectHTTP(_ context.Context, req *http.Request, 
 		q.Del("password")
 		req.URL.RawQuery = q.Encode()
 	}
+	// The X-ClickHouse-User / X-ClickHouse-Key placeholder form must go
+	// too: ClickHouse rejects a request that carries those headers and
+	// an Authorization header at the same time.
+	req.Header.Del("X-ClickHouse-User")
+	req.Header.Del("X-ClickHouse-Key")
 	return nil
 }
 

--- a/internal/config/plugins/credentials/query_secret_test.go
+++ b/internal/config/plugins/credentials/query_secret_test.go
@@ -13,6 +13,8 @@ import (
 // the agent put in the query string must not reach upstream.
 func TestClickhouseInjectKeepsSecretOutOfQuery(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://ch.example.test/?query=SELECT+1&user=PH_user&password=PH_pw", strings.NewReader("SELECT 1"))
+	req.Header.Set("X-ClickHouse-User", "PH_user")
+	req.Header.Set("X-ClickHouse-Key", "PH_pw")
 	c := &ClickhouseCredential{User: "svc"}
 	if err := c.InjectHTTP(context.Background(), req, runtime.Secret{Bytes: []byte("s3cret")}); err != nil {
 		t.Fatal(err)
@@ -29,6 +31,9 @@ func TestClickhouseInjectKeepsSecretOutOfQuery(t *testing.T) {
 	}
 	if strings.Contains(req.URL.String(), "s3cret") {
 		t.Fatalf("secret in URL: %s", req.URL)
+	}
+	if req.Header.Get("X-ClickHouse-User") != "" || req.Header.Get("X-ClickHouse-Key") != "" {
+		t.Fatalf("X-ClickHouse-* placeholder headers survived: %v", req.Header)
 	}
 }
 

--- a/site/doc/rules.md
+++ b/site/doc/rules.md
@@ -402,13 +402,15 @@ before a final allow decision, Claw Patrol does **not** call upstream.
 Deny and timeout responses are gateway-generated failures, not upstream
 responses.
 
-For `llm_approver`, a model call that cannot complete (credential
-fetch or injection failure, transport error or timeout, non-200
-status, undecodable response) is resolved by `defaults.llm_fail_mode`:
-`"closed"` (the default) denies, `"open"` allows and records the
-failure as the reason. A model that answers is judged as usual, and
-an ambiguous answer denies. Misconfiguration, such as a missing
-credential, always denies.
+For `llm_approver`, a model call that cannot complete (the
+credential's secret cannot be fetched or injected, transport error
+or timeout, any non-200 status including 401/403 from a revoked
+judge key, undecodable response) is resolved by
+`defaults.llm_fail_mode`: `"closed"` (the default) denies, `"open"`
+allows and records the failure as the reason. A model that answers
+is judged as usual, and an ambiguous answer denies. Misconfiguration
+(no model, a credential that is not declared, unknown model family)
+always denies.
 
 For `human_approver`, [set `timeout` to the maximum time Claw Patrol
 should wait for a human decision](/docs/config-reference/#approver-human_approver-name).


### PR DESCRIPTION
* `clickhouse`: also strip the `X-ClickHouse-User` / `X-ClickHouse-Key`
  placeholder headers. ClickHouse rejects a request carrying those and
  an `Authorization` header together, so that placeholder form failed
  upstream once Basic auth was injected (#823), and the placeholder
  still travelled to the server.
* `onboard`: publish the approved auth key only after the peer's api
  token is minted. A poll landing in between delivered a key with no
  token; since #824 made the poll one-shot, the client had to re-join.
* `run`: `lastLogLineSince` read the first 64 KiB after the recorded
  offset and returned its last line; a verbose boot pushed the real
  fatal line past the window (#807). Read the last 64 KiB instead,
  with a test.
* docs: `llm_fail_mode`: "credential not declared" denies but "secret
  unavailable" is a call failure, and non-200 includes 401/403 from a
  revoked judge key; `multi-file-config.md`: absolute and escaping
  include paths are rejected.
