### PR TITLE
run: reap the relay supervisor as soon as it exits

### DIFF
--- a/cmd/clawpatrol/relay_linux.go
+++ b/cmd/clawpatrol/relay_linux.go
@@ -270,6 +270,12 @@ func runRelaySupervisor(_ []string) {
 	// SIGPIPE on the worker socket shouldn't kill the supervisor — log
 	// from the accept goroutines instead.
 	ignoreSIGPIPE()
+	// We share the terminal's foreground process group with the wrapped
+	// command, so a Ctrl-C reaches us too. Interactive commands (Claude
+	// Code) survive their first Ctrl-C and would then run relay-less,
+	// with `run` reporting a relay death. Only SIGTERM — run's explicit
+	// kill and our Pdeathsig — and the seccomp ENOENT end us.
+	ignoreTerminalSignals()
 
 	// Hand the per-direction loops RawConns rather than raw int fds.
 	// RawConn carries an internal reference to the underlying *os.File
@@ -291,8 +297,10 @@ func runRelaySupervisor(_ []string) {
 	// and we don't want it auto-exposed back to the host.
 	workerPID, err := recvWorkerPID(lbRC)
 	if err != nil {
-		relayDebugf("[clawpatrol relay] read worker pid: %v\n", err)
-		return
+		// Raw cause only; `run` quotes our last stderr line in its own
+		// warning, so this is what the operator sees as the reason.
+		fmt.Fprintf(os.Stderr, "relay-supervisor: read worker pid: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Loopback direction: worker forwards each agent → 127.0.0.0/8:port
@@ -320,14 +328,12 @@ func runRelaySupervisor(_ []string) {
 			if errors.Is(err, unix.EINTR) || errors.Is(err, unix.EAGAIN) {
 				continue
 			}
-			// Anything else means we can no longer service notifications.
-			// Surface it unconditionally (not just under CLAWPATROL_DEBUG):
-			// the worker will now fail the REDIRECT open and host-loopback
-			// forwarding stops, so operators can see why telemetry/webhooks
-			// to host services went quiet.
-			fmt.Fprintf(os.Stderr, "⚠ clawpatrol relay: notification channel failed (%v); "+
-				"host-loopback forwarding disabled, reverting wrapped process to direct loopback\n", err)
-			return
+			// Anything else means we can no longer service notifications:
+			// host-loopback forwarding and port auto-expose stop. Print the
+			// raw cause and exit non-zero; `run` reaps us, quotes this line
+			// and explains the consequences, so it stays the one reporter.
+			fmt.Fprintf(os.Stderr, "relay-supervisor: notif_recv: %v\n", err)
+			os.Exit(1)
 		}
 
 		isListen := uint32(n.Data.NR) == listenNR
@@ -779,6 +785,11 @@ func runRelayWorker(_ []string) {
 		fail("relay-worker: expected fds 3,4,5 to be open")
 	}
 	ignoreSIGPIPE()
+	// Same foreground process group as the wrapped command (see the
+	// supervisor): a Ctrl-C the command survives must not take the
+	// forwarder — and with it host-loopback — away for the rest of the
+	// session. Pdeathsig SIGTERM and EOF on the supervisor sock end us.
+	ignoreTerminalSignals()
 
 	rc, err := sock.SyscallConn()
 	if err != nil {
@@ -818,9 +829,10 @@ func runRelayWorker(_ []string) {
 		defer cleanup()
 		// Pdeathsig delivers SIGTERM when the agent exits, which would
 		// otherwise skip the deferred cleanup; trap it so the rule is
-		// always removed before we exit.
+		// always removed before we exit. SIGINT/SIGHUP are ignored above:
+		// only SIGTERM and EOF from the supervisor end this worker.
 		sigCh := make(chan os.Signal, 2)
-		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		signal.Notify(sigCh, syscall.SIGTERM)
 		go func() {
 			<-sigCh
 			cleanup()
@@ -1375,10 +1387,11 @@ func setupRelayInChild(parentSock *os.File) {
 
 // spawnRelaySupervisor re-execs self as `relay-supervisor`, passing the
 // seccomp notify fd, worker socket, and loopback supervisor socket via
-// ExtraFiles (fds 3, 4, 5). Returns the started *exec.Cmd; the caller
-// does not Wait — Pdeathsig reaps the supervisor when the top parent
-// exits.
-func spawnRelaySupervisor(notifyFile, workerSock, lbSock *os.File) (*exec.Cmd, error) {
+// ExtraFiles (fds 3, 4, 5). The supervisor's stderr goes to the given
+// writer (run wires a last-line-capturing tee in front of os.Stderr so
+// it can quote the supervisor's final line if it exits early). Returns
+// the started *exec.Cmd; the caller must Wait on it.
+func spawnRelaySupervisor(notifyFile, workerSock, lbSock *os.File, stderr io.Writer) (*exec.Cmd, error) {
 	self, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("relay-supervisor: self path: %w", err)
@@ -1387,7 +1400,7 @@ func spawnRelaySupervisor(notifyFile, workerSock, lbSock *os.File) (*exec.Cmd, e
 	c.ExtraFiles = []*os.File{notifyFile, workerSock, lbSock}
 	c.Stdin = nil
 	c.Stdout = nil
-	c.Stderr = os.Stderr
+	c.Stderr = stderr
 	c.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGTERM,
 	}
@@ -1433,4 +1446,13 @@ func spawnRelayWorker(workerSock, lbSock, readyW *os.File) (*exec.Cmd, error) {
 // and starve the running webhook.
 func ignoreSIGPIPE() {
 	signal.Ignore(syscall.SIGPIPE)
+}
+
+// ignoreTerminalSignals makes a relay process immune to the terminal's
+// SIGINT (Ctrl-C) and SIGHUP. Both relay processes sit in the wrapped
+// command's foreground process group, and the command may legitimately
+// survive those signals; the relay's lifetime is tied to the command
+// via Pdeathsig/SIGTERM and socket EOF instead.
+func ignoreTerminalSignals() {
+	signal.Ignore(syscall.SIGINT, syscall.SIGHUP)
 }

--- a/cmd/clawpatrol/run_linux.go
+++ b/cmd/clawpatrol/run_linux.go
@@ -54,6 +54,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -276,12 +277,13 @@ func runRun(args []string) {
 	// sup sock fd), fork the supervisor in the host netns. Absence
 	// (--no-auto-expose, unsupported arch) is non-fatal.
 	var relaySup *exec.Cmd
+	relayStderr := newLastLineWriter(os.Stderr)
 	if autoExpose {
 		if relayFDs, err := recvFDs(pSock, 3); err == nil {
 			notifyFile := os.NewFile(uintptr(relayFDs[0]), "seccomp-notify")
 			supSock := os.NewFile(uintptr(relayFDs[1]), "relay-sup-sock")
 			lbSock := os.NewFile(uintptr(relayFDs[2]), "relay-lb-sock")
-			if c, serr := spawnRelaySupervisor(notifyFile, supSock, lbSock); serr != nil {
+			if c, serr := spawnRelaySupervisor(notifyFile, supSock, lbSock, relayStderr); serr != nil {
 				fmt.Fprintf(os.Stderr, "warning: auto-expose relay: %v (webhooks won't be reachable from host, host loopback unreachable from wrapped cmd)\n", serr)
 			} else {
 				relaySup = c
@@ -302,12 +304,26 @@ func runRun(args []string) {
 		}
 	}()
 
-	waitErr := child.Wait()
-
-	if relaySup != nil && relaySup.Process != nil {
-		_ = relaySup.Process.Signal(syscall.SIGTERM)
-		_, _ = relaySup.Process.Wait()
+	// Wait on the wrapped child and the relay supervisor concurrently.
+	// Normally the child exits first and we SIGTERM the supervisor. If
+	// the supervisor exits first the relay is gone for the rest of the
+	// run: the worker has already removed its REDIRECT (#688), so the
+	// wrapped command keeps running with plain in-netns loopback. We
+	// reap the supervisor right away (no <defunct> lingering until the
+	// command ends), warn once with its last stderr line, and keep
+	// waiting on the child — its exit code is the run's exit code.
+	childDoneCh := make(chan error, 1)
+	go func() { childDoneCh <- child.Wait() }()
+	var supDoneCh chan error
+	if relaySup != nil {
+		supDoneCh = make(chan error, 1)
+		go func() { supDoneCh <- relaySup.Wait() }()
 	}
+	waitErr := awaitRunExit(childDoneCh, supDoneCh, relayExitGrace,
+		func() { _ = relaySup.Process.Signal(syscall.SIGTERM) },
+		func(supErr error) {
+			fmt.Fprintln(os.Stderr, relayExitWarning(supErr, relayStderr.LastLine()))
+		})
 
 	// Closing ctrl (via the deferred Close) tears the session down on
 	// the daemon side.
@@ -319,6 +335,109 @@ func runRun(args []string) {
 		}
 		fail("wait: %v", waitErr)
 	}
+}
+
+// relayExitGrace is how long runRun waits for the child's Wait to
+// report after the relay supervisor exits before treating the exit as
+// a relay failure rather than the tail of a normal shutdown.
+const relayExitGrace = 500 * time.Millisecond
+
+// awaitRunExit is runRun's wait/decision logic, factored out so it can
+// be tested with fake channels. childDone carries the wrapped child's
+// Wait result; supDone the relay supervisor's (nil when there is no
+// supervisor). Returns the child's Wait result — the child's exit is
+// always the run's exit.
+//
+//   - Child first: killSup is invoked and supDone drained.
+//   - Supervisor first: the normal cascade (child exits → seccomp filter
+//     empties → supervisor gets ENOENT and exits 0) can reach us before
+//     the child's own Wait does, so the child waiter gets grace to
+//     report. Only if it doesn't is warn called (once) with the
+//     supervisor's Wait result; either way we keep waiting on the
+//     child. The grace only delays the warning, never the run's exit.
+func awaitRunExit(childDone, supDone <-chan error, grace time.Duration, killSup func(), warn func(error)) error {
+	select {
+	case err := <-childDone:
+		if supDone != nil {
+			killSup()
+			<-supDone
+		}
+		return err
+	case supErr := <-supDone:
+		select {
+		case err := <-childDone:
+			return err
+		case <-time.After(grace):
+			warn(supErr)
+			return <-childDone
+		}
+	}
+}
+
+// relayLastLineMaxRunes caps the supervisor line quoted in
+// relayExitWarning so one runaway log line can't swamp the terminal.
+const relayLastLineMaxRunes = 200
+
+// relayExitWarning formats the one-line warning `clawpatrol run` prints
+// when the auto-expose relay supervisor exits while the wrapped command
+// is still running. waitErr is the supervisor's Wait result (nil for a
+// clean exit 0); lastLine is its final stderr line, quoted when present
+// so the operator sees the cause without tailing anything.
+func relayExitWarning(waitErr error, lastLine string) string {
+	var b strings.Builder
+	b.WriteString("⚠ clawpatrol run: auto-expose relay supervisor exited")
+	if waitErr != nil {
+		fmt.Fprintf(&b, " (%v)", waitErr)
+	}
+	b.WriteString("; port auto-expose and host-loopback forwarding are off for the rest of this run")
+	if lastLine != "" {
+		if r := []rune(lastLine); len(r) > relayLastLineMaxRunes {
+			lastLine = string(r[:relayLastLineMaxRunes]) + "…"
+		}
+		fmt.Fprintf(&b, "; last output: %q", lastLine)
+	}
+	return b.String()
+}
+
+// lastLineWriter tees writes to w while keeping a bounded tail so the
+// last line a child wrote can be retrieved after it exits. Live output
+// still streams through in real time; a chatty child can't grow the
+// buffer past lastLineMaxBytes.
+type lastLineWriter struct {
+	mu  sync.Mutex
+	buf []byte
+	w   io.Writer
+}
+
+const lastLineMaxBytes = 4096
+
+func newLastLineWriter(w io.Writer) *lastLineWriter {
+	return &lastLineWriter{w: w}
+}
+
+func (l *lastLineWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	l.buf = append(l.buf, p...)
+	if len(l.buf) > lastLineMaxBytes {
+		l.buf = l.buf[len(l.buf)-lastLineMaxBytes:]
+	}
+	l.mu.Unlock()
+	if l.w == nil {
+		return len(p), nil
+	}
+	return l.w.Write(p)
+}
+
+// LastLine returns the trailing non-empty line with surrounding
+// whitespace stripped, or "" if nothing was captured.
+func (l *lastLineWriter) LastLine() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	s := strings.TrimRight(string(l.buf), "\r\n \t")
+	if i := strings.LastIndexAny(s, "\r\n"); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.TrimSpace(s)
 }
 
 // runWholeMachineDirect handles `clawpatrol run <cmd>` on a

--- a/cmd/clawpatrol/run_linux_test.go
+++ b/cmd/clawpatrol/run_linux_test.go
@@ -3,9 +3,12 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRewriteHostsLines(t *testing.T) {
@@ -302,4 +305,189 @@ func TestSplitWGAddresses(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLastLineWriter pins the contract used to quote the relay
+// supervisor's final stderr line: every byte is forwarded to the sink
+// (live output is never suppressed) and LastLine returns the trailing
+// non-empty line.
+func TestLastLineWriter(t *testing.T) {
+	cases := []struct {
+		name   string
+		writes []string
+		want   string
+	}{
+		{"single line no trailing newline", []string{"hello world"}, "hello world"},
+		{"two lines trailing newline", []string{"first\nsecond\n"}, "second"},
+		{"split writes", []string{"par", "tial\nsec", "ond line\n"}, "second line"},
+		{"trailing whitespace stripped", []string{"last line   \n\n\r\n"}, "last line"},
+		{"empty", nil, ""},
+		{"only newlines", []string{"\n\n\n"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sink bytes.Buffer
+			lw := newLastLineWriter(&sink)
+			for _, w := range tc.writes {
+				n, err := lw.Write([]byte(w))
+				if err != nil || n != len(w) {
+					t.Fatalf("Write = %d, %v; want %d, nil", n, err, len(w))
+				}
+			}
+			if got, want := sink.String(), strings.Join(tc.writes, ""); got != want {
+				t.Errorf("sink = %q, want %q (must pass through every byte)", got, want)
+			}
+			if got := lw.LastLine(); got != tc.want {
+				t.Errorf("LastLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLastLineWriterBounded ensures a chatty child can't grow the tail
+// buffer past its bound, and that the last line survives the trimming.
+func TestLastLineWriterBounded(t *testing.T) {
+	lw := newLastLineWriter(nil)
+	for i := 0; i < 20; i++ {
+		if _, err := lw.Write([]byte(strings.Repeat("a", 1024) + "\n")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if _, err := lw.Write([]byte("final\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := len(lw.buf); got > lastLineMaxBytes {
+		t.Fatalf("buf size %d exceeds bound %d", got, lastLineMaxBytes)
+	}
+	if got := lw.LastLine(); got != "final" {
+		t.Fatalf("LastLine() = %q, want %q", got, "final")
+	}
+}
+
+func TestRelayExitWarning(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		lastLine string
+		want     string
+	}{
+		{
+			name: "clean exit no output",
+			want: "⚠ clawpatrol run: auto-expose relay supervisor exited; port auto-expose and host-loopback forwarding are off for the rest of this run",
+		},
+		{
+			name:     "error with last line",
+			err:      errors.New("exit status 1"),
+			lastLine: "relay-supervisor: boom",
+			want:     "⚠ clawpatrol run: auto-expose relay supervisor exited (exit status 1); port auto-expose and host-loopback forwarding are off for the rest of this run; last output: \"relay-supervisor: boom\"",
+		},
+		{
+			name:     "long last line truncated at rune boundary",
+			lastLine: strings.Repeat("é", relayLastLineMaxRunes+50),
+			want: "⚠ clawpatrol run: auto-expose relay supervisor exited; port auto-expose and host-loopback forwarding are off for the rest of this run; last output: \"" +
+				strings.Repeat("é", relayLastLineMaxRunes) + "…\"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relayExitWarning(tc.err, tc.lastLine); got != tc.want {
+				t.Errorf("relayExitWarning() =\n %q\nwant\n %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAwaitRunExit pins runRun's wait/decision logic: the child's Wait
+// result is always returned, the supervisor is killed and drained when
+// the child goes first, and the warning fires only when the supervisor
+// exits and the child does not follow within the grace.
+func TestAwaitRunExit(t *testing.T) {
+	const grace = 30 * time.Millisecond
+	childErr := errors.New("exit status 3")
+	supErr := errors.New("exit status 1")
+
+	type result struct {
+		err    error
+		killed int
+		warned []error
+	}
+	run := func(t *testing.T, drive func(childDone, supDone chan error), supDone chan error) result {
+		t.Helper()
+		childDone := make(chan error, 1)
+		var res result
+		done := make(chan struct{})
+		go func() {
+			res.err = awaitRunExit(childDone, supDone, grace,
+				func() { res.killed++ },
+				func(err error) { res.warned = append(res.warned, err) })
+			close(done)
+		}()
+		drive(childDone, supDone)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("awaitRunExit did not return")
+		}
+		return res
+	}
+
+	t.Run("child first kills supervisor, no warning", func(t *testing.T) {
+		supDone := make(chan error, 1)
+		res := run(t, func(childDone, supDone chan error) {
+			childDone <- childErr
+			// Supervisor "exits" in response to the kill.
+			time.Sleep(grace / 3)
+			supDone <- errors.New("signal: terminated")
+		}, supDone)
+		if !errors.Is(res.err, childErr) || res.killed != 1 || len(res.warned) != 0 {
+			t.Fatalf("got err=%v killed=%d warned=%v", res.err, res.killed, res.warned)
+		}
+	})
+
+	t.Run("no supervisor", func(t *testing.T) {
+		res := run(t, func(childDone, _ chan error) { childDone <- nil }, nil)
+		if res.err != nil || res.killed != 0 || len(res.warned) != 0 {
+			t.Fatalf("got err=%v killed=%d warned=%v", res.err, res.killed, res.warned)
+		}
+	})
+
+	t.Run("supervisor first, child within grace: no warning", func(t *testing.T) {
+		supDone := make(chan error, 1)
+		res := run(t, func(childDone, supDone chan error) {
+			supDone <- nil
+			time.Sleep(grace / 3)
+			childDone <- childErr
+		}, supDone)
+		if !errors.Is(res.err, childErr) || res.killed != 0 || len(res.warned) != 0 {
+			t.Fatalf("got err=%v killed=%d warned=%v", res.err, res.killed, res.warned)
+		}
+	})
+
+	t.Run("supervisor first, grace expires: warn once, child result wins", func(t *testing.T) {
+		supDone := make(chan error, 1)
+		res := run(t, func(childDone, supDone chan error) {
+			supDone <- supErr
+			time.Sleep(3 * grace)
+			childDone <- childErr
+		}, supDone)
+		if !errors.Is(res.err, childErr) || res.killed != 0 {
+			t.Fatalf("got err=%v killed=%d", res.err, res.killed)
+		}
+		if len(res.warned) != 1 || !errors.Is(res.warned[0], supErr) {
+			t.Fatalf("warned = %v, want exactly [%v]", res.warned, supErr)
+		}
+	})
+
+	t.Run("both ready: no warning", func(t *testing.T) {
+		for i := 0; i < 20; i++ {
+			supDone := make(chan error, 1)
+			res := run(t, func(childDone, supDone chan error) {
+				supDone <- nil
+				childDone <- childErr
+			}, supDone)
+			if !errors.Is(res.err, childErr) || len(res.warned) != 0 {
+				t.Fatalf("iteration %d: got err=%v killed=%d warned=%v", i, res.err, res.killed, res.warned)
+			}
+		}
+	})
 }


### PR DESCRIPTION
`clawpatrol run` only waited on the relay supervisor after the wrapped
command had exited, so a supervisor that died early sat `<defunct>`
for the rest of the session (the zombie seen in #688) and its last
stderr line was lost.

* wait on the child and the supervisor concurrently
* supervisor first: allow a 500 ms grace for the normal exit cascade
  (child exit -> worker ENOENT -> supervisor exit 0); otherwise print
  one warning with the supervisor's error and its last stderr line
  (bounded last-line tee), then keep waiting on the child
* child first: SIGTERM the supervisor and drain, as before

The fail-open policy from #688 and the exit code are unchanged: the
wrapped command keeps running with in-namespace loopback. Supersedes
#587, which killed the command instead.
