### PR TITLE
fixtures: record the resolved credential on the action

### DIFF
--- a/cmd/clawpatrol/credential_match_test.go
+++ b/cmd/clawpatrol/credential_match_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
@@ -99,10 +100,22 @@ profile "default" {
 		if end.ReqBody != "" {
 			t.Fatalf("recorded request body = %q, want empty", end.ReqBody)
 		}
+		// The resolved credential rides on the event and into the
+		// exported fixture so a replay reaches the same pinned rule.
+		if end.Credential != "pat" {
+			t.Fatalf("event credential = %q, want pat", end.Credential)
+		}
 		rw := httptest.NewRecorder()
 		(&webMux{g: h.gateway}).writeActionFixture(rw, &end)
 		if rw.Code != http.StatusOK {
 			t.Fatalf("fixture export status = %d, want 200; body=%s", rw.Code, rw.Body.String())
+		}
+		var f Fixture
+		if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+			t.Fatalf("reparse fixture: %v\nbody=%s", err, rw.Body.String())
+		}
+		if f.Action.Credential != "pat" {
+			t.Fatalf("fixture action.credential = %q, want pat", f.Action.Credential)
 		}
 	})
 }

--- a/cmd/clawpatrol/main.go
+++ b/cmd/clawpatrol/main.go
@@ -1916,6 +1916,7 @@ func (g *Gateway) handlePostgresConn(c net.Conn, dstIP string) {
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,
 				Endpoint: ep.Name, Rule: ev.Rule,
+				Credential:   ev.Credential,
 				Approver:     ev.Approver,
 				ApproverType: ev.ApproverType,
 				ApproverBy:   ev.ApproverBy,
@@ -2087,6 +2088,7 @@ func (g *Gateway) dispatchConnEndpoint(c net.Conn, dstIP string, dstPort uint16,
 				Action: ev.Action, Reason: ev.Reason,
 				Facets:   ev.Facets,
 				Endpoint: ep.Name, Rule: ev.Rule,
+				Credential:   ev.Credential,
 				Approver:     ev.Approver,
 				ApproverType: ev.ApproverType,
 				ApproverBy:   ev.ApproverBy,
@@ -2530,8 +2532,9 @@ func (g *Gateway) mitmHTTPSWithCertHost(c net.Conn, host, certHost string, ep *c
 			Family: ep.Family,
 			Host:   host,
 			Method: req.Method, Path: req.URL.Path,
-			AgentIP:  agentAddr,
-			Endpoint: ep.Name,
+			AgentIP:    agentAddr,
+			Endpoint:   ep.Name,
+			Credential: mreq.Credential,
 		}
 		if fac != nil {
 			ev.Facets = fac.Report(mreq)

--- a/cmd/clawpatrol/migrations/sqlite/0022_action_credential.sql
+++ b/cmd/clawpatrol/migrations/sqlite/0022_action_credential.sql
@@ -1,0 +1,10 @@
+-- Carry the resolved credential's bare name on every action row. The
+-- dispatch sites already resolve the credential before matching so
+-- credential-pinned rules can fire; without recording it the exported
+-- action fixture replays with an empty credential and `clawpatrol test`
+-- can report a different verdict than the gateway produced. NULL for
+-- pre-existing rows and for events that never resolved a credential.
+
+ALTER TABLE actions ADD COLUMN credential TEXT;
+
+INSERT INTO _schema (version) VALUES (22);

--- a/cmd/clawpatrol/web.go
+++ b/cmd/clawpatrol/web.go
@@ -1766,6 +1766,7 @@ func (w *webMux) loadAction(actionID string) (*Event, error) {
 		extra          sql.NullString
 		endpoint       sql.NullString
 		rule           sql.NullString
+		credential     sql.NullString
 		approver       sql.NullString
 		approverType   sql.NullString
 		approverBy     sql.NullString
@@ -1776,7 +1777,7 @@ func (w *webMux) loadAction(actionID string) (*Event, error) {
 		       reason, req_sha, resp_sha,
 		       req_body, resp_body, req_body_state, resp_body_state, req_transformed,
 		       req_headers, resp_headers, extra,
-		       endpoint, rule,
+		       endpoint, rule, credential,
 		       approver, approver_type, approver_by
 		FROM actions WHERE action_id = ?`, actionID,
 	).Scan(
@@ -1785,7 +1786,7 @@ func (w *webMux) loadAction(actionID string) (*Event, error) {
 		&action, &reason, &reqSha, &respSha,
 		&reqBody, &respBody, &reqBodyState, &respBodyState, &reqTransformed,
 		&reqHeaders, &respHeaders, &extra,
-		&endpoint, &rule,
+		&endpoint, &rule, &credential,
 		&approver, &approverType, &approverBy,
 	)
 	if err != nil {
@@ -1818,6 +1819,7 @@ func (w *webMux) loadAction(actionID string) (*Event, error) {
 	}
 	e.Endpoint = endpoint.String
 	e.Rule = rule.String
+	e.Credential = credential.String
 	e.Approver = approver.String
 	e.ApproverType = approverType.String
 	e.ApproverBy = approverBy.String
@@ -1877,7 +1879,11 @@ func (w *webMux) writeActionFixture(rw http.ResponseWriter, ev *Event) {
 	// the bare DB-recorded name; the policy supplies the type.
 	m.Endpoint = endpointRef(ep)
 
-	fx := &Fixture{Match: m, Action: Action{PeerIP: ev.AgentIP}}
+	// Credential is the bare name the dispatch site resolved before
+	// matching. Without it a fixture for a request whose rule pinned
+	// one of several credentials bound to the endpoint replays with an
+	// empty credential and never reaches that rule.
+	fx := &Fixture{Match: m, Action: Action{PeerIP: ev.AgentIP, Credential: ev.Credential}}
 	switch ep.Family {
 	case "http":
 		if err := validateHTTPFixtureBodyCapture(ev); err != nil {
@@ -2532,6 +2538,14 @@ type Event struct {
 	// the rule that produced its verdict (site/doc/clawpatrol-test.md).
 	Endpoint string `json:"endpoint,omitempty"`
 	Rule     string `json:"rule,omitempty"`
+
+	// Credential is the bare name of the credential the dispatch site
+	// resolved for this request (what it set on
+	// match.Request.Credential before matching), "" when none was
+	// resolved. The fixture exporter stamps it into action.credential
+	// so a replay reaches the same credential-pinned rules the gateway
+	// evaluated.
+	Credential string `json:"credential,omitempty"`
 }
 
 // eventPacket carries an event plus its marshaled JSON bytes. drain()
@@ -2598,7 +2612,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		       method, path, status, bytes_in, bytes_out,
 		       ms, action, reason, req_sha, resp_sha,
 		       req_body_state, resp_body_state, req_transformed, extra,
-		       endpoint, rule,
+		       endpoint, rule, credential,
 		       approver, approver_type, approver_by
 		FROM actions ORDER BY id DESC LIMIT ?`, n)
 	if err != nil {
@@ -2629,6 +2643,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 			extra          sql.NullString
 			endpoint       sql.NullString
 			rule           sql.NullString
+			credential     sql.NullString
 			approver       sql.NullString
 			approverType   sql.NullString
 			approverBy     sql.NullString
@@ -2638,7 +2653,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 			&method, &path, &status, &in, &ot, &ms,
 			&action, &reason, &reqSha, &respSha,
 			&reqBodyState, &respBodyState, &reqTransformed, &extra,
-			&endpoint, &rule,
+			&endpoint, &rule, &credential,
 			&approver, &approverType, &approverBy,
 		); err != nil {
 			return nil, err
@@ -2649,6 +2664,7 @@ func readTailEvents(db *sql.DB, n int) ([]Event, error) {
 		e.Family = family.String
 		e.Endpoint = endpoint.String
 		e.Rule = rule.String
+		e.Credential = credential.String
 		e.AgentIP = agentIP.String
 		e.Method = method.String
 		e.Path = path.String
@@ -2768,9 +2784,9 @@ func (s *Sink) drain() {
 				  ms, action, reason, req_sha, resp_sha,
 				  req_body, resp_body, req_body_state, resp_body_state, req_transformed,
 				  req_headers, resp_headers, extra,
-				  endpoint, rule,
+				  endpoint, rule, credential,
 				  approver, approver_type, approver_by)
-				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+				VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 			`, e.ID, e.Ts.UnixNano(), e.Mode, e.Family, e.AgentIP,
 				e.Host, e.Method, e.Path, e.Status,
 				e.In, e.Out, e.Ms, e.Action, e.Reason,
@@ -2778,7 +2794,7 @@ func (s *Sink) drain() {
 				e.ReqBody, e.RespBody, e.ReqBodyState, e.RespBodyState, e.ReqTransformed,
 				string(rqhJSON), string(rshJSON),
 				string(extraJSON),
-				e.Endpoint, e.Rule,
+				e.Endpoint, e.Rule, e.Credential,
 				e.Approver, e.ApproverType, e.ApproverBy)
 		}
 

--- a/cmd/clawpatrol/web_fixture_export_test.go
+++ b/cmd/clawpatrol/web_fixture_export_test.go
@@ -655,3 +655,115 @@ func TestRunnerRejectsPassthrough(t *testing.T) {
 		t.Fatalf("err=%v, want passthrough rejection", err)
 	}
 }
+
+// The exporter stamps the credential the dispatch site resolved into
+// action.credential. With two credentials bound to one endpoint and a
+// rule pinned to one of them, the fixture only reaches the pinned rule
+// when it carries that credential — the same fixture with the field
+// removed falls through to the default rule, which is the verdict drift
+// the field exists to prevent.
+func TestExporterRecordsResolvedCredentialRoundTrip(t *testing.T) {
+	const hcl = `
+
+endpoint "https" "api" {
+  hosts = ["api.example.com"]
+}
+credential "bearer_token" "reader" { endpoint = https.api }
+credential "bearer_token" "writer" { endpoint = https.api }
+rule "writer-mutations" {
+  endpoint   = https.api
+  credential = bearer_token.writer
+  priority   = 100
+  condition  = "http.method != 'GET'"
+  verdict    = "allow"
+}
+rule "api-default" {
+  endpoint = https.api
+  priority = -100
+  verdict  = "deny"
+}
+profile "default" {
+  credentials = [
+    { placeholder = "PH_reader", credential = bearer_token.reader },
+    { placeholder = "PH_writer", credential = bearer_token.writer },
+  ]
+}
+`
+	gw := gatewayWithPolicy(t, hcl)
+	w := &webMux{g: gw}
+	ev := &Event{
+		ID: "evt-cred", Mode: "mitm", Family: "https",
+		Host: "api.example.com", Method: "POST", Path: "/repos",
+		AgentIP: "100.64.0.7", Action: "allow",
+		Endpoint: "api", Rule: "writer-mutations", Credential: "writer",
+		ReqBodyState: bodyCaptureComplete,
+		ReqHeaders:   map[string]string{"Authorization": "***"},
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("export status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var f Fixture
+	if err := json.Unmarshal(rw.Body.Bytes(), &f); err != nil {
+		t.Fatalf("reparse: %v\nbody=%s", err, rw.Body.String())
+	}
+	if f.Action.Credential != "writer" {
+		t.Fatalf("action.credential=%q want writer", f.Action.Credential)
+	}
+
+	dir := t.TempDir()
+	withCred := filepath.Join(dir, "with-credential.json")
+	if err := os.WriteFile(withCred, rw.Body.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, msg, err := runOneFixture(gw.Policy(), withCred)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !ok {
+		t.Fatalf("fixture with credential should match the pinned rule:\n%s", msg)
+	}
+
+	// Same fixture, credential stripped (what the exporter produced
+	// before the field was recorded): the pinned rule is unreachable
+	// and the replay lands on the default deny.
+	f.Action.Credential = ""
+	stripped, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutCred := filepath.Join(dir, "without-credential.json")
+	if err := os.WriteFile(withoutCred, stripped, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, msg, err = runOneFixture(gw.Policy(), withoutCred)
+	if err != nil {
+		t.Fatalf("run without credential: %v", err)
+	}
+	if ok {
+		t.Fatal("fixture without credential must not reach the credential-pinned rule")
+	}
+	if !strings.Contains(msg, "api-default") {
+		t.Fatalf("mismatch should land on api-default, got:\n%s", msg)
+	}
+}
+
+// Events that resolved no credential export without the field, so
+// fixtures for single-credential endpoints are unchanged.
+func TestExporterOmitsCredentialWhenUnresolved(t *testing.T) {
+	w := &webMux{g: gatewayWithPolicy(t, fixtureHCL)}
+	ev := &Event{
+		ID: "evt-nocred", Mode: "mitm", Family: "https",
+		Host: "api.github.com", Method: "GET", Path: "/user",
+		Action: "allow", Endpoint: "github", ReqBodyState: bodyCaptureComplete,
+	}
+	rw := httptest.NewRecorder()
+	w.writeActionFixture(rw, ev)
+	if rw.Code != 200 {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	if strings.Contains(rw.Body.String(), `"credential"`) {
+		t.Fatalf("expected no credential key in export:\n%s", rw.Body.String())
+	}
+}

--- a/cmd/clawpatrol/web_sink_test.go
+++ b/cmd/clawpatrol/web_sink_test.go
@@ -96,6 +96,7 @@ func TestSinkPersistsBodyCaptureState(t *testing.T) {
 		ID: "body-state", Phase: "end", Mode: "mitm", Host: "api.example.com",
 		ReqBody: "partial request", ReqBodyState: bodyCaptureIncomplete,
 		RespBody: "complete response", RespBodyState: bodyCaptureComplete,
+		Endpoint: "api", Rule: "writes", Credential: "writer",
 	})
 
 	select {
@@ -114,6 +115,16 @@ func TestSinkPersistsBodyCaptureState(t *testing.T) {
 	}
 	if got.RespBodyState != bodyCaptureComplete {
 		t.Fatalf("response body state = %q, want %q", got.RespBodyState, bodyCaptureComplete)
+	}
+	if got.Credential != "writer" {
+		t.Fatalf("credential = %q, want writer", got.Credential)
+	}
+	tail, err := readTailEvents(db, 1)
+	if err != nil {
+		t.Fatalf("readTailEvents: %v", err)
+	}
+	if len(tail) != 1 || tail[0].Credential != "writer" {
+		t.Fatalf("tail credential = %+v, want one event with credential writer", tail)
 	}
 }
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -555,6 +555,9 @@ export type EventRecord = {
   // Download action button (site/doc/clawpatrol-test.md).
   endpoint?: string;
   rule?: string;
+  // credential is the bare name of the credential the gateway resolved
+  // for the request before matching; absent when none was resolved.
+  credential?: string;
   // approver/* are populated when action is "approved" or "denied":
   // the approver entity's HCL block name, plugin type
   // (human_approver / llm_approver / dashboard) and the per-approver

--- a/internal/config/plugins/endpoints/clickhouse_native_runtime.go
+++ b/internal/config/plugins/endpoints/clickhouse_native_runtime.go
@@ -193,6 +193,16 @@ func (ClickhouseNativeEndpointRuntime) HandleConn(ctx context.Context, ch *runti
 	}
 	if cc := runtime.ResolveCredential(ch.Policy, ch.Profile, ch.Endpoint, credReq); cc != nil {
 		credName = cc.Credential.Symbol.Name
+		// Every event this connection emits from here on — connect,
+		// query, data, and error events alike — ran under the resolved
+		// credential. Wrap Emit once (the same way ch.Conn is swapped
+		// above) instead of threading credName into each emitter.
+		if inner := ch.Emit; inner != nil {
+			ch.Emit = func(ev runtime.ConnEvent) {
+				ev.Credential = credName
+				inner(ev)
+			}
+		}
 		auth, ok := cc.Credential.Body.(runtime.ClickhouseAuthCredential)
 		if !ok {
 			chEmitError(ch, "credential-not-clickhouse-auth", cc.Credential.Symbol.Name)

--- a/internal/config/plugins/endpoints/postgres.go
+++ b/internal/config/plugins/endpoints/postgres.go
@@ -583,7 +583,8 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName, 
 		}
 		pgWriteDeny(ch.Conn, reason)
 		emit(ch, runtime.ConnEvent{
-			Action: "deny", Reason: reason, Summary: summary, Facets: facets,
+			Credential: credName,
+			Action:     "deny", Reason: reason, Summary: summary, Facets: facets,
 		})
 		log.Printf("pg-deny-truncated %s: %s", ch.PeerIP, reason)
 		return rest, true
@@ -598,7 +599,8 @@ func pgHandleOversizeFrame(ch *runtime.ConnHandle, upstream net.Conn, credName, 
 		}
 	}
 	emit(ch, runtime.ConnEvent{
-		Action: "allow-overflow", Summary: summary, Facets: facets,
+		Credential: credName,
+		Action:     "allow-overflow", Summary: summary, Facets: facets,
 	})
 	return rest, true
 }
@@ -678,7 +680,8 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 		// recorded).
 		if !shadow {
 			emit(ch, runtime.ConnEvent{
-				Action: "allow", Verb: info.Verb, Summary: summary, Facets: facets,
+				Credential: credName,
+				Action:     "allow", Verb: info.Verb, Summary: summary, Facets: facets,
 			})
 		}
 		return "", ""
@@ -694,7 +697,8 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 	if len(cr.Outcome.Approve) > 0 {
 		if ch.Approve == nil {
 			emit(ch, runtime.ConnEvent{
-				Action: "deny", Reason: "HITL not configured",
+				Credential: credName,
+				Action:     "deny", Reason: "HITL not configured",
 				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 			})
 			return "deny", "approval required but HITL is not configured"
@@ -709,7 +713,8 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 				reason = "denied by approver"
 			}
 			emit(ch, runtime.ConnEvent{
-				Action: "denied", Reason: reason,
+				Credential: credName,
+				Action:     "denied", Reason: reason,
 				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 				Approver: v.ApproverName, ApproverType: v.ApproverType, ApproverBy: v.By,
 			})
@@ -717,7 +722,8 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 		}
 		if !shadow {
 			emit(ch, runtime.ConnEvent{
-				Action: "approved", Reason: v.Reason,
+				Credential: credName,
+				Action:     "approved", Reason: v.Reason,
 				Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 				Approver: v.ApproverName, ApproverType: v.ApproverType, ApproverBy: v.By,
 			})
@@ -731,14 +737,16 @@ func pgEvaluateInfo(ch *runtime.ConnHandle, info pgInfo, credName, database stri
 			reason = "denied by policy"
 		}
 		emit(ch, runtime.ConnEvent{
-			Action: "deny", Reason: reason,
+			Credential: credName,
+			Action:     "deny", Reason: reason,
 			Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 		})
 		return "deny", reason
 	}
 	if !shadow {
 		emit(ch, runtime.ConnEvent{
-			Action: "allow", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
+			Credential: credName,
+			Action:     "allow", Verb: info.Verb, Summary: summary, Facets: facets, Rule: rule,
 		})
 	}
 	return "", ""

--- a/internal/config/plugins/endpoints/ssh.go
+++ b/internal/config/plugins/endpoints/ssh.go
@@ -234,8 +234,13 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	}
 	defer func() { _ = clientConn.Close() }()
 
+	// Every event on this connection ran under the credential picked
+	// above; stamp it here so the gate's per-action events don't have
+	// to repeat it.
+	credName := cc.Credential.Symbol.Name
 	emit := func(ev runtime.ConnEvent) {
 		if ch.Emit != nil {
+			ev.Credential = credName
 			ch.Emit(ev)
 		}
 	}
@@ -251,7 +256,7 @@ func (rt *SSHEndpointRuntime) HandleConn(ctx context.Context, ch *runtime.ConnHa
 	// mirrors the postgres per-statement path: build a match.Request,
 	// run MatchRequest, honor an approve chain through ch.Approve, and
 	// default-deny an approve-gated action when HITL isn't wired.
-	gate := rt.makeGate(ch, emit, agentUser, cc.Credential.Symbol.Name)
+	gate := rt.makeGate(ch, emit, agentUser, credName)
 	agentHooks := sshHooks{emit: emit, gate: gate}
 
 	// Step 6: bidirectional pump. Two waitgroups — `dispatch` covers

--- a/internal/config/runtime/runtime.go
+++ b/internal/config/runtime/runtime.go
@@ -311,6 +311,12 @@ type ConnEvent struct {
 	// the action-fixture exporter can pin a downloaded action to a
 	// specific rule (site/doc/clawpatrol-test.md).
 	Rule string
+	// Credential is the bare name of the credential the runtime
+	// resolved for this connection (the value it put on
+	// match.Request.Credential), "" when none was resolved. Copied
+	// onto the dashboard Event so the fixture exporter can replay
+	// the action against the same credential-pinned rules.
+	Credential string
 	// Approver* mirror ApproveVerdict — set for Action=="approved" /
 	// "denied" so the dashboard can show which approver (and what
 	// kind: human / llm / dashboard) produced the verdict.


### PR DESCRIPTION
Fixes #841.

Events never carried the credential that dispatch resolved for a
request, so a fixture downloaded for a request whose rule pinned one
of several credentials bound to the same endpoint replayed with an
empty credential and `clawpatrol test` reported a different verdict
than the gateway had.

* new nullable `actions.credential` column (migration 0022,
  additive; older binaries name their columns and ignore it)
* `Event.Credential` / `runtime.ConnEvent.Credential`, persisted by
  the sink and read back for the detail page, fixture download and
  the SSE backlog
* populated on every family that resolves a credential: HTTPS MITM
  (incl. k8s), postgres, ssh, clickhouse native (one wrapper on the
  handle's Emit after resolution)
* `writeActionFixture` stamps it into `action.credential`; omitted
  when empty, so fixtures without it behave as before
* round-trip test: two bearer tokens on one endpoint, rule pinned to
  one; the exported fixture matches, the same fixture without the
  field drifts to the default rule

External plugin endpoints are unchanged: the adapter never learns
which credential the plugin used, so recording it needs a protocol
addition first.
