### PR TITLE
gateway: drop UDP/443 for every destination, not only VIPs

### DIFF
--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -3658,12 +3658,13 @@ func runGateway(args []string) {
 				g.dnsvip.ServeUDP(c, dstIP)
 				return true
 			}
-			if dstPort == 443 && g.dnsvip.IsVIP(dstIP) {
-				// QUIC / HTTP-3 to an intercepted (VIP'd) host: drop so
-				// the client falls back to TCP/443, which we MITM.
-				// Relaying it would let that host's HTTPS bypass
-				// interception. UDP/443 to a passed-through host falls
-				// through to relayUDP — we don't intercept it.
+			if dstPort == 443 {
+				// QUIC / HTTP-3, for every destination. The gateway never
+				// inspects HTTP/3, and plain https endpoints are dispatched
+				// by SNI on TCP/443 without a VIP, so relaying UDP/443
+				// would carry an intercepted host's traffic past every
+				// rule and past unknown_host = deny (TCP only). Drop it;
+				// the client falls back to TCP/443, where policy applies.
 				_ = c.Close()
 				return true
 			}
@@ -3672,7 +3673,7 @@ func runGateway(args []string) {
 		if err := wg.EnablePromiscuousForwarder(tcpDispatch, udpDispatch); err != nil {
 			log.Fatalf("wireguard forwarder: %v", err)
 		}
-		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, UDP/443→drop(quic) for VIPs, :5432=pg, :53=dns-vip, VIP=ssh|ch_native, :%d=dash, plugins=conn-index, else=relay)", dashPort)
+		log.Printf("wireguard promiscuous forwarder ready (any dst → :443=mitm, UDP/443→drop(quic), :5432=pg, :53=dns-vip, VIP=ssh|ch_native, :%d=dash, plugins=conn-index, else=relay)", dashPort)
 	}
 
 	tsnetServer, ln, err := openListener(cfg, stateDir)

--- a/cmd/clawpatrol/response_sanitize.go
+++ b/cmd/clawpatrol/response_sanitize.go
@@ -39,10 +39,12 @@ func isAuthResponseHeader(name string) bool {
 // altSvcHeader advertises HTTP/3 (and other alternative services). The
 // gateway intercepts HTTPS on TCP/443 and drops UDP/443, so letting the
 // origin's Alt-Svc through would tell the agent to retry over QUIC —
-// which the gateway can't MITM and now black-holes. Strip it so the
-// agent never learns to leave the interceptable TCP path. (The UDP/443
-// drop is the enforcement; this and the SVCB/HTTPS h3 strip just stop
-// the agent from trying in the first place.)
+// which the gateway can't MITM and black-holes. Strip it so the agent
+// never learns to leave the interceptable TCP path. (The UDP/443 drop
+// is the enforcement; this just stops the agent from trying. DNS
+// HTTPS/SVCB records are suppressed only for VIP'd names; for plain
+// https hosts they are relayed, which costs h3-capable clients a
+// fallback delay, nothing more.)
 const altSvcHeader = "Alt-Svc"
 
 // stripAltSvc removes the Alt-Svc header in-place from a parsed

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -355,7 +355,7 @@ func (g *Gateway) installTsnetUDPCatchAll(s *tsnet.Server) {
 			return nil, false
 		}
 	}
-	log.Printf("tsnet: UDP catch-all installed (:53 → dnsvip, :443 QUIC dropped for VIPs, other → relay for onboarded peers)")
+	log.Printf("tsnet: UDP catch-all installed (:53 → dnsvip, :443 QUIC dropped, other → relay for onboarded peers)")
 }
 
 // udpDisposition is what the gateway does with a forwarded UDP flow.

