### PR TITLE
docs: run has no --conf flag

### DIFF
--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -77,13 +77,16 @@ clawpatrol login [flags]
 Run a command with its traffic routed through the joined gateway.
 
 ```bash
-clawpatrol run [--conf <path>] -- <command> [args...]
+clawpatrol run [--no-auto-expose] -- <command> [args...]
 ```
 
-`--conf` points at the WG conf written by `clawpatrol join`; defaults
-to the standard location so you rarely need it. On Linux the wrapped
+`run` reads the WG conf that `clawpatrol join` wrote to the standard
+location; there is no flag to point it elsewhere. On Linux the wrapped
 command runs in an unprivileged user namespace with a private WG
 tunnel; on macOS the Network Extension does the capture.
+`--no-auto-expose` disables the loopback relay that mirrors TCP
+listeners inside the namespace back to the host and forwards the
+wrapped command's connections to 127.0.0.1 out to host services.
 
 ```bash
 clawpatrol run -- claude

--- a/site/doc/cli.md
+++ b/site/doc/cli.md
@@ -77,16 +77,19 @@ clawpatrol login [flags]
 Run a command with its traffic routed through the joined gateway.
 
 ```bash
-clawpatrol run [--no-auto-expose] -- <command> [args...]
+clawpatrol run -- <command> [args...]
 ```
 
 `run` reads the WG conf that `clawpatrol join` wrote to the standard
 location; there is no flag to point it elsewhere. On Linux the wrapped
 command runs in an unprivileged user namespace with a private WG
 tunnel; on macOS the Network Extension does the capture.
-`--no-auto-expose` disables the loopback relay that mirrors TCP
-listeners inside the namespace back to the host and forwards the
-wrapped command's connections to 127.0.0.1 out to host services.
+
+Linux only, and only on the no-`sudo` path described below:
+`--no-auto-expose` (before the `--`) disables the loopback relay that
+mirrors TCP listeners inside the namespace back to the host and
+forwards the wrapped command's connections to 127.0.0.1 out to host
+services. macOS does not parse it.
 
 ```bash
 clawpatrol run -- claude


### PR DESCRIPTION
cli.md documented `clawpatrol run [--conf <path>]`, but `run` has never
had that flag: the conf always comes from the location `join` writes.
Document the one flag it does have, `--no-auto-expose`, instead.

Noticed while running the v0.5.10 pre-release checks on Linux.