--- a/cmd/clawpatrol/tailscale.go
+++ b/cmd/clawpatrol/tailscale.go
@@ -371,19 +371,15 @@ const (
 // tsnetUDPDisposition decides how an exit-node UDP flow is handled.
 //
 //   - UDP/53 → dnsvip (resolve via clawpatrol regardless of resolver IP).
-//   - UDP/443 to an intercepted (VIP'd) host → drop. That's QUIC / HTTP-3
-//     to a host we MITM; relaying it would let HTTPS ride UDP straight
-//     past the TCP/443 SNI-peek MITM. Dropping makes the client fall back
-//     to TCP/443, which the gateway intercepts. UDP/443 to a host we
-//     pass through (no VIP) is *not* dropped — we don't intercept that
-//     host's HTTPS either, so there's nothing to bypass, and breaking its
-//     HTTP/3 would be gratuitous. (WG mode's udpDispatch does the same.)
-//     Limitation: an https-mitm endpoint bound to an IP literal isn't
-//     VIP'd, so its UDP/443 isn't dropped here — rare (those are dialled
-//     by IP, e.g. kubectl, and over TCP), and Alt-Svc stripping still
-//     suppresses h3 discovery for it on the MITM'd TCP path.
-//   - other UDP from an onboarded peer → relay (e.g. NTP, a custom
-//     protocol, or QUIC to a passed-through host).
+//   - UDP/443 → drop, for every destination. That is QUIC / HTTP-3,
+//     which the gateway never inspects. Plain https endpoints are
+//     dispatched by SNI on TCP/443 and carry no VIP, so relaying
+//     UDP/443 would let an intercepted host's HTTPS ride straight
+//     past its rules (and past unknown_host = deny, which is TCP
+//     only). Dropping makes every HTTP/3 client fall back to TCP/443.
+//     (WG mode's udpDispatch does the same.)
+//   - other UDP from an onboarded peer → relay (e.g. NTP or a custom
+//     protocol).
 //   - everything else → tsnet's default handler.
 func (g *Gateway) tsnetUDPDisposition(dst netip.AddrPort, src netip.Addr) udpDisposition {
 	switch dst.Port() {
@@ -392,9 +388,7 @@ func (g *Gateway) tsnetUDPDisposition(dst netip.AddrPort, src netip.Addr) udpDis
 			return udpDNS
 		}
 	case 443:
-		if g.dnsvip != nil && g.dnsvip.IsVIP(dst.Addr().String()) {
-			return udpDrop
-		}
+		return udpDrop
 	}
 	if g.tsnetUDPPeerOnboarded(src) {
 		return udpRelay

--- a/cmd/clawpatrol/tsnet_udp_catchall_test.go
+++ b/cmd/clawpatrol/tsnet_udp_catchall_test.go
@@ -60,10 +60,10 @@ func newTestDNSVIP(t *testing.T) *dnsvip.Allocator {
 	return a
 }
 
-// tsnetUDPDisposition: UDP/53 → dnsvip; UDP/443 to an intercepted (VIP'd)
-// host → drop (force HTTPS to the TCP MITM); UDP/443 to a pass-through
-// host is NOT dropped (we don't intercept it); other UDP from an
-// onboarded peer → relay; the rest → tsnet's default handler.
+// tsnetUDPDisposition: UDP/53 → dnsvip; UDP/443 → drop for every
+// destination (QUIC is never inspected, so HTTPS must take the TCP
+// MITM path); other UDP from an onboarded peer → relay; the rest →
+// tsnet's default handler.
 func TestTsnetUDPDisposition(t *testing.T) {
 	r := newOnboardRegistry()
 	r.knownDeviceIPs["100.64.0.2"] = true

--- a/cmd/clawpatrol/tsnet_udp_catchall_test.go
+++ b/cmd/clawpatrol/tsnet_udp_catchall_test.go
@@ -85,8 +85,8 @@ func TestTsnetUDPDisposition(t *testing.T) {
 		{"dns stranger", mk(pub, 53), stranger, udpDNS},
 		{"quic to intercepted VIP dropped", mk(vip, 443), onboarded, udpDrop},
 		{"quic to intercepted VIP dropped (stranger)", mk(vip, 443), stranger, udpDrop},
-		{"quic to pass-through relayed", mk(pub, 443), onboarded, udpRelay},
-		{"quic to pass-through not relayed for stranger", mk(pub, 443), stranger, udpPassthrough},
+		{"quic to pass-through dropped too", mk(pub, 443), onboarded, udpDrop},
+		{"quic to pass-through dropped for stranger", mk(pub, 443), stranger, udpDrop},
 		{"ntp onboarded relayed", mk(pub, 123), onboarded, udpRelay},
 		{"ntp stranger passthrough", mk(pub, 123), stranger, udpPassthrough},
 	}
@@ -96,10 +96,10 @@ func TestTsnetUDPDisposition(t *testing.T) {
 		}
 	}
 
-	// Without a dnsvip there's no VIP table, so UDP/443 isn't dropped —
-	// it relays for onboarded peers like any other UDP.
+	// The QUIC drop does not depend on the VIP table: it holds with
+	// no dnsvip at all.
 	g2 := &Gateway{onboard: r}
-	if got := g2.tsnetUDPDisposition(mk(vip, 443), onboarded); got != udpRelay {
-		t.Errorf("443 w/o dnsvip from onboarded: disposition = %d, want relay", got)
+	if got := g2.tsnetUDPDisposition(mk(vip, 443), onboarded); got != udpDrop {
+		t.Errorf("443 w/o dnsvip from onboarded: disposition = %d, want drop", got)
 	}
 }

--- a/doc/tailscale.md
+++ b/doc/tailscale.md
@@ -34,15 +34,18 @@ no subnet allocation — Tailscale's control plane handles all of that.
    and relays other UDP from onboarded peers via `relayUDP` — so a
    tsnet-mode `clawpatrol run` child gets arbitrary UDP (NTP, custom
    protocols) without a UDP-over-TCP shim, since the userspace exit node
-   already receives the datagrams. **QUIC / HTTP-3 (UDP/443) to an
-   intercepted host is dropped** in both modes so HTTPS can't ride UDP
-   past the TCP/443 SNI-peek MITM — the client falls back to
-   interceptable TCP. UDP/443 to a host the gateway *passes through* (no
-   VIP) is relayed normally: clawpatrol doesn't intercept that host's
-   HTTPS either, so there's nothing to bypass and no reason to break its
-   HTTP/3. For the hosts it does MITM, the gateway also strips the
-   `Alt-Svc` response header so agents don't discover h3 in the first
-   place (intercepted names already return no SVCB/HTTPS DNS record).
+   already receives the datagrams. **QUIC / HTTP-3 (UDP/443) is dropped for every
+   destination** in both modes, so HTTPS can't ride UDP past the
+   TCP/443 SNI-peek MITM; the client falls back to interceptable TCP.
+   The drop is unconditional because plain `https` endpoints are
+   dispatched by SNI and carry no VIP, so a per-destination rule would
+   miss exactly the hosts that have rules. Pass-through hosts lose
+   HTTP/3 too (and anything else on UDP/443, such as DTLS or TURN on
+   that port). For the hosts it MITMs, the gateway also strips the
+   `Alt-Svc` response header so agents don't try h3 in the first
+   place; VIP'd names return no SVCB/HTTPS DNS record, other names'
+   HTTPS records are relayed as-is, which only costs h3-capable
+   clients their own fallback delay.
 5. Device identity (hostname, OS, Tailscale user) is populated via
    `tailscale whois` at first connection — richer than WireGuard mode
    which only captures hostname at join time.

--- a/site/doc/architecture.md
+++ b/site/doc/architecture.md
@@ -380,5 +380,10 @@ pipes bytes both ways. The top-level `unknown_host` setting in
 an HTTPS SNI doesn’t match any configured endpoint — splice it
 unchanged or close it.
 
-UDP dispatch is narrower: only `:53` is handled today (DNS-VIP);
-other UDP datagrams are dropped.
+UDP dispatch is a three-way split on both transports: `:53` goes to
+the DNS-VIP responder; `:443` is dropped for every destination, since
+that is QUIC / HTTP-3, which the gateway never inspects and which
+would otherwise carry an intercepted host's HTTPS past its rules
+(clients fall back to TCP/443); any other UDP from an onboarded peer
+(NTP, a custom protocol) is relayed to the real destination without
+policy evaluation. UDP is not part of the policy surface.


### PR DESCRIPTION
UDP/443 (QUIC / HTTP-3) was dropped only when the destination was a
DNS VIP, on the theory that a non-VIP host is not intercepted either.
But VIPs are allocated only for endpoints that need them to route
(postgres, clickhouse_native, ssh, tunnel-backed); a plain `https`
endpoint is dispatched by SNI on TCP/443 and never gets one. So QUIC
to an intercepted host's real IP was relayed with no rule evaluation,
and `unknown_host = "deny"` never applied to UDP at all (#835). Not a
credential leak (the agent holds placeholders), but a bypass of deny
rules for any HTTP/3-capable client.

* Drop UDP/443 unconditionally on both the WireGuard and tsnet
  paths. The gateway never inspects HTTP/3; every HTTP/3 client falls
  back to TCP/443, where policy lives. Passthrough hosts lose HTTP/3
  and nothing else.
* Tests updated: QUIC to a pass-through host is dropped for onboarded
  and stranger peers alike, and the drop does not depend on the VIP
  table.
* Architecture page: describe the real three-way UDP disposition (53
  to DNS-VIP, 443 dropped, other UDP relayed for onboarded peers
  without policy) instead of "other UDP datagrams are dropped".

Fixes #835